### PR TITLE
impl(generator): add non-path fields as query parameters

### DIFF
--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_stub.cc
@@ -46,7 +46,8 @@ DefaultGoldenKitchenSinkRestStub::GenerateAccessToken(
       google::test::admin::database::v1::GenerateAccessTokenRequest const& request) {
   return rest_internal::Post<google::test::admin::database::v1::GenerateAccessTokenResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/", "v1", "/", request.name(), ":generateAccessToken"));
+      absl::StrCat("/", "v1", "/", request.name(), ":generateAccessToken"),
+      rest_internal::TrimEmptyQueryParameters({std::make_pair("not_used_anymore", request.not_used_anymore())}));
 }
 
 StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
@@ -55,7 +56,10 @@ DefaultGoldenKitchenSinkRestStub::GenerateIdToken(
       google::test::admin::database::v1::GenerateIdTokenRequest const& request) {
   return rest_internal::Post<google::test::admin::database::v1::GenerateIdTokenResponse>(
       *service_, rest_context, request,
-      "/v1/token:generate");
+      "/v1/token:generate",
+      rest_internal::TrimEmptyQueryParameters({std::make_pair("name", request.name()),
+        std::make_pair("audience", request.audience()),
+        std::make_pair("include_email", request.include_email() ? "1" : "0")}));
 }
 
 StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
@@ -64,7 +68,8 @@ DefaultGoldenKitchenSinkRestStub::WriteLogEntries(
       google::test::admin::database::v1::WriteLogEntriesRequest const& request) {
   return rest_internal::Post<google::test::admin::database::v1::WriteLogEntriesResponse>(
       *service_, rest_context, request,
-      "/v2/entries:write");
+      "/v2/entries:write",
+      rest_internal::TrimEmptyQueryParameters({std::make_pair("log_name", request.log_name())}));
 }
 
 StatusOr<google::test::admin::database::v1::ListLogsResponse>
@@ -74,8 +79,8 @@ DefaultGoldenKitchenSinkRestStub::ListLogs(
   return rest_internal::Get<google::test::admin::database::v1::ListLogsResponse>(
       *service_, rest_context, request,
       absl::StrCat("/", "v2", "/", request.parent(), "/", "logs"),
-      {std::make_pair("page_size", std::to_string(request.page_size())),
-       std::make_pair("page_token", request.page_token())});
+      rest_internal::TrimEmptyQueryParameters({std::make_pair("page_size", std::to_string(request.page_size())),
+        std::make_pair("page_token", request.page_token())}));
 }
 
 StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
@@ -84,7 +89,7 @@ DefaultGoldenKitchenSinkRestStub::ListServiceAccountKeys(
       google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) {
   return rest_internal::Get<google::test::admin::database::v1::ListServiceAccountKeysResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/", "v1", "/", request.name(), "/", "keys"), {});
+      absl::StrCat("/", "v1", "/", request.name(), "/", "keys"));
 }
 
 Status DefaultGoldenKitchenSinkRestStub::DoNothing(
@@ -100,7 +105,9 @@ Status DefaultGoldenKitchenSinkRestStub::ExplicitRouting1(
       google::test::admin::database::v1::ExplicitRoutingRequest const& request) {
   return rest_internal::Post(
       *service_, rest_context, request,
-      absl::StrCat("/", "v1", "/", request.table_name(), ":explicitRouting1"));
+      absl::StrCat("/", "v1", "/", request.table_name(), ":explicitRouting1"),
+      rest_internal::TrimEmptyQueryParameters({std::make_pair("app_profile_id", request.app_profile_id()),
+        std::make_pair("no_regex_needed", request.no_regex_needed())}));
 }
 
 Status DefaultGoldenKitchenSinkRestStub::ExplicitRouting2(
@@ -108,7 +115,9 @@ Status DefaultGoldenKitchenSinkRestStub::ExplicitRouting2(
       google::test::admin::database::v1::ExplicitRoutingRequest const& request) {
   return rest_internal::Post(
       *service_, rest_context, request,
-      absl::StrCat("/", "v1", "/", request.table_name(), ":explicitRouting2"));
+      absl::StrCat("/", "v1", "/", request.table_name(), ":explicitRouting2"),
+      rest_internal::TrimEmptyQueryParameters({std::make_pair("app_profile_id", request.app_profile_id()),
+        std::make_pair("no_regex_needed", request.no_regex_needed())}));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_stub.cc
@@ -46,8 +46,7 @@ DefaultGoldenKitchenSinkRestStub::GenerateAccessToken(
       google::test::admin::database::v1::GenerateAccessTokenRequest const& request) {
   return rest_internal::Post<google::test::admin::database::v1::GenerateAccessTokenResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/", "v1", "/", request.name(), ":generateAccessToken"),
-      rest_internal::TrimEmptyQueryParameters({std::make_pair("not_used_anymore", request.not_used_anymore())}));
+      absl::StrCat("/", "v1", "/", request.name(), ":generateAccessToken"));
 }
 
 StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_stub.cc
@@ -52,8 +52,8 @@ DefaultGoldenThingAdminRestStub::ListDatabases(
   return rest_internal::Get<google::test::admin::database::v1::ListDatabasesResponse>(
       *service_, rest_context, request,
       absl::StrCat("/", "v1", "/", request.parent(), "/", "databases"),
-      {std::make_pair("page_size", std::to_string(request.page_size())),
-       std::make_pair("page_token", request.page_token())});
+      rest_internal::TrimEmptyQueryParameters({std::make_pair("page_size", std::to_string(request.page_size())),
+        std::make_pair("page_token", request.page_token())}));
 }
 
 future<StatusOr<google::longrunning::Operation>>
@@ -66,7 +66,8 @@ DefaultGoldenThingAdminRestStub::AsyncCreateDatabase(
   std::thread t{[](auto p, auto service, auto request, auto rest_context) {
       p.set_value(rest_internal::Post<google::longrunning::Operation>(
           *service, *rest_context, request,
-          absl::StrCat("/", "v1", "/", request.parent(), "/", "databases")));
+          absl::StrCat("/", "v1", "/", request.parent(), "/", "databases"),
+      rest_internal::TrimEmptyQueryParameters({std::make_pair("create_statement", request.create_statement())})));
   }, std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {
@@ -82,7 +83,7 @@ DefaultGoldenThingAdminRestStub::GetDatabase(
       google::test::admin::database::v1::GetDatabaseRequest const& request) {
   return rest_internal::Get<google::test::admin::database::v1::Database>(
       *service_, rest_context, request,
-      absl::StrCat("/", "v1", "/", request.name()), {});
+      absl::StrCat("/", "v1", "/", request.name()));
 }
 
 future<StatusOr<google::longrunning::Operation>>
@@ -95,7 +96,8 @@ DefaultGoldenThingAdminRestStub::AsyncUpdateDatabaseDdl(
   std::thread t{[](auto p, auto service, auto request, auto rest_context) {
       p.set_value(rest_internal::Patch<google::longrunning::Operation>(
           *service, *rest_context, request,
-          absl::StrCat("/", "v1", "/", request.database(), "/", "ddl")));
+          absl::StrCat("/", "v1", "/", request.database(), "/", "ddl"),
+      rest_internal::TrimEmptyQueryParameters({std::make_pair("operation_id", request.operation_id())})));
   }, std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {
@@ -119,7 +121,7 @@ DefaultGoldenThingAdminRestStub::GetDatabaseDdl(
       google::test::admin::database::v1::GetDatabaseDdlRequest const& request) {
   return rest_internal::Get<google::test::admin::database::v1::GetDatabaseDdlResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/", "v1", "/", request.database(), "/", "ddl"), {});
+      absl::StrCat("/", "v1", "/", request.database(), "/", "ddl"));
 }
 
 StatusOr<google::iam::v1::Policy>
@@ -159,7 +161,8 @@ DefaultGoldenThingAdminRestStub::AsyncCreateBackup(
   std::thread t{[](auto p, auto service, auto request, auto rest_context) {
       p.set_value(rest_internal::Post<google::longrunning::Operation>(
           *service, *rest_context, request.backup(),
-          absl::StrCat("/", "v1", "/", request.parent(), "/", "backups")));
+          absl::StrCat("/", "v1", "/", request.parent(), "/", "backups"),
+      rest_internal::TrimEmptyQueryParameters({std::make_pair("backup_id", request.backup_id())})));
   }, std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {
@@ -175,7 +178,7 @@ DefaultGoldenThingAdminRestStub::GetBackup(
       google::test::admin::database::v1::GetBackupRequest const& request) {
   return rest_internal::Get<google::test::admin::database::v1::Backup>(
       *service_, rest_context, request,
-      absl::StrCat("/", "v1", "/", request.name()), {});
+      absl::StrCat("/", "v1", "/", request.name()));
 }
 
 StatusOr<google::test::admin::database::v1::Backup>
@@ -202,9 +205,9 @@ DefaultGoldenThingAdminRestStub::ListBackups(
   return rest_internal::Get<google::test::admin::database::v1::ListBackupsResponse>(
       *service_, rest_context, request,
       absl::StrCat("/", "v1", "/", request.parent(), "/", "backups"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("page_size", std::to_string(request.page_size())),
-       std::make_pair("page_token", request.page_token())});
+      rest_internal::TrimEmptyQueryParameters({std::make_pair("filter", request.filter()),
+        std::make_pair("page_size", std::to_string(request.page_size())),
+        std::make_pair("page_token", request.page_token())}));
 }
 
 future<StatusOr<google::longrunning::Operation>>
@@ -217,7 +220,9 @@ DefaultGoldenThingAdminRestStub::AsyncRestoreDatabase(
   std::thread t{[](auto p, auto service, auto request, auto rest_context) {
       p.set_value(rest_internal::Post<google::longrunning::Operation>(
           *service, *rest_context, request,
-          absl::StrCat("/", "v1", "/", request.parent(), "/", "databases", ":restore")));
+          absl::StrCat("/", "v1", "/", request.parent(), "/", "databases", ":restore"),
+      rest_internal::TrimEmptyQueryParameters({std::make_pair("database_id", request.database_id()),
+        std::make_pair("backup", request.backup())})));
   }, std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {
@@ -234,9 +239,9 @@ DefaultGoldenThingAdminRestStub::ListDatabaseOperations(
   return rest_internal::Get<google::test::admin::database::v1::ListDatabaseOperationsResponse>(
       *service_, rest_context, request,
       absl::StrCat("/", "v1", "/", request.parent(), "/", "databaseOperations"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("page_size", std::to_string(request.page_size())),
-       std::make_pair("page_token", request.page_token())});
+      rest_internal::TrimEmptyQueryParameters({std::make_pair("filter", request.filter()),
+        std::make_pair("page_size", std::to_string(request.page_size())),
+        std::make_pair("page_token", request.page_token())}));
 }
 
 StatusOr<google::test::admin::database::v1::ListBackupOperationsResponse>
@@ -246,9 +251,9 @@ DefaultGoldenThingAdminRestStub::ListBackupOperations(
   return rest_internal::Get<google::test::admin::database::v1::ListBackupOperationsResponse>(
       *service_, rest_context, request,
       absl::StrCat("/", "v1", "/", request.parent(), "/", "backupOperations"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("page_size", std::to_string(request.page_size())),
-       std::make_pair("page_token", request.page_token())});
+      rest_internal::TrimEmptyQueryParameters({std::make_pair("filter", request.filter()),
+        std::make_pair("page_size", std::to_string(request.page_size())),
+        std::make_pair("page_token", request.page_token())}));
 }
 
 future<StatusOr<google::test::admin::database::v1::Database>>
@@ -261,7 +266,7 @@ DefaultGoldenThingAdminRestStub::AsyncGetDatabase(
   std::thread t{[](auto p, auto service, auto request, auto rest_context) {
       p.set_value(rest_internal::Get<google::test::admin::database::v1::Database>(
           *service, *rest_context, request,
-          absl::StrCat("/", "v1", "/", request.name()), {}));
+          absl::StrCat("/", "v1", "/", request.name())));
   }, std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -916,7 +916,7 @@ std::map<std::string, VarsDictionary> CreateMethodVars(
     method_vars["request_resource"] =
         FormatRequestResource(*method.input_type(), parsed_http_info);
     SetHttpDerivedMethodVars(parsed_http_info, method, method_vars);
-    SetHttpGetQueryParameters(parsed_http_info, method, method_vars);
+    SetHttpQueryParameters(parsed_http_info, method, method_vars);
     service_methods_vars[method.full_name()] = method_vars;
   }
   return service_methods_vars;

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -1030,8 +1030,7 @@ INSTANTIATE_TEST_SUITE_P(
             "google.protobuf.Service.Method6", "method_request_setters1",
             "  *request.mutable_labels() = {labels.begin(), labels.end()};\n"),
         MethodVarsTestValues("google.protobuf.Service.Method6",
-                             "method_http_query_parameters", R"""(,
-      rest_internal::TrimEmptyQueryParameters({std::make_pair("not_used_anymore", request.not_used_anymore())}))"""),
+                             "method_http_query_parameters", ""),
         // Method7
         MethodVarsTestValues("google.protobuf.Service.Method7",
                              "longrunning_metadata_type",

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -919,7 +919,11 @@ INSTANTIATE_TEST_SUITE_P(
                              "@googleapis_link{google::protobuf::Bar,google/"
                              "foo/v1/service.proto#L17}"),
         MethodVarsTestValues("google.protobuf.Service.Method1",
-                             "method_http_query_parameters", ""),
+                             "method_http_query_parameters", R"""(,
+      rest_internal::TrimEmptyQueryParameters({std::make_pair("number", std::to_string(request.number())),
+        std::make_pair("toggle", request.toggle() ? "1" : "0"),
+        std::make_pair("title", request.title()),
+        std::make_pair("parent", request.parent())}))"""),
         // Method2
         MethodVarsTestValues("google.protobuf.Service.Method2",
                              "longrunning_metadata_type",
@@ -943,7 +947,11 @@ INSTANTIATE_TEST_SUITE_P(
                              "@googleapis_link{google::protobuf::Bar,google/"
                              "foo/v1/service.proto#L17}"),
         MethodVarsTestValues("google.protobuf.Service.Method2",
-                             "method_http_query_parameters", ""),
+                             "method_http_query_parameters", R"""(,
+      rest_internal::TrimEmptyQueryParameters({std::make_pair("number", std::to_string(request.number())),
+        std::make_pair("name", request.name()),
+        std::make_pair("toggle", request.toggle() ? "1" : "0"),
+        std::make_pair("title", request.title())}))"""),
         // Method3
         MethodVarsTestValues("google.protobuf.Service.Method3",
                              "longrunning_metadata_type",
@@ -1022,9 +1030,8 @@ INSTANTIATE_TEST_SUITE_P(
             "google.protobuf.Service.Method6", "method_request_setters1",
             "  *request.mutable_labels() = {labels.begin(), labels.end()};\n"),
         MethodVarsTestValues("google.protobuf.Service.Method6",
-                             "method_http_query_parameters",
-                             R"""(,
-      {std::make_pair("not_used_anymore", request.not_used_anymore())})"""),
+                             "method_http_query_parameters", R"""(,
+      rest_internal::TrimEmptyQueryParameters({std::make_pair("not_used_anymore", request.not_used_anymore())}))"""),
         // Method7
         MethodVarsTestValues("google.protobuf.Service.Method7",
                              "longrunning_metadata_type",
@@ -1062,9 +1069,9 @@ INSTANTIATE_TEST_SUITE_P(
         MethodVarsTestValues("google.protobuf.Service.Method9",
                              "method_http_query_parameters",
                              R"""(,
-      {std::make_pair("page_size", std::to_string(request.page_size())),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("name", request.name())})"""),
+      rest_internal::TrimEmptyQueryParameters({std::make_pair("page_size", std::to_string(request.page_size())),
+        std::make_pair("page_token", request.page_token()),
+        std::make_pair("name", request.name())}))"""),
         // Method11
         MethodVarsTestValues("google.protobuf.Service.Method11",
                              "request_resource", "request.foo_resource()"),

--- a/generator/internal/http_option_utils.cc
+++ b/generator/internal/http_option_utils.cc
@@ -154,11 +154,12 @@ void SetHttpDerivedMethodVars(
   absl::visit(HttpInfoVisitor(method, method_vars), parsed_http_info);
 }
 
-// RestClient::Get does not use request body, so per
-// https://cloud.google.com/apis/design/standard_methods, for HTTP transcoding
-// we need to turn the request fields into query parameters.
+// Request fields not appering in the path may not wind up as part of the json
+// request body, so per https://cloud.google.com/apis/design/standard_methods,
+// for HTTP transcoding we need to turn the request fields into query
+// parameters.
 // TODO(#10176): Consider adding support for repeated simple fields.
-void SetHttpGetQueryParameters(
+void SetHttpQueryParameters(
     absl::variant<absl::monostate, HttpSimpleInfo, HttpExtensionInfo>
         parsed_http_info,
     google::protobuf::MethodDescriptor const& method,
@@ -170,45 +171,43 @@ void SetHttpGetQueryParameters(
     void FormatQueryParameterCode(
         std::string const& http_verb,
         std::vector<std::string> const& param_field_names) {
-      if (http_verb == "Get") {
-        std::vector<std::pair<std::string, protobuf::FieldDescriptor::CppType>>
-            remaining_request_fields;
-        auto const* request = method.input_type();
-        for (int i = 0; i < request->field_count(); ++i) {
-          auto const* field = request->field(i);
-          // Only attempt to make non-repeated, simple fields query parameters.
-          if (!field->is_repeated() &&
-              field->cpp_type() != protobuf::FieldDescriptor::CPPTYPE_MESSAGE) {
-            if (!internal::Contains(param_field_names, field->name())) {
-              remaining_request_fields.emplace_back(field->name(),
-                                                    field->cpp_type());
-            }
+      std::vector<std::pair<std::string, protobuf::FieldDescriptor::CppType>>
+          remaining_request_fields;
+      auto const* request = method.input_type();
+      for (int i = 0; i < request->field_count(); ++i) {
+        auto const* field = request->field(i);
+        // Only attempt to make non-repeated, simple fields query parameters.
+        if (!field->is_repeated() &&
+            field->cpp_type() != protobuf::FieldDescriptor::CPPTYPE_MESSAGE) {
+          if (!internal::Contains(param_field_names, field->name())) {
+            remaining_request_fields.emplace_back(field->name(),
+                                                  field->cpp_type());
           }
         }
-        auto format = [](auto* out, auto const& i) {
-          if (i.second == protobuf::FieldDescriptor::CPPTYPE_STRING) {
-            out->append(absl::StrFormat("std::make_pair(\"%s\", request.%s())",
-                                        i.first, i.first));
-            return;
-          }
-          if (i.second == protobuf::FieldDescriptor::CPPTYPE_BOOL) {
-            out->append(absl::StrFormat(
-                R"""(std::make_pair("%s", request.%s() ? "1" : "0"))""",
-                i.first, i.first));
-            return;
-          }
+      }
+      auto format = [](auto* out, auto const& i) {
+        if (i.second == protobuf::FieldDescriptor::CPPTYPE_STRING) {
+          out->append(absl::StrFormat("std::make_pair(\"%s\", request.%s())",
+                                      i.first, i.first));
+          return;
+        }
+        if (i.second == protobuf::FieldDescriptor::CPPTYPE_BOOL) {
           out->append(absl::StrFormat(
-              "std::make_pair(\"%s\", std::to_string(request.%s()))", i.first,
+              R"""(std::make_pair("%s", request.%s() ? "1" : "0"))""", i.first,
               i.first));
-        };
-        if (remaining_request_fields.empty()) {
-          method_vars["method_http_query_parameters"] = ", {}";
-        } else {
-          method_vars["method_http_query_parameters"] = absl::StrCat(
-              ",\n      {",
-              absl::StrJoin(remaining_request_fields, ",\n       ", format),
-              "}");
+          return;
         }
+        out->append(absl::StrFormat(
+            "std::make_pair(\"%s\", std::to_string(request.%s()))", i.first,
+            i.first));
+      };
+      if (remaining_request_fields.empty()) {
+        method_vars["method_http_query_parameters"] = "";
+      } else {
+        method_vars["method_http_query_parameters"] = absl::StrCat(
+            ",\n      rest_internal::TrimEmptyQueryParameters({",
+            absl::StrJoin(remaining_request_fields, ",\n        ", format),
+            "})");
       }
     }
 

--- a/generator/internal/http_option_utils.cc
+++ b/generator/internal/http_option_utils.cc
@@ -176,13 +176,11 @@ void SetHttpQueryParameters(
       for (int i = 0; i < request->field_count(); ++i) {
         auto const* field = request->field(i);
         // Only attempt to make non-repeated, simple fields query parameters.
-        if (!field->is_repeated() &&
+        if (!field->is_repeated() && !field->options().deprecated() &&
             field->cpp_type() != protobuf::FieldDescriptor::CPPTYPE_MESSAGE) {
           if (!internal::Contains(param_field_names, field->name())) {
-            if (!field->options().deprecated()) {
-              remaining_request_fields.emplace_back(field->name(),
-                                                    field->cpp_type());
-            }
+            remaining_request_fields.emplace_back(field->name(),
+                                                  field->cpp_type());
           }
         }
       }

--- a/generator/internal/http_option_utils.h
+++ b/generator/internal/http_option_utils.h
@@ -72,7 +72,7 @@ void SetHttpDerivedMethodVars(
  * Sets the "method_http_query_parameters" value in method_vars based on the
  * parsed_http_info.
  */
-void SetHttpGetQueryParameters(
+void SetHttpQueryParameters(
     absl::variant<absl::monostate, HttpSimpleInfo, HttpExtensionInfo>
         parsed_http_info,
     google::protobuf::MethodDescriptor const& method,

--- a/generator/internal/http_option_utils_test.cc
+++ b/generator/internal/http_option_utils_test.cc
@@ -467,25 +467,25 @@ TEST_F(HttpOptionUtilsTest,
       Eq(R"""(absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/", "instances", "/", request.instance(), "/", "databases"))"""));
 }
 
-TEST_F(HttpOptionUtilsTest, SetHttpGetQueryParametersNonGet) {
+TEST_F(HttpOptionUtilsTest, SetHttpQueryParametersNoParams) {
   FileDescriptor const* service_file_descriptor =
       pool_.FindFileByName("google/foo/v1/service.proto");
   MethodDescriptor const* method =
-      service_file_descriptor->service(0)->method(2);
+      service_file_descriptor->service(0)->method(5);
   VarsDictionary vars;
-  SetHttpGetQueryParameters(ParseHttpExtension(*method), *method, vars);
+  SetHttpQueryParameters(ParseHttpExtension(*method), *method, vars);
   EXPECT_THAT(vars.at("method_http_query_parameters"), Eq(""));
 }
 
-TEST_F(HttpOptionUtilsTest, SetHttpGetQueryParametersGet) {
+TEST_F(HttpOptionUtilsTest, SetHttpQueryParametersGetWithParams) {
   FileDescriptor const* service_file_descriptor =
       pool_.FindFileByName("google/foo/v1/service.proto");
   MethodDescriptor const* method =
       service_file_descriptor->service(0)->method(4);
   VarsDictionary vars;
-  SetHttpGetQueryParameters(ParseHttpExtension(*method), *method, vars);
+  SetHttpQueryParameters(ParseHttpExtension(*method), *method, vars);
   EXPECT_THAT(vars.at("method_http_query_parameters"), Eq(R"""(,
-      {std::make_pair("not_used_anymore", request.not_used_anymore())})"""));
+      rest_internal::TrimEmptyQueryParameters({std::make_pair("not_used_anymore", request.not_used_anymore())}))"""));
 }
 
 TEST_F(HttpOptionUtilsTest, SetHttpGetQueryParametersGetPaginated) {
@@ -494,12 +494,12 @@ TEST_F(HttpOptionUtilsTest, SetHttpGetQueryParametersGetPaginated) {
   MethodDescriptor const* method =
       service_file_descriptor->service(0)->method(3);
   VarsDictionary vars;
-  SetHttpGetQueryParameters(ParseHttpExtension(*method), *method, vars);
+  SetHttpQueryParameters(ParseHttpExtension(*method), *method, vars);
   EXPECT_THAT(vars.at("method_http_query_parameters"), Eq(R"""(,
-      {std::make_pair("page_size", std::to_string(request.page_size())),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("name", request.name()),
-       std::make_pair("include_foo", request.include_foo() ? "1" : "0")})"""));
+      rest_internal::TrimEmptyQueryParameters({std::make_pair("page_size", std::to_string(request.page_size())),
+        std::make_pair("page_token", request.page_token()),
+        std::make_pair("name", request.name()),
+        std::make_pair("include_foo", request.include_foo() ? "1" : "0")}))"""));
 }
 
 TEST_F(HttpOptionUtilsTest, HasHttpAnnotationRoutingHeaderSuccess) {

--- a/generator/internal/http_option_utils_test.cc
+++ b/generator/internal/http_option_utils_test.cc
@@ -484,8 +484,7 @@ TEST_F(HttpOptionUtilsTest, SetHttpQueryParametersGetWithParams) {
       service_file_descriptor->service(0)->method(4);
   VarsDictionary vars;
   SetHttpQueryParameters(ParseHttpExtension(*method), *method, vars);
-  EXPECT_THAT(vars.at("method_http_query_parameters"), Eq(R"""(,
-      rest_internal::TrimEmptyQueryParameters({std::make_pair("not_used_anymore", request.not_used_anymore())}))"""));
+  EXPECT_THAT(vars.at("method_http_query_parameters"), Eq(""));
 }
 
 TEST_F(HttpOptionUtilsTest, SetHttpGetQueryParametersGetPaginated) {

--- a/google/cloud/compute/accelerator_types/v1/internal/accelerator_types_rest_stub.cc
+++ b/google/cloud/compute/accelerator_types/v1/internal/accelerator_types_rest_stub.cc
@@ -50,14 +50,15 @@ DefaultAcceleratorTypesRestStub::AggregatedListAcceleratorTypes(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "acceleratorTypes"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::AcceleratorType>
@@ -69,8 +70,7 @@ DefaultAcceleratorTypesRestStub::GetAcceleratorType(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
-                   "acceleratorTypes", "/", request.accelerator_type()),
-      {});
+                   "acceleratorTypes", "/", request.accelerator_type()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::AcceleratorTypeList>
@@ -84,12 +84,13 @@ DefaultAcceleratorTypesRestStub::ListAcceleratorTypes(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "acceleratorTypes"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/compute/addresses/v1/internal/addresses_rest_stub.cc
+++ b/google/cloud/compute/addresses/v1/internal/addresses_rest_stub.cc
@@ -54,14 +54,15 @@ DefaultAddressesRestStub::AggregatedListAddresses(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "addresses"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -81,7 +82,9 @@ DefaultAddressesRestStub::AsyncDeleteAddress(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "addresses", "/",
-                             request.address())));
+                             request.address()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -99,8 +102,7 @@ DefaultAddressesRestStub::GetAddress(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
-                   "/", "addresses", "/", request.address()),
-      {});
+                   "/", "addresses", "/", request.address()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -119,7 +121,9 @@ DefaultAddressesRestStub::AsyncInsertAddress(
                 *service, *rest_context, request.address_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "addresses")));
+                             request.region(), "/", "addresses"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -138,12 +142,13 @@ DefaultAddressesRestStub::ListAddresses(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "addresses"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -163,7 +168,9 @@ DefaultAddressesRestStub::AsyncMove(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "addresses", "/",
-                             request.address(), "/", "move")));
+                             request.address(), "/", "move"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -190,7 +197,9 @@ DefaultAddressesRestStub::AsyncSetLabels(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "addresses", "/",
-                             request.resource(), "/", "setLabels")));
+                             request.resource(), "/", "setLabels"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/autoscalers/v1/internal/autoscalers_rest_stub.cc
+++ b/google/cloud/compute/autoscalers/v1/internal/autoscalers_rest_stub.cc
@@ -54,14 +54,15 @@ DefaultAutoscalersRestStub::AggregatedListAutoscalers(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "autoscalers"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -81,7 +82,9 @@ DefaultAutoscalersRestStub::AsyncDeleteAutoscaler(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "autoscalers", "/",
-                             request.autoscaler())));
+                             request.autoscaler()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -99,8 +102,7 @@ DefaultAutoscalersRestStub::GetAutoscaler(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
-                   "autoscalers", "/", request.autoscaler()),
-      {});
+                   "autoscalers", "/", request.autoscaler()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -119,7 +121,9 @@ DefaultAutoscalersRestStub::AsyncInsertAutoscaler(
                 *service, *rest_context, request.autoscaler_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
-                             request.zone(), "/", "autoscalers")));
+                             request.zone(), "/", "autoscalers"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -138,12 +142,13 @@ DefaultAutoscalersRestStub::ListAutoscalers(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "autoscalers"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -162,7 +167,10 @@ DefaultAutoscalersRestStub::AsyncPatchAutoscaler(
                 *service, *rest_context, request.autoscaler_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
-                             request.zone(), "/", "autoscalers")));
+                             request.zone(), "/", "autoscalers"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("autoscaler", request.autoscaler()),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -187,7 +195,10 @@ DefaultAutoscalersRestStub::AsyncUpdateAutoscaler(
                 *service, *rest_context, request.autoscaler_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
-                             request.zone(), "/", "autoscalers")));
+                             request.zone(), "/", "autoscalers"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("autoscaler", request.autoscaler()),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/backend_buckets/v1/internal/backend_buckets_rest_stub.cc
+++ b/google/cloud/compute/backend_buckets/v1/internal/backend_buckets_rest_stub.cc
@@ -61,7 +61,9 @@ DefaultBackendBucketsRestStub::AsyncAddSignedUrlKey(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "backendBuckets", "/", request.backend_bucket(),
-                             "/", "addSignedUrlKey")));
+                             "/", "addSignedUrlKey"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -86,7 +88,9 @@ DefaultBackendBucketsRestStub::AsyncDeleteBackendBucket(
                 *service, *rest_context, request,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "backendBuckets", "/", request.backend_bucket())));
+                             "backendBuckets", "/", request.backend_bucket()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -112,7 +116,10 @@ DefaultBackendBucketsRestStub::AsyncDeleteSignedUrlKey(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "backendBuckets", "/", request.backend_bucket(),
-                             "/", "deleteSignedUrlKey")));
+                             "/", "deleteSignedUrlKey"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("key_name", request.key_name()),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -130,8 +137,7 @@ DefaultBackendBucketsRestStub::GetBackendBucket(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "backendBuckets", "/",
-                   request.backend_bucket()),
-      {});
+                   request.backend_bucket()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -150,7 +156,9 @@ DefaultBackendBucketsRestStub::AsyncInsertBackendBucket(
                 *service, *rest_context, request.backend_bucket_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "backendBuckets")));
+                             "backendBuckets"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -168,12 +176,13 @@ DefaultBackendBucketsRestStub::ListBackendBuckets(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "backendBuckets"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -192,7 +201,9 @@ DefaultBackendBucketsRestStub::AsyncPatchBackendBucket(
                 *service, *rest_context, request.backend_bucket_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "backendBuckets", "/", request.backend_bucket())));
+                             "backendBuckets", "/", request.backend_bucket()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -219,7 +230,9 @@ DefaultBackendBucketsRestStub::AsyncSetEdgeSecurityPolicy(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "backendBuckets", "/", request.backend_bucket(),
-                             "/", "setEdgeSecurityPolicy")));
+                             "/", "setEdgeSecurityPolicy"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -244,7 +257,9 @@ DefaultBackendBucketsRestStub::AsyncUpdateBackendBucket(
                 *service, *rest_context, request.backend_bucket_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "backendBuckets", "/", request.backend_bucket())));
+                             "backendBuckets", "/", request.backend_bucket()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/backend_services/v1/internal/backend_services_rest_stub.cc
+++ b/google/cloud/compute/backend_services/v1/internal/backend_services_rest_stub.cc
@@ -61,7 +61,9 @@ DefaultBackendServicesRestStub::AsyncAddSignedUrlKey(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "backendServices", "/", request.backend_service(),
-                             "/", "addSignedUrlKey")));
+                             "/", "addSignedUrlKey"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -81,14 +83,15 @@ DefaultBackendServicesRestStub::AggregatedListBackendServices(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "backendServices"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -107,8 +110,9 @@ DefaultBackendServicesRestStub::AsyncDeleteBackendService(
                 *service, *rest_context, request,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "backendServices", "/",
-                             request.backend_service())));
+                             "backendServices", "/", request.backend_service()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -134,7 +138,10 @@ DefaultBackendServicesRestStub::AsyncDeleteSignedUrlKey(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "backendServices", "/", request.backend_service(),
-                             "/", "deleteSignedUrlKey")));
+                             "/", "deleteSignedUrlKey"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("key_name", request.key_name()),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -152,8 +159,7 @@ DefaultBackendServicesRestStub::GetBackendService(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "backendServices",
-                   "/", request.backend_service()),
-      {});
+                   "/", request.backend_service()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::BackendServiceGroupHealth>
@@ -179,9 +185,9 @@ DefaultBackendServicesRestStub::GetIamPolicy(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "backendServices",
                    "/", request.resource(), "/", "getIamPolicy"),
-      {std::make_pair(
+      rest_internal::TrimEmptyQueryParameters({std::make_pair(
           "options_requested_policy_version",
-          std::to_string(request.options_requested_policy_version()))});
+          std::to_string(request.options_requested_policy_version()))}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -200,7 +206,9 @@ DefaultBackendServicesRestStub::AsyncInsertBackendService(
                 *service, *rest_context, request.backend_service_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "backendServices")));
+                             "backendServices"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -219,12 +227,13 @@ DefaultBackendServicesRestStub::ListBackendServices(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "backendServices"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -243,8 +252,9 @@ DefaultBackendServicesRestStub::AsyncPatchBackendService(
                 *service, *rest_context, request.backend_service_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "backendServices", "/",
-                             request.backend_service())));
+                             "backendServices", "/", request.backend_service()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -271,7 +281,9 @@ DefaultBackendServicesRestStub::AsyncSetEdgeSecurityPolicy(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "backendServices", "/", request.backend_service(),
-                             "/", "setEdgeSecurityPolicy")));
+                             "/", "setEdgeSecurityPolicy"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -310,7 +322,9 @@ DefaultBackendServicesRestStub::AsyncSetSecurityPolicy(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "backendServices", "/", request.backend_service(),
-                             "/", "setSecurityPolicy")));
+                             "/", "setSecurityPolicy"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -335,8 +349,9 @@ DefaultBackendServicesRestStub::AsyncUpdateBackendService(
                 *service, *rest_context, request.backend_service_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "backendServices", "/",
-                             request.backend_service())));
+                             "backendServices", "/", request.backend_service()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/disk_types/v1/internal/disk_types_rest_stub.cc
+++ b/google/cloud/compute/disk_types/v1/internal/disk_types_rest_stub.cc
@@ -48,14 +48,15 @@ DefaultDiskTypesRestStub::AggregatedListDiskTypes(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "diskTypes"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::DiskType>
@@ -67,8 +68,7 @@ DefaultDiskTypesRestStub::GetDiskType(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
-                   "diskTypes", "/", request.disk_type()),
-      {});
+                   "diskTypes", "/", request.disk_type()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::DiskTypeList>
@@ -81,12 +81,13 @@ DefaultDiskTypesRestStub::ListDiskTypes(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "diskTypes"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/compute/disks/v1/internal/disks_rest_stub.cc
+++ b/google/cloud/compute/disks/v1/internal/disks_rest_stub.cc
@@ -62,7 +62,9 @@ DefaultDisksRestStub::AsyncAddResourcePolicies(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "disks", "/", request.disk(),
-                             "/", "addResourcePolicies")));
+                             "/", "addResourcePolicies"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -81,14 +83,15 @@ DefaultDisksRestStub::AggregatedListDisks(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "disks"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -106,7 +109,9 @@ DefaultDisksRestStub::AsyncBulkInsert(
                 *service, *rest_context, request.bulk_insert_disk_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
-                             request.zone(), "/", "disks", "/", "bulkInsert")));
+                             request.zone(), "/", "disks", "/", "bulkInsert"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -132,7 +137,11 @@ DefaultDisksRestStub::AsyncCreateSnapshot(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "disks", "/", request.disk(),
-                             "/", "createSnapshot")));
+                             "/", "createSnapshot"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("guest_flush",
+                                    request.guest_flush() ? "1" : "0"),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -156,8 +165,9 @@ DefaultDisksRestStub::AsyncDeleteDisk(
                 *service, *rest_context, request,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
-                             request.zone(), "/", "disks", "/",
-                             request.disk())));
+                             request.zone(), "/", "disks", "/", request.disk()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -173,8 +183,7 @@ StatusOr<google::cloud::cpp::compute::v1::Disk> DefaultDisksRestStub::GetDisk(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
-                   "disks", "/", request.disk()),
-      {});
+                   "disks", "/", request.disk()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>
@@ -187,9 +196,9 @@ DefaultDisksRestStub::GetIamPolicy(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "disks", "/", request.resource(), "/", "getIamPolicy"),
-      {std::make_pair(
+      rest_internal::TrimEmptyQueryParameters({std::make_pair(
           "options_requested_policy_version",
-          std::to_string(request.options_requested_policy_version()))});
+          std::to_string(request.options_requested_policy_version()))}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -207,7 +216,10 @@ DefaultDisksRestStub::AsyncInsertDisk(
                 *service, *rest_context, request.disk_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
-                             request.zone(), "/", "disks")));
+                             request.zone(), "/", "disks"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id()),
+                     std::make_pair("source_image", request.source_image())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -225,12 +237,13 @@ DefaultDisksRestStub::ListDisks(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "disks"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -251,7 +264,9 @@ DefaultDisksRestStub::AsyncRemoveResourcePolicies(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "disks", "/", request.disk(),
-                             "/", "removeResourcePolicies")));
+                             "/", "removeResourcePolicies"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -277,7 +292,9 @@ DefaultDisksRestStub::AsyncResize(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "disks", "/", request.disk(),
-                             "/", "resize")));
+                             "/", "resize"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -315,7 +332,9 @@ DefaultDisksRestStub::AsyncSetLabels(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "disks", "/",
-                             request.resource(), "/", "setLabels")));
+                             request.resource(), "/", "setLabels"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -342,7 +361,9 @@ DefaultDisksRestStub::AsyncStartAsyncReplication(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "disks", "/", request.disk(),
-                             "/", "startAsyncReplication")));
+                             "/", "startAsyncReplication"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -368,7 +389,9 @@ DefaultDisksRestStub::AsyncStopAsyncReplication(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "disks", "/", request.disk(),
-                             "/", "stopAsyncReplication")));
+                             "/", "stopAsyncReplication"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -395,7 +418,9 @@ DefaultDisksRestStub::AsyncStopGroupAsyncReplication(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "disks", "/",
-                             "stopGroupAsyncReplication")));
+                             "stopGroupAsyncReplication"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -433,8 +458,11 @@ DefaultDisksRestStub::AsyncUpdateDisk(
                 *service, *rest_context, request.disk_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
-                             request.zone(), "/", "disks", "/",
-                             request.disk())));
+                             request.zone(), "/", "disks", "/", request.disk()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("paths", request.paths()),
+                     std::make_pair("request_id", request.request_id()),
+                     std::make_pair("update_mask", request.update_mask())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/external_vpn_gateways/v1/internal/external_vpn_gateways_rest_stub.cc
+++ b/google/cloud/compute/external_vpn_gateways/v1/internal/external_vpn_gateways_rest_stub.cc
@@ -63,7 +63,9 @@ DefaultExternalVpnGatewaysRestStub::AsyncDeleteExternalVpnGateway(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "externalVpnGateways", "/",
-                             request.external_vpn_gateway())));
+                             request.external_vpn_gateway()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -82,8 +84,7 @@ DefaultExternalVpnGatewaysRestStub::GetExternalVpnGateway(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "externalVpnGateways",
-                   "/", request.external_vpn_gateway()),
-      {});
+                   "/", request.external_vpn_gateway()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -103,7 +104,9 @@ DefaultExternalVpnGatewaysRestStub::AsyncInsertExternalVpnGateway(
                 request.external_vpn_gateway_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "externalVpnGateways")));
+                             "externalVpnGateways"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -123,12 +126,13 @@ DefaultExternalVpnGatewaysRestStub::ListExternalVpnGateways(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/",
                    "externalVpnGateways"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/firewall_policies/v1/internal/firewall_policies_rest_stub.cc
+++ b/google/cloud/compute/firewall_policies/v1/internal/firewall_policies_rest_stub.cc
@@ -62,8 +62,12 @@ DefaultFirewallPoliciesRestStub::AsyncAddAssociation(
                 request.firewall_policy_association_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/",
                              "global", "/", "firewallPolicies", "/",
-                             request.firewall_policy(), "/",
-                             "addAssociation")));
+                             request.firewall_policy(), "/", "addAssociation"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair(
+                         "replace_existing_association",
+                         request.replace_existing_association() ? "1" : "0"),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -89,7 +93,9 @@ DefaultFirewallPoliciesRestStub::AsyncAddRule(
                 request.firewall_policy_rule_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/",
                              "global", "/", "firewallPolicies", "/",
-                             request.firewall_policy(), "/", "addRule")));
+                             request.firewall_policy(), "/", "addRule"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -114,7 +120,11 @@ DefaultFirewallPoliciesRestStub::AsyncCloneRules(
                 *service, *rest_context, request,
                 absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/",
                              "global", "/", "firewallPolicies", "/",
-                             request.firewall_policy(), "/", "cloneRules")));
+                             request.firewall_policy(), "/", "cloneRules"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id()),
+                     std::make_pair("source_firewall_policy",
+                                    request.source_firewall_policy())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -139,7 +149,9 @@ DefaultFirewallPoliciesRestStub::AsyncDeleteFirewallPolicy(
                 *service, *rest_context, request,
                 absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/",
                              "global", "/", "firewallPolicies", "/",
-                             request.firewall_policy())));
+                             request.firewall_policy()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -156,8 +168,7 @@ DefaultFirewallPoliciesRestStub::GetFirewallPolicy(
   return rest_internal::Get<google::cloud::cpp::compute::v1::FirewallPolicy>(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/", "global",
-                   "/", "firewallPolicies", "/", request.firewall_policy()),
-      {});
+                   "/", "firewallPolicies", "/", request.firewall_policy()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::FirewallPolicyAssociation>
@@ -171,7 +182,8 @@ DefaultFirewallPoliciesRestStub::GetAssociation(
       absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/", "global",
                    "/", "firewallPolicies", "/", request.firewall_policy(), "/",
                    "getAssociation"),
-      {std::make_pair("name", request.name())});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("name", request.name())}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>
@@ -184,9 +196,9 @@ DefaultFirewallPoliciesRestStub::GetIamPolicy(
       absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/", "global",
                    "/", "firewallPolicies", "/", request.resource(), "/",
                    "getIamPolicy"),
-      {std::make_pair(
+      rest_internal::TrimEmptyQueryParameters({std::make_pair(
           "options_requested_policy_version",
-          std::to_string(request.options_requested_policy_version()))});
+          std::to_string(request.options_requested_policy_version()))}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::FirewallPolicyRule>
@@ -200,7 +212,8 @@ DefaultFirewallPoliciesRestStub::GetRule(
       absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/", "global",
                    "/", "firewallPolicies", "/", request.firewall_policy(), "/",
                    "getRule"),
-      {std::make_pair("priority", std::to_string(request.priority()))});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("priority", std::to_string(request.priority()))}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -217,7 +230,10 @@ DefaultFirewallPoliciesRestStub::AsyncInsertFirewallPolicy(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.firewall_policy_resource(),
-                "/compute/v1/locations/global/firewallPolicies"));
+                "/compute/v1/locations/global/firewallPolicies",
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("parent_id", request.parent_id()),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -235,13 +251,14 @@ DefaultFirewallPoliciesRestStub::ListFirewallPolicies(
       google::cloud::cpp::compute::v1::FirewallPolicyList>(
       *service_, rest_context, request,
       "/compute/v1/locations/global/firewallPolicies",
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("parent_id", request.parent_id()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("parent_id", request.parent_id()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<
@@ -254,7 +271,8 @@ DefaultFirewallPoliciesRestStub::ListAssociations(
                                 FirewallPoliciesListAssociationsResponse>(
       *service_, rest_context, request,
       "/compute/v1/locations/global/firewallPolicies/listAssociations",
-      {std::make_pair("target_resource", request.target_resource())});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("target_resource", request.target_resource())}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -273,7 +291,10 @@ DefaultFirewallPoliciesRestStub::AsyncMove(
                 *service, *rest_context, request,
                 absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/",
                              "global", "/", "firewallPolicies", "/",
-                             request.firewall_policy(), "/", "move")));
+                             request.firewall_policy(), "/", "move"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("parent_id", request.parent_id()),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -298,7 +319,9 @@ DefaultFirewallPoliciesRestStub::AsyncPatchFirewallPolicy(
                 *service, *rest_context, request.firewall_policy_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/",
                              "global", "/", "firewallPolicies", "/",
-                             request.firewall_policy())));
+                             request.firewall_policy()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -324,7 +347,11 @@ DefaultFirewallPoliciesRestStub::AsyncPatchRule(
                 request.firewall_policy_rule_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/",
                              "global", "/", "firewallPolicies", "/",
-                             request.firewall_policy(), "/", "patchRule")));
+                             request.firewall_policy(), "/", "patchRule"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("priority",
+                                    std::to_string(request.priority())),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -350,7 +377,10 @@ DefaultFirewallPoliciesRestStub::AsyncRemoveAssociation(
                 absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/",
                              "global", "/", "firewallPolicies", "/",
                              request.firewall_policy(), "/",
-                             "removeAssociation")));
+                             "removeAssociation"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("name", request.name()),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -375,7 +405,11 @@ DefaultFirewallPoliciesRestStub::AsyncRemoveRule(
                 *service, *rest_context, request,
                 absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/",
                              "global", "/", "firewallPolicies", "/",
-                             request.firewall_policy(), "/", "removeRule")));
+                             request.firewall_policy(), "/", "removeRule"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("priority",
+                                    std::to_string(request.priority())),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/firewalls/v1/internal/firewalls_rest_stub.cc
+++ b/google/cloud/compute/firewalls/v1/internal/firewalls_rest_stub.cc
@@ -60,7 +60,9 @@ DefaultFirewallsRestStub::AsyncDeleteFirewall(
                 *service, *rest_context, request,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "firewalls",
-                             "/", request.firewall())));
+                             "/", request.firewall()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -78,8 +80,7 @@ DefaultFirewallsRestStub::GetFirewall(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "firewalls", "/",
-                   request.firewall()),
-      {});
+                   request.firewall()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -98,7 +99,9 @@ DefaultFirewallsRestStub::AsyncInsertFirewall(
                 *service, *rest_context, request.firewall_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "firewalls")));
+                             "firewalls"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -116,12 +119,13 @@ DefaultFirewallsRestStub::ListFirewalls(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "firewalls"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -140,7 +144,9 @@ DefaultFirewallsRestStub::AsyncPatchFirewall(
                 *service, *rest_context, request.firewall_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "firewalls",
-                             "/", request.firewall())));
+                             "/", request.firewall()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -165,7 +171,9 @@ DefaultFirewallsRestStub::AsyncUpdateFirewall(
                 *service, *rest_context, request.firewall_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "firewalls",
-                             "/", request.firewall())));
+                             "/", request.firewall()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/forwarding_rules/v1/internal/forwarding_rules_rest_stub.cc
+++ b/google/cloud/compute/forwarding_rules/v1/internal/forwarding_rules_rest_stub.cc
@@ -55,14 +55,15 @@ DefaultForwardingRulesRestStub::AggregatedListForwardingRules(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "forwardingRules"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -82,7 +83,9 @@ DefaultForwardingRulesRestStub::AsyncDeleteForwardingRule(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "forwardingRules", "/",
-                             request.forwarding_rule())));
+                             request.forwarding_rule()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -100,8 +103,7 @@ DefaultForwardingRulesRestStub::GetForwardingRule(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
-                   "/", "forwardingRules", "/", request.forwarding_rule()),
-      {});
+                   "/", "forwardingRules", "/", request.forwarding_rule()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -120,7 +122,9 @@ DefaultForwardingRulesRestStub::AsyncInsertForwardingRule(
                 *service, *rest_context, request.forwarding_rule_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "forwardingRules")));
+                             request.region(), "/", "forwardingRules"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -140,12 +144,13 @@ DefaultForwardingRulesRestStub::ListForwardingRules(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "forwardingRules"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -165,7 +170,9 @@ DefaultForwardingRulesRestStub::AsyncPatchForwardingRule(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "forwardingRules", "/",
-                             request.forwarding_rule())));
+                             request.forwarding_rule()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -192,7 +199,9 @@ DefaultForwardingRulesRestStub::AsyncSetLabels(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "forwardingRules", "/",
-                             request.resource(), "/", "setLabels")));
+                             request.resource(), "/", "setLabels"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -218,7 +227,9 @@ DefaultForwardingRulesRestStub::AsyncSetTarget(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "forwardingRules", "/",
-                             request.forwarding_rule(), "/", "setTarget")));
+                             request.forwarding_rule(), "/", "setTarget"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/global_addresses/v1/internal/global_addresses_rest_stub.cc
+++ b/google/cloud/compute/global_addresses/v1/internal/global_addresses_rest_stub.cc
@@ -60,7 +60,9 @@ DefaultGlobalAddressesRestStub::AsyncDeleteAddress(
                 *service, *rest_context, request,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "addresses",
-                             "/", request.address())));
+                             "/", request.address()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -78,8 +80,7 @@ DefaultGlobalAddressesRestStub::GetAddress(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "addresses", "/",
-                   request.address()),
-      {});
+                   request.address()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -98,7 +99,9 @@ DefaultGlobalAddressesRestStub::AsyncInsertAddress(
                 *service, *rest_context, request.address_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "addresses")));
+                             "addresses"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -116,12 +119,13 @@ DefaultGlobalAddressesRestStub::ListGlobalAddresses(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "addresses"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -141,7 +145,9 @@ DefaultGlobalAddressesRestStub::AsyncMove(
                 request.global_addresses_move_request_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "addresses",
-                             "/", request.address(), "/", "move")));
+                             "/", request.address(), "/", "move"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/global_forwarding_rules/v1/internal/global_forwarding_rules_rest_stub.cc
+++ b/google/cloud/compute/global_forwarding_rules/v1/internal/global_forwarding_rules_rest_stub.cc
@@ -62,8 +62,9 @@ DefaultGlobalForwardingRulesRestStub::AsyncDeleteForwardingRule(
                 *service, *rest_context, request,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "forwardingRules", "/",
-                             request.forwarding_rule())));
+                             "forwardingRules", "/", request.forwarding_rule()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -81,8 +82,7 @@ DefaultGlobalForwardingRulesRestStub::GetForwardingRule(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "forwardingRules",
-                   "/", request.forwarding_rule()),
-      {});
+                   "/", request.forwarding_rule()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -101,7 +101,9 @@ DefaultGlobalForwardingRulesRestStub::AsyncInsertForwardingRule(
                 *service, *rest_context, request.forwarding_rule_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "forwardingRules")));
+                             "forwardingRules"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -120,12 +122,13 @@ DefaultGlobalForwardingRulesRestStub::ListGlobalForwardingRules(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "forwardingRules"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -144,8 +147,9 @@ DefaultGlobalForwardingRulesRestStub::AsyncPatchForwardingRule(
                 *service, *rest_context, request.forwarding_rule_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "forwardingRules", "/",
-                             request.forwarding_rule())));
+                             "forwardingRules", "/", request.forwarding_rule()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -198,7 +202,9 @@ DefaultGlobalForwardingRulesRestStub::AsyncSetTarget(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "forwardingRules", "/", request.forwarding_rule(),
-                             "/", "setTarget")));
+                             "/", "setTarget"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/global_network_endpoint_groups/v1/internal/global_network_endpoint_groups_rest_stub.cc
+++ b/google/cloud/compute/global_network_endpoint_groups/v1/internal/global_network_endpoint_groups_rest_stub.cc
@@ -67,7 +67,9 @@ DefaultGlobalNetworkEndpointGroupsRestStub::AsyncAttachNetworkEndpoints(
                          request.project(), "/", "global", "/",
                          "networkEndpointGroups", "/",
                          request.network_endpoint_group(), "/",
-                         "attachNetworkEndpoints")));
+                         "attachNetworkEndpoints"),
+            rest_internal::TrimEmptyQueryParameters(
+                {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -93,7 +95,9 @@ DefaultGlobalNetworkEndpointGroupsRestStub::AsyncDeleteNetworkEndpointGroup(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "networkEndpointGroups", "/",
-                             request.network_endpoint_group())));
+                             request.network_endpoint_group()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -122,7 +126,9 @@ DefaultGlobalNetworkEndpointGroupsRestStub::AsyncDetachNetworkEndpoints(
                          request.project(), "/", "global", "/",
                          "networkEndpointGroups", "/",
                          request.network_endpoint_group(), "/",
-                         "detachNetworkEndpoints")));
+                         "detachNetworkEndpoints"),
+            rest_internal::TrimEmptyQueryParameters(
+                {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -142,8 +148,7 @@ DefaultGlobalNetworkEndpointGroupsRestStub::GetNetworkEndpointGroup(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/",
                    "networkEndpointGroups", "/",
-                   request.network_endpoint_group()),
-      {});
+                   request.network_endpoint_group()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -163,7 +168,9 @@ DefaultGlobalNetworkEndpointGroupsRestStub::AsyncInsertNetworkEndpointGroup(
                 request.network_endpoint_group_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "networkEndpointGroups")));
+                             "networkEndpointGroups"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -183,12 +190,13 @@ DefaultGlobalNetworkEndpointGroupsRestStub::ListGlobalNetworkEndpointGroups(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/",
                    "networkEndpointGroups"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<
@@ -203,7 +211,14 @@ DefaultGlobalNetworkEndpointGroupsRestStub::ListNetworkEndpoints(
       absl::StrCat(
           "/", "compute", "/", "v1", "/", "projects", "/", request.project(),
           "/", "global", "/", "networkEndpointGroups", "/",
-          request.network_endpoint_group(), "/", "listNetworkEndpoints"));
+          request.network_endpoint_group(), "/", "listNetworkEndpoints"),
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/global_operations/v1/internal/global_operations_rest_stub.cc
+++ b/google/cloud/compute/global_operations/v1/internal/global_operations_rest_stub.cc
@@ -49,14 +49,15 @@ DefaultGlobalOperationsRestStub::AggregatedListGlobalOperations(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "operations"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 Status DefaultGlobalOperationsRestStub::DeleteOperation(
@@ -79,8 +80,7 @@ DefaultGlobalOperationsRestStub::GetOperation(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "operations", "/",
-                   request.operation()),
-      {});
+                   request.operation()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::OperationList>
@@ -92,12 +92,13 @@ DefaultGlobalOperationsRestStub::ListGlobalOperations(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "operations"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Operation>

--- a/google/cloud/compute/global_organization_operations/v1/internal/global_organization_operations_rest_stub.cc
+++ b/google/cloud/compute/global_organization_operations/v1/internal/global_organization_operations_rest_stub.cc
@@ -48,7 +48,9 @@ Status DefaultGlobalOrganizationOperationsRestStub::DeleteOperation(
   return rest_internal::Delete(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/", "global",
-                   "/", "operations", "/", request.operation()));
+                   "/", "operations", "/", request.operation()),
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("parent_id", request.parent_id())}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Operation>
@@ -60,7 +62,8 @@ DefaultGlobalOrganizationOperationsRestStub::GetOperation(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/", "global",
                    "/", "operations", "/", request.operation()),
-      {std::make_pair("parent_id", request.parent_id())});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("parent_id", request.parent_id())}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::OperationList>
@@ -71,13 +74,14 @@ DefaultGlobalOrganizationOperationsRestStub::ListGlobalOrganizationOperations(
   return rest_internal::Get<google::cloud::cpp::compute::v1::OperationList>(
       *service_, rest_context, request,
       "/compute/v1/locations/global/operations",
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("parent_id", request.parent_id()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("parent_id", request.parent_id()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/compute/global_public_delegated_prefixes/v1/internal/global_public_delegated_prefixes_rest_stub.cc
+++ b/google/cloud/compute/global_public_delegated_prefixes/v1/internal/global_public_delegated_prefixes_rest_stub.cc
@@ -64,7 +64,9 @@ DefaultGlobalPublicDelegatedPrefixesRestStub::AsyncDeletePublicDelegatedPrefix(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "publicDelegatedPrefixes", "/",
-                             request.public_delegated_prefix())));
+                             request.public_delegated_prefix()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -84,8 +86,7 @@ DefaultGlobalPublicDelegatedPrefixesRestStub::GetPublicDelegatedPrefix(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/",
                    "publicDelegatedPrefixes", "/",
-                   request.public_delegated_prefix()),
-      {});
+                   request.public_delegated_prefix()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -105,7 +106,9 @@ DefaultGlobalPublicDelegatedPrefixesRestStub::AsyncInsertPublicDelegatedPrefix(
                 request.public_delegated_prefix_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "publicDelegatedPrefixes")));
+                             "publicDelegatedPrefixes"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -125,12 +128,13 @@ DefaultGlobalPublicDelegatedPrefixesRestStub::ListGlobalPublicDelegatedPrefixes(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/",
                    "publicDelegatedPrefixes"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -151,7 +155,9 @@ DefaultGlobalPublicDelegatedPrefixesRestStub::AsyncPatchPublicDelegatedPrefix(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "publicDelegatedPrefixes", "/",
-                             request.public_delegated_prefix())));
+                             request.public_delegated_prefix()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/health_checks/v1/internal/health_checks_rest_stub.cc
+++ b/google/cloud/compute/health_checks/v1/internal/health_checks_rest_stub.cc
@@ -54,14 +54,15 @@ DefaultHealthChecksRestStub::AggregatedListHealthChecks(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "healthChecks"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -80,7 +81,9 @@ DefaultHealthChecksRestStub::AsyncDeleteHealthCheck(
                 *service, *rest_context, request,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "healthChecks", "/", request.health_check())));
+                             "healthChecks", "/", request.health_check()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -98,8 +101,7 @@ DefaultHealthChecksRestStub::GetHealthCheck(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "healthChecks", "/",
-                   request.health_check()),
-      {});
+                   request.health_check()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -118,7 +120,9 @@ DefaultHealthChecksRestStub::AsyncInsertHealthCheck(
                 *service, *rest_context, request.health_check_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "healthChecks")));
+                             "healthChecks"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -136,12 +140,13 @@ DefaultHealthChecksRestStub::ListHealthChecks(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "healthChecks"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -160,7 +165,9 @@ DefaultHealthChecksRestStub::AsyncPatchHealthCheck(
                 *service, *rest_context, request.health_check_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "healthChecks", "/", request.health_check())));
+                             "healthChecks", "/", request.health_check()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -185,7 +192,9 @@ DefaultHealthChecksRestStub::AsyncUpdateHealthCheck(
                 *service, *rest_context, request.health_check_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "healthChecks", "/", request.health_check())));
+                             "healthChecks", "/", request.health_check()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/http_health_checks/v1/internal/http_health_checks_rest_stub.cc
+++ b/google/cloud/compute/http_health_checks/v1/internal/http_health_checks_rest_stub.cc
@@ -62,7 +62,9 @@ DefaultHttpHealthChecksRestStub::AsyncDeleteHttpHealthCheck(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "httpHealthChecks", "/",
-                             request.http_health_check())));
+                             request.http_health_check()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -80,8 +82,7 @@ DefaultHttpHealthChecksRestStub::GetHttpHealthCheck(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "httpHealthChecks",
-                   "/", request.http_health_check()),
-      {});
+                   "/", request.http_health_check()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -100,7 +101,9 @@ DefaultHttpHealthChecksRestStub::AsyncInsertHttpHealthCheck(
                 *service, *rest_context, request.http_health_check_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "httpHealthChecks")));
+                             "httpHealthChecks"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -119,12 +122,13 @@ DefaultHttpHealthChecksRestStub::ListHttpHealthChecks(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "httpHealthChecks"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -144,7 +148,9 @@ DefaultHttpHealthChecksRestStub::AsyncPatchHttpHealthCheck(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "httpHealthChecks", "/",
-                             request.http_health_check())));
+                             request.http_health_check()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -170,7 +176,9 @@ DefaultHttpHealthChecksRestStub::AsyncUpdateHttpHealthCheck(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "httpHealthChecks", "/",
-                             request.http_health_check())));
+                             request.http_health_check()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/https_health_checks/v1/internal/https_health_checks_rest_stub.cc
+++ b/google/cloud/compute/https_health_checks/v1/internal/https_health_checks_rest_stub.cc
@@ -62,7 +62,9 @@ DefaultHttpsHealthChecksRestStub::AsyncDeleteHttpsHealthCheck(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "httpsHealthChecks", "/",
-                             request.https_health_check())));
+                             request.https_health_check()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -80,8 +82,7 @@ DefaultHttpsHealthChecksRestStub::GetHttpsHealthCheck(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "httpsHealthChecks",
-                   "/", request.https_health_check()),
-      {});
+                   "/", request.https_health_check()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -100,7 +101,9 @@ DefaultHttpsHealthChecksRestStub::AsyncInsertHttpsHealthCheck(
                 *service, *rest_context, request.https_health_check_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "httpsHealthChecks")));
+                             "httpsHealthChecks"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -119,12 +122,13 @@ DefaultHttpsHealthChecksRestStub::ListHttpsHealthChecks(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "httpsHealthChecks"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -144,7 +148,9 @@ DefaultHttpsHealthChecksRestStub::AsyncPatchHttpsHealthCheck(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "httpsHealthChecks", "/",
-                             request.https_health_check())));
+                             request.https_health_check()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -170,7 +176,9 @@ DefaultHttpsHealthChecksRestStub::AsyncUpdateHttpsHealthCheck(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "httpsHealthChecks", "/",
-                             request.https_health_check())));
+                             request.https_health_check()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/image_family_views/v1/internal/image_family_views_rest_stub.cc
+++ b/google/cloud/compute/image_family_views/v1/internal/image_family_views_rest_stub.cc
@@ -48,8 +48,7 @@ DefaultImageFamilyViewsRestStub::GetImageFamilyView(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
-                   "imageFamilyViews", "/", request.family()),
-      {});
+                   "imageFamilyViews", "/", request.family()));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/compute/images/v1/internal/images_rest_stub.cc
+++ b/google/cloud/compute/images/v1/internal/images_rest_stub.cc
@@ -60,7 +60,9 @@ DefaultImagesRestStub::AsyncDeleteImage(
                 *service, *rest_context, request,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "images",
-                             "/", request.image())));
+                             "/", request.image()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -84,7 +86,9 @@ DefaultImagesRestStub::AsyncDeprecate(
                 *service, *rest_context, request.deprecation_status_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "images",
-                             "/", request.image(), "/", "deprecate")));
+                             "/", request.image(), "/", "deprecate"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -101,8 +105,7 @@ DefaultImagesRestStub::GetImage(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "images", "/",
-                   request.image()),
-      {});
+                   request.image()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Image>
@@ -114,8 +117,7 @@ DefaultImagesRestStub::GetFromFamily(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "images", "/",
-                   "family", "/", request.family()),
-      {});
+                   "family", "/", request.family()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>
@@ -128,9 +130,9 @@ DefaultImagesRestStub::GetIamPolicy(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "images", "/",
                    request.resource(), "/", "getIamPolicy"),
-      {std::make_pair(
+      rest_internal::TrimEmptyQueryParameters({std::make_pair(
           "options_requested_policy_version",
-          std::to_string(request.options_requested_policy_version()))});
+          std::to_string(request.options_requested_policy_version()))}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -148,7 +150,11 @@ DefaultImagesRestStub::AsyncInsertImage(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.image_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
-                             request.project(), "/", "global", "/", "images")));
+                             request.project(), "/", "global", "/", "images"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("force_create",
+                                    request.force_create() ? "1" : "0"),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -165,12 +171,13 @@ DefaultImagesRestStub::ListImages(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "images"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -188,7 +195,9 @@ DefaultImagesRestStub::AsyncPatchImage(
                 *service, *rest_context, request.image_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "images",
-                             "/", request.image())));
+                             "/", request.image()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/instance_group_managers/v1/internal/instance_group_managers_rest_stub.cc
+++ b/google/cloud/compute/instance_group_managers/v1/internal/instance_group_managers_rest_stub.cc
@@ -66,7 +66,9 @@ DefaultInstanceGroupManagersRestStub::AsyncAbandonInstances(
                          request.project(), "/", "zones", "/", request.zone(),
                          "/", "instanceGroupManagers", "/",
                          request.instance_group_manager(), "/",
-                         "abandonInstances")));
+                         "abandonInstances"),
+            rest_internal::TrimEmptyQueryParameters(
+                {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -86,14 +88,15 @@ DefaultInstanceGroupManagersRestStub::AggregatedListInstanceGroupManagers(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "instanceGroupManagers"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -144,7 +147,9 @@ DefaultInstanceGroupManagersRestStub::AsyncCreateInstances(
                          request.project(), "/", "zones", "/", request.zone(),
                          "/", "instanceGroupManagers", "/",
                          request.instance_group_manager(), "/",
-                         "createInstances")));
+                         "createInstances"),
+            rest_internal::TrimEmptyQueryParameters(
+                {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -170,7 +175,9 @@ DefaultInstanceGroupManagersRestStub::AsyncDeleteInstanceGroupManager(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instanceGroupManagers", "/",
-                             request.instance_group_manager())));
+                             request.instance_group_manager()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -198,7 +205,9 @@ DefaultInstanceGroupManagersRestStub::AsyncDeleteInstances(
                          request.project(), "/", "zones", "/", request.zone(),
                          "/", "instanceGroupManagers", "/",
                          request.instance_group_manager(), "/",
-                         "deleteInstances")));
+                         "deleteInstances"),
+            rest_internal::TrimEmptyQueryParameters(
+                {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -247,8 +256,7 @@ DefaultInstanceGroupManagersRestStub::GetInstanceGroupManager(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "instanceGroupManagers", "/",
-                   request.instance_group_manager()),
-      {});
+                   request.instance_group_manager()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -268,7 +276,9 @@ DefaultInstanceGroupManagersRestStub::AsyncInsertInstanceGroupManager(
                 request.instance_group_manager_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
-                             request.zone(), "/", "instanceGroupManagers")));
+                             request.zone(), "/", "instanceGroupManagers"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -288,12 +298,13 @@ DefaultInstanceGroupManagersRestStub::ListInstanceGroupManagers(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "instanceGroupManagers"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<
@@ -309,12 +320,13 @@ DefaultInstanceGroupManagersRestStub::ListErrors(
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "instanceGroupManagers", "/",
                    request.instance_group_manager(), "/", "listErrors"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::
@@ -330,7 +342,14 @@ DefaultInstanceGroupManagersRestStub::ListManagedInstances(
       absl::StrCat(
           "/", "compute", "/", "v1", "/", "projects", "/", request.project(),
           "/", "zones", "/", request.zone(), "/", "instanceGroupManagers", "/",
-          request.instance_group_manager(), "/", "listManagedInstances"));
+          request.instance_group_manager(), "/", "listManagedInstances"),
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::
@@ -346,7 +365,14 @@ DefaultInstanceGroupManagersRestStub::ListPerInstanceConfigs(
       absl::StrCat(
           "/", "compute", "/", "v1", "/", "projects", "/", request.project(),
           "/", "zones", "/", request.zone(), "/", "instanceGroupManagers", "/",
-          request.instance_group_manager(), "/", "listPerInstanceConfigs"));
+          request.instance_group_manager(), "/", "listPerInstanceConfigs"),
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -367,7 +393,9 @@ DefaultInstanceGroupManagersRestStub::AsyncPatchInstanceGroupManager(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instanceGroupManagers", "/",
-                             request.instance_group_manager())));
+                             request.instance_group_manager()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -396,7 +424,9 @@ DefaultInstanceGroupManagersRestStub::AsyncPatchPerInstanceConfigs(
                          request.project(), "/", "zones", "/", request.zone(),
                          "/", "instanceGroupManagers", "/",
                          request.instance_group_manager(), "/",
-                         "patchPerInstanceConfigs")));
+                         "patchPerInstanceConfigs"),
+            rest_internal::TrimEmptyQueryParameters(
+                {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -425,7 +455,9 @@ DefaultInstanceGroupManagersRestStub::AsyncRecreateInstances(
                          request.project(), "/", "zones", "/", request.zone(),
                          "/", "instanceGroupManagers", "/",
                          request.instance_group_manager(), "/",
-                         "recreateInstances")));
+                         "recreateInstances"),
+            rest_internal::TrimEmptyQueryParameters(
+                {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -451,7 +483,10 @@ DefaultInstanceGroupManagersRestStub::AsyncResize(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instanceGroupManagers", "/",
-                             request.instance_group_manager(), "/", "resize")));
+                             request.instance_group_manager(), "/", "resize"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id()),
+                     std::make_pair("size", std::to_string(request.size()))})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -480,7 +515,9 @@ DefaultInstanceGroupManagersRestStub::AsyncSetInstanceTemplate(
                          request.project(), "/", "zones", "/", request.zone(),
                          "/", "instanceGroupManagers", "/",
                          request.instance_group_manager(), "/",
-                         "setInstanceTemplate")));
+                         "setInstanceTemplate"),
+            rest_internal::TrimEmptyQueryParameters(
+                {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -508,7 +545,9 @@ DefaultInstanceGroupManagersRestStub::AsyncSetTargetPools(
                          request.project(), "/", "zones", "/", request.zone(),
                          "/", "instanceGroupManagers", "/",
                          request.instance_group_manager(), "/",
-                         "setTargetPools")));
+                         "setTargetPools"),
+            rest_internal::TrimEmptyQueryParameters(
+                {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -537,7 +576,9 @@ DefaultInstanceGroupManagersRestStub::AsyncUpdatePerInstanceConfigs(
                          request.project(), "/", "zones", "/", request.zone(),
                          "/", "instanceGroupManagers", "/",
                          request.instance_group_manager(), "/",
-                         "updatePerInstanceConfigs")));
+                         "updatePerInstanceConfigs"),
+            rest_internal::TrimEmptyQueryParameters(
+                {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/instance_groups/v1/internal/instance_groups_rest_stub.cc
+++ b/google/cloud/compute/instance_groups/v1/internal/instance_groups_rest_stub.cc
@@ -62,7 +62,9 @@ DefaultInstanceGroupsRestStub::AsyncAddInstances(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instanceGroups", "/",
-                             request.instance_group(), "/", "addInstances")));
+                             request.instance_group(), "/", "addInstances"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -81,14 +83,15 @@ DefaultInstanceGroupsRestStub::AggregatedListInstanceGroups(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "instanceGroups"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -108,7 +111,9 @@ DefaultInstanceGroupsRestStub::AsyncDeleteInstanceGroup(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instanceGroups", "/",
-                             request.instance_group())));
+                             request.instance_group()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -126,8 +131,7 @@ DefaultInstanceGroupsRestStub::GetInstanceGroup(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
-                   "instanceGroups", "/", request.instance_group()),
-      {});
+                   "instanceGroups", "/", request.instance_group()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -146,7 +150,9 @@ DefaultInstanceGroupsRestStub::AsyncInsertInstanceGroup(
                 *service, *rest_context, request.instance_group_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
-                             request.zone(), "/", "instanceGroups")));
+                             request.zone(), "/", "instanceGroups"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -165,12 +171,13 @@ DefaultInstanceGroupsRestStub::ListInstanceGroups(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "instanceGroups"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::InstanceGroupsListInstances>
@@ -185,7 +192,14 @@ DefaultInstanceGroupsRestStub::ListInstances(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "instanceGroups", "/", request.instance_group(), "/",
-                   "listInstances"));
+                   "listInstances"),
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -206,8 +220,9 @@ DefaultInstanceGroupsRestStub::AsyncRemoveInstances(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instanceGroups", "/",
-                             request.instance_group(), "/",
-                             "removeInstances")));
+                             request.instance_group(), "/", "removeInstances"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -234,7 +249,9 @@ DefaultInstanceGroupsRestStub::AsyncSetNamedPorts(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instanceGroups", "/",
-                             request.instance_group(), "/", "setNamedPorts")));
+                             request.instance_group(), "/", "setNamedPorts"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/instance_templates/v1/internal/instance_templates_rest_stub.cc
+++ b/google/cloud/compute/instance_templates/v1/internal/instance_templates_rest_stub.cc
@@ -56,14 +56,15 @@ DefaultInstanceTemplatesRestStub::AggregatedListInstanceTemplates(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "instanceTemplates"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -83,7 +84,9 @@ DefaultInstanceTemplatesRestStub::AsyncDeleteInstanceTemplate(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "instanceTemplates", "/",
-                             request.instance_template())));
+                             request.instance_template()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -101,8 +104,7 @@ DefaultInstanceTemplatesRestStub::GetInstanceTemplate(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "instanceTemplates",
-                   "/", request.instance_template()),
-      {});
+                   "/", request.instance_template()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>
@@ -115,9 +117,9 @@ DefaultInstanceTemplatesRestStub::GetIamPolicy(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "instanceTemplates",
                    "/", request.resource(), "/", "getIamPolicy"),
-      {std::make_pair(
+      rest_internal::TrimEmptyQueryParameters({std::make_pair(
           "options_requested_policy_version",
-          std::to_string(request.options_requested_policy_version()))});
+          std::to_string(request.options_requested_policy_version()))}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -136,7 +138,9 @@ DefaultInstanceTemplatesRestStub::AsyncInsertInstanceTemplate(
                 *service, *rest_context, request.instance_template_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "instanceTemplates")));
+                             "instanceTemplates"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -155,12 +159,13 @@ DefaultInstanceTemplatesRestStub::ListInstanceTemplates(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "instanceTemplates"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>

--- a/google/cloud/compute/instances/v1/internal/instances_rest_stub.cc
+++ b/google/cloud/compute/instances/v1/internal/instances_rest_stub.cc
@@ -61,7 +61,11 @@ DefaultInstancesRestStub::AsyncAddAccessConfig(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
-                             request.instance(), "/", "addAccessConfig")));
+                             request.instance(), "/", "addAccessConfig"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("network_interface",
+                                    request.network_interface()),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -88,7 +92,9 @@ DefaultInstancesRestStub::AsyncAddResourcePolicies(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
-                             request.instance(), "/", "addResourcePolicies")));
+                             request.instance(), "/", "addResourcePolicies"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -107,14 +113,15 @@ DefaultInstancesRestStub::AggregatedListInstances(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "instances"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -134,7 +141,11 @@ DefaultInstancesRestStub::AsyncAttachDisk(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
-                             request.instance(), "/", "attachDisk")));
+                             request.instance(), "/", "attachDisk"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("force_attach",
+                                    request.force_attach() ? "1" : "0"),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -161,7 +172,9 @@ DefaultInstancesRestStub::AsyncBulkInsert(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
-                             "bulkInsert")));
+                             "bulkInsert"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -187,7 +200,9 @@ DefaultInstancesRestStub::AsyncDeleteInstance(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
-                             request.instance())));
+                             request.instance()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -213,7 +228,12 @@ DefaultInstancesRestStub::AsyncDeleteAccessConfig(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
-                             request.instance(), "/", "deleteAccessConfig")));
+                             request.instance(), "/", "deleteAccessConfig"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("access_config", request.access_config()),
+                     std::make_pair("network_interface",
+                                    request.network_interface()),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -239,7 +259,10 @@ DefaultInstancesRestStub::AsyncDetachDisk(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
-                             request.instance(), "/", "detachDisk")));
+                             request.instance(), "/", "detachDisk"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("device_name", request.device_name()),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -257,8 +280,7 @@ DefaultInstancesRestStub::GetInstance(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
-                   "instances", "/", request.instance()),
-      {});
+                   "instances", "/", request.instance()));
 }
 
 StatusOr<
@@ -274,7 +296,8 @@ DefaultInstancesRestStub::GetEffectiveFirewalls(
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "instances", "/", request.instance(), "/",
                    "getEffectiveFirewalls"),
-      {std::make_pair("network_interface", request.network_interface())});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("network_interface", request.network_interface())}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::GuestAttributes>
@@ -288,8 +311,9 @@ DefaultInstancesRestStub::GetGuestAttributes(
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "instances", "/", request.instance(), "/",
                    "getGuestAttributes"),
-      {std::make_pair("query_path", request.query_path()),
-       std::make_pair("variable_key", request.variable_key())});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("query_path", request.query_path()),
+           std::make_pair("variable_key", request.variable_key())}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>
@@ -302,9 +326,9 @@ DefaultInstancesRestStub::GetIamPolicy(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "instances", "/", request.resource(), "/", "getIamPolicy"),
-      {std::make_pair(
+      rest_internal::TrimEmptyQueryParameters({std::make_pair(
           "options_requested_policy_version",
-          std::to_string(request.options_requested_policy_version()))});
+          std::to_string(request.options_requested_policy_version()))}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Screenshot>
@@ -316,8 +340,7 @@ DefaultInstancesRestStub::GetScreenshot(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
-                   "instances", "/", request.instance(), "/", "screenshot"),
-      {});
+                   "instances", "/", request.instance(), "/", "screenshot"));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::SerialPortOutput>
@@ -330,8 +353,9 @@ DefaultInstancesRestStub::GetSerialPortOutput(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "instances", "/", request.instance(), "/", "serialPort"),
-      {std::make_pair("port", std::to_string(request.port())),
-       std::make_pair("start", request.start())});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("port", std::to_string(request.port())),
+           std::make_pair("start", request.start())}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::ShieldedInstanceIdentity>
@@ -345,8 +369,7 @@ DefaultInstancesRestStub::GetShieldedInstanceIdentity(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "instances", "/", request.instance(), "/",
-                   "getShieldedInstanceIdentity"),
-      {});
+                   "getShieldedInstanceIdentity"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -365,7 +388,13 @@ DefaultInstancesRestStub::AsyncInsertInstance(
                 *service, *rest_context, request.instance_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
-                             request.zone(), "/", "instances")));
+                             request.zone(), "/", "instances"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id()),
+                     std::make_pair("source_instance_template",
+                                    request.source_instance_template()),
+                     std::make_pair("source_machine_image",
+                                    request.source_machine_image())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -384,12 +413,13 @@ DefaultInstancesRestStub::ListInstances(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "instances"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::InstanceListReferrers>
@@ -403,12 +433,13 @@ DefaultInstancesRestStub::ListReferrers(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "instances", "/", request.instance(), "/", "referrers"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -429,8 +460,9 @@ DefaultInstancesRestStub::AsyncRemoveResourcePolicies(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
-                             request.instance(), "/",
-                             "removeResourcePolicies")));
+                             request.instance(), "/", "removeResourcePolicies"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -455,7 +487,9 @@ DefaultInstancesRestStub::AsyncReset(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
-                             request.instance(), "/", "reset")));
+                             request.instance(), "/", "reset"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -480,7 +514,9 @@ DefaultInstancesRestStub::AsyncResume(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
-                             request.instance(), "/", "resume")));
+                             request.instance(), "/", "resume"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -518,8 +554,11 @@ DefaultInstancesRestStub::AsyncSetDeletionProtection(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
-                             request.resource(), "/",
-                             "setDeletionProtection")));
+                             request.resource(), "/", "setDeletionProtection"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("deletion_protection",
+                                    request.deletion_protection() ? "1" : "0"),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -545,7 +584,12 @@ DefaultInstancesRestStub::AsyncSetDiskAutoDelete(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
-                             request.instance(), "/", "setDiskAutoDelete")));
+                             request.instance(), "/", "setDiskAutoDelete"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("auto_delete",
+                                    request.auto_delete() ? "1" : "0"),
+                     std::make_pair("device_name", request.device_name()),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -584,7 +628,9 @@ DefaultInstancesRestStub::AsyncSetLabels(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
-                             request.instance(), "/", "setLabels")));
+                             request.instance(), "/", "setLabels"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -611,7 +657,9 @@ DefaultInstancesRestStub::AsyncSetMachineResources(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
-                             request.instance(), "/", "setMachineResources")));
+                             request.instance(), "/", "setMachineResources"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -638,7 +686,9 @@ DefaultInstancesRestStub::AsyncSetMachineType(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
-                             request.instance(), "/", "setMachineType")));
+                             request.instance(), "/", "setMachineType"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -664,7 +714,9 @@ DefaultInstancesRestStub::AsyncSetMetadata(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
-                             request.instance(), "/", "setMetadata")));
+                             request.instance(), "/", "setMetadata"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -691,7 +743,9 @@ DefaultInstancesRestStub::AsyncSetMinCpuPlatform(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
-                             request.instance(), "/", "setMinCpuPlatform")));
+                             request.instance(), "/", "setMinCpuPlatform"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -717,7 +771,9 @@ DefaultInstancesRestStub::AsyncSetName(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
-                             request.instance(), "/", "setName")));
+                             request.instance(), "/", "setName"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -743,7 +799,9 @@ DefaultInstancesRestStub::AsyncSetScheduling(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
-                             request.instance(), "/", "setScheduling")));
+                             request.instance(), "/", "setScheduling"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -770,7 +828,9 @@ DefaultInstancesRestStub::AsyncSetServiceAccount(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
-                             request.instance(), "/", "setServiceAccount")));
+                             request.instance(), "/", "setServiceAccount"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -798,7 +858,9 @@ DefaultInstancesRestStub::AsyncSetShieldedInstanceIntegrityPolicy(
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
                              request.instance(), "/",
-                             "setShieldedInstanceIntegrityPolicy")));
+                             "setShieldedInstanceIntegrityPolicy"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -823,7 +885,9 @@ DefaultInstancesRestStub::AsyncSetTags(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
-                             request.instance(), "/", "setTags")));
+                             request.instance(), "/", "setTags"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -850,7 +914,9 @@ DefaultInstancesRestStub::AsyncSimulateMaintenanceEvent(
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
                              request.instance(), "/",
-                             "simulateMaintenanceEvent")));
+                             "simulateMaintenanceEvent"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -875,7 +941,9 @@ DefaultInstancesRestStub::AsyncStart(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
-                             request.instance(), "/", "start")));
+                             request.instance(), "/", "start"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -902,8 +970,9 @@ DefaultInstancesRestStub::AsyncStartWithEncryptionKey(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
-                             request.instance(), "/",
-                             "startWithEncryptionKey")));
+                             request.instance(), "/", "startWithEncryptionKey"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -928,7 +997,11 @@ DefaultInstancesRestStub::AsyncStop(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
-                             request.instance(), "/", "stop")));
+                             request.instance(), "/", "stop"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("discard_local_ssd",
+                                    request.discard_local_ssd() ? "1" : "0"),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -953,7 +1026,11 @@ DefaultInstancesRestStub::AsyncSuspend(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
-                             request.instance(), "/", "suspend")));
+                             request.instance(), "/", "suspend"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("discard_local_ssd",
+                                    request.discard_local_ssd() ? "1" : "0"),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -993,7 +1070,12 @@ DefaultInstancesRestStub::AsyncUpdateInstance(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
-                             request.instance())));
+                             request.instance()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("minimal_action", request.minimal_action()),
+                     std::make_pair("most_disruptive_allowed_action",
+                                    request.most_disruptive_allowed_action()),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -1019,7 +1101,11 @@ DefaultInstancesRestStub::AsyncUpdateAccessConfig(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
-                             request.instance(), "/", "updateAccessConfig")));
+                             request.instance(), "/", "updateAccessConfig"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("network_interface",
+                                    request.network_interface()),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -1045,7 +1131,9 @@ DefaultInstancesRestStub::AsyncUpdateDisplayDevice(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
-                             request.instance(), "/", "updateDisplayDevice")));
+                             request.instance(), "/", "updateDisplayDevice"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -1071,8 +1159,11 @@ DefaultInstancesRestStub::AsyncUpdateNetworkInterface(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
-                             request.instance(), "/",
-                             "updateNetworkInterface")));
+                             request.instance(), "/", "updateNetworkInterface"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("network_interface",
+                                    request.network_interface()),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -1100,7 +1191,9 @@ DefaultInstancesRestStub::AsyncUpdateShieldedInstanceConfig(
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
                              request.instance(), "/",
-                             "updateShieldedInstanceConfig")));
+                             "updateShieldedInstanceConfig"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/interconnect_attachments/v1/internal/interconnect_attachments_rest_stub.cc
+++ b/google/cloud/compute/interconnect_attachments/v1/internal/interconnect_attachments_rest_stub.cc
@@ -57,14 +57,15 @@ DefaultInterconnectAttachmentsRestStub::AggregatedListInterconnectAttachments(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "interconnectAttachments"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -84,7 +85,9 @@ DefaultInterconnectAttachmentsRestStub::AsyncDeleteInterconnectAttachment(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "interconnectAttachments",
-                             "/", request.interconnect_attachment())));
+                             "/", request.interconnect_attachment()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -104,8 +107,7 @@ DefaultInterconnectAttachmentsRestStub::GetInterconnectAttachment(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "interconnectAttachments", "/",
-                   request.interconnect_attachment()),
-      {});
+                   request.interconnect_attachment()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -125,8 +127,11 @@ DefaultInterconnectAttachmentsRestStub::AsyncInsertInterconnectAttachment(
                 request.interconnect_attachment_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/",
-                             "interconnectAttachments")));
+                             request.region(), "/", "interconnectAttachments"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id()),
+                     std::make_pair("validate_only",
+                                    request.validate_only() ? "1" : "0")})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -146,12 +151,13 @@ DefaultInterconnectAttachmentsRestStub::ListInterconnectAttachments(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "interconnectAttachments"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -172,7 +178,9 @@ DefaultInterconnectAttachmentsRestStub::AsyncPatchInterconnectAttachment(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "interconnectAttachments",
-                             "/", request.interconnect_attachment())));
+                             "/", request.interconnect_attachment()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -199,7 +207,9 @@ DefaultInterconnectAttachmentsRestStub::AsyncSetLabels(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "interconnectAttachments",
-                             "/", request.resource(), "/", "setLabels")));
+                             "/", request.resource(), "/", "setLabels"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/interconnect_locations/v1/internal/interconnect_locations_rest_stub.cc
+++ b/google/cloud/compute/interconnect_locations/v1/internal/interconnect_locations_rest_stub.cc
@@ -51,8 +51,7 @@ DefaultInterconnectLocationsRestStub::GetInterconnectLocation(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/",
                    "interconnectLocations", "/",
-                   request.interconnect_location()),
-      {});
+                   request.interconnect_location()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::InterconnectLocationList>
@@ -66,12 +65,13 @@ DefaultInterconnectLocationsRestStub::ListInterconnectLocations(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/",
                    "interconnectLocations"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/compute/interconnect_remote_locations/v1/internal/interconnect_remote_locations_rest_stub.cc
+++ b/google/cloud/compute/interconnect_remote_locations/v1/internal/interconnect_remote_locations_rest_stub.cc
@@ -52,8 +52,7 @@ DefaultInterconnectRemoteLocationsRestStub::GetInterconnectRemoteLocation(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/",
                    "interconnectRemoteLocations", "/",
-                   request.interconnect_remote_location()),
-      {});
+                   request.interconnect_remote_location()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::InterconnectRemoteLocationList>
@@ -67,12 +66,13 @@ DefaultInterconnectRemoteLocationsRestStub::ListInterconnectRemoteLocations(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/",
                    "interconnectRemoteLocations"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/compute/interconnects/v1/internal/interconnects_rest_stub.cc
+++ b/google/cloud/compute/interconnects/v1/internal/interconnects_rest_stub.cc
@@ -60,7 +60,9 @@ DefaultInterconnectsRestStub::AsyncDeleteInterconnect(
                 *service, *rest_context, request,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "interconnects", "/", request.interconnect())));
+                             "interconnects", "/", request.interconnect()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -78,8 +80,7 @@ DefaultInterconnectsRestStub::GetInterconnect(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "interconnects", "/",
-                   request.interconnect()),
-      {});
+                   request.interconnect()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::InterconnectsGetDiagnosticsResponse>
@@ -92,8 +93,7 @@ DefaultInterconnectsRestStub::GetDiagnostics(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "interconnects", "/",
-                   request.interconnect(), "/", "getDiagnostics"),
-      {});
+                   request.interconnect(), "/", "getDiagnostics"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -112,7 +112,9 @@ DefaultInterconnectsRestStub::AsyncInsertInterconnect(
                 *service, *rest_context, request.interconnect_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "interconnects")));
+                             "interconnects"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -130,12 +132,13 @@ DefaultInterconnectsRestStub::ListInterconnects(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "interconnects"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -154,7 +157,9 @@ DefaultInterconnectsRestStub::AsyncPatchInterconnect(
                 *service, *rest_context, request.interconnect_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "interconnects", "/", request.interconnect())));
+                             "interconnects", "/", request.interconnect()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/license_codes/v1/internal/license_codes_rest_stub.cc
+++ b/google/cloud/compute/license_codes/v1/internal/license_codes_rest_stub.cc
@@ -47,8 +47,7 @@ DefaultLicenseCodesRestStub::GetLicenseCode(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "licenseCodes", "/",
-                   request.license_code()),
-      {});
+                   request.license_code()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>

--- a/google/cloud/compute/licenses/v1/internal/licenses_rest_stub.cc
+++ b/google/cloud/compute/licenses/v1/internal/licenses_rest_stub.cc
@@ -60,7 +60,9 @@ DefaultLicensesRestStub::AsyncDeleteLicense(
                 *service, *rest_context, request,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "licenses",
-                             "/", request.license())));
+                             "/", request.license()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -78,8 +80,7 @@ DefaultLicensesRestStub::GetLicense(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "licenses", "/",
-                   request.license()),
-      {});
+                   request.license()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>
@@ -92,9 +93,9 @@ DefaultLicensesRestStub::GetIamPolicy(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "licenses", "/",
                    request.resource(), "/", "getIamPolicy"),
-      {std::make_pair(
+      rest_internal::TrimEmptyQueryParameters({std::make_pair(
           "options_requested_policy_version",
-          std::to_string(request.options_requested_policy_version()))});
+          std::to_string(request.options_requested_policy_version()))}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -112,8 +113,9 @@ DefaultLicensesRestStub::AsyncInsertLicense(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.license_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
-                             request.project(), "/", "global", "/",
-                             "licenses")));
+                             request.project(), "/", "global", "/", "licenses"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -132,12 +134,13 @@ DefaultLicensesRestStub::ListLicenses(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "licenses"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>

--- a/google/cloud/compute/machine_images/v1/internal/machine_images_rest_stub.cc
+++ b/google/cloud/compute/machine_images/v1/internal/machine_images_rest_stub.cc
@@ -60,7 +60,9 @@ DefaultMachineImagesRestStub::AsyncDeleteMachineImage(
                 *service, *rest_context, request,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "machineImages", "/", request.machine_image())));
+                             "machineImages", "/", request.machine_image()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -78,8 +80,7 @@ DefaultMachineImagesRestStub::GetMachineImage(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "machineImages", "/",
-                   request.machine_image()),
-      {});
+                   request.machine_image()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>
@@ -92,9 +93,9 @@ DefaultMachineImagesRestStub::GetIamPolicy(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "machineImages", "/",
                    request.resource(), "/", "getIamPolicy"),
-      {std::make_pair(
+      rest_internal::TrimEmptyQueryParameters({std::make_pair(
           "options_requested_policy_version",
-          std::to_string(request.options_requested_policy_version()))});
+          std::to_string(request.options_requested_policy_version()))}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -113,7 +114,11 @@ DefaultMachineImagesRestStub::AsyncInsertMachineImage(
                 *service, *rest_context, request.machine_image_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "machineImages")));
+                             "machineImages"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id()),
+                     std::make_pair("source_instance",
+                                    request.source_instance())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -131,12 +136,13 @@ DefaultMachineImagesRestStub::ListMachineImages(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "machineImages"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>

--- a/google/cloud/compute/machine_types/v1/internal/machine_types_rest_stub.cc
+++ b/google/cloud/compute/machine_types/v1/internal/machine_types_rest_stub.cc
@@ -48,14 +48,15 @@ DefaultMachineTypesRestStub::AggregatedListMachineTypes(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "machineTypes"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::MachineType>
@@ -67,8 +68,7 @@ DefaultMachineTypesRestStub::GetMachineType(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
-                   "machineTypes", "/", request.machine_type()),
-      {});
+                   "machineTypes", "/", request.machine_type()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::MachineTypeList>
@@ -81,12 +81,13 @@ DefaultMachineTypesRestStub::ListMachineTypes(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "machineTypes"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/compute/network_attachments/v1/internal/network_attachments_rest_stub.cc
+++ b/google/cloud/compute/network_attachments/v1/internal/network_attachments_rest_stub.cc
@@ -56,14 +56,15 @@ DefaultNetworkAttachmentsRestStub::AggregatedListNetworkAttachments(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "networkAttachments"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -83,7 +84,9 @@ DefaultNetworkAttachmentsRestStub::AsyncDeleteNetworkAttachment(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "networkAttachments", "/",
-                             request.network_attachment())));
+                             request.network_attachment()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -102,8 +105,7 @@ DefaultNetworkAttachmentsRestStub::GetNetworkAttachment(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "networkAttachments", "/",
-                   request.network_attachment()),
-      {});
+                   request.network_attachment()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>
@@ -117,9 +119,9 @@ DefaultNetworkAttachmentsRestStub::GetIamPolicy(
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "networkAttachments", "/", request.resource(), "/",
                    "getIamPolicy"),
-      {std::make_pair(
+      rest_internal::TrimEmptyQueryParameters({std::make_pair(
           "options_requested_policy_version",
-          std::to_string(request.options_requested_policy_version()))});
+          std::to_string(request.options_requested_policy_version()))}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -138,7 +140,9 @@ DefaultNetworkAttachmentsRestStub::AsyncInsertNetworkAttachment(
                 *service, *rest_context, request.network_attachment_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "networkAttachments")));
+                             request.region(), "/", "networkAttachments"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -158,12 +162,13 @@ DefaultNetworkAttachmentsRestStub::ListNetworkAttachments(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "networkAttachments"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>

--- a/google/cloud/compute/network_edge_security_services/v1/internal/network_edge_security_services_rest_stub.cc
+++ b/google/cloud/compute/network_edge_security_services/v1/internal/network_edge_security_services_rest_stub.cc
@@ -60,14 +60,15 @@ DefaultNetworkEdgeSecurityServicesRestStub::
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "networkEdgeSecurityServices"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -89,7 +90,9 @@ DefaultNetworkEdgeSecurityServicesRestStub::
                              request.project(), "/", "regions", "/",
                              request.region(), "/",
                              "networkEdgeSecurityServices", "/",
-                             request.network_edge_security_service())));
+                             request.network_edge_security_service()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -109,8 +112,7 @@ DefaultNetworkEdgeSecurityServicesRestStub::GetNetworkEdgeSecurityService(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "networkEdgeSecurityServices", "/",
-                   request.network_edge_security_service()),
-      {});
+                   request.network_edge_security_service()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -132,7 +134,11 @@ DefaultNetworkEdgeSecurityServicesRestStub::
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/",
-                             "networkEdgeSecurityServices")));
+                             "networkEdgeSecurityServices"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id()),
+                     std::make_pair("validate_only",
+                                    request.validate_only() ? "1" : "0")})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -161,7 +167,11 @@ DefaultNetworkEdgeSecurityServicesRestStub::
                              request.project(), "/", "regions", "/",
                              request.region(), "/",
                              "networkEdgeSecurityServices", "/",
-                             request.network_edge_security_service())));
+                             request.network_edge_security_service()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("paths", request.paths()),
+                     std::make_pair("request_id", request.request_id()),
+                     std::make_pair("update_mask", request.update_mask())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/network_endpoint_groups/v1/internal/network_endpoint_groups_rest_stub.cc
+++ b/google/cloud/compute/network_endpoint_groups/v1/internal/network_endpoint_groups_rest_stub.cc
@@ -57,14 +57,15 @@ DefaultNetworkEndpointGroupsRestStub::AggregatedListNetworkEndpointGroups(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "networkEndpointGroups"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -86,7 +87,9 @@ DefaultNetworkEndpointGroupsRestStub::AsyncAttachNetworkEndpoints(
                          request.project(), "/", "zones", "/", request.zone(),
                          "/", "networkEndpointGroups", "/",
                          request.network_endpoint_group(), "/",
-                         "attachNetworkEndpoints")));
+                         "attachNetworkEndpoints"),
+            rest_internal::TrimEmptyQueryParameters(
+                {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -112,7 +115,9 @@ DefaultNetworkEndpointGroupsRestStub::AsyncDeleteNetworkEndpointGroup(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "networkEndpointGroups", "/",
-                             request.network_endpoint_group())));
+                             request.network_endpoint_group()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -140,7 +145,9 @@ DefaultNetworkEndpointGroupsRestStub::AsyncDetachNetworkEndpoints(
                          request.project(), "/", "zones", "/", request.zone(),
                          "/", "networkEndpointGroups", "/",
                          request.network_endpoint_group(), "/",
-                         "detachNetworkEndpoints")));
+                         "detachNetworkEndpoints"),
+            rest_internal::TrimEmptyQueryParameters(
+                {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -160,8 +167,7 @@ DefaultNetworkEndpointGroupsRestStub::GetNetworkEndpointGroup(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "networkEndpointGroups", "/",
-                   request.network_endpoint_group()),
-      {});
+                   request.network_endpoint_group()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -181,7 +187,9 @@ DefaultNetworkEndpointGroupsRestStub::AsyncInsertNetworkEndpointGroup(
                 request.network_endpoint_group_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
-                             request.zone(), "/", "networkEndpointGroups")));
+                             request.zone(), "/", "networkEndpointGroups"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -201,12 +209,13 @@ DefaultNetworkEndpointGroupsRestStub::ListNetworkEndpointGroups(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "networkEndpointGroups"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<
@@ -222,7 +231,14 @@ DefaultNetworkEndpointGroupsRestStub::ListNetworkEndpoints(
       absl::StrCat(
           "/", "compute", "/", "v1", "/", "projects", "/", request.project(),
           "/", "zones", "/", request.zone(), "/", "networkEndpointGroups", "/",
-          request.network_endpoint_group(), "/", "listNetworkEndpoints"));
+          request.network_endpoint_group(), "/", "listNetworkEndpoints"),
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>

--- a/google/cloud/compute/network_firewall_policies/v1/internal/network_firewall_policies_rest_stub.cc
+++ b/google/cloud/compute/network_firewall_policies/v1/internal/network_firewall_policies_rest_stub.cc
@@ -64,7 +64,12 @@ DefaultNetworkFirewallPoliciesRestStub::AsyncAddAssociation(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "firewallPolicies", "/", request.firewall_policy(),
-                             "/", "addAssociation")));
+                             "/", "addAssociation"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair(
+                         "replace_existing_association",
+                         request.replace_existing_association() ? "1" : "0"),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -91,7 +96,13 @@ DefaultNetworkFirewallPoliciesRestStub::AsyncAddRule(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "firewallPolicies", "/", request.firewall_policy(),
-                             "/", "addRule")));
+                             "/", "addRule"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("max_priority",
+                                    std::to_string(request.max_priority())),
+                     std::make_pair("min_priority",
+                                    std::to_string(request.min_priority())),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -117,7 +128,11 @@ DefaultNetworkFirewallPoliciesRestStub::AsyncCloneRules(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "firewallPolicies", "/", request.firewall_policy(),
-                             "/", "cloneRules")));
+                             "/", "cloneRules"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id()),
+                     std::make_pair("source_firewall_policy",
+                                    request.source_firewall_policy())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -143,7 +158,9 @@ DefaultNetworkFirewallPoliciesRestStub::AsyncDeleteFirewallPolicy(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "firewallPolicies", "/",
-                             request.firewall_policy())));
+                             request.firewall_policy()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -161,8 +178,7 @@ DefaultNetworkFirewallPoliciesRestStub::GetFirewallPolicy(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "firewallPolicies",
-                   "/", request.firewall_policy()),
-      {});
+                   "/", request.firewall_policy()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::FirewallPolicyAssociation>
@@ -176,7 +192,8 @@ DefaultNetworkFirewallPoliciesRestStub::GetAssociation(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "firewallPolicies",
                    "/", request.firewall_policy(), "/", "getAssociation"),
-      {std::make_pair("name", request.name())});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("name", request.name())}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>
@@ -189,9 +206,9 @@ DefaultNetworkFirewallPoliciesRestStub::GetIamPolicy(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "firewallPolicies",
                    "/", request.resource(), "/", "getIamPolicy"),
-      {std::make_pair(
+      rest_internal::TrimEmptyQueryParameters({std::make_pair(
           "options_requested_policy_version",
-          std::to_string(request.options_requested_policy_version()))});
+          std::to_string(request.options_requested_policy_version()))}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::FirewallPolicyRule>
@@ -205,7 +222,8 @@ DefaultNetworkFirewallPoliciesRestStub::GetRule(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "firewallPolicies",
                    "/", request.firewall_policy(), "/", "getRule"),
-      {std::make_pair("priority", std::to_string(request.priority()))});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("priority", std::to_string(request.priority()))}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -224,7 +242,9 @@ DefaultNetworkFirewallPoliciesRestStub::AsyncInsertFirewallPolicy(
                 *service, *rest_context, request.firewall_policy_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "firewallPolicies")));
+                             "firewallPolicies"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -243,12 +263,13 @@ DefaultNetworkFirewallPoliciesRestStub::ListNetworkFirewallPolicies(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "firewallPolicies"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -268,7 +289,9 @@ DefaultNetworkFirewallPoliciesRestStub::AsyncPatchFirewallPolicy(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "firewallPolicies", "/",
-                             request.firewall_policy())));
+                             request.firewall_policy()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -295,7 +318,11 @@ DefaultNetworkFirewallPoliciesRestStub::AsyncPatchRule(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "firewallPolicies", "/", request.firewall_policy(),
-                             "/", "patchRule")));
+                             "/", "patchRule"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("priority",
+                                    std::to_string(request.priority())),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -321,7 +348,10 @@ DefaultNetworkFirewallPoliciesRestStub::AsyncRemoveAssociation(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "firewallPolicies", "/", request.firewall_policy(),
-                             "/", "removeAssociation")));
+                             "/", "removeAssociation"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("name", request.name()),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -347,7 +377,11 @@ DefaultNetworkFirewallPoliciesRestStub::AsyncRemoveRule(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "firewallPolicies", "/", request.firewall_policy(),
-                             "/", "removeRule")));
+                             "/", "removeRule"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("priority",
+                                    std::to_string(request.priority())),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/networks/v1/internal/networks_rest_stub.cc
+++ b/google/cloud/compute/networks/v1/internal/networks_rest_stub.cc
@@ -61,7 +61,9 @@ DefaultNetworksRestStub::AsyncAddPeering(
                 request.networks_add_peering_request_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "networks",
-                             "/", request.network(), "/", "addPeering")));
+                             "/", request.network(), "/", "addPeering"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -86,7 +88,9 @@ DefaultNetworksRestStub::AsyncDeleteNetwork(
                 *service, *rest_context, request,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "networks",
-                             "/", request.network())));
+                             "/", request.network()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -104,8 +108,7 @@ DefaultNetworksRestStub::GetNetwork(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "networks", "/",
-                   request.network()),
-      {});
+                   request.network()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::NetworksGetEffectiveFirewallsResponse>
@@ -118,8 +121,7 @@ DefaultNetworksRestStub::GetEffectiveFirewalls(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "networks", "/",
-                   request.network(), "/", "getEffectiveFirewalls"),
-      {});
+                   request.network(), "/", "getEffectiveFirewalls"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -137,8 +139,9 @@ DefaultNetworksRestStub::AsyncInsertNetwork(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.network_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
-                             request.project(), "/", "global", "/",
-                             "networks")));
+                             request.project(), "/", "global", "/", "networks"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -156,12 +159,13 @@ DefaultNetworksRestStub::ListNetworks(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "networks"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::ExchangedPeeringRoutesList>
@@ -175,15 +179,16 @@ DefaultNetworksRestStub::ListPeeringRoutes(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "networks", "/",
                    request.network(), "/", "listPeeringRoutes"),
-      {std::make_pair("direction", request.direction()),
-       std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("peering_name", request.peering_name()),
-       std::make_pair("region", request.region()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("direction", request.direction()),
+           std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("peering_name", request.peering_name()),
+           std::make_pair("region", request.region()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -202,7 +207,9 @@ DefaultNetworksRestStub::AsyncPatchNetwork(
                 *service, *rest_context, request.network_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "networks",
-                             "/", request.network())));
+                             "/", request.network()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -228,7 +235,9 @@ DefaultNetworksRestStub::AsyncRemovePeering(
                 request.networks_remove_peering_request_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "networks",
-                             "/", request.network(), "/", "removePeering")));
+                             "/", request.network(), "/", "removePeering"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -253,8 +262,9 @@ DefaultNetworksRestStub::AsyncSwitchToCustomMode(
                 *service, *rest_context, request,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "networks",
-                             "/", request.network(), "/",
-                             "switchToCustomMode")));
+                             "/", request.network(), "/", "switchToCustomMode"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -280,7 +290,9 @@ DefaultNetworksRestStub::AsyncUpdatePeering(
                 request.networks_update_peering_request_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "networks",
-                             "/", request.network(), "/", "updatePeering")));
+                             "/", request.network(), "/", "updatePeering"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/node_groups/v1/internal/node_groups_rest_stub.cc
+++ b/google/cloud/compute/node_groups/v1/internal/node_groups_rest_stub.cc
@@ -62,7 +62,9 @@ DefaultNodeGroupsRestStub::AsyncAddNodes(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "nodeGroups", "/",
-                             request.node_group(), "/", "addNodes")));
+                             request.node_group(), "/", "addNodes"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -81,14 +83,15 @@ DefaultNodeGroupsRestStub::AggregatedListNodeGroups(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "nodeGroups"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -108,7 +111,9 @@ DefaultNodeGroupsRestStub::AsyncDeleteNodeGroup(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "nodeGroups", "/",
-                             request.node_group())));
+                             request.node_group()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -135,7 +140,9 @@ DefaultNodeGroupsRestStub::AsyncDeleteNodes(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "nodeGroups", "/",
-                             request.node_group(), "/", "deleteNodes")));
+                             request.node_group(), "/", "deleteNodes"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -153,8 +160,7 @@ DefaultNodeGroupsRestStub::GetNodeGroup(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
-                   "nodeGroups", "/", request.node_group()),
-      {});
+                   "nodeGroups", "/", request.node_group()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>
@@ -167,9 +173,9 @@ DefaultNodeGroupsRestStub::GetIamPolicy(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "nodeGroups", "/", request.resource(), "/", "getIamPolicy"),
-      {std::make_pair(
+      rest_internal::TrimEmptyQueryParameters({std::make_pair(
           "options_requested_policy_version",
-          std::to_string(request.options_requested_policy_version()))});
+          std::to_string(request.options_requested_policy_version()))}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -188,7 +194,12 @@ DefaultNodeGroupsRestStub::AsyncInsertNodeGroup(
                 *service, *rest_context, request.node_group_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
-                             request.zone(), "/", "nodeGroups")));
+                             request.zone(), "/", "nodeGroups"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair(
+                         "initial_node_count",
+                         std::to_string(request.initial_node_count())),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -207,12 +218,13 @@ DefaultNodeGroupsRestStub::ListNodeGroups(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "nodeGroups"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::NodeGroupsListNodes>
@@ -225,7 +237,14 @@ DefaultNodeGroupsRestStub::ListNodes(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
-                   "nodeGroups", "/", request.node_group(), "/", "listNodes"));
+                   "nodeGroups", "/", request.node_group(), "/", "listNodes"),
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -245,7 +264,9 @@ DefaultNodeGroupsRestStub::AsyncPatchNodeGroup(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "nodeGroups", "/",
-                             request.node_group())));
+                             request.node_group()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -284,7 +305,9 @@ DefaultNodeGroupsRestStub::AsyncSetNodeTemplate(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "nodeGroups", "/",
-                             request.node_group(), "/", "setNodeTemplate")));
+                             request.node_group(), "/", "setNodeTemplate"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -313,7 +336,9 @@ DefaultNodeGroupsRestStub::AsyncSimulateMaintenanceEvent(
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "nodeGroups", "/",
                              request.node_group(), "/",
-                             "simulateMaintenanceEvent")));
+                             "simulateMaintenanceEvent"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/node_templates/v1/internal/node_templates_rest_stub.cc
+++ b/google/cloud/compute/node_templates/v1/internal/node_templates_rest_stub.cc
@@ -54,14 +54,15 @@ DefaultNodeTemplatesRestStub::AggregatedListNodeTemplates(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "nodeTemplates"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -81,7 +82,9 @@ DefaultNodeTemplatesRestStub::AsyncDeleteNodeTemplate(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "nodeTemplates", "/",
-                             request.node_template())));
+                             request.node_template()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -99,8 +102,7 @@ DefaultNodeTemplatesRestStub::GetNodeTemplate(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
-                   "/", "nodeTemplates", "/", request.node_template()),
-      {});
+                   "/", "nodeTemplates", "/", request.node_template()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>
@@ -114,9 +116,9 @@ DefaultNodeTemplatesRestStub::GetIamPolicy(
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "nodeTemplates", "/", request.resource(), "/",
                    "getIamPolicy"),
-      {std::make_pair(
+      rest_internal::TrimEmptyQueryParameters({std::make_pair(
           "options_requested_policy_version",
-          std::to_string(request.options_requested_policy_version()))});
+          std::to_string(request.options_requested_policy_version()))}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -135,7 +137,9 @@ DefaultNodeTemplatesRestStub::AsyncInsertNodeTemplate(
                 *service, *rest_context, request.node_template_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "nodeTemplates")));
+                             request.region(), "/", "nodeTemplates"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -154,12 +158,13 @@ DefaultNodeTemplatesRestStub::ListNodeTemplates(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "nodeTemplates"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>

--- a/google/cloud/compute/node_types/v1/internal/node_types_rest_stub.cc
+++ b/google/cloud/compute/node_types/v1/internal/node_types_rest_stub.cc
@@ -48,14 +48,15 @@ DefaultNodeTypesRestStub::AggregatedListNodeTypes(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "nodeTypes"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::NodeType>
@@ -67,8 +68,7 @@ DefaultNodeTypesRestStub::GetNodeType(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
-                   "nodeTypes", "/", request.node_type()),
-      {});
+                   "nodeTypes", "/", request.node_type()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::NodeTypeList>
@@ -81,12 +81,13 @@ DefaultNodeTypesRestStub::ListNodeTypes(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "nodeTypes"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/compute/packet_mirrorings/v1/internal/packet_mirrorings_rest_stub.cc
+++ b/google/cloud/compute/packet_mirrorings/v1/internal/packet_mirrorings_rest_stub.cc
@@ -56,14 +56,15 @@ DefaultPacketMirroringsRestStub::AggregatedListPacketMirrorings(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "packetMirrorings"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -83,7 +84,9 @@ DefaultPacketMirroringsRestStub::AsyncDeletePacketMirroring(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "packetMirrorings", "/",
-                             request.packet_mirroring())));
+                             request.packet_mirroring()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -101,8 +104,7 @@ DefaultPacketMirroringsRestStub::GetPacketMirroring(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
-                   "/", "packetMirrorings", "/", request.packet_mirroring()),
-      {});
+                   "/", "packetMirrorings", "/", request.packet_mirroring()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -121,7 +123,9 @@ DefaultPacketMirroringsRestStub::AsyncInsertPacketMirroring(
                 *service, *rest_context, request.packet_mirroring_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "packetMirrorings")));
+                             request.region(), "/", "packetMirrorings"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -141,12 +145,13 @@ DefaultPacketMirroringsRestStub::ListPacketMirrorings(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "packetMirrorings"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -166,7 +171,9 @@ DefaultPacketMirroringsRestStub::AsyncPatchPacketMirroring(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "packetMirrorings", "/",
-                             request.packet_mirroring())));
+                             request.packet_mirroring()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/projects/v1/internal/projects_rest_stub.cc
+++ b/google/cloud/compute/projects/v1/internal/projects_rest_stub.cc
@@ -59,7 +59,9 @@ DefaultProjectsRestStub::AsyncDisableXpnHost(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
-                             request.project(), "/", "disableXpnHost")));
+                             request.project(), "/", "disableXpnHost"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -84,7 +86,9 @@ DefaultProjectsRestStub::AsyncDisableXpnResource(
                 *service, *rest_context,
                 request.projects_disable_xpn_resource_request_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
-                             request.project(), "/", "disableXpnResource")));
+                             request.project(), "/", "disableXpnResource"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -108,7 +112,9 @@ DefaultProjectsRestStub::AsyncEnableXpnHost(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
-                             request.project(), "/", "enableXpnHost")));
+                             request.project(), "/", "enableXpnHost"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -133,7 +139,9 @@ DefaultProjectsRestStub::AsyncEnableXpnResource(
                 *service, *rest_context,
                 request.projects_enable_xpn_resource_request_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
-                             request.project(), "/", "enableXpnResource")));
+                             request.project(), "/", "enableXpnResource"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -150,8 +158,7 @@ DefaultProjectsRestStub::GetProject(
   return rest_internal::Get<google::cloud::cpp::compute::v1::Project>(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
-                   request.project()),
-      {});
+                   request.project()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Project>
@@ -162,8 +169,7 @@ DefaultProjectsRestStub::GetXpnHost(
   return rest_internal::Get<google::cloud::cpp::compute::v1::Project>(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
-                   request.project(), "/", "getXpnHost"),
-      {});
+                   request.project(), "/", "getXpnHost"));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::ProjectsGetXpnResources>
@@ -176,12 +182,13 @@ DefaultProjectsRestStub::GetXpnResources(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "getXpnResources"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::XpnHostList>
@@ -193,7 +200,14 @@ DefaultProjectsRestStub::ListXpnHosts(
       *service_, rest_context,
       request.projects_list_xpn_hosts_request_resource(),
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
-                   request.project(), "/", "listXpnHosts"));
+                   request.project(), "/", "listXpnHosts"),
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -210,7 +224,9 @@ DefaultProjectsRestStub::AsyncMoveDisk(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.disk_move_request_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
-                             request.project(), "/", "moveDisk")));
+                             request.project(), "/", "moveDisk"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -235,7 +251,9 @@ DefaultProjectsRestStub::AsyncMoveInstance(
                 *service, *rest_context,
                 request.instance_move_request_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
-                             request.project(), "/", "moveInstance")));
+                             request.project(), "/", "moveInstance"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -260,7 +278,9 @@ DefaultProjectsRestStub::AsyncSetCommonInstanceMetadata(
                 *service, *rest_context, request.metadata_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/",
-                             "setCommonInstanceMetadata")));
+                             "setCommonInstanceMetadata"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -285,7 +305,9 @@ DefaultProjectsRestStub::AsyncSetDefaultNetworkTier(
                 *service, *rest_context,
                 request.projects_set_default_network_tier_request_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
-                             request.project(), "/", "setDefaultNetworkTier")));
+                             request.project(), "/", "setDefaultNetworkTier"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -310,7 +332,9 @@ DefaultProjectsRestStub::AsyncSetUsageExportBucket(
                 *service, *rest_context,
                 request.usage_export_location_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
-                             request.project(), "/", "setUsageExportBucket")));
+                             request.project(), "/", "setUsageExportBucket"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/public_advertised_prefixes/v1/internal/public_advertised_prefixes_rest_stub.cc
+++ b/google/cloud/compute/public_advertised_prefixes/v1/internal/public_advertised_prefixes_rest_stub.cc
@@ -64,7 +64,9 @@ DefaultPublicAdvertisedPrefixesRestStub::AsyncDeletePublicAdvertisedPrefix(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "publicAdvertisedPrefixes", "/",
-                             request.public_advertised_prefix())));
+                             request.public_advertised_prefix()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -84,8 +86,7 @@ DefaultPublicAdvertisedPrefixesRestStub::GetPublicAdvertisedPrefix(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/",
                    "publicAdvertisedPrefixes", "/",
-                   request.public_advertised_prefix()),
-      {});
+                   request.public_advertised_prefix()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -105,7 +106,9 @@ DefaultPublicAdvertisedPrefixesRestStub::AsyncInsertPublicAdvertisedPrefix(
                 request.public_advertised_prefix_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "publicAdvertisedPrefixes")));
+                             "publicAdvertisedPrefixes"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -125,12 +128,13 @@ DefaultPublicAdvertisedPrefixesRestStub::ListPublicAdvertisedPrefixes(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/",
                    "publicAdvertisedPrefixes"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -151,7 +155,9 @@ DefaultPublicAdvertisedPrefixesRestStub::AsyncPatchPublicAdvertisedPrefix(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "publicAdvertisedPrefixes", "/",
-                             request.public_advertised_prefix())));
+                             request.public_advertised_prefix()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/public_delegated_prefixes/v1/internal/public_delegated_prefixes_rest_stub.cc
+++ b/google/cloud/compute/public_delegated_prefixes/v1/internal/public_delegated_prefixes_rest_stub.cc
@@ -57,14 +57,15 @@ DefaultPublicDelegatedPrefixesRestStub::AggregatedListPublicDelegatedPrefixes(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "publicDelegatedPrefixes"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -84,7 +85,9 @@ DefaultPublicDelegatedPrefixesRestStub::AsyncDeletePublicDelegatedPrefix(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "publicDelegatedPrefixes",
-                             "/", request.public_delegated_prefix())));
+                             "/", request.public_delegated_prefix()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -104,8 +107,7 @@ DefaultPublicDelegatedPrefixesRestStub::GetPublicDelegatedPrefix(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "publicDelegatedPrefixes", "/",
-                   request.public_delegated_prefix()),
-      {});
+                   request.public_delegated_prefix()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -125,8 +127,9 @@ DefaultPublicDelegatedPrefixesRestStub::AsyncInsertPublicDelegatedPrefix(
                 request.public_delegated_prefix_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/",
-                             "publicDelegatedPrefixes")));
+                             request.region(), "/", "publicDelegatedPrefixes"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -146,12 +149,13 @@ DefaultPublicDelegatedPrefixesRestStub::ListPublicDelegatedPrefixes(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "publicDelegatedPrefixes"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -172,7 +176,9 @@ DefaultPublicDelegatedPrefixesRestStub::AsyncPatchPublicDelegatedPrefix(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "publicDelegatedPrefixes",
-                             "/", request.public_delegated_prefix())));
+                             "/", request.public_delegated_prefix()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/region_autoscalers/v1/internal/region_autoscalers_rest_stub.cc
+++ b/google/cloud/compute/region_autoscalers/v1/internal/region_autoscalers_rest_stub.cc
@@ -62,7 +62,9 @@ DefaultRegionAutoscalersRestStub::AsyncDeleteAutoscaler(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "autoscalers", "/",
-                             request.autoscaler())));
+                             request.autoscaler()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -80,8 +82,7 @@ DefaultRegionAutoscalersRestStub::GetAutoscaler(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
-                   "/", "autoscalers", "/", request.autoscaler()),
-      {});
+                   "/", "autoscalers", "/", request.autoscaler()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -100,7 +101,9 @@ DefaultRegionAutoscalersRestStub::AsyncInsertAutoscaler(
                 *service, *rest_context, request.autoscaler_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "autoscalers")));
+                             request.region(), "/", "autoscalers"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -120,12 +123,13 @@ DefaultRegionAutoscalersRestStub::ListRegionAutoscalers(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "autoscalers"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -144,7 +148,10 @@ DefaultRegionAutoscalersRestStub::AsyncPatchAutoscaler(
                 *service, *rest_context, request.autoscaler_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "autoscalers")));
+                             request.region(), "/", "autoscalers"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("autoscaler", request.autoscaler()),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -169,7 +176,10 @@ DefaultRegionAutoscalersRestStub::AsyncUpdateAutoscaler(
                 *service, *rest_context, request.autoscaler_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "autoscalers")));
+                             request.region(), "/", "autoscalers"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("autoscaler", request.autoscaler()),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/region_backend_services/v1/internal/region_backend_services_rest_stub.cc
+++ b/google/cloud/compute/region_backend_services/v1/internal/region_backend_services_rest_stub.cc
@@ -63,7 +63,9 @@ DefaultRegionBackendServicesRestStub::AsyncDeleteBackendService(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "backendServices", "/",
-                             request.backend_service())));
+                             request.backend_service()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -81,8 +83,7 @@ DefaultRegionBackendServicesRestStub::GetBackendService(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
-                   "/", "backendServices", "/", request.backend_service()),
-      {});
+                   "/", "backendServices", "/", request.backend_service()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::BackendServiceGroupHealth>
@@ -110,9 +111,9 @@ DefaultRegionBackendServicesRestStub::GetIamPolicy(
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "backendServices", "/", request.resource(), "/",
                    "getIamPolicy"),
-      {std::make_pair(
+      rest_internal::TrimEmptyQueryParameters({std::make_pair(
           "options_requested_policy_version",
-          std::to_string(request.options_requested_policy_version()))});
+          std::to_string(request.options_requested_policy_version()))}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -131,7 +132,9 @@ DefaultRegionBackendServicesRestStub::AsyncInsertBackendService(
                 *service, *rest_context, request.backend_service_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "backendServices")));
+                             request.region(), "/", "backendServices"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -151,12 +154,13 @@ DefaultRegionBackendServicesRestStub::ListRegionBackendServices(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "backendServices"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -176,7 +180,9 @@ DefaultRegionBackendServicesRestStub::AsyncPatchBackendService(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "backendServices", "/",
-                             request.backend_service())));
+                             request.backend_service()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -215,7 +221,9 @@ DefaultRegionBackendServicesRestStub::AsyncUpdateBackendService(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "backendServices", "/",
-                             request.backend_service())));
+                             request.backend_service()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/region_commitments/v1/internal/region_commitments_rest_stub.cc
+++ b/google/cloud/compute/region_commitments/v1/internal/region_commitments_rest_stub.cc
@@ -55,14 +55,15 @@ DefaultRegionCommitmentsRestStub::AggregatedListRegionCommitments(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "commitments"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Commitment>
@@ -74,8 +75,7 @@ DefaultRegionCommitmentsRestStub::GetCommitment(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
-                   "/", "commitments", "/", request.commitment()),
-      {});
+                   "/", "commitments", "/", request.commitment()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -94,7 +94,9 @@ DefaultRegionCommitmentsRestStub::AsyncInsertCommitment(
                 *service, *rest_context, request.commitment_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "commitments")));
+                             request.region(), "/", "commitments"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -113,12 +115,13 @@ DefaultRegionCommitmentsRestStub::ListRegionCommitments(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "commitments"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -138,7 +141,11 @@ DefaultRegionCommitmentsRestStub::AsyncUpdateCommitment(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "commitments", "/",
-                             request.commitment())));
+                             request.commitment()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("paths", request.paths()),
+                     std::make_pair("request_id", request.request_id()),
+                     std::make_pair("update_mask", request.update_mask())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/region_disk_types/v1/internal/region_disk_types_rest_stub.cc
+++ b/google/cloud/compute/region_disk_types/v1/internal/region_disk_types_rest_stub.cc
@@ -47,8 +47,7 @@ DefaultRegionDiskTypesRestStub::GetDiskType(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
-                   "/", "diskTypes", "/", request.disk_type()),
-      {});
+                   "/", "diskTypes", "/", request.disk_type()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::RegionDiskTypeList>
@@ -62,12 +61,13 @@ DefaultRegionDiskTypesRestStub::ListRegionDiskTypes(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "diskTypes"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/compute/region_disks/v1/internal/region_disks_rest_stub.cc
+++ b/google/cloud/compute/region_disks/v1/internal/region_disks_rest_stub.cc
@@ -62,7 +62,9 @@ DefaultRegionDisksRestStub::AsyncAddResourcePolicies(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "disks", "/",
-                             request.disk(), "/", "addResourcePolicies")));
+                             request.disk(), "/", "addResourcePolicies"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -87,8 +89,9 @@ DefaultRegionDisksRestStub::AsyncBulkInsert(
                 *service, *rest_context, request.bulk_insert_disk_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "disks", "/",
-                             "bulkInsert")));
+                             request.region(), "/", "disks", "/", "bulkInsert"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -114,7 +117,9 @@ DefaultRegionDisksRestStub::AsyncCreateSnapshot(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "disks", "/",
-                             request.disk(), "/", "createSnapshot")));
+                             request.disk(), "/", "createSnapshot"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -140,7 +145,9 @@ DefaultRegionDisksRestStub::AsyncDeleteDisk(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "disks", "/",
-                             request.disk())));
+                             request.disk()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -158,8 +165,7 @@ DefaultRegionDisksRestStub::GetDisk(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
-                   "/", "disks", "/", request.disk()),
-      {});
+                   "/", "disks", "/", request.disk()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>
@@ -172,9 +178,9 @@ DefaultRegionDisksRestStub::GetIamPolicy(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "disks", "/", request.resource(), "/", "getIamPolicy"),
-      {std::make_pair(
+      rest_internal::TrimEmptyQueryParameters({std::make_pair(
           "options_requested_policy_version",
-          std::to_string(request.options_requested_policy_version()))});
+          std::to_string(request.options_requested_policy_version()))}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -193,7 +199,10 @@ DefaultRegionDisksRestStub::AsyncInsertDisk(
                 *service, *rest_context, request.disk_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "disks")));
+                             request.region(), "/", "disks"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id()),
+                     std::make_pair("source_image", request.source_image())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -212,12 +221,13 @@ DefaultRegionDisksRestStub::ListRegionDisks(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "disks"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -239,7 +249,9 @@ DefaultRegionDisksRestStub::AsyncRemoveResourcePolicies(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "disks", "/",
-                             request.disk(), "/", "removeResourcePolicies")));
+                             request.disk(), "/", "removeResourcePolicies"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -266,7 +278,9 @@ DefaultRegionDisksRestStub::AsyncResize(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "disks", "/",
-                             request.disk(), "/", "resize")));
+                             request.disk(), "/", "resize"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -305,7 +319,9 @@ DefaultRegionDisksRestStub::AsyncSetLabels(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "disks", "/",
-                             request.resource(), "/", "setLabels")));
+                             request.resource(), "/", "setLabels"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -332,7 +348,9 @@ DefaultRegionDisksRestStub::AsyncStartAsyncReplication(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "disks", "/",
-                             request.disk(), "/", "startAsyncReplication")));
+                             request.disk(), "/", "startAsyncReplication"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -358,7 +376,9 @@ DefaultRegionDisksRestStub::AsyncStopAsyncReplication(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "disks", "/",
-                             request.disk(), "/", "stopAsyncReplication")));
+                             request.disk(), "/", "stopAsyncReplication"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -385,7 +405,9 @@ DefaultRegionDisksRestStub::AsyncStopGroupAsyncReplication(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "disks", "/",
-                             "stopGroupAsyncReplication")));
+                             "stopGroupAsyncReplication"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -425,7 +447,11 @@ DefaultRegionDisksRestStub::AsyncUpdateDisk(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "disks", "/",
-                             request.disk())));
+                             request.disk()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("paths", request.paths()),
+                     std::make_pair("request_id", request.request_id()),
+                     std::make_pair("update_mask", request.update_mask())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/region_health_check_services/v1/internal/region_health_check_services_rest_stub.cc
+++ b/google/cloud/compute/region_health_check_services/v1/internal/region_health_check_services_rest_stub.cc
@@ -64,7 +64,9 @@ DefaultRegionHealthCheckServicesRestStub::AsyncDeleteHealthCheckService(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "healthCheckServices", "/",
-                             request.health_check_service())));
+                             request.health_check_service()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -84,8 +86,7 @@ DefaultRegionHealthCheckServicesRestStub::GetHealthCheckService(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "healthCheckServices", "/",
-                   request.health_check_service()),
-      {});
+                   request.health_check_service()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -105,7 +106,9 @@ DefaultRegionHealthCheckServicesRestStub::AsyncInsertHealthCheckService(
                 request.health_check_service_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "healthCheckServices")));
+                             request.region(), "/", "healthCheckServices"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -125,12 +128,13 @@ DefaultRegionHealthCheckServicesRestStub::ListRegionHealthCheckServices(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "healthCheckServices"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -151,7 +155,9 @@ DefaultRegionHealthCheckServicesRestStub::AsyncPatchHealthCheckService(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "healthCheckServices", "/",
-                             request.health_check_service())));
+                             request.health_check_service()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/region_health_checks/v1/internal/region_health_checks_rest_stub.cc
+++ b/google/cloud/compute/region_health_checks/v1/internal/region_health_checks_rest_stub.cc
@@ -63,7 +63,9 @@ DefaultRegionHealthChecksRestStub::AsyncDeleteHealthCheck(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "healthChecks", "/",
-                             request.health_check())));
+                             request.health_check()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -81,8 +83,7 @@ DefaultRegionHealthChecksRestStub::GetHealthCheck(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
-                   "/", "healthChecks", "/", request.health_check()),
-      {});
+                   "/", "healthChecks", "/", request.health_check()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -101,7 +102,9 @@ DefaultRegionHealthChecksRestStub::AsyncInsertHealthCheck(
                 *service, *rest_context, request.health_check_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "healthChecks")));
+                             request.region(), "/", "healthChecks"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -120,12 +123,13 @@ DefaultRegionHealthChecksRestStub::ListRegionHealthChecks(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "healthChecks"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -145,7 +149,9 @@ DefaultRegionHealthChecksRestStub::AsyncPatchHealthCheck(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "healthChecks", "/",
-                             request.health_check())));
+                             request.health_check()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -171,7 +177,9 @@ DefaultRegionHealthChecksRestStub::AsyncUpdateHealthCheck(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "healthChecks", "/",
-                             request.health_check())));
+                             request.health_check()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/region_instance_group_managers/v1/internal/region_instance_group_managers_rest_stub.cc
+++ b/google/cloud/compute/region_instance_group_managers/v1/internal/region_instance_group_managers_rest_stub.cc
@@ -67,7 +67,9 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncAbandonInstances(
                          request.project(), "/", "regions", "/",
                          request.region(), "/", "instanceGroupManagers", "/",
                          request.instance_group_manager(), "/",
-                         "abandonInstances")));
+                         "abandonInstances"),
+            rest_internal::TrimEmptyQueryParameters(
+                {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -125,7 +127,9 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncCreateInstances(
                          request.project(), "/", "regions", "/",
                          request.region(), "/", "instanceGroupManagers", "/",
                          request.instance_group_manager(), "/",
-                         "createInstances")));
+                         "createInstances"),
+            rest_internal::TrimEmptyQueryParameters(
+                {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -151,7 +155,9 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncDeleteInstanceGroupManager(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "instanceGroupManagers",
-                             "/", request.instance_group_manager())));
+                             "/", request.instance_group_manager()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -180,7 +186,9 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncDeleteInstances(
                          request.project(), "/", "regions", "/",
                          request.region(), "/", "instanceGroupManagers", "/",
                          request.instance_group_manager(), "/",
-                         "deleteInstances")));
+                         "deleteInstances"),
+            rest_internal::TrimEmptyQueryParameters(
+                {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -229,8 +237,7 @@ DefaultRegionInstanceGroupManagersRestStub::GetInstanceGroupManager(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "instanceGroupManagers", "/",
-                   request.instance_group_manager()),
-      {});
+                   request.instance_group_manager()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -250,7 +257,9 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncInsertInstanceGroupManager(
                 request.instance_group_manager_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "instanceGroupManagers")));
+                             request.region(), "/", "instanceGroupManagers"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -270,12 +279,13 @@ DefaultRegionInstanceGroupManagersRestStub::ListRegionInstanceGroupManagers(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "instanceGroupManagers"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::
@@ -291,12 +301,13 @@ DefaultRegionInstanceGroupManagersRestStub::ListErrors(
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "instanceGroupManagers", "/",
                    request.instance_group_manager(), "/", "listErrors"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::
@@ -312,7 +323,14 @@ DefaultRegionInstanceGroupManagersRestStub::ListManagedInstances(
       absl::StrCat(
           "/", "compute", "/", "v1", "/", "projects", "/", request.project(),
           "/", "regions", "/", request.region(), "/", "instanceGroupManagers",
-          "/", request.instance_group_manager(), "/", "listManagedInstances"));
+          "/", request.instance_group_manager(), "/", "listManagedInstances"),
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::
@@ -325,11 +343,17 @@ DefaultRegionInstanceGroupManagersRestStub::ListPerInstanceConfigs(
       google::cloud::cpp::compute::v1::
           RegionInstanceGroupManagersListInstanceConfigsResp>(
       *service_, rest_context, request,
-      absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
-                   request.project(), "/", "regions", "/", request.region(),
-                   "/", "instanceGroupManagers", "/",
-                   request.instance_group_manager(), "/",
-                   "listPerInstanceConfigs"));
+      absl::StrCat(
+          "/", "compute", "/", "v1", "/", "projects", "/", request.project(),
+          "/", "regions", "/", request.region(), "/", "instanceGroupManagers",
+          "/", request.instance_group_manager(), "/", "listPerInstanceConfigs"),
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -350,7 +374,9 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncPatchInstanceGroupManager(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "instanceGroupManagers",
-                             "/", request.instance_group_manager())));
+                             "/", request.instance_group_manager()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -379,7 +405,9 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncPatchPerInstanceConfigs(
                          request.project(), "/", "regions", "/",
                          request.region(), "/", "instanceGroupManagers", "/",
                          request.instance_group_manager(), "/",
-                         "patchPerInstanceConfigs")));
+                         "patchPerInstanceConfigs"),
+            rest_internal::TrimEmptyQueryParameters(
+                {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -408,7 +436,9 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncRecreateInstances(
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "instanceGroupManagers",
                              "/", request.instance_group_manager(), "/",
-                             "recreateInstances")));
+                             "recreateInstances"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -435,7 +465,10 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncResize(
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "instanceGroupManagers",
                              "/", request.instance_group_manager(), "/",
-                             "resize")));
+                             "resize"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id()),
+                     std::make_pair("size", std::to_string(request.size()))})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -464,7 +497,9 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncSetInstanceTemplate(
                          request.project(), "/", "regions", "/",
                          request.region(), "/", "instanceGroupManagers", "/",
                          request.instance_group_manager(), "/",
-                         "setInstanceTemplate")));
+                         "setInstanceTemplate"),
+            rest_internal::TrimEmptyQueryParameters(
+                {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -493,7 +528,9 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncSetTargetPools(
                          request.project(), "/", "regions", "/",
                          request.region(), "/", "instanceGroupManagers", "/",
                          request.instance_group_manager(), "/",
-                         "setTargetPools")));
+                         "setTargetPools"),
+            rest_internal::TrimEmptyQueryParameters(
+                {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -522,7 +559,9 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncUpdatePerInstanceConfigs(
                          request.project(), "/", "regions", "/",
                          request.region(), "/", "instanceGroupManagers", "/",
                          request.instance_group_manager(), "/",
-                         "updatePerInstanceConfigs")));
+                         "updatePerInstanceConfigs"),
+            rest_internal::TrimEmptyQueryParameters(
+                {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/region_instance_groups/v1/internal/region_instance_groups_rest_stub.cc
+++ b/google/cloud/compute/region_instance_groups/v1/internal/region_instance_groups_rest_stub.cc
@@ -55,8 +55,7 @@ DefaultRegionInstanceGroupsRestStub::GetInstanceGroup(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
-                   "/", "instanceGroups", "/", request.instance_group()),
-      {});
+                   "/", "instanceGroups", "/", request.instance_group()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::RegionInstanceGroupList>
@@ -70,12 +69,13 @@ DefaultRegionInstanceGroupsRestStub::ListRegionInstanceGroups(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "instanceGroups"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::RegionInstanceGroupsListInstances>
@@ -90,7 +90,14 @@ DefaultRegionInstanceGroupsRestStub::ListInstances(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "instanceGroups", "/", request.instance_group(), "/",
-                   "listInstances"));
+                   "listInstances"),
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -112,7 +119,9 @@ DefaultRegionInstanceGroupsRestStub::AsyncSetNamedPorts(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "instanceGroups", "/",
-                             request.instance_group(), "/", "setNamedPorts")));
+                             request.instance_group(), "/", "setNamedPorts"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/region_instance_templates/v1/internal/region_instance_templates_rest_stub.cc
+++ b/google/cloud/compute/region_instance_templates/v1/internal/region_instance_templates_rest_stub.cc
@@ -63,7 +63,9 @@ DefaultRegionInstanceTemplatesRestStub::AsyncDeleteInstanceTemplate(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "instanceTemplates", "/",
-                             request.instance_template())));
+                             request.instance_template()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -81,8 +83,7 @@ DefaultRegionInstanceTemplatesRestStub::GetInstanceTemplate(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
-                   "/", "instanceTemplates", "/", request.instance_template()),
-      {});
+                   "/", "instanceTemplates", "/", request.instance_template()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -101,7 +102,9 @@ DefaultRegionInstanceTemplatesRestStub::AsyncInsertInstanceTemplate(
                 *service, *rest_context, request.instance_template_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "instanceTemplates")));
+                             request.region(), "/", "instanceTemplates"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -121,12 +124,13 @@ DefaultRegionInstanceTemplatesRestStub::ListRegionInstanceTemplates(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "instanceTemplates"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/region_instances/v1/internal/region_instances_rest_stub.cc
+++ b/google/cloud/compute/region_instances/v1/internal/region_instances_rest_stub.cc
@@ -62,7 +62,9 @@ DefaultRegionInstancesRestStub::AsyncBulkInsert(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "instances", "/",
-                             "bulkInsert")));
+                             "bulkInsert"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/region_network_endpoint_groups/v1/internal/region_network_endpoint_groups_rest_stub.cc
+++ b/google/cloud/compute/region_network_endpoint_groups/v1/internal/region_network_endpoint_groups_rest_stub.cc
@@ -64,7 +64,9 @@ DefaultRegionNetworkEndpointGroupsRestStub::AsyncDeleteNetworkEndpointGroup(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "networkEndpointGroups",
-                             "/", request.network_endpoint_group())));
+                             "/", request.network_endpoint_group()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -84,8 +86,7 @@ DefaultRegionNetworkEndpointGroupsRestStub::GetNetworkEndpointGroup(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "networkEndpointGroups", "/",
-                   request.network_endpoint_group()),
-      {});
+                   request.network_endpoint_group()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -105,7 +106,9 @@ DefaultRegionNetworkEndpointGroupsRestStub::AsyncInsertNetworkEndpointGroup(
                 request.network_endpoint_group_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "networkEndpointGroups")));
+                             request.region(), "/", "networkEndpointGroups"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -125,12 +128,13 @@ DefaultRegionNetworkEndpointGroupsRestStub::ListRegionNetworkEndpointGroups(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "networkEndpointGroups"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/region_network_firewall_policies/v1/internal/region_network_firewall_policies_rest_stub.cc
+++ b/google/cloud/compute/region_network_firewall_policies/v1/internal/region_network_firewall_policies_rest_stub.cc
@@ -65,8 +65,12 @@ DefaultRegionNetworkFirewallPoliciesRestStub::AsyncAddAssociation(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "firewallPolicies", "/",
-                             request.firewall_policy(), "/",
-                             "addAssociation")));
+                             request.firewall_policy(), "/", "addAssociation"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair(
+                         "replace_existing_association",
+                         request.replace_existing_association() ? "1" : "0"),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -93,7 +97,13 @@ DefaultRegionNetworkFirewallPoliciesRestStub::AsyncAddRule(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "firewallPolicies", "/",
-                             request.firewall_policy(), "/", "addRule")));
+                             request.firewall_policy(), "/", "addRule"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("max_priority",
+                                    std::to_string(request.max_priority())),
+                     std::make_pair("min_priority",
+                                    std::to_string(request.min_priority())),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -119,7 +129,11 @@ DefaultRegionNetworkFirewallPoliciesRestStub::AsyncCloneRules(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "firewallPolicies", "/",
-                             request.firewall_policy(), "/", "cloneRules")));
+                             request.firewall_policy(), "/", "cloneRules"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id()),
+                     std::make_pair("source_firewall_policy",
+                                    request.source_firewall_policy())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -145,7 +159,9 @@ DefaultRegionNetworkFirewallPoliciesRestStub::AsyncDeleteFirewallPolicy(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "firewallPolicies", "/",
-                             request.firewall_policy())));
+                             request.firewall_policy()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -163,8 +179,7 @@ DefaultRegionNetworkFirewallPoliciesRestStub::GetFirewallPolicy(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
-                   "/", "firewallPolicies", "/", request.firewall_policy()),
-      {});
+                   "/", "firewallPolicies", "/", request.firewall_policy()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::FirewallPolicyAssociation>
@@ -179,7 +194,8 @@ DefaultRegionNetworkFirewallPoliciesRestStub::GetAssociation(
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "firewallPolicies", "/", request.firewall_policy(), "/",
                    "getAssociation"),
-      {std::make_pair("name", request.name())});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("name", request.name())}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::
@@ -195,7 +211,8 @@ DefaultRegionNetworkFirewallPoliciesRestStub::GetEffectiveFirewalls(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "firewallPolicies", "/", "getEffectiveFirewalls"),
-      {std::make_pair("network", request.network())});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("network", request.network())}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>
@@ -209,9 +226,9 @@ DefaultRegionNetworkFirewallPoliciesRestStub::GetIamPolicy(
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "firewallPolicies", "/", request.resource(), "/",
                    "getIamPolicy"),
-      {std::make_pair(
+      rest_internal::TrimEmptyQueryParameters({std::make_pair(
           "options_requested_policy_version",
-          std::to_string(request.options_requested_policy_version()))});
+          std::to_string(request.options_requested_policy_version()))}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::FirewallPolicyRule>
@@ -226,7 +243,8 @@ DefaultRegionNetworkFirewallPoliciesRestStub::GetRule(
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "firewallPolicies", "/", request.firewall_policy(), "/",
                    "getRule"),
-      {std::make_pair("priority", std::to_string(request.priority()))});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("priority", std::to_string(request.priority()))}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -245,7 +263,9 @@ DefaultRegionNetworkFirewallPoliciesRestStub::AsyncInsertFirewallPolicy(
                 *service, *rest_context, request.firewall_policy_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "firewallPolicies")));
+                             request.region(), "/", "firewallPolicies"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -265,12 +285,13 @@ DefaultRegionNetworkFirewallPoliciesRestStub::ListRegionNetworkFirewallPolicies(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "firewallPolicies"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -290,7 +311,9 @@ DefaultRegionNetworkFirewallPoliciesRestStub::AsyncPatchFirewallPolicy(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "firewallPolicies", "/",
-                             request.firewall_policy())));
+                             request.firewall_policy()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -317,7 +340,11 @@ DefaultRegionNetworkFirewallPoliciesRestStub::AsyncPatchRule(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "firewallPolicies", "/",
-                             request.firewall_policy(), "/", "patchRule")));
+                             request.firewall_policy(), "/", "patchRule"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("priority",
+                                    std::to_string(request.priority())),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -344,7 +371,10 @@ DefaultRegionNetworkFirewallPoliciesRestStub::AsyncRemoveAssociation(
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "firewallPolicies", "/",
                              request.firewall_policy(), "/",
-                             "removeAssociation")));
+                             "removeAssociation"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("name", request.name()),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -370,7 +400,11 @@ DefaultRegionNetworkFirewallPoliciesRestStub::AsyncRemoveRule(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "firewallPolicies", "/",
-                             request.firewall_policy(), "/", "removeRule")));
+                             request.firewall_policy(), "/", "removeRule"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("priority",
+                                    std::to_string(request.priority())),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/region_notification_endpoints/v1/internal/region_notification_endpoints_rest_stub.cc
+++ b/google/cloud/compute/region_notification_endpoints/v1/internal/region_notification_endpoints_rest_stub.cc
@@ -64,7 +64,9 @@ DefaultRegionNotificationEndpointsRestStub::AsyncDeleteNotificationEndpoint(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "notificationEndpoints",
-                             "/", request.notification_endpoint())));
+                             "/", request.notification_endpoint()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -84,8 +86,7 @@ DefaultRegionNotificationEndpointsRestStub::GetNotificationEndpoint(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "notificationEndpoints", "/",
-                   request.notification_endpoint()),
-      {});
+                   request.notification_endpoint()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -105,7 +106,9 @@ DefaultRegionNotificationEndpointsRestStub::AsyncInsertNotificationEndpoint(
                 request.notification_endpoint_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "notificationEndpoints")));
+                             request.region(), "/", "notificationEndpoints"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -125,12 +128,13 @@ DefaultRegionNotificationEndpointsRestStub::ListRegionNotificationEndpoints(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "notificationEndpoints"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/region_operations/v1/internal/region_operations_rest_stub.cc
+++ b/google/cloud/compute/region_operations/v1/internal/region_operations_rest_stub.cc
@@ -59,8 +59,7 @@ DefaultRegionOperationsRestStub::GetOperation(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
-                   "/", "operations", "/", request.operation()),
-      {});
+                   "/", "operations", "/", request.operation()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::OperationList>
@@ -73,12 +72,13 @@ DefaultRegionOperationsRestStub::ListRegionOperations(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "operations"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Operation>

--- a/google/cloud/compute/region_security_policies/v1/internal/region_security_policies_rest_stub.cc
+++ b/google/cloud/compute/region_security_policies/v1/internal/region_security_policies_rest_stub.cc
@@ -63,7 +63,9 @@ DefaultRegionSecurityPoliciesRestStub::AsyncDeleteSecurityPolicy(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "securityPolicies", "/",
-                             request.security_policy())));
+                             request.security_policy()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -81,8 +83,7 @@ DefaultRegionSecurityPoliciesRestStub::GetSecurityPolicy(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
-                   "/", "securityPolicies", "/", request.security_policy()),
-      {});
+                   "/", "securityPolicies", "/", request.security_policy()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -101,7 +102,11 @@ DefaultRegionSecurityPoliciesRestStub::AsyncInsertSecurityPolicy(
                 *service, *rest_context, request.security_policy_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "securityPolicies")));
+                             request.region(), "/", "securityPolicies"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id()),
+                     std::make_pair("validate_only",
+                                    request.validate_only() ? "1" : "0")})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -121,12 +126,13 @@ DefaultRegionSecurityPoliciesRestStub::ListRegionSecurityPolicies(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "securityPolicies"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -146,7 +152,9 @@ DefaultRegionSecurityPoliciesRestStub::AsyncPatchSecurityPolicy(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "securityPolicies", "/",
-                             request.security_policy())));
+                             request.security_policy()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/region_ssl_certificates/v1/internal/region_ssl_certificates_rest_stub.cc
+++ b/google/cloud/compute/region_ssl_certificates/v1/internal/region_ssl_certificates_rest_stub.cc
@@ -63,7 +63,9 @@ DefaultRegionSslCertificatesRestStub::AsyncDeleteSslCertificate(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "sslCertificates", "/",
-                             request.ssl_certificate())));
+                             request.ssl_certificate()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -81,8 +83,7 @@ DefaultRegionSslCertificatesRestStub::GetSslCertificate(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
-                   "/", "sslCertificates", "/", request.ssl_certificate()),
-      {});
+                   "/", "sslCertificates", "/", request.ssl_certificate()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -101,7 +102,9 @@ DefaultRegionSslCertificatesRestStub::AsyncInsertSslCertificate(
                 *service, *rest_context, request.ssl_certificate_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "sslCertificates")));
+                             request.region(), "/", "sslCertificates"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -121,12 +124,13 @@ DefaultRegionSslCertificatesRestStub::ListRegionSslCertificates(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "sslCertificates"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/region_ssl_policies/v1/internal/region_ssl_policies_rest_stub.cc
+++ b/google/cloud/compute/region_ssl_policies/v1/internal/region_ssl_policies_rest_stub.cc
@@ -62,7 +62,9 @@ DefaultRegionSslPoliciesRestStub::AsyncDeleteSslPolicy(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "sslPolicies", "/",
-                             request.ssl_policy())));
+                             request.ssl_policy()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -80,8 +82,7 @@ DefaultRegionSslPoliciesRestStub::GetSslPolicy(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
-                   "/", "sslPolicies", "/", request.ssl_policy()),
-      {});
+                   "/", "sslPolicies", "/", request.ssl_policy()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -100,7 +101,9 @@ DefaultRegionSslPoliciesRestStub::AsyncInsertSslPolicy(
                 *service, *rest_context, request.ssl_policy_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "sslPolicies")));
+                             request.region(), "/", "sslPolicies"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -119,12 +122,13 @@ DefaultRegionSslPoliciesRestStub::ListRegionSslPolicies(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "sslPolicies"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<
@@ -139,12 +143,13 @@ DefaultRegionSslPoliciesRestStub::ListAvailableFeatures(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "sslPolicies", "/", "listAvailableFeatures"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -164,7 +169,9 @@ DefaultRegionSslPoliciesRestStub::AsyncPatchSslPolicy(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "sslPolicies", "/",
-                             request.ssl_policy())));
+                             request.ssl_policy()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/region_target_http_proxies/v1/internal/region_target_http_proxies_rest_stub.cc
+++ b/google/cloud/compute/region_target_http_proxies/v1/internal/region_target_http_proxies_rest_stub.cc
@@ -63,7 +63,9 @@ DefaultRegionTargetHttpProxiesRestStub::AsyncDeleteTargetHttpProxy(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetHttpProxies", "/",
-                             request.target_http_proxy())));
+                             request.target_http_proxy()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -81,8 +83,7 @@ DefaultRegionTargetHttpProxiesRestStub::GetTargetHttpProxy(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
-                   "/", "targetHttpProxies", "/", request.target_http_proxy()),
-      {});
+                   "/", "targetHttpProxies", "/", request.target_http_proxy()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -101,7 +102,9 @@ DefaultRegionTargetHttpProxiesRestStub::AsyncInsertTargetHttpProxy(
                 *service, *rest_context, request.target_http_proxy_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "targetHttpProxies")));
+                             request.region(), "/", "targetHttpProxies"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -121,12 +124,13 @@ DefaultRegionTargetHttpProxiesRestStub::ListRegionTargetHttpProxies(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "targetHttpProxies"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -146,7 +150,9 @@ DefaultRegionTargetHttpProxiesRestStub::AsyncSetUrlMap(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetHttpProxies", "/",
-                             request.target_http_proxy(), "/", "setUrlMap")));
+                             request.target_http_proxy(), "/", "setUrlMap"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/region_target_https_proxies/v1/internal/region_target_https_proxies_rest_stub.cc
+++ b/google/cloud/compute/region_target_https_proxies/v1/internal/region_target_https_proxies_rest_stub.cc
@@ -64,7 +64,9 @@ DefaultRegionTargetHttpsProxiesRestStub::AsyncDeleteTargetHttpsProxy(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetHttpsProxies", "/",
-                             request.target_https_proxy())));
+                             request.target_https_proxy()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -83,8 +85,7 @@ DefaultRegionTargetHttpsProxiesRestStub::GetTargetHttpsProxy(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "targetHttpsProxies", "/",
-                   request.target_https_proxy()),
-      {});
+                   request.target_https_proxy()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -103,7 +104,9 @@ DefaultRegionTargetHttpsProxiesRestStub::AsyncInsertTargetHttpsProxy(
                 *service, *rest_context, request.target_https_proxy_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "targetHttpsProxies")));
+                             request.region(), "/", "targetHttpsProxies"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -123,12 +126,13 @@ DefaultRegionTargetHttpsProxiesRestStub::ListRegionTargetHttpsProxies(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "targetHttpsProxies"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -148,7 +152,9 @@ DefaultRegionTargetHttpsProxiesRestStub::AsyncPatchTargetHttpsProxy(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetHttpsProxies", "/",
-                             request.target_https_proxy())));
+                             request.target_https_proxy()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -177,7 +183,9 @@ DefaultRegionTargetHttpsProxiesRestStub::AsyncSetSslCertificates(
                          request.project(), "/", "regions", "/",
                          request.region(), "/", "targetHttpsProxies", "/",
                          request.target_https_proxy(), "/",
-                         "setSslCertificates")));
+                         "setSslCertificates"),
+            rest_internal::TrimEmptyQueryParameters(
+                {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -203,7 +211,9 @@ DefaultRegionTargetHttpsProxiesRestStub::AsyncSetUrlMap(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetHttpsProxies", "/",
-                             request.target_https_proxy(), "/", "setUrlMap")));
+                             request.target_https_proxy(), "/", "setUrlMap"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/region_target_tcp_proxies/v1/internal/region_target_tcp_proxies_rest_stub.cc
+++ b/google/cloud/compute/region_target_tcp_proxies/v1/internal/region_target_tcp_proxies_rest_stub.cc
@@ -63,7 +63,9 @@ DefaultRegionTargetTcpProxiesRestStub::AsyncDeleteTargetTcpProxy(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetTcpProxies", "/",
-                             request.target_tcp_proxy())));
+                             request.target_tcp_proxy()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -81,8 +83,7 @@ DefaultRegionTargetTcpProxiesRestStub::GetTargetTcpProxy(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
-                   "/", "targetTcpProxies", "/", request.target_tcp_proxy()),
-      {});
+                   "/", "targetTcpProxies", "/", request.target_tcp_proxy()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -101,7 +102,9 @@ DefaultRegionTargetTcpProxiesRestStub::AsyncInsertTargetTcpProxy(
                 *service, *rest_context, request.target_tcp_proxy_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "targetTcpProxies")));
+                             request.region(), "/", "targetTcpProxies"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -121,12 +124,13 @@ DefaultRegionTargetTcpProxiesRestStub::ListRegionTargetTcpProxies(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "targetTcpProxies"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/region_url_maps/v1/internal/region_url_maps_rest_stub.cc
+++ b/google/cloud/compute/region_url_maps/v1/internal/region_url_maps_rest_stub.cc
@@ -61,7 +61,9 @@ DefaultRegionUrlMapsRestStub::AsyncDeleteUrlMap(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "urlMaps", "/",
-                             request.url_map())));
+                             request.url_map()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -79,8 +81,7 @@ DefaultRegionUrlMapsRestStub::GetUrlMap(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
-                   "/", "urlMaps", "/", request.url_map()),
-      {});
+                   "/", "urlMaps", "/", request.url_map()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -99,7 +100,9 @@ DefaultRegionUrlMapsRestStub::AsyncInsertUrlMap(
                 *service, *rest_context, request.url_map_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "urlMaps")));
+                             request.region(), "/", "urlMaps"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -118,12 +121,13 @@ DefaultRegionUrlMapsRestStub::ListRegionUrlMaps(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "urlMaps"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -143,7 +147,9 @@ DefaultRegionUrlMapsRestStub::AsyncPatchUrlMap(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "urlMaps", "/",
-                             request.url_map())));
+                             request.url_map()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -169,7 +175,9 @@ DefaultRegionUrlMapsRestStub::AsyncUpdateUrlMap(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "urlMaps", "/",
-                             request.url_map())));
+                             request.url_map()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/regions/v1/internal/regions_rest_stub.cc
+++ b/google/cloud/compute/regions/v1/internal/regions_rest_stub.cc
@@ -45,8 +45,7 @@ DefaultRegionsRestStub::GetRegion(
   return rest_internal::Get<google::cloud::cpp::compute::v1::Region>(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
-                   request.project(), "/", "regions", "/", request.region()),
-      {});
+                   request.project(), "/", "regions", "/", request.region()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::RegionList>
@@ -58,12 +57,13 @@ DefaultRegionsRestStub::ListRegions(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/compute/reservations/v1/internal/reservations_rest_stub.cc
+++ b/google/cloud/compute/reservations/v1/internal/reservations_rest_stub.cc
@@ -54,14 +54,15 @@ DefaultReservationsRestStub::AggregatedListReservations(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "reservations"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -81,7 +82,9 @@ DefaultReservationsRestStub::AsyncDeleteReservation(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "reservations", "/",
-                             request.reservation())));
+                             request.reservation()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -99,8 +102,7 @@ DefaultReservationsRestStub::GetReservation(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
-                   "reservations", "/", request.reservation()),
-      {});
+                   "reservations", "/", request.reservation()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>
@@ -114,9 +116,9 @@ DefaultReservationsRestStub::GetIamPolicy(
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "reservations", "/", request.resource(), "/",
                    "getIamPolicy"),
-      {std::make_pair(
+      rest_internal::TrimEmptyQueryParameters({std::make_pair(
           "options_requested_policy_version",
-          std::to_string(request.options_requested_policy_version()))});
+          std::to_string(request.options_requested_policy_version()))}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -135,7 +137,9 @@ DefaultReservationsRestStub::AsyncInsertReservation(
                 *service, *rest_context, request.reservation_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
-                             request.zone(), "/", "reservations")));
+                             request.zone(), "/", "reservations"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -154,12 +158,13 @@ DefaultReservationsRestStub::ListReservations(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "reservations"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -180,7 +185,9 @@ DefaultReservationsRestStub::AsyncResize(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "reservations", "/",
-                             request.reservation(), "/", "resize")));
+                             request.reservation(), "/", "resize"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -233,7 +240,11 @@ DefaultReservationsRestStub::AsyncUpdateReservation(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "reservations", "/",
-                             request.reservation())));
+                             request.reservation()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("paths", request.paths()),
+                     std::make_pair("request_id", request.request_id()),
+                     std::make_pair("update_mask", request.update_mask())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/resource_policies/v1/internal/resource_policies_rest_stub.cc
+++ b/google/cloud/compute/resource_policies/v1/internal/resource_policies_rest_stub.cc
@@ -56,14 +56,15 @@ DefaultResourcePoliciesRestStub::AggregatedListResourcePolicies(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "resourcePolicies"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -83,7 +84,9 @@ DefaultResourcePoliciesRestStub::AsyncDeleteResourcePolicy(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "resourcePolicies", "/",
-                             request.resource_policy())));
+                             request.resource_policy()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -101,8 +104,7 @@ DefaultResourcePoliciesRestStub::GetResourcePolicy(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
-                   "/", "resourcePolicies", "/", request.resource_policy()),
-      {});
+                   "/", "resourcePolicies", "/", request.resource_policy()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>
@@ -116,9 +118,9 @@ DefaultResourcePoliciesRestStub::GetIamPolicy(
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "resourcePolicies", "/", request.resource(), "/",
                    "getIamPolicy"),
-      {std::make_pair(
+      rest_internal::TrimEmptyQueryParameters({std::make_pair(
           "options_requested_policy_version",
-          std::to_string(request.options_requested_policy_version()))});
+          std::to_string(request.options_requested_policy_version()))}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -137,7 +139,9 @@ DefaultResourcePoliciesRestStub::AsyncInsertResourcePolicy(
                 *service, *rest_context, request.resource_policy_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "resourcePolicies")));
+                             request.region(), "/", "resourcePolicies"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -157,12 +161,13 @@ DefaultResourcePoliciesRestStub::ListResourcePolicies(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "resourcePolicies"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -182,7 +187,10 @@ DefaultResourcePoliciesRestStub::AsyncPatchResourcePolicy(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "resourcePolicies", "/",
-                             request.resource_policy())));
+                             request.resource_policy()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id()),
+                     std::make_pair("update_mask", request.update_mask())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/routers/v1/internal/routers_rest_stub.cc
+++ b/google/cloud/compute/routers/v1/internal/routers_rest_stub.cc
@@ -54,14 +54,15 @@ DefaultRoutersRestStub::AggregatedListRouters(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "routers"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -81,7 +82,9 @@ DefaultRoutersRestStub::AsyncDeleteRouter(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "routers", "/",
-                             request.router())));
+                             request.router()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -98,8 +101,7 @@ DefaultRoutersRestStub::GetRouter(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
-                   "/", "routers", "/", request.router()),
-      {});
+                   "/", "routers", "/", request.router()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::VmEndpointNatMappingsList>
@@ -114,13 +116,14 @@ DefaultRoutersRestStub::GetNatMappingInfo(
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "routers", "/", request.router(), "/",
                    "getNatMappingInfo"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("nat_name", request.nat_name()),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("nat_name", request.nat_name()),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::RouterStatusResponse>
@@ -134,8 +137,7 @@ DefaultRoutersRestStub::GetRouterStatus(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "routers", "/", request.router(), "/",
-                   "getRouterStatus"),
-      {});
+                   "getRouterStatus"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -154,7 +156,9 @@ DefaultRoutersRestStub::AsyncInsertRouter(
                 *service, *rest_context, request.router_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "routers")));
+                             request.region(), "/", "routers"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -173,12 +177,13 @@ DefaultRoutersRestStub::ListRouters(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "routers"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -198,7 +203,9 @@ DefaultRoutersRestStub::AsyncPatchRouter(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "routers", "/",
-                             request.router())));
+                             request.router()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -236,7 +243,9 @@ DefaultRoutersRestStub::AsyncUpdateRouter(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "routers", "/",
-                             request.router())));
+                             request.router()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/routes/v1/internal/routes_rest_stub.cc
+++ b/google/cloud/compute/routes/v1/internal/routes_rest_stub.cc
@@ -60,7 +60,9 @@ DefaultRoutesRestStub::AsyncDeleteRoute(
                 *service, *rest_context, request,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "routes",
-                             "/", request.route())));
+                             "/", request.route()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -77,8 +79,7 @@ DefaultRoutesRestStub::GetRoute(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "routes", "/",
-                   request.route()),
-      {});
+                   request.route()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -96,7 +97,9 @@ DefaultRoutesRestStub::AsyncInsertRoute(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.route_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
-                             request.project(), "/", "global", "/", "routes")));
+                             request.project(), "/", "global", "/", "routes"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -113,12 +116,13 @@ DefaultRoutesRestStub::ListRoutes(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "routes"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/security_policies/v1/internal/security_policies_rest_stub.cc
+++ b/google/cloud/compute/security_policies/v1/internal/security_policies_rest_stub.cc
@@ -63,7 +63,9 @@ DefaultSecurityPoliciesRestStub::AsyncAddRule(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "securityPolicies", "/", request.security_policy(),
-                             "/", "addRule")));
+                             "/", "addRule"),
+                rest_internal::TrimEmptyQueryParameters({std::make_pair(
+                    "validate_only", request.validate_only() ? "1" : "0")})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -83,14 +85,15 @@ DefaultSecurityPoliciesRestStub::AggregatedListSecurityPolicies(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "securityPolicies"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -110,7 +113,9 @@ DefaultSecurityPoliciesRestStub::AsyncDeleteSecurityPolicy(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "securityPolicies", "/",
-                             request.security_policy())));
+                             request.security_policy()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -128,8 +133,7 @@ DefaultSecurityPoliciesRestStub::GetSecurityPolicy(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "securityPolicies",
-                   "/", request.security_policy()),
-      {});
+                   "/", request.security_policy()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::SecurityPolicyRule>
@@ -143,7 +147,8 @@ DefaultSecurityPoliciesRestStub::GetRule(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "securityPolicies",
                    "/", request.security_policy(), "/", "getRule"),
-      {std::make_pair("priority", std::to_string(request.priority()))});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("priority", std::to_string(request.priority()))}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -162,7 +167,11 @@ DefaultSecurityPoliciesRestStub::AsyncInsertSecurityPolicy(
                 *service, *rest_context, request.security_policy_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "securityPolicies")));
+                             "securityPolicies"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id()),
+                     std::make_pair("validate_only",
+                                    request.validate_only() ? "1" : "0")})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -181,12 +190,13 @@ DefaultSecurityPoliciesRestStub::ListSecurityPolicies(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "securityPolicies"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::
@@ -202,12 +212,13 @@ DefaultSecurityPoliciesRestStub::ListPreconfiguredExpressionSets(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "securityPolicies",
                    "/", "listPreconfiguredExpressionSets"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -227,7 +238,9 @@ DefaultSecurityPoliciesRestStub::AsyncPatchSecurityPolicy(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "securityPolicies", "/",
-                             request.security_policy())));
+                             request.security_policy()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -254,7 +267,12 @@ DefaultSecurityPoliciesRestStub::AsyncPatchRule(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "securityPolicies", "/", request.security_policy(),
-                             "/", "patchRule")));
+                             "/", "patchRule"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("priority",
+                                    std::to_string(request.priority())),
+                     std::make_pair("validate_only",
+                                    request.validate_only() ? "1" : "0")})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -280,7 +298,9 @@ DefaultSecurityPoliciesRestStub::AsyncRemoveRule(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "securityPolicies", "/", request.security_policy(),
-                             "/", "removeRule")));
+                             "/", "removeRule"),
+                rest_internal::TrimEmptyQueryParameters({std::make_pair(
+                    "priority", std::to_string(request.priority()))})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/service_attachments/v1/internal/service_attachments_rest_stub.cc
+++ b/google/cloud/compute/service_attachments/v1/internal/service_attachments_rest_stub.cc
@@ -56,14 +56,15 @@ DefaultServiceAttachmentsRestStub::AggregatedListServiceAttachments(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "serviceAttachments"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -83,7 +84,9 @@ DefaultServiceAttachmentsRestStub::AsyncDeleteServiceAttachment(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "serviceAttachments", "/",
-                             request.service_attachment())));
+                             request.service_attachment()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -102,8 +105,7 @@ DefaultServiceAttachmentsRestStub::GetServiceAttachment(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "serviceAttachments", "/",
-                   request.service_attachment()),
-      {});
+                   request.service_attachment()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>
@@ -117,9 +119,9 @@ DefaultServiceAttachmentsRestStub::GetIamPolicy(
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "serviceAttachments", "/", request.resource(), "/",
                    "getIamPolicy"),
-      {std::make_pair(
+      rest_internal::TrimEmptyQueryParameters({std::make_pair(
           "options_requested_policy_version",
-          std::to_string(request.options_requested_policy_version()))});
+          std::to_string(request.options_requested_policy_version()))}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -138,7 +140,9 @@ DefaultServiceAttachmentsRestStub::AsyncInsertServiceAttachment(
                 *service, *rest_context, request.service_attachment_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "serviceAttachments")));
+                             request.region(), "/", "serviceAttachments"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -158,12 +162,13 @@ DefaultServiceAttachmentsRestStub::ListServiceAttachments(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "serviceAttachments"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -183,7 +188,9 @@ DefaultServiceAttachmentsRestStub::AsyncPatchServiceAttachment(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "serviceAttachments", "/",
-                             request.service_attachment())));
+                             request.service_attachment()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/snapshots/v1/internal/snapshots_rest_stub.cc
+++ b/google/cloud/compute/snapshots/v1/internal/snapshots_rest_stub.cc
@@ -60,7 +60,9 @@ DefaultSnapshotsRestStub::AsyncDeleteSnapshot(
                 *service, *rest_context, request,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "snapshots",
-                             "/", request.snapshot())));
+                             "/", request.snapshot()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -78,8 +80,7 @@ DefaultSnapshotsRestStub::GetSnapshot(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "snapshots", "/",
-                   request.snapshot()),
-      {});
+                   request.snapshot()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>
@@ -92,9 +93,9 @@ DefaultSnapshotsRestStub::GetIamPolicy(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "snapshots", "/",
                    request.resource(), "/", "getIamPolicy"),
-      {std::make_pair(
+      rest_internal::TrimEmptyQueryParameters({std::make_pair(
           "options_requested_policy_version",
-          std::to_string(request.options_requested_policy_version()))});
+          std::to_string(request.options_requested_policy_version()))}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -113,7 +114,9 @@ DefaultSnapshotsRestStub::AsyncInsertSnapshot(
                 *service, *rest_context, request.snapshot_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "snapshots")));
+                             "snapshots"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -131,12 +134,13 @@ DefaultSnapshotsRestStub::ListSnapshots(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "snapshots"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>

--- a/google/cloud/compute/ssl_certificates/v1/internal/ssl_certificates_rest_stub.cc
+++ b/google/cloud/compute/ssl_certificates/v1/internal/ssl_certificates_rest_stub.cc
@@ -55,14 +55,15 @@ DefaultSslCertificatesRestStub::AggregatedListSslCertificates(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "sslCertificates"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -81,8 +82,9 @@ DefaultSslCertificatesRestStub::AsyncDeleteSslCertificate(
                 *service, *rest_context, request,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "sslCertificates", "/",
-                             request.ssl_certificate())));
+                             "sslCertificates", "/", request.ssl_certificate()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -100,8 +102,7 @@ DefaultSslCertificatesRestStub::GetSslCertificate(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "sslCertificates",
-                   "/", request.ssl_certificate()),
-      {});
+                   "/", request.ssl_certificate()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -120,7 +121,9 @@ DefaultSslCertificatesRestStub::AsyncInsertSslCertificate(
                 *service, *rest_context, request.ssl_certificate_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "sslCertificates")));
+                             "sslCertificates"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -139,12 +142,13 @@ DefaultSslCertificatesRestStub::ListSslCertificates(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "sslCertificates"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/ssl_policies/v1/internal/ssl_policies_rest_stub.cc
+++ b/google/cloud/compute/ssl_policies/v1/internal/ssl_policies_rest_stub.cc
@@ -54,14 +54,15 @@ DefaultSslPoliciesRestStub::AggregatedListSslPolicies(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "sslPolicies"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -80,7 +81,9 @@ DefaultSslPoliciesRestStub::AsyncDeleteSslPolicy(
                 *service, *rest_context, request,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "sslPolicies", "/", request.ssl_policy())));
+                             "sslPolicies", "/", request.ssl_policy()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -98,8 +101,7 @@ DefaultSslPoliciesRestStub::GetSslPolicy(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "sslPolicies", "/",
-                   request.ssl_policy()),
-      {});
+                   request.ssl_policy()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -118,7 +120,9 @@ DefaultSslPoliciesRestStub::AsyncInsertSslPolicy(
                 *service, *rest_context, request.ssl_policy_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "sslPolicies")));
+                             "sslPolicies"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -136,12 +140,13 @@ DefaultSslPoliciesRestStub::ListSslPolicies(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "sslPolicies"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<
@@ -156,12 +161,13 @@ DefaultSslPoliciesRestStub::ListAvailableFeatures(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "sslPolicies", "/",
                    "listAvailableFeatures"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -180,7 +186,9 @@ DefaultSslPoliciesRestStub::AsyncPatchSslPolicy(
                 *service, *rest_context, request.ssl_policy_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "sslPolicies", "/", request.ssl_policy())));
+                             "sslPolicies", "/", request.ssl_policy()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/subnetworks/v1/internal/subnetworks_rest_stub.cc
+++ b/google/cloud/compute/subnetworks/v1/internal/subnetworks_rest_stub.cc
@@ -54,14 +54,15 @@ DefaultSubnetworksRestStub::AggregatedListSubnetworks(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "subnetworks"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -81,7 +82,9 @@ DefaultSubnetworksRestStub::AsyncDeleteSubnetwork(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "subnetworks", "/",
-                             request.subnetwork())));
+                             request.subnetwork()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -108,7 +111,9 @@ DefaultSubnetworksRestStub::AsyncExpandIpCidrRange(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "subnetworks", "/",
-                             request.subnetwork(), "/", "expandIpCidrRange")));
+                             request.subnetwork(), "/", "expandIpCidrRange"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -126,8 +131,7 @@ DefaultSubnetworksRestStub::GetSubnetwork(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
-                   "/", "subnetworks", "/", request.subnetwork()),
-      {});
+                   "/", "subnetworks", "/", request.subnetwork()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>
@@ -141,9 +145,9 @@ DefaultSubnetworksRestStub::GetIamPolicy(
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "subnetworks", "/", request.resource(), "/",
                    "getIamPolicy"),
-      {std::make_pair(
+      rest_internal::TrimEmptyQueryParameters({std::make_pair(
           "options_requested_policy_version",
-          std::to_string(request.options_requested_policy_version()))});
+          std::to_string(request.options_requested_policy_version()))}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -162,7 +166,9 @@ DefaultSubnetworksRestStub::AsyncInsertSubnetwork(
                 *service, *rest_context, request.subnetwork_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "subnetworks")));
+                             request.region(), "/", "subnetworks"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -181,12 +187,13 @@ DefaultSubnetworksRestStub::ListSubnetworks(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "subnetworks"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::UsableSubnetworksAggregatedList>
@@ -200,12 +207,13 @@ DefaultSubnetworksRestStub::ListUsable(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "subnetworks",
                    "/", "listUsable"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -225,7 +233,12 @@ DefaultSubnetworksRestStub::AsyncPatchSubnetwork(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "subnetworks", "/",
-                             request.subnetwork())));
+                             request.subnetwork()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair(
+                         "drain_timeout_seconds",
+                         std::to_string(request.drain_timeout_seconds())),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -265,8 +278,9 @@ DefaultSubnetworksRestStub::AsyncSetPrivateIpGoogleAccess(
             absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                          request.project(), "/", "regions", "/",
                          request.region(), "/", "subnetworks", "/",
-                         request.subnetwork(), "/",
-                         "setPrivateIpGoogleAccess")));
+                         request.subnetwork(), "/", "setPrivateIpGoogleAccess"),
+            rest_internal::TrimEmptyQueryParameters(
+                {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/target_grpc_proxies/v1/internal/target_grpc_proxies_rest_stub.cc
+++ b/google/cloud/compute/target_grpc_proxies/v1/internal/target_grpc_proxies_rest_stub.cc
@@ -62,7 +62,9 @@ DefaultTargetGrpcProxiesRestStub::AsyncDeleteTargetGrpcProxy(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "targetGrpcProxies", "/",
-                             request.target_grpc_proxy())));
+                             request.target_grpc_proxy()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -80,8 +82,7 @@ DefaultTargetGrpcProxiesRestStub::GetTargetGrpcProxy(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "targetGrpcProxies",
-                   "/", request.target_grpc_proxy()),
-      {});
+                   "/", request.target_grpc_proxy()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -100,7 +101,9 @@ DefaultTargetGrpcProxiesRestStub::AsyncInsertTargetGrpcProxy(
                 *service, *rest_context, request.target_grpc_proxy_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "targetGrpcProxies")));
+                             "targetGrpcProxies"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -119,12 +122,13 @@ DefaultTargetGrpcProxiesRestStub::ListTargetGrpcProxies(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "targetGrpcProxies"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -144,7 +148,9 @@ DefaultTargetGrpcProxiesRestStub::AsyncPatchTargetGrpcProxy(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "targetGrpcProxies", "/",
-                             request.target_grpc_proxy())));
+                             request.target_grpc_proxy()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/target_http_proxies/v1/internal/target_http_proxies_rest_stub.cc
+++ b/google/cloud/compute/target_http_proxies/v1/internal/target_http_proxies_rest_stub.cc
@@ -56,14 +56,15 @@ DefaultTargetHttpProxiesRestStub::AggregatedListTargetHttpProxies(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "targetHttpProxies"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -83,7 +84,9 @@ DefaultTargetHttpProxiesRestStub::AsyncDeleteTargetHttpProxy(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "targetHttpProxies", "/",
-                             request.target_http_proxy())));
+                             request.target_http_proxy()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -101,8 +104,7 @@ DefaultTargetHttpProxiesRestStub::GetTargetHttpProxy(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "targetHttpProxies",
-                   "/", request.target_http_proxy()),
-      {});
+                   "/", request.target_http_proxy()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -121,7 +123,9 @@ DefaultTargetHttpProxiesRestStub::AsyncInsertTargetHttpProxy(
                 *service, *rest_context, request.target_http_proxy_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "targetHttpProxies")));
+                             "targetHttpProxies"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -140,12 +144,13 @@ DefaultTargetHttpProxiesRestStub::ListTargetHttpProxies(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "targetHttpProxies"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -165,7 +170,9 @@ DefaultTargetHttpProxiesRestStub::AsyncPatchTargetHttpProxy(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "targetHttpProxies", "/",
-                             request.target_http_proxy())));
+                             request.target_http_proxy()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -190,7 +197,9 @@ DefaultTargetHttpProxiesRestStub::AsyncSetUrlMap(
                 *service, *rest_context, request.url_map_reference_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "targetHttpProxies", "/",
-                             request.target_http_proxy(), "/", "setUrlMap")));
+                             request.target_http_proxy(), "/", "setUrlMap"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/target_https_proxies/v1/internal/target_https_proxies_rest_stub.cc
+++ b/google/cloud/compute/target_https_proxies/v1/internal/target_https_proxies_rest_stub.cc
@@ -57,14 +57,15 @@ DefaultTargetHttpsProxiesRestStub::AggregatedListTargetHttpsProxies(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "targetHttpsProxies"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -84,7 +85,9 @@ DefaultTargetHttpsProxiesRestStub::AsyncDeleteTargetHttpsProxy(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "targetHttpsProxies", "/",
-                             request.target_https_proxy())));
+                             request.target_https_proxy()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -102,8 +105,7 @@ DefaultTargetHttpsProxiesRestStub::GetTargetHttpsProxy(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "targetHttpsProxies",
-                   "/", request.target_https_proxy()),
-      {});
+                   "/", request.target_https_proxy()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -122,7 +124,9 @@ DefaultTargetHttpsProxiesRestStub::AsyncInsertTargetHttpsProxy(
                 *service, *rest_context, request.target_https_proxy_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "targetHttpsProxies")));
+                             "targetHttpsProxies"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -141,12 +145,13 @@ DefaultTargetHttpsProxiesRestStub::ListTargetHttpsProxies(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "targetHttpsProxies"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -166,7 +171,9 @@ DefaultTargetHttpsProxiesRestStub::AsyncPatchTargetHttpsProxy(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "targetHttpsProxies", "/",
-                             request.target_https_proxy())));
+                             request.target_https_proxy()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -193,7 +200,9 @@ DefaultTargetHttpsProxiesRestStub::AsyncSetCertificateMap(
             absl::StrCat(
                 "/", "compute", "/", "v1", "/", "projects", "/",
                 request.project(), "/", "global", "/", "targetHttpsProxies",
-                "/", request.target_https_proxy(), "/", "setCertificateMap")));
+                "/", request.target_https_proxy(), "/", "setCertificateMap"),
+            rest_internal::TrimEmptyQueryParameters(
+                {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -218,11 +227,12 @@ DefaultTargetHttpsProxiesRestStub::AsyncSetQuicOverride(
                 *service, *rest_context,
                 request
                     .target_https_proxies_set_quic_override_request_resource(),
-                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
-                             request.project(), "/", "global", "/",
-                             "targetHttpsProxies", "/",
-                             request.target_https_proxy(), "/",
-                             "setQuicOverride")));
+                absl::StrCat(
+                    "/", "compute", "/", "v1", "/", "projects", "/",
+                    request.project(), "/", "global", "/", "targetHttpsProxies",
+                    "/", request.target_https_proxy(), "/", "setQuicOverride"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -250,7 +260,9 @@ DefaultTargetHttpsProxiesRestStub::AsyncSetSslCertificates(
             absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                          request.project(), "/", "targetHttpsProxies", "/",
                          request.target_https_proxy(), "/",
-                         "setSslCertificates")));
+                         "setSslCertificates"),
+            rest_internal::TrimEmptyQueryParameters(
+                {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -274,10 +286,12 @@ DefaultTargetHttpsProxiesRestStub::AsyncSetSslPolicy(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.ssl_policy_reference_resource(),
-                absl::StrCat(
-                    "/", "compute", "/", "v1", "/", "projects", "/",
-                    request.project(), "/", "global", "/", "targetHttpsProxies",
-                    "/", request.target_https_proxy(), "/", "setSslPolicy")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "targetHttpsProxies", "/",
+                             request.target_https_proxy(), "/", "setSslPolicy"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -302,7 +316,9 @@ DefaultTargetHttpsProxiesRestStub::AsyncSetUrlMap(
                 *service, *rest_context, request.url_map_reference_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "targetHttpsProxies", "/",
-                             request.target_https_proxy(), "/", "setUrlMap")));
+                             request.target_https_proxy(), "/", "setUrlMap"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/target_instances/v1/internal/target_instances_rest_stub.cc
+++ b/google/cloud/compute/target_instances/v1/internal/target_instances_rest_stub.cc
@@ -55,14 +55,15 @@ DefaultTargetInstancesRestStub::AggregatedListTargetInstances(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "targetInstances"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -82,7 +83,9 @@ DefaultTargetInstancesRestStub::AsyncDeleteTargetInstance(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "targetInstances", "/",
-                             request.target_instance())));
+                             request.target_instance()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -100,8 +103,7 @@ DefaultTargetInstancesRestStub::GetTargetInstance(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
-                   "targetInstances", "/", request.target_instance()),
-      {});
+                   "targetInstances", "/", request.target_instance()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -120,7 +122,9 @@ DefaultTargetInstancesRestStub::AsyncInsertTargetInstance(
                 *service, *rest_context, request.target_instance_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
-                             request.zone(), "/", "targetInstances")));
+                             request.zone(), "/", "targetInstances"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -140,12 +144,13 @@ DefaultTargetInstancesRestStub::ListTargetInstances(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "targetInstances"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/target_pools/v1/internal/target_pools_rest_stub.cc
+++ b/google/cloud/compute/target_pools/v1/internal/target_pools_rest_stub.cc
@@ -62,7 +62,9 @@ DefaultTargetPoolsRestStub::AsyncAddHealthCheck(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetPools", "/",
-                             request.target_pool(), "/", "addHealthCheck")));
+                             request.target_pool(), "/", "addHealthCheck"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -89,7 +91,9 @@ DefaultTargetPoolsRestStub::AsyncAddInstance(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetPools", "/",
-                             request.target_pool(), "/", "addInstance")));
+                             request.target_pool(), "/", "addInstance"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -108,14 +112,15 @@ DefaultTargetPoolsRestStub::AggregatedListTargetPools(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "targetPools"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -135,7 +140,9 @@ DefaultTargetPoolsRestStub::AsyncDeleteTargetPool(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetPools", "/",
-                             request.target_pool())));
+                             request.target_pool()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -153,8 +160,7 @@ DefaultTargetPoolsRestStub::GetTargetPool(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
-                   "/", "targetPools", "/", request.target_pool()),
-      {});
+                   "/", "targetPools", "/", request.target_pool()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::TargetPoolInstanceHealth>
@@ -187,7 +193,9 @@ DefaultTargetPoolsRestStub::AsyncInsertTargetPool(
                 *service, *rest_context, request.target_pool_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "targetPools")));
+                             request.region(), "/", "targetPools"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -206,12 +214,13 @@ DefaultTargetPoolsRestStub::ListTargetPools(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "targetPools"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -232,7 +241,9 @@ DefaultTargetPoolsRestStub::AsyncRemoveHealthCheck(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetPools", "/",
-                             request.target_pool(), "/", "removeHealthCheck")));
+                             request.target_pool(), "/", "removeHealthCheck"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -259,7 +270,9 @@ DefaultTargetPoolsRestStub::AsyncRemoveInstance(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetPools", "/",
-                             request.target_pool(), "/", "removeInstance")));
+                             request.target_pool(), "/", "removeInstance"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -285,7 +298,11 @@ DefaultTargetPoolsRestStub::AsyncSetBackup(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetPools", "/",
-                             request.target_pool(), "/", "setBackup")));
+                             request.target_pool(), "/", "setBackup"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("failover_ratio",
+                                    std::to_string(request.failover_ratio())),
+                     std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/target_ssl_proxies/v1/internal/target_ssl_proxies_rest_stub.cc
+++ b/google/cloud/compute/target_ssl_proxies/v1/internal/target_ssl_proxies_rest_stub.cc
@@ -62,7 +62,9 @@ DefaultTargetSslProxiesRestStub::AsyncDeleteTargetSslProxy(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "targetSslProxies", "/",
-                             request.target_ssl_proxy())));
+                             request.target_ssl_proxy()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -80,8 +82,7 @@ DefaultTargetSslProxiesRestStub::GetTargetSslProxy(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "targetSslProxies",
-                   "/", request.target_ssl_proxy()),
-      {});
+                   "/", request.target_ssl_proxy()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -100,7 +101,9 @@ DefaultTargetSslProxiesRestStub::AsyncInsertTargetSslProxy(
                 *service, *rest_context, request.target_ssl_proxy_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "targetSslProxies")));
+                             "targetSslProxies"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -119,12 +122,13 @@ DefaultTargetSslProxiesRestStub::ListTargetSslProxies(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "targetSslProxies"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -143,11 +147,12 @@ DefaultTargetSslProxiesRestStub::AsyncSetBackendService(
                 *service, *rest_context,
                 request
                     .target_ssl_proxies_set_backend_service_request_resource(),
-                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
-                             request.project(), "/", "global", "/",
-                             "targetSslProxies", "/",
-                             request.target_ssl_proxy(), "/",
-                             "setBackendService")));
+                absl::StrCat(
+                    "/", "compute", "/", "v1", "/", "projects", "/",
+                    request.project(), "/", "global", "/", "targetSslProxies",
+                    "/", request.target_ssl_proxy(), "/", "setBackendService"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -172,11 +177,12 @@ DefaultTargetSslProxiesRestStub::AsyncSetCertificateMap(
                 *service, *rest_context,
                 request
                     .target_ssl_proxies_set_certificate_map_request_resource(),
-                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
-                             request.project(), "/", "global", "/",
-                             "targetSslProxies", "/",
-                             request.target_ssl_proxy(), "/",
-                             "setCertificateMap")));
+                absl::StrCat(
+                    "/", "compute", "/", "v1", "/", "projects", "/",
+                    request.project(), "/", "global", "/", "targetSslProxies",
+                    "/", request.target_ssl_proxy(), "/", "setCertificateMap"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -200,10 +206,12 @@ DefaultTargetSslProxiesRestStub::AsyncSetProxyHeader(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.target_ssl_proxies_set_proxy_header_request_resource(),
-                absl::StrCat(
-                    "/", "compute", "/", "v1", "/", "projects", "/",
-                    request.project(), "/", "global", "/", "targetSslProxies",
-                    "/", request.target_ssl_proxy(), "/", "setProxyHeader")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "targetSslProxies", "/",
+                             request.target_ssl_proxy(), "/", "setProxyHeader"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -228,11 +236,12 @@ DefaultTargetSslProxiesRestStub::AsyncSetSslCertificates(
                 *service, *rest_context,
                 request
                     .target_ssl_proxies_set_ssl_certificates_request_resource(),
-                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
-                             request.project(), "/", "global", "/",
-                             "targetSslProxies", "/",
-                             request.target_ssl_proxy(), "/",
-                             "setSslCertificates")));
+                absl::StrCat(
+                    "/", "compute", "/", "v1", "/", "projects", "/",
+                    request.project(), "/", "global", "/", "targetSslProxies",
+                    "/", request.target_ssl_proxy(), "/", "setSslCertificates"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -259,7 +268,9 @@ DefaultTargetSslProxiesRestStub::AsyncSetSslPolicy(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "targetSslProxies", "/",
-                             request.target_ssl_proxy(), "/", "setSslPolicy")));
+                             request.target_ssl_proxy(), "/", "setSslPolicy"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/target_tcp_proxies/v1/internal/target_tcp_proxies_rest_stub.cc
+++ b/google/cloud/compute/target_tcp_proxies/v1/internal/target_tcp_proxies_rest_stub.cc
@@ -56,14 +56,15 @@ DefaultTargetTcpProxiesRestStub::AggregatedListTargetTcpProxies(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "targetTcpProxies"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -83,7 +84,9 @@ DefaultTargetTcpProxiesRestStub::AsyncDeleteTargetTcpProxy(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "targetTcpProxies", "/",
-                             request.target_tcp_proxy())));
+                             request.target_tcp_proxy()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -101,8 +104,7 @@ DefaultTargetTcpProxiesRestStub::GetTargetTcpProxy(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "targetTcpProxies",
-                   "/", request.target_tcp_proxy()),
-      {});
+                   "/", request.target_tcp_proxy()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -121,7 +123,9 @@ DefaultTargetTcpProxiesRestStub::AsyncInsertTargetTcpProxy(
                 *service, *rest_context, request.target_tcp_proxy_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
-                             "targetTcpProxies")));
+                             "targetTcpProxies"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -140,12 +144,13 @@ DefaultTargetTcpProxiesRestStub::ListTargetTcpProxies(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "targetTcpProxies"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -164,11 +169,12 @@ DefaultTargetTcpProxiesRestStub::AsyncSetBackendService(
                 *service, *rest_context,
                 request
                     .target_tcp_proxies_set_backend_service_request_resource(),
-                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
-                             request.project(), "/", "global", "/",
-                             "targetTcpProxies", "/",
-                             request.target_tcp_proxy(), "/",
-                             "setBackendService")));
+                absl::StrCat(
+                    "/", "compute", "/", "v1", "/", "projects", "/",
+                    request.project(), "/", "global", "/", "targetTcpProxies",
+                    "/", request.target_tcp_proxy(), "/", "setBackendService"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -192,10 +198,12 @@ DefaultTargetTcpProxiesRestStub::AsyncSetProxyHeader(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.target_tcp_proxies_set_proxy_header_request_resource(),
-                absl::StrCat(
-                    "/", "compute", "/", "v1", "/", "projects", "/",
-                    request.project(), "/", "global", "/", "targetTcpProxies",
-                    "/", request.target_tcp_proxy(), "/", "setProxyHeader")));
+                absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
+                             request.project(), "/", "global", "/",
+                             "targetTcpProxies", "/",
+                             request.target_tcp_proxy(), "/", "setProxyHeader"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/target_vpn_gateways/v1/internal/target_vpn_gateways_rest_stub.cc
+++ b/google/cloud/compute/target_vpn_gateways/v1/internal/target_vpn_gateways_rest_stub.cc
@@ -56,14 +56,15 @@ DefaultTargetVpnGatewaysRestStub::AggregatedListTargetVpnGateways(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "targetVpnGateways"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -83,7 +84,9 @@ DefaultTargetVpnGatewaysRestStub::AsyncDeleteTargetVpnGateway(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetVpnGateways", "/",
-                             request.target_vpn_gateway())));
+                             request.target_vpn_gateway()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -101,8 +104,8 @@ DefaultTargetVpnGatewaysRestStub::GetTargetVpnGateway(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
-                   "/", "targetVpnGateways", "/", request.target_vpn_gateway()),
-      {});
+                   "/", "targetVpnGateways", "/",
+                   request.target_vpn_gateway()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -121,7 +124,9 @@ DefaultTargetVpnGatewaysRestStub::AsyncInsertTargetVpnGateway(
                 *service, *rest_context, request.target_vpn_gateway_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "targetVpnGateways")));
+                             request.region(), "/", "targetVpnGateways"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -141,12 +146,13 @@ DefaultTargetVpnGatewaysRestStub::ListTargetVpnGateways(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "targetVpnGateways"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -167,7 +173,9 @@ DefaultTargetVpnGatewaysRestStub::AsyncSetLabels(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetVpnGateways", "/",
-                             request.resource(), "/", "setLabels")));
+                             request.resource(), "/", "setLabels"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/url_maps/v1/internal/url_maps_rest_stub.cc
+++ b/google/cloud/compute/url_maps/v1/internal/url_maps_rest_stub.cc
@@ -54,14 +54,15 @@ DefaultUrlMapsRestStub::AggregatedListUrlMaps(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "urlMaps"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -80,7 +81,9 @@ DefaultUrlMapsRestStub::AsyncDeleteUrlMap(
                 *service, *rest_context, request,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "urlMaps",
-                             "/", request.url_map())));
+                             "/", request.url_map()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -98,8 +101,7 @@ DefaultUrlMapsRestStub::GetUrlMap(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "urlMaps", "/",
-                   request.url_map()),
-      {});
+                   request.url_map()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -117,8 +119,9 @@ DefaultUrlMapsRestStub::AsyncInsertUrlMap(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.url_map_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
-                             request.project(), "/", "global", "/",
-                             "urlMaps")));
+                             request.project(), "/", "global", "/", "urlMaps"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -144,7 +147,9 @@ DefaultUrlMapsRestStub::AsyncInvalidateCache(
                 request.cache_invalidation_rule_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "urlMaps",
-                             "/", request.url_map(), "/", "invalidateCache")));
+                             "/", request.url_map(), "/", "invalidateCache"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -162,12 +167,13 @@ DefaultUrlMapsRestStub::ListUrlMaps(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "urlMaps"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -186,7 +192,9 @@ DefaultUrlMapsRestStub::AsyncPatchUrlMap(
                 *service, *rest_context, request.url_map_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "urlMaps",
-                             "/", request.url_map())));
+                             "/", request.url_map()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -211,7 +219,9 @@ DefaultUrlMapsRestStub::AsyncUpdateUrlMap(
                 *service, *rest_context, request.url_map_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "urlMaps",
-                             "/", request.url_map())));
+                             "/", request.url_map()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/vpn_gateways/v1/internal/vpn_gateways_rest_stub.cc
+++ b/google/cloud/compute/vpn_gateways/v1/internal/vpn_gateways_rest_stub.cc
@@ -54,14 +54,15 @@ DefaultVpnGatewaysRestStub::AggregatedListVpnGateways(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "vpnGateways"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -81,7 +82,9 @@ DefaultVpnGatewaysRestStub::AsyncDeleteVpnGateway(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "vpnGateways", "/",
-                             request.vpn_gateway())));
+                             request.vpn_gateway()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -99,8 +102,7 @@ DefaultVpnGatewaysRestStub::GetVpnGateway(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
-                   "/", "vpnGateways", "/", request.vpn_gateway()),
-      {});
+                   "/", "vpnGateways", "/", request.vpn_gateway()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::VpnGatewaysGetStatusResponse>
@@ -114,8 +116,7 @@ DefaultVpnGatewaysRestStub::GetStatus(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "vpnGateways", "/", request.vpn_gateway(), "/",
-                   "getStatus"),
-      {});
+                   "getStatus"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -134,7 +135,9 @@ DefaultVpnGatewaysRestStub::AsyncInsertVpnGateway(
                 *service, *rest_context, request.vpn_gateway_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "vpnGateways")));
+                             request.region(), "/", "vpnGateways"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -153,12 +156,13 @@ DefaultVpnGatewaysRestStub::ListVpnGateways(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "vpnGateways"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -179,7 +183,9 @@ DefaultVpnGatewaysRestStub::AsyncSetLabels(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "vpnGateways", "/",
-                             request.resource(), "/", "setLabels")));
+                             request.resource(), "/", "setLabels"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/vpn_tunnels/v1/internal/vpn_tunnels_rest_stub.cc
+++ b/google/cloud/compute/vpn_tunnels/v1/internal/vpn_tunnels_rest_stub.cc
@@ -54,14 +54,15 @@ DefaultVpnTunnelsRestStub::AggregatedListVpnTunnels(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "vpnTunnels"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("include_all_scopes",
-                      request.include_all_scopes() ? "1" : "0"),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("include_all_scopes",
+                          request.include_all_scopes() ? "1" : "0"),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -81,7 +82,9 @@ DefaultVpnTunnelsRestStub::AsyncDeleteVpnTunnel(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "vpnTunnels", "/",
-                             request.vpn_tunnel())));
+                             request.vpn_tunnel()),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -99,8 +102,7 @@ DefaultVpnTunnelsRestStub::GetVpnTunnel(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
-                   "/", "vpnTunnels", "/", request.vpn_tunnel()),
-      {});
+                   "/", "vpnTunnels", "/", request.vpn_tunnel()));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -119,7 +121,9 @@ DefaultVpnTunnelsRestStub::AsyncInsertVpnTunnel(
                 *service, *rest_context, request.vpn_tunnel_resource(),
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
-                             request.region(), "/", "vpnTunnels")));
+                             request.region(), "/", "vpnTunnels"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -138,12 +142,13 @@ DefaultVpnTunnelsRestStub::ListVpnTunnels(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "vpnTunnels"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -164,7 +169,9 @@ DefaultVpnTunnelsRestStub::AsyncSetLabels(
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "vpnTunnels", "/",
-                             request.resource(), "/", "setLabels")));
+                             request.resource(), "/", "setLabels"),
+                rest_internal::TrimEmptyQueryParameters(
+                    {std::make_pair("request_id", request.request_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/compute/zone_operations/v1/internal/zone_operations_rest_stub.cc
+++ b/google/cloud/compute/zone_operations/v1/internal/zone_operations_rest_stub.cc
@@ -58,8 +58,7 @@ DefaultZoneOperationsRestStub::GetOperation(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
-                   "operations", "/", request.operation()),
-      {});
+                   "operations", "/", request.operation()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::OperationList>
@@ -72,12 +71,13 @@ DefaultZoneOperationsRestStub::ListZoneOperations(
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "operations"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Operation>

--- a/google/cloud/compute/zones/v1/internal/zones_rest_stub.cc
+++ b/google/cloud/compute/zones/v1/internal/zones_rest_stub.cc
@@ -44,8 +44,7 @@ StatusOr<google::cloud::cpp::compute::v1::Zone> DefaultZonesRestStub::GetZone(
   return rest_internal::Get<google::cloud::cpp::compute::v1::Zone>(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
-                   request.project(), "/", "zones", "/", request.zone()),
-      {});
+                   request.project(), "/", "zones", "/", request.zone()));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::ZoneList>
@@ -56,12 +55,13 @@ DefaultZonesRestStub::ListZones(
       *service_, rest_context, request,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("order_by", request.order_by()),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("return_partial_success",
-                      request.return_partial_success() ? "1" : "0")});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("order_by", request.order_by()),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("return_partial_success",
+                          request.return_partial_success() ? "1" : "0")}));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/rest_stub_helpers.cc
+++ b/google/cloud/internal/rest_stub_helpers.cc
@@ -72,6 +72,17 @@ rest_internal::RestRequest CreateRestRequest(
   return rest_request;
 }
 
+std::vector<std::pair<std::string, std::string>> TrimEmptyQueryParameters(
+    std::vector<std::pair<std::string, std::string>> query_params) {
+  std::vector<std::pair<std::string, std::string>> trimmed_params;
+  for (auto& qp : query_params) {
+    if (!qp.first.empty() && !qp.second.empty()) {
+      trimmed_params.push_back(std::move(qp));
+    }
+  }
+  return trimmed_params;
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace rest_internal
 }  // namespace cloud

--- a/google/cloud/internal/rest_stub_helpers.h
+++ b/google/cloud/internal/rest_stub_helpers.h
@@ -30,6 +30,9 @@ namespace cloud {
 namespace rest_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+std::vector<std::pair<std::string, std::string>> TrimEmptyQueryParameters(
+    std::vector<std::pair<std::string, std::string>> query_params);
+
 Status RestResponseToProto(google::protobuf::Message& destination,
                            RestResponse&& rest_response);
 

--- a/google/cloud/internal/rest_stub_helpers_test.cc
+++ b/google/cloud/internal/rest_stub_helpers_test.cc
@@ -39,7 +39,9 @@ using ::google::cloud::testing_util::StatusIs;
 using ::testing::_;
 using ::testing::A;
 using ::testing::Contains;
+using ::testing::ElementsAre;
 using ::testing::Eq;
+using ::testing::IsEmpty;
 using ::testing::Pair;
 
 using Request = google::protobuf::Duration;
@@ -457,6 +459,34 @@ TEST(RestStubHelpers, Put) {
   ASSERT_THAT(result, IsOk());
   EXPECT_THAT(result->seconds(), Eq(123));
   EXPECT_THAT(result->nanos(), Eq(456));
+}
+
+TEST(TrimEmptyQueryParameters, RemoveEmptyPairFirst) {
+  auto trimmed_params =
+      TrimEmptyQueryParameters({{"not_empty", "not_empty"}, {"", "empty"}});
+  EXPECT_THAT(trimmed_params, ElementsAre(Pair("not_empty", "not_empty")));
+}
+
+TEST(TrimEmptyQueryParameters, RemoveEmptyPairSecond) {
+  auto trimmed_params =
+      TrimEmptyQueryParameters({{"not_empty", "not_empty"}, {"empty", ""}});
+  EXPECT_THAT(trimmed_params, ElementsAre(Pair("not_empty", "not_empty")));
+}
+
+TEST(TrimEmptyQueryParameters, RemoveEmptyPairFirstAndSecond) {
+  auto trimmed_params =
+      TrimEmptyQueryParameters({{"", ""}, {"not_empty", "not_empty"}});
+  EXPECT_THAT(trimmed_params, ElementsAre(Pair("not_empty", "not_empty")));
+}
+
+TEST(TrimEmptyQueryParameters, RemovingEmptyPairProduceEmptyVector) {
+  auto trimmed_params = TrimEmptyQueryParameters({{"empty", ""}});
+  EXPECT_THAT(trimmed_params, IsEmpty());
+}
+
+TEST(TrimEmptyQueryParameters, EmptyInput) {
+  auto trimmed_params = TrimEmptyQueryParameters({});
+  EXPECT_THAT(trimmed_params, IsEmpty());
 }
 
 }  // namespace

--- a/google/cloud/spanner/admin/internal/database_admin_rest_stub.cc
+++ b/google/cloud/spanner/admin/internal/database_admin_rest_stub.cc
@@ -52,8 +52,9 @@ DefaultDatabaseAdminRestStub::ListDatabases(
       google::spanner::admin::database::v1::ListDatabasesResponse>(
       *service_, rest_context, request,
       absl::StrCat("/", "v1", "/", request.parent(), "/", "databases"),
-      {std::make_pair("page_size", std::to_string(request.page_size())),
-       std::make_pair("page_token", request.page_token())});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("page_size", std::to_string(request.page_size())),
+           std::make_pair("page_token", request.page_token())}));
 }
 
 future<StatusOr<google::longrunning::Operation>>
@@ -68,7 +69,11 @@ DefaultDatabaseAdminRestStub::AsyncCreateDatabase(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::longrunning::Operation>(
             *service, *rest_context, request,
-            absl::StrCat("/", "v1", "/", request.parent(), "/", "databases")));
+            absl::StrCat("/", "v1", "/", request.parent(), "/", "databases"),
+            rest_internal::TrimEmptyQueryParameters(
+                {std::make_pair("create_statement", request.create_statement()),
+                 std::make_pair("database_dialect",
+                                std::to_string(request.database_dialect()))})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -83,7 +88,7 @@ DefaultDatabaseAdminRestStub::GetDatabase(
     google::spanner::admin::database::v1::GetDatabaseRequest const& request) {
   return rest_internal::Get<google::spanner::admin::database::v1::Database>(
       *service_, rest_context, request,
-      absl::StrCat("/", "v1", "/", request.name()), {});
+      absl::StrCat("/", "v1", "/", request.name()));
 }
 
 future<StatusOr<google::longrunning::Operation>>
@@ -119,7 +124,9 @@ DefaultDatabaseAdminRestStub::AsyncUpdateDatabaseDdl(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(rest_internal::Patch<google::longrunning::Operation>(
             *service, *rest_context, request,
-            absl::StrCat("/", "v1", "/", request.database(), "/", "ddl")));
+            absl::StrCat("/", "v1", "/", request.database(), "/", "ddl"),
+            rest_internal::TrimEmptyQueryParameters(
+                {std::make_pair("operation_id", request.operation_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -144,7 +151,7 @@ DefaultDatabaseAdminRestStub::GetDatabaseDdl(
   return rest_internal::Get<
       google::spanner::admin::database::v1::GetDatabaseDdlResponse>(
       *service_, rest_context, request,
-      absl::StrCat("/", "v1", "/", request.database(), "/", "ddl"), {});
+      absl::StrCat("/", "v1", "/", request.database(), "/", "ddl"));
 }
 
 StatusOr<google::iam::v1::Policy> DefaultDatabaseAdminRestStub::SetIamPolicy(
@@ -183,7 +190,9 @@ DefaultDatabaseAdminRestStub::AsyncCreateBackup(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::longrunning::Operation>(
             *service, *rest_context, request.backup(),
-            absl::StrCat("/", "v1", "/", request.parent(), "/", "backups")));
+            absl::StrCat("/", "v1", "/", request.parent(), "/", "backups"),
+            rest_internal::TrimEmptyQueryParameters(
+                {std::make_pair("backup_id", request.backup_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -204,7 +213,10 @@ DefaultDatabaseAdminRestStub::AsyncCopyBackup(
         p.set_value(rest_internal::Post<google::longrunning::Operation>(
             *service, *rest_context, request,
             absl::StrCat("/", "v1", "/", request.parent(), "/", "backups",
-                         ":copy")));
+                         ":copy"),
+            rest_internal::TrimEmptyQueryParameters(
+                {std::make_pair("backup_id", request.backup_id()),
+                 std::make_pair("source_backup", request.source_backup())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -219,7 +231,7 @@ DefaultDatabaseAdminRestStub::GetBackup(
     google::spanner::admin::database::v1::GetBackupRequest const& request) {
   return rest_internal::Get<google::spanner::admin::database::v1::Backup>(
       *service_, rest_context, request,
-      absl::StrCat("/", "v1", "/", request.name()), {});
+      absl::StrCat("/", "v1", "/", request.name()));
 }
 
 StatusOr<google::spanner::admin::database::v1::Backup>
@@ -246,9 +258,10 @@ DefaultDatabaseAdminRestStub::ListBackups(
       google::spanner::admin::database::v1::ListBackupsResponse>(
       *service_, rest_context, request,
       absl::StrCat("/", "v1", "/", request.parent(), "/", "backups"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("page_size", std::to_string(request.page_size())),
-       std::make_pair("page_token", request.page_token())});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("page_size", std::to_string(request.page_size())),
+           std::make_pair("page_token", request.page_token())}));
 }
 
 future<StatusOr<google::longrunning::Operation>>
@@ -264,7 +277,10 @@ DefaultDatabaseAdminRestStub::AsyncRestoreDatabase(
         p.set_value(rest_internal::Post<google::longrunning::Operation>(
             *service, *rest_context, request,
             absl::StrCat("/", "v1", "/", request.parent(), "/", "databases",
-                         ":restore")));
+                         ":restore"),
+            rest_internal::TrimEmptyQueryParameters(
+                {std::make_pair("database_id", request.database_id()),
+                 std::make_pair("backup", request.backup())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -282,9 +298,10 @@ DefaultDatabaseAdminRestStub::ListDatabaseOperations(
       google::spanner::admin::database::v1::ListDatabaseOperationsResponse>(
       *service_, rest_context, request,
       absl::StrCat("/", "v1", "/", request.parent(), "/", "databaseOperations"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("page_size", std::to_string(request.page_size())),
-       std::make_pair("page_token", request.page_token())});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("page_size", std::to_string(request.page_size())),
+           std::make_pair("page_token", request.page_token())}));
 }
 
 StatusOr<google::spanner::admin::database::v1::ListBackupOperationsResponse>
@@ -296,9 +313,10 @@ DefaultDatabaseAdminRestStub::ListBackupOperations(
       google::spanner::admin::database::v1::ListBackupOperationsResponse>(
       *service_, rest_context, request,
       absl::StrCat("/", "v1", "/", request.parent(), "/", "backupOperations"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("page_size", std::to_string(request.page_size())),
-       std::make_pair("page_token", request.page_token())});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("page_size", std::to_string(request.page_size())),
+           std::make_pair("page_token", request.page_token())}));
 }
 
 StatusOr<google::spanner::admin::database::v1::ListDatabaseRolesResponse>
@@ -310,8 +328,9 @@ DefaultDatabaseAdminRestStub::ListDatabaseRoles(
       google::spanner::admin::database::v1::ListDatabaseRolesResponse>(
       *service_, rest_context, request,
       absl::StrCat("/", "v1", "/", request.parent(), "/", "databaseRoles"),
-      {std::make_pair("page_size", std::to_string(request.page_size())),
-       std::make_pair("page_token", request.page_token())});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("page_size", std::to_string(request.page_size())),
+           std::make_pair("page_token", request.page_token())}));
 }
 
 future<StatusOr<google::longrunning::Operation>>

--- a/google/cloud/spanner/admin/internal/instance_admin_rest_stub.cc
+++ b/google/cloud/spanner/admin/internal/instance_admin_rest_stub.cc
@@ -53,8 +53,9 @@ DefaultInstanceAdminRestStub::ListInstanceConfigs(
       google::spanner::admin::instance::v1::ListInstanceConfigsResponse>(
       *service_, rest_context, request,
       absl::StrCat("/", "v1", "/", request.parent(), "/", "instanceConfigs"),
-      {std::make_pair("page_size", std::to_string(request.page_size())),
-       std::make_pair("page_token", request.page_token())});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("page_size", std::to_string(request.page_size())),
+           std::make_pair("page_token", request.page_token())}));
 }
 
 StatusOr<google::spanner::admin::instance::v1::InstanceConfig>
@@ -65,7 +66,7 @@ DefaultInstanceAdminRestStub::GetInstanceConfig(
   return rest_internal::Get<
       google::spanner::admin::instance::v1::InstanceConfig>(
       *service_, rest_context, request,
-      absl::StrCat("/", "v1", "/", request.name()), {});
+      absl::StrCat("/", "v1", "/", request.name()));
 }
 
 future<StatusOr<google::longrunning::Operation>>
@@ -81,7 +82,12 @@ DefaultInstanceAdminRestStub::AsyncCreateInstanceConfig(
         p.set_value(rest_internal::Post<google::longrunning::Operation>(
             *service, *rest_context, request,
             absl::StrCat("/", "v1", "/", request.parent(), "/",
-                         "instanceConfigs")));
+                         "instanceConfigs"),
+            rest_internal::TrimEmptyQueryParameters(
+                {std::make_pair("instance_config_id",
+                                request.instance_config_id()),
+                 std::make_pair("validate_only",
+                                request.validate_only() ? "1" : "0")})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -102,7 +108,9 @@ DefaultInstanceAdminRestStub::AsyncUpdateInstanceConfig(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(rest_internal::Patch<google::longrunning::Operation>(
             *service, *rest_context, request,
-            absl::StrCat("/", "v1", "/", request.instance_config().name())));
+            absl::StrCat("/", "v1", "/", request.instance_config().name()),
+            rest_internal::TrimEmptyQueryParameters({std::make_pair(
+                "validate_only", request.validate_only() ? "1" : "0")})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -115,8 +123,13 @@ Status DefaultInstanceAdminRestStub::DeleteInstanceConfig(
     google::cloud::rest_internal::RestContext& rest_context,
     google::spanner::admin::instance::v1::DeleteInstanceConfigRequest const&
         request) {
-  return rest_internal::Delete(*service_, rest_context, request,
-                               absl::StrCat("/", "v1", "/", request.name()));
+  return rest_internal::Delete(
+      *service_, rest_context, request,
+      absl::StrCat("/", "v1", "/", request.name()),
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("etag", request.etag()),
+           std::make_pair("validate_only",
+                          request.validate_only() ? "1" : "0")}));
 }
 
 StatusOr<
@@ -130,9 +143,10 @@ DefaultInstanceAdminRestStub::ListInstanceConfigOperations(
       *service_, rest_context, request,
       absl::StrCat("/", "v1", "/", request.parent(), "/",
                    "instanceConfigOperations"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("page_size", std::to_string(request.page_size())),
-       std::make_pair("page_token", request.page_token())});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("page_size", std::to_string(request.page_size())),
+           std::make_pair("page_token", request.page_token())}));
 }
 
 StatusOr<google::spanner::admin::instance::v1::ListInstancesResponse>
@@ -143,9 +157,10 @@ DefaultInstanceAdminRestStub::ListInstances(
       google::spanner::admin::instance::v1::ListInstancesResponse>(
       *service_, rest_context, request,
       absl::StrCat("/", "v1", "/", request.parent(), "/", "instances"),
-      {std::make_pair("page_size", std::to_string(request.page_size())),
-       std::make_pair("page_token", request.page_token()),
-       std::make_pair("filter", request.filter())});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("page_size", std::to_string(request.page_size())),
+           std::make_pair("page_token", request.page_token()),
+           std::make_pair("filter", request.filter())}));
 }
 
 StatusOr<google::spanner::admin::instance::v1::Instance>
@@ -154,7 +169,7 @@ DefaultInstanceAdminRestStub::GetInstance(
     google::spanner::admin::instance::v1::GetInstanceRequest const& request) {
   return rest_internal::Get<google::spanner::admin::instance::v1::Instance>(
       *service_, rest_context, request,
-      absl::StrCat("/", "v1", "/", request.name()), {});
+      absl::StrCat("/", "v1", "/", request.name()));
 }
 
 future<StatusOr<google::longrunning::Operation>>
@@ -169,7 +184,9 @@ DefaultInstanceAdminRestStub::AsyncCreateInstance(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::longrunning::Operation>(
             *service, *rest_context, request,
-            absl::StrCat("/", "v1", "/", request.parent(), "/", "instances")));
+            absl::StrCat("/", "v1", "/", request.parent(), "/", "instances"),
+            rest_internal::TrimEmptyQueryParameters(
+                {std::make_pair("instance_id", request.instance_id())})));
       },
       std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/google/cloud/sql/v1/internal/sql_backup_runs_rest_stub.cc
+++ b/google/cloud/sql/v1/internal/sql_backup_runs_rest_stub.cc
@@ -58,8 +58,7 @@ DefaultSqlBackupRunsServiceRestStub::Get(
       *service_, rest_context, request,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "backupRuns", "/",
-                   request.id()),
-      {});
+                   request.id()));
 }
 
 StatusOr<google::cloud::sql::v1::Operation>
@@ -80,8 +79,9 @@ DefaultSqlBackupRunsServiceRestStub::List(
       *service_, rest_context, request,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "backupRuns"),
-      {std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("page_token", request.page_token())});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("page_token", request.page_token())}));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/sql/v1/internal/sql_connect_rest_stub.cc
+++ b/google/cloud/sql/v1/internal/sql_connect_rest_stub.cc
@@ -47,8 +47,7 @@ DefaultSqlConnectServiceRestStub::GetConnectSettings(
       *service_, rest_context, request,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/",
-                   "connectSettings"),
-      {});
+                   "connectSettings"));
 }
 
 StatusOr<google::cloud::sql::v1::GenerateEphemeralCertResponse>
@@ -60,7 +59,10 @@ DefaultSqlConnectServiceRestStub::GenerateEphemeralCert(
       *service_, rest_context, request,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(),
-                   ":generateEphemeralCert"));
+                   ":generateEphemeralCert"),
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("public_key", request.public_key()),
+           std::make_pair("access_token", request.access_token())}));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/sql/v1/internal/sql_databases_rest_stub.cc
+++ b/google/cloud/sql/v1/internal/sql_databases_rest_stub.cc
@@ -58,8 +58,7 @@ DefaultSqlDatabasesServiceRestStub::Get(
       *service_, rest_context, request,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "databases", "/",
-                   request.database()),
-      {});
+                   request.database()));
 }
 
 StatusOr<google::cloud::sql::v1::Operation>
@@ -79,8 +78,7 @@ DefaultSqlDatabasesServiceRestStub::List(
   return rest_internal::Get<google::cloud::sql::v1::DatabasesListResponse>(
       *service_, rest_context, request,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
-                   "instances", "/", request.instance(), "/", "databases"),
-      {});
+                   "instances", "/", request.instance(), "/", "databases"));
 }
 
 StatusOr<google::cloud::sql::v1::Operation>

--- a/google/cloud/sql/v1/internal/sql_flags_rest_stub.cc
+++ b/google/cloud/sql/v1/internal/sql_flags_rest_stub.cc
@@ -44,7 +44,8 @@ DefaultSqlFlagsServiceRestStub::List(
     google::cloud::sql::v1::SqlFlagsListRequest const& request) {
   return rest_internal::Get<google::cloud::sql::v1::FlagsListResponse>(
       *service_, rest_context, request, "/v1/flags",
-      {std::make_pair("database_version", request.database_version())});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("database_version", request.database_version())}));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/sql/v1/internal/sql_instances_rest_stub.cc
+++ b/google/cloud/sql/v1/internal/sql_instances_rest_stub.cc
@@ -116,8 +116,7 @@ DefaultSqlInstancesServiceRestStub::Get(
   return rest_internal::Get<google::cloud::sql::v1::DatabaseInstance>(
       *service_, rest_context, request,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
-                   "instances", "/", request.instance()),
-      {});
+                   "instances", "/", request.instance()));
 }
 
 StatusOr<google::cloud::sql::v1::Operation>
@@ -148,9 +147,10 @@ DefaultSqlInstancesServiceRestStub::List(
       *service_, rest_context, request,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances"),
-      {std::make_pair("filter", request.filter()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("page_token", request.page_token())});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("filter", request.filter()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("page_token", request.page_token())}));
 }
 
 StatusOr<google::cloud::sql::v1::InstancesListServerCasResponse>
@@ -161,8 +161,7 @@ DefaultSqlInstancesServiceRestStub::ListServerCas(
       google::cloud::sql::v1::InstancesListServerCasResponse>(
       *service_, rest_context, request,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
-                   "instances", "/", request.instance(), "/", "listServerCas"),
-      {});
+                   "instances", "/", request.instance(), "/", "listServerCas"));
 }
 
 StatusOr<google::cloud::sql::v1::Operation>
@@ -302,7 +301,13 @@ DefaultSqlInstancesServiceRestStub::VerifyExternalSyncSettings(
       *service_, rest_context, request,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/",
-                   "verifyExternalSyncSettings"));
+                   "verifyExternalSyncSettings"),
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("verify_connection_only",
+                          request.verify_connection_only() ? "1" : "0"),
+           std::make_pair("sync_mode", std::to_string(request.sync_mode())),
+           std::make_pair("verify_replication_only",
+                          request.verify_replication_only() ? "1" : "0")}));
 }
 
 StatusOr<google::cloud::sql::v1::Operation>
@@ -314,7 +319,13 @@ DefaultSqlInstancesServiceRestStub::StartExternalSync(
       *service_, rest_context, request,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/",
-                   "startExternalSync"));
+                   "startExternalSync"),
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("sync_mode", std::to_string(request.sync_mode())),
+           std::make_pair("skip_verification",
+                          request.skip_verification() ? "1" : "0"),
+           std::make_pair("sync_parallel_level",
+                          std::to_string(request.sync_parallel_level()))}));
 }
 
 StatusOr<google::cloud::sql::v1::Operation>
@@ -339,8 +350,7 @@ DefaultSqlInstancesServiceRestStub::GetDiskShrinkConfig(
       *service_, rest_context, request,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/",
-                   "getDiskShrinkConfig"),
-      {});
+                   "getDiskShrinkConfig"));
 }
 
 StatusOr<google::cloud::sql::v1::Operation>
@@ -365,8 +375,7 @@ DefaultSqlInstancesServiceRestStub::GetLatestRecoveryTime(
       *service_, rest_context, request,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/",
-                   "getLatestRecoveryTime"),
-      {});
+                   "getLatestRecoveryTime"));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/sql/v1/internal/sql_operations_rest_stub.cc
+++ b/google/cloud/sql/v1/internal/sql_operations_rest_stub.cc
@@ -46,8 +46,7 @@ DefaultSqlOperationsServiceRestStub::Get(
   return rest_internal::Get<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
-                   "operations", "/", request.operation()),
-      {});
+                   "operations", "/", request.operation()));
 }
 
 StatusOr<google::cloud::sql::v1::OperationsListResponse>
@@ -58,9 +57,10 @@ DefaultSqlOperationsServiceRestStub::List(
       *service_, rest_context, request,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "operations"),
-      {std::make_pair("instance", request.instance()),
-       std::make_pair("max_results", std::to_string(request.max_results())),
-       std::make_pair("page_token", request.page_token())});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("instance", request.instance()),
+           std::make_pair("max_results", std::to_string(request.max_results())),
+           std::make_pair("page_token", request.page_token())}));
 }
 
 Status DefaultSqlOperationsServiceRestStub::Cancel(

--- a/google/cloud/sql/v1/internal/sql_ssl_certs_rest_stub.cc
+++ b/google/cloud/sql/v1/internal/sql_ssl_certs_rest_stub.cc
@@ -58,8 +58,7 @@ DefaultSqlSslCertsServiceRestStub::Get(
       *service_, rest_context, request,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "sslCerts", "/",
-                   request.sha1_fingerprint()),
-      {});
+                   request.sha1_fingerprint()));
 }
 
 StatusOr<google::cloud::sql::v1::SslCertsInsertResponse>
@@ -79,8 +78,7 @@ DefaultSqlSslCertsServiceRestStub::List(
   return rest_internal::Get<google::cloud::sql::v1::SslCertsListResponse>(
       *service_, rest_context, request,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
-                   "instances", "/", request.instance(), "/", "sslCerts"),
-      {});
+                   "instances", "/", request.instance(), "/", "sslCerts"));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/sql/v1/internal/sql_tiers_rest_stub.cc
+++ b/google/cloud/sql/v1/internal/sql_tiers_rest_stub.cc
@@ -45,8 +45,7 @@ DefaultSqlTiersServiceRestStub::List(
   return rest_internal::Get<google::cloud::sql::v1::TiersListResponse>(
       *service_, rest_context, request,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
-                   "tiers"),
-      {});
+                   "tiers"));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/sql/v1/internal/sql_users_rest_stub.cc
+++ b/google/cloud/sql/v1/internal/sql_users_rest_stub.cc
@@ -45,7 +45,10 @@ DefaultSqlUsersServiceRestStub::Delete(
   return rest_internal::Delete<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
-                   "instances", "/", request.instance(), "/", "users"));
+                   "instances", "/", request.instance(), "/", "users"),
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("host", request.host()),
+           std::make_pair("name", request.name())}));
 }
 
 StatusOr<google::cloud::sql::v1::User> DefaultSqlUsersServiceRestStub::Get(
@@ -56,7 +59,8 @@ StatusOr<google::cloud::sql::v1::User> DefaultSqlUsersServiceRestStub::Get(
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "users", "/",
                    request.name()),
-      {std::make_pair("host", request.host())});
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("host", request.host())}));
 }
 
 StatusOr<google::cloud::sql::v1::Operation>
@@ -76,8 +80,7 @@ DefaultSqlUsersServiceRestStub::List(
   return rest_internal::Get<google::cloud::sql::v1::UsersListResponse>(
       *service_, rest_context, request,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
-                   "instances", "/", request.instance(), "/", "users"),
-      {});
+                   "instances", "/", request.instance(), "/", "users"));
 }
 
 StatusOr<google::cloud::sql::v1::Operation>
@@ -87,7 +90,10 @@ DefaultSqlUsersServiceRestStub::Update(
   return rest_internal::Put<google::cloud::sql::v1::Operation>(
       *service_, rest_context, request.body(),
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
-                   "instances", "/", request.instance(), "/", "users"));
+                   "instances", "/", request.instance(), "/", "users"),
+      rest_internal::TrimEmptyQueryParameters(
+          {std::make_pair("host", request.host()),
+           std::make_pair("name", request.name())}));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
So we used to transcode the entire request proto in json. This worked for some cases but not all, so we then built the query path from some of the fields in the proto and transcode the "resource' field into the json request body. In the process, we dropped fields that should have been query params on the floor for non-GET http methods. This PR reinstates those non-path, non-resource fields as query parameters.

Sending empty query parameters is an error for Compute methods, so we make sure to omit them.

The accompanying integration test verifies the query parameter is being passed, but not a successful update. This is do to the lack of update methods for easily configurable test resources in compute.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12721)
<!-- Reviewable:end -->
