### PR TITLE
feat(otel): GA bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -43,7 +43,7 @@ test --test_env=GTEST_SHUFFLE --test_env=GTEST_RANDOM_SEED
 
 # By default, build the library with OpenTelemetry
 build --@io_opentelemetry_cpp//api:with_abseil
-build --//:enable-experimental-opentelemetry
+build --//:enable_opentelemetry
 
 # Clang Sanitizers, use with (for example):
 #

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -172,6 +172,15 @@ cc_library(
 
 cc_library(
     name = "experimental-opentelemetry",
+    deprecation = "this library is now GA, please use //:opentelemetry instead.",
+    tags = ["manual"],
+    deps = [
+        "//google/cloud/opentelemetry:google_cloud_cpp_opentelemetry",
+    ],
+)
+
+cc_library(
+    name = "opentelemetry",
     deps = [
         "//google/cloud/opentelemetry:google_cloud_cpp_opentelemetry",
     ],
@@ -186,6 +195,13 @@ cc_library(
 
 bool_flag(
     name = "enable-experimental-opentelemetry",
+    build_setting_default = False,
+    deprecation = "this flag is now GA, please use //:enable_opentelemetry instead.",
+    visibility = ["//:__subpackages__"],
+)
+
+bool_flag(
+    name = "enable_opentelemetry",
     build_setting_default = False,
     visibility = ["//:__subpackages__"],
 )

--- a/ci/cloudbuild/builds/otel-disabled-bazel.sh
+++ b/ci/cloudbuild/builds/otel-disabled-bazel.sh
@@ -23,9 +23,9 @@ export CC=clang
 export CXX=clang++
 
 mapfile -t args < <(bazel::common_args)
-args+=("--//:enable-experimental-opentelemetry=false")
-# Note that we do not ignore `//:experimental-opentelemetry`, as the exporters
-# should be usable whether google-cloud-cpp is built with OpenTelemetry or not.
+args+=("--//:enable_opentelemetry=false")
+# Note that we do not ignore `//:opentelemetry`, as the exporters should be
+# usable whether google-cloud-cpp is built with OpenTelemetry or not.
 ignore=(
   # These integration tests use opentelemetry matchers out of convenience.
   "-//google/cloud/opentelemetry/integration_tests/..."

--- a/doc/compile-time-configuration.md
+++ b/doc/compile-time-configuration.md
@@ -94,13 +94,15 @@ The `--host_cxxopt` may be unfamiliar. This is required to support Protobuf and
 gRPC, which compile code generators for the "host" environment, and generate
 libraries for the "target" environment.
 
-### Disabling OpenTelemetry
+### Enabling OpenTelemetry
 
-[OpenTelemetry] is enabled by default. Turning this off may reduce your build
-times but will also lose the benefits of instrumenting the libraries for
-distributed tracing. Add `--//:experimental-opentelemetry=false` to your Bazel
-command-line parameters to disable Open Telemetry.
+[OpenTelemetry] is disabled by default. Add `--//:enable_opentelemetry` to your
+Bazel command-line parameters to enable OpenTelemetry features, such as
+instrumentation to collect distributed traces.
+
+See the [OpenTelemetry quickstart] for more details.
 
 [ccmake]: https://cmake.org/cmake/help/latest/manual/ccmake.1.html
 [github discussion]: https://github.com/googleapis/google-cloud-cpp/discussions
 [opentelemetry]: https://opentelemetry.io/
+[opentelemetry quickstart]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/opentelemetry/quickstart

--- a/google/cloud/BUILD.bazel
+++ b/google/cloud/BUILD.bazel
@@ -45,6 +45,15 @@ capture_build_info(
 config_setting(
     name = "enable_opentelemetry_valid",
     flag_values = {
+        "//:enable_opentelemetry": "true",
+        "@io_opentelemetry_cpp//api:with_abseil": "true",
+    },
+)
+
+config_setting(
+    name = "enable_opentelemetry_valid-transition",
+    flag_values = {
+        "//:enable_opentelemetry": "false",
         "//:enable-experimental-opentelemetry": "true",
         "@io_opentelemetry_cpp//api:with_abseil": "true",
     },
@@ -53,6 +62,7 @@ config_setting(
 config_setting(
     name = "disable_opentelemetry",
     flag_values = {
+        "//:enable_opentelemetry": "false",
         "//:enable-experimental-opentelemetry": "false",
     },
 )
@@ -66,11 +76,16 @@ cc_library(
             # Enable OpenTelemetry features in google-cloud-cpp
             "GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY",
         ],
+        ":enable_opentelemetry_valid-transition": [
+            # Enable OpenTelemetry features in google-cloud-cpp
+            "GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY",
+        ],
         "//conditions:default": [],
     }),
     target_compatible_with = select(
         {
             ":enable_opentelemetry_valid": [],
+            ":enable_opentelemetry_valid-transition": [],
             ":disable_opentelemetry": [],
         },
         # else, OpenTelemetry is enabled, but with an invalid configuration.
@@ -100,6 +115,9 @@ to your build command, or set this value in your `.bazelrc` file(s).
         "@com_google_absl//absl/types:variant",
     ] + select({
         ":enable_opentelemetry_valid": [
+            "@io_opentelemetry_cpp//api",
+        ],
+        ":enable_opentelemetry_valid-transition": [
             "@io_opentelemetry_cpp//api",
         ],
         "//conditions:default": [],

--- a/google/cloud/opentelemetry/integration_tests/BUILD.bazel
+++ b/google/cloud/opentelemetry/integration_tests/BUILD.bazel
@@ -24,7 +24,7 @@ load(":tests.bzl", "opentelemetry_integration_tests")
     srcs = [test],
     tags = ["integration-test"],
     deps = [
-        "//:experimental-opentelemetry",
+        "//:opentelemetry",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc_private",
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
         "@com_google_googletest//:gtest_main",

--- a/google/cloud/opentelemetry/quickstart/.bazelrc
+++ b/google/cloud/opentelemetry/quickstart/.bazelrc
@@ -31,4 +31,4 @@ build --experimental_convenience_symlinks=ignore
 
 # Enable OpenTelemetry tracing instrumentation for google-cloud-cpp.
 build --@io_opentelemetry_cpp//api:with_abseil
-build --@google_cloud_cpp//:enable-experimental-opentelemetry
+build --@google_cloud_cpp//:enable_opentelemetry

--- a/google/cloud/opentelemetry/quickstart/BUILD.bazel
+++ b/google/cloud/opentelemetry/quickstart/BUILD.bazel
@@ -22,7 +22,7 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@google_cloud_cpp//:experimental-opentelemetry",
+        "@google_cloud_cpp//:opentelemetry",
         "@google_cloud_cpp//:storage",
     ],
 )

--- a/google/cloud/opentelemetry/quickstart/README.md
+++ b/google/cloud/opentelemetry/quickstart/README.md
@@ -90,7 +90,7 @@ Without these flags, the above `bazel build ...` command would fail.
 build --@io_opentelemetry_cpp//api:with_abseil
 
 # Enables tracing instrumentation in google-cloud-cpp
-build --@google_cloud_cpp//:enable-experimental-opentelemetry
+build --@google_cloud_cpp//:enable_opentelemetry
 ```
 
 Also note that we explicitly load OpenTelemetry's dependencies in the

--- a/google/cloud/opentelemetry/samples/BUILD.bazel
+++ b/google/cloud/opentelemetry/samples/BUILD.bazel
@@ -21,7 +21,7 @@ licenses(["notice"])  # Apache 2.0
     srcs = [test],
     tags = ["integration-test"],
     deps = [
-        "//:experimental-opentelemetry",
+        "//:opentelemetry",
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
     ],
 ) for test in glob(["*.cc"])]

--- a/google/cloud/testing_util/BUILD.bazel
+++ b/google/cloud/testing_util/BUILD.bazel
@@ -45,6 +45,10 @@ cc_library(
             "@io_opentelemetry_cpp//exporters/memory:in_memory_span_exporter",
             "@io_opentelemetry_cpp//sdk/src/trace",
         ],
+        "//google/cloud:enable_opentelemetry_valid-transition": [
+            "@io_opentelemetry_cpp//exporters/memory:in_memory_span_exporter",
+            "@io_opentelemetry_cpp//sdk/src/trace",
+        ],
         "//conditions:default": [],
     }),
 )


### PR DESCRIPTION
Part of the work for #12726 

We have:
- `--//:enable-experimental-opentelemetry`
- `//:experimental-opentelemetry`

Introduce:
- `--//:enable_opentelemetry` (Note that we take this opportunity to use snake_case)
- `//:opentelemetry`

We will leave around the old targets for a release to ease transition for our dependents (if they even exist).

Also correct the documentation about whether OTel is enabled/disabled by default with Bazel.

---

Note that `config_settings` must be mutually exclusive, and they only support AND logic over the `flag_values`.

---

cc: @yashykt - at some point this will affect you.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12732)
<!-- Reviewable:end -->
