### PR TITLE
impl(generator): add preserve proto field name option

### DIFF
--- a/generator/generator_config.proto
+++ b/generator/generator_config.proto
@@ -154,6 +154,14 @@ message ServiceConfiguration {
     DISCOVERY_DOCUMENT = 1;
   }
   ProtoFileSource proto_file_source = 24;
+
+  // Some REST services expect JSON fields names in snake_case, while most other
+  // REST services expect JSON in camelCase. When true this flag instructs the
+  // generator to emit field names as they are defined in the proto files,
+  // which by style convention is typically snake_case. When false, the field
+  // names will be converted to camelCase.
+  // The generator will default this flag to false if no value is provided.
+  optional bool preserve_proto_field_names_in_json = 25;
 }
 
 message DiscoveryDocumentDefinedProduct {

--- a/generator/generator_config.proto
+++ b/generator/generator_config.proto
@@ -160,8 +160,7 @@ message ServiceConfiguration {
   // generator to emit field names as they are defined in the proto files,
   // which by style convention is typically snake_case. When false, the field
   // names will be converted to camelCase.
-  // The generator will default this flag to false if no value is provided.
-  optional bool preserve_proto_field_names_in_json = 25;
+  bool preserve_proto_field_names_in_json = 25;
 }
 
 message DiscoveryDocumentDefinedProduct {

--- a/generator/generator_config.textproto
+++ b/generator/generator_config.textproto
@@ -2988,6 +2988,7 @@ service {
   experimental: true
   generate_rest_transport: true
   generate_grpc_transport: false
+  preserve_proto_field_names_in_json: true
 }
 
 service {
@@ -2998,6 +2999,7 @@ service {
   experimental: true
   generate_rest_transport: true
   generate_grpc_transport: false
+  preserve_proto_field_names_in_json: true
 }
 
 service {
@@ -3008,6 +3010,7 @@ service {
   experimental: true
   generate_rest_transport: true
   generate_grpc_transport: false
+  preserve_proto_field_names_in_json: true
 }
 
 service {
@@ -3018,6 +3021,7 @@ service {
   experimental: true
   generate_rest_transport: true
   generate_grpc_transport: false
+  preserve_proto_field_names_in_json: true
 }
 
 service {
@@ -3028,6 +3032,7 @@ service {
   experimental: true
   generate_rest_transport: true
   generate_grpc_transport: false
+  preserve_proto_field_names_in_json: true
 }
 
 service {
@@ -3038,6 +3043,7 @@ service {
   experimental: true
   generate_rest_transport: true
   generate_grpc_transport: false
+  preserve_proto_field_names_in_json: true
 }
 
 service {
@@ -3048,6 +3054,7 @@ service {
   experimental: true
   generate_rest_transport: true
   generate_grpc_transport: false
+  preserve_proto_field_names_in_json: true
 }
 
 service {
@@ -3058,6 +3065,7 @@ service {
   experimental: true
   generate_rest_transport: true
   generate_grpc_transport: false
+  preserve_proto_field_names_in_json: true
 }
 
 service {
@@ -3068,6 +3076,7 @@ service {
   experimental: true
   generate_rest_transport: true
   generate_grpc_transport: false
+  preserve_proto_field_names_in_json: true
 }
 
 # Storage

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_stub.cc
@@ -45,7 +45,7 @@ DefaultGoldenKitchenSinkRestStub::GenerateAccessToken(
       google::cloud::rest_internal::RestContext& rest_context,
       google::test::admin::database::v1::GenerateAccessTokenRequest const& request) {
   return rest_internal::Post<google::test::admin::database::v1::GenerateAccessTokenResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.name(), ":generateAccessToken"));
 }
 
@@ -54,7 +54,7 @@ DefaultGoldenKitchenSinkRestStub::GenerateIdToken(
       google::cloud::rest_internal::RestContext& rest_context,
       google::test::admin::database::v1::GenerateIdTokenRequest const& request) {
   return rest_internal::Post<google::test::admin::database::v1::GenerateIdTokenResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       "/v1/token:generate",
       rest_internal::TrimEmptyQueryParameters({std::make_pair("name", request.name()),
         std::make_pair("audience", request.audience()),
@@ -66,7 +66,7 @@ DefaultGoldenKitchenSinkRestStub::WriteLogEntries(
       google::cloud::rest_internal::RestContext& rest_context,
       google::test::admin::database::v1::WriteLogEntriesRequest const& request) {
   return rest_internal::Post<google::test::admin::database::v1::WriteLogEntriesResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       "/v2/entries:write",
       rest_internal::TrimEmptyQueryParameters({std::make_pair("log_name", request.log_name())}));
 }
@@ -76,7 +76,7 @@ DefaultGoldenKitchenSinkRestStub::ListLogs(
       google::cloud::rest_internal::RestContext& rest_context,
       google::test::admin::database::v1::ListLogsRequest const& request) {
   return rest_internal::Get<google::test::admin::database::v1::ListLogsResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v2", "/", request.parent(), "/", "logs"),
       rest_internal::TrimEmptyQueryParameters({std::make_pair("page_size", std::to_string(request.page_size())),
         std::make_pair("page_token", request.page_token())}));
@@ -87,7 +87,7 @@ DefaultGoldenKitchenSinkRestStub::ListServiceAccountKeys(
       google::cloud::rest_internal::RestContext& rest_context,
       google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) {
   return rest_internal::Get<google::test::admin::database::v1::ListServiceAccountKeysResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.name(), "/", "keys"));
 }
 
@@ -95,7 +95,7 @@ Status DefaultGoldenKitchenSinkRestStub::DoNothing(
       google::cloud::rest_internal::RestContext& rest_context,
       google::protobuf::Empty const& request) {
   return rest_internal::Post(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       "/v1/doNothing");
 }
 
@@ -103,7 +103,7 @@ Status DefaultGoldenKitchenSinkRestStub::ExplicitRouting1(
       google::cloud::rest_internal::RestContext& rest_context,
       google::test::admin::database::v1::ExplicitRoutingRequest const& request) {
   return rest_internal::Post(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.table_name(), ":explicitRouting1"),
       rest_internal::TrimEmptyQueryParameters({std::make_pair("app_profile_id", request.app_profile_id()),
         std::make_pair("no_regex_needed", request.no_regex_needed())}));
@@ -113,7 +113,7 @@ Status DefaultGoldenKitchenSinkRestStub::ExplicitRouting2(
       google::cloud::rest_internal::RestContext& rest_context,
       google::test::admin::database::v1::ExplicitRoutingRequest const& request) {
   return rest_internal::Post(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.table_name(), ":explicitRouting2"),
       rest_internal::TrimEmptyQueryParameters({std::make_pair("app_profile_id", request.app_profile_id()),
         std::make_pair("no_regex_needed", request.no_regex_needed())}));

--- a/generator/integration_tests/golden/v1/internal/golden_rest_only_rest_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_rest_only_rest_stub.cc
@@ -44,7 +44,7 @@ Status DefaultGoldenRestOnlyRestStub::Noop(
       google::cloud::rest_internal::RestContext& rest_context,
       google::protobuf::Empty const& request) {
   return rest_internal::Post(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       "/v1/noop");
 }
 

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_stub.cc
@@ -50,7 +50,7 @@ DefaultGoldenThingAdminRestStub::ListDatabases(
       google::cloud::rest_internal::RestContext& rest_context,
       google::test::admin::database::v1::ListDatabasesRequest const& request) {
   return rest_internal::Get<google::test::admin::database::v1::ListDatabasesResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.parent(), "/", "databases"),
       rest_internal::TrimEmptyQueryParameters({std::make_pair("page_size", std::to_string(request.page_size())),
         std::make_pair("page_token", request.page_token())}));
@@ -65,7 +65,7 @@ DefaultGoldenThingAdminRestStub::AsyncCreateDatabase(
   future<StatusOr<google::longrunning::Operation>> f = p.get_future();
   std::thread t{[](auto p, auto service, auto request, auto rest_context) {
       p.set_value(rest_internal::Post<google::longrunning::Operation>(
-          *service, *rest_context, request,
+          *service, *rest_context, request, false,
           absl::StrCat("/", "v1", "/", request.parent(), "/", "databases"),
       rest_internal::TrimEmptyQueryParameters({std::make_pair("create_statement", request.create_statement())})));
   }, std::move(p), service_, request, std::move(rest_context)};
@@ -82,7 +82,7 @@ DefaultGoldenThingAdminRestStub::GetDatabase(
       google::cloud::rest_internal::RestContext& rest_context,
       google::test::admin::database::v1::GetDatabaseRequest const& request) {
   return rest_internal::Get<google::test::admin::database::v1::Database>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.name()));
 }
 
@@ -95,7 +95,7 @@ DefaultGoldenThingAdminRestStub::AsyncUpdateDatabaseDdl(
   future<StatusOr<google::longrunning::Operation>> f = p.get_future();
   std::thread t{[](auto p, auto service, auto request, auto rest_context) {
       p.set_value(rest_internal::Patch<google::longrunning::Operation>(
-          *service, *rest_context, request,
+          *service, *rest_context, request, false,
           absl::StrCat("/", "v1", "/", request.database(), "/", "ddl"),
       rest_internal::TrimEmptyQueryParameters({std::make_pair("operation_id", request.operation_id())})));
   }, std::move(p), service_, request, std::move(rest_context)};
@@ -111,7 +111,7 @@ Status DefaultGoldenThingAdminRestStub::DropDatabase(
       google::cloud::rest_internal::RestContext& rest_context,
       google::test::admin::database::v1::DropDatabaseRequest const& request) {
   return rest_internal::Delete(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.database()));
 }
 
@@ -120,7 +120,7 @@ DefaultGoldenThingAdminRestStub::GetDatabaseDdl(
       google::cloud::rest_internal::RestContext& rest_context,
       google::test::admin::database::v1::GetDatabaseDdlRequest const& request) {
   return rest_internal::Get<google::test::admin::database::v1::GetDatabaseDdlResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.database(), "/", "ddl"));
 }
 
@@ -129,7 +129,7 @@ DefaultGoldenThingAdminRestStub::SetIamPolicy(
       google::cloud::rest_internal::RestContext& rest_context,
       google::iam::v1::SetIamPolicyRequest const& request) {
   return rest_internal::Post<google::iam::v1::Policy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.resource(), ":setIamPolicy"));
 }
 
@@ -138,7 +138,7 @@ DefaultGoldenThingAdminRestStub::GetIamPolicy(
       google::cloud::rest_internal::RestContext& rest_context,
       google::iam::v1::GetIamPolicyRequest const& request) {
   return rest_internal::Post<google::iam::v1::Policy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.resource(), ":getIamPolicy"));
 }
 
@@ -147,7 +147,7 @@ DefaultGoldenThingAdminRestStub::TestIamPermissions(
       google::cloud::rest_internal::RestContext& rest_context,
       google::iam::v1::TestIamPermissionsRequest const& request) {
   return rest_internal::Post<google::iam::v1::TestIamPermissionsResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.resource(), ":testIamPermissions"));
 }
 
@@ -160,7 +160,7 @@ DefaultGoldenThingAdminRestStub::AsyncCreateBackup(
   future<StatusOr<google::longrunning::Operation>> f = p.get_future();
   std::thread t{[](auto p, auto service, auto request, auto rest_context) {
       p.set_value(rest_internal::Post<google::longrunning::Operation>(
-          *service, *rest_context, request.backup(),
+          *service, *rest_context, request.backup(), false,
           absl::StrCat("/", "v1", "/", request.parent(), "/", "backups"),
       rest_internal::TrimEmptyQueryParameters({std::make_pair("backup_id", request.backup_id())})));
   }, std::move(p), service_, request, std::move(rest_context)};
@@ -177,7 +177,7 @@ DefaultGoldenThingAdminRestStub::GetBackup(
       google::cloud::rest_internal::RestContext& rest_context,
       google::test::admin::database::v1::GetBackupRequest const& request) {
   return rest_internal::Get<google::test::admin::database::v1::Backup>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.name()));
 }
 
@@ -186,7 +186,7 @@ DefaultGoldenThingAdminRestStub::UpdateBackup(
       google::cloud::rest_internal::RestContext& rest_context,
       google::test::admin::database::v1::UpdateBackupRequest const& request) {
   return rest_internal::Patch<google::test::admin::database::v1::Backup>(
-      *service_, rest_context, request.backup(),
+      *service_, rest_context, request.backup(), false,
       absl::StrCat("/", "v1", "/", request.backup().name()));
 }
 
@@ -194,7 +194,7 @@ Status DefaultGoldenThingAdminRestStub::DeleteBackup(
       google::cloud::rest_internal::RestContext& rest_context,
       google::test::admin::database::v1::DeleteBackupRequest const& request) {
   return rest_internal::Delete(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.name()));
 }
 
@@ -203,7 +203,7 @@ DefaultGoldenThingAdminRestStub::ListBackups(
       google::cloud::rest_internal::RestContext& rest_context,
       google::test::admin::database::v1::ListBackupsRequest const& request) {
   return rest_internal::Get<google::test::admin::database::v1::ListBackupsResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.parent(), "/", "backups"),
       rest_internal::TrimEmptyQueryParameters({std::make_pair("filter", request.filter()),
         std::make_pair("page_size", std::to_string(request.page_size())),
@@ -219,7 +219,7 @@ DefaultGoldenThingAdminRestStub::AsyncRestoreDatabase(
   future<StatusOr<google::longrunning::Operation>> f = p.get_future();
   std::thread t{[](auto p, auto service, auto request, auto rest_context) {
       p.set_value(rest_internal::Post<google::longrunning::Operation>(
-          *service, *rest_context, request,
+          *service, *rest_context, request, false,
           absl::StrCat("/", "v1", "/", request.parent(), "/", "databases", ":restore"),
       rest_internal::TrimEmptyQueryParameters({std::make_pair("database_id", request.database_id()),
         std::make_pair("backup", request.backup())})));
@@ -237,7 +237,7 @@ DefaultGoldenThingAdminRestStub::ListDatabaseOperations(
       google::cloud::rest_internal::RestContext& rest_context,
       google::test::admin::database::v1::ListDatabaseOperationsRequest const& request) {
   return rest_internal::Get<google::test::admin::database::v1::ListDatabaseOperationsResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.parent(), "/", "databaseOperations"),
       rest_internal::TrimEmptyQueryParameters({std::make_pair("filter", request.filter()),
         std::make_pair("page_size", std::to_string(request.page_size())),
@@ -249,7 +249,7 @@ DefaultGoldenThingAdminRestStub::ListBackupOperations(
       google::cloud::rest_internal::RestContext& rest_context,
       google::test::admin::database::v1::ListBackupOperationsRequest const& request) {
   return rest_internal::Get<google::test::admin::database::v1::ListBackupOperationsResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.parent(), "/", "backupOperations"),
       rest_internal::TrimEmptyQueryParameters({std::make_pair("filter", request.filter()),
         std::make_pair("page_size", std::to_string(request.page_size())),
@@ -265,7 +265,7 @@ DefaultGoldenThingAdminRestStub::AsyncGetDatabase(
   future<StatusOr<google::test::admin::database::v1::Database>> f = p.get_future();
   std::thread t{[](auto p, auto service, auto request, auto rest_context) {
       p.set_value(rest_internal::Get<google::test::admin::database::v1::Database>(
-          *service, *rest_context, request,
+          *service, *rest_context, request, false,
           absl::StrCat("/", "v1", "/", request.name())));
   }, std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -285,7 +285,7 @@ DefaultGoldenThingAdminRestStub::AsyncDropDatabase(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto service, auto request, auto rest_context) {
       p.set_value(rest_internal::Delete<google::protobuf::Empty>(
-          *service, *rest_context, request,
+          *service, *rest_context, request, false,
           absl::StrCat("/", "v1", "/", request.database())));
   }, std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -305,7 +305,7 @@ DefaultGoldenThingAdminRestStub::AsyncGetOperation(
   future<StatusOr<google::longrunning::Operation>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
       p.set_value(rest_internal::Get<google::longrunning::Operation>(
-          *operations, *rest_context, request,
+          *operations, *rest_context, request, false,
           absl::StrCat("/v1/", request.name())));
   }, std::move(p), operations_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -325,7 +325,7 @@ DefaultGoldenThingAdminRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
       p.set_value(rest_internal::Post<google::protobuf::Empty>(
-          *operations, *rest_context, request,
+          *operations, *rest_context, request, false,
           absl::StrCat("/v1/", request.name(), ":cancel")));
   }, std::move(p), operations_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/generator/internal/service_code_generator.cc
+++ b/generator/internal/service_code_generator.cc
@@ -200,13 +200,6 @@ bool ServiceCodeGenerator::HasGenerateGrpcTransport() const {
          generate_grpc_transport->second == "true";
 }
 
-bool ServiceCodeGenerator::HasPreserveProtoFieldNamesInJson() const {
-  auto const preserve_proto_field_names_in_json =
-      service_vars_.find("preserve_proto_field_names_in_json");
-  return preserve_proto_field_names_in_json != service_vars_.end() &&
-         preserve_proto_field_names_in_json->second == "true";
-}
-
 std::vector<std::string>
 ServiceCodeGenerator::MethodSignatureWellKnownProtobufTypeIncludes() const {
   std::vector<std::string> include_paths;

--- a/generator/internal/service_code_generator.cc
+++ b/generator/internal/service_code_generator.cc
@@ -200,6 +200,13 @@ bool ServiceCodeGenerator::HasGenerateGrpcTransport() const {
          generate_grpc_transport->second == "true";
 }
 
+bool ServiceCodeGenerator::HasPreserveProtoFieldNamesInJson() const {
+  auto const preserve_proto_field_names_in_json =
+      service_vars_.find("preserve_proto_field_names_in_json");
+  return preserve_proto_field_names_in_json != service_vars_.end() &&
+         preserve_proto_field_names_in_json->second == "true";
+}
+
 std::vector<std::string>
 ServiceCodeGenerator::MethodSignatureWellKnownProtobufTypeIncludes() const {
   std::vector<std::string> include_paths;

--- a/generator/internal/service_code_generator.h
+++ b/generator/internal/service_code_generator.h
@@ -186,6 +186,12 @@ class ServiceCodeGenerator : public GeneratorInterface {
   bool HasGenerateGrpcTransport() const;
 
   /**
+   * Determines if protobuf to JSON transcoding should preserve field names as
+   * they appear in the proto definition or render the field names in camelCase.
+   */
+  bool HasPreserveProtoFieldNamesInJson() const;
+
+  /**
    * Determines if any of the method signatures has any Protocol Buffer
    * Well-Known Types per
    * https://developers.google.com/protocol-buffers/docs/reference/google.protobuf

--- a/generator/internal/service_code_generator.h
+++ b/generator/internal/service_code_generator.h
@@ -186,12 +186,6 @@ class ServiceCodeGenerator : public GeneratorInterface {
   bool HasGenerateGrpcTransport() const;
 
   /**
-   * Determines if protobuf to JSON transcoding should preserve field names as
-   * they appear in the proto definition or render the field names in camelCase.
-   */
-  bool HasPreserveProtoFieldNamesInJson() const;
-
-  /**
    * Determines if any of the method signatures has any Protocol Buffer
    * Well-Known Types per
    * https://developers.google.com/protocol-buffers/docs/reference/google.protobuf

--- a/generator/internal/stub_rest_generator.cc
+++ b/generator/internal/stub_rest_generator.cc
@@ -326,7 +326,7 @@ Default$stub_rest_class_name$::Async$method_name$(
   future<StatusOr<$response_type$>> f = p.get_future();
   std::thread t{[](auto p, auto service, auto request, auto rest_context) {
       p.set_value(rest_internal::$method_http_verb$<$response_type$>(
-          *service, *rest_context, $request_resource$,
+          *service, *rest_context, $request_resource$, $preserve_proto_field_names_in_json$,
           $method_rest_path$$method_http_query_parameters$));
   }, std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -344,7 +344,7 @@ Status Default$stub_rest_class_name$::$method_name$(
       google::cloud::rest_internal::RestContext& rest_context,
       $request_type$ const& request) {
   return rest_internal::$method_http_verb$(
-      *service_, rest_context, $request_resource$,
+      *service_, rest_context, $request_resource$, $preserve_proto_field_names_in_json$,
       $method_rest_path$$method_http_query_parameters$);
 }
 )""");
@@ -355,7 +355,7 @@ Default$stub_rest_class_name$::$method_name$(
       google::cloud::rest_internal::RestContext& rest_context,
       $request_type$ const& request) {
   return rest_internal::$method_http_verb$<$response_type$>(
-      *service_, rest_context, $request_resource$,
+      *service_, rest_context, $request_resource$, $preserve_proto_field_names_in_json$,
       $method_rest_path$$method_http_query_parameters$);
 }
 )""");
@@ -377,7 +377,7 @@ Default$stub_rest_class_name$::Async$method_name$(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto service, auto request, auto rest_context) {
       p.set_value(rest_internal::$method_http_verb$<google::protobuf::Empty>(
-          *service, *rest_context, $request_resource$,
+          *service, *rest_context, $request_resource$, $preserve_proto_field_names_in_json$,
           $method_rest_path$$method_http_query_parameters$));
   }, std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -399,7 +399,7 @@ Default$stub_rest_class_name$::Async$method_name$(
   future<StatusOr<$response_type$>> f = p.get_future();
   std::thread t{[](auto p, auto service, auto request, auto rest_context) {
       p.set_value(rest_internal::$method_http_verb$<$response_type$>(
-          *service, *rest_context, $request_resource$,
+          *service, *rest_context, $request_resource$, $preserve_proto_field_names_in_json$,
           $method_rest_path$$method_http_query_parameters$));
   }, std::move(p), service_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -425,7 +425,7 @@ Default$stub_rest_class_name$::AsyncGetOperation(
   future<StatusOr<$longrunning_response_type$>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
       p.set_value(rest_internal::Get<$longrunning_response_type$>(
-          *operations, *rest_context, request,
+          *operations, *rest_context, request, $preserve_proto_field_names_in_json$,
           $longrunning_get_operation_path$));
   }, std::move(p), operations_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {
@@ -445,7 +445,7 @@ Default$stub_rest_class_name$::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
       p.set_value(rest_internal::Post<google::protobuf::Empty>(
-          *operations, *rest_context, request,
+          *operations, *rest_context, request, $preserve_proto_field_names_in_json$,
           $longrunning_cancel_operation_path$));
   }, std::move(p), operations_, request, std::move(rest_context)};
   return f.then([t = std::move(t), cq](auto f) mutable {

--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -347,8 +347,7 @@ std::vector<std::future<google::cloud::Status>> GenerateCodeFromProtos(
 
     // Unless preserve_proto_field_names_in_json has been explicitly set to
     // true, treat it as having a default value of false.
-    if (service.has_preserve_proto_field_names_in_json() &&
-        service.preserve_proto_field_names_in_json()) {
+    if (service.preserve_proto_field_names_in_json()) {
       args.emplace_back(
           "--cpp_codegen_opt=preserve_proto_field_names_in_json=true");
     } else {

--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -345,6 +345,17 @@ std::vector<std::future<google::cloud::Status>> GenerateCodeFromProtos(
       args.emplace_back("--cpp_codegen_opt=proto_file_source=googleapis");
     }
 
+    // Unless preserve_proto_field_names_in_json has been explicitly set to
+    // true, treat it as having a default value of false.
+    if (service.has_preserve_proto_field_names_in_json() &&
+        service.preserve_proto_field_names_in_json()) {
+      args.emplace_back(
+          "--cpp_codegen_opt=preserve_proto_field_names_in_json=true");
+    } else {
+      args.emplace_back(
+          "--cpp_codegen_opt=preserve_proto_field_names_in_json=false");
+    }
+
     GCP_LOG(INFO) << "Generating service code using: "
                   << absl::StrJoin(args, ";") << "\n";
 

--- a/google/cloud/compute/accelerator_types/v1/internal/accelerator_types_rest_stub.cc
+++ b/google/cloud/compute/accelerator_types/v1/internal/accelerator_types_rest_stub.cc
@@ -46,7 +46,7 @@ DefaultAcceleratorTypesRestStub::AggregatedListAcceleratorTypes(
         AggregatedListAcceleratorTypesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::AcceleratorTypeAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "acceleratorTypes"),
@@ -67,7 +67,7 @@ DefaultAcceleratorTypesRestStub::GetAcceleratorType(
     google::cloud::cpp::compute::accelerator_types::v1::
         GetAcceleratorTypeRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::AcceleratorType>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "acceleratorTypes", "/", request.accelerator_type()));
@@ -80,7 +80,7 @@ DefaultAcceleratorTypesRestStub::ListAcceleratorTypes(
         ListAcceleratorTypesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::AcceleratorTypeList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "acceleratorTypes"),

--- a/google/cloud/compute/addresses/v1/internal/addresses_rest_stub.cc
+++ b/google/cloud/compute/addresses/v1/internal/addresses_rest_stub.cc
@@ -51,7 +51,7 @@ DefaultAddressesRestStub::AggregatedListAddresses(
         AggregatedListAddressesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::AddressAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "addresses"),
       rest_internal::TrimEmptyQueryParameters(
@@ -78,7 +78,7 @@ DefaultAddressesRestStub::AsyncDeleteAddress(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "addresses", "/",
@@ -99,7 +99,7 @@ DefaultAddressesRestStub::GetAddress(
     google::cloud::cpp::compute::addresses::v1::GetAddressRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Address>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "addresses", "/", request.address()));
@@ -118,7 +118,7 @@ DefaultAddressesRestStub::AsyncInsertAddress(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.address_resource(),
+                *service, *rest_context, request.address_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "addresses"),
@@ -138,7 +138,7 @@ DefaultAddressesRestStub::ListAddresses(
     google::cloud::cpp::compute::addresses::v1::ListAddressesRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::AddressList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "addresses"),
@@ -164,7 +164,7 @@ DefaultAddressesRestStub::AsyncMove(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.region_addresses_move_request_resource(),
+                request.region_addresses_move_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "addresses", "/",
@@ -193,7 +193,7 @@ DefaultAddressesRestStub::AsyncSetLabels(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.region_set_labels_request_resource(),
+                request.region_set_labels_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "addresses", "/",
@@ -221,7 +221,7 @@ DefaultAddressesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -242,7 +242,7 @@ future<Status> DefaultAddressesRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/autoscalers/v1/internal/autoscalers_rest_stub.cc
+++ b/google/cloud/compute/autoscalers/v1/internal/autoscalers_rest_stub.cc
@@ -51,7 +51,7 @@ DefaultAutoscalersRestStub::AggregatedListAutoscalers(
         AggregatedListAutoscalersRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::AutoscalerAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "autoscalers"),
       rest_internal::TrimEmptyQueryParameters(
@@ -78,7 +78,7 @@ DefaultAutoscalersRestStub::AsyncDeleteAutoscaler(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "autoscalers", "/",
@@ -99,7 +99,7 @@ DefaultAutoscalersRestStub::GetAutoscaler(
     google::cloud::cpp::compute::autoscalers::v1::GetAutoscalerRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Autoscaler>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "autoscalers", "/", request.autoscaler()));
@@ -118,7 +118,7 @@ DefaultAutoscalersRestStub::AsyncInsertAutoscaler(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.autoscaler_resource(),
+                *service, *rest_context, request.autoscaler_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "autoscalers"),
@@ -138,7 +138,7 @@ DefaultAutoscalersRestStub::ListAutoscalers(
     google::cloud::cpp::compute::autoscalers::v1::ListAutoscalersRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::AutoscalerList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "autoscalers"),
@@ -164,7 +164,7 @@ DefaultAutoscalersRestStub::AsyncPatchAutoscaler(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.autoscaler_resource(),
+                *service, *rest_context, request.autoscaler_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "autoscalers"),
@@ -192,7 +192,7 @@ DefaultAutoscalersRestStub::AsyncUpdateAutoscaler(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Put<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.autoscaler_resource(),
+                *service, *rest_context, request.autoscaler_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "autoscalers"),
@@ -220,7 +220,7 @@ DefaultAutoscalersRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/zones/", request.zone(), "/operations/",
                              request.operation())));
@@ -242,7 +242,7 @@ future<Status> DefaultAutoscalersRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
                          request.zone(), "/operations/", request.operation())));
       },

--- a/google/cloud/compute/backend_buckets/v1/internal/backend_buckets_rest_stub.cc
+++ b/google/cloud/compute/backend_buckets/v1/internal/backend_buckets_rest_stub.cc
@@ -58,6 +58,7 @@ DefaultBackendBucketsRestStub::AsyncAddSignedUrlKey(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.signed_url_key_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "backendBuckets", "/", request.backend_bucket(),
@@ -85,7 +86,7 @@ DefaultBackendBucketsRestStub::AsyncDeleteBackendBucket(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "backendBuckets", "/", request.backend_bucket()),
@@ -112,7 +113,7 @@ DefaultBackendBucketsRestStub::AsyncDeleteSignedUrlKey(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "backendBuckets", "/", request.backend_bucket(),
@@ -134,7 +135,7 @@ DefaultBackendBucketsRestStub::GetBackendBucket(
     google::cloud::cpp::compute::backend_buckets::v1::
         GetBackendBucketRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::BackendBucket>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "backendBuckets", "/",
                    request.backend_bucket()));
@@ -154,6 +155,7 @@ DefaultBackendBucketsRestStub::AsyncInsertBackendBucket(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.backend_bucket_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "backendBuckets"),
@@ -173,7 +175,7 @@ DefaultBackendBucketsRestStub::ListBackendBuckets(
     google::cloud::cpp::compute::backend_buckets::v1::
         ListBackendBucketsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::BackendBucketList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "backendBuckets"),
       rest_internal::TrimEmptyQueryParameters(
@@ -199,6 +201,7 @@ DefaultBackendBucketsRestStub::AsyncPatchBackendBucket(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.backend_bucket_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "backendBuckets", "/", request.backend_bucket()),
@@ -226,7 +229,7 @@ DefaultBackendBucketsRestStub::AsyncSetEdgeSecurityPolicy(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.security_policy_reference_resource(),
+                request.security_policy_reference_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "backendBuckets", "/", request.backend_bucket(),
@@ -255,6 +258,7 @@ DefaultBackendBucketsRestStub::AsyncUpdateBackendBucket(
         p.set_value(
             rest_internal::Put<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.backend_bucket_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "backendBuckets", "/", request.backend_bucket()),
@@ -281,7 +285,7 @@ DefaultBackendBucketsRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/global/operations/", request.operation())));
       },
@@ -302,7 +306,7 @@ future<Status> DefaultBackendBucketsRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(),
                          "/global/operations/", request.operation())));
       },

--- a/google/cloud/compute/backend_services/v1/internal/backend_services_rest_stub.cc
+++ b/google/cloud/compute/backend_services/v1/internal/backend_services_rest_stub.cc
@@ -58,6 +58,7 @@ DefaultBackendServicesRestStub::AsyncAddSignedUrlKey(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.signed_url_key_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "backendServices", "/", request.backend_service(),
@@ -79,7 +80,7 @@ DefaultBackendServicesRestStub::AggregatedListBackendServices(
         AggregatedListBackendServicesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::BackendServiceAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "backendServices"),
@@ -107,7 +108,7 @@ DefaultBackendServicesRestStub::AsyncDeleteBackendService(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "backendServices", "/", request.backend_service()),
@@ -134,7 +135,7 @@ DefaultBackendServicesRestStub::AsyncDeleteSignedUrlKey(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "backendServices", "/", request.backend_service(),
@@ -156,7 +157,7 @@ DefaultBackendServicesRestStub::GetBackendService(
     google::cloud::cpp::compute::backend_services::v1::
         GetBackendServiceRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::BackendService>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "backendServices",
                    "/", request.backend_service()));
@@ -170,6 +171,7 @@ DefaultBackendServicesRestStub::GetHealth(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::BackendServiceGroupHealth>(
       *service_, rest_context, request.resource_group_reference_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "backendServices",
                    "/", request.backend_service(), "/", "getHealth"));
@@ -181,7 +183,7 @@ DefaultBackendServicesRestStub::GetIamPolicy(
     google::cloud::cpp::compute::backend_services::v1::
         GetIamPolicyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "backendServices",
                    "/", request.resource(), "/", "getIamPolicy"),
@@ -204,6 +206,7 @@ DefaultBackendServicesRestStub::AsyncInsertBackendService(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.backend_service_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "backendServices"),
@@ -224,7 +227,7 @@ DefaultBackendServicesRestStub::ListBackendServices(
         ListBackendServicesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::BackendServiceList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "backendServices"),
       rest_internal::TrimEmptyQueryParameters(
@@ -250,6 +253,7 @@ DefaultBackendServicesRestStub::AsyncPatchBackendService(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.backend_service_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "backendServices", "/", request.backend_service()),
@@ -277,7 +281,7 @@ DefaultBackendServicesRestStub::AsyncSetEdgeSecurityPolicy(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.security_policy_reference_resource(),
+                request.security_policy_reference_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "backendServices", "/", request.backend_service(),
@@ -299,6 +303,7 @@ DefaultBackendServicesRestStub::SetIamPolicy(
         SetIamPolicyRequest const& request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.global_set_policy_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "backendServices",
                    "/", request.resource(), "/", "setIamPolicy"));
@@ -318,7 +323,7 @@ DefaultBackendServicesRestStub::AsyncSetSecurityPolicy(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.security_policy_reference_resource(),
+                request.security_policy_reference_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "backendServices", "/", request.backend_service(),
@@ -347,6 +352,7 @@ DefaultBackendServicesRestStub::AsyncUpdateBackendService(
         p.set_value(
             rest_internal::Put<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.backend_service_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "backendServices", "/", request.backend_service()),
@@ -373,7 +379,7 @@ DefaultBackendServicesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/global/operations/", request.operation())));
       },
@@ -394,7 +400,7 @@ future<Status> DefaultBackendServicesRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(),
                          "/global/operations/", request.operation())));
       },

--- a/google/cloud/compute/disk_types/v1/internal/disk_types_rest_stub.cc
+++ b/google/cloud/compute/disk_types/v1/internal/disk_types_rest_stub.cc
@@ -45,7 +45,7 @@ DefaultDiskTypesRestStub::AggregatedListDiskTypes(
         AggregatedListDiskTypesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::DiskTypeAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "diskTypes"),
       rest_internal::TrimEmptyQueryParameters(
@@ -65,7 +65,7 @@ DefaultDiskTypesRestStub::GetDiskType(
     google::cloud::cpp::compute::disk_types::v1::GetDiskTypeRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::DiskType>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "diskTypes", "/", request.disk_type()));
@@ -77,7 +77,7 @@ DefaultDiskTypesRestStub::ListDiskTypes(
     google::cloud::cpp::compute::disk_types::v1::ListDiskTypesRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::DiskTypeList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "diskTypes"),

--- a/google/cloud/compute/disks/v1/internal/disks_rest_stub.cc
+++ b/google/cloud/compute/disks/v1/internal/disks_rest_stub.cc
@@ -58,7 +58,7 @@ DefaultDisksRestStub::AsyncAddResourcePolicies(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.disks_add_resource_policies_request_resource(),
+                request.disks_add_resource_policies_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "disks", "/", request.disk(),
@@ -80,7 +80,7 @@ DefaultDisksRestStub::AggregatedListDisks(
         request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::DiskAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "disks"),
       rest_internal::TrimEmptyQueryParameters(
@@ -107,6 +107,7 @@ DefaultDisksRestStub::AsyncBulkInsert(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.bulk_insert_disk_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "disks", "/", "bulkInsert"),
@@ -133,7 +134,7 @@ DefaultDisksRestStub::AsyncCreateSnapshot(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.snapshot_resource(),
+                *service, *rest_context, request.snapshot_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "disks", "/", request.disk(),
@@ -162,7 +163,7 @@ DefaultDisksRestStub::AsyncDeleteDisk(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "disks", "/", request.disk()),
@@ -180,7 +181,7 @@ StatusOr<google::cloud::cpp::compute::v1::Disk> DefaultDisksRestStub::GetDisk(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::cpp::compute::disks::v1::GetDiskRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Disk>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "disks", "/", request.disk()));
@@ -192,7 +193,7 @@ DefaultDisksRestStub::GetIamPolicy(
     google::cloud::cpp::compute::disks::v1::GetIamPolicyRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "disks", "/", request.resource(), "/", "getIamPolicy"),
@@ -213,7 +214,7 @@ DefaultDisksRestStub::AsyncInsertDisk(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.disk_resource(),
+                *service, *rest_context, request.disk_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "disks"),
@@ -233,7 +234,7 @@ DefaultDisksRestStub::ListDisks(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::cpp::compute::disks::v1::ListDisksRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::DiskList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "disks"),
@@ -261,6 +262,7 @@ DefaultDisksRestStub::AsyncRemoveResourcePolicies(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.disks_remove_resource_policies_request_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "disks", "/", request.disk(),
@@ -288,7 +290,7 @@ DefaultDisksRestStub::AsyncResize(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.disks_resize_request_resource(),
+                request.disks_resize_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "disks", "/", request.disk(),
@@ -310,6 +312,7 @@ DefaultDisksRestStub::SetIamPolicy(
         request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.zone_set_policy_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "disks", "/", request.resource(), "/", "setIamPolicy"));
@@ -328,7 +331,7 @@ DefaultDisksRestStub::AsyncSetLabels(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.zone_set_labels_request_resource(),
+                request.zone_set_labels_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "disks", "/",
@@ -357,7 +360,7 @@ DefaultDisksRestStub::AsyncStartAsyncReplication(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.disks_start_async_replication_request_resource(),
+                request.disks_start_async_replication_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "disks", "/", request.disk(),
@@ -385,7 +388,7 @@ DefaultDisksRestStub::AsyncStopAsyncReplication(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "disks", "/", request.disk(),
@@ -414,7 +417,7 @@ DefaultDisksRestStub::AsyncStopGroupAsyncReplication(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.disks_stop_group_async_replication_resource(),
+                request.disks_stop_group_async_replication_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "disks", "/",
@@ -437,6 +440,7 @@ DefaultDisksRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "disks", "/", request.resource(), "/",
@@ -455,7 +459,7 @@ DefaultDisksRestStub::AsyncUpdateDisk(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.disk_resource(),
+                *service, *rest_context, request.disk_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "disks", "/", request.disk()),
@@ -484,7 +488,7 @@ DefaultDisksRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/zones/", request.zone(), "/operations/",
                              request.operation())));
@@ -506,7 +510,7 @@ future<Status> DefaultDisksRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
                          request.zone(), "/operations/", request.operation())));
       },

--- a/google/cloud/compute/external_vpn_gateways/v1/internal/external_vpn_gateways_rest_stub.cc
+++ b/google/cloud/compute/external_vpn_gateways/v1/internal/external_vpn_gateways_rest_stub.cc
@@ -59,7 +59,7 @@ DefaultExternalVpnGatewaysRestStub::AsyncDeleteExternalVpnGateway(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "externalVpnGateways", "/",
@@ -81,7 +81,7 @@ DefaultExternalVpnGatewaysRestStub::GetExternalVpnGateway(
         GetExternalVpnGatewayRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::ExternalVpnGateway>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "externalVpnGateways",
                    "/", request.external_vpn_gateway()));
@@ -101,7 +101,7 @@ DefaultExternalVpnGatewaysRestStub::AsyncInsertExternalVpnGateway(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.external_vpn_gateway_resource(),
+                request.external_vpn_gateway_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "externalVpnGateways"),
@@ -122,7 +122,7 @@ DefaultExternalVpnGatewaysRestStub::ListExternalVpnGateways(
         ListExternalVpnGatewaysRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::ExternalVpnGatewayList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/",
                    "externalVpnGateways"),
@@ -149,7 +149,7 @@ DefaultExternalVpnGatewaysRestStub::AsyncSetLabels(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.global_set_labels_request_resource(),
+                request.global_set_labels_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "externalVpnGateways", "/", request.resource(),
@@ -170,6 +170,7 @@ DefaultExternalVpnGatewaysRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "externalVpnGateways",
                    "/", request.resource(), "/", "testIamPermissions"));
@@ -188,7 +189,7 @@ DefaultExternalVpnGatewaysRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/global/operations/", request.operation())));
       },
@@ -209,7 +210,7 @@ future<Status> DefaultExternalVpnGatewaysRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(),
                          "/global/operations/", request.operation())));
       },

--- a/google/cloud/compute/firewall_policies/v1/internal/firewall_policies_rest_stub.cc
+++ b/google/cloud/compute/firewall_policies/v1/internal/firewall_policies_rest_stub.cc
@@ -59,7 +59,7 @@ DefaultFirewallPoliciesRestStub::AsyncAddAssociation(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.firewall_policy_association_resource(),
+                request.firewall_policy_association_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/",
                              "global", "/", "firewallPolicies", "/",
                              request.firewall_policy(), "/", "addAssociation"),
@@ -90,7 +90,7 @@ DefaultFirewallPoliciesRestStub::AsyncAddRule(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.firewall_policy_rule_resource(),
+                request.firewall_policy_rule_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/",
                              "global", "/", "firewallPolicies", "/",
                              request.firewall_policy(), "/", "addRule"),
@@ -117,7 +117,7 @@ DefaultFirewallPoliciesRestStub::AsyncCloneRules(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/",
                              "global", "/", "firewallPolicies", "/",
                              request.firewall_policy(), "/", "cloneRules"),
@@ -146,7 +146,7 @@ DefaultFirewallPoliciesRestStub::AsyncDeleteFirewallPolicy(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/",
                              "global", "/", "firewallPolicies", "/",
                              request.firewall_policy()),
@@ -166,7 +166,7 @@ DefaultFirewallPoliciesRestStub::GetFirewallPolicy(
     google::cloud::cpp::compute::firewall_policies::v1::
         GetFirewallPolicyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::FirewallPolicy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/", "global",
                    "/", "firewallPolicies", "/", request.firewall_policy()));
 }
@@ -178,7 +178,7 @@ DefaultFirewallPoliciesRestStub::GetAssociation(
         GetAssociationRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::FirewallPolicyAssociation>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/", "global",
                    "/", "firewallPolicies", "/", request.firewall_policy(), "/",
                    "getAssociation"),
@@ -192,7 +192,7 @@ DefaultFirewallPoliciesRestStub::GetIamPolicy(
     google::cloud::cpp::compute::firewall_policies::v1::
         GetIamPolicyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/", "global",
                    "/", "firewallPolicies", "/", request.resource(), "/",
                    "getIamPolicy"),
@@ -208,7 +208,7 @@ DefaultFirewallPoliciesRestStub::GetRule(
         request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::FirewallPolicyRule>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/", "global",
                    "/", "firewallPolicies", "/", request.firewall_policy(), "/",
                    "getRule"),
@@ -230,7 +230,7 @@ DefaultFirewallPoliciesRestStub::AsyncInsertFirewallPolicy(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.firewall_policy_resource(),
-                "/compute/v1/locations/global/firewallPolicies",
+                false, "/compute/v1/locations/global/firewallPolicies",
                 rest_internal::TrimEmptyQueryParameters(
                     {std::make_pair("parent_id", request.parent_id()),
                      std::make_pair("request_id", request.request_id())})));
@@ -249,7 +249,7 @@ DefaultFirewallPoliciesRestStub::ListFirewallPolicies(
         ListFirewallPoliciesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::FirewallPolicyList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       "/compute/v1/locations/global/firewallPolicies",
       rest_internal::TrimEmptyQueryParameters(
           {std::make_pair("filter", request.filter()),
@@ -269,7 +269,7 @@ DefaultFirewallPoliciesRestStub::ListAssociations(
         ListAssociationsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::
                                 FirewallPoliciesListAssociationsResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       "/compute/v1/locations/global/firewallPolicies/listAssociations",
       rest_internal::TrimEmptyQueryParameters(
           {std::make_pair("target_resource", request.target_resource())}));
@@ -288,7 +288,7 @@ DefaultFirewallPoliciesRestStub::AsyncMove(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/",
                              "global", "/", "firewallPolicies", "/",
                              request.firewall_policy(), "/", "move"),
@@ -317,6 +317,7 @@ DefaultFirewallPoliciesRestStub::AsyncPatchFirewallPolicy(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.firewall_policy_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/",
                              "global", "/", "firewallPolicies", "/",
                              request.firewall_policy()),
@@ -344,7 +345,7 @@ DefaultFirewallPoliciesRestStub::AsyncPatchRule(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.firewall_policy_rule_resource(),
+                request.firewall_policy_rule_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/",
                              "global", "/", "firewallPolicies", "/",
                              request.firewall_policy(), "/", "patchRule"),
@@ -373,7 +374,7 @@ DefaultFirewallPoliciesRestStub::AsyncRemoveAssociation(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/",
                              "global", "/", "firewallPolicies", "/",
                              request.firewall_policy(), "/",
@@ -402,7 +403,7 @@ DefaultFirewallPoliciesRestStub::AsyncRemoveRule(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/",
                              "global", "/", "firewallPolicies", "/",
                              request.firewall_policy(), "/", "removeRule"),
@@ -425,7 +426,7 @@ DefaultFirewallPoliciesRestStub::SetIamPolicy(
         SetIamPolicyRequest const& request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context,
-      request.global_organization_set_policy_request_resource(),
+      request.global_organization_set_policy_request_resource(), false,
       absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/", "global",
                    "/", "firewallPolicies", "/", request.resource(), "/",
                    "setIamPolicy"));
@@ -439,6 +440,7 @@ DefaultFirewallPoliciesRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/", "global",
                    "/", "firewallPolicies", "/", request.resource(), "/",
                    "testIamPermissions"));
@@ -457,7 +459,7 @@ DefaultFirewallPoliciesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/locations/global/operations/",
                              request.operation())));
       },
@@ -477,7 +479,7 @@ future<Status> DefaultFirewallPoliciesRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/locations/global/operations/",
                                    request.operation())));
                 },

--- a/google/cloud/compute/firewalls/v1/internal/firewalls_rest_stub.cc
+++ b/google/cloud/compute/firewalls/v1/internal/firewalls_rest_stub.cc
@@ -57,7 +57,7 @@ DefaultFirewallsRestStub::AsyncDeleteFirewall(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "firewalls",
                              "/", request.firewall()),
@@ -77,7 +77,7 @@ DefaultFirewallsRestStub::GetFirewall(
     google::cloud::cpp::compute::firewalls::v1::GetFirewallRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Firewall>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "firewalls", "/",
                    request.firewall()));
@@ -96,7 +96,7 @@ DefaultFirewallsRestStub::AsyncInsertFirewall(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.firewall_resource(),
+                *service, *rest_context, request.firewall_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "firewalls"),
@@ -116,7 +116,7 @@ DefaultFirewallsRestStub::ListFirewalls(
     google::cloud::cpp::compute::firewalls::v1::ListFirewallsRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::FirewallList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "firewalls"),
       rest_internal::TrimEmptyQueryParameters(
@@ -141,7 +141,7 @@ DefaultFirewallsRestStub::AsyncPatchFirewall(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.firewall_resource(),
+                *service, *rest_context, request.firewall_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "firewalls",
                              "/", request.firewall()),
@@ -168,7 +168,7 @@ DefaultFirewallsRestStub::AsyncUpdateFirewall(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Put<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.firewall_resource(),
+                *service, *rest_context, request.firewall_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "firewalls",
                              "/", request.firewall()),
@@ -195,7 +195,7 @@ DefaultFirewallsRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/global/operations/", request.operation())));
       },
@@ -216,7 +216,7 @@ future<Status> DefaultFirewallsRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(),
                          "/global/operations/", request.operation())));
       },

--- a/google/cloud/compute/forwarding_rules/v1/internal/forwarding_rules_rest_stub.cc
+++ b/google/cloud/compute/forwarding_rules/v1/internal/forwarding_rules_rest_stub.cc
@@ -51,7 +51,7 @@ DefaultForwardingRulesRestStub::AggregatedListForwardingRules(
         AggregatedListForwardingRulesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::ForwardingRuleAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "forwardingRules"),
@@ -79,7 +79,7 @@ DefaultForwardingRulesRestStub::AsyncDeleteForwardingRule(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "forwardingRules", "/",
@@ -100,7 +100,7 @@ DefaultForwardingRulesRestStub::GetForwardingRule(
     google::cloud::cpp::compute::forwarding_rules::v1::
         GetForwardingRuleRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::ForwardingRule>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "forwardingRules", "/", request.forwarding_rule()));
@@ -120,6 +120,7 @@ DefaultForwardingRulesRestStub::AsyncInsertForwardingRule(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.forwarding_rule_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "forwardingRules"),
@@ -140,7 +141,7 @@ DefaultForwardingRulesRestStub::ListForwardingRules(
         ListForwardingRulesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::ForwardingRuleList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "forwardingRules"),
@@ -167,6 +168,7 @@ DefaultForwardingRulesRestStub::AsyncPatchForwardingRule(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.forwarding_rule_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "forwardingRules", "/",
@@ -195,7 +197,7 @@ DefaultForwardingRulesRestStub::AsyncSetLabels(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.region_set_labels_request_resource(),
+                request.region_set_labels_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "forwardingRules", "/",
@@ -224,6 +226,7 @@ DefaultForwardingRulesRestStub::AsyncSetTarget(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_reference_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "forwardingRules", "/",
@@ -251,7 +254,7 @@ DefaultForwardingRulesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -272,7 +275,7 @@ future<Status> DefaultForwardingRulesRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/global_addresses/v1/internal/global_addresses_rest_stub.cc
+++ b/google/cloud/compute/global_addresses/v1/internal/global_addresses_rest_stub.cc
@@ -57,7 +57,7 @@ DefaultGlobalAddressesRestStub::AsyncDeleteAddress(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "addresses",
                              "/", request.address()),
@@ -77,7 +77,7 @@ DefaultGlobalAddressesRestStub::GetAddress(
     google::cloud::cpp::compute::global_addresses::v1::GetAddressRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Address>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "addresses", "/",
                    request.address()));
@@ -96,7 +96,7 @@ DefaultGlobalAddressesRestStub::AsyncInsertAddress(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.address_resource(),
+                *service, *rest_context, request.address_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "addresses"),
@@ -116,7 +116,7 @@ DefaultGlobalAddressesRestStub::ListGlobalAddresses(
     google::cloud::cpp::compute::global_addresses::v1::
         ListGlobalAddressesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::AddressList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "addresses"),
       rest_internal::TrimEmptyQueryParameters(
@@ -142,7 +142,7 @@ DefaultGlobalAddressesRestStub::AsyncMove(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.global_addresses_move_request_resource(),
+                request.global_addresses_move_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "addresses",
                              "/", request.address(), "/", "move"),
@@ -170,7 +170,7 @@ DefaultGlobalAddressesRestStub::AsyncSetLabels(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.global_set_labels_request_resource(),
+                request.global_set_labels_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "addresses",
                              "/", request.resource(), "/", "setLabels")));
@@ -195,7 +195,7 @@ DefaultGlobalAddressesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/global/operations/", request.operation())));
       },
@@ -216,7 +216,7 @@ future<Status> DefaultGlobalAddressesRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(),
                          "/global/operations/", request.operation())));
       },

--- a/google/cloud/compute/global_forwarding_rules/v1/internal/global_forwarding_rules_rest_stub.cc
+++ b/google/cloud/compute/global_forwarding_rules/v1/internal/global_forwarding_rules_rest_stub.cc
@@ -59,7 +59,7 @@ DefaultGlobalForwardingRulesRestStub::AsyncDeleteForwardingRule(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "forwardingRules", "/", request.forwarding_rule()),
@@ -79,7 +79,7 @@ DefaultGlobalForwardingRulesRestStub::GetForwardingRule(
     google::cloud::cpp::compute::global_forwarding_rules::v1::
         GetForwardingRuleRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::ForwardingRule>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "forwardingRules",
                    "/", request.forwarding_rule()));
@@ -99,6 +99,7 @@ DefaultGlobalForwardingRulesRestStub::AsyncInsertForwardingRule(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.forwarding_rule_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "forwardingRules"),
@@ -119,7 +120,7 @@ DefaultGlobalForwardingRulesRestStub::ListGlobalForwardingRules(
         ListGlobalForwardingRulesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::ForwardingRuleList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "forwardingRules"),
       rest_internal::TrimEmptyQueryParameters(
@@ -145,6 +146,7 @@ DefaultGlobalForwardingRulesRestStub::AsyncPatchForwardingRule(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.forwarding_rule_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "forwardingRules", "/", request.forwarding_rule()),
@@ -172,7 +174,7 @@ DefaultGlobalForwardingRulesRestStub::AsyncSetLabels(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.global_set_labels_request_resource(),
+                request.global_set_labels_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "forwardingRules", "/", request.resource(), "/",
@@ -199,6 +201,7 @@ DefaultGlobalForwardingRulesRestStub::AsyncSetTarget(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_reference_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "forwardingRules", "/", request.forwarding_rule(),
@@ -226,7 +229,7 @@ DefaultGlobalForwardingRulesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/global/operations/", request.operation())));
       },
@@ -247,7 +250,7 @@ future<Status> DefaultGlobalForwardingRulesRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(),
                          "/global/operations/", request.operation())));
       },

--- a/google/cloud/compute/global_network_endpoint_groups/v1/internal/global_network_endpoint_groups_rest_stub.cc
+++ b/google/cloud/compute/global_network_endpoint_groups/v1/internal/global_network_endpoint_groups_rest_stub.cc
@@ -63,6 +63,7 @@ DefaultGlobalNetworkEndpointGroupsRestStub::AsyncAttachNetworkEndpoints(
             *service, *rest_context,
             request
                 .global_network_endpoint_groups_attach_endpoints_request_resource(),
+            false,
             absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                          request.project(), "/", "global", "/",
                          "networkEndpointGroups", "/",
@@ -91,7 +92,7 @@ DefaultGlobalNetworkEndpointGroupsRestStub::AsyncDeleteNetworkEndpointGroup(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "networkEndpointGroups", "/",
@@ -122,6 +123,7 @@ DefaultGlobalNetworkEndpointGroupsRestStub::AsyncDetachNetworkEndpoints(
             *service, *rest_context,
             request
                 .global_network_endpoint_groups_detach_endpoints_request_resource(),
+            false,
             absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                          request.project(), "/", "global", "/",
                          "networkEndpointGroups", "/",
@@ -144,7 +146,7 @@ DefaultGlobalNetworkEndpointGroupsRestStub::GetNetworkEndpointGroup(
         GetNetworkEndpointGroupRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::NetworkEndpointGroup>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/",
                    "networkEndpointGroups", "/",
@@ -165,7 +167,7 @@ DefaultGlobalNetworkEndpointGroupsRestStub::AsyncInsertNetworkEndpointGroup(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.network_endpoint_group_resource(),
+                request.network_endpoint_group_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "networkEndpointGroups"),
@@ -186,7 +188,7 @@ DefaultGlobalNetworkEndpointGroupsRestStub::ListGlobalNetworkEndpointGroups(
         ListGlobalNetworkEndpointGroupsRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::NetworkEndpointGroupList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/",
                    "networkEndpointGroups"),
@@ -207,7 +209,7 @@ DefaultGlobalNetworkEndpointGroupsRestStub::ListNetworkEndpoints(
         ListNetworkEndpointsRequest const& request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::
                                  NetworkEndpointGroupsListNetworkEndpoints>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat(
           "/", "compute", "/", "v1", "/", "projects", "/", request.project(),
           "/", "global", "/", "networkEndpointGroups", "/",
@@ -234,7 +236,7 @@ DefaultGlobalNetworkEndpointGroupsRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/global/operations/", request.operation())));
       },
@@ -255,7 +257,7 @@ future<Status> DefaultGlobalNetworkEndpointGroupsRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(),
                          "/global/operations/", request.operation())));
       },

--- a/google/cloud/compute/global_operations/v1/internal/global_operations_rest_stub.cc
+++ b/google/cloud/compute/global_operations/v1/internal/global_operations_rest_stub.cc
@@ -46,7 +46,7 @@ DefaultGlobalOperationsRestStub::AggregatedListGlobalOperations(
         AggregatedListGlobalOperationsRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::OperationAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "operations"),
       rest_internal::TrimEmptyQueryParameters(
@@ -65,7 +65,7 @@ Status DefaultGlobalOperationsRestStub::DeleteOperation(
     google::cloud::cpp::compute::global_operations::v1::
         DeleteOperationRequest const& request) {
   return rest_internal::Delete(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "operations", "/",
                    request.operation()));
@@ -77,7 +77,7 @@ DefaultGlobalOperationsRestStub::GetOperation(
     google::cloud::cpp::compute::global_operations::v1::
         GetOperationRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "operations", "/",
                    request.operation()));
@@ -89,7 +89,7 @@ DefaultGlobalOperationsRestStub::ListGlobalOperations(
     google::cloud::cpp::compute::global_operations::v1::
         ListGlobalOperationsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::OperationList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "operations"),
       rest_internal::TrimEmptyQueryParameters(
@@ -107,7 +107,7 @@ DefaultGlobalOperationsRestStub::Wait(
     google::cloud::cpp::compute::global_operations::v1::WaitRequest const&
         request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "operations", "/",
                    request.operation(), "/", "wait"));

--- a/google/cloud/compute/global_organization_operations/v1/internal/global_organization_operations_rest_stub.cc
+++ b/google/cloud/compute/global_organization_operations/v1/internal/global_organization_operations_rest_stub.cc
@@ -46,7 +46,7 @@ Status DefaultGlobalOrganizationOperationsRestStub::DeleteOperation(
     google::cloud::cpp::compute::global_organization_operations::v1::
         DeleteOperationRequest const& request) {
   return rest_internal::Delete(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/", "global",
                    "/", "operations", "/", request.operation()),
       rest_internal::TrimEmptyQueryParameters(
@@ -59,7 +59,7 @@ DefaultGlobalOrganizationOperationsRestStub::GetOperation(
     google::cloud::cpp::compute::global_organization_operations::v1::
         GetOperationRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "locations", "/", "global",
                    "/", "operations", "/", request.operation()),
       rest_internal::TrimEmptyQueryParameters(
@@ -72,7 +72,7 @@ DefaultGlobalOrganizationOperationsRestStub::ListGlobalOrganizationOperations(
     google::cloud::cpp::compute::global_organization_operations::v1::
         ListGlobalOrganizationOperationsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::OperationList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       "/compute/v1/locations/global/operations",
       rest_internal::TrimEmptyQueryParameters(
           {std::make_pair("filter", request.filter()),

--- a/google/cloud/compute/global_public_delegated_prefixes/v1/internal/global_public_delegated_prefixes_rest_stub.cc
+++ b/google/cloud/compute/global_public_delegated_prefixes/v1/internal/global_public_delegated_prefixes_rest_stub.cc
@@ -60,7 +60,7 @@ DefaultGlobalPublicDelegatedPrefixesRestStub::AsyncDeletePublicDelegatedPrefix(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "publicDelegatedPrefixes", "/",
@@ -82,7 +82,7 @@ DefaultGlobalPublicDelegatedPrefixesRestStub::GetPublicDelegatedPrefix(
         GetPublicDelegatedPrefixRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::PublicDelegatedPrefix>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/",
                    "publicDelegatedPrefixes", "/",
@@ -103,7 +103,7 @@ DefaultGlobalPublicDelegatedPrefixesRestStub::AsyncInsertPublicDelegatedPrefix(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.public_delegated_prefix_resource(),
+                request.public_delegated_prefix_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "publicDelegatedPrefixes"),
@@ -124,7 +124,7 @@ DefaultGlobalPublicDelegatedPrefixesRestStub::ListGlobalPublicDelegatedPrefixes(
         ListGlobalPublicDelegatedPrefixesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::PublicDelegatedPrefixList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/",
                    "publicDelegatedPrefixes"),
@@ -151,7 +151,7 @@ DefaultGlobalPublicDelegatedPrefixesRestStub::AsyncPatchPublicDelegatedPrefix(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.public_delegated_prefix_resource(),
+                request.public_delegated_prefix_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "publicDelegatedPrefixes", "/",
@@ -179,7 +179,7 @@ DefaultGlobalPublicDelegatedPrefixesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/global/operations/", request.operation())));
       },
@@ -201,7 +201,7 @@ DefaultGlobalPublicDelegatedPrefixesRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(),
                          "/global/operations/", request.operation())));
       },

--- a/google/cloud/compute/health_checks/v1/internal/health_checks_rest_stub.cc
+++ b/google/cloud/compute/health_checks/v1/internal/health_checks_rest_stub.cc
@@ -51,7 +51,7 @@ DefaultHealthChecksRestStub::AggregatedListHealthChecks(
         AggregatedListHealthChecksRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::HealthChecksAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "healthChecks"),
       rest_internal::TrimEmptyQueryParameters(
@@ -78,7 +78,7 @@ DefaultHealthChecksRestStub::AsyncDeleteHealthCheck(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "healthChecks", "/", request.health_check()),
@@ -98,7 +98,7 @@ DefaultHealthChecksRestStub::GetHealthCheck(
     google::cloud::cpp::compute::health_checks::v1::GetHealthCheckRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::HealthCheck>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "healthChecks", "/",
                    request.health_check()));
@@ -117,7 +117,7 @@ DefaultHealthChecksRestStub::AsyncInsertHealthCheck(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.health_check_resource(),
+                *service, *rest_context, request.health_check_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "healthChecks"),
@@ -137,7 +137,7 @@ DefaultHealthChecksRestStub::ListHealthChecks(
     google::cloud::cpp::compute::health_checks::v1::
         ListHealthChecksRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::HealthCheckList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "healthChecks"),
       rest_internal::TrimEmptyQueryParameters(
@@ -162,7 +162,7 @@ DefaultHealthChecksRestStub::AsyncPatchHealthCheck(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.health_check_resource(),
+                *service, *rest_context, request.health_check_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "healthChecks", "/", request.health_check()),
@@ -189,7 +189,7 @@ DefaultHealthChecksRestStub::AsyncUpdateHealthCheck(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Put<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.health_check_resource(),
+                *service, *rest_context, request.health_check_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "healthChecks", "/", request.health_check()),
@@ -216,7 +216,7 @@ DefaultHealthChecksRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/global/operations/", request.operation())));
       },
@@ -237,7 +237,7 @@ future<Status> DefaultHealthChecksRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(),
                          "/global/operations/", request.operation())));
       },

--- a/google/cloud/compute/http_health_checks/v1/internal/http_health_checks_rest_stub.cc
+++ b/google/cloud/compute/http_health_checks/v1/internal/http_health_checks_rest_stub.cc
@@ -58,7 +58,7 @@ DefaultHttpHealthChecksRestStub::AsyncDeleteHttpHealthCheck(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "httpHealthChecks", "/",
@@ -79,7 +79,7 @@ DefaultHttpHealthChecksRestStub::GetHttpHealthCheck(
     google::cloud::cpp::compute::http_health_checks::v1::
         GetHttpHealthCheckRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::HttpHealthCheck>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "httpHealthChecks",
                    "/", request.http_health_check()));
@@ -99,6 +99,7 @@ DefaultHttpHealthChecksRestStub::AsyncInsertHttpHealthCheck(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.http_health_check_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "httpHealthChecks"),
@@ -119,7 +120,7 @@ DefaultHttpHealthChecksRestStub::ListHttpHealthChecks(
         ListHttpHealthChecksRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::HttpHealthCheckList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "httpHealthChecks"),
       rest_internal::TrimEmptyQueryParameters(
@@ -145,6 +146,7 @@ DefaultHttpHealthChecksRestStub::AsyncPatchHttpHealthCheck(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.http_health_check_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "httpHealthChecks", "/",
@@ -173,6 +175,7 @@ DefaultHttpHealthChecksRestStub::AsyncUpdateHttpHealthCheck(
         p.set_value(
             rest_internal::Put<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.http_health_check_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "httpHealthChecks", "/",
@@ -200,7 +203,7 @@ DefaultHttpHealthChecksRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/global/operations/", request.operation())));
       },
@@ -221,7 +224,7 @@ future<Status> DefaultHttpHealthChecksRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(),
                          "/global/operations/", request.operation())));
       },

--- a/google/cloud/compute/https_health_checks/v1/internal/https_health_checks_rest_stub.cc
+++ b/google/cloud/compute/https_health_checks/v1/internal/https_health_checks_rest_stub.cc
@@ -58,7 +58,7 @@ DefaultHttpsHealthChecksRestStub::AsyncDeleteHttpsHealthCheck(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "httpsHealthChecks", "/",
@@ -79,7 +79,7 @@ DefaultHttpsHealthChecksRestStub::GetHttpsHealthCheck(
     google::cloud::cpp::compute::https_health_checks::v1::
         GetHttpsHealthCheckRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::HttpsHealthCheck>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "httpsHealthChecks",
                    "/", request.https_health_check()));
@@ -99,6 +99,7 @@ DefaultHttpsHealthChecksRestStub::AsyncInsertHttpsHealthCheck(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.https_health_check_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "httpsHealthChecks"),
@@ -119,7 +120,7 @@ DefaultHttpsHealthChecksRestStub::ListHttpsHealthChecks(
         ListHttpsHealthChecksRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::HttpsHealthCheckList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "httpsHealthChecks"),
       rest_internal::TrimEmptyQueryParameters(
@@ -145,6 +146,7 @@ DefaultHttpsHealthChecksRestStub::AsyncPatchHttpsHealthCheck(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.https_health_check_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "httpsHealthChecks", "/",
@@ -173,6 +175,7 @@ DefaultHttpsHealthChecksRestStub::AsyncUpdateHttpsHealthCheck(
         p.set_value(
             rest_internal::Put<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.https_health_check_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "httpsHealthChecks", "/",
@@ -200,7 +203,7 @@ DefaultHttpsHealthChecksRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/global/operations/", request.operation())));
       },
@@ -221,7 +224,7 @@ future<Status> DefaultHttpsHealthChecksRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(),
                          "/global/operations/", request.operation())));
       },

--- a/google/cloud/compute/image_family_views/v1/internal/image_family_views_rest_stub.cc
+++ b/google/cloud/compute/image_family_views/v1/internal/image_family_views_rest_stub.cc
@@ -45,7 +45,7 @@ DefaultImageFamilyViewsRestStub::GetImageFamilyView(
     google::cloud::cpp::compute::image_family_views::v1::
         GetImageFamilyViewRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::ImageFamilyView>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "imageFamilyViews", "/", request.family()));

--- a/google/cloud/compute/images/v1/internal/images_rest_stub.cc
+++ b/google/cloud/compute/images/v1/internal/images_rest_stub.cc
@@ -57,7 +57,7 @@ DefaultImagesRestStub::AsyncDeleteImage(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "images",
                              "/", request.image()),
@@ -84,6 +84,7 @@ DefaultImagesRestStub::AsyncDeprecate(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.deprecation_status_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "images",
                              "/", request.image(), "/", "deprecate"),
@@ -102,7 +103,7 @@ DefaultImagesRestStub::GetImage(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::cpp::compute::images::v1::GetImageRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Image>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "images", "/",
                    request.image()));
@@ -114,7 +115,7 @@ DefaultImagesRestStub::GetFromFamily(
     google::cloud::cpp::compute::images::v1::GetFromFamilyRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Image>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "images", "/",
                    "family", "/", request.family()));
@@ -126,7 +127,7 @@ DefaultImagesRestStub::GetIamPolicy(
     google::cloud::cpp::compute::images::v1::GetIamPolicyRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "images", "/",
                    request.resource(), "/", "getIamPolicy"),
@@ -148,7 +149,7 @@ DefaultImagesRestStub::AsyncInsertImage(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.image_resource(),
+                *service, *rest_context, request.image_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "images"),
                 rest_internal::TrimEmptyQueryParameters(
@@ -168,7 +169,7 @@ DefaultImagesRestStub::ListImages(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::cpp::compute::images::v1::ListImagesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::ImageList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "images"),
       rest_internal::TrimEmptyQueryParameters(
@@ -192,7 +193,7 @@ DefaultImagesRestStub::AsyncPatchImage(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.image_resource(),
+                *service, *rest_context, request.image_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "images",
                              "/", request.image()),
@@ -213,6 +214,7 @@ DefaultImagesRestStub::SetIamPolicy(
         request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.global_set_policy_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "images", "/",
                    request.resource(), "/", "setIamPolicy"));
@@ -231,7 +233,7 @@ DefaultImagesRestStub::AsyncSetLabels(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.global_set_labels_request_resource(),
+                request.global_set_labels_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "images",
                              "/", request.resource(), "/", "setLabels")));
@@ -251,6 +253,7 @@ DefaultImagesRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "images", "/",
                    request.resource(), "/", "testIamPermissions"));
@@ -269,7 +272,7 @@ DefaultImagesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/global/operations/", request.operation())));
       },
@@ -290,7 +293,7 @@ future<Status> DefaultImagesRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(),
                          "/global/operations/", request.operation())));
       },

--- a/google/cloud/compute/instance_group_managers/v1/internal/instance_group_managers_rest_stub.cc
+++ b/google/cloud/compute/instance_group_managers/v1/internal/instance_group_managers_rest_stub.cc
@@ -62,6 +62,7 @@ DefaultInstanceGroupManagersRestStub::AsyncAbandonInstances(
             *service, *rest_context,
             request
                 .instance_group_managers_abandon_instances_request_resource(),
+            false,
             absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                          request.project(), "/", "zones", "/", request.zone(),
                          "/", "instanceGroupManagers", "/",
@@ -84,7 +85,7 @@ DefaultInstanceGroupManagersRestStub::AggregatedListInstanceGroupManagers(
         AggregatedListInstanceGroupManagersRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InstanceGroupManagerAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "instanceGroupManagers"),
@@ -115,6 +116,7 @@ DefaultInstanceGroupManagersRestStub::AsyncApplyUpdatesToInstances(
                 *service, *rest_context,
                 request
                     .instance_group_managers_apply_updates_request_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instanceGroupManagers", "/",
@@ -143,6 +145,7 @@ DefaultInstanceGroupManagersRestStub::AsyncCreateInstances(
                     google::cloud::cpp::compute::v1::Operation>(
             *service, *rest_context,
             request.instance_group_managers_create_instances_request_resource(),
+            false,
             absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                          request.project(), "/", "zones", "/", request.zone(),
                          "/", "instanceGroupManagers", "/",
@@ -171,7 +174,7 @@ DefaultInstanceGroupManagersRestStub::AsyncDeleteInstanceGroupManager(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instanceGroupManagers", "/",
@@ -201,6 +204,7 @@ DefaultInstanceGroupManagersRestStub::AsyncDeleteInstances(
                     google::cloud::cpp::compute::v1::Operation>(
             *service, *rest_context,
             request.instance_group_managers_delete_instances_request_resource(),
+            false,
             absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                          request.project(), "/", "zones", "/", request.zone(),
                          "/", "instanceGroupManagers", "/",
@@ -232,6 +236,7 @@ DefaultInstanceGroupManagersRestStub::AsyncDeletePerInstanceConfigs(
             *service, *rest_context,
             request
                 .instance_group_managers_delete_per_instance_configs_req_resource(),
+            false,
             absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                          request.project(), "/", "zones", "/", request.zone(),
                          "/", "instanceGroupManagers", "/",
@@ -252,7 +257,7 @@ DefaultInstanceGroupManagersRestStub::GetInstanceGroupManager(
         GetInstanceGroupManagerRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InstanceGroupManager>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "instanceGroupManagers", "/",
@@ -273,7 +278,7 @@ DefaultInstanceGroupManagersRestStub::AsyncInsertInstanceGroupManager(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.instance_group_manager_resource(),
+                request.instance_group_manager_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instanceGroupManagers"),
@@ -294,7 +299,7 @@ DefaultInstanceGroupManagersRestStub::ListInstanceGroupManagers(
         ListInstanceGroupManagersRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InstanceGroupManagerList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "instanceGroupManagers"),
@@ -315,7 +320,7 @@ DefaultInstanceGroupManagersRestStub::ListErrors(
         ListErrorsRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InstanceGroupManagersListErrorsResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "instanceGroupManagers", "/",
@@ -338,7 +343,7 @@ DefaultInstanceGroupManagersRestStub::ListManagedInstances(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::
           InstanceGroupManagersListManagedInstancesResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat(
           "/", "compute", "/", "v1", "/", "projects", "/", request.project(),
           "/", "zones", "/", request.zone(), "/", "instanceGroupManagers", "/",
@@ -361,7 +366,7 @@ DefaultInstanceGroupManagersRestStub::ListPerInstanceConfigs(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::
           InstanceGroupManagersListPerInstanceConfigsResp>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat(
           "/", "compute", "/", "v1", "/", "projects", "/", request.project(),
           "/", "zones", "/", request.zone(), "/", "instanceGroupManagers", "/",
@@ -389,7 +394,7 @@ DefaultInstanceGroupManagersRestStub::AsyncPatchInstanceGroupManager(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.instance_group_manager_resource(),
+                request.instance_group_manager_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instanceGroupManagers", "/",
@@ -420,6 +425,7 @@ DefaultInstanceGroupManagersRestStub::AsyncPatchPerInstanceConfigs(
             *service, *rest_context,
             request
                 .instance_group_managers_patch_per_instance_configs_req_resource(),
+            false,
             absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                          request.project(), "/", "zones", "/", request.zone(),
                          "/", "instanceGroupManagers", "/",
@@ -451,6 +457,7 @@ DefaultInstanceGroupManagersRestStub::AsyncRecreateInstances(
             *service, *rest_context,
             request
                 .instance_group_managers_recreate_instances_request_resource(),
+            false,
             absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                          request.project(), "/", "zones", "/", request.zone(),
                          "/", "instanceGroupManagers", "/",
@@ -479,7 +486,7 @@ DefaultInstanceGroupManagersRestStub::AsyncResize(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instanceGroupManagers", "/",
@@ -511,6 +518,7 @@ DefaultInstanceGroupManagersRestStub::AsyncSetInstanceTemplate(
             *service, *rest_context,
             request
                 .instance_group_managers_set_instance_template_request_resource(),
+            false,
             absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                          request.project(), "/", "zones", "/", request.zone(),
                          "/", "instanceGroupManagers", "/",
@@ -541,6 +549,7 @@ DefaultInstanceGroupManagersRestStub::AsyncSetTargetPools(
                     google::cloud::cpp::compute::v1::Operation>(
             *service, *rest_context,
             request.instance_group_managers_set_target_pools_request_resource(),
+            false,
             absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                          request.project(), "/", "zones", "/", request.zone(),
                          "/", "instanceGroupManagers", "/",
@@ -572,6 +581,7 @@ DefaultInstanceGroupManagersRestStub::AsyncUpdatePerInstanceConfigs(
             *service, *rest_context,
             request
                 .instance_group_managers_update_per_instance_configs_req_resource(),
+            false,
             absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                          request.project(), "/", "zones", "/", request.zone(),
                          "/", "instanceGroupManagers", "/",
@@ -600,7 +610,7 @@ DefaultInstanceGroupManagersRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/zones/", request.zone(), "/operations/",
                              request.operation())));
@@ -622,7 +632,7 @@ future<Status> DefaultInstanceGroupManagersRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
                          request.zone(), "/operations/", request.operation())));
       },

--- a/google/cloud/compute/instance_groups/v1/internal/instance_groups_rest_stub.cc
+++ b/google/cloud/compute/instance_groups/v1/internal/instance_groups_rest_stub.cc
@@ -58,7 +58,7 @@ DefaultInstanceGroupsRestStub::AsyncAddInstances(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.instance_groups_add_instances_request_resource(),
+                request.instance_groups_add_instances_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instanceGroups", "/",
@@ -80,7 +80,7 @@ DefaultInstanceGroupsRestStub::AggregatedListInstanceGroups(
         AggregatedListInstanceGroupsRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InstanceGroupAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "instanceGroups"),
       rest_internal::TrimEmptyQueryParameters(
@@ -107,7 +107,7 @@ DefaultInstanceGroupsRestStub::AsyncDeleteInstanceGroup(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instanceGroups", "/",
@@ -128,7 +128,7 @@ DefaultInstanceGroupsRestStub::GetInstanceGroup(
     google::cloud::cpp::compute::instance_groups::v1::
         GetInstanceGroupRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::InstanceGroup>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "instanceGroups", "/", request.instance_group()));
@@ -148,6 +148,7 @@ DefaultInstanceGroupsRestStub::AsyncInsertInstanceGroup(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.instance_group_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instanceGroups"),
@@ -167,7 +168,7 @@ DefaultInstanceGroupsRestStub::ListInstanceGroups(
     google::cloud::cpp::compute::instance_groups::v1::
         ListInstanceGroupsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::InstanceGroupList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "instanceGroups"),
@@ -188,7 +189,7 @@ DefaultInstanceGroupsRestStub::ListInstances(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::InstanceGroupsListInstances>(
       *service_, rest_context,
-      request.instance_groups_list_instances_request_resource(),
+      request.instance_groups_list_instances_request_resource(), false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "instanceGroups", "/", request.instance_group(), "/",
@@ -217,6 +218,7 @@ DefaultInstanceGroupsRestStub::AsyncRemoveInstances(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.instance_groups_remove_instances_request_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instanceGroups", "/",
@@ -246,6 +248,7 @@ DefaultInstanceGroupsRestStub::AsyncSetNamedPorts(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.instance_groups_set_named_ports_request_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instanceGroups", "/",
@@ -273,7 +276,7 @@ DefaultInstanceGroupsRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/zones/", request.zone(), "/operations/",
                              request.operation())));
@@ -295,7 +298,7 @@ future<Status> DefaultInstanceGroupsRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
                          request.zone(), "/operations/", request.operation())));
       },

--- a/google/cloud/compute/instance_templates/v1/internal/instance_templates_rest_stub.cc
+++ b/google/cloud/compute/instance_templates/v1/internal/instance_templates_rest_stub.cc
@@ -52,7 +52,7 @@ DefaultInstanceTemplatesRestStub::AggregatedListInstanceTemplates(
         AggregatedListInstanceTemplatesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InstanceTemplateAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "instanceTemplates"),
@@ -80,7 +80,7 @@ DefaultInstanceTemplatesRestStub::AsyncDeleteInstanceTemplate(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "instanceTemplates", "/",
@@ -101,7 +101,7 @@ DefaultInstanceTemplatesRestStub::GetInstanceTemplate(
     google::cloud::cpp::compute::instance_templates::v1::
         GetInstanceTemplateRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::InstanceTemplate>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "instanceTemplates",
                    "/", request.instance_template()));
@@ -113,7 +113,7 @@ DefaultInstanceTemplatesRestStub::GetIamPolicy(
     google::cloud::cpp::compute::instance_templates::v1::
         GetIamPolicyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "instanceTemplates",
                    "/", request.resource(), "/", "getIamPolicy"),
@@ -136,6 +136,7 @@ DefaultInstanceTemplatesRestStub::AsyncInsertInstanceTemplate(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.instance_template_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "instanceTemplates"),
@@ -156,7 +157,7 @@ DefaultInstanceTemplatesRestStub::ListInstanceTemplates(
         ListInstanceTemplatesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InstanceTemplateList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "instanceTemplates"),
       rest_internal::TrimEmptyQueryParameters(
@@ -175,6 +176,7 @@ DefaultInstanceTemplatesRestStub::SetIamPolicy(
         SetIamPolicyRequest const& request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.global_set_policy_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "instanceTemplates",
                    "/", request.resource(), "/", "setIamPolicy"));
@@ -188,6 +190,7 @@ DefaultInstanceTemplatesRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "instanceTemplates",
                    "/", request.resource(), "/", "testIamPermissions"));
@@ -206,7 +209,7 @@ DefaultInstanceTemplatesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/global/operations/", request.operation())));
       },
@@ -227,7 +230,7 @@ future<Status> DefaultInstanceTemplatesRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(),
                          "/global/operations/", request.operation())));
       },

--- a/google/cloud/compute/instances/v1/internal/instances_rest_stub.cc
+++ b/google/cloud/compute/instances/v1/internal/instances_rest_stub.cc
@@ -58,6 +58,7 @@ DefaultInstancesRestStub::AsyncAddAccessConfig(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.access_config_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
@@ -89,6 +90,7 @@ DefaultInstancesRestStub::AsyncAddResourcePolicies(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.instances_add_resource_policies_request_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
@@ -110,7 +112,7 @@ DefaultInstancesRestStub::AggregatedListInstances(
         AggregatedListInstancesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InstanceAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "instances"),
       rest_internal::TrimEmptyQueryParameters(
@@ -138,6 +140,7 @@ DefaultInstancesRestStub::AsyncAttachDisk(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.attached_disk_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
@@ -168,7 +171,7 @@ DefaultInstancesRestStub::AsyncBulkInsert(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.bulk_insert_instance_resource(),
+                request.bulk_insert_instance_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
@@ -196,7 +199,7 @@ DefaultInstancesRestStub::AsyncDeleteInstance(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
@@ -224,7 +227,7 @@ DefaultInstancesRestStub::AsyncDeleteAccessConfig(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
@@ -255,7 +258,7 @@ DefaultInstancesRestStub::AsyncDetachDisk(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
@@ -277,7 +280,7 @@ DefaultInstancesRestStub::GetInstance(
     google::cloud::cpp::compute::instances::v1::GetInstanceRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Instance>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "instances", "/", request.instance()));
@@ -291,7 +294,7 @@ DefaultInstancesRestStub::GetEffectiveFirewalls(
         GetEffectiveFirewallsRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InstancesGetEffectiveFirewallsResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "instances", "/", request.instance(), "/",
@@ -306,7 +309,7 @@ DefaultInstancesRestStub::GetGuestAttributes(
     google::cloud::cpp::compute::instances::v1::GetGuestAttributesRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::GuestAttributes>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "instances", "/", request.instance(), "/",
@@ -322,7 +325,7 @@ DefaultInstancesRestStub::GetIamPolicy(
     google::cloud::cpp::compute::instances::v1::GetIamPolicyRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "instances", "/", request.resource(), "/", "getIamPolicy"),
@@ -337,7 +340,7 @@ DefaultInstancesRestStub::GetScreenshot(
     google::cloud::cpp::compute::instances::v1::GetScreenshotRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Screenshot>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "instances", "/", request.instance(), "/", "screenshot"));
@@ -349,7 +352,7 @@ DefaultInstancesRestStub::GetSerialPortOutput(
     google::cloud::cpp::compute::instances::v1::
         GetSerialPortOutputRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::SerialPortOutput>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "instances", "/", request.instance(), "/", "serialPort"),
@@ -365,7 +368,7 @@ DefaultInstancesRestStub::GetShieldedInstanceIdentity(
         GetShieldedInstanceIdentityRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::ShieldedInstanceIdentity>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "instances", "/", request.instance(), "/",
@@ -385,7 +388,7 @@ DefaultInstancesRestStub::AsyncInsertInstance(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.instance_resource(),
+                *service, *rest_context, request.instance_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances"),
@@ -409,7 +412,7 @@ DefaultInstancesRestStub::ListInstances(
     google::cloud::cpp::compute::instances::v1::ListInstancesRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::InstanceList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "instances"),
@@ -429,7 +432,7 @@ DefaultInstancesRestStub::ListReferrers(
         request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InstanceListReferrers>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "instances", "/", request.instance(), "/", "referrers"),
@@ -457,6 +460,7 @@ DefaultInstancesRestStub::AsyncRemoveResourcePolicies(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.instances_remove_resource_policies_request_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
@@ -483,7 +487,7 @@ DefaultInstancesRestStub::AsyncReset(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
@@ -510,7 +514,7 @@ DefaultInstancesRestStub::AsyncResume(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
@@ -530,7 +534,7 @@ Status DefaultInstancesRestStub::SendDiagnosticInterrupt(
     google::cloud::cpp::compute::instances::v1::
         SendDiagnosticInterruptRequest const& request) {
   return rest_internal::Post(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "instances", "/", request.instance(), "/",
@@ -550,7 +554,7 @@ DefaultInstancesRestStub::AsyncSetDeletionProtection(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
@@ -580,7 +584,7 @@ DefaultInstancesRestStub::AsyncSetDiskAutoDelete(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
@@ -605,6 +609,7 @@ DefaultInstancesRestStub::SetIamPolicy(
         request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.zone_set_policy_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "instances", "/", request.resource(), "/", "setIamPolicy"));
@@ -624,7 +629,7 @@ DefaultInstancesRestStub::AsyncSetLabels(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.instances_set_labels_request_resource(),
+                request.instances_set_labels_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
@@ -654,6 +659,7 @@ DefaultInstancesRestStub::AsyncSetMachineResources(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.instances_set_machine_resources_request_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
@@ -682,7 +688,7 @@ DefaultInstancesRestStub::AsyncSetMachineType(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.instances_set_machine_type_request_resource(),
+                request.instances_set_machine_type_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
@@ -710,7 +716,7 @@ DefaultInstancesRestStub::AsyncSetMetadata(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.metadata_resource(),
+                *service, *rest_context, request.metadata_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
@@ -740,6 +746,7 @@ DefaultInstancesRestStub::AsyncSetMinCpuPlatform(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.instances_set_min_cpu_platform_request_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
@@ -767,7 +774,7 @@ DefaultInstancesRestStub::AsyncSetName(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.instances_set_name_request_resource(),
+                request.instances_set_name_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
@@ -795,7 +802,7 @@ DefaultInstancesRestStub::AsyncSetScheduling(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.scheduling_resource(),
+                *service, *rest_context, request.scheduling_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
@@ -824,7 +831,7 @@ DefaultInstancesRestStub::AsyncSetServiceAccount(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.instances_set_service_account_request_resource(),
+                request.instances_set_service_account_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
@@ -853,7 +860,7 @@ DefaultInstancesRestStub::AsyncSetShieldedInstanceIntegrityPolicy(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.shielded_instance_integrity_policy_resource(),
+                request.shielded_instance_integrity_policy_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
@@ -881,7 +888,7 @@ DefaultInstancesRestStub::AsyncSetTags(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.tags_resource(),
+                *service, *rest_context, request.tags_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
@@ -909,7 +916,7 @@ DefaultInstancesRestStub::AsyncSimulateMaintenanceEvent(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
@@ -937,7 +944,7 @@ DefaultInstancesRestStub::AsyncStart(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
@@ -967,6 +974,7 @@ DefaultInstancesRestStub::AsyncStartWithEncryptionKey(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.instances_start_with_encryption_key_request_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
@@ -993,7 +1001,7 @@ DefaultInstancesRestStub::AsyncStop(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
@@ -1022,7 +1030,7 @@ DefaultInstancesRestStub::AsyncSuspend(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
@@ -1047,6 +1055,7 @@ DefaultInstancesRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "instances", "/", request.resource(), "/",
@@ -1066,7 +1075,7 @@ DefaultInstancesRestStub::AsyncUpdateInstance(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Put<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.instance_resource(),
+                *service, *rest_context, request.instance_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
@@ -1098,6 +1107,7 @@ DefaultInstancesRestStub::AsyncUpdateAccessConfig(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.access_config_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
@@ -1128,6 +1138,7 @@ DefaultInstancesRestStub::AsyncUpdateDisplayDevice(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.display_device_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
@@ -1156,6 +1167,7 @@ DefaultInstancesRestStub::AsyncUpdateNetworkInterface(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.network_interface_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
@@ -1186,7 +1198,7 @@ DefaultInstancesRestStub::AsyncUpdateShieldedInstanceConfig(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.shielded_instance_config_resource(),
+                request.shielded_instance_config_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "instances", "/",
@@ -1215,7 +1227,7 @@ DefaultInstancesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/zones/", request.zone(), "/operations/",
                              request.operation())));
@@ -1237,7 +1249,7 @@ future<Status> DefaultInstancesRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
                          request.zone(), "/operations/", request.operation())));
       },

--- a/google/cloud/compute/integration_tests/BUILD.bazel
+++ b/google/cloud/compute/integration_tests/BUILD.bazel
@@ -28,6 +28,7 @@ licenses(["notice"])  # Apache 2.0
     ],
     deps = [
         "//:compute_disks",
+        "//:compute_instances",
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
     ],
 ) for test in glob(["*_test.cc"])]

--- a/google/cloud/compute/integration_tests/CMakeLists.txt
+++ b/google/cloud/compute/integration_tests/CMakeLists.txt
@@ -31,7 +31,8 @@ foreach (fname ${compute_client_integration_tests})
     google_cloud_cpp_add_executable(target "compute" ${fname})
     target_link_libraries(
         ${target}
-        PRIVATE google-cloud-cpp::compute_disks google_cloud_cpp_testing
+        PRIVATE google-cloud-cpp::compute_disks
+                google-cloud-cpp::compute_instances google_cloud_cpp_testing
                 GTest::gmock_main GTest::gmock GTest::gtest)
     google_cloud_cpp_add_common_options(${target})
     add_test(NAME ${target} COMMAND ${target})

--- a/google/cloud/compute/interconnect_attachments/v1/internal/interconnect_attachments_rest_stub.cc
+++ b/google/cloud/compute/interconnect_attachments/v1/internal/interconnect_attachments_rest_stub.cc
@@ -53,7 +53,7 @@ DefaultInterconnectAttachmentsRestStub::AggregatedListInterconnectAttachments(
         AggregatedListInterconnectAttachmentsRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InterconnectAttachmentAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "interconnectAttachments"),
@@ -81,7 +81,7 @@ DefaultInterconnectAttachmentsRestStub::AsyncDeleteInterconnectAttachment(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "interconnectAttachments",
@@ -103,7 +103,7 @@ DefaultInterconnectAttachmentsRestStub::GetInterconnectAttachment(
         GetInterconnectAttachmentRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InterconnectAttachment>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "interconnectAttachments", "/",
@@ -124,7 +124,7 @@ DefaultInterconnectAttachmentsRestStub::AsyncInsertInterconnectAttachment(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.interconnect_attachment_resource(),
+                request.interconnect_attachment_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "interconnectAttachments"),
@@ -147,7 +147,7 @@ DefaultInterconnectAttachmentsRestStub::ListInterconnectAttachments(
         ListInterconnectAttachmentsRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InterconnectAttachmentList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "interconnectAttachments"),
@@ -174,7 +174,7 @@ DefaultInterconnectAttachmentsRestStub::AsyncPatchInterconnectAttachment(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.interconnect_attachment_resource(),
+                request.interconnect_attachment_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "interconnectAttachments",
@@ -203,7 +203,7 @@ DefaultInterconnectAttachmentsRestStub::AsyncSetLabels(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.region_set_labels_request_resource(),
+                request.region_set_labels_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "interconnectAttachments",
@@ -231,7 +231,7 @@ DefaultInterconnectAttachmentsRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -252,7 +252,7 @@ future<Status> DefaultInterconnectAttachmentsRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/interconnect_locations/v1/internal/interconnect_locations_rest_stub.cc
+++ b/google/cloud/compute/interconnect_locations/v1/internal/interconnect_locations_rest_stub.cc
@@ -47,7 +47,7 @@ DefaultInterconnectLocationsRestStub::GetInterconnectLocation(
         GetInterconnectLocationRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InterconnectLocation>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/",
                    "interconnectLocations", "/",
@@ -61,7 +61,7 @@ DefaultInterconnectLocationsRestStub::ListInterconnectLocations(
         ListInterconnectLocationsRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InterconnectLocationList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/",
                    "interconnectLocations"),

--- a/google/cloud/compute/interconnect_remote_locations/v1/internal/interconnect_remote_locations_rest_stub.cc
+++ b/google/cloud/compute/interconnect_remote_locations/v1/internal/interconnect_remote_locations_rest_stub.cc
@@ -48,7 +48,7 @@ DefaultInterconnectRemoteLocationsRestStub::GetInterconnectRemoteLocation(
         GetInterconnectRemoteLocationRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InterconnectRemoteLocation>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/",
                    "interconnectRemoteLocations", "/",
@@ -62,7 +62,7 @@ DefaultInterconnectRemoteLocationsRestStub::ListInterconnectRemoteLocations(
         ListInterconnectRemoteLocationsRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InterconnectRemoteLocationList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/",
                    "interconnectRemoteLocations"),

--- a/google/cloud/compute/interconnects/v1/internal/interconnects_rest_stub.cc
+++ b/google/cloud/compute/interconnects/v1/internal/interconnects_rest_stub.cc
@@ -57,7 +57,7 @@ DefaultInterconnectsRestStub::AsyncDeleteInterconnect(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "interconnects", "/", request.interconnect()),
@@ -77,7 +77,7 @@ DefaultInterconnectsRestStub::GetInterconnect(
     google::cloud::cpp::compute::interconnects::v1::
         GetInterconnectRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Interconnect>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "interconnects", "/",
                    request.interconnect()));
@@ -90,7 +90,7 @@ DefaultInterconnectsRestStub::GetDiagnostics(
         request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InterconnectsGetDiagnosticsResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "interconnects", "/",
                    request.interconnect(), "/", "getDiagnostics"));
@@ -109,7 +109,7 @@ DefaultInterconnectsRestStub::AsyncInsertInterconnect(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.interconnect_resource(),
+                *service, *rest_context, request.interconnect_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "interconnects"),
@@ -129,7 +129,7 @@ DefaultInterconnectsRestStub::ListInterconnects(
     google::cloud::cpp::compute::interconnects::v1::
         ListInterconnectsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::InterconnectList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "interconnects"),
       rest_internal::TrimEmptyQueryParameters(
@@ -154,7 +154,7 @@ DefaultInterconnectsRestStub::AsyncPatchInterconnect(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.interconnect_resource(),
+                *service, *rest_context, request.interconnect_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "interconnects", "/", request.interconnect()),
@@ -182,7 +182,7 @@ DefaultInterconnectsRestStub::AsyncSetLabels(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.global_set_labels_request_resource(),
+                request.global_set_labels_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "interconnects", "/", request.resource(), "/",
@@ -208,7 +208,7 @@ DefaultInterconnectsRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/global/operations/", request.operation())));
       },
@@ -229,7 +229,7 @@ future<Status> DefaultInterconnectsRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(),
                          "/global/operations/", request.operation())));
       },

--- a/google/cloud/compute/license_codes/v1/internal/license_codes_rest_stub.cc
+++ b/google/cloud/compute/license_codes/v1/internal/license_codes_rest_stub.cc
@@ -44,7 +44,7 @@ DefaultLicenseCodesRestStub::GetLicenseCode(
     google::cloud::cpp::compute::license_codes::v1::GetLicenseCodeRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::LicenseCode>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "licenseCodes", "/",
                    request.license_code()));
@@ -58,6 +58,7 @@ DefaultLicenseCodesRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "licenseCodes", "/",
                    request.resource(), "/", "testIamPermissions"));

--- a/google/cloud/compute/licenses/v1/internal/licenses_rest_stub.cc
+++ b/google/cloud/compute/licenses/v1/internal/licenses_rest_stub.cc
@@ -57,7 +57,7 @@ DefaultLicensesRestStub::AsyncDeleteLicense(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "licenses",
                              "/", request.license()),
@@ -77,7 +77,7 @@ DefaultLicensesRestStub::GetLicense(
     google::cloud::cpp::compute::licenses::v1::GetLicenseRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::License>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "licenses", "/",
                    request.license()));
@@ -89,7 +89,7 @@ DefaultLicensesRestStub::GetIamPolicy(
     google::cloud::cpp::compute::licenses::v1::GetIamPolicyRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "licenses", "/",
                    request.resource(), "/", "getIamPolicy"),
@@ -111,7 +111,7 @@ DefaultLicensesRestStub::AsyncInsertLicense(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.license_resource(),
+                *service, *rest_context, request.license_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "licenses"),
                 rest_internal::TrimEmptyQueryParameters(
@@ -131,7 +131,7 @@ DefaultLicensesRestStub::ListLicenses(
         request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::LicensesListResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "licenses"),
       rest_internal::TrimEmptyQueryParameters(
@@ -150,6 +150,7 @@ DefaultLicensesRestStub::SetIamPolicy(
         request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.global_set_policy_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "licenses", "/",
                    request.resource(), "/", "setIamPolicy"));
@@ -163,6 +164,7 @@ DefaultLicensesRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "licenses", "/",
                    request.resource(), "/", "testIamPermissions"));
@@ -181,7 +183,7 @@ DefaultLicensesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/global/operations/", request.operation())));
       },
@@ -202,7 +204,7 @@ future<Status> DefaultLicensesRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(),
                          "/global/operations/", request.operation())));
       },

--- a/google/cloud/compute/machine_images/v1/internal/machine_images_rest_stub.cc
+++ b/google/cloud/compute/machine_images/v1/internal/machine_images_rest_stub.cc
@@ -57,7 +57,7 @@ DefaultMachineImagesRestStub::AsyncDeleteMachineImage(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "machineImages", "/", request.machine_image()),
@@ -77,7 +77,7 @@ DefaultMachineImagesRestStub::GetMachineImage(
     google::cloud::cpp::compute::machine_images::v1::
         GetMachineImageRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::MachineImage>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "machineImages", "/",
                    request.machine_image()));
@@ -89,7 +89,7 @@ DefaultMachineImagesRestStub::GetIamPolicy(
     google::cloud::cpp::compute::machine_images::v1::GetIamPolicyRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "machineImages", "/",
                    request.resource(), "/", "getIamPolicy"),
@@ -112,6 +112,7 @@ DefaultMachineImagesRestStub::AsyncInsertMachineImage(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.machine_image_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "machineImages"),
@@ -133,7 +134,7 @@ DefaultMachineImagesRestStub::ListMachineImages(
     google::cloud::cpp::compute::machine_images::v1::
         ListMachineImagesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::MachineImageList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "machineImages"),
       rest_internal::TrimEmptyQueryParameters(
@@ -152,6 +153,7 @@ DefaultMachineImagesRestStub::SetIamPolicy(
         request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.global_set_policy_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "machineImages", "/",
                    request.resource(), "/", "setIamPolicy"));
@@ -165,6 +167,7 @@ DefaultMachineImagesRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "machineImages", "/",
                    request.resource(), "/", "testIamPermissions"));
@@ -183,7 +186,7 @@ DefaultMachineImagesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/global/operations/", request.operation())));
       },
@@ -204,7 +207,7 @@ future<Status> DefaultMachineImagesRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(),
                          "/global/operations/", request.operation())));
       },

--- a/google/cloud/compute/machine_types/v1/internal/machine_types_rest_stub.cc
+++ b/google/cloud/compute/machine_types/v1/internal/machine_types_rest_stub.cc
@@ -45,7 +45,7 @@ DefaultMachineTypesRestStub::AggregatedListMachineTypes(
         AggregatedListMachineTypesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::MachineTypeAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "machineTypes"),
       rest_internal::TrimEmptyQueryParameters(
@@ -65,7 +65,7 @@ DefaultMachineTypesRestStub::GetMachineType(
     google::cloud::cpp::compute::machine_types::v1::GetMachineTypeRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::MachineType>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "machineTypes", "/", request.machine_type()));
@@ -77,7 +77,7 @@ DefaultMachineTypesRestStub::ListMachineTypes(
     google::cloud::cpp::compute::machine_types::v1::
         ListMachineTypesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::MachineTypeList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "machineTypes"),

--- a/google/cloud/compute/network_attachments/v1/internal/network_attachments_rest_stub.cc
+++ b/google/cloud/compute/network_attachments/v1/internal/network_attachments_rest_stub.cc
@@ -52,7 +52,7 @@ DefaultNetworkAttachmentsRestStub::AggregatedListNetworkAttachments(
         AggregatedListNetworkAttachmentsRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::NetworkAttachmentAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "networkAttachments"),
@@ -80,7 +80,7 @@ DefaultNetworkAttachmentsRestStub::AsyncDeleteNetworkAttachment(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "networkAttachments", "/",
@@ -101,7 +101,7 @@ DefaultNetworkAttachmentsRestStub::GetNetworkAttachment(
     google::cloud::cpp::compute::network_attachments::v1::
         GetNetworkAttachmentRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::NetworkAttachment>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "networkAttachments", "/",
@@ -114,7 +114,7 @@ DefaultNetworkAttachmentsRestStub::GetIamPolicy(
     google::cloud::cpp::compute::network_attachments::v1::
         GetIamPolicyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "networkAttachments", "/", request.resource(), "/",
@@ -138,6 +138,7 @@ DefaultNetworkAttachmentsRestStub::AsyncInsertNetworkAttachment(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.network_attachment_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "networkAttachments"),
@@ -158,7 +159,7 @@ DefaultNetworkAttachmentsRestStub::ListNetworkAttachments(
         ListNetworkAttachmentsRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::NetworkAttachmentList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "networkAttachments"),
@@ -178,6 +179,7 @@ DefaultNetworkAttachmentsRestStub::SetIamPolicy(
         SetIamPolicyRequest const& request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.region_set_policy_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "networkAttachments", "/", request.resource(), "/",
@@ -192,6 +194,7 @@ DefaultNetworkAttachmentsRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "networkAttachments", "/", request.resource(), "/",
@@ -211,7 +214,7 @@ DefaultNetworkAttachmentsRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -232,7 +235,7 @@ future<Status> DefaultNetworkAttachmentsRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/network_edge_security_services/v1/internal/network_edge_security_services_rest_stub.cc
+++ b/google/cloud/compute/network_edge_security_services/v1/internal/network_edge_security_services_rest_stub.cc
@@ -56,7 +56,7 @@ DefaultNetworkEdgeSecurityServicesRestStub::
             AggregatedListNetworkEdgeSecurityServicesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::
                                 NetworkEdgeSecurityServiceAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "networkEdgeSecurityServices"),
@@ -85,7 +85,7 @@ DefaultNetworkEdgeSecurityServicesRestStub::
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/",
@@ -108,7 +108,7 @@ DefaultNetworkEdgeSecurityServicesRestStub::GetNetworkEdgeSecurityService(
         GetNetworkEdgeSecurityServiceRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::NetworkEdgeSecurityService>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "networkEdgeSecurityServices", "/",
@@ -130,7 +130,7 @@ DefaultNetworkEdgeSecurityServicesRestStub::
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.network_edge_security_service_resource(),
+                request.network_edge_security_service_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/",
@@ -162,7 +162,7 @@ DefaultNetworkEdgeSecurityServicesRestStub::
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.network_edge_security_service_resource(),
+                request.network_edge_security_service_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/",
@@ -193,7 +193,7 @@ DefaultNetworkEdgeSecurityServicesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -214,7 +214,7 @@ future<Status> DefaultNetworkEdgeSecurityServicesRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/network_endpoint_groups/v1/internal/network_endpoint_groups_rest_stub.cc
+++ b/google/cloud/compute/network_endpoint_groups/v1/internal/network_endpoint_groups_rest_stub.cc
@@ -53,7 +53,7 @@ DefaultNetworkEndpointGroupsRestStub::AggregatedListNetworkEndpointGroups(
         AggregatedListNetworkEndpointGroupsRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::NetworkEndpointGroupAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "networkEndpointGroups"),
@@ -83,6 +83,7 @@ DefaultNetworkEndpointGroupsRestStub::AsyncAttachNetworkEndpoints(
                     google::cloud::cpp::compute::v1::Operation>(
             *service, *rest_context,
             request.network_endpoint_groups_attach_endpoints_request_resource(),
+            false,
             absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                          request.project(), "/", "zones", "/", request.zone(),
                          "/", "networkEndpointGroups", "/",
@@ -111,7 +112,7 @@ DefaultNetworkEndpointGroupsRestStub::AsyncDeleteNetworkEndpointGroup(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "networkEndpointGroups", "/",
@@ -141,6 +142,7 @@ DefaultNetworkEndpointGroupsRestStub::AsyncDetachNetworkEndpoints(
                     google::cloud::cpp::compute::v1::Operation>(
             *service, *rest_context,
             request.network_endpoint_groups_detach_endpoints_request_resource(),
+            false,
             absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                          request.project(), "/", "zones", "/", request.zone(),
                          "/", "networkEndpointGroups", "/",
@@ -163,7 +165,7 @@ DefaultNetworkEndpointGroupsRestStub::GetNetworkEndpointGroup(
         GetNetworkEndpointGroupRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::NetworkEndpointGroup>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "networkEndpointGroups", "/",
@@ -184,7 +186,7 @@ DefaultNetworkEndpointGroupsRestStub::AsyncInsertNetworkEndpointGroup(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.network_endpoint_group_resource(),
+                request.network_endpoint_group_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "networkEndpointGroups"),
@@ -205,7 +207,7 @@ DefaultNetworkEndpointGroupsRestStub::ListNetworkEndpointGroups(
         ListNetworkEndpointGroupsRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::NetworkEndpointGroupList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "networkEndpointGroups"),
@@ -227,7 +229,7 @@ DefaultNetworkEndpointGroupsRestStub::ListNetworkEndpoints(
   return rest_internal::Post<google::cloud::cpp::compute::v1::
                                  NetworkEndpointGroupsListNetworkEndpoints>(
       *service_, rest_context,
-      request.network_endpoint_groups_list_endpoints_request_resource(),
+      request.network_endpoint_groups_list_endpoints_request_resource(), false,
       absl::StrCat(
           "/", "compute", "/", "v1", "/", "projects", "/", request.project(),
           "/", "zones", "/", request.zone(), "/", "networkEndpointGroups", "/",
@@ -249,6 +251,7 @@ DefaultNetworkEndpointGroupsRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "networkEndpointGroups", "/", request.resource(), "/",
@@ -268,7 +271,7 @@ DefaultNetworkEndpointGroupsRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/zones/", request.zone(), "/operations/",
                              request.operation())));
@@ -290,7 +293,7 @@ future<Status> DefaultNetworkEndpointGroupsRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
                          request.zone(), "/operations/", request.operation())));
       },

--- a/google/cloud/compute/network_firewall_policies/v1/internal/network_firewall_policies_rest_stub.cc
+++ b/google/cloud/compute/network_firewall_policies/v1/internal/network_firewall_policies_rest_stub.cc
@@ -60,7 +60,7 @@ DefaultNetworkFirewallPoliciesRestStub::AsyncAddAssociation(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.firewall_policy_association_resource(),
+                request.firewall_policy_association_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "firewallPolicies", "/", request.firewall_policy(),
@@ -92,7 +92,7 @@ DefaultNetworkFirewallPoliciesRestStub::AsyncAddRule(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.firewall_policy_rule_resource(),
+                request.firewall_policy_rule_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "firewallPolicies", "/", request.firewall_policy(),
@@ -124,7 +124,7 @@ DefaultNetworkFirewallPoliciesRestStub::AsyncCloneRules(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "firewallPolicies", "/", request.firewall_policy(),
@@ -154,7 +154,7 @@ DefaultNetworkFirewallPoliciesRestStub::AsyncDeleteFirewallPolicy(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "firewallPolicies", "/",
@@ -175,7 +175,7 @@ DefaultNetworkFirewallPoliciesRestStub::GetFirewallPolicy(
     google::cloud::cpp::compute::network_firewall_policies::v1::
         GetFirewallPolicyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::FirewallPolicy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "firewallPolicies",
                    "/", request.firewall_policy()));
@@ -188,7 +188,7 @@ DefaultNetworkFirewallPoliciesRestStub::GetAssociation(
         GetAssociationRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::FirewallPolicyAssociation>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "firewallPolicies",
                    "/", request.firewall_policy(), "/", "getAssociation"),
@@ -202,7 +202,7 @@ DefaultNetworkFirewallPoliciesRestStub::GetIamPolicy(
     google::cloud::cpp::compute::network_firewall_policies::v1::
         GetIamPolicyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "firewallPolicies",
                    "/", request.resource(), "/", "getIamPolicy"),
@@ -218,7 +218,7 @@ DefaultNetworkFirewallPoliciesRestStub::GetRule(
         GetRuleRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::FirewallPolicyRule>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "firewallPolicies",
                    "/", request.firewall_policy(), "/", "getRule"),
@@ -240,6 +240,7 @@ DefaultNetworkFirewallPoliciesRestStub::AsyncInsertFirewallPolicy(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.firewall_policy_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "firewallPolicies"),
@@ -260,7 +261,7 @@ DefaultNetworkFirewallPoliciesRestStub::ListNetworkFirewallPolicies(
         ListNetworkFirewallPoliciesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::FirewallPolicyList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "firewallPolicies"),
       rest_internal::TrimEmptyQueryParameters(
@@ -286,6 +287,7 @@ DefaultNetworkFirewallPoliciesRestStub::AsyncPatchFirewallPolicy(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.firewall_policy_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "firewallPolicies", "/",
@@ -314,7 +316,7 @@ DefaultNetworkFirewallPoliciesRestStub::AsyncPatchRule(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.firewall_policy_rule_resource(),
+                request.firewall_policy_rule_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "firewallPolicies", "/", request.firewall_policy(),
@@ -344,7 +346,7 @@ DefaultNetworkFirewallPoliciesRestStub::AsyncRemoveAssociation(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "firewallPolicies", "/", request.firewall_policy(),
@@ -373,7 +375,7 @@ DefaultNetworkFirewallPoliciesRestStub::AsyncRemoveRule(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "firewallPolicies", "/", request.firewall_policy(),
@@ -397,6 +399,7 @@ DefaultNetworkFirewallPoliciesRestStub::SetIamPolicy(
         SetIamPolicyRequest const& request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.global_set_policy_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "firewallPolicies",
                    "/", request.resource(), "/", "setIamPolicy"));
@@ -410,6 +413,7 @@ DefaultNetworkFirewallPoliciesRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "firewallPolicies",
                    "/", request.resource(), "/", "testIamPermissions"));
@@ -428,7 +432,7 @@ DefaultNetworkFirewallPoliciesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/global/operations/", request.operation())));
       },
@@ -449,7 +453,7 @@ future<Status> DefaultNetworkFirewallPoliciesRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(),
                          "/global/operations/", request.operation())));
       },

--- a/google/cloud/compute/networks/v1/internal/networks_rest_stub.cc
+++ b/google/cloud/compute/networks/v1/internal/networks_rest_stub.cc
@@ -58,7 +58,7 @@ DefaultNetworksRestStub::AsyncAddPeering(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.networks_add_peering_request_resource(),
+                request.networks_add_peering_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "networks",
                              "/", request.network(), "/", "addPeering"),
@@ -85,7 +85,7 @@ DefaultNetworksRestStub::AsyncDeleteNetwork(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "networks",
                              "/", request.network()),
@@ -105,7 +105,7 @@ DefaultNetworksRestStub::GetNetwork(
     google::cloud::cpp::compute::networks::v1::GetNetworkRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Network>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "networks", "/",
                    request.network()));
@@ -118,7 +118,7 @@ DefaultNetworksRestStub::GetEffectiveFirewalls(
         GetEffectiveFirewallsRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::NetworksGetEffectiveFirewallsResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "networks", "/",
                    request.network(), "/", "getEffectiveFirewalls"));
@@ -137,7 +137,7 @@ DefaultNetworksRestStub::AsyncInsertNetwork(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.network_resource(),
+                *service, *rest_context, request.network_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "networks"),
                 rest_internal::TrimEmptyQueryParameters(
@@ -156,7 +156,7 @@ DefaultNetworksRestStub::ListNetworks(
     google::cloud::cpp::compute::networks::v1::ListNetworksRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::NetworkList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "networks"),
       rest_internal::TrimEmptyQueryParameters(
@@ -175,7 +175,7 @@ DefaultNetworksRestStub::ListPeeringRoutes(
         request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::ExchangedPeeringRoutesList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "networks", "/",
                    request.network(), "/", "listPeeringRoutes"),
@@ -204,7 +204,7 @@ DefaultNetworksRestStub::AsyncPatchNetwork(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.network_resource(),
+                *service, *rest_context, request.network_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "networks",
                              "/", request.network()),
@@ -232,7 +232,7 @@ DefaultNetworksRestStub::AsyncRemovePeering(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.networks_remove_peering_request_resource(),
+                request.networks_remove_peering_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "networks",
                              "/", request.network(), "/", "removePeering"),
@@ -259,7 +259,7 @@ DefaultNetworksRestStub::AsyncSwitchToCustomMode(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "networks",
                              "/", request.network(), "/", "switchToCustomMode"),
@@ -287,7 +287,7 @@ DefaultNetworksRestStub::AsyncUpdatePeering(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.networks_update_peering_request_resource(),
+                request.networks_update_peering_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "networks",
                              "/", request.network(), "/", "updatePeering"),
@@ -314,7 +314,7 @@ DefaultNetworksRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/global/operations/", request.operation())));
       },
@@ -335,7 +335,7 @@ future<Status> DefaultNetworksRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(),
                          "/global/operations/", request.operation())));
       },

--- a/google/cloud/compute/node_groups/v1/internal/node_groups_rest_stub.cc
+++ b/google/cloud/compute/node_groups/v1/internal/node_groups_rest_stub.cc
@@ -58,7 +58,7 @@ DefaultNodeGroupsRestStub::AsyncAddNodes(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.node_groups_add_nodes_request_resource(),
+                request.node_groups_add_nodes_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "nodeGroups", "/",
@@ -80,7 +80,7 @@ DefaultNodeGroupsRestStub::AggregatedListNodeGroups(
         AggregatedListNodeGroupsRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::NodeGroupAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "nodeGroups"),
       rest_internal::TrimEmptyQueryParameters(
@@ -107,7 +107,7 @@ DefaultNodeGroupsRestStub::AsyncDeleteNodeGroup(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "nodeGroups", "/",
@@ -136,7 +136,7 @@ DefaultNodeGroupsRestStub::AsyncDeleteNodes(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.node_groups_delete_nodes_request_resource(),
+                request.node_groups_delete_nodes_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "nodeGroups", "/",
@@ -157,7 +157,7 @@ DefaultNodeGroupsRestStub::GetNodeGroup(
     google::cloud::cpp::compute::node_groups::v1::GetNodeGroupRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::NodeGroup>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "nodeGroups", "/", request.node_group()));
@@ -169,7 +169,7 @@ DefaultNodeGroupsRestStub::GetIamPolicy(
     google::cloud::cpp::compute::node_groups::v1::GetIamPolicyRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "nodeGroups", "/", request.resource(), "/", "getIamPolicy"),
@@ -191,7 +191,7 @@ DefaultNodeGroupsRestStub::AsyncInsertNodeGroup(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.node_group_resource(),
+                *service, *rest_context, request.node_group_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "nodeGroups"),
@@ -214,7 +214,7 @@ DefaultNodeGroupsRestStub::ListNodeGroups(
     google::cloud::cpp::compute::node_groups::v1::ListNodeGroupsRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::NodeGroupList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "nodeGroups"),
@@ -234,7 +234,7 @@ DefaultNodeGroupsRestStub::ListNodes(
         request) {
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::NodeGroupsListNodes>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "nodeGroups", "/", request.node_group(), "/", "listNodes"),
@@ -260,7 +260,7 @@ DefaultNodeGroupsRestStub::AsyncPatchNodeGroup(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.node_group_resource(),
+                *service, *rest_context, request.node_group_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "nodeGroups", "/",
@@ -282,6 +282,7 @@ DefaultNodeGroupsRestStub::SetIamPolicy(
         request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.zone_set_policy_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "nodeGroups", "/", request.resource(), "/", "setIamPolicy"));
@@ -301,7 +302,7 @@ DefaultNodeGroupsRestStub::AsyncSetNodeTemplate(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.node_groups_set_node_template_request_resource(),
+                request.node_groups_set_node_template_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "nodeGroups", "/",
@@ -332,6 +333,7 @@ DefaultNodeGroupsRestStub::AsyncSimulateMaintenanceEvent(
                 *service, *rest_context,
                 request
                     .node_groups_simulate_maintenance_event_request_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "nodeGroups", "/",
@@ -355,6 +357,7 @@ DefaultNodeGroupsRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "nodeGroups", "/", request.resource(), "/",
@@ -374,7 +377,7 @@ DefaultNodeGroupsRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/zones/", request.zone(), "/operations/",
                              request.operation())));
@@ -396,7 +399,7 @@ future<Status> DefaultNodeGroupsRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
                          request.zone(), "/operations/", request.operation())));
       },

--- a/google/cloud/compute/node_templates/v1/internal/node_templates_rest_stub.cc
+++ b/google/cloud/compute/node_templates/v1/internal/node_templates_rest_stub.cc
@@ -51,7 +51,7 @@ DefaultNodeTemplatesRestStub::AggregatedListNodeTemplates(
         AggregatedListNodeTemplatesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::NodeTemplateAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "nodeTemplates"),
       rest_internal::TrimEmptyQueryParameters(
@@ -78,7 +78,7 @@ DefaultNodeTemplatesRestStub::AsyncDeleteNodeTemplate(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "nodeTemplates", "/",
@@ -99,7 +99,7 @@ DefaultNodeTemplatesRestStub::GetNodeTemplate(
     google::cloud::cpp::compute::node_templates::v1::
         GetNodeTemplateRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::NodeTemplate>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "nodeTemplates", "/", request.node_template()));
@@ -111,7 +111,7 @@ DefaultNodeTemplatesRestStub::GetIamPolicy(
     google::cloud::cpp::compute::node_templates::v1::GetIamPolicyRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "nodeTemplates", "/", request.resource(), "/",
@@ -135,6 +135,7 @@ DefaultNodeTemplatesRestStub::AsyncInsertNodeTemplate(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.node_template_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "nodeTemplates"),
@@ -154,7 +155,7 @@ DefaultNodeTemplatesRestStub::ListNodeTemplates(
     google::cloud::cpp::compute::node_templates::v1::
         ListNodeTemplatesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::NodeTemplateList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "nodeTemplates"),
@@ -174,6 +175,7 @@ DefaultNodeTemplatesRestStub::SetIamPolicy(
         request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.region_set_policy_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "nodeTemplates", "/", request.resource(), "/",
@@ -188,6 +190,7 @@ DefaultNodeTemplatesRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "nodeTemplates", "/", request.resource(), "/",
@@ -207,7 +210,7 @@ DefaultNodeTemplatesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -228,7 +231,7 @@ future<Status> DefaultNodeTemplatesRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/node_types/v1/internal/node_types_rest_stub.cc
+++ b/google/cloud/compute/node_types/v1/internal/node_types_rest_stub.cc
@@ -45,7 +45,7 @@ DefaultNodeTypesRestStub::AggregatedListNodeTypes(
         AggregatedListNodeTypesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::NodeTypeAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "nodeTypes"),
       rest_internal::TrimEmptyQueryParameters(
@@ -65,7 +65,7 @@ DefaultNodeTypesRestStub::GetNodeType(
     google::cloud::cpp::compute::node_types::v1::GetNodeTypeRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::NodeType>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "nodeTypes", "/", request.node_type()));
@@ -77,7 +77,7 @@ DefaultNodeTypesRestStub::ListNodeTypes(
     google::cloud::cpp::compute::node_types::v1::ListNodeTypesRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::NodeTypeList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "nodeTypes"),

--- a/google/cloud/compute/packet_mirrorings/v1/internal/packet_mirrorings_rest_stub.cc
+++ b/google/cloud/compute/packet_mirrorings/v1/internal/packet_mirrorings_rest_stub.cc
@@ -52,7 +52,7 @@ DefaultPacketMirroringsRestStub::AggregatedListPacketMirrorings(
         AggregatedListPacketMirroringsRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::PacketMirroringAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "packetMirrorings"),
@@ -80,7 +80,7 @@ DefaultPacketMirroringsRestStub::AsyncDeletePacketMirroring(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "packetMirrorings", "/",
@@ -101,7 +101,7 @@ DefaultPacketMirroringsRestStub::GetPacketMirroring(
     google::cloud::cpp::compute::packet_mirrorings::v1::
         GetPacketMirroringRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::PacketMirroring>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "packetMirrorings", "/", request.packet_mirroring()));
@@ -121,6 +121,7 @@ DefaultPacketMirroringsRestStub::AsyncInsertPacketMirroring(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.packet_mirroring_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "packetMirrorings"),
@@ -141,7 +142,7 @@ DefaultPacketMirroringsRestStub::ListPacketMirrorings(
         ListPacketMirroringsRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::PacketMirroringList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "packetMirrorings"),
@@ -168,6 +169,7 @@ DefaultPacketMirroringsRestStub::AsyncPatchPacketMirroring(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.packet_mirroring_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "packetMirrorings", "/",
@@ -190,6 +192,7 @@ DefaultPacketMirroringsRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "packetMirrorings", "/", request.resource(), "/",
@@ -209,7 +212,7 @@ DefaultPacketMirroringsRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -230,7 +233,7 @@ future<Status> DefaultPacketMirroringsRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/projects/v1/internal/projects_rest_stub.cc
+++ b/google/cloud/compute/projects/v1/internal/projects_rest_stub.cc
@@ -57,7 +57,7 @@ DefaultProjectsRestStub::AsyncDisableXpnHost(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "disableXpnHost"),
                 rest_internal::TrimEmptyQueryParameters(
@@ -84,7 +84,7 @@ DefaultProjectsRestStub::AsyncDisableXpnResource(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.projects_disable_xpn_resource_request_resource(),
+                request.projects_disable_xpn_resource_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "disableXpnResource"),
                 rest_internal::TrimEmptyQueryParameters(
@@ -110,7 +110,7 @@ DefaultProjectsRestStub::AsyncEnableXpnHost(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "enableXpnHost"),
                 rest_internal::TrimEmptyQueryParameters(
@@ -137,7 +137,7 @@ DefaultProjectsRestStub::AsyncEnableXpnResource(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.projects_enable_xpn_resource_request_resource(),
+                request.projects_enable_xpn_resource_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "enableXpnResource"),
                 rest_internal::TrimEmptyQueryParameters(
@@ -156,7 +156,7 @@ DefaultProjectsRestStub::GetProject(
     google::cloud::cpp::compute::projects::v1::GetProjectRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Project>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project()));
 }
@@ -167,7 +167,7 @@ DefaultProjectsRestStub::GetXpnHost(
     google::cloud::cpp::compute::projects::v1::GetXpnHostRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Project>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "getXpnHost"));
 }
@@ -179,7 +179,7 @@ DefaultProjectsRestStub::GetXpnResources(
         request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::ProjectsGetXpnResources>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "getXpnResources"),
       rest_internal::TrimEmptyQueryParameters(
@@ -198,7 +198,7 @@ DefaultProjectsRestStub::ListXpnHosts(
         request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::XpnHostList>(
       *service_, rest_context,
-      request.projects_list_xpn_hosts_request_resource(),
+      request.projects_list_xpn_hosts_request_resource(), false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "listXpnHosts"),
       rest_internal::TrimEmptyQueryParameters(
@@ -223,6 +223,7 @@ DefaultProjectsRestStub::AsyncMoveDisk(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.disk_move_request_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "moveDisk"),
                 rest_internal::TrimEmptyQueryParameters(
@@ -249,7 +250,7 @@ DefaultProjectsRestStub::AsyncMoveInstance(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.instance_move_request_resource(),
+                request.instance_move_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "moveInstance"),
                 rest_internal::TrimEmptyQueryParameters(
@@ -275,7 +276,7 @@ DefaultProjectsRestStub::AsyncSetCommonInstanceMetadata(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.metadata_resource(),
+                *service, *rest_context, request.metadata_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/",
                              "setCommonInstanceMetadata"),
@@ -304,6 +305,7 @@ DefaultProjectsRestStub::AsyncSetDefaultNetworkTier(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.projects_set_default_network_tier_request_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "setDefaultNetworkTier"),
                 rest_internal::TrimEmptyQueryParameters(
@@ -330,7 +332,7 @@ DefaultProjectsRestStub::AsyncSetUsageExportBucket(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.usage_export_location_resource(),
+                request.usage_export_location_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "setUsageExportBucket"),
                 rest_internal::TrimEmptyQueryParameters(
@@ -356,7 +358,7 @@ DefaultProjectsRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/global/operations/", request.operation())));
       },
@@ -377,7 +379,7 @@ future<Status> DefaultProjectsRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(),
                          "/global/operations/", request.operation())));
       },

--- a/google/cloud/compute/public_advertised_prefixes/v1/internal/public_advertised_prefixes_rest_stub.cc
+++ b/google/cloud/compute/public_advertised_prefixes/v1/internal/public_advertised_prefixes_rest_stub.cc
@@ -60,7 +60,7 @@ DefaultPublicAdvertisedPrefixesRestStub::AsyncDeletePublicAdvertisedPrefix(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "publicAdvertisedPrefixes", "/",
@@ -82,7 +82,7 @@ DefaultPublicAdvertisedPrefixesRestStub::GetPublicAdvertisedPrefix(
         GetPublicAdvertisedPrefixRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::PublicAdvertisedPrefix>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/",
                    "publicAdvertisedPrefixes", "/",
@@ -103,7 +103,7 @@ DefaultPublicAdvertisedPrefixesRestStub::AsyncInsertPublicAdvertisedPrefix(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.public_advertised_prefix_resource(),
+                request.public_advertised_prefix_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "publicAdvertisedPrefixes"),
@@ -124,7 +124,7 @@ DefaultPublicAdvertisedPrefixesRestStub::ListPublicAdvertisedPrefixes(
         ListPublicAdvertisedPrefixesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::PublicAdvertisedPrefixList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/",
                    "publicAdvertisedPrefixes"),
@@ -151,7 +151,7 @@ DefaultPublicAdvertisedPrefixesRestStub::AsyncPatchPublicAdvertisedPrefix(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.public_advertised_prefix_resource(),
+                request.public_advertised_prefix_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "publicAdvertisedPrefixes", "/",
@@ -179,7 +179,7 @@ DefaultPublicAdvertisedPrefixesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/global/operations/", request.operation())));
       },
@@ -200,7 +200,7 @@ future<Status> DefaultPublicAdvertisedPrefixesRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(),
                          "/global/operations/", request.operation())));
       },

--- a/google/cloud/compute/public_delegated_prefixes/v1/internal/public_delegated_prefixes_rest_stub.cc
+++ b/google/cloud/compute/public_delegated_prefixes/v1/internal/public_delegated_prefixes_rest_stub.cc
@@ -53,7 +53,7 @@ DefaultPublicDelegatedPrefixesRestStub::AggregatedListPublicDelegatedPrefixes(
         AggregatedListPublicDelegatedPrefixesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::PublicDelegatedPrefixAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "publicDelegatedPrefixes"),
@@ -81,7 +81,7 @@ DefaultPublicDelegatedPrefixesRestStub::AsyncDeletePublicDelegatedPrefix(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "publicDelegatedPrefixes",
@@ -103,7 +103,7 @@ DefaultPublicDelegatedPrefixesRestStub::GetPublicDelegatedPrefix(
         GetPublicDelegatedPrefixRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::PublicDelegatedPrefix>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "publicDelegatedPrefixes", "/",
@@ -124,7 +124,7 @@ DefaultPublicDelegatedPrefixesRestStub::AsyncInsertPublicDelegatedPrefix(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.public_delegated_prefix_resource(),
+                request.public_delegated_prefix_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "publicDelegatedPrefixes"),
@@ -145,7 +145,7 @@ DefaultPublicDelegatedPrefixesRestStub::ListPublicDelegatedPrefixes(
         ListPublicDelegatedPrefixesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::PublicDelegatedPrefixList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "publicDelegatedPrefixes"),
@@ -172,7 +172,7 @@ DefaultPublicDelegatedPrefixesRestStub::AsyncPatchPublicDelegatedPrefix(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.public_delegated_prefix_resource(),
+                request.public_delegated_prefix_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "publicDelegatedPrefixes",
@@ -200,7 +200,7 @@ DefaultPublicDelegatedPrefixesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -221,7 +221,7 @@ future<Status> DefaultPublicDelegatedPrefixesRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/region_autoscalers/v1/internal/region_autoscalers_rest_stub.cc
+++ b/google/cloud/compute/region_autoscalers/v1/internal/region_autoscalers_rest_stub.cc
@@ -58,7 +58,7 @@ DefaultRegionAutoscalersRestStub::AsyncDeleteAutoscaler(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "autoscalers", "/",
@@ -79,7 +79,7 @@ DefaultRegionAutoscalersRestStub::GetAutoscaler(
     google::cloud::cpp::compute::region_autoscalers::v1::
         GetAutoscalerRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Autoscaler>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "autoscalers", "/", request.autoscaler()));
@@ -98,7 +98,7 @@ DefaultRegionAutoscalersRestStub::AsyncInsertAutoscaler(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.autoscaler_resource(),
+                *service, *rest_context, request.autoscaler_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "autoscalers"),
@@ -119,7 +119,7 @@ DefaultRegionAutoscalersRestStub::ListRegionAutoscalers(
         ListRegionAutoscalersRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::RegionAutoscalerList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "autoscalers"),
@@ -145,7 +145,7 @@ DefaultRegionAutoscalersRestStub::AsyncPatchAutoscaler(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.autoscaler_resource(),
+                *service, *rest_context, request.autoscaler_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "autoscalers"),
@@ -173,7 +173,7 @@ DefaultRegionAutoscalersRestStub::AsyncUpdateAutoscaler(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Put<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.autoscaler_resource(),
+                *service, *rest_context, request.autoscaler_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "autoscalers"),
@@ -201,7 +201,7 @@ DefaultRegionAutoscalersRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -222,7 +222,7 @@ future<Status> DefaultRegionAutoscalersRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/region_backend_services/v1/internal/region_backend_services_rest_stub.cc
+++ b/google/cloud/compute/region_backend_services/v1/internal/region_backend_services_rest_stub.cc
@@ -59,7 +59,7 @@ DefaultRegionBackendServicesRestStub::AsyncDeleteBackendService(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "backendServices", "/",
@@ -80,7 +80,7 @@ DefaultRegionBackendServicesRestStub::GetBackendService(
     google::cloud::cpp::compute::region_backend_services::v1::
         GetBackendServiceRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::BackendService>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "backendServices", "/", request.backend_service()));
@@ -94,6 +94,7 @@ DefaultRegionBackendServicesRestStub::GetHealth(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::BackendServiceGroupHealth>(
       *service_, rest_context, request.resource_group_reference_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "backendServices", "/", request.backend_service(), "/",
@@ -106,7 +107,7 @@ DefaultRegionBackendServicesRestStub::GetIamPolicy(
     google::cloud::cpp::compute::region_backend_services::v1::
         GetIamPolicyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "backendServices", "/", request.resource(), "/",
@@ -130,6 +131,7 @@ DefaultRegionBackendServicesRestStub::AsyncInsertBackendService(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.backend_service_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "backendServices"),
@@ -150,7 +152,7 @@ DefaultRegionBackendServicesRestStub::ListRegionBackendServices(
         ListRegionBackendServicesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::BackendServiceList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "backendServices"),
@@ -177,6 +179,7 @@ DefaultRegionBackendServicesRestStub::AsyncPatchBackendService(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.backend_service_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "backendServices", "/",
@@ -198,6 +201,7 @@ DefaultRegionBackendServicesRestStub::SetIamPolicy(
         SetIamPolicyRequest const& request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.region_set_policy_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "backendServices", "/", request.resource(), "/",
@@ -218,6 +222,7 @@ DefaultRegionBackendServicesRestStub::AsyncUpdateBackendService(
         p.set_value(
             rest_internal::Put<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.backend_service_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "backendServices", "/",
@@ -245,7 +250,7 @@ DefaultRegionBackendServicesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -266,7 +271,7 @@ future<Status> DefaultRegionBackendServicesRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/region_commitments/v1/internal/region_commitments_rest_stub.cc
+++ b/google/cloud/compute/region_commitments/v1/internal/region_commitments_rest_stub.cc
@@ -52,7 +52,7 @@ DefaultRegionCommitmentsRestStub::AggregatedListRegionCommitments(
         AggregatedListRegionCommitmentsRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::CommitmentAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "commitments"),
       rest_internal::TrimEmptyQueryParameters(
@@ -72,7 +72,7 @@ DefaultRegionCommitmentsRestStub::GetCommitment(
     google::cloud::cpp::compute::region_commitments::v1::
         GetCommitmentRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Commitment>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "commitments", "/", request.commitment()));
@@ -91,7 +91,7 @@ DefaultRegionCommitmentsRestStub::AsyncInsertCommitment(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.commitment_resource(),
+                *service, *rest_context, request.commitment_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "commitments"),
@@ -111,7 +111,7 @@ DefaultRegionCommitmentsRestStub::ListRegionCommitments(
     google::cloud::cpp::compute::region_commitments::v1::
         ListRegionCommitmentsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::CommitmentList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "commitments"),
@@ -137,7 +137,7 @@ DefaultRegionCommitmentsRestStub::AsyncUpdateCommitment(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.commitment_resource(),
+                *service, *rest_context, request.commitment_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "commitments", "/",
@@ -167,7 +167,7 @@ DefaultRegionCommitmentsRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -188,7 +188,7 @@ future<Status> DefaultRegionCommitmentsRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/region_disk_types/v1/internal/region_disk_types_rest_stub.cc
+++ b/google/cloud/compute/region_disk_types/v1/internal/region_disk_types_rest_stub.cc
@@ -44,7 +44,7 @@ DefaultRegionDiskTypesRestStub::GetDiskType(
     google::cloud::cpp::compute::region_disk_types::v1::
         GetDiskTypeRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::DiskType>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "diskTypes", "/", request.disk_type()));
@@ -57,7 +57,7 @@ DefaultRegionDiskTypesRestStub::ListRegionDiskTypes(
         ListRegionDiskTypesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::RegionDiskTypeList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "diskTypes"),

--- a/google/cloud/compute/region_disks/v1/internal/region_disks_rest_stub.cc
+++ b/google/cloud/compute/region_disks/v1/internal/region_disks_rest_stub.cc
@@ -59,6 +59,7 @@ DefaultRegionDisksRestStub::AsyncAddResourcePolicies(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.region_disks_add_resource_policies_request_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "disks", "/",
@@ -87,6 +88,7 @@ DefaultRegionDisksRestStub::AsyncBulkInsert(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.bulk_insert_disk_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "disks", "/", "bulkInsert"),
@@ -113,7 +115,7 @@ DefaultRegionDisksRestStub::AsyncCreateSnapshot(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.snapshot_resource(),
+                *service, *rest_context, request.snapshot_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "disks", "/",
@@ -141,7 +143,7 @@ DefaultRegionDisksRestStub::AsyncDeleteDisk(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "disks", "/",
@@ -162,7 +164,7 @@ DefaultRegionDisksRestStub::GetDisk(
     google::cloud::cpp::compute::region_disks::v1::GetDiskRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Disk>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "disks", "/", request.disk()));
@@ -174,7 +176,7 @@ DefaultRegionDisksRestStub::GetIamPolicy(
     google::cloud::cpp::compute::region_disks::v1::GetIamPolicyRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "disks", "/", request.resource(), "/", "getIamPolicy"),
@@ -196,7 +198,7 @@ DefaultRegionDisksRestStub::AsyncInsertDisk(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.disk_resource(),
+                *service, *rest_context, request.disk_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "disks"),
@@ -217,7 +219,7 @@ DefaultRegionDisksRestStub::ListRegionDisks(
     google::cloud::cpp::compute::region_disks::v1::ListRegionDisksRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::DiskList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "disks"),
@@ -246,6 +248,7 @@ DefaultRegionDisksRestStub::AsyncRemoveResourcePolicies(
                 *service, *rest_context,
                 request
                     .region_disks_remove_resource_policies_request_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "disks", "/",
@@ -274,7 +277,7 @@ DefaultRegionDisksRestStub::AsyncResize(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.region_disks_resize_request_resource(),
+                request.region_disks_resize_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "disks", "/",
@@ -296,6 +299,7 @@ DefaultRegionDisksRestStub::SetIamPolicy(
         request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.region_set_policy_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "disks", "/", request.resource(), "/", "setIamPolicy"));
@@ -315,7 +319,7 @@ DefaultRegionDisksRestStub::AsyncSetLabels(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.region_set_labels_request_resource(),
+                request.region_set_labels_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "disks", "/",
@@ -345,6 +349,7 @@ DefaultRegionDisksRestStub::AsyncStartAsyncReplication(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.region_disks_start_async_replication_request_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "disks", "/",
@@ -372,7 +377,7 @@ DefaultRegionDisksRestStub::AsyncStopAsyncReplication(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "disks", "/",
@@ -401,7 +406,7 @@ DefaultRegionDisksRestStub::AsyncStopGroupAsyncReplication(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.disks_stop_group_async_replication_resource(),
+                request.disks_stop_group_async_replication_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "disks", "/",
@@ -424,6 +429,7 @@ DefaultRegionDisksRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "disks", "/", request.resource(), "/",
@@ -443,7 +449,7 @@ DefaultRegionDisksRestStub::AsyncUpdateDisk(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.disk_resource(),
+                *service, *rest_context, request.disk_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "disks", "/",
@@ -473,7 +479,7 @@ DefaultRegionDisksRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -494,7 +500,7 @@ future<Status> DefaultRegionDisksRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/region_health_check_services/v1/internal/region_health_check_services_rest_stub.cc
+++ b/google/cloud/compute/region_health_check_services/v1/internal/region_health_check_services_rest_stub.cc
@@ -60,7 +60,7 @@ DefaultRegionHealthCheckServicesRestStub::AsyncDeleteHealthCheckService(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "healthCheckServices", "/",
@@ -82,7 +82,7 @@ DefaultRegionHealthCheckServicesRestStub::GetHealthCheckService(
         GetHealthCheckServiceRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::HealthCheckService>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "healthCheckServices", "/",
@@ -103,7 +103,7 @@ DefaultRegionHealthCheckServicesRestStub::AsyncInsertHealthCheckService(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.health_check_service_resource(),
+                request.health_check_service_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "healthCheckServices"),
@@ -124,7 +124,7 @@ DefaultRegionHealthCheckServicesRestStub::ListRegionHealthCheckServices(
         ListRegionHealthCheckServicesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::HealthCheckServicesList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "healthCheckServices"),
@@ -151,7 +151,7 @@ DefaultRegionHealthCheckServicesRestStub::AsyncPatchHealthCheckService(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.health_check_service_resource(),
+                request.health_check_service_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "healthCheckServices", "/",
@@ -179,7 +179,7 @@ DefaultRegionHealthCheckServicesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -200,7 +200,7 @@ future<Status> DefaultRegionHealthCheckServicesRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/region_health_checks/v1/internal/region_health_checks_rest_stub.cc
+++ b/google/cloud/compute/region_health_checks/v1/internal/region_health_checks_rest_stub.cc
@@ -59,7 +59,7 @@ DefaultRegionHealthChecksRestStub::AsyncDeleteHealthCheck(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "healthChecks", "/",
@@ -80,7 +80,7 @@ DefaultRegionHealthChecksRestStub::GetHealthCheck(
     google::cloud::cpp::compute::region_health_checks::v1::
         GetHealthCheckRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::HealthCheck>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "healthChecks", "/", request.health_check()));
@@ -99,7 +99,7 @@ DefaultRegionHealthChecksRestStub::AsyncInsertHealthCheck(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.health_check_resource(),
+                *service, *rest_context, request.health_check_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "healthChecks"),
@@ -119,7 +119,7 @@ DefaultRegionHealthChecksRestStub::ListRegionHealthChecks(
     google::cloud::cpp::compute::region_health_checks::v1::
         ListRegionHealthChecksRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::HealthCheckList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "healthChecks"),
@@ -145,7 +145,7 @@ DefaultRegionHealthChecksRestStub::AsyncPatchHealthCheck(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.health_check_resource(),
+                *service, *rest_context, request.health_check_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "healthChecks", "/",
@@ -173,7 +173,7 @@ DefaultRegionHealthChecksRestStub::AsyncUpdateHealthCheck(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Put<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.health_check_resource(),
+                *service, *rest_context, request.health_check_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "healthChecks", "/",
@@ -201,7 +201,7 @@ DefaultRegionHealthChecksRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -222,7 +222,7 @@ future<Status> DefaultRegionHealthChecksRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/region_instance_group_managers/v1/internal/region_instance_group_managers_rest_stub.cc
+++ b/google/cloud/compute/region_instance_group_managers/v1/internal/region_instance_group_managers_rest_stub.cc
@@ -63,6 +63,7 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncAbandonInstances(
             *service, *rest_context,
             request
                 .region_instance_group_managers_abandon_instances_request_resource(),
+            false,
             absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                          request.project(), "/", "regions", "/",
                          request.region(), "/", "instanceGroupManagers", "/",
@@ -94,6 +95,7 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncApplyUpdatesToInstances(
             *service, *rest_context,
             request
                 .region_instance_group_managers_apply_updates_request_resource(),
+            false,
             absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                          request.project(), "/", "regions", "/",
                          request.region(), "/", "instanceGroupManagers", "/",
@@ -123,6 +125,7 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncCreateInstances(
             *service, *rest_context,
             request
                 .region_instance_group_managers_create_instances_request_resource(),
+            false,
             absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                          request.project(), "/", "regions", "/",
                          request.region(), "/", "instanceGroupManagers", "/",
@@ -151,7 +154,7 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncDeleteInstanceGroupManager(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "instanceGroupManagers",
@@ -182,6 +185,7 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncDeleteInstances(
             *service, *rest_context,
             request
                 .region_instance_group_managers_delete_instances_request_resource(),
+            false,
             absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                          request.project(), "/", "regions", "/",
                          request.region(), "/", "instanceGroupManagers", "/",
@@ -213,6 +217,7 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncDeletePerInstanceConfigs(
             *service, *rest_context,
             request
                 .region_instance_group_manager_delete_instance_config_req_resource(),
+            false,
             absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                          request.project(), "/", "regions", "/",
                          request.region(), "/", "instanceGroupManagers", "/",
@@ -233,7 +238,7 @@ DefaultRegionInstanceGroupManagersRestStub::GetInstanceGroupManager(
         GetInstanceGroupManagerRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InstanceGroupManager>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "instanceGroupManagers", "/",
@@ -254,7 +259,7 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncInsertInstanceGroupManager(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.instance_group_manager_resource(),
+                request.instance_group_manager_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "instanceGroupManagers"),
@@ -275,7 +280,7 @@ DefaultRegionInstanceGroupManagersRestStub::ListRegionInstanceGroupManagers(
         ListRegionInstanceGroupManagersRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::RegionInstanceGroupManagerList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "instanceGroupManagers"),
@@ -296,7 +301,7 @@ DefaultRegionInstanceGroupManagersRestStub::ListErrors(
         ListErrorsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::
                                 RegionInstanceGroupManagersListErrorsResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "instanceGroupManagers", "/",
@@ -319,7 +324,7 @@ DefaultRegionInstanceGroupManagersRestStub::ListManagedInstances(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::
           RegionInstanceGroupManagersListInstancesResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat(
           "/", "compute", "/", "v1", "/", "projects", "/", request.project(),
           "/", "regions", "/", request.region(), "/", "instanceGroupManagers",
@@ -342,7 +347,7 @@ DefaultRegionInstanceGroupManagersRestStub::ListPerInstanceConfigs(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::
           RegionInstanceGroupManagersListInstanceConfigsResp>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat(
           "/", "compute", "/", "v1", "/", "projects", "/", request.project(),
           "/", "regions", "/", request.region(), "/", "instanceGroupManagers",
@@ -370,7 +375,7 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncPatchInstanceGroupManager(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.instance_group_manager_resource(),
+                request.instance_group_manager_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "instanceGroupManagers",
@@ -401,6 +406,7 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncPatchPerInstanceConfigs(
             *service, *rest_context,
             request
                 .region_instance_group_manager_patch_instance_config_req_resource(),
+            false,
             absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                          request.project(), "/", "regions", "/",
                          request.region(), "/", "instanceGroupManagers", "/",
@@ -432,6 +438,7 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncRecreateInstances(
                 *service, *rest_context,
                 request
                     .region_instance_group_managers_recreate_request_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "instanceGroupManagers",
@@ -460,7 +467,7 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncResize(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "instanceGroupManagers",
@@ -493,6 +500,7 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncSetInstanceTemplate(
             *service, *rest_context,
             request
                 .region_instance_group_managers_set_template_request_resource(),
+            false,
             absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                          request.project(), "/", "regions", "/",
                          request.region(), "/", "instanceGroupManagers", "/",
@@ -524,6 +532,7 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncSetTargetPools(
             *service, *rest_context,
             request
                 .region_instance_group_managers_set_target_pools_request_resource(),
+            false,
             absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                          request.project(), "/", "regions", "/",
                          request.region(), "/", "instanceGroupManagers", "/",
@@ -555,6 +564,7 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncUpdatePerInstanceConfigs(
             *service, *rest_context,
             request
                 .region_instance_group_manager_update_instance_config_req_resource(),
+            false,
             absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                          request.project(), "/", "regions", "/",
                          request.region(), "/", "instanceGroupManagers", "/",
@@ -583,7 +593,7 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -604,7 +614,7 @@ future<Status> DefaultRegionInstanceGroupManagersRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/region_instance_groups/v1/internal/region_instance_groups_rest_stub.cc
+++ b/google/cloud/compute/region_instance_groups/v1/internal/region_instance_groups_rest_stub.cc
@@ -52,7 +52,7 @@ DefaultRegionInstanceGroupsRestStub::GetInstanceGroup(
     google::cloud::cpp::compute::region_instance_groups::v1::
         GetInstanceGroupRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::InstanceGroup>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "instanceGroups", "/", request.instance_group()));
@@ -65,7 +65,7 @@ DefaultRegionInstanceGroupsRestStub::ListRegionInstanceGroups(
         ListRegionInstanceGroupsRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::RegionInstanceGroupList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "instanceGroups"),
@@ -86,7 +86,7 @@ DefaultRegionInstanceGroupsRestStub::ListInstances(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::RegionInstanceGroupsListInstances>(
       *service_, rest_context,
-      request.region_instance_groups_list_instances_request_resource(),
+      request.region_instance_groups_list_instances_request_resource(), false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "instanceGroups", "/", request.instance_group(), "/",
@@ -116,6 +116,7 @@ DefaultRegionInstanceGroupsRestStub::AsyncSetNamedPorts(
                 *service, *rest_context,
                 request
                     .region_instance_groups_set_named_ports_request_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "instanceGroups", "/",
@@ -143,7 +144,7 @@ DefaultRegionInstanceGroupsRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -164,7 +165,7 @@ future<Status> DefaultRegionInstanceGroupsRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/region_instance_templates/v1/internal/region_instance_templates_rest_stub.cc
+++ b/google/cloud/compute/region_instance_templates/v1/internal/region_instance_templates_rest_stub.cc
@@ -59,7 +59,7 @@ DefaultRegionInstanceTemplatesRestStub::AsyncDeleteInstanceTemplate(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "instanceTemplates", "/",
@@ -80,7 +80,7 @@ DefaultRegionInstanceTemplatesRestStub::GetInstanceTemplate(
     google::cloud::cpp::compute::region_instance_templates::v1::
         GetInstanceTemplateRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::InstanceTemplate>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "instanceTemplates", "/", request.instance_template()));
@@ -100,6 +100,7 @@ DefaultRegionInstanceTemplatesRestStub::AsyncInsertInstanceTemplate(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.instance_template_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "instanceTemplates"),
@@ -120,7 +121,7 @@ DefaultRegionInstanceTemplatesRestStub::ListRegionInstanceTemplates(
         ListRegionInstanceTemplatesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::InstanceTemplateList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "instanceTemplates"),
@@ -146,7 +147,7 @@ DefaultRegionInstanceTemplatesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -167,7 +168,7 @@ future<Status> DefaultRegionInstanceTemplatesRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/region_instances/v1/internal/region_instances_rest_stub.cc
+++ b/google/cloud/compute/region_instances/v1/internal/region_instances_rest_stub.cc
@@ -58,7 +58,7 @@ DefaultRegionInstancesRestStub::AsyncBulkInsert(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.bulk_insert_instance_resource(),
+                request.bulk_insert_instance_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "instances", "/",
@@ -86,7 +86,7 @@ DefaultRegionInstancesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -107,7 +107,7 @@ future<Status> DefaultRegionInstancesRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/region_network_endpoint_groups/v1/internal/region_network_endpoint_groups_rest_stub.cc
+++ b/google/cloud/compute/region_network_endpoint_groups/v1/internal/region_network_endpoint_groups_rest_stub.cc
@@ -60,7 +60,7 @@ DefaultRegionNetworkEndpointGroupsRestStub::AsyncDeleteNetworkEndpointGroup(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "networkEndpointGroups",
@@ -82,7 +82,7 @@ DefaultRegionNetworkEndpointGroupsRestStub::GetNetworkEndpointGroup(
         GetNetworkEndpointGroupRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::NetworkEndpointGroup>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "networkEndpointGroups", "/",
@@ -103,7 +103,7 @@ DefaultRegionNetworkEndpointGroupsRestStub::AsyncInsertNetworkEndpointGroup(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.network_endpoint_group_resource(),
+                request.network_endpoint_group_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "networkEndpointGroups"),
@@ -124,7 +124,7 @@ DefaultRegionNetworkEndpointGroupsRestStub::ListRegionNetworkEndpointGroups(
         ListRegionNetworkEndpointGroupsRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::NetworkEndpointGroupList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "networkEndpointGroups"),
@@ -150,7 +150,7 @@ DefaultRegionNetworkEndpointGroupsRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -171,7 +171,7 @@ future<Status> DefaultRegionNetworkEndpointGroupsRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/region_network_firewall_policies/v1/internal/region_network_firewall_policies_rest_stub.cc
+++ b/google/cloud/compute/region_network_firewall_policies/v1/internal/region_network_firewall_policies_rest_stub.cc
@@ -61,7 +61,7 @@ DefaultRegionNetworkFirewallPoliciesRestStub::AsyncAddAssociation(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.firewall_policy_association_resource(),
+                request.firewall_policy_association_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "firewallPolicies", "/",
@@ -93,7 +93,7 @@ DefaultRegionNetworkFirewallPoliciesRestStub::AsyncAddRule(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.firewall_policy_rule_resource(),
+                request.firewall_policy_rule_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "firewallPolicies", "/",
@@ -125,7 +125,7 @@ DefaultRegionNetworkFirewallPoliciesRestStub::AsyncCloneRules(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "firewallPolicies", "/",
@@ -155,7 +155,7 @@ DefaultRegionNetworkFirewallPoliciesRestStub::AsyncDeleteFirewallPolicy(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "firewallPolicies", "/",
@@ -176,7 +176,7 @@ DefaultRegionNetworkFirewallPoliciesRestStub::GetFirewallPolicy(
     google::cloud::cpp::compute::region_network_firewall_policies::v1::
         GetFirewallPolicyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::FirewallPolicy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "firewallPolicies", "/", request.firewall_policy()));
@@ -189,7 +189,7 @@ DefaultRegionNetworkFirewallPoliciesRestStub::GetAssociation(
         GetAssociationRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::FirewallPolicyAssociation>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "firewallPolicies", "/", request.firewall_policy(), "/",
@@ -207,7 +207,7 @@ DefaultRegionNetworkFirewallPoliciesRestStub::GetEffectiveFirewalls(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::
           RegionNetworkFirewallPoliciesGetEffectiveFirewallsResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "firewallPolicies", "/", "getEffectiveFirewalls"),
@@ -221,7 +221,7 @@ DefaultRegionNetworkFirewallPoliciesRestStub::GetIamPolicy(
     google::cloud::cpp::compute::region_network_firewall_policies::v1::
         GetIamPolicyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "firewallPolicies", "/", request.resource(), "/",
@@ -238,7 +238,7 @@ DefaultRegionNetworkFirewallPoliciesRestStub::GetRule(
         GetRuleRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::FirewallPolicyRule>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "firewallPolicies", "/", request.firewall_policy(), "/",
@@ -261,6 +261,7 @@ DefaultRegionNetworkFirewallPoliciesRestStub::AsyncInsertFirewallPolicy(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.firewall_policy_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "firewallPolicies"),
@@ -281,7 +282,7 @@ DefaultRegionNetworkFirewallPoliciesRestStub::ListRegionNetworkFirewallPolicies(
         ListRegionNetworkFirewallPoliciesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::FirewallPolicyList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "firewallPolicies"),
@@ -308,6 +309,7 @@ DefaultRegionNetworkFirewallPoliciesRestStub::AsyncPatchFirewallPolicy(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.firewall_policy_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "firewallPolicies", "/",
@@ -336,7 +338,7 @@ DefaultRegionNetworkFirewallPoliciesRestStub::AsyncPatchRule(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.firewall_policy_rule_resource(),
+                request.firewall_policy_rule_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "firewallPolicies", "/",
@@ -366,7 +368,7 @@ DefaultRegionNetworkFirewallPoliciesRestStub::AsyncRemoveAssociation(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "firewallPolicies", "/",
@@ -396,7 +398,7 @@ DefaultRegionNetworkFirewallPoliciesRestStub::AsyncRemoveRule(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "firewallPolicies", "/",
@@ -420,6 +422,7 @@ DefaultRegionNetworkFirewallPoliciesRestStub::SetIamPolicy(
         SetIamPolicyRequest const& request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.region_set_policy_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "firewallPolicies", "/", request.resource(), "/",
@@ -434,6 +437,7 @@ DefaultRegionNetworkFirewallPoliciesRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "firewallPolicies", "/", request.resource(), "/",
@@ -453,7 +457,7 @@ DefaultRegionNetworkFirewallPoliciesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -475,7 +479,7 @@ DefaultRegionNetworkFirewallPoliciesRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/region_notification_endpoints/v1/internal/region_notification_endpoints_rest_stub.cc
+++ b/google/cloud/compute/region_notification_endpoints/v1/internal/region_notification_endpoints_rest_stub.cc
@@ -60,7 +60,7 @@ DefaultRegionNotificationEndpointsRestStub::AsyncDeleteNotificationEndpoint(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "notificationEndpoints",
@@ -82,7 +82,7 @@ DefaultRegionNotificationEndpointsRestStub::GetNotificationEndpoint(
         GetNotificationEndpointRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::NotificationEndpoint>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "notificationEndpoints", "/",
@@ -103,7 +103,7 @@ DefaultRegionNotificationEndpointsRestStub::AsyncInsertNotificationEndpoint(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.notification_endpoint_resource(),
+                request.notification_endpoint_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "notificationEndpoints"),
@@ -124,7 +124,7 @@ DefaultRegionNotificationEndpointsRestStub::ListRegionNotificationEndpoints(
         ListRegionNotificationEndpointsRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::NotificationEndpointList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "notificationEndpoints"),
@@ -150,7 +150,7 @@ DefaultRegionNotificationEndpointsRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -171,7 +171,7 @@ future<Status> DefaultRegionNotificationEndpointsRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/region_operations/v1/internal/region_operations_rest_stub.cc
+++ b/google/cloud/compute/region_operations/v1/internal/region_operations_rest_stub.cc
@@ -44,7 +44,7 @@ Status DefaultRegionOperationsRestStub::DeleteOperation(
     google::cloud::cpp::compute::region_operations::v1::
         DeleteOperationRequest const& request) {
   return rest_internal::Delete(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "operations", "/", request.operation()));
@@ -56,7 +56,7 @@ DefaultRegionOperationsRestStub::GetOperation(
     google::cloud::cpp::compute::region_operations::v1::
         GetOperationRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "operations", "/", request.operation()));
@@ -68,7 +68,7 @@ DefaultRegionOperationsRestStub::ListRegionOperations(
     google::cloud::cpp::compute::region_operations::v1::
         ListRegionOperationsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::OperationList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "operations"),
@@ -87,7 +87,7 @@ DefaultRegionOperationsRestStub::Wait(
     google::cloud::cpp::compute::region_operations::v1::WaitRequest const&
         request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "operations", "/", request.operation(), "/", "wait"));

--- a/google/cloud/compute/region_security_policies/v1/internal/region_security_policies_rest_stub.cc
+++ b/google/cloud/compute/region_security_policies/v1/internal/region_security_policies_rest_stub.cc
@@ -59,7 +59,7 @@ DefaultRegionSecurityPoliciesRestStub::AsyncDeleteSecurityPolicy(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "securityPolicies", "/",
@@ -80,7 +80,7 @@ DefaultRegionSecurityPoliciesRestStub::GetSecurityPolicy(
     google::cloud::cpp::compute::region_security_policies::v1::
         GetSecurityPolicyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::SecurityPolicy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "securityPolicies", "/", request.security_policy()));
@@ -100,6 +100,7 @@ DefaultRegionSecurityPoliciesRestStub::AsyncInsertSecurityPolicy(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.security_policy_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "securityPolicies"),
@@ -122,7 +123,7 @@ DefaultRegionSecurityPoliciesRestStub::ListRegionSecurityPolicies(
         ListRegionSecurityPoliciesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::SecurityPolicyList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "securityPolicies"),
@@ -149,6 +150,7 @@ DefaultRegionSecurityPoliciesRestStub::AsyncPatchSecurityPolicy(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.security_policy_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "securityPolicies", "/",
@@ -176,7 +178,7 @@ DefaultRegionSecurityPoliciesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -197,7 +199,7 @@ future<Status> DefaultRegionSecurityPoliciesRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/region_ssl_certificates/v1/internal/region_ssl_certificates_rest_stub.cc
+++ b/google/cloud/compute/region_ssl_certificates/v1/internal/region_ssl_certificates_rest_stub.cc
@@ -59,7 +59,7 @@ DefaultRegionSslCertificatesRestStub::AsyncDeleteSslCertificate(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "sslCertificates", "/",
@@ -80,7 +80,7 @@ DefaultRegionSslCertificatesRestStub::GetSslCertificate(
     google::cloud::cpp::compute::region_ssl_certificates::v1::
         GetSslCertificateRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::SslCertificate>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "sslCertificates", "/", request.ssl_certificate()));
@@ -100,6 +100,7 @@ DefaultRegionSslCertificatesRestStub::AsyncInsertSslCertificate(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.ssl_certificate_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "sslCertificates"),
@@ -120,7 +121,7 @@ DefaultRegionSslCertificatesRestStub::ListRegionSslCertificates(
         ListRegionSslCertificatesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::SslCertificateList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "sslCertificates"),
@@ -146,7 +147,7 @@ DefaultRegionSslCertificatesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -167,7 +168,7 @@ future<Status> DefaultRegionSslCertificatesRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/region_ssl_policies/v1/internal/region_ssl_policies_rest_stub.cc
+++ b/google/cloud/compute/region_ssl_policies/v1/internal/region_ssl_policies_rest_stub.cc
@@ -58,7 +58,7 @@ DefaultRegionSslPoliciesRestStub::AsyncDeleteSslPolicy(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "sslPolicies", "/",
@@ -79,7 +79,7 @@ DefaultRegionSslPoliciesRestStub::GetSslPolicy(
     google::cloud::cpp::compute::region_ssl_policies::v1::
         GetSslPolicyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::SslPolicy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "sslPolicies", "/", request.ssl_policy()));
@@ -98,7 +98,7 @@ DefaultRegionSslPoliciesRestStub::AsyncInsertSslPolicy(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.ssl_policy_resource(),
+                *service, *rest_context, request.ssl_policy_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "sslPolicies"),
@@ -118,7 +118,7 @@ DefaultRegionSslPoliciesRestStub::ListRegionSslPolicies(
     google::cloud::cpp::compute::region_ssl_policies::v1::
         ListRegionSslPoliciesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::SslPoliciesList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "sslPolicies"),
@@ -139,7 +139,7 @@ DefaultRegionSslPoliciesRestStub::ListAvailableFeatures(
         ListAvailableFeaturesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::
                                 SslPoliciesListAvailableFeaturesResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "sslPolicies", "/", "listAvailableFeatures"),
@@ -165,7 +165,7 @@ DefaultRegionSslPoliciesRestStub::AsyncPatchSslPolicy(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.ssl_policy_resource(),
+                *service, *rest_context, request.ssl_policy_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "sslPolicies", "/",
@@ -193,7 +193,7 @@ DefaultRegionSslPoliciesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -214,7 +214,7 @@ future<Status> DefaultRegionSslPoliciesRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/region_target_http_proxies/v1/internal/region_target_http_proxies_rest_stub.cc
+++ b/google/cloud/compute/region_target_http_proxies/v1/internal/region_target_http_proxies_rest_stub.cc
@@ -59,7 +59,7 @@ DefaultRegionTargetHttpProxiesRestStub::AsyncDeleteTargetHttpProxy(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetHttpProxies", "/",
@@ -80,7 +80,7 @@ DefaultRegionTargetHttpProxiesRestStub::GetTargetHttpProxy(
     google::cloud::cpp::compute::region_target_http_proxies::v1::
         GetTargetHttpProxyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::TargetHttpProxy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "targetHttpProxies", "/", request.target_http_proxy()));
@@ -100,6 +100,7 @@ DefaultRegionTargetHttpProxiesRestStub::AsyncInsertTargetHttpProxy(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_http_proxy_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetHttpProxies"),
@@ -120,7 +121,7 @@ DefaultRegionTargetHttpProxiesRestStub::ListRegionTargetHttpProxies(
         ListRegionTargetHttpProxiesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::TargetHttpProxyList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "targetHttpProxies"),
@@ -147,6 +148,7 @@ DefaultRegionTargetHttpProxiesRestStub::AsyncSetUrlMap(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.url_map_reference_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetHttpProxies", "/",
@@ -174,7 +176,7 @@ DefaultRegionTargetHttpProxiesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -195,7 +197,7 @@ future<Status> DefaultRegionTargetHttpProxiesRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/region_target_https_proxies/v1/internal/region_target_https_proxies_rest_stub.cc
+++ b/google/cloud/compute/region_target_https_proxies/v1/internal/region_target_https_proxies_rest_stub.cc
@@ -60,7 +60,7 @@ DefaultRegionTargetHttpsProxiesRestStub::AsyncDeleteTargetHttpsProxy(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetHttpsProxies", "/",
@@ -81,7 +81,7 @@ DefaultRegionTargetHttpsProxiesRestStub::GetTargetHttpsProxy(
     google::cloud::cpp::compute::region_target_https_proxies::v1::
         GetTargetHttpsProxyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::TargetHttpsProxy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "targetHttpsProxies", "/",
@@ -102,6 +102,7 @@ DefaultRegionTargetHttpsProxiesRestStub::AsyncInsertTargetHttpsProxy(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_https_proxy_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetHttpsProxies"),
@@ -122,7 +123,7 @@ DefaultRegionTargetHttpsProxiesRestStub::ListRegionTargetHttpsProxies(
         ListRegionTargetHttpsProxiesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::TargetHttpsProxyList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "targetHttpsProxies"),
@@ -149,6 +150,7 @@ DefaultRegionTargetHttpsProxiesRestStub::AsyncPatchTargetHttpsProxy(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_https_proxy_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetHttpsProxies", "/",
@@ -179,6 +181,7 @@ DefaultRegionTargetHttpsProxiesRestStub::AsyncSetSslCertificates(
             *service, *rest_context,
             request
                 .region_target_https_proxies_set_ssl_certificates_request_resource(),
+            false,
             absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                          request.project(), "/", "regions", "/",
                          request.region(), "/", "targetHttpsProxies", "/",
@@ -208,6 +211,7 @@ DefaultRegionTargetHttpsProxiesRestStub::AsyncSetUrlMap(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.url_map_reference_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetHttpsProxies", "/",
@@ -235,7 +239,7 @@ DefaultRegionTargetHttpsProxiesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -256,7 +260,7 @@ future<Status> DefaultRegionTargetHttpsProxiesRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/region_target_tcp_proxies/v1/internal/region_target_tcp_proxies_rest_stub.cc
+++ b/google/cloud/compute/region_target_tcp_proxies/v1/internal/region_target_tcp_proxies_rest_stub.cc
@@ -59,7 +59,7 @@ DefaultRegionTargetTcpProxiesRestStub::AsyncDeleteTargetTcpProxy(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetTcpProxies", "/",
@@ -80,7 +80,7 @@ DefaultRegionTargetTcpProxiesRestStub::GetTargetTcpProxy(
     google::cloud::cpp::compute::region_target_tcp_proxies::v1::
         GetTargetTcpProxyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::TargetTcpProxy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "targetTcpProxies", "/", request.target_tcp_proxy()));
@@ -100,6 +100,7 @@ DefaultRegionTargetTcpProxiesRestStub::AsyncInsertTargetTcpProxy(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_tcp_proxy_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetTcpProxies"),
@@ -120,7 +121,7 @@ DefaultRegionTargetTcpProxiesRestStub::ListRegionTargetTcpProxies(
         ListRegionTargetTcpProxiesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::TargetTcpProxyList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "targetTcpProxies"),
@@ -146,7 +147,7 @@ DefaultRegionTargetTcpProxiesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -167,7 +168,7 @@ future<Status> DefaultRegionTargetTcpProxiesRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/region_url_maps/v1/internal/region_url_maps_rest_stub.cc
+++ b/google/cloud/compute/region_url_maps/v1/internal/region_url_maps_rest_stub.cc
@@ -57,7 +57,7 @@ DefaultRegionUrlMapsRestStub::AsyncDeleteUrlMap(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "urlMaps", "/",
@@ -78,7 +78,7 @@ DefaultRegionUrlMapsRestStub::GetUrlMap(
     google::cloud::cpp::compute::region_url_maps::v1::GetUrlMapRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::UrlMap>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "urlMaps", "/", request.url_map()));
@@ -97,7 +97,7 @@ DefaultRegionUrlMapsRestStub::AsyncInsertUrlMap(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.url_map_resource(),
+                *service, *rest_context, request.url_map_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "urlMaps"),
@@ -117,7 +117,7 @@ DefaultRegionUrlMapsRestStub::ListRegionUrlMaps(
     google::cloud::cpp::compute::region_url_maps::v1::
         ListRegionUrlMapsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::UrlMapList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "urlMaps"),
@@ -143,7 +143,7 @@ DefaultRegionUrlMapsRestStub::AsyncPatchUrlMap(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.url_map_resource(),
+                *service, *rest_context, request.url_map_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "urlMaps", "/",
@@ -171,7 +171,7 @@ DefaultRegionUrlMapsRestStub::AsyncUpdateUrlMap(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Put<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.url_map_resource(),
+                *service, *rest_context, request.url_map_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "urlMaps", "/",
@@ -194,7 +194,7 @@ DefaultRegionUrlMapsRestStub::Validate(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::UrlMapsValidateResponse>(
       *service_, rest_context,
-      request.region_url_maps_validate_request_resource(),
+      request.region_url_maps_validate_request_resource(), false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "urlMaps", "/", request.url_map(), "/", "validate"));
@@ -213,7 +213,7 @@ DefaultRegionUrlMapsRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -234,7 +234,7 @@ future<Status> DefaultRegionUrlMapsRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/regions/v1/internal/regions_rest_stub.cc
+++ b/google/cloud/compute/regions/v1/internal/regions_rest_stub.cc
@@ -43,7 +43,7 @@ DefaultRegionsRestStub::GetRegion(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::cpp::compute::regions::v1::GetRegionRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Region>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region()));
 }
@@ -54,7 +54,7 @@ DefaultRegionsRestStub::ListRegions(
     google::cloud::cpp::compute::regions::v1::ListRegionsRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::RegionList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions"),
       rest_internal::TrimEmptyQueryParameters(

--- a/google/cloud/compute/reservations/v1/internal/reservations_rest_stub.cc
+++ b/google/cloud/compute/reservations/v1/internal/reservations_rest_stub.cc
@@ -51,7 +51,7 @@ DefaultReservationsRestStub::AggregatedListReservations(
         AggregatedListReservationsRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::ReservationAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "reservations"),
       rest_internal::TrimEmptyQueryParameters(
@@ -78,7 +78,7 @@ DefaultReservationsRestStub::AsyncDeleteReservation(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "reservations", "/",
@@ -99,7 +99,7 @@ DefaultReservationsRestStub::GetReservation(
     google::cloud::cpp::compute::reservations::v1::GetReservationRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Reservation>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "reservations", "/", request.reservation()));
@@ -111,7 +111,7 @@ DefaultReservationsRestStub::GetIamPolicy(
     google::cloud::cpp::compute::reservations::v1::GetIamPolicyRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "reservations", "/", request.resource(), "/",
@@ -134,7 +134,7 @@ DefaultReservationsRestStub::AsyncInsertReservation(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.reservation_resource(),
+                *service, *rest_context, request.reservation_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "reservations"),
@@ -154,7 +154,7 @@ DefaultReservationsRestStub::ListReservations(
     google::cloud::cpp::compute::reservations::v1::
         ListReservationsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::ReservationList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "reservations"),
@@ -181,7 +181,7 @@ DefaultReservationsRestStub::AsyncResize(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.reservations_resize_request_resource(),
+                request.reservations_resize_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "reservations", "/",
@@ -203,6 +203,7 @@ DefaultReservationsRestStub::SetIamPolicy(
         request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.zone_set_policy_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "reservations", "/", request.resource(), "/",
@@ -217,6 +218,7 @@ DefaultReservationsRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "reservations", "/", request.resource(), "/",
@@ -236,7 +238,7 @@ DefaultReservationsRestStub::AsyncUpdateReservation(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.reservation_resource(),
+                *service, *rest_context, request.reservation_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "reservations", "/",
@@ -266,7 +268,7 @@ DefaultReservationsRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/zones/", request.zone(), "/operations/",
                              request.operation())));
@@ -288,7 +290,7 @@ future<Status> DefaultReservationsRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
                          request.zone(), "/operations/", request.operation())));
       },

--- a/google/cloud/compute/resource_policies/v1/internal/resource_policies_rest_stub.cc
+++ b/google/cloud/compute/resource_policies/v1/internal/resource_policies_rest_stub.cc
@@ -52,7 +52,7 @@ DefaultResourcePoliciesRestStub::AggregatedListResourcePolicies(
         AggregatedListResourcePoliciesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::ResourcePolicyAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "resourcePolicies"),
@@ -80,7 +80,7 @@ DefaultResourcePoliciesRestStub::AsyncDeleteResourcePolicy(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "resourcePolicies", "/",
@@ -101,7 +101,7 @@ DefaultResourcePoliciesRestStub::GetResourcePolicy(
     google::cloud::cpp::compute::resource_policies::v1::
         GetResourcePolicyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::ResourcePolicy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "resourcePolicies", "/", request.resource_policy()));
@@ -113,7 +113,7 @@ DefaultResourcePoliciesRestStub::GetIamPolicy(
     google::cloud::cpp::compute::resource_policies::v1::
         GetIamPolicyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "resourcePolicies", "/", request.resource(), "/",
@@ -137,6 +137,7 @@ DefaultResourcePoliciesRestStub::AsyncInsertResourcePolicy(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.resource_policy_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "resourcePolicies"),
@@ -157,7 +158,7 @@ DefaultResourcePoliciesRestStub::ListResourcePolicies(
         ListResourcePoliciesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::ResourcePolicyList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "resourcePolicies"),
@@ -184,6 +185,7 @@ DefaultResourcePoliciesRestStub::AsyncPatchResourcePolicy(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.resource_policy_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "resourcePolicies", "/",
@@ -206,6 +208,7 @@ DefaultResourcePoliciesRestStub::SetIamPolicy(
         SetIamPolicyRequest const& request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.region_set_policy_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "resourcePolicies", "/", request.resource(), "/",
@@ -220,6 +223,7 @@ DefaultResourcePoliciesRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "resourcePolicies", "/", request.resource(), "/",
@@ -239,7 +243,7 @@ DefaultResourcePoliciesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -260,7 +264,7 @@ future<Status> DefaultResourcePoliciesRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/routers/v1/internal/routers_rest_stub.cc
+++ b/google/cloud/compute/routers/v1/internal/routers_rest_stub.cc
@@ -51,7 +51,7 @@ DefaultRoutersRestStub::AggregatedListRouters(
         AggregatedListRoutersRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::RouterAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "routers"),
       rest_internal::TrimEmptyQueryParameters(
@@ -78,7 +78,7 @@ DefaultRoutersRestStub::AsyncDeleteRouter(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "routers", "/",
@@ -98,7 +98,7 @@ DefaultRoutersRestStub::GetRouter(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::cpp::compute::routers::v1::GetRouterRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Router>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "routers", "/", request.router()));
@@ -111,7 +111,7 @@ DefaultRoutersRestStub::GetNatMappingInfo(
         request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::VmEndpointNatMappingsList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "routers", "/", request.router(), "/",
@@ -133,7 +133,7 @@ DefaultRoutersRestStub::GetRouterStatus(
         request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::RouterStatusResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "routers", "/", request.router(), "/",
@@ -153,7 +153,7 @@ DefaultRoutersRestStub::AsyncInsertRouter(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.router_resource(),
+                *service, *rest_context, request.router_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "routers"),
@@ -173,7 +173,7 @@ DefaultRoutersRestStub::ListRouters(
     google::cloud::cpp::compute::routers::v1::ListRoutersRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::RouterList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "routers"),
@@ -199,7 +199,7 @@ DefaultRoutersRestStub::AsyncPatchRouter(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.router_resource(),
+                *service, *rest_context, request.router_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "routers", "/",
@@ -220,7 +220,7 @@ DefaultRoutersRestStub::Preview(
     google::cloud::cpp::compute::routers::v1::PreviewRequest const& request) {
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::RoutersPreviewResponse>(
-      *service_, rest_context, request.router_resource(),
+      *service_, rest_context, request.router_resource(), false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "routers", "/", request.router(), "/", "preview"));
@@ -239,7 +239,7 @@ DefaultRoutersRestStub::AsyncUpdateRouter(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Put<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.router_resource(),
+                *service, *rest_context, request.router_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "routers", "/",
@@ -267,7 +267,7 @@ DefaultRoutersRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -288,7 +288,7 @@ future<Status> DefaultRoutersRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/routes/v1/internal/routes_rest_stub.cc
+++ b/google/cloud/compute/routes/v1/internal/routes_rest_stub.cc
@@ -57,7 +57,7 @@ DefaultRoutesRestStub::AsyncDeleteRoute(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "routes",
                              "/", request.route()),
@@ -76,7 +76,7 @@ DefaultRoutesRestStub::GetRoute(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::cpp::compute::routes::v1::GetRouteRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Route>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "routes", "/",
                    request.route()));
@@ -95,7 +95,7 @@ DefaultRoutesRestStub::AsyncInsertRoute(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.route_resource(),
+                *service, *rest_context, request.route_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "routes"),
                 rest_internal::TrimEmptyQueryParameters(
@@ -113,7 +113,7 @@ DefaultRoutesRestStub::ListRoutes(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::cpp::compute::routes::v1::ListRoutesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::RouteList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "routes"),
       rest_internal::TrimEmptyQueryParameters(
@@ -138,7 +138,7 @@ DefaultRoutesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/global/operations/", request.operation())));
       },
@@ -159,7 +159,7 @@ future<Status> DefaultRoutesRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(),
                          "/global/operations/", request.operation())));
       },

--- a/google/cloud/compute/security_policies/v1/internal/security_policies_rest_stub.cc
+++ b/google/cloud/compute/security_policies/v1/internal/security_policies_rest_stub.cc
@@ -59,7 +59,7 @@ DefaultSecurityPoliciesRestStub::AsyncAddRule(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.security_policy_rule_resource(),
+                request.security_policy_rule_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "securityPolicies", "/", request.security_policy(),
@@ -81,7 +81,7 @@ DefaultSecurityPoliciesRestStub::AggregatedListSecurityPolicies(
         AggregatedListSecurityPoliciesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::SecurityPoliciesAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "securityPolicies"),
@@ -109,7 +109,7 @@ DefaultSecurityPoliciesRestStub::AsyncDeleteSecurityPolicy(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "securityPolicies", "/",
@@ -130,7 +130,7 @@ DefaultSecurityPoliciesRestStub::GetSecurityPolicy(
     google::cloud::cpp::compute::security_policies::v1::
         GetSecurityPolicyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::SecurityPolicy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "securityPolicies",
                    "/", request.security_policy()));
@@ -143,7 +143,7 @@ DefaultSecurityPoliciesRestStub::GetRule(
         request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::SecurityPolicyRule>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "securityPolicies",
                    "/", request.security_policy(), "/", "getRule"),
@@ -165,6 +165,7 @@ DefaultSecurityPoliciesRestStub::AsyncInsertSecurityPolicy(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.security_policy_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "securityPolicies"),
@@ -187,7 +188,7 @@ DefaultSecurityPoliciesRestStub::ListSecurityPolicies(
         ListSecurityPoliciesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::SecurityPolicyList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "securityPolicies"),
       rest_internal::TrimEmptyQueryParameters(
@@ -208,7 +209,7 @@ DefaultSecurityPoliciesRestStub::ListPreconfiguredExpressionSets(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::
           SecurityPoliciesListPreconfiguredExpressionSetsResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "securityPolicies",
                    "/", "listPreconfiguredExpressionSets"),
@@ -235,6 +236,7 @@ DefaultSecurityPoliciesRestStub::AsyncPatchSecurityPolicy(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.security_policy_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "securityPolicies", "/",
@@ -263,7 +265,7 @@ DefaultSecurityPoliciesRestStub::AsyncPatchRule(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.security_policy_rule_resource(),
+                request.security_policy_rule_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "securityPolicies", "/", request.security_policy(),
@@ -294,7 +296,7 @@ DefaultSecurityPoliciesRestStub::AsyncRemoveRule(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "securityPolicies", "/", request.security_policy(),
@@ -323,7 +325,7 @@ DefaultSecurityPoliciesRestStub::AsyncSetLabels(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.global_set_labels_request_resource(),
+                request.global_set_labels_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "securityPolicies", "/", request.resource(), "/",
@@ -349,7 +351,7 @@ DefaultSecurityPoliciesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/global/operations/", request.operation())));
       },
@@ -370,7 +372,7 @@ future<Status> DefaultSecurityPoliciesRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(),
                          "/global/operations/", request.operation())));
       },

--- a/google/cloud/compute/service_attachments/v1/internal/service_attachments_rest_stub.cc
+++ b/google/cloud/compute/service_attachments/v1/internal/service_attachments_rest_stub.cc
@@ -52,7 +52,7 @@ DefaultServiceAttachmentsRestStub::AggregatedListServiceAttachments(
         AggregatedListServiceAttachmentsRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::ServiceAttachmentAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "serviceAttachments"),
@@ -80,7 +80,7 @@ DefaultServiceAttachmentsRestStub::AsyncDeleteServiceAttachment(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "serviceAttachments", "/",
@@ -101,7 +101,7 @@ DefaultServiceAttachmentsRestStub::GetServiceAttachment(
     google::cloud::cpp::compute::service_attachments::v1::
         GetServiceAttachmentRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::ServiceAttachment>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "serviceAttachments", "/",
@@ -114,7 +114,7 @@ DefaultServiceAttachmentsRestStub::GetIamPolicy(
     google::cloud::cpp::compute::service_attachments::v1::
         GetIamPolicyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "serviceAttachments", "/", request.resource(), "/",
@@ -138,6 +138,7 @@ DefaultServiceAttachmentsRestStub::AsyncInsertServiceAttachment(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.service_attachment_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "serviceAttachments"),
@@ -158,7 +159,7 @@ DefaultServiceAttachmentsRestStub::ListServiceAttachments(
         ListServiceAttachmentsRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::ServiceAttachmentList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "serviceAttachments"),
@@ -185,6 +186,7 @@ DefaultServiceAttachmentsRestStub::AsyncPatchServiceAttachment(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.service_attachment_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "serviceAttachments", "/",
@@ -206,6 +208,7 @@ DefaultServiceAttachmentsRestStub::SetIamPolicy(
         SetIamPolicyRequest const& request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.region_set_policy_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "serviceAttachments", "/", request.resource(), "/",
@@ -220,6 +223,7 @@ DefaultServiceAttachmentsRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "serviceAttachments", "/", request.resource(), "/",
@@ -239,7 +243,7 @@ DefaultServiceAttachmentsRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -260,7 +264,7 @@ future<Status> DefaultServiceAttachmentsRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/snapshots/v1/internal/snapshots_rest_stub.cc
+++ b/google/cloud/compute/snapshots/v1/internal/snapshots_rest_stub.cc
@@ -57,7 +57,7 @@ DefaultSnapshotsRestStub::AsyncDeleteSnapshot(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "snapshots",
                              "/", request.snapshot()),
@@ -77,7 +77,7 @@ DefaultSnapshotsRestStub::GetSnapshot(
     google::cloud::cpp::compute::snapshots::v1::GetSnapshotRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Snapshot>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "snapshots", "/",
                    request.snapshot()));
@@ -89,7 +89,7 @@ DefaultSnapshotsRestStub::GetIamPolicy(
     google::cloud::cpp::compute::snapshots::v1::GetIamPolicyRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "snapshots", "/",
                    request.resource(), "/", "getIamPolicy"),
@@ -111,7 +111,7 @@ DefaultSnapshotsRestStub::AsyncInsertSnapshot(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.snapshot_resource(),
+                *service, *rest_context, request.snapshot_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "snapshots"),
@@ -131,7 +131,7 @@ DefaultSnapshotsRestStub::ListSnapshots(
     google::cloud::cpp::compute::snapshots::v1::ListSnapshotsRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::SnapshotList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "snapshots"),
       rest_internal::TrimEmptyQueryParameters(
@@ -150,6 +150,7 @@ DefaultSnapshotsRestStub::SetIamPolicy(
         request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.global_set_policy_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "snapshots", "/",
                    request.resource(), "/", "setIamPolicy"));
@@ -169,7 +170,7 @@ DefaultSnapshotsRestStub::AsyncSetLabels(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.global_set_labels_request_resource(),
+                request.global_set_labels_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "snapshots",
                              "/", request.resource(), "/", "setLabels")));
@@ -189,6 +190,7 @@ DefaultSnapshotsRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "snapshots", "/",
                    request.resource(), "/", "testIamPermissions"));
@@ -207,7 +209,7 @@ DefaultSnapshotsRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/global/operations/", request.operation())));
       },
@@ -228,7 +230,7 @@ future<Status> DefaultSnapshotsRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(),
                          "/global/operations/", request.operation())));
       },

--- a/google/cloud/compute/ssl_certificates/v1/internal/ssl_certificates_rest_stub.cc
+++ b/google/cloud/compute/ssl_certificates/v1/internal/ssl_certificates_rest_stub.cc
@@ -51,7 +51,7 @@ DefaultSslCertificatesRestStub::AggregatedListSslCertificates(
         AggregatedListSslCertificatesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::SslCertificateAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "sslCertificates"),
@@ -79,7 +79,7 @@ DefaultSslCertificatesRestStub::AsyncDeleteSslCertificate(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "sslCertificates", "/", request.ssl_certificate()),
@@ -99,7 +99,7 @@ DefaultSslCertificatesRestStub::GetSslCertificate(
     google::cloud::cpp::compute::ssl_certificates::v1::
         GetSslCertificateRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::SslCertificate>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "sslCertificates",
                    "/", request.ssl_certificate()));
@@ -119,6 +119,7 @@ DefaultSslCertificatesRestStub::AsyncInsertSslCertificate(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.ssl_certificate_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "sslCertificates"),
@@ -139,7 +140,7 @@ DefaultSslCertificatesRestStub::ListSslCertificates(
         ListSslCertificatesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::SslCertificateList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "sslCertificates"),
       rest_internal::TrimEmptyQueryParameters(
@@ -164,7 +165,7 @@ DefaultSslCertificatesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/global/operations/", request.operation())));
       },
@@ -185,7 +186,7 @@ future<Status> DefaultSslCertificatesRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(),
                          "/global/operations/", request.operation())));
       },

--- a/google/cloud/compute/ssl_policies/v1/internal/ssl_policies_rest_stub.cc
+++ b/google/cloud/compute/ssl_policies/v1/internal/ssl_policies_rest_stub.cc
@@ -51,7 +51,7 @@ DefaultSslPoliciesRestStub::AggregatedListSslPolicies(
         AggregatedListSslPoliciesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::SslPoliciesAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "sslPolicies"),
       rest_internal::TrimEmptyQueryParameters(
@@ -78,7 +78,7 @@ DefaultSslPoliciesRestStub::AsyncDeleteSslPolicy(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "sslPolicies", "/", request.ssl_policy()),
@@ -98,7 +98,7 @@ DefaultSslPoliciesRestStub::GetSslPolicy(
     google::cloud::cpp::compute::ssl_policies::v1::GetSslPolicyRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::SslPolicy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "sslPolicies", "/",
                    request.ssl_policy()));
@@ -117,7 +117,7 @@ DefaultSslPoliciesRestStub::AsyncInsertSslPolicy(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.ssl_policy_resource(),
+                *service, *rest_context, request.ssl_policy_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "sslPolicies"),
@@ -137,7 +137,7 @@ DefaultSslPoliciesRestStub::ListSslPolicies(
     google::cloud::cpp::compute::ssl_policies::v1::ListSslPoliciesRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::SslPoliciesList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "sslPolicies"),
       rest_internal::TrimEmptyQueryParameters(
@@ -157,7 +157,7 @@ DefaultSslPoliciesRestStub::ListAvailableFeatures(
         ListAvailableFeaturesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::
                                 SslPoliciesListAvailableFeaturesResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "sslPolicies", "/",
                    "listAvailableFeatures"),
@@ -183,7 +183,7 @@ DefaultSslPoliciesRestStub::AsyncPatchSslPolicy(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.ssl_policy_resource(),
+                *service, *rest_context, request.ssl_policy_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "sslPolicies", "/", request.ssl_policy()),
@@ -210,7 +210,7 @@ DefaultSslPoliciesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/global/operations/", request.operation())));
       },
@@ -231,7 +231,7 @@ future<Status> DefaultSslPoliciesRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(),
                          "/global/operations/", request.operation())));
       },

--- a/google/cloud/compute/subnetworks/v1/internal/subnetworks_rest_stub.cc
+++ b/google/cloud/compute/subnetworks/v1/internal/subnetworks_rest_stub.cc
@@ -51,7 +51,7 @@ DefaultSubnetworksRestStub::AggregatedListSubnetworks(
         AggregatedListSubnetworksRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::SubnetworkAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "subnetworks"),
       rest_internal::TrimEmptyQueryParameters(
@@ -78,7 +78,7 @@ DefaultSubnetworksRestStub::AsyncDeleteSubnetwork(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "subnetworks", "/",
@@ -108,6 +108,7 @@ DefaultSubnetworksRestStub::AsyncExpandIpCidrRange(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.subnetworks_expand_ip_cidr_range_request_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "subnetworks", "/",
@@ -128,7 +129,7 @@ DefaultSubnetworksRestStub::GetSubnetwork(
     google::cloud::cpp::compute::subnetworks::v1::GetSubnetworkRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Subnetwork>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "subnetworks", "/", request.subnetwork()));
@@ -140,7 +141,7 @@ DefaultSubnetworksRestStub::GetIamPolicy(
     google::cloud::cpp::compute::subnetworks::v1::GetIamPolicyRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Policy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "subnetworks", "/", request.resource(), "/",
@@ -163,7 +164,7 @@ DefaultSubnetworksRestStub::AsyncInsertSubnetwork(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.subnetwork_resource(),
+                *service, *rest_context, request.subnetwork_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "subnetworks"),
@@ -183,7 +184,7 @@ DefaultSubnetworksRestStub::ListSubnetworks(
     google::cloud::cpp::compute::subnetworks::v1::ListSubnetworksRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::SubnetworkList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "subnetworks"),
@@ -203,7 +204,7 @@ DefaultSubnetworksRestStub::ListUsable(
         request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::UsableSubnetworksAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "subnetworks",
                    "/", "listUsable"),
@@ -229,7 +230,7 @@ DefaultSubnetworksRestStub::AsyncPatchSubnetwork(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.subnetwork_resource(),
+                *service, *rest_context, request.subnetwork_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "subnetworks", "/",
@@ -254,6 +255,7 @@ DefaultSubnetworksRestStub::SetIamPolicy(
         request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Policy>(
       *service_, rest_context, request.region_set_policy_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "subnetworks", "/", request.resource(), "/",
@@ -275,6 +277,7 @@ DefaultSubnetworksRestStub::AsyncSetPrivateIpGoogleAccess(
                     google::cloud::cpp::compute::v1::Operation>(
             *service, *rest_context,
             request.subnetworks_set_private_ip_google_access_request_resource(),
+            false,
             absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                          request.project(), "/", "regions", "/",
                          request.region(), "/", "subnetworks", "/",
@@ -297,6 +300,7 @@ DefaultSubnetworksRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "subnetworks", "/", request.resource(), "/",
@@ -316,7 +320,7 @@ DefaultSubnetworksRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -337,7 +341,7 @@ future<Status> DefaultSubnetworksRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/target_grpc_proxies/v1/internal/target_grpc_proxies_rest_stub.cc
+++ b/google/cloud/compute/target_grpc_proxies/v1/internal/target_grpc_proxies_rest_stub.cc
@@ -58,7 +58,7 @@ DefaultTargetGrpcProxiesRestStub::AsyncDeleteTargetGrpcProxy(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "targetGrpcProxies", "/",
@@ -79,7 +79,7 @@ DefaultTargetGrpcProxiesRestStub::GetTargetGrpcProxy(
     google::cloud::cpp::compute::target_grpc_proxies::v1::
         GetTargetGrpcProxyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::TargetGrpcProxy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "targetGrpcProxies",
                    "/", request.target_grpc_proxy()));
@@ -99,6 +99,7 @@ DefaultTargetGrpcProxiesRestStub::AsyncInsertTargetGrpcProxy(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_grpc_proxy_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "targetGrpcProxies"),
@@ -119,7 +120,7 @@ DefaultTargetGrpcProxiesRestStub::ListTargetGrpcProxies(
         ListTargetGrpcProxiesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::TargetGrpcProxyList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "targetGrpcProxies"),
       rest_internal::TrimEmptyQueryParameters(
@@ -145,6 +146,7 @@ DefaultTargetGrpcProxiesRestStub::AsyncPatchTargetGrpcProxy(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_grpc_proxy_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "targetGrpcProxies", "/",
@@ -172,7 +174,7 @@ DefaultTargetGrpcProxiesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/global/operations/", request.operation())));
       },
@@ -193,7 +195,7 @@ future<Status> DefaultTargetGrpcProxiesRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(),
                          "/global/operations/", request.operation())));
       },

--- a/google/cloud/compute/target_http_proxies/v1/internal/target_http_proxies_rest_stub.cc
+++ b/google/cloud/compute/target_http_proxies/v1/internal/target_http_proxies_rest_stub.cc
@@ -52,7 +52,7 @@ DefaultTargetHttpProxiesRestStub::AggregatedListTargetHttpProxies(
         AggregatedListTargetHttpProxiesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::TargetHttpProxyAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "targetHttpProxies"),
@@ -80,7 +80,7 @@ DefaultTargetHttpProxiesRestStub::AsyncDeleteTargetHttpProxy(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "targetHttpProxies", "/",
@@ -101,7 +101,7 @@ DefaultTargetHttpProxiesRestStub::GetTargetHttpProxy(
     google::cloud::cpp::compute::target_http_proxies::v1::
         GetTargetHttpProxyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::TargetHttpProxy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "targetHttpProxies",
                    "/", request.target_http_proxy()));
@@ -121,6 +121,7 @@ DefaultTargetHttpProxiesRestStub::AsyncInsertTargetHttpProxy(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_http_proxy_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "targetHttpProxies"),
@@ -141,7 +142,7 @@ DefaultTargetHttpProxiesRestStub::ListTargetHttpProxies(
         ListTargetHttpProxiesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::TargetHttpProxyList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "targetHttpProxies"),
       rest_internal::TrimEmptyQueryParameters(
@@ -167,6 +168,7 @@ DefaultTargetHttpProxiesRestStub::AsyncPatchTargetHttpProxy(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_http_proxy_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "targetHttpProxies", "/",
@@ -195,6 +197,7 @@ DefaultTargetHttpProxiesRestStub::AsyncSetUrlMap(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.url_map_reference_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "targetHttpProxies", "/",
                              request.target_http_proxy(), "/", "setUrlMap"),
@@ -221,7 +224,7 @@ DefaultTargetHttpProxiesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/global/operations/", request.operation())));
       },
@@ -242,7 +245,7 @@ future<Status> DefaultTargetHttpProxiesRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(),
                          "/global/operations/", request.operation())));
       },

--- a/google/cloud/compute/target_https_proxies/v1/internal/target_https_proxies_rest_stub.cc
+++ b/google/cloud/compute/target_https_proxies/v1/internal/target_https_proxies_rest_stub.cc
@@ -53,7 +53,7 @@ DefaultTargetHttpsProxiesRestStub::AggregatedListTargetHttpsProxies(
         AggregatedListTargetHttpsProxiesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::TargetHttpsProxyAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "targetHttpsProxies"),
@@ -81,7 +81,7 @@ DefaultTargetHttpsProxiesRestStub::AsyncDeleteTargetHttpsProxy(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "targetHttpsProxies", "/",
@@ -102,7 +102,7 @@ DefaultTargetHttpsProxiesRestStub::GetTargetHttpsProxy(
     google::cloud::cpp::compute::target_https_proxies::v1::
         GetTargetHttpsProxyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::TargetHttpsProxy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "targetHttpsProxies",
                    "/", request.target_https_proxy()));
@@ -122,6 +122,7 @@ DefaultTargetHttpsProxiesRestStub::AsyncInsertTargetHttpsProxy(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_https_proxy_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "targetHttpsProxies"),
@@ -142,7 +143,7 @@ DefaultTargetHttpsProxiesRestStub::ListTargetHttpsProxies(
         ListTargetHttpsProxiesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::TargetHttpsProxyList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "targetHttpsProxies"),
       rest_internal::TrimEmptyQueryParameters(
@@ -168,6 +169,7 @@ DefaultTargetHttpsProxiesRestStub::AsyncPatchTargetHttpsProxy(
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_https_proxy_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "targetHttpsProxies", "/",
@@ -197,6 +199,7 @@ DefaultTargetHttpsProxiesRestStub::AsyncSetCertificateMap(
                     google::cloud::cpp::compute::v1::Operation>(
             *service, *rest_context,
             request.target_https_proxies_set_certificate_map_request_resource(),
+            false,
             absl::StrCat(
                 "/", "compute", "/", "v1", "/", "projects", "/",
                 request.project(), "/", "global", "/", "targetHttpsProxies",
@@ -227,6 +230,7 @@ DefaultTargetHttpsProxiesRestStub::AsyncSetQuicOverride(
                 *service, *rest_context,
                 request
                     .target_https_proxies_set_quic_override_request_resource(),
+                false,
                 absl::StrCat(
                     "/", "compute", "/", "v1", "/", "projects", "/",
                     request.project(), "/", "global", "/", "targetHttpsProxies",
@@ -257,6 +261,7 @@ DefaultTargetHttpsProxiesRestStub::AsyncSetSslCertificates(
             *service, *rest_context,
             request
                 .target_https_proxies_set_ssl_certificates_request_resource(),
+            false,
             absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                          request.project(), "/", "targetHttpsProxies", "/",
                          request.target_https_proxy(), "/",
@@ -285,7 +290,7 @@ DefaultTargetHttpsProxiesRestStub::AsyncSetSslPolicy(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.ssl_policy_reference_resource(),
+                request.ssl_policy_reference_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "targetHttpsProxies", "/",
@@ -314,6 +319,7 @@ DefaultTargetHttpsProxiesRestStub::AsyncSetUrlMap(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.url_map_reference_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "targetHttpsProxies", "/",
                              request.target_https_proxy(), "/", "setUrlMap"),
@@ -340,7 +346,7 @@ DefaultTargetHttpsProxiesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/global/operations/", request.operation())));
       },
@@ -361,7 +367,7 @@ future<Status> DefaultTargetHttpsProxiesRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(),
                          "/global/operations/", request.operation())));
       },

--- a/google/cloud/compute/target_instances/v1/internal/target_instances_rest_stub.cc
+++ b/google/cloud/compute/target_instances/v1/internal/target_instances_rest_stub.cc
@@ -51,7 +51,7 @@ DefaultTargetInstancesRestStub::AggregatedListTargetInstances(
         AggregatedListTargetInstancesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::TargetInstanceAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "targetInstances"),
@@ -79,7 +79,7 @@ DefaultTargetInstancesRestStub::AsyncDeleteTargetInstance(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "targetInstances", "/",
@@ -100,7 +100,7 @@ DefaultTargetInstancesRestStub::GetTargetInstance(
     google::cloud::cpp::compute::target_instances::v1::
         GetTargetInstanceRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::TargetInstance>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "targetInstances", "/", request.target_instance()));
@@ -120,6 +120,7 @@ DefaultTargetInstancesRestStub::AsyncInsertTargetInstance(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_instance_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "zones", "/",
                              request.zone(), "/", "targetInstances"),
@@ -140,7 +141,7 @@ DefaultTargetInstancesRestStub::ListTargetInstances(
         ListTargetInstancesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::TargetInstanceList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "targetInstances"),
@@ -166,7 +167,7 @@ DefaultTargetInstancesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/zones/", request.zone(), "/operations/",
                              request.operation())));
@@ -188,7 +189,7 @@ future<Status> DefaultTargetInstancesRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(), "/zones/",
                          request.zone(), "/operations/", request.operation())));
       },

--- a/google/cloud/compute/target_pools/v1/internal/target_pools_rest_stub.cc
+++ b/google/cloud/compute/target_pools/v1/internal/target_pools_rest_stub.cc
@@ -58,7 +58,7 @@ DefaultTargetPoolsRestStub::AsyncAddHealthCheck(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.target_pools_add_health_check_request_resource(),
+                request.target_pools_add_health_check_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetPools", "/",
@@ -87,7 +87,7 @@ DefaultTargetPoolsRestStub::AsyncAddInstance(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.target_pools_add_instance_request_resource(),
+                request.target_pools_add_instance_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetPools", "/",
@@ -109,7 +109,7 @@ DefaultTargetPoolsRestStub::AggregatedListTargetPools(
         AggregatedListTargetPoolsRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::TargetPoolAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "targetPools"),
       rest_internal::TrimEmptyQueryParameters(
@@ -136,7 +136,7 @@ DefaultTargetPoolsRestStub::AsyncDeleteTargetPool(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetPools", "/",
@@ -157,7 +157,7 @@ DefaultTargetPoolsRestStub::GetTargetPool(
     google::cloud::cpp::compute::target_pools::v1::GetTargetPoolRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::TargetPool>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "targetPools", "/", request.target_pool()));
@@ -170,7 +170,7 @@ DefaultTargetPoolsRestStub::GetHealth(
         request) {
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TargetPoolInstanceHealth>(
-      *service_, rest_context, request.instance_reference_resource(),
+      *service_, rest_context, request.instance_reference_resource(), false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "targetPools", "/", request.target_pool(), "/",
@@ -190,7 +190,7 @@ DefaultTargetPoolsRestStub::AsyncInsertTargetPool(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.target_pool_resource(),
+                *service, *rest_context, request.target_pool_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetPools"),
@@ -210,7 +210,7 @@ DefaultTargetPoolsRestStub::ListTargetPools(
     google::cloud::cpp::compute::target_pools::v1::ListTargetPoolsRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::TargetPoolList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "targetPools"),
@@ -238,6 +238,7 @@ DefaultTargetPoolsRestStub::AsyncRemoveHealthCheck(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.target_pools_remove_health_check_request_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetPools", "/",
@@ -266,7 +267,7 @@ DefaultTargetPoolsRestStub::AsyncRemoveInstance(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.target_pools_remove_instance_request_resource(),
+                request.target_pools_remove_instance_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetPools", "/",
@@ -295,6 +296,7 @@ DefaultTargetPoolsRestStub::AsyncSetBackup(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_reference_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetPools", "/",
@@ -324,7 +326,7 @@ DefaultTargetPoolsRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -345,7 +347,7 @@ future<Status> DefaultTargetPoolsRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/target_ssl_proxies/v1/internal/target_ssl_proxies_rest_stub.cc
+++ b/google/cloud/compute/target_ssl_proxies/v1/internal/target_ssl_proxies_rest_stub.cc
@@ -58,7 +58,7 @@ DefaultTargetSslProxiesRestStub::AsyncDeleteTargetSslProxy(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "targetSslProxies", "/",
@@ -79,7 +79,7 @@ DefaultTargetSslProxiesRestStub::GetTargetSslProxy(
     google::cloud::cpp::compute::target_ssl_proxies::v1::
         GetTargetSslProxyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::TargetSslProxy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "targetSslProxies",
                    "/", request.target_ssl_proxy()));
@@ -99,6 +99,7 @@ DefaultTargetSslProxiesRestStub::AsyncInsertTargetSslProxy(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_ssl_proxy_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "targetSslProxies"),
@@ -119,7 +120,7 @@ DefaultTargetSslProxiesRestStub::ListTargetSslProxies(
         ListTargetSslProxiesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::TargetSslProxyList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "targetSslProxies"),
       rest_internal::TrimEmptyQueryParameters(
@@ -147,6 +148,7 @@ DefaultTargetSslProxiesRestStub::AsyncSetBackendService(
                 *service, *rest_context,
                 request
                     .target_ssl_proxies_set_backend_service_request_resource(),
+                false,
                 absl::StrCat(
                     "/", "compute", "/", "v1", "/", "projects", "/",
                     request.project(), "/", "global", "/", "targetSslProxies",
@@ -177,6 +179,7 @@ DefaultTargetSslProxiesRestStub::AsyncSetCertificateMap(
                 *service, *rest_context,
                 request
                     .target_ssl_proxies_set_certificate_map_request_resource(),
+                false,
                 absl::StrCat(
                     "/", "compute", "/", "v1", "/", "projects", "/",
                     request.project(), "/", "global", "/", "targetSslProxies",
@@ -206,6 +209,7 @@ DefaultTargetSslProxiesRestStub::AsyncSetProxyHeader(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.target_ssl_proxies_set_proxy_header_request_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "targetSslProxies", "/",
@@ -236,6 +240,7 @@ DefaultTargetSslProxiesRestStub::AsyncSetSslCertificates(
                 *service, *rest_context,
                 request
                     .target_ssl_proxies_set_ssl_certificates_request_resource(),
+                false,
                 absl::StrCat(
                     "/", "compute", "/", "v1", "/", "projects", "/",
                     request.project(), "/", "global", "/", "targetSslProxies",
@@ -264,7 +269,7 @@ DefaultTargetSslProxiesRestStub::AsyncSetSslPolicy(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.ssl_policy_reference_resource(),
+                request.ssl_policy_reference_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "targetSslProxies", "/",
@@ -292,7 +297,7 @@ DefaultTargetSslProxiesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/global/operations/", request.operation())));
       },
@@ -313,7 +318,7 @@ future<Status> DefaultTargetSslProxiesRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(),
                          "/global/operations/", request.operation())));
       },

--- a/google/cloud/compute/target_tcp_proxies/v1/internal/target_tcp_proxies_rest_stub.cc
+++ b/google/cloud/compute/target_tcp_proxies/v1/internal/target_tcp_proxies_rest_stub.cc
@@ -52,7 +52,7 @@ DefaultTargetTcpProxiesRestStub::AggregatedListTargetTcpProxies(
         AggregatedListTargetTcpProxiesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::TargetTcpProxyAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "targetTcpProxies"),
@@ -80,7 +80,7 @@ DefaultTargetTcpProxiesRestStub::AsyncDeleteTargetTcpProxy(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "targetTcpProxies", "/",
@@ -101,7 +101,7 @@ DefaultTargetTcpProxiesRestStub::GetTargetTcpProxy(
     google::cloud::cpp::compute::target_tcp_proxies::v1::
         GetTargetTcpProxyRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::TargetTcpProxy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "targetTcpProxies",
                    "/", request.target_tcp_proxy()));
@@ -121,6 +121,7 @@ DefaultTargetTcpProxiesRestStub::AsyncInsertTargetTcpProxy(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_tcp_proxy_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "targetTcpProxies"),
@@ -141,7 +142,7 @@ DefaultTargetTcpProxiesRestStub::ListTargetTcpProxies(
         ListTargetTcpProxiesRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::TargetTcpProxyList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "targetTcpProxies"),
       rest_internal::TrimEmptyQueryParameters(
@@ -169,6 +170,7 @@ DefaultTargetTcpProxiesRestStub::AsyncSetBackendService(
                 *service, *rest_context,
                 request
                     .target_tcp_proxies_set_backend_service_request_resource(),
+                false,
                 absl::StrCat(
                     "/", "compute", "/", "v1", "/", "projects", "/",
                     request.project(), "/", "global", "/", "targetTcpProxies",
@@ -198,6 +200,7 @@ DefaultTargetTcpProxiesRestStub::AsyncSetProxyHeader(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
                 request.target_tcp_proxies_set_proxy_header_request_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/",
                              "targetTcpProxies", "/",
@@ -225,7 +228,7 @@ DefaultTargetTcpProxiesRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/global/operations/", request.operation())));
       },
@@ -246,7 +249,7 @@ future<Status> DefaultTargetTcpProxiesRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(),
                          "/global/operations/", request.operation())));
       },

--- a/google/cloud/compute/target_vpn_gateways/v1/internal/target_vpn_gateways_rest_stub.cc
+++ b/google/cloud/compute/target_vpn_gateways/v1/internal/target_vpn_gateways_rest_stub.cc
@@ -52,7 +52,7 @@ DefaultTargetVpnGatewaysRestStub::AggregatedListTargetVpnGateways(
         AggregatedListTargetVpnGatewaysRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::TargetVpnGatewayAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/",
                    "targetVpnGateways"),
@@ -80,7 +80,7 @@ DefaultTargetVpnGatewaysRestStub::AsyncDeleteTargetVpnGateway(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetVpnGateways", "/",
@@ -101,7 +101,7 @@ DefaultTargetVpnGatewaysRestStub::GetTargetVpnGateway(
     google::cloud::cpp::compute::target_vpn_gateways::v1::
         GetTargetVpnGatewayRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::TargetVpnGateway>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "targetVpnGateways", "/",
@@ -122,6 +122,7 @@ DefaultTargetVpnGatewaysRestStub::AsyncInsertTargetVpnGateway(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.target_vpn_gateway_resource(),
+                false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetVpnGateways"),
@@ -142,7 +143,7 @@ DefaultTargetVpnGatewaysRestStub::ListTargetVpnGateways(
         ListTargetVpnGatewaysRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::TargetVpnGatewayList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "targetVpnGateways"),
@@ -169,7 +170,7 @@ DefaultTargetVpnGatewaysRestStub::AsyncSetLabels(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.region_set_labels_request_resource(),
+                request.region_set_labels_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "targetVpnGateways", "/",
@@ -197,7 +198,7 @@ DefaultTargetVpnGatewaysRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -218,7 +219,7 @@ future<Status> DefaultTargetVpnGatewaysRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/url_maps/v1/internal/url_maps_rest_stub.cc
+++ b/google/cloud/compute/url_maps/v1/internal/url_maps_rest_stub.cc
@@ -51,7 +51,7 @@ DefaultUrlMapsRestStub::AggregatedListUrlMaps(
         AggregatedListUrlMapsRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::UrlMapsAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "urlMaps"),
       rest_internal::TrimEmptyQueryParameters(
@@ -78,7 +78,7 @@ DefaultUrlMapsRestStub::AsyncDeleteUrlMap(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "urlMaps",
                              "/", request.url_map()),
@@ -98,7 +98,7 @@ DefaultUrlMapsRestStub::GetUrlMap(
     google::cloud::cpp::compute::url_maps::v1::GetUrlMapRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::UrlMap>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "urlMaps", "/",
                    request.url_map()));
@@ -117,7 +117,7 @@ DefaultUrlMapsRestStub::AsyncInsertUrlMap(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.url_map_resource(),
+                *service, *rest_context, request.url_map_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "urlMaps"),
                 rest_internal::TrimEmptyQueryParameters(
@@ -144,7 +144,7 @@ DefaultUrlMapsRestStub::AsyncInvalidateCache(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.cache_invalidation_rule_resource(),
+                request.cache_invalidation_rule_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "urlMaps",
                              "/", request.url_map(), "/", "invalidateCache"),
@@ -164,7 +164,7 @@ DefaultUrlMapsRestStub::ListUrlMaps(
     google::cloud::cpp::compute::url_maps::v1::ListUrlMapsRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::UrlMapList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "urlMaps"),
       rest_internal::TrimEmptyQueryParameters(
@@ -189,7 +189,7 @@ DefaultUrlMapsRestStub::AsyncPatchUrlMap(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Patch<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.url_map_resource(),
+                *service, *rest_context, request.url_map_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "urlMaps",
                              "/", request.url_map()),
@@ -216,7 +216,7 @@ DefaultUrlMapsRestStub::AsyncUpdateUrlMap(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Put<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.url_map_resource(),
+                *service, *rest_context, request.url_map_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "global", "/", "urlMaps",
                              "/", request.url_map()),
@@ -237,6 +237,7 @@ DefaultUrlMapsRestStub::Validate(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::UrlMapsValidateResponse>(
       *service_, rest_context, request.url_maps_validate_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "global", "/", "urlMaps", "/",
                    request.url_map(), "/", "validate"));
@@ -255,7 +256,7 @@ DefaultUrlMapsRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/global/operations/", request.operation())));
       },
@@ -276,7 +277,7 @@ future<Status> DefaultUrlMapsRestStub::AsyncCancelOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::protobuf::Empty>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/compute/v1/projects/", request.project(),
                          "/global/operations/", request.operation())));
       },

--- a/google/cloud/compute/vpn_gateways/v1/internal/vpn_gateways_rest_stub.cc
+++ b/google/cloud/compute/vpn_gateways/v1/internal/vpn_gateways_rest_stub.cc
@@ -51,7 +51,7 @@ DefaultVpnGatewaysRestStub::AggregatedListVpnGateways(
         AggregatedListVpnGatewaysRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::VpnGatewayAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "vpnGateways"),
       rest_internal::TrimEmptyQueryParameters(
@@ -78,7 +78,7 @@ DefaultVpnGatewaysRestStub::AsyncDeleteVpnGateway(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "vpnGateways", "/",
@@ -99,7 +99,7 @@ DefaultVpnGatewaysRestStub::GetVpnGateway(
     google::cloud::cpp::compute::vpn_gateways::v1::GetVpnGatewayRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::VpnGateway>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "vpnGateways", "/", request.vpn_gateway()));
@@ -112,7 +112,7 @@ DefaultVpnGatewaysRestStub::GetStatus(
         request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::VpnGatewaysGetStatusResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "vpnGateways", "/", request.vpn_gateway(), "/",
@@ -132,7 +132,7 @@ DefaultVpnGatewaysRestStub::AsyncInsertVpnGateway(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.vpn_gateway_resource(),
+                *service, *rest_context, request.vpn_gateway_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "vpnGateways"),
@@ -152,7 +152,7 @@ DefaultVpnGatewaysRestStub::ListVpnGateways(
     google::cloud::cpp::compute::vpn_gateways::v1::ListVpnGatewaysRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::VpnGatewayList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "vpnGateways"),
@@ -179,7 +179,7 @@ DefaultVpnGatewaysRestStub::AsyncSetLabels(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.region_set_labels_request_resource(),
+                request.region_set_labels_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "vpnGateways", "/",
@@ -202,6 +202,7 @@ DefaultVpnGatewaysRestStub::TestIamPermissions(
   return rest_internal::Post<
       google::cloud::cpp::compute::v1::TestPermissionsResponse>(
       *service_, rest_context, request.test_permissions_request_resource(),
+      false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "vpnGateways", "/", request.resource(), "/",
@@ -221,7 +222,7 @@ DefaultVpnGatewaysRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -242,7 +243,7 @@ future<Status> DefaultVpnGatewaysRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/vpn_tunnels/v1/internal/vpn_tunnels_rest_stub.cc
+++ b/google/cloud/compute/vpn_tunnels/v1/internal/vpn_tunnels_rest_stub.cc
@@ -51,7 +51,7 @@ DefaultVpnTunnelsRestStub::AggregatedListVpnTunnels(
         AggregatedListVpnTunnelsRequest const& request) {
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::VpnTunnelAggregatedList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "aggregated", "/", "vpnTunnels"),
       rest_internal::TrimEmptyQueryParameters(
@@ -78,7 +78,7 @@ DefaultVpnTunnelsRestStub::AsyncDeleteVpnTunnel(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Delete<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request,
+                *service, *rest_context, request, false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "vpnTunnels", "/",
@@ -99,7 +99,7 @@ DefaultVpnTunnelsRestStub::GetVpnTunnel(
     google::cloud::cpp::compute::vpn_tunnels::v1::GetVpnTunnelRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::VpnTunnel>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "vpnTunnels", "/", request.vpn_tunnel()));
@@ -118,7 +118,7 @@ DefaultVpnTunnelsRestStub::AsyncInsertVpnTunnel(
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-                *service, *rest_context, request.vpn_tunnel_resource(),
+                *service, *rest_context, request.vpn_tunnel_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "vpnTunnels"),
@@ -138,7 +138,7 @@ DefaultVpnTunnelsRestStub::ListVpnTunnels(
     google::cloud::cpp::compute::vpn_tunnels::v1::ListVpnTunnelsRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::VpnTunnelList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "regions", "/", request.region(),
                    "/", "vpnTunnels"),
@@ -165,7 +165,7 @@ DefaultVpnTunnelsRestStub::AsyncSetLabels(
         p.set_value(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context,
-                request.region_set_labels_request_resource(),
+                request.region_set_labels_request_resource(), false,
                 absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                              request.project(), "/", "regions", "/",
                              request.region(), "/", "vpnTunnels", "/",
@@ -193,7 +193,7 @@ DefaultVpnTunnelsRestStub::AsyncGetOperation(
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(
             rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-                *operations, *rest_context, request,
+                *operations, *rest_context, request, false,
                 absl::StrCat("/compute/v1/projects/", request.project(),
                              "/regions/", request.region(), "/operations/",
                              request.operation())));
@@ -214,7 +214,7 @@ future<Status> DefaultVpnTunnelsRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/compute/v1/projects/", request.project(),
                                    "/regions/", request.region(),
                                    "/operations/", request.operation())));

--- a/google/cloud/compute/zone_operations/v1/internal/zone_operations_rest_stub.cc
+++ b/google/cloud/compute/zone_operations/v1/internal/zone_operations_rest_stub.cc
@@ -43,7 +43,7 @@ Status DefaultZoneOperationsRestStub::DeleteOperation(
     google::cloud::cpp::compute::zone_operations::v1::
         DeleteOperationRequest const& request) {
   return rest_internal::Delete(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "operations", "/", request.operation()));
@@ -55,7 +55,7 @@ DefaultZoneOperationsRestStub::GetOperation(
     google::cloud::cpp::compute::zone_operations::v1::GetOperationRequest const&
         request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Operation>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "operations", "/", request.operation()));
@@ -67,7 +67,7 @@ DefaultZoneOperationsRestStub::ListZoneOperations(
     google::cloud::cpp::compute::zone_operations::v1::
         ListZoneOperationsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::OperationList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "operations"),
@@ -86,7 +86,7 @@ DefaultZoneOperationsRestStub::Wait(
     google::cloud::cpp::compute::zone_operations::v1::WaitRequest const&
         request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone(), "/",
                    "operations", "/", request.operation(), "/", "wait"));

--- a/google/cloud/compute/zones/v1/internal/zones_rest_stub.cc
+++ b/google/cloud/compute/zones/v1/internal/zones_rest_stub.cc
@@ -42,7 +42,7 @@ StatusOr<google::cloud::cpp::compute::v1::Zone> DefaultZonesRestStub::GetZone(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::cpp::compute::zones::v1::GetZoneRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::Zone>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones", "/", request.zone()));
 }
@@ -52,7 +52,7 @@ DefaultZonesRestStub::ListZones(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::cpp::compute::zones::v1::ListZonesRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::ZoneList>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/", "v1", "/", "projects", "/",
                    request.project(), "/", "zones"),
       rest_internal::TrimEmptyQueryParameters(

--- a/google/cloud/internal/rest_stub_helpers.cc
+++ b/google/cloud/internal/rest_stub_helpers.cc
@@ -46,11 +46,13 @@ Status RestResponseToProto(google::protobuf::Message& destination,
 }
 
 Status ProtoRequestToJsonPayload(google::protobuf::Message const& request,
-                                 std::string& json_payload) {
+                                 std::string& json_payload,
+                                 bool preserve_proto_field_names) {
   google::protobuf::util::JsonPrintOptions print_options;
-  print_options.preserve_proto_field_names = true;
+  print_options.preserve_proto_field_names = preserve_proto_field_names;
   auto proto_to_json_status = google::protobuf::util::MessageToJsonString(
       request, &json_payload, print_options);
+
   if (!proto_to_json_status.ok()) {
     return internal::InternalError(
         std::string(proto_to_json_status.message()),

--- a/google/cloud/internal/rest_stub_helpers.cc
+++ b/google/cloud/internal/rest_stub_helpers.cc
@@ -46,8 +46,8 @@ Status RestResponseToProto(google::protobuf::Message& destination,
 }
 
 Status ProtoRequestToJsonPayload(google::protobuf::Message const& request,
-                                 std::string& json_payload,
-                                 bool preserve_proto_field_names) {
+                                 bool preserve_proto_field_names,
+                                 std::string& json_payload) {
   google::protobuf::util::JsonPrintOptions print_options;
   print_options.preserve_proto_field_names = preserve_proto_field_names;
   auto proto_to_json_status = google::protobuf::util::MessageToJsonString(

--- a/google/cloud/internal/rest_stub_helpers.h
+++ b/google/cloud/internal/rest_stub_helpers.h
@@ -37,8 +37,8 @@ Status RestResponseToProto(google::protobuf::Message& destination,
                            RestResponse&& rest_response);
 
 Status ProtoRequestToJsonPayload(google::protobuf::Message const& request,
-                                 std::string& json_payload,
-                                 bool preserve_proto_field_names);
+                                 bool preserve_proto_field_names,
+                                 std::string& json_payload);
 
 rest_internal::RestRequest CreateRestRequest(
     std::string path,
@@ -94,8 +94,8 @@ StatusOr<Response> Patch(
     Request const& request, bool preserve_proto_field_names, std::string path,
     std::vector<std::pair<std::string, std::string>> query_params = {}) {
   std::string json_payload;
-  auto status = ProtoRequestToJsonPayload(request, json_payload,
-                                          preserve_proto_field_names);
+  auto status = ProtoRequestToJsonPayload(request, preserve_proto_field_names,
+                                          json_payload);
   if (!status.ok()) return status;
   auto rest_request =
       CreateRestRequest(std::move(path), std::move(query_params));
@@ -112,8 +112,8 @@ StatusOr<Response> Post(
     Request const& request, bool preserve_proto_field_names, std::string path,
     std::vector<std::pair<std::string, std::string>> query_params = {}) {
   std::string json_payload;
-  auto status = ProtoRequestToJsonPayload(request, json_payload,
-                                          preserve_proto_field_names);
+  auto status = ProtoRequestToJsonPayload(request, preserve_proto_field_names,
+                                          json_payload);
   if (!status.ok()) return status;
   auto rest_request =
       CreateRestRequest(std::move(path), std::move(query_params));
@@ -130,8 +130,8 @@ Status Post(
     Request const& request, bool preserve_proto_field_names, std::string path,
     std::vector<std::pair<std::string, std::string>> query_params = {}) {
   std::string json_payload;
-  auto status = ProtoRequestToJsonPayload(request, json_payload,
-                                          preserve_proto_field_names);
+  auto status = ProtoRequestToJsonPayload(request, preserve_proto_field_names,
+                                          json_payload);
   if (!status.ok()) return status;
   auto rest_request =
       CreateRestRequest(std::move(path), std::move(query_params));
@@ -148,8 +148,8 @@ StatusOr<Response> Put(
     Request const& request, bool preserve_proto_field_names, std::string path,
     std::vector<std::pair<std::string, std::string>> query_params = {}) {
   std::string json_payload;
-  auto status = ProtoRequestToJsonPayload(request, json_payload,
-                                          preserve_proto_field_names);
+  auto status = ProtoRequestToJsonPayload(request, preserve_proto_field_names,
+                                          json_payload);
   if (!status.ok()) return status;
   auto rest_request =
       CreateRestRequest(std::move(path), std::move(query_params));

--- a/google/cloud/internal/rest_stub_helpers.h
+++ b/google/cloud/internal/rest_stub_helpers.h
@@ -44,10 +44,6 @@ rest_internal::RestRequest CreateRestRequest(
     std::string path,
     std::vector<std::pair<std::string, std::string>> query_params);
 
-rest_internal::RestRequest CreateRestRequest(
-    std::string path,
-    std::vector<std::pair<std::string, std::string>> query_params);
-
 template <typename Response>
 StatusOr<Response> RestResponseToProto(RestResponse&& rest_response) {
   Response destination;

--- a/google/cloud/internal/rest_stub_helpers.h
+++ b/google/cloud/internal/rest_stub_helpers.h
@@ -37,7 +37,12 @@ Status RestResponseToProto(google::protobuf::Message& destination,
                            RestResponse&& rest_response);
 
 Status ProtoRequestToJsonPayload(google::protobuf::Message const& request,
-                                 std::string& json_payload);
+                                 std::string& json_payload,
+                                 bool preserve_proto_field_names);
+
+rest_internal::RestRequest CreateRestRequest(
+    std::string path,
+    std::vector<std::pair<std::string, std::string>> query_params);
 
 rest_internal::RestRequest CreateRestRequest(
     std::string path,
@@ -54,7 +59,7 @@ StatusOr<Response> RestResponseToProto(RestResponse&& rest_response) {
 template <typename Request>
 Status Delete(
     rest_internal::RestClient& client, rest_internal::RestContext& rest_context,
-    Request const&, std::string path,
+    Request const&, bool, std::string path,
     std::vector<std::pair<std::string, std::string>> query_params = {}) {
   auto rest_request =
       CreateRestRequest(std::move(path), std::move(query_params));
@@ -66,7 +71,7 @@ Status Delete(
 template <typename Response, typename Request>
 StatusOr<Response> Delete(
     rest_internal::RestClient& client, rest_internal::RestContext& rest_context,
-    Request const&, std::string path,
+    Request const&, bool, std::string path,
     std::vector<std::pair<std::string, std::string>> query_params = {}) {
   auto rest_request =
       CreateRestRequest(std::move(path), std::move(query_params));
@@ -78,7 +83,7 @@ StatusOr<Response> Delete(
 template <typename Response, typename Request>
 StatusOr<Response> Get(
     rest_internal::RestClient& client, rest_internal::RestContext& rest_context,
-    Request const&, std::string path,
+    Request const&, bool, std::string path,
     std::vector<std::pair<std::string, std::string>> query_params = {}) {
   auto rest_request =
       CreateRestRequest(std::move(path), std::move(query_params));
@@ -90,10 +95,11 @@ StatusOr<Response> Get(
 template <typename Response, typename Request>
 StatusOr<Response> Patch(
     rest_internal::RestClient& client, rest_internal::RestContext& rest_context,
-    Request const& request, std::string path,
+    Request const& request, bool preserve_proto_field_names, std::string path,
     std::vector<std::pair<std::string, std::string>> query_params = {}) {
   std::string json_payload;
-  auto status = ProtoRequestToJsonPayload(request, json_payload);
+  auto status = ProtoRequestToJsonPayload(request, json_payload,
+                                          preserve_proto_field_names);
   if (!status.ok()) return status;
   auto rest_request =
       CreateRestRequest(std::move(path), std::move(query_params));
@@ -107,10 +113,11 @@ StatusOr<Response> Patch(
 template <typename Response, typename Request>
 StatusOr<Response> Post(
     rest_internal::RestClient& client, rest_internal::RestContext& rest_context,
-    Request const& request, std::string path,
+    Request const& request, bool preserve_proto_field_names, std::string path,
     std::vector<std::pair<std::string, std::string>> query_params = {}) {
   std::string json_payload;
-  auto status = ProtoRequestToJsonPayload(request, json_payload);
+  auto status = ProtoRequestToJsonPayload(request, json_payload,
+                                          preserve_proto_field_names);
   if (!status.ok()) return status;
   auto rest_request =
       CreateRestRequest(std::move(path), std::move(query_params));
@@ -124,10 +131,11 @@ StatusOr<Response> Post(
 template <typename Request>
 Status Post(
     rest_internal::RestClient& client, rest_internal::RestContext& rest_context,
-    Request const& request, std::string path,
+    Request const& request, bool preserve_proto_field_names, std::string path,
     std::vector<std::pair<std::string, std::string>> query_params = {}) {
   std::string json_payload;
-  auto status = ProtoRequestToJsonPayload(request, json_payload);
+  auto status = ProtoRequestToJsonPayload(request, json_payload,
+                                          preserve_proto_field_names);
   if (!status.ok()) return status;
   auto rest_request =
       CreateRestRequest(std::move(path), std::move(query_params));
@@ -141,10 +149,11 @@ Status Post(
 template <typename Response, typename Request>
 StatusOr<Response> Put(
     rest_internal::RestClient& client, rest_internal::RestContext& rest_context,
-    Request const& request, std::string path,
+    Request const& request, bool preserve_proto_field_names, std::string path,
     std::vector<std::pair<std::string, std::string>> query_params = {}) {
   std::string json_payload;
-  auto status = ProtoRequestToJsonPayload(request, json_payload);
+  auto status = ProtoRequestToJsonPayload(request, json_payload,
+                                          preserve_proto_field_names);
   if (!status.ok()) return status;
   auto rest_request =
       CreateRestRequest(std::move(path), std::move(query_params));

--- a/google/cloud/internal/rest_stub_helpers_test.cc
+++ b/google/cloud/internal/rest_stub_helpers_test.cc
@@ -271,7 +271,7 @@ TEST(RestStubHelpers, ProtoRequestToJsonPayloadSuccess) {
   proto_request.set_response_type("response_value");
   proto_request.set_metadata_type("metadata_value");
 
-  auto status = ProtoRequestToJsonPayload(proto_request, json_payload, true);
+  auto status = ProtoRequestToJsonPayload(proto_request, true, json_payload);
   ASSERT_THAT(status, IsOk());
   EXPECT_THAT(json_payload, Eq(kJsonUpdatePayload));
 }

--- a/google/cloud/internal/rest_stub_helpers_test.cc
+++ b/google/cloud/internal/rest_stub_helpers_test.cc
@@ -155,13 +155,13 @@ TEST(RestStubHelpers, DeleteWithEmptyResponse) {
 
   RestContext context;
   Request request;
-  auto result = Delete(*mock_client, context, request, "/v1/delete/");
+  auto result = Delete(*mock_client, context, request, false, "/v1/delete/");
   EXPECT_THAT(result, IsOk());
 
-  result = Delete(*mock_client, context, request, "/v1/delete/");
+  result = Delete(*mock_client, context, request, false, "/v1/delete/");
   EXPECT_THAT(result, StatusIs(StatusCode::kInternal));
 
-  result = Delete(*mock_client, context, request, "/v1/delete/");
+  result = Delete(*mock_client, context, request, false, "/v1/delete/");
   EXPECT_THAT(result, StatusIs(StatusCode::kPermissionDenied));
   EXPECT_THAT(result.message(), Eq("Permission foo denied on resource bar."));
   EXPECT_THAT(result.error_info().domain(), Eq("googleapis.com"));
@@ -200,10 +200,12 @@ TEST(RestStubHelpers, DeleteWithNonEmptyResponse) {
 
   RestContext context;
   Request request;
-  auto result = Delete<Response>(*mock_client, context, request, "/v1/delete/");
+  auto result =
+      Delete<Response>(*mock_client, context, request, false, "/v1/delete/");
   EXPECT_THAT(result, StatusIs(StatusCode::kInternal));
 
-  result = Delete<Response>(*mock_client, context, request, "/v1/delete/");
+  result =
+      Delete<Response>(*mock_client, context, request, false, "/v1/delete/");
   ASSERT_THAT(result, IsOk());
   EXPECT_THAT(result->seconds(), Eq(123));
   EXPECT_THAT(result->nanos(), Eq(456));
@@ -242,11 +244,12 @@ TEST(RestStubHelpers, Get) {
   RestContext context;
   std::vector<std::pair<std::string, std::string>> params = {
       {"seconds", std::to_string(proto_request.seconds())}};
-  auto result =
-      Get<Response>(*mock_client, context, proto_request, "/v1/", params);
+  auto result = Get<Response>(*mock_client, context, proto_request, false,
+                              "/v1/", params);
   EXPECT_THAT(result, StatusIs(StatusCode::kInternal));
 
-  result = Get<Response>(*mock_client, context, proto_request, "/v1/", params);
+  result = Get<Response>(*mock_client, context, proto_request, false, "/v1/",
+                         params);
   ASSERT_THAT(result, IsOk());
   EXPECT_THAT(result->seconds(), Eq(123));
   EXPECT_THAT(result->nanos(), Eq(456));
@@ -268,7 +271,7 @@ TEST(RestStubHelpers, ProtoRequestToJsonPayloadSuccess) {
   proto_request.set_response_type("response_value");
   proto_request.set_metadata_type("metadata_value");
 
-  auto status = ProtoRequestToJsonPayload(proto_request, json_payload);
+  auto status = ProtoRequestToJsonPayload(proto_request, json_payload, true);
   ASSERT_THAT(status, IsOk());
   EXPECT_THAT(json_payload, Eq(kJsonUpdatePayload));
 }
@@ -307,11 +310,12 @@ TEST(RestStubHelpers, Patch) {
       });
 
   RestContext context;
-  auto result = Patch<Response>(*mock_client, context, proto_request, "/v1/");
+  auto result =
+      Patch<Response>(*mock_client, context, proto_request, true, "/v1/");
   EXPECT_THAT(result, StatusIs(StatusCode::kInternal));
 
   context.AddHeader("custom", "header");
-  result = Patch<Response>(*mock_client, context, proto_request, "/v1/");
+  result = Patch<Response>(*mock_client, context, proto_request, true, "/v1/");
   ASSERT_THAT(result, IsOk());
   EXPECT_THAT(result->seconds(), Eq(123));
   EXPECT_THAT(result->nanos(), Eq(456));
@@ -360,11 +364,12 @@ TEST(RestStubHelpers, PostWithNonEmptyResponse) {
   RestContext context;
   std::vector<std::pair<std::string, std::string>> params = {
       {"response_type", proto_request.response_type()}, {"foo", "bar"}};
-  auto result =
-      Post<Response>(*mock_client, context, proto_request, "/v1/", params);
+  auto result = Post<Response>(*mock_client, context, proto_request, true,
+                               "/v1/", params);
   EXPECT_THAT(result, StatusIs(StatusCode::kInternal));
 
-  result = Post<Response>(*mock_client, context, proto_request, "/v1/", params);
+  result = Post<Response>(*mock_client, context, proto_request, true, "/v1/",
+                          params);
   ASSERT_THAT(result, IsOk());
   EXPECT_THAT(result->seconds(), Eq(123));
   EXPECT_THAT(result->nanos(), Eq(456));
@@ -410,10 +415,11 @@ TEST(RestStubHelpers, PostWithEmptyResponse) {
   RestContext context;
   std::vector<std::pair<std::string, std::string>> params = {
       {"response_type", proto_request.response_type()}, {"foo", "bar"}};
-  auto result = Post(*mock_client, context, proto_request, "/v1/", params);
+  auto result =
+      Post(*mock_client, context, proto_request, true, "/v1/", params);
   EXPECT_THAT(result, StatusIs(StatusCode::kInternal));
 
-  result = Post(*mock_client, context, proto_request, "/v1/", params);
+  result = Post(*mock_client, context, proto_request, true, "/v1/", params);
   EXPECT_THAT(result, IsOk());
 }
 
@@ -452,10 +458,11 @@ TEST(RestStubHelpers, Put) {
       });
 
   RestContext context;
-  auto result = Put<Response>(*mock_client, context, proto_request, "/v1/");
+  auto result =
+      Put<Response>(*mock_client, context, proto_request, true, "/v1/");
   EXPECT_THAT(result, StatusIs(StatusCode::kInternal));
 
-  result = Put<Response>(*mock_client, context, proto_request, "/v1/");
+  result = Put<Response>(*mock_client, context, proto_request, true, "/v1/");
   ASSERT_THAT(result, IsOk());
   EXPECT_THAT(result->seconds(), Eq(123));
   EXPECT_THAT(result->nanos(), Eq(456));

--- a/google/cloud/spanner/admin/internal/database_admin_rest_stub.cc
+++ b/google/cloud/spanner/admin/internal/database_admin_rest_stub.cc
@@ -50,7 +50,7 @@ DefaultDatabaseAdminRestStub::ListDatabases(
     google::spanner::admin::database::v1::ListDatabasesRequest const& request) {
   return rest_internal::Get<
       google::spanner::admin::database::v1::ListDatabasesResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.parent(), "/", "databases"),
       rest_internal::TrimEmptyQueryParameters(
           {std::make_pair("page_size", std::to_string(request.page_size())),
@@ -68,7 +68,7 @@ DefaultDatabaseAdminRestStub::AsyncCreateDatabase(
   std::thread t{
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::longrunning::Operation>(
-            *service, *rest_context, request,
+            *service, *rest_context, request, false,
             absl::StrCat("/", "v1", "/", request.parent(), "/", "databases"),
             rest_internal::TrimEmptyQueryParameters(
                 {std::make_pair("create_statement", request.create_statement()),
@@ -87,7 +87,7 @@ DefaultDatabaseAdminRestStub::GetDatabase(
     google::cloud::rest_internal::RestContext& rest_context,
     google::spanner::admin::database::v1::GetDatabaseRequest const& request) {
   return rest_internal::Get<google::spanner::admin::database::v1::Database>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.name()));
 }
 
@@ -102,7 +102,7 @@ DefaultDatabaseAdminRestStub::AsyncUpdateDatabase(
   std::thread t{
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(rest_internal::Patch<google::longrunning::Operation>(
-            *service, *rest_context, request.database(),
+            *service, *rest_context, request.database(), false,
             absl::StrCat("/", "v1", "/", request.database().name())));
       },
       std::move(p), service_, request, std::move(rest_context)};
@@ -123,7 +123,7 @@ DefaultDatabaseAdminRestStub::AsyncUpdateDatabaseDdl(
   std::thread t{
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(rest_internal::Patch<google::longrunning::Operation>(
-            *service, *rest_context, request,
+            *service, *rest_context, request, false,
             absl::StrCat("/", "v1", "/", request.database(), "/", "ddl"),
             rest_internal::TrimEmptyQueryParameters(
                 {std::make_pair("operation_id", request.operation_id())})));
@@ -139,7 +139,7 @@ Status DefaultDatabaseAdminRestStub::DropDatabase(
     google::cloud::rest_internal::RestContext& rest_context,
     google::spanner::admin::database::v1::DropDatabaseRequest const& request) {
   return rest_internal::Delete(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.database()));
 }
 
@@ -150,7 +150,7 @@ DefaultDatabaseAdminRestStub::GetDatabaseDdl(
         request) {
   return rest_internal::Get<
       google::spanner::admin::database::v1::GetDatabaseDdlResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.database(), "/", "ddl"));
 }
 
@@ -158,7 +158,7 @@ StatusOr<google::iam::v1::Policy> DefaultDatabaseAdminRestStub::SetIamPolicy(
     google::cloud::rest_internal::RestContext& rest_context,
     google::iam::v1::SetIamPolicyRequest const& request) {
   return rest_internal::Post<google::iam::v1::Policy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.resource(), ":setIamPolicy"));
 }
 
@@ -166,7 +166,7 @@ StatusOr<google::iam::v1::Policy> DefaultDatabaseAdminRestStub::GetIamPolicy(
     google::cloud::rest_internal::RestContext& rest_context,
     google::iam::v1::GetIamPolicyRequest const& request) {
   return rest_internal::Post<google::iam::v1::Policy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.resource(), ":getIamPolicy"));
 }
 
@@ -175,7 +175,7 @@ DefaultDatabaseAdminRestStub::TestIamPermissions(
     google::cloud::rest_internal::RestContext& rest_context,
     google::iam::v1::TestIamPermissionsRequest const& request) {
   return rest_internal::Post<google::iam::v1::TestIamPermissionsResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.resource(), ":testIamPermissions"));
 }
 
@@ -189,7 +189,7 @@ DefaultDatabaseAdminRestStub::AsyncCreateBackup(
   std::thread t{
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::longrunning::Operation>(
-            *service, *rest_context, request.backup(),
+            *service, *rest_context, request.backup(), false,
             absl::StrCat("/", "v1", "/", request.parent(), "/", "backups"),
             rest_internal::TrimEmptyQueryParameters(
                 {std::make_pair("backup_id", request.backup_id())})));
@@ -211,7 +211,7 @@ DefaultDatabaseAdminRestStub::AsyncCopyBackup(
   std::thread t{
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::longrunning::Operation>(
-            *service, *rest_context, request,
+            *service, *rest_context, request, false,
             absl::StrCat("/", "v1", "/", request.parent(), "/", "backups",
                          ":copy"),
             rest_internal::TrimEmptyQueryParameters(
@@ -230,7 +230,7 @@ DefaultDatabaseAdminRestStub::GetBackup(
     google::cloud::rest_internal::RestContext& rest_context,
     google::spanner::admin::database::v1::GetBackupRequest const& request) {
   return rest_internal::Get<google::spanner::admin::database::v1::Backup>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.name()));
 }
 
@@ -239,14 +239,14 @@ DefaultDatabaseAdminRestStub::UpdateBackup(
     google::cloud::rest_internal::RestContext& rest_context,
     google::spanner::admin::database::v1::UpdateBackupRequest const& request) {
   return rest_internal::Patch<google::spanner::admin::database::v1::Backup>(
-      *service_, rest_context, request.backup(),
+      *service_, rest_context, request.backup(), false,
       absl::StrCat("/", "v1", "/", request.backup().name()));
 }
 
 Status DefaultDatabaseAdminRestStub::DeleteBackup(
     google::cloud::rest_internal::RestContext& rest_context,
     google::spanner::admin::database::v1::DeleteBackupRequest const& request) {
-  return rest_internal::Delete(*service_, rest_context, request,
+  return rest_internal::Delete(*service_, rest_context, request, false,
                                absl::StrCat("/", "v1", "/", request.name()));
 }
 
@@ -256,7 +256,7 @@ DefaultDatabaseAdminRestStub::ListBackups(
     google::spanner::admin::database::v1::ListBackupsRequest const& request) {
   return rest_internal::Get<
       google::spanner::admin::database::v1::ListBackupsResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.parent(), "/", "backups"),
       rest_internal::TrimEmptyQueryParameters(
           {std::make_pair("filter", request.filter()),
@@ -275,7 +275,7 @@ DefaultDatabaseAdminRestStub::AsyncRestoreDatabase(
   std::thread t{
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::longrunning::Operation>(
-            *service, *rest_context, request,
+            *service, *rest_context, request, false,
             absl::StrCat("/", "v1", "/", request.parent(), "/", "databases",
                          ":restore"),
             rest_internal::TrimEmptyQueryParameters(
@@ -296,7 +296,7 @@ DefaultDatabaseAdminRestStub::ListDatabaseOperations(
         request) {
   return rest_internal::Get<
       google::spanner::admin::database::v1::ListDatabaseOperationsResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.parent(), "/", "databaseOperations"),
       rest_internal::TrimEmptyQueryParameters(
           {std::make_pair("filter", request.filter()),
@@ -311,7 +311,7 @@ DefaultDatabaseAdminRestStub::ListBackupOperations(
         request) {
   return rest_internal::Get<
       google::spanner::admin::database::v1::ListBackupOperationsResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.parent(), "/", "backupOperations"),
       rest_internal::TrimEmptyQueryParameters(
           {std::make_pair("filter", request.filter()),
@@ -326,7 +326,7 @@ DefaultDatabaseAdminRestStub::ListDatabaseRoles(
         request) {
   return rest_internal::Get<
       google::spanner::admin::database::v1::ListDatabaseRolesResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.parent(), "/", "databaseRoles"),
       rest_internal::TrimEmptyQueryParameters(
           {std::make_pair("page_size", std::to_string(request.page_size())),
@@ -343,7 +343,7 @@ DefaultDatabaseAdminRestStub::AsyncGetOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Get<google::longrunning::Operation>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/v1/", request.name())));
       },
       std::move(p), operations_, request, std::move(rest_context)};
@@ -361,7 +361,7 @@ future<Status> DefaultDatabaseAdminRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/v1/", request.name(), ":cancel")));
                 },
                 std::move(p), operations_, request, std::move(rest_context)};

--- a/google/cloud/spanner/admin/internal/instance_admin_rest_stub.cc
+++ b/google/cloud/spanner/admin/internal/instance_admin_rest_stub.cc
@@ -51,7 +51,7 @@ DefaultInstanceAdminRestStub::ListInstanceConfigs(
         request) {
   return rest_internal::Get<
       google::spanner::admin::instance::v1::ListInstanceConfigsResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.parent(), "/", "instanceConfigs"),
       rest_internal::TrimEmptyQueryParameters(
           {std::make_pair("page_size", std::to_string(request.page_size())),
@@ -65,7 +65,7 @@ DefaultInstanceAdminRestStub::GetInstanceConfig(
         request) {
   return rest_internal::Get<
       google::spanner::admin::instance::v1::InstanceConfig>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.name()));
 }
 
@@ -80,7 +80,7 @@ DefaultInstanceAdminRestStub::AsyncCreateInstanceConfig(
   std::thread t{
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::longrunning::Operation>(
-            *service, *rest_context, request,
+            *service, *rest_context, request, false,
             absl::StrCat("/", "v1", "/", request.parent(), "/",
                          "instanceConfigs"),
             rest_internal::TrimEmptyQueryParameters(
@@ -107,7 +107,7 @@ DefaultInstanceAdminRestStub::AsyncUpdateInstanceConfig(
   std::thread t{
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(rest_internal::Patch<google::longrunning::Operation>(
-            *service, *rest_context, request,
+            *service, *rest_context, request, false,
             absl::StrCat("/", "v1", "/", request.instance_config().name()),
             rest_internal::TrimEmptyQueryParameters({std::make_pair(
                 "validate_only", request.validate_only() ? "1" : "0")})));
@@ -124,7 +124,7 @@ Status DefaultInstanceAdminRestStub::DeleteInstanceConfig(
     google::spanner::admin::instance::v1::DeleteInstanceConfigRequest const&
         request) {
   return rest_internal::Delete(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.name()),
       rest_internal::TrimEmptyQueryParameters(
           {std::make_pair("etag", request.etag()),
@@ -140,7 +140,7 @@ DefaultInstanceAdminRestStub::ListInstanceConfigOperations(
         ListInstanceConfigOperationsRequest const& request) {
   return rest_internal::Get<google::spanner::admin::instance::v1::
                                 ListInstanceConfigOperationsResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.parent(), "/",
                    "instanceConfigOperations"),
       rest_internal::TrimEmptyQueryParameters(
@@ -155,7 +155,7 @@ DefaultInstanceAdminRestStub::ListInstances(
     google::spanner::admin::instance::v1::ListInstancesRequest const& request) {
   return rest_internal::Get<
       google::spanner::admin::instance::v1::ListInstancesResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.parent(), "/", "instances"),
       rest_internal::TrimEmptyQueryParameters(
           {std::make_pair("page_size", std::to_string(request.page_size())),
@@ -168,7 +168,7 @@ DefaultInstanceAdminRestStub::GetInstance(
     google::cloud::rest_internal::RestContext& rest_context,
     google::spanner::admin::instance::v1::GetInstanceRequest const& request) {
   return rest_internal::Get<google::spanner::admin::instance::v1::Instance>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.name()));
 }
 
@@ -183,7 +183,7 @@ DefaultInstanceAdminRestStub::AsyncCreateInstance(
   std::thread t{
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(rest_internal::Post<google::longrunning::Operation>(
-            *service, *rest_context, request,
+            *service, *rest_context, request, false,
             absl::StrCat("/", "v1", "/", request.parent(), "/", "instances"),
             rest_internal::TrimEmptyQueryParameters(
                 {std::make_pair("instance_id", request.instance_id())})));
@@ -206,7 +206,7 @@ DefaultInstanceAdminRestStub::AsyncUpdateInstance(
   std::thread t{
       [](auto p, auto service, auto request, auto rest_context) {
         p.set_value(rest_internal::Patch<google::longrunning::Operation>(
-            *service, *rest_context, request,
+            *service, *rest_context, request, false,
             absl::StrCat("/", "v1", "/", request.instance().name())));
       },
       std::move(p), service_, request, std::move(rest_context)};
@@ -220,7 +220,7 @@ Status DefaultInstanceAdminRestStub::DeleteInstance(
     google::cloud::rest_internal::RestContext& rest_context,
     google::spanner::admin::instance::v1::DeleteInstanceRequest const&
         request) {
-  return rest_internal::Delete(*service_, rest_context, request,
+  return rest_internal::Delete(*service_, rest_context, request, false,
                                absl::StrCat("/", "v1", "/", request.name()));
 }
 
@@ -228,7 +228,7 @@ StatusOr<google::iam::v1::Policy> DefaultInstanceAdminRestStub::SetIamPolicy(
     google::cloud::rest_internal::RestContext& rest_context,
     google::iam::v1::SetIamPolicyRequest const& request) {
   return rest_internal::Post<google::iam::v1::Policy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.resource(), ":setIamPolicy"));
 }
 
@@ -236,7 +236,7 @@ StatusOr<google::iam::v1::Policy> DefaultInstanceAdminRestStub::GetIamPolicy(
     google::cloud::rest_internal::RestContext& rest_context,
     google::iam::v1::GetIamPolicyRequest const& request) {
   return rest_internal::Post<google::iam::v1::Policy>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.resource(), ":getIamPolicy"));
 }
 
@@ -245,7 +245,7 @@ DefaultInstanceAdminRestStub::TestIamPermissions(
     google::cloud::rest_internal::RestContext& rest_context,
     google::iam::v1::TestIamPermissionsRequest const& request) {
   return rest_internal::Post<google::iam::v1::TestIamPermissionsResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, false,
       absl::StrCat("/", "v1", "/", request.resource(), ":testIamPermissions"));
 }
 
@@ -259,7 +259,7 @@ DefaultInstanceAdminRestStub::AsyncGetOperation(
   std::thread t{
       [](auto p, auto operations, auto request, auto rest_context) {
         p.set_value(rest_internal::Get<google::longrunning::Operation>(
-            *operations, *rest_context, request,
+            *operations, *rest_context, request, false,
             absl::StrCat("/v1/", request.name())));
       },
       std::move(p), operations_, request, std::move(rest_context)};
@@ -277,7 +277,7 @@ future<Status> DefaultInstanceAdminRestStub::AsyncCancelOperation(
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
   std::thread t{[](auto p, auto operations, auto request, auto rest_context) {
                   p.set_value(rest_internal::Post<google::protobuf::Empty>(
-                      *operations, *rest_context, request,
+                      *operations, *rest_context, request, false,
                       absl::StrCat("/v1/", request.name(), ":cancel")));
                 },
                 std::move(p), operations_, request, std::move(rest_context)};

--- a/google/cloud/sql/v1/internal/sql_backup_runs_rest_stub.cc
+++ b/google/cloud/sql/v1/internal/sql_backup_runs_rest_stub.cc
@@ -44,7 +44,7 @@ DefaultSqlBackupRunsServiceRestStub::Delete(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlBackupRunsDeleteRequest const& request) {
   return rest_internal::Delete<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "backupRuns", "/",
                    request.id()));
@@ -55,7 +55,7 @@ DefaultSqlBackupRunsServiceRestStub::Get(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlBackupRunsGetRequest const& request) {
   return rest_internal::Get<google::cloud::sql::v1::BackupRun>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "backupRuns", "/",
                    request.id()));
@@ -66,7 +66,7 @@ DefaultSqlBackupRunsServiceRestStub::Insert(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlBackupRunsInsertRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request.body(),
+      *service_, rest_context, request.body(), true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "backupRuns"));
 }
@@ -76,7 +76,7 @@ DefaultSqlBackupRunsServiceRestStub::List(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlBackupRunsListRequest const& request) {
   return rest_internal::Get<google::cloud::sql::v1::BackupRunsListResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "backupRuns"),
       rest_internal::TrimEmptyQueryParameters(

--- a/google/cloud/sql/v1/internal/sql_connect_rest_stub.cc
+++ b/google/cloud/sql/v1/internal/sql_connect_rest_stub.cc
@@ -44,7 +44,7 @@ DefaultSqlConnectServiceRestStub::GetConnectSettings(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::GetConnectSettingsRequest const& request) {
   return rest_internal::Get<google::cloud::sql::v1::ConnectSettings>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/",
                    "connectSettings"));
@@ -56,7 +56,7 @@ DefaultSqlConnectServiceRestStub::GenerateEphemeralCert(
     google::cloud::sql::v1::GenerateEphemeralCertRequest const& request) {
   return rest_internal::Post<
       google::cloud::sql::v1::GenerateEphemeralCertResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(),
                    ":generateEphemeralCert"),

--- a/google/cloud/sql/v1/internal/sql_databases_rest_stub.cc
+++ b/google/cloud/sql/v1/internal/sql_databases_rest_stub.cc
@@ -44,7 +44,7 @@ DefaultSqlDatabasesServiceRestStub::Delete(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlDatabasesDeleteRequest const& request) {
   return rest_internal::Delete<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "databases", "/",
                    request.database()));
@@ -55,7 +55,7 @@ DefaultSqlDatabasesServiceRestStub::Get(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlDatabasesGetRequest const& request) {
   return rest_internal::Get<google::cloud::sql::v1::Database>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "databases", "/",
                    request.database()));
@@ -66,7 +66,7 @@ DefaultSqlDatabasesServiceRestStub::Insert(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlDatabasesInsertRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request.body(),
+      *service_, rest_context, request.body(), true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "databases"));
 }
@@ -76,7 +76,7 @@ DefaultSqlDatabasesServiceRestStub::List(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlDatabasesListRequest const& request) {
   return rest_internal::Get<google::cloud::sql::v1::DatabasesListResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "databases"));
 }
@@ -86,7 +86,7 @@ DefaultSqlDatabasesServiceRestStub::Patch(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlDatabasesUpdateRequest const& request) {
   return rest_internal::Patch<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request.body(),
+      *service_, rest_context, request.body(), true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "databases", "/",
                    request.database()));
@@ -97,7 +97,7 @@ DefaultSqlDatabasesServiceRestStub::Update(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlDatabasesUpdateRequest const& request) {
   return rest_internal::Put<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request.body(),
+      *service_, rest_context, request.body(), true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "databases", "/",
                    request.database()));

--- a/google/cloud/sql/v1/internal/sql_flags_rest_stub.cc
+++ b/google/cloud/sql/v1/internal/sql_flags_rest_stub.cc
@@ -43,7 +43,7 @@ DefaultSqlFlagsServiceRestStub::List(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlFlagsListRequest const& request) {
   return rest_internal::Get<google::cloud::sql::v1::FlagsListResponse>(
-      *service_, rest_context, request, "/v1/flags",
+      *service_, rest_context, request, true, "/v1/flags",
       rest_internal::TrimEmptyQueryParameters(
           {std::make_pair("database_version", request.database_version())}));
 }

--- a/google/cloud/sql/v1/internal/sql_instances_rest_stub.cc
+++ b/google/cloud/sql/v1/internal/sql_instances_rest_stub.cc
@@ -44,7 +44,7 @@ DefaultSqlInstancesServiceRestStub::AddServerCa(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlInstancesAddServerCaRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "addServerCa"));
 }
@@ -54,7 +54,7 @@ DefaultSqlInstancesServiceRestStub::Clone(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlInstancesCloneRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request.body(),
+      *service_, rest_context, request.body(), true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "clone"));
 }
@@ -64,7 +64,7 @@ DefaultSqlInstancesServiceRestStub::Delete(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlInstancesDeleteRequest const& request) {
   return rest_internal::Delete<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance()));
 }
@@ -74,7 +74,7 @@ DefaultSqlInstancesServiceRestStub::DemoteMaster(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlInstancesDemoteMasterRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request.body(),
+      *service_, rest_context, request.body(), true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "demoteMaster"));
 }
@@ -84,7 +84,7 @@ DefaultSqlInstancesServiceRestStub::Export(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlInstancesExportRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request.body(),
+      *service_, rest_context, request.body(), true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "export"));
 }
@@ -94,7 +94,7 @@ DefaultSqlInstancesServiceRestStub::Failover(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlInstancesFailoverRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request.body(),
+      *service_, rest_context, request.body(), true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "failover"));
 }
@@ -104,7 +104,7 @@ DefaultSqlInstancesServiceRestStub::Reencrypt(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlInstancesReencryptRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request.body(),
+      *service_, rest_context, request.body(), true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "reencrypt"));
 }
@@ -114,7 +114,7 @@ DefaultSqlInstancesServiceRestStub::Get(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlInstancesGetRequest const& request) {
   return rest_internal::Get<google::cloud::sql::v1::DatabaseInstance>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance()));
 }
@@ -124,7 +124,7 @@ DefaultSqlInstancesServiceRestStub::Import(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlInstancesImportRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request.body(),
+      *service_, rest_context, request.body(), true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "import"));
 }
@@ -134,7 +134,7 @@ DefaultSqlInstancesServiceRestStub::Insert(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlInstancesInsertRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request.body(),
+      *service_, rest_context, request.body(), true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances"));
 }
@@ -144,7 +144,7 @@ DefaultSqlInstancesServiceRestStub::List(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlInstancesListRequest const& request) {
   return rest_internal::Get<google::cloud::sql::v1::InstancesListResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances"),
       rest_internal::TrimEmptyQueryParameters(
@@ -159,7 +159,7 @@ DefaultSqlInstancesServiceRestStub::ListServerCas(
     google::cloud::sql::v1::SqlInstancesListServerCasRequest const& request) {
   return rest_internal::Get<
       google::cloud::sql::v1::InstancesListServerCasResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "listServerCas"));
 }
@@ -169,7 +169,7 @@ DefaultSqlInstancesServiceRestStub::Patch(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlInstancesPatchRequest const& request) {
   return rest_internal::Patch<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request.body(),
+      *service_, rest_context, request.body(), true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance()));
 }
@@ -179,7 +179,7 @@ DefaultSqlInstancesServiceRestStub::PromoteReplica(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlInstancesPromoteReplicaRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/",
                    "promoteReplica"));
@@ -190,7 +190,7 @@ DefaultSqlInstancesServiceRestStub::ResetSslConfig(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlInstancesResetSslConfigRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/",
                    "resetSslConfig"));
@@ -201,7 +201,7 @@ DefaultSqlInstancesServiceRestStub::Restart(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlInstancesRestartRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "restart"));
 }
@@ -211,7 +211,7 @@ DefaultSqlInstancesServiceRestStub::RestoreBackup(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlInstancesRestoreBackupRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request.body(),
+      *service_, rest_context, request.body(), true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "restoreBackup"));
 }
@@ -221,7 +221,7 @@ DefaultSqlInstancesServiceRestStub::RotateServerCa(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlInstancesRotateServerCaRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request.body(),
+      *service_, rest_context, request.body(), true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/",
                    "rotateServerCa"));
@@ -232,7 +232,7 @@ DefaultSqlInstancesServiceRestStub::StartReplica(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlInstancesStartReplicaRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "startReplica"));
 }
@@ -242,7 +242,7 @@ DefaultSqlInstancesServiceRestStub::StopReplica(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlInstancesStopReplicaRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "stopReplica"));
 }
@@ -252,7 +252,7 @@ DefaultSqlInstancesServiceRestStub::TruncateLog(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlInstancesTruncateLogRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request.body(),
+      *service_, rest_context, request.body(), true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "truncateLog"));
 }
@@ -262,7 +262,7 @@ DefaultSqlInstancesServiceRestStub::Update(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlInstancesUpdateRequest const& request) {
   return rest_internal::Put<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request.body(),
+      *service_, rest_context, request.body(), true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance()));
 }
@@ -273,7 +273,7 @@ DefaultSqlInstancesServiceRestStub::CreateEphemeral(
     google::cloud::sql::v1::SqlInstancesCreateEphemeralCertRequest const&
         request) {
   return rest_internal::Post<google::cloud::sql::v1::SslCert>(
-      *service_, rest_context, request.body(),
+      *service_, rest_context, request.body(), true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/",
                    "createEphemeral"));
@@ -285,7 +285,7 @@ DefaultSqlInstancesServiceRestStub::RescheduleMaintenance(
     google::cloud::sql::v1::SqlInstancesRescheduleMaintenanceRequest const&
         request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request.body(),
+      *service_, rest_context, request.body(), true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/",
                    "rescheduleMaintenance"));
@@ -298,7 +298,7 @@ DefaultSqlInstancesServiceRestStub::VerifyExternalSyncSettings(
         request) {
   return rest_internal::Post<
       google::cloud::sql::v1::SqlInstancesVerifyExternalSyncSettingsResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/",
                    "verifyExternalSyncSettings"),
@@ -316,7 +316,7 @@ DefaultSqlInstancesServiceRestStub::StartExternalSync(
     google::cloud::sql::v1::SqlInstancesStartExternalSyncRequest const&
         request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/",
                    "startExternalSync"),
@@ -334,7 +334,7 @@ DefaultSqlInstancesServiceRestStub::PerformDiskShrink(
     google::cloud::sql::v1::SqlInstancesPerformDiskShrinkRequest const&
         request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request.body(),
+      *service_, rest_context, request.body(), true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/",
                    "performDiskShrink"));
@@ -347,7 +347,7 @@ DefaultSqlInstancesServiceRestStub::GetDiskShrinkConfig(
         request) {
   return rest_internal::Get<
       google::cloud::sql::v1::SqlInstancesGetDiskShrinkConfigResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/",
                    "getDiskShrinkConfig"));
@@ -359,7 +359,7 @@ DefaultSqlInstancesServiceRestStub::ResetReplicaSize(
     google::cloud::sql::v1::SqlInstancesResetReplicaSizeRequest const&
         request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/",
                    "resetReplicaSize"));
@@ -372,7 +372,7 @@ DefaultSqlInstancesServiceRestStub::GetLatestRecoveryTime(
         request) {
   return rest_internal::Get<
       google::cloud::sql::v1::SqlInstancesGetLatestRecoveryTimeResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/",
                    "getLatestRecoveryTime"));

--- a/google/cloud/sql/v1/internal/sql_operations_rest_stub.cc
+++ b/google/cloud/sql/v1/internal/sql_operations_rest_stub.cc
@@ -44,7 +44,7 @@ DefaultSqlOperationsServiceRestStub::Get(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlOperationsGetRequest const& request) {
   return rest_internal::Get<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "operations", "/", request.operation()));
 }
@@ -54,7 +54,7 @@ DefaultSqlOperationsServiceRestStub::List(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlOperationsListRequest const& request) {
   return rest_internal::Get<google::cloud::sql::v1::OperationsListResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "operations"),
       rest_internal::TrimEmptyQueryParameters(
@@ -67,7 +67,7 @@ Status DefaultSqlOperationsServiceRestStub::Cancel(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlOperationsCancelRequest const& request) {
   return rest_internal::Post(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "operations", "/", request.operation(), "/", "cancel"));
 }

--- a/google/cloud/sql/v1/internal/sql_ssl_certs_rest_stub.cc
+++ b/google/cloud/sql/v1/internal/sql_ssl_certs_rest_stub.cc
@@ -44,7 +44,7 @@ DefaultSqlSslCertsServiceRestStub::Delete(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlSslCertsDeleteRequest const& request) {
   return rest_internal::Delete<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "sslCerts", "/",
                    request.sha1_fingerprint()));
@@ -55,7 +55,7 @@ DefaultSqlSslCertsServiceRestStub::Get(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlSslCertsGetRequest const& request) {
   return rest_internal::Get<google::cloud::sql::v1::SslCert>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "sslCerts", "/",
                    request.sha1_fingerprint()));
@@ -66,7 +66,7 @@ DefaultSqlSslCertsServiceRestStub::Insert(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlSslCertsInsertRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::SslCertsInsertResponse>(
-      *service_, rest_context, request.body(),
+      *service_, rest_context, request.body(), true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "sslCerts"));
 }
@@ -76,7 +76,7 @@ DefaultSqlSslCertsServiceRestStub::List(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlSslCertsListRequest const& request) {
   return rest_internal::Get<google::cloud::sql::v1::SslCertsListResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "sslCerts"));
 }

--- a/google/cloud/sql/v1/internal/sql_tiers_rest_stub.cc
+++ b/google/cloud/sql/v1/internal/sql_tiers_rest_stub.cc
@@ -43,7 +43,7 @@ DefaultSqlTiersServiceRestStub::List(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlTiersListRequest const& request) {
   return rest_internal::Get<google::cloud::sql::v1::TiersListResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "tiers"));
 }

--- a/google/cloud/sql/v1/internal/sql_users_rest_stub.cc
+++ b/google/cloud/sql/v1/internal/sql_users_rest_stub.cc
@@ -43,7 +43,7 @@ DefaultSqlUsersServiceRestStub::Delete(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlUsersDeleteRequest const& request) {
   return rest_internal::Delete<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "users"),
       rest_internal::TrimEmptyQueryParameters(
@@ -55,7 +55,7 @@ StatusOr<google::cloud::sql::v1::User> DefaultSqlUsersServiceRestStub::Get(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlUsersGetRequest const& request) {
   return rest_internal::Get<google::cloud::sql::v1::User>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "users", "/",
                    request.name()),
@@ -68,7 +68,7 @@ DefaultSqlUsersServiceRestStub::Insert(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlUsersInsertRequest const& request) {
   return rest_internal::Post<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request.body(),
+      *service_, rest_context, request.body(), true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "users"));
 }
@@ -78,7 +78,7 @@ DefaultSqlUsersServiceRestStub::List(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlUsersListRequest const& request) {
   return rest_internal::Get<google::cloud::sql::v1::UsersListResponse>(
-      *service_, rest_context, request,
+      *service_, rest_context, request, true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "users"));
 }
@@ -88,7 +88,7 @@ DefaultSqlUsersServiceRestStub::Update(
     google::cloud::rest_internal::RestContext& rest_context,
     google::cloud::sql::v1::SqlUsersUpdateRequest const& request) {
   return rest_internal::Put<google::cloud::sql::v1::Operation>(
-      *service_, rest_context, request.body(),
+      *service_, rest_context, request.body(), true,
       absl::StrCat("/", "v1", "/", "projects", "/", request.project(), "/",
                    "instances", "/", request.instance(), "/", "users"),
       rest_internal::TrimEmptyQueryParameters(


### PR DESCRIPTION
Discovery doc generated services (e.g. compute) require JSON field names to be in camelCase. sql admin is an exception and requires JSON field names to be in snake_case. Add support for both in the generator.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12731)
<!-- Reviewable:end -->
