### PR TITLE
ci: move checkers build to Fedora:38

### DIFF
--- a/ci/cloudbuild/builds/check-api.sh
+++ b/ci/cloudbuild/builds/check-api.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2317
 #
 # Copyright 2021 Google LLC
 #

--- a/ci/cloudbuild/builds/publish-docs.sh
+++ b/ci/cloudbuild/builds/publish-docs.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2317
 #
 # Copyright 2021 Google LLC
 #

--- a/ci/cloudbuild/dockerfiles/checkers.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/checkers.Dockerfile
@@ -17,7 +17,7 @@
 # than to the extent that certain distros offer certain versions of software
 # that the build needs. It's fine to add more deps that are needed by the
 # `checkers.sh` build.
-FROM fedora:37
+FROM fedora:38
 ARG NCPU=4
 ARG ARCH=amd64
 


### PR DESCRIPTION
We need to ignore some "unreachable code" warnings in ShellCheck because the functions are called after being exported.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12738)
<!-- Reviewable:end -->
