### PR TITLE
ci: move clang-tidy build to Fedora:38

### DIFF
--- a/ci/cloudbuild/dockerfiles/fedora-latest-cmake.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-latest-cmake.Dockerfile
@@ -1,0 +1,237 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM fedora:38
+ARG NCPU=4
+ARG ARCH=amd64
+
+# Fedora includes packages for gRPC, libcurl, and OpenSSL that are recent enough
+# for `google-cloud-cpp`. Install these packages and additional development
+# tools to compile the dependencies:
+RUN dnf makecache && \
+    dnf install -y abi-compliance-checker autoconf automake \
+        clang clang-analyzer clang-tools-extra \
+        cmake diffutils doxygen findutils gcc-c++ git \
+        libcurl-devel llvm make ninja-build \
+        openssl-devel patch python python3 \
+        python-pip tar unzip w3m wget which zip zlib-devel
+
+# Install the Python modules needed to run the storage emulator
+RUN dnf makecache && dnf install -y python3-devel
+RUN pip3 install --upgrade pip
+RUN pip3 install setuptools wheel
+
+# The Cloud Pub/Sub emulator needs Java :shrug:
+RUN dnf makecache && dnf install -y java-latest-openjdk
+
+# This is used to improve the output in check-api builds
+RUN dnf makecache && dnf install -y "dnf-command(debuginfo-install)"
+RUN dnf makecache && dnf debuginfo-install -y libstdc++
+
+# This is used by the docfx tool.
+RUN dnf makecache && dnf install -y pugixml-devel
+
+# This is used in the `publish-docs` build
+RUN dnf makecache && dnf install -y libxslt
+
+# Sets root's password to the empty string to enable users to get a root shell
+# inside the container with `su -` and no password. Sudo would not work because
+# we run these containers as the invoking user's uid, which does not exist in
+# the container's /etc/passwd file.
+RUN echo 'root:' | chpasswd
+
+# Fedora's version of `pkg-config` (https://github.com/pkgconf/pkgconf) is slow
+# when handling `.pc` files with lots of `Requires:` deps.  This problem is
+# triggered by the Abseil `.pc` files, which we use (indirectly) when testing
+# our own `.pc` files.  We install the more traditional `pkg-config` binary.
+# For more details see
+#     https://github.com/googleapis/google-cloud-cpp/issues/7052
+WORKDIR /var/tmp/build/pkg-config-cpp
+RUN curl -fsSL https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    ./configure --with-internal-glib && \
+    make -j ${NCPU:-4} && \
+    make install && \
+    ldconfig
+ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/lib64/pkgconfig
+
+# Installs the yaml-cpp-devel from source. The version included with Fedora:37
+# leaves trailing whitespace in the output:
+#     https://github.com/jbeder/yaml-cpp/pull/1005
+WORKDIR /var/tmp/build
+RUN curl -fsSL https://github.com/jbeder/yaml-cpp/archive/refs/tags/yaml-cpp-0.7.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=ON \
+      -DBUILD_TESTING=OFF \
+      -GNinja -S . -B cmake-out && \
+    cmake --build cmake-out --target install && \
+    ldconfig && cd /var/tmp && rm -fr build
+
+# We expose `absl::optional<>` in our public API. An Abseil LTS update will
+# break our `check-api` build, unless we disable the inline namespace.
+WORKDIR /var/tmp/build
+RUN curl -fsSL https://github.com/abseil/abseil-cpp/archive/20230802.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
+    sed -i 's/^#define ABSL_OPTION_USE_INLINE_NAMESPACE 1$/#define ABSL_OPTION_USE_INLINE_NAMESPACE 0/' "absl/base/options.h" && \
+    cmake \
+      -DCMAKE_BUILD_TYPE="Release" \
+      -DABSL_BUILD_TESTING=OFF \
+      -DBUILD_SHARED_LIBS=yes \
+      -GNinja -S . -B cmake-out && \
+    cmake --build cmake-out --target install && \
+    ldconfig && cd /var/tmp && rm -fr build
+
+WORKDIR /var/tmp/build
+RUN curl -fsSL https://github.com/google/googletest/archive/v1.14.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+      -DCMAKE_BUILD_TYPE="Release" \
+      -DBUILD_SHARED_LIBS=yes \
+      -GNinja -S . -B cmake-out && \
+    cmake --build cmake-out --target install && \
+    ldconfig && cd /var/tmp && rm -fr build
+
+WORKDIR /var/tmp/build
+RUN curl -fsSL https://github.com/google/benchmark/archive/v1.8.3.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+      -DCMAKE_BUILD_TYPE="Release" \
+      -DBUILD_SHARED_LIBS=yes \
+      -DBENCHMARK_ENABLE_TESTING=OFF \
+      -GNinja -S . -B cmake-out && \
+    cmake --build cmake-out --target install && \
+    ldconfig && cd /var/tmp && rm -fr build
+
+WORKDIR /var/tmp/build
+RUN curl -fsSL https://github.com/google/crc32c/archive/1.1.2.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=yes \
+      -DCRC32C_BUILD_TESTS=OFF \
+      -DCRC32C_BUILD_BENCHMARKS=OFF \
+      -DCRC32C_USE_GLOG=OFF \
+      -GNinja -S . -B cmake-out && \
+    cmake --build cmake-out --target install && \
+    ldconfig && cd /var/tmp && rm -fr build
+
+WORKDIR /var/tmp/build
+RUN curl -fsSL https://github.com/nlohmann/json/archive/v3.11.2.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=yes \
+      -DBUILD_TESTING=OFF \
+      -DJSON_BuildTests=OFF \
+      -GNinja -S . -B cmake-out && \
+    cmake --build cmake-out --target install && \
+    ldconfig && cd /var/tmp && rm -fr build
+
+WORKDIR /var/tmp/build/protobuf
+RUN curl -fsSL https://github.com/protocolbuffers/protobuf/archive/v24.3.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -Dprotobuf_BUILD_TESTS=OFF \
+        -Dprotobuf_ABSL_PROVIDER=package \
+      -GNinja -S . -B cmake-out && \
+    cmake --build cmake-out --target install && \
+    ldconfig && cd /var/tmp && rm -fr build
+
+WORKDIR /var/tmp/build/grpc
+RUN dnf makecache && dnf install -y c-ares-devel re2-devel
+RUN curl -fsSL https://github.com/grpc/grpc/archive/v1.58.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=ON \
+      -DgRPC_INSTALL=ON \
+      -DgRPC_BUILD_TESTS=OFF \
+      -DgRPC_ABSL_PROVIDER=package \
+      -DgRPC_CARES_PROVIDER=package \
+      -DgRPC_PROTOBUF_PROVIDER=package \
+      -DgRPC_PROTOBUF_PACKAGE_TYPE=CONFIG \
+      -DgRPC_RE2_PROVIDER=package \
+      -DgRPC_SSL_PROVIDER=package \
+      -DgRPC_ZLIB_PROVIDER=package \
+      -GNinja -S . -B cmake-out && \
+    cmake --build cmake-out --target install && \
+    ldconfig && cd /var/tmp && rm -fr build
+
+WORKDIR /var/tmp/build/
+RUN curl -fsSL https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.11.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+        -DCMAKE_CXX_STANDARD=14 \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE \
+        -DBUILD_SHARED_LIBS=ON \
+        -DWITH_EXAMPLES=OFF \
+        -DWITH_ABSEIL=ON \
+        -DBUILD_TESTING=OFF \
+        -DOPENTELEMETRY_INSTALL=ON \
+        -S . -B cmake-out -GNinja && \
+    cmake --build cmake-out --target install && \
+    ldconfig && cd /var/tmp && rm -fr build
+
+# Install ctcache to speed up our clang-tidy build
+WORKDIR /var/tmp/build
+RUN curl -fsSL https://github.com/matus-chochlik/ctcache/archive/0ad2e227e8a981a9c1a6060ee6c8ec144bb976c6.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cp clang-tidy /usr/local/bin/clang-tidy-wrapper && \
+    cp clang-tidy-cache /usr/local/bin/clang-tidy-cache && \
+    cd /var/tmp && rm -fr build
+
+# Installs Universal Ctags (which is different than the default "Exuberant
+# Ctags"), which is needed by the ABI checker. See https://ctags.io/
+WORKDIR /var/tmp/build
+RUN curl -fsSL https://github.com/universal-ctags/ctags/archive/refs/tags/p5.9.20210418.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    ./autogen.sh && \
+    ./configure --prefix=/usr/local && \
+    make && \
+    make install && \
+    cd /var/tmp && rm -fr build
+
+# Installs the abi-dumper with the integer overflow fix from
+# https://github.com/lvc/abi-dumper/pull/29. We can switch back to `dnf install
+# abi-dumper` once it has the fix.
+WORKDIR /var/tmp/build
+RUN curl -fsSL https://github.com/lvc/abi-dumper/archive/16bb467cd7d343dd3a16782b151b56cf15509594.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    mv abi-dumper.pl /usr/local/bin/abi-dumper && \
+    chmod +x /usr/local/bin/abi-dumper
+
+# Install the Cloud SDK and some of the emulators. We use the emulators to run
+# integration tests for the client libraries.
+COPY . /var/tmp/ci
+WORKDIR /var/tmp/downloads
+ENV CLOUDSDK_PYTHON=python3
+RUN /var/tmp/ci/install-cloud-sdk.sh
+ENV CLOUD_SDK_LOCATION=/usr/local/google-cloud-sdk
+ENV PATH=${CLOUD_SDK_LOCATION}/bin:${PATH}
+
+WORKDIR /var/tmp/sccache
+RUN curl -fsSL https://github.com/mozilla/sccache/releases/download/v0.5.4/sccache-v0.5.4-x86_64-unknown-linux-musl.tar.gz | \
+    tar -zxf - --strip-components=1 && \
+    mkdir -p /usr/local/bin && \
+    mv sccache /usr/local/bin/sccache && \
+    chmod +x /usr/local/bin/sccache
+
+# Update the ld.conf cache in case any libraries were installed in /usr/local/lib*
+RUN ldconfig /usr/local/lib*

--- a/ci/cloudbuild/triggers/clang-tidy-ci.yaml
+++ b/ci/cloudbuild/triggers/clang-tidy-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: clang-tidy-ci
 substitutions:
   _BUILD_NAME: clang-tidy
-  _DISTRO: fedora-37-cmake
+  _DISTRO: fedora-latest-cmake
   _TRIGGER_TYPE: ci
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
 tags:

--- a/ci/cloudbuild/triggers/clang-tidy-pr.yaml
+++ b/ci/cloudbuild/triggers/clang-tidy-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: clang-tidy-pr
 substitutions:
   _BUILD_NAME: clang-tidy
-  _DISTRO: fedora-37-cmake
+  _DISTRO: fedora-latest-cmake
   _TRIGGER_TYPE: pr
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
 tags:

--- a/google/cloud/compute/integration_tests/compute_integration_test.cc
+++ b/google/cloud/compute/integration_tests/compute_integration_test.cc
@@ -34,7 +34,6 @@ using ::google::cloud::testing_util::StatusIs;
 using ::testing::Contains;
 using ::testing::Eq;
 using ::testing::HasSubstr;
-using ::testing::IsEmpty;
 using ::testing::Property;
 
 class ComputeIntegrationTest

--- a/google/cloud/spanner/internal/defaults_test.cc
+++ b/google/cloud/spanner/internal/defaults_test.cc
@@ -285,8 +285,8 @@ TEST(Options, OverrideTracingOptions) {
 
 TEST(Options, AppendToUserAgent) {
   Options opts;
-  opts.lookup<UserAgentProductsOption>().push_back("product-a/1.2.3");
-  opts.lookup<UserAgentProductsOption>().push_back("product-b/4.5.6");
+  opts.lookup<UserAgentProductsOption>().emplace_back("product-a/1.2.3");
+  opts.lookup<UserAgentProductsOption>().emplace_back("product-b/4.5.6");
 
   opts = spanner_internal::DefaultOptions(std::move(opts));
   // The gcloud user-agent string should be first.

--- a/google/cloud/storage/internal/grpc/synthetic_self_link.h
+++ b/google/cloud/storage/internal/grpc/synthetic_self_link.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/storage/version.h"
 #include "google/cloud/options.h"
+#include <cstdint>
 #include <string>
 
 namespace google {


### PR DESCRIPTION
The `google/cloud/storage/*` code changes are really related to libstdc++ 13.  And the `google/clouod/compute/*` code changes are (I think) just because I manually ran the build for compute.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12705)
<!-- Reviewable:end -->
