### PR TITLE
impl(bigquery): Benchmark program for InsertJob api

### DIFF
--- a/google/cloud/bigquery/v2/minimal/benchmarks/CMakeLists.txt
+++ b/google/cloud/bigquery/v2/minimal/benchmarks/CMakeLists.txt
@@ -67,8 +67,11 @@ endforeach ()
 # Runs benchmark integration tests.
 set(experimental_bigquery_rest_client_benchmark_programs
     # cmake-format: sort
-    dataset_benchmark_programs.cc job_readonly_benchmark_programs.cc
-    project_benchmark_programs.cc table_benchmark_programs.cc)
+    dataset_benchmark_programs.cc
+    job_insert_benchmark_programs.cc
+    job_readonly_benchmark_programs.cc
+    project_benchmark_programs.cc
+    table_benchmark_programs.cc)
 
 # Export the list of benchmark integration tests to a .bzl file so we do not
 # need to maintain the list in two places.

--- a/google/cloud/bigquery/v2/minimal/benchmarks/benchmarks_config.cc
+++ b/google/cloud/bigquery/v2/minimal/benchmarks/benchmarks_config.cc
@@ -41,52 +41,42 @@ auto invalid_argument = [](std::string msg) {
 
 auto status_ok = google::cloud::Status(StatusCode::kOk, "");
 
-std::string GenerateJobId() {
-  auto constexpr kJobPrefix = "bqOdbcJob_benchmark_test_";
-  auto generator = google::cloud::internal::MakeDefaultPRNG();
-  auto job_id = kJobPrefix + google::cloud::internal::Sample(
-                                 generator, 32, "abcdefghijklmnopqrstuvwxyz");
-  return job_id;
-}
-
 std::string insert_job_dr_request_body =
     R"({"jobReference":{"projectId":"bigquery-devtools-drivers")"
-    R"(,"jobId":")" +
-    GenerateJobId() +
-    R"("})"
+    R"(,"location":"US")"
+    R"(})"
     R"(,"configuration":{"dryRun":true)"
-    R"(,"query":{"query":'insert into ODBCTESTDATASET.ODBCTESTTABLE VALUES(?)')"
+    R"(,"query":{"query":"insert into ODBCTESTDATASET.ODBCTESTTABLE_INSERT VALUES\u0028\u003f\u0029")"
     R"(,"useQueryCache":true,"useLegacySql":false,"createSession":false,"parameterMode":"POSITIONAL"}}})";
 
 std::string insert_job_request_body =
     R"({"jobReference":{"projectId":"bigquery-devtools-drivers")"
-    R"(,"jobId":")" +
-    GenerateJobId() +
-    R"("})"
+    R"(,"location":"US")"
+    R"(})"
     R"(,"configuration":{"dryRun":false)"
-    R"(,"query":{"query":'insert into ODBCTESTDATASET.ODBCTESTTABLE VALUES(?)')"
+    R"(,"query":{"query":"insert into ODBCTESTDATASET.ODBCTESTTABLE_INSERT VALUES\u0028\u003f\u0029")"
     R"(,"useQueryCache":true,"useLegacySql":false)"
     R"(,"createSession":false,"parameterMode":"POSITIONAL")"
     R"(,"queryParameters":[{"parameterType":{"type":"STRING"},"parameterValue":{"value":"testdata"}}]}}})";
 
 std::string query_create_replace_dr_request_body =
-    R"({"query":'create or replace table ODBCTESTDATASET.ODBCTESTTABLE (name STRING)')"
+    R"({"query":"create or replace table ODBCTESTDATASET.ODBCTESTTABLE_QUERY \u0028name STRING\u0029")"
     R"(,"dryRun":true,"maxResults":100000,"useLegacySql":false)"
     R"(,"timeoutMs":10000,"useQueryCache":true,"createSession":false,"parameterMode":"POSITIONAL"})";
 
 std::string query_create_replace_request_body =
-    R"({"query":'create or replace table ODBCTESTDATASET.ODBCTESTTABLE (name STRING)')"
+    R"({"query":"create or replace table ODBCTESTDATASET.ODBCTESTTABLE_QUERY \u0028name STRING\u0029")"
     R"(,"dryRun":false,"maxResults":100000,"useLegacySql":false)"
     R"(,"timeoutMs":10000,"useQueryCache":true,"createSession":false})";
 
 std::string query_drop_dr_request_body =
-    R"({"query":"drop table if exists ODBCTESTDATASET.ODBCTESTTABLE")"
+    R"({"query":"drop table if exists ODBCTESTDATASET.ODBCTESTTABLE_QUERY")"
     R"(,"dryRun":true,"maxResults":100000)"
     R"(,"useLegacySql":false,"timeoutMs":10000)"
     R"(,"useQueryCache":true,"createSession":false,"parameterMode":"POSITIONAL"})";
 
 std::string query_drop_request_body =
-    R"({"query":"drop table if exists ODBCTESTDATASET.ODBCTESTTABLE")"
+    R"({"query":"drop table if exists ODBCTESTDATASET.ODBCTESTTABLE_QUERY")"
     R"(,"dryRun":false,"maxResults":100000)"
     R"(,"useLegacySql":false,"timeoutMs":10000)"
     R"(,"useQueryCache":true,"createSession":false})";

--- a/google/cloud/bigquery/v2/minimal/benchmarks/experimental_bigquery_rest_client_benchmark_programs.bzl
+++ b/google/cloud/bigquery/v2/minimal/benchmarks/experimental_bigquery_rest_client_benchmark_programs.bzl
@@ -18,6 +18,7 @@
 
 experimental_bigquery_rest_client_benchmark_programs = [
     "dataset_benchmark_programs.cc",
+    "job_insert_benchmark_programs.cc",
     "job_readonly_benchmark_programs.cc",
     "project_benchmark_programs.cc",
     "table_benchmark_programs.cc",

--- a/google/cloud/bigquery/v2/minimal/benchmarks/job_insert_benchmark_programs.cc
+++ b/google/cloud/bigquery/v2/minimal/benchmarks/job_insert_benchmark_programs.cc
@@ -1,0 +1,234 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigquery/v2/minimal/benchmarks/benchmark.h"
+#include "google/cloud/bigquery/v2/minimal/benchmarks/benchmarks_config.h"
+#include "google/cloud/internal/make_status.h"
+#include "absl/strings/match.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
+#include <cctype>
+#include <chrono>
+#include <future>
+#include <iomanip>
+#include <sstream>
+
+using ::google::cloud::bigquery_v2_minimal_benchmarks::Benchmark;
+using ::google::cloud::bigquery_v2_minimal_benchmarks::BenchmarkResult;
+using ::google::cloud::bigquery_v2_minimal_benchmarks::FormatDuration;
+using ::google::cloud::bigquery_v2_minimal_benchmarks::JobBenchmark;
+using ::google::cloud::bigquery_v2_minimal_benchmarks::JobConfig;
+using ::google::cloud::bigquery_v2_minimal_benchmarks::OperationResult;
+
+char const kDescription[] =
+    R"""(Measures the latency of Bigquery's `InsertJob()` api.
+
+This benchmark measures the latency of Bigquery's `InsertJob()` api.
+
+PreRequisites:
+- Ensure the project given as command line argument, has a dataset called `ODBCTESTDATASET`
+  and table called `ODBCTESTTABLE_INSERT`. The test data will be inserted to this table
+- Ensure the service account or user credentials has write access to the above table.
+- Ensure the service account or user credentials has write access to the project.
+- Setting the test duration for more than a minute for non dry-run mode may result
+  in rate limit when the query given in the JobConfiguration is executed. Please
+  ensure the test-duration does not cause the rate limit to exceed.
+  A reasonable number is 60 secs
+
+The benchmark:
+- Starts T threads as supplied in the command-line, executing the
+  following loop:
+- Runs for the test duration as supplied in the command-line, constantly
+  executing this basic block:
+  - Makes a rest call to `InsertJob()` api.
+  - If the call fails, the test returns with the failure message.
+  - if the call fails due to duplicate job id then loop continues and duplicate
+    count is registered.This should ideally not happen if jobId is unique
+  - Reports progress based on the total executing time and where the
+    test is currently.
+
+The test then waits for all the threads to finish and:
+
+- Collects the results from all the threads.
+- Reports the total running time.
+- Reports the latency results, including p0 (minimum), p50, p90, p95, p99, p99.9, and
+  p100 (maximum) latencies.
+)""";
+
+// Helper functions and types for job benchmark program.
+namespace {
+// Number of Progress report threads.
+constexpr int kBenchmarkProgressMarks = 4;
+
+struct JobBenchmarkResult {
+  int dup_insert_jobs_count;
+  BenchmarkResult insert_job_results;
+};
+
+// Runs delayed InsertJob() operation;
+OperationResult RunInsertJob(JobBenchmark& benchmark) {
+  auto op = [&benchmark]() -> google::cloud::Status {
+    return benchmark.InsertJob().status();
+  };
+  return Benchmark::TimeOperation(std::move(op));
+}
+
+// Run an iteration of the test.
+google::cloud::StatusOr<JobBenchmarkResult> RunJobBenchmark(
+    JobBenchmark& benchmark, absl::Duration test_duration) {
+  JobBenchmarkResult result = {};
+
+  auto start = absl::Now();
+  auto mark = start + test_duration / kBenchmarkProgressMarks;
+  auto end = start + test_duration;
+  auto local_time_zone = absl::LocalTimeZone();
+  for (auto now = start; now < end; now = absl::Now()) {
+    // Call InsertJob.
+    auto op_result = RunInsertJob(benchmark);
+    auto is_dup =
+        (!op_result.status.ok() &&
+         absl::StrContains(op_result.status.message(), "Already Exists"));
+
+    if (!op_result.status.ok() && !is_dup) {
+      std::cout << "Job Benchmark failed with error=" << op_result.status
+                << std::endl;
+      return op_result.status;
+    }
+
+    if (!is_dup) {
+      result.insert_job_results.operations.emplace_back(op_result);
+    } else {
+      result.dup_insert_jobs_count++;
+    }
+
+    if (now >= mark) {
+      mark = now + test_duration / kBenchmarkProgressMarks;
+      std::cout << "Start Time=" << absl::FormatTime(start, local_time_zone)
+                << "\nCurrent Progress Mark="
+                << absl::FormatTime(now, local_time_zone)
+                << "\nNext Progress Mark="
+                << absl::FormatTime(mark, local_time_zone)
+                << "\nEnd Time=" << absl::FormatTime(end, local_time_zone)
+                << "\nNumber of InsertJob operations performed thus far= "
+                << result.insert_job_results.operations.size()
+                << "\nDuplicate insert jobs count= "
+                << result.dup_insert_jobs_count << "\n...\n"
+                << std::flush;
+    } else if (now > end) {
+      std::cout << "\nStart Time=" << absl::FormatTime(start, local_time_zone)
+                << "\nEnd Time=" << absl::FormatTime(end, local_time_zone)
+                << "\nTotal Number of InsertJob operations= "
+                << result.insert_job_results.operations.size()
+                << "\nDuplicate insert jobs count= "
+                << result.dup_insert_jobs_count << "\n...\n"
+                << std::flush;
+    }
+  }
+  return result;
+}
+}  // anonymous namespace
+
+int main(int argc, char* argv[]) {
+  JobConfig config;
+  {
+    std::vector<std::string> args{argv, argv + argc};
+    auto c = config.ParseArgs(args);
+    if (!c) {
+      std::cerr << "Error parsing command-line arguments: " << c.status()
+                << "\n"
+                << std::flush;
+      return 1;
+    }
+    config = *std::move(c);
+  }
+
+  if (config.ExitAfterParse()) {
+    if (config.wants_description) {
+      std::cout << kDescription << "\n" << std::flush;
+    }
+    if (config.wants_help) {
+      std::cout
+          << "The usage information for Job benchmark lists out all the "
+             "flags needed by all the apis being benchmarked, namely: GetJob, "
+             "ListJobs, Query, GetqueryResults and InsertJob."
+          << "\n"
+          << std::flush;
+      config.PrintUsage();
+    }
+    std::cout << "Exiting..."
+              << "\n"
+              << std::flush;
+    return 0;
+  }
+  std::cout << "# Job Benchmark STARTED For InsertJob() api with test "
+               "duration as ["
+            << config.test_duration.count() << "] seconds"
+            << "\n"
+            << std::flush;
+
+  JobBenchmark benchmark(config);
+  // Start the threads running the job benchmark test.
+  auto latency_test_start = absl::Now();
+  std::vector<std::future<google::cloud::StatusOr<JobBenchmarkResult>>> tasks;
+  // If the user requests only one thread, use the current thread.
+  auto launch_policy =
+      config.thread_count == 1 ? std::launch::deferred : std::launch::async;
+  for (int i = 0; i != config.thread_count; ++i) {
+    tasks.emplace_back(std::async(launch_policy, RunJobBenchmark,
+                                  std::ref(benchmark),
+                                  absl::FromChrono(config.test_duration)));
+  }
+
+  // Wait for the threads and combine all the results.
+  JobBenchmarkResult combined{};
+  int count = 0;
+  auto append = [](JobBenchmarkResult& destination,
+                   JobBenchmarkResult const& source) {
+    auto append_ops = [](BenchmarkResult& d, BenchmarkResult const& s) {
+      d.operations.insert(d.operations.end(), s.operations.begin(),
+                          s.operations.end());
+    };
+    append_ops(destination.insert_job_results, source.insert_job_results);
+    destination.dup_insert_jobs_count = source.dup_insert_jobs_count;
+  };
+  for (auto& future : tasks) {
+    auto result = future.get();
+    if (!result) {
+      std::cerr << "Standard exception raised by task[" << count
+                << "]: " << result.status() << "\n"
+                << std::flush;
+    } else {
+      append(combined, *result);
+    }
+    ++count;
+  }
+  auto latency_test_elapsed =
+      absl::ToChronoMilliseconds(absl::Now() - latency_test_start);
+  combined.insert_job_results.elapsed = latency_test_elapsed;
+  std::cout << " DONE. Elapsed Test Duration="
+            << FormatDuration(latency_test_elapsed) << "\n"
+            << std::flush;
+
+  Benchmark::PrintLatencyResult(std::cout, "Latency-Results", "InsertJob()",
+                                combined.insert_job_results);
+
+  Benchmark::PrintThroughputResult(std::cout, "Throughput-Results",
+                                   "InsertJob()", combined.insert_job_results);
+  std::cout << "# Total Duplicate InsertJobs operation="
+            << combined.dup_insert_jobs_count << "\n# Job Benchmark ENDED"
+            << "\n"
+            << std::flush;
+
+  return 0;
+}


### PR DESCRIPTION
This PR includes the following benchmark changes:

- A new benchmark program that tests the InsertJob api end to end and prints out latency and throughput results. 
  The output is [here]( https://paste.googleplex.com/5338571408932864). Additionally, verified the query
  given in the job configuration executed successfully ie in this specific case inserts were successful.
- Benchmark fixes related to InsertJob api as listed below:

> - Fixed the test Json payload for dry-run and real-run mode for InsertJob
> - Fixed benchmark InsertJob to set the job_id values correctly in the test request.
> - Fixed benchmark InsertJob to set the needed enum values in the test request.
> - Fixed benchmark to remove the not needed keys for InsertJob api.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12755)
<!-- Reviewable:end -->
