### PR TITLE
fix: gRPC auth logging enabled by "auth"

### DIFF
--- a/google/cloud/internal/minimal_iam_credentials_stub.cc
+++ b/google/cloud/internal/minimal_iam_credentials_stub.cc
@@ -203,7 +203,8 @@ class AsyncAccessTokenGeneratorTracing : public MinimalIamCredentialsStub {
 std::shared_ptr<MinimalIamCredentialsStub> DecorateMinimalIamCredentialsStub(
     std::shared_ptr<MinimalIamCredentialsStub> impl, Options const& options) {
   impl = std::make_shared<AsyncAccessTokenGeneratorMetadata>(std::move(impl));
-  if (Contains(options.get<TracingComponentsOption>(), "rpc")) {
+  auto const& components = options.get<TracingComponentsOption>();
+  if (Contains(components, "auth") || Contains(components, "rpc")) {
     impl = std::make_shared<AsyncAccessTokenGeneratorLogging>(
         std::move(impl), options.get<GrpcTracingOptionsOption>());
   }


### PR DESCRIPTION
Look for "auth" or "rpc" to enable logging in the minimal IAM credentials stub.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12702)
<!-- Reviewable:end -->
