### PR TITLE
ci: move `check-api` to Fedora:38

### DIFF
--- a/ci/cloudbuild/triggers/check-api-ci.yaml
+++ b/ci/cloudbuild/triggers/check-api-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: check-api-ci
 substitutions:
   _BUILD_NAME: check-api
-  _DISTRO: fedora-37-cmake
+  _DISTRO: fedora-latest-cmake
   _TRIGGER_TYPE: ci
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
 tags:

--- a/ci/cloudbuild/triggers/check-api-pr.yaml
+++ b/ci/cloudbuild/triggers/check-api-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: check-api-pr
 substitutions:
   _BUILD_NAME: check-api
-  _DISTRO: fedora-37-cmake
+  _DISTRO: fedora-latest-cmake
   _TRIGGER_TYPE: pr
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
 tags:


### PR DESCRIPTION
I already updated the triggers because the build passed locally.  If I did something wrong, we would need to revert the trigger changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12727)
<!-- Reviewable:end -->
