### PR TITLE
ci: compile `storage-grpc` in most builds

### DIFF
--- a/ci/cloudbuild/builds/lib/features.sh
+++ b/ci/cloudbuild/builds/lib/features.sh
@@ -40,7 +40,7 @@ function features::always_build() {
     # Build our code with OpenTelemetry. This feature includes both the client
     # library instrumentation, and the GCP exporters.
     experimental-opentelemetry
-    # Enable storage-grpc in most builds.
+    # Enable storage_grpc in most builds.
     experimental-storage_grpc
   )
   printf "%s\n" "${list[@]}" | sort -u

--- a/ci/cloudbuild/builds/lib/features.sh
+++ b/ci/cloudbuild/builds/lib/features.sh
@@ -40,6 +40,8 @@ function features::always_build() {
     # Build our code with OpenTelemetry. This feature includes both the client
     # library instrumentation, and the GCP exporters.
     experimental-opentelemetry
+    # Enable storage-grpc in most builds.
+    experimental-storage_grpc
   )
   printf "%s\n" "${list[@]}" | sort -u
 }

--- a/google/cloud/storage/examples/storage_async_samples.cc
+++ b/google/cloud/storage/examples/storage_async_samples.cc
@@ -358,7 +358,7 @@ int main(int argc, char* argv[]) try {
         throw examples::Usage{std::move(os).str()};
       }
       auto client = google::cloud::storage_experimental::AsyncClient();
-      command(client, std::move(argv));
+      command(client, argv);
     };
     return {name, std::move(adapter)};
   };

--- a/google/cloud/storage/internal/async/read_payload_impl_test.cc
+++ b/google/cloud/storage/internal/async/read_payload_impl_test.cc
@@ -49,7 +49,7 @@ TEST(ReadPayload, FromString) {
 
 TEST(ReadPayload, FromVector) {
   auto const actual = storage_experimental::ReadPayload(
-      {std::string(kQuick), std::string(kQuick)});
+      std::vector<std::string>({std::string(kQuick), std::string(kQuick)}));
   EXPECT_THAT(actual.contents(), ElementsAre(absl::string_view(kQuick),
                                              absl::string_view(kQuick)));
 }


### PR DESCRIPTION
Time to start testing `storage-grpc` in the `cxx20` and similar builds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12707)
<!-- Reviewable:end -->
