### PR TITLE
fix: restore credential logic

### DIFF
--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_stub_factory.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_stub_factory.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<GoldenKitchenSinkRestStub>
 CreateDefaultGoldenKitchenSinkRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/generator/integration_tests/golden/v1/internal/golden_rest_only_rest_stub_factory.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_rest_only_rest_stub_factory.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<GoldenRestOnlyRestStub>
 CreateDefaultGoldenRestOnlyRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_stub_factory.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_stub_factory.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<GoldenThingAdminRestStub>
 CreateDefaultGoldenThingAdminRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/generator/internal/stub_factory_rest_generator.cc
+++ b/generator/internal/stub_factory_rest_generator.cc
@@ -76,6 +76,7 @@ Status StubFactoryRestGenerator::GenerateCc() {
       {vars("stub_factory_rest_header_path"), vars("logging_rest_header_path"),
        vars("metadata_rest_header_path"), vars("stub_rest_header_path"),
        "google/cloud/common_options.h", "google/cloud/credentials.h",
+       "google/cloud/internal/populate_common_options.h",
        "google/cloud/internal/rest_options.h", "google/cloud/rest_options.h",
        "google/cloud/internal/absl_str_cat_quiet.h",
        "google/cloud/internal/algorithm.h", "google/cloud/options.h",
@@ -91,7 +92,8 @@ std::shared_ptr<$stub_rest_class_name$>
 CreateDefault$stub_rest_class_name$(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/accelerator_types/v1/internal/accelerator_types_rest_stub_factory.cc
+++ b/google/cloud/compute/accelerator_types/v1/internal/accelerator_types_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<AcceleratorTypesRestStub> CreateDefaultAcceleratorTypesRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/addresses/v1/internal/addresses_rest_stub_factory.cc
+++ b/google/cloud/compute/addresses/v1/internal/addresses_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<AddressesRestStub> CreateDefaultAddressesRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/autoscalers/v1/internal/autoscalers_rest_stub_factory.cc
+++ b/google/cloud/compute/autoscalers/v1/internal/autoscalers_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<AutoscalersRestStub> CreateDefaultAutoscalersRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/backend_buckets/v1/internal/backend_buckets_rest_stub_factory.cc
+++ b/google/cloud/compute/backend_buckets/v1/internal/backend_buckets_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<BackendBucketsRestStub> CreateDefaultBackendBucketsRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/backend_services/v1/internal/backend_services_rest_stub_factory.cc
+++ b/google/cloud/compute/backend_services/v1/internal/backend_services_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<BackendServicesRestStub> CreateDefaultBackendServicesRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/disk_types/v1/internal/disk_types_rest_stub_factory.cc
+++ b/google/cloud/compute/disk_types/v1/internal/disk_types_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<DiskTypesRestStub> CreateDefaultDiskTypesRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/disks/v1/internal/disks_rest_stub_factory.cc
+++ b/google/cloud/compute/disks/v1/internal/disks_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<DisksRestStub> CreateDefaultDisksRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/external_vpn_gateways/v1/internal/external_vpn_gateways_rest_stub_factory.cc
+++ b/google/cloud/compute/external_vpn_gateways/v1/internal/external_vpn_gateways_rest_stub_factory.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -41,7 +42,8 @@ std::shared_ptr<ExternalVpnGatewaysRestStub>
 CreateDefaultExternalVpnGatewaysRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/firewall_policies/v1/internal/firewall_policies_rest_stub_factory.cc
+++ b/google/cloud/compute/firewall_policies/v1/internal/firewall_policies_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<FirewallPoliciesRestStub> CreateDefaultFirewallPoliciesRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/firewalls/v1/internal/firewalls_rest_stub_factory.cc
+++ b/google/cloud/compute/firewalls/v1/internal/firewalls_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<FirewallsRestStub> CreateDefaultFirewallsRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/forwarding_rules/v1/internal/forwarding_rules_rest_stub_factory.cc
+++ b/google/cloud/compute/forwarding_rules/v1/internal/forwarding_rules_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<ForwardingRulesRestStub> CreateDefaultForwardingRulesRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/global_addresses/v1/internal/global_addresses_rest_stub_factory.cc
+++ b/google/cloud/compute/global_addresses/v1/internal/global_addresses_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<GlobalAddressesRestStub> CreateDefaultGlobalAddressesRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/global_forwarding_rules/v1/internal/global_forwarding_rules_rest_stub_factory.cc
+++ b/google/cloud/compute/global_forwarding_rules/v1/internal/global_forwarding_rules_rest_stub_factory.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -41,7 +42,8 @@ std::shared_ptr<GlobalForwardingRulesRestStub>
 CreateDefaultGlobalForwardingRulesRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/global_network_endpoint_groups/v1/internal/global_network_endpoint_groups_rest_stub_factory.cc
+++ b/google/cloud/compute/global_network_endpoint_groups/v1/internal/global_network_endpoint_groups_rest_stub_factory.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -41,7 +42,8 @@ std::shared_ptr<GlobalNetworkEndpointGroupsRestStub>
 CreateDefaultGlobalNetworkEndpointGroupsRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/global_operations/v1/internal/global_operations_rest_stub_factory.cc
+++ b/google/cloud/compute/global_operations/v1/internal/global_operations_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<GlobalOperationsRestStub> CreateDefaultGlobalOperationsRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/global_organization_operations/v1/internal/global_organization_operations_rest_stub_factory.cc
+++ b/google/cloud/compute/global_organization_operations/v1/internal/global_organization_operations_rest_stub_factory.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -41,7 +42,8 @@ std::shared_ptr<GlobalOrganizationOperationsRestStub>
 CreateDefaultGlobalOrganizationOperationsRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/global_public_delegated_prefixes/v1/internal/global_public_delegated_prefixes_rest_stub_factory.cc
+++ b/google/cloud/compute/global_public_delegated_prefixes/v1/internal/global_public_delegated_prefixes_rest_stub_factory.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -41,7 +42,8 @@ std::shared_ptr<GlobalPublicDelegatedPrefixesRestStub>
 CreateDefaultGlobalPublicDelegatedPrefixesRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/health_checks/v1/internal/health_checks_rest_stub_factory.cc
+++ b/google/cloud/compute/health_checks/v1/internal/health_checks_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<HealthChecksRestStub> CreateDefaultHealthChecksRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/http_health_checks/v1/internal/http_health_checks_rest_stub_factory.cc
+++ b/google/cloud/compute/http_health_checks/v1/internal/http_health_checks_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<HttpHealthChecksRestStub> CreateDefaultHttpHealthChecksRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/https_health_checks/v1/internal/https_health_checks_rest_stub_factory.cc
+++ b/google/cloud/compute/https_health_checks/v1/internal/https_health_checks_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<HttpsHealthChecksRestStub>
 CreateDefaultHttpsHealthChecksRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/image_family_views/v1/internal/image_family_views_rest_stub_factory.cc
+++ b/google/cloud/compute/image_family_views/v1/internal/image_family_views_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<ImageFamilyViewsRestStub> CreateDefaultImageFamilyViewsRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/images/v1/internal/images_rest_stub_factory.cc
+++ b/google/cloud/compute/images/v1/internal/images_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<ImagesRestStub> CreateDefaultImagesRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/instance_group_managers/v1/internal/instance_group_managers_rest_stub_factory.cc
+++ b/google/cloud/compute/instance_group_managers/v1/internal/instance_group_managers_rest_stub_factory.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -41,7 +42,8 @@ std::shared_ptr<InstanceGroupManagersRestStub>
 CreateDefaultInstanceGroupManagersRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/instance_groups/v1/internal/instance_groups_rest_stub_factory.cc
+++ b/google/cloud/compute/instance_groups/v1/internal/instance_groups_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<InstanceGroupsRestStub> CreateDefaultInstanceGroupsRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/instance_templates/v1/internal/instance_templates_rest_stub_factory.cc
+++ b/google/cloud/compute/instance_templates/v1/internal/instance_templates_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<InstanceTemplatesRestStub>
 CreateDefaultInstanceTemplatesRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/instances/v1/internal/instances_rest_stub_factory.cc
+++ b/google/cloud/compute/instances/v1/internal/instances_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<InstancesRestStub> CreateDefaultInstancesRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/interconnect_attachments/v1/internal/interconnect_attachments_rest_stub_factory.cc
+++ b/google/cloud/compute/interconnect_attachments/v1/internal/interconnect_attachments_rest_stub_factory.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -41,7 +42,8 @@ std::shared_ptr<InterconnectAttachmentsRestStub>
 CreateDefaultInterconnectAttachmentsRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/interconnect_locations/v1/internal/interconnect_locations_rest_stub_factory.cc
+++ b/google/cloud/compute/interconnect_locations/v1/internal/interconnect_locations_rest_stub_factory.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -41,7 +42,8 @@ std::shared_ptr<InterconnectLocationsRestStub>
 CreateDefaultInterconnectLocationsRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/interconnect_remote_locations/v1/internal/interconnect_remote_locations_rest_stub_factory.cc
+++ b/google/cloud/compute/interconnect_remote_locations/v1/internal/interconnect_remote_locations_rest_stub_factory.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -41,7 +42,8 @@ std::shared_ptr<InterconnectRemoteLocationsRestStub>
 CreateDefaultInterconnectRemoteLocationsRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/interconnects/v1/internal/interconnects_rest_stub_factory.cc
+++ b/google/cloud/compute/interconnects/v1/internal/interconnects_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<InterconnectsRestStub> CreateDefaultInterconnectsRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/license_codes/v1/internal/license_codes_rest_stub_factory.cc
+++ b/google/cloud/compute/license_codes/v1/internal/license_codes_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<LicenseCodesRestStub> CreateDefaultLicenseCodesRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/licenses/v1/internal/licenses_rest_stub_factory.cc
+++ b/google/cloud/compute/licenses/v1/internal/licenses_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<LicensesRestStub> CreateDefaultLicensesRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/machine_images/v1/internal/machine_images_rest_stub_factory.cc
+++ b/google/cloud/compute/machine_images/v1/internal/machine_images_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<MachineImagesRestStub> CreateDefaultMachineImagesRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/machine_types/v1/internal/machine_types_rest_stub_factory.cc
+++ b/google/cloud/compute/machine_types/v1/internal/machine_types_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<MachineTypesRestStub> CreateDefaultMachineTypesRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/network_attachments/v1/internal/network_attachments_rest_stub_factory.cc
+++ b/google/cloud/compute/network_attachments/v1/internal/network_attachments_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<NetworkAttachmentsRestStub>
 CreateDefaultNetworkAttachmentsRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/network_edge_security_services/v1/internal/network_edge_security_services_rest_stub_factory.cc
+++ b/google/cloud/compute/network_edge_security_services/v1/internal/network_edge_security_services_rest_stub_factory.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -41,7 +42,8 @@ std::shared_ptr<NetworkEdgeSecurityServicesRestStub>
 CreateDefaultNetworkEdgeSecurityServicesRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/network_endpoint_groups/v1/internal/network_endpoint_groups_rest_stub_factory.cc
+++ b/google/cloud/compute/network_endpoint_groups/v1/internal/network_endpoint_groups_rest_stub_factory.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -41,7 +42,8 @@ std::shared_ptr<NetworkEndpointGroupsRestStub>
 CreateDefaultNetworkEndpointGroupsRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/network_firewall_policies/v1/internal/network_firewall_policies_rest_stub_factory.cc
+++ b/google/cloud/compute/network_firewall_policies/v1/internal/network_firewall_policies_rest_stub_factory.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -41,7 +42,8 @@ std::shared_ptr<NetworkFirewallPoliciesRestStub>
 CreateDefaultNetworkFirewallPoliciesRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/networks/v1/internal/networks_rest_stub_factory.cc
+++ b/google/cloud/compute/networks/v1/internal/networks_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<NetworksRestStub> CreateDefaultNetworksRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/node_groups/v1/internal/node_groups_rest_stub_factory.cc
+++ b/google/cloud/compute/node_groups/v1/internal/node_groups_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<NodeGroupsRestStub> CreateDefaultNodeGroupsRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/node_templates/v1/internal/node_templates_rest_stub_factory.cc
+++ b/google/cloud/compute/node_templates/v1/internal/node_templates_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<NodeTemplatesRestStub> CreateDefaultNodeTemplatesRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/node_types/v1/internal/node_types_rest_stub_factory.cc
+++ b/google/cloud/compute/node_types/v1/internal/node_types_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<NodeTypesRestStub> CreateDefaultNodeTypesRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/packet_mirrorings/v1/internal/packet_mirrorings_rest_stub_factory.cc
+++ b/google/cloud/compute/packet_mirrorings/v1/internal/packet_mirrorings_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<PacketMirroringsRestStub> CreateDefaultPacketMirroringsRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/projects/v1/internal/projects_rest_stub_factory.cc
+++ b/google/cloud/compute/projects/v1/internal/projects_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<ProjectsRestStub> CreateDefaultProjectsRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/public_advertised_prefixes/v1/internal/public_advertised_prefixes_rest_stub_factory.cc
+++ b/google/cloud/compute/public_advertised_prefixes/v1/internal/public_advertised_prefixes_rest_stub_factory.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -41,7 +42,8 @@ std::shared_ptr<PublicAdvertisedPrefixesRestStub>
 CreateDefaultPublicAdvertisedPrefixesRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/public_delegated_prefixes/v1/internal/public_delegated_prefixes_rest_stub_factory.cc
+++ b/google/cloud/compute/public_delegated_prefixes/v1/internal/public_delegated_prefixes_rest_stub_factory.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -41,7 +42,8 @@ std::shared_ptr<PublicDelegatedPrefixesRestStub>
 CreateDefaultPublicDelegatedPrefixesRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/region_autoscalers/v1/internal/region_autoscalers_rest_stub_factory.cc
+++ b/google/cloud/compute/region_autoscalers/v1/internal/region_autoscalers_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<RegionAutoscalersRestStub>
 CreateDefaultRegionAutoscalersRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/region_backend_services/v1/internal/region_backend_services_rest_stub_factory.cc
+++ b/google/cloud/compute/region_backend_services/v1/internal/region_backend_services_rest_stub_factory.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -41,7 +42,8 @@ std::shared_ptr<RegionBackendServicesRestStub>
 CreateDefaultRegionBackendServicesRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/region_commitments/v1/internal/region_commitments_rest_stub_factory.cc
+++ b/google/cloud/compute/region_commitments/v1/internal/region_commitments_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<RegionCommitmentsRestStub>
 CreateDefaultRegionCommitmentsRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/region_disk_types/v1/internal/region_disk_types_rest_stub_factory.cc
+++ b/google/cloud/compute/region_disk_types/v1/internal/region_disk_types_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<RegionDiskTypesRestStub> CreateDefaultRegionDiskTypesRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/region_disks/v1/internal/region_disks_rest_stub_factory.cc
+++ b/google/cloud/compute/region_disks/v1/internal/region_disks_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<RegionDisksRestStub> CreateDefaultRegionDisksRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/region_health_check_services/v1/internal/region_health_check_services_rest_stub_factory.cc
+++ b/google/cloud/compute/region_health_check_services/v1/internal/region_health_check_services_rest_stub_factory.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -41,7 +42,8 @@ std::shared_ptr<RegionHealthCheckServicesRestStub>
 CreateDefaultRegionHealthCheckServicesRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/region_health_checks/v1/internal/region_health_checks_rest_stub_factory.cc
+++ b/google/cloud/compute/region_health_checks/v1/internal/region_health_checks_rest_stub_factory.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -41,7 +42,8 @@ std::shared_ptr<RegionHealthChecksRestStub>
 CreateDefaultRegionHealthChecksRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/region_instance_group_managers/v1/internal/region_instance_group_managers_rest_stub_factory.cc
+++ b/google/cloud/compute/region_instance_group_managers/v1/internal/region_instance_group_managers_rest_stub_factory.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -41,7 +42,8 @@ std::shared_ptr<RegionInstanceGroupManagersRestStub>
 CreateDefaultRegionInstanceGroupManagersRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/region_instance_groups/v1/internal/region_instance_groups_rest_stub_factory.cc
+++ b/google/cloud/compute/region_instance_groups/v1/internal/region_instance_groups_rest_stub_factory.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -41,7 +42,8 @@ std::shared_ptr<RegionInstanceGroupsRestStub>
 CreateDefaultRegionInstanceGroupsRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/region_instance_templates/v1/internal/region_instance_templates_rest_stub_factory.cc
+++ b/google/cloud/compute/region_instance_templates/v1/internal/region_instance_templates_rest_stub_factory.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -41,7 +42,8 @@ std::shared_ptr<RegionInstanceTemplatesRestStub>
 CreateDefaultRegionInstanceTemplatesRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/region_instances/v1/internal/region_instances_rest_stub_factory.cc
+++ b/google/cloud/compute/region_instances/v1/internal/region_instances_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<RegionInstancesRestStub> CreateDefaultRegionInstancesRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/region_network_endpoint_groups/v1/internal/region_network_endpoint_groups_rest_stub_factory.cc
+++ b/google/cloud/compute/region_network_endpoint_groups/v1/internal/region_network_endpoint_groups_rest_stub_factory.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -41,7 +42,8 @@ std::shared_ptr<RegionNetworkEndpointGroupsRestStub>
 CreateDefaultRegionNetworkEndpointGroupsRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/region_network_firewall_policies/v1/internal/region_network_firewall_policies_rest_stub_factory.cc
+++ b/google/cloud/compute/region_network_firewall_policies/v1/internal/region_network_firewall_policies_rest_stub_factory.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -41,7 +42,8 @@ std::shared_ptr<RegionNetworkFirewallPoliciesRestStub>
 CreateDefaultRegionNetworkFirewallPoliciesRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/region_notification_endpoints/v1/internal/region_notification_endpoints_rest_stub_factory.cc
+++ b/google/cloud/compute/region_notification_endpoints/v1/internal/region_notification_endpoints_rest_stub_factory.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -41,7 +42,8 @@ std::shared_ptr<RegionNotificationEndpointsRestStub>
 CreateDefaultRegionNotificationEndpointsRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/region_operations/v1/internal/region_operations_rest_stub_factory.cc
+++ b/google/cloud/compute/region_operations/v1/internal/region_operations_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<RegionOperationsRestStub> CreateDefaultRegionOperationsRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/region_security_policies/v1/internal/region_security_policies_rest_stub_factory.cc
+++ b/google/cloud/compute/region_security_policies/v1/internal/region_security_policies_rest_stub_factory.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -41,7 +42,8 @@ std::shared_ptr<RegionSecurityPoliciesRestStub>
 CreateDefaultRegionSecurityPoliciesRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/region_ssl_certificates/v1/internal/region_ssl_certificates_rest_stub_factory.cc
+++ b/google/cloud/compute/region_ssl_certificates/v1/internal/region_ssl_certificates_rest_stub_factory.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -41,7 +42,8 @@ std::shared_ptr<RegionSslCertificatesRestStub>
 CreateDefaultRegionSslCertificatesRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/region_ssl_policies/v1/internal/region_ssl_policies_rest_stub_factory.cc
+++ b/google/cloud/compute/region_ssl_policies/v1/internal/region_ssl_policies_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<RegionSslPoliciesRestStub>
 CreateDefaultRegionSslPoliciesRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/region_target_http_proxies/v1/internal/region_target_http_proxies_rest_stub_factory.cc
+++ b/google/cloud/compute/region_target_http_proxies/v1/internal/region_target_http_proxies_rest_stub_factory.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -41,7 +42,8 @@ std::shared_ptr<RegionTargetHttpProxiesRestStub>
 CreateDefaultRegionTargetHttpProxiesRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/region_target_https_proxies/v1/internal/region_target_https_proxies_rest_stub_factory.cc
+++ b/google/cloud/compute/region_target_https_proxies/v1/internal/region_target_https_proxies_rest_stub_factory.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -41,7 +42,8 @@ std::shared_ptr<RegionTargetHttpsProxiesRestStub>
 CreateDefaultRegionTargetHttpsProxiesRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/region_target_tcp_proxies/v1/internal/region_target_tcp_proxies_rest_stub_factory.cc
+++ b/google/cloud/compute/region_target_tcp_proxies/v1/internal/region_target_tcp_proxies_rest_stub_factory.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -41,7 +42,8 @@ std::shared_ptr<RegionTargetTcpProxiesRestStub>
 CreateDefaultRegionTargetTcpProxiesRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/region_url_maps/v1/internal/region_url_maps_rest_stub_factory.cc
+++ b/google/cloud/compute/region_url_maps/v1/internal/region_url_maps_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<RegionUrlMapsRestStub> CreateDefaultRegionUrlMapsRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/regions/v1/internal/regions_rest_stub_factory.cc
+++ b/google/cloud/compute/regions/v1/internal/regions_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<RegionsRestStub> CreateDefaultRegionsRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/reservations/v1/internal/reservations_rest_stub_factory.cc
+++ b/google/cloud/compute/reservations/v1/internal/reservations_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<ReservationsRestStub> CreateDefaultReservationsRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/resource_policies/v1/internal/resource_policies_rest_stub_factory.cc
+++ b/google/cloud/compute/resource_policies/v1/internal/resource_policies_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<ResourcePoliciesRestStub> CreateDefaultResourcePoliciesRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/routers/v1/internal/routers_rest_stub_factory.cc
+++ b/google/cloud/compute/routers/v1/internal/routers_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<RoutersRestStub> CreateDefaultRoutersRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/routes/v1/internal/routes_rest_stub_factory.cc
+++ b/google/cloud/compute/routes/v1/internal/routes_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<RoutesRestStub> CreateDefaultRoutesRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/security_policies/v1/internal/security_policies_rest_stub_factory.cc
+++ b/google/cloud/compute/security_policies/v1/internal/security_policies_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<SecurityPoliciesRestStub> CreateDefaultSecurityPoliciesRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/service_attachments/v1/internal/service_attachments_rest_stub_factory.cc
+++ b/google/cloud/compute/service_attachments/v1/internal/service_attachments_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<ServiceAttachmentsRestStub>
 CreateDefaultServiceAttachmentsRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/snapshots/v1/internal/snapshots_rest_stub_factory.cc
+++ b/google/cloud/compute/snapshots/v1/internal/snapshots_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<SnapshotsRestStub> CreateDefaultSnapshotsRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/ssl_certificates/v1/internal/ssl_certificates_rest_stub_factory.cc
+++ b/google/cloud/compute/ssl_certificates/v1/internal/ssl_certificates_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<SslCertificatesRestStub> CreateDefaultSslCertificatesRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/ssl_policies/v1/internal/ssl_policies_rest_stub_factory.cc
+++ b/google/cloud/compute/ssl_policies/v1/internal/ssl_policies_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<SslPoliciesRestStub> CreateDefaultSslPoliciesRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/subnetworks/v1/internal/subnetworks_rest_stub_factory.cc
+++ b/google/cloud/compute/subnetworks/v1/internal/subnetworks_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<SubnetworksRestStub> CreateDefaultSubnetworksRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/target_grpc_proxies/v1/internal/target_grpc_proxies_rest_stub_factory.cc
+++ b/google/cloud/compute/target_grpc_proxies/v1/internal/target_grpc_proxies_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<TargetGrpcProxiesRestStub>
 CreateDefaultTargetGrpcProxiesRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/target_http_proxies/v1/internal/target_http_proxies_rest_stub_factory.cc
+++ b/google/cloud/compute/target_http_proxies/v1/internal/target_http_proxies_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<TargetHttpProxiesRestStub>
 CreateDefaultTargetHttpProxiesRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/target_https_proxies/v1/internal/target_https_proxies_rest_stub_factory.cc
+++ b/google/cloud/compute/target_https_proxies/v1/internal/target_https_proxies_rest_stub_factory.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -41,7 +42,8 @@ std::shared_ptr<TargetHttpsProxiesRestStub>
 CreateDefaultTargetHttpsProxiesRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/target_instances/v1/internal/target_instances_rest_stub_factory.cc
+++ b/google/cloud/compute/target_instances/v1/internal/target_instances_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<TargetInstancesRestStub> CreateDefaultTargetInstancesRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/target_pools/v1/internal/target_pools_rest_stub_factory.cc
+++ b/google/cloud/compute/target_pools/v1/internal/target_pools_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<TargetPoolsRestStub> CreateDefaultTargetPoolsRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/target_ssl_proxies/v1/internal/target_ssl_proxies_rest_stub_factory.cc
+++ b/google/cloud/compute/target_ssl_proxies/v1/internal/target_ssl_proxies_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<TargetSslProxiesRestStub> CreateDefaultTargetSslProxiesRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/target_tcp_proxies/v1/internal/target_tcp_proxies_rest_stub_factory.cc
+++ b/google/cloud/compute/target_tcp_proxies/v1/internal/target_tcp_proxies_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<TargetTcpProxiesRestStub> CreateDefaultTargetTcpProxiesRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/target_vpn_gateways/v1/internal/target_vpn_gateways_rest_stub_factory.cc
+++ b/google/cloud/compute/target_vpn_gateways/v1/internal/target_vpn_gateways_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<TargetVpnGatewaysRestStub>
 CreateDefaultTargetVpnGatewaysRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/url_maps/v1/internal/url_maps_rest_stub_factory.cc
+++ b/google/cloud/compute/url_maps/v1/internal/url_maps_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<UrlMapsRestStub> CreateDefaultUrlMapsRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/vpn_gateways/v1/internal/vpn_gateways_rest_stub_factory.cc
+++ b/google/cloud/compute/vpn_gateways/v1/internal/vpn_gateways_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<VpnGatewaysRestStub> CreateDefaultVpnGatewaysRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/vpn_tunnels/v1/internal/vpn_tunnels_rest_stub_factory.cc
+++ b/google/cloud/compute/vpn_tunnels/v1/internal/vpn_tunnels_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<VpnTunnelsRestStub> CreateDefaultVpnTunnelsRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/zone_operations/v1/internal/zone_operations_rest_stub_factory.cc
+++ b/google/cloud/compute/zone_operations/v1/internal/zone_operations_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<ZoneOperationsRestStub> CreateDefaultZoneOperationsRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/compute/zones/v1/internal/zones_rest_stub_factory.cc
+++ b/google/cloud/compute/zones/v1/internal/zones_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<ZonesRestStub> CreateDefaultZonesRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/internal/populate_common_options.cc
+++ b/google/cloud/internal/populate_common_options.cc
@@ -79,6 +79,15 @@ std::set<std::string> DefaultTracingComponents() {
   return absl::StrSplit(*tracing, ',');
 }
 
+Options MakeAuthOptions(Options const& options) {
+  Options opts;
+  if (options.has<experimental::OpenTelemetryTracingOption>()) {
+    opts.set<experimental::OpenTelemetryTracingOption>(
+        options.get<experimental::OpenTelemetryTracingOption>());
+  }
+  return opts;
+}
+
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud

--- a/google/cloud/internal/populate_common_options.h
+++ b/google/cloud/internal/populate_common_options.h
@@ -61,6 +61,16 @@ Options PopulateCommonOptions(Options opts, std::string const& endpoint_env_var,
 /// Compute the default value for the tracing components.
 std::set<std::string> DefaultTracingComponents();
 
+/**
+ * Given client options, returns a minimal set of matching options to be used by
+ * the authentication components.
+ *
+ * For example, if tracing is enabled in a client via the
+ * `OpenTelemetryTracingOption`, we also want to enable tracing in the auth
+ * components.
+ */
+Options MakeAuthOptions(Options const& options);
+
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud

--- a/google/cloud/internal/populate_common_options_test.cc
+++ b/google/cloud/internal/populate_common_options_test.cc
@@ -154,6 +154,22 @@ TEST(DefaultTracingComponents, WithValue) {
   EXPECT_THAT(actual, ElementsAre("a", "b", "c"));
 }
 
+TEST(MakeAuthOptions, WithoutTracing) {
+  auto options = Options{}.set<EndpointOption>("endpoint_option");
+  auto auth_options = MakeAuthOptions(options);
+  EXPECT_FALSE(auth_options.has<EndpointOption>());
+  EXPECT_FALSE(auth_options.get<experimental::OpenTelemetryTracingOption>());
+}
+
+TEST(MakeAuthOptions, WithTracing) {
+  auto options = Options{}
+                     .set<EndpointOption>("endpoint_option")
+                     .set<experimental::OpenTelemetryTracingOption>(true);
+  auto auth_options = MakeAuthOptions(options);
+  EXPECT_FALSE(auth_options.has<EndpointOption>());
+  EXPECT_TRUE(auth_options.get<experimental::OpenTelemetryTracingOption>());
+}
+
 }  // namespace
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/spanner/admin/internal/database_admin_rest_stub_factory.cc
+++ b/google/cloud/spanner/admin/internal/database_admin_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<DatabaseAdminRestStub> CreateDefaultDatabaseAdminRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/spanner/admin/internal/instance_admin_rest_stub_factory.cc
+++ b/google/cloud/spanner/admin/internal/instance_admin_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<InstanceAdminRestStub> CreateDefaultInstanceAdminRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/sql/v1/internal/sql_backup_runs_rest_stub_factory.cc
+++ b/google/cloud/sql/v1/internal/sql_backup_runs_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<SqlBackupRunsServiceRestStub>
 CreateDefaultSqlBackupRunsServiceRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/sql/v1/internal/sql_connect_rest_stub_factory.cc
+++ b/google/cloud/sql/v1/internal/sql_connect_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<SqlConnectServiceRestStub>
 CreateDefaultSqlConnectServiceRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/sql/v1/internal/sql_databases_rest_stub_factory.cc
+++ b/google/cloud/sql/v1/internal/sql_databases_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<SqlDatabasesServiceRestStub>
 CreateDefaultSqlDatabasesServiceRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/sql/v1/internal/sql_flags_rest_stub_factory.cc
+++ b/google/cloud/sql/v1/internal/sql_flags_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<SqlFlagsServiceRestStub> CreateDefaultSqlFlagsServiceRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/sql/v1/internal/sql_instances_rest_stub_factory.cc
+++ b/google/cloud/sql/v1/internal/sql_instances_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<SqlInstancesServiceRestStub>
 CreateDefaultSqlInstancesServiceRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/sql/v1/internal/sql_operations_rest_stub_factory.cc
+++ b/google/cloud/sql/v1/internal/sql_operations_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<SqlOperationsServiceRestStub>
 CreateDefaultSqlOperationsServiceRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/sql/v1/internal/sql_ssl_certs_rest_stub_factory.cc
+++ b/google/cloud/sql/v1/internal/sql_ssl_certs_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<SqlSslCertsServiceRestStub>
 CreateDefaultSqlSslCertsServiceRestStub(Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/sql/v1/internal/sql_tiers_rest_stub_factory.cc
+++ b/google/cloud/sql/v1/internal/sql_tiers_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<SqlTiersServiceRestStub> CreateDefaultSqlTiersServiceRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/sql/v1/internal/sql_users_rest_stub_factory.cc
+++ b/google/cloud/sql/v1/internal/sql_users_rest_stub_factory.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
@@ -40,7 +41,8 @@ std::shared_ptr<SqlUsersServiceRestStub> CreateDefaultSqlUsersServiceRestStub(
     Options const& options) {
   Options opts = options;
   if (!opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials(options));
+    opts.set<UnifiedCredentialsOption>(
+        MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
   if (!opts.has<rest_internal::LongrunningEndpointOption>()) {
     opts.set<rest_internal::LongrunningEndpointOption>(

--- a/google/cloud/storage/client_options.cc
+++ b/google/cloud/storage/client_options.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include "google/cloud/internal/curl_options.h"
 #include "google/cloud/internal/getenv.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/internal/rest_response.h"
 #include "google/cloud/log.h"
@@ -290,8 +291,9 @@ Options DefaultOptionsWithCredentials(Options opts) {
         internal::MapCredentials(*google::cloud::MakeInsecureCredentials()),
         std::move(opts));
   }
-  auto credentials = internal::MapCredentials(
-      *google::cloud::MakeGoogleDefaultCredentials(opts));
+  auto credentials =
+      internal::MapCredentials(*google::cloud::MakeGoogleDefaultCredentials(
+          google::cloud::internal::MakeAuthOptions(opts)));
   return internal::DefaultOptions(std::move(credentials), std::move(opts));
 }
 

--- a/google/cloud/storage/internal/grpc/stub.cc
+++ b/google/cloud/storage/internal/grpc/stub.cc
@@ -37,6 +37,7 @@
 #include "google/cloud/internal/big_endian.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/invoke_result.h"
+#include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/log.h"
 #include "absl/strings/match.h"
 #include <grpcpp/grpcpp.h>
@@ -216,7 +217,8 @@ Options DefaultOptionsGrpc(Options options) {
   if (!options.has<UnifiedCredentialsOption>() &&
       !options.has<GrpcCredentialOption>()) {
     options.set<UnifiedCredentialsOption>(
-        google::cloud::MakeGoogleDefaultCredentials(options));
+        google::cloud::MakeGoogleDefaultCredentials(
+            google::cloud::internal::MakeAuthOptions(options)));
   }
   auto const testbench =
       GetEnv("CLOUD_STORAGE_EXPERIMENTAL_GRPC_TESTBENCH_ENDPOINT");


### PR DESCRIPTION
Modifies #12671 and #12672 to only forward the OTel tracing option in cases where the library is responsible for creating the default credentials.

Passing extra options was breaking at least authorized user credential authentication, and possibly more.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12690)
<!-- Reviewable:end -->
