### PR TITLE
fix(otel): bazel works with OTel curl client

### DIFF
--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -276,4 +276,5 @@ def google_cloud_cpp_deps(name = None):
         ],
         sha256 = "f30cd88bf898a5726d245eba882b8e81012021eb00df34109f4dfb203f005cea",
         strip_prefix = "opentelemetry-cpp-1.11.0",
+        repo_mapping = {"@curl": "@com_github_curl_curl"},
     )

--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -276,5 +276,9 @@ def google_cloud_cpp_deps(name = None):
         ],
         sha256 = "f30cd88bf898a5726d245eba882b8e81012021eb00df34109f4dfb203f005cea",
         strip_prefix = "opentelemetry-cpp-1.11.0",
-        repo_mapping = {"@curl": "@com_github_curl_curl"},
+        repo_mapping = {
+            "@curl": "@com_github_curl_curl",
+            "@com_github_google_benchmark": "@com_github_benchmark",
+            "@github_nlohmann_json": "@com_github_nlohmann_json",
+        },
     )


### PR DESCRIPTION
We have different names for this repo. With this PR we are saying: "When `opentelemetry-cpp` refers to `@curl`, they really mean our `@com_github_curl_curl`."

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12706)
<!-- Reviewable:end -->
