### PR TITLE
cleanup(otel)!: Drop `Options` from resource detector API.

### DIFF
--- a/google/cloud/opentelemetry/configure_basic_tracing.cc
+++ b/google/cloud/opentelemetry/configure_basic_tracing.cc
@@ -60,7 +60,7 @@ std::unique_ptr<BasicTracingConfiguration> ConfigureBasicTracing(
   auto ratio = options.has<BasicTracingRateOption>()
                    ? options.get<BasicTracingRateOption>()
                    : 1.0;
-  auto detector = MakeResourceDetector(options);
+  auto detector = MakeResourceDetector();
   auto processor =
       std::make_unique<opentelemetry::sdk::trace::BatchSpanProcessor>(
           MakeTraceExporter(std::move(project), std::move(options)),

--- a/google/cloud/opentelemetry/resource_detector.cc
+++ b/google/cloud/opentelemetry/resource_detector.cc
@@ -23,7 +23,7 @@ namespace otel {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 std::unique_ptr<opentelemetry::sdk::resource::ResourceDetector>
-MakeResourceDetector(Options options) {
+MakeResourceDetector() {
   auto retry = internal::LimitedTimeRetryPolicy<otel_internal::StatusTraits>(
       std::chrono::seconds(10));
   auto backoff =
@@ -33,7 +33,7 @@ MakeResourceDetector(Options options) {
       [](Options const& options) {
         return rest_internal::MakeDefaultRestClient("", options);
       },
-      retry.clone(), backoff.clone(), std::move(options));
+      retry.clone(), backoff.clone(), Options{});
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/opentelemetry/resource_detector.h
+++ b/google/cloud/opentelemetry/resource_detector.h
@@ -27,7 +27,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Make an OpenTelemetry Resource Detector for Google Cloud Platform.
 std::unique_ptr<opentelemetry::sdk::resource::ResourceDetector>
-MakeResourceDetector(Options options = {});
+MakeResourceDetector();
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace otel


### PR DESCRIPTION
Part of the work for #12726. Anti-work for #12114. 

Remove `google::cloud::Options` from the API to create a GCP resource detector. This opens up the possibility to switch out the implementation of this thing to something that does not depend on `google_cloud_cpp_common`, and other libraries.

We do not want to remove the API because it has value on its own. In the future we can add defaulted arguments to it, e.g. a `ResourceDetectorOptions o = {}`.

---

cc: @yashykt - [This change will not affect you](https://github.com/grpc/grpc/blob/3bdd972c4aad5578dde5a383b00fdf542ede8fb7/src/cpp/ext/csm/csm_observability.cc#L81C32-L81C52), but FYI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12730)
<!-- Reviewable:end -->
