### PR TITLE
ci: all CMake-based builds on Fedora:38

### DIFF
--- a/ci/cloudbuild/triggers/cmake-split-install-ci.yaml
+++ b/ci/cloudbuild/triggers/cmake-split-install-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: cmake-split-install-ci
 substitutions:
   _BUILD_NAME: cmake-split-install
-  _DISTRO: fedora-37-cmake
+  _DISTRO: fedora-latest-cmake
   _TRIGGER_TYPE: ci
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
 tags:

--- a/ci/cloudbuild/triggers/cmake-split-install-pr.yaml
+++ b/ci/cloudbuild/triggers/cmake-split-install-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: cmake-split-install-pr
 substitutions:
   _BUILD_NAME: cmake-split-install
-  _DISTRO: fedora-37-cmake
+  _DISTRO: fedora-latest-cmake
   _TRIGGER_TYPE: pr
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
 tags:

--- a/ci/cloudbuild/triggers/publish-docs-compute-pr.yaml
+++ b/ci/cloudbuild/triggers/publish-docs-compute-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: publish-docs-compute-pr
 substitutions:
   _BUILD_NAME: publish-docs
-  _DISTRO: fedora-37-cmake
+  _DISTRO: fedora-latest-cmake
   _TRIGGER_TYPE: pr
   _LIBRARIES: compute
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS

--- a/docfx/README.md
+++ b/docfx/README.md
@@ -39,7 +39,7 @@ git clone https://github.com/microsoft/vcpkg.git $HOME/vcpkg
 ```
 cd google-cloud-cpp
 cmake -S . -B .build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
-PUBLISH=$PWD/build-out/fedora-37-cmake-publish-docs/cmake-out/google/cloud
+PUBLISH=$PWD/build-out/fedora-latest-cmake-publish-docs/cmake-out/google/cloud
 cmake --build .build/ --target docfx/all \
   && rm -f $HOME/doc-pipeline/testdata/cpp/* \
   && env -C $HOME/doc-pipeline/testdata/cpp $PWD/.build/docfx/doxygen2docfx $PUBLISH/xml/cloud.doxygen.xml cloud 2.9.0


### PR DESCRIPTION
This moves the remaining CMake-based builds to Fedora:38.