### PR TITLE
fix(GCS+gRPC): race condition in async `Insert()`

### DIFF
--- a/google/cloud/storage/internal/async/insert_object.h
+++ b/google/cloud/storage/internal/async/insert_object.h
@@ -117,7 +117,7 @@ class InsertObject : public std::enable_shared_from_this<InsertObject> {
   void OnStart(bool ok);
   void Write();
   void OnError(Status status);
-  void OnWrite(bool ok);
+  void OnWrite(std::size_t n, bool ok);
   void OnFinish(StatusOr<google::storage::v2::WriteObjectResponse> response);
 
   std::weak_ptr<InsertObject> WeakFromThis() { return shared_from_this(); }

--- a/google/cloud/storage/tests/async_client_integration_test.cc
+++ b/google/cloud/storage/tests/async_client_integration_test.cc
@@ -173,9 +173,9 @@ TEST_F(AsyncClientIntegrationTest, StreamingRead) {
   for (auto const& expected : insert_data) {
     ASSERT_GE(view.size(), expected.size());
     ASSERT_EQ(expected, view.substr(0, expected.size()));
-    view = view.substr(expected.size());
+    view.remove_prefix(expected.size());
   }
-  ASSERT_EQ(view, absl::string_view{});
+  EXPECT_EQ(view, absl::string_view{});
 }
 
 }  // namespace


### PR DESCRIPTION
The code assumed the `OnWrite()` callback (and the follow-on `Write()` call) would be invoked after it had a chance to prepare for the `Write()` call.  Clever in that overlapped some I/O with CPU operations, but wrong in that scheduling does not work like this.

I also changed the test to make the errors easier to interpret.

Fixes #12710

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12715)
<!-- Reviewable:end -->
