### PR TITLE
feat(common): new `*Option` to configure HTTP proxy

### DIFF
--- a/google/cloud/common_options.h
+++ b/google/cloud/common_options.h
@@ -116,7 +116,7 @@ struct AuthorityOption {
  *
  * The full URI is constructed as:
  *
- * {scheme}://{username}:{password}@{host}:{port}
+ * {scheme}://{username}:{password}@{hostname}:{port}
  *
  * Any empty values are omitted, except for the `scheme` which defaults to
  * `https`. If the `hostname` value is empty, no HTTP proxy is configured.

--- a/google/cloud/common_options.h
+++ b/google/cloud/common_options.h
@@ -19,6 +19,7 @@
 #include "google/cloud/version.h"
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace google {
@@ -104,6 +105,111 @@ struct UserProjectOption {
  */
 struct AuthorityOption {
   using Type = std::string;
+};
+
+/**
+ * The configuration for a HTTP Proxy.
+ *
+ * This configuration can be used for both REST-based and gRPC-based clients.
+ * The client library sets the underlying configuration parameters based on
+ * the values in this struct.
+ *
+ * The full URI is constructed as:
+ *
+ * {scheme}://{username}:{password}@{host}:port
+ *
+ * Any empty values are omitted, except for the `scheme` which defaults to
+ * `https`. If the `hostname` value is empty, no HTTP proxy is configured.
+ */
+class ProxyConfig {
+ public:
+  ProxyConfig() = default;
+
+  /// Configure the HTTP proxy host.
+  std::string const& hostname() const { return hostname_; }
+
+  /// Configure the HTTP proxy port.
+  std::string const& port() const { return port_; }
+
+  /// Configure the HTTP username.
+  std::string const& username() const { return username_; }
+
+  /// Configure the HTTP password.
+  std::string const& password() const { return password_; }
+
+  /**
+   * Set the scheme for the proxy.
+   *
+   * Use `http` or `https` the client library will append the separator (`://`)
+   * as needed. If empty, the library defaults to `https`.
+   */
+  std::string const& scheme() const { return scheme_; }
+
+  ///@{
+  ///@ name Modifiers.
+  ProxyConfig& set_hostname(std::string v) & {
+    hostname_ = std::move(v);
+    return *this;
+  }
+  ProxyConfig&& set_hostname(std::string v) && {
+    return std::move(set_hostname(std::move(v)));
+  }
+
+  ProxyConfig& set_port(std::string v) & {
+    port_ = std::move(v);
+    return *this;
+  }
+  ProxyConfig&& set_port(std::string v) && {
+    return std::move(set_port(std::move(v)));
+  }
+
+  ProxyConfig& set_username(std::string v) & {
+    username_ = std::move(v);
+    return *this;
+  }
+  ProxyConfig&& set_username(std::string v) && {
+    return std::move(set_username(std::move(v)));
+  }
+
+  ProxyConfig& set_password(std::string v) & {
+    password_ = std::move(v);
+    return *this;
+  }
+  ProxyConfig&& set_password(std::string v) && {
+    return std::move(set_password(std::move(v)));
+  }
+
+  ProxyConfig& set_scheme(std::string v) & {
+    scheme_ = std::move(v);
+    return *this;
+  }
+  ProxyConfig&& set_scheme(std::string v) && {
+    return std::move(set_scheme(std::move(v)));
+  }
+  ///@}
+
+ private:
+  std::string hostname_;
+  std::string port_;
+  std::string username_;
+  std::string password_;
+  std::string scheme_ = "https";
+};
+
+/**
+ * Configure the HTTP Proxy.
+ *
+ * Both HTTP and gRPC-based clients can be configured to use an HTTP proxy for
+ * requests. Prox
+ *
+ * @see https://github.com/grpc/grpc/blob/master/doc/core/default_http_proxy_mapper.md
+ * @see https://curl.se/libcurl/c/CURLOPT_PROXYAUTH.html
+ * @see https://curl.se/libcurl/c/CURLOPT_PROXY.html
+ *
+ * @ingroup options
+ */
+struct ProxyOption {
+  using Type = ProxyConfig;
 };
 
 /**

--- a/google/cloud/common_options.h
+++ b/google/cloud/common_options.h
@@ -116,7 +116,7 @@ struct AuthorityOption {
  *
  * The full URI is constructed as:
  *
- * {scheme}://{username}:{password}@{host}:port
+ * {scheme}://{username}:{password}@{host}:{port}
  *
  * Any empty values are omitted, except for the `scheme` which defaults to
  * `https`. If the `hostname` value is empty, no HTTP proxy is configured.
@@ -125,24 +125,19 @@ class ProxyConfig {
  public:
   ProxyConfig() = default;
 
-  /// Configure the HTTP proxy host.
+  /// The HTTP proxy host.
   std::string const& hostname() const { return hostname_; }
 
-  /// Configure the HTTP proxy port.
+  /// The HTTP proxy port.
   std::string const& port() const { return port_; }
 
-  /// Configure the HTTP username.
+  /// The HTTP proxy username.
   std::string const& username() const { return username_; }
 
-  /// Configure the HTTP password.
+  /// The HTTP proxy password.
   std::string const& password() const { return password_; }
 
-  /**
-   * Set the scheme for the proxy.
-   *
-   * Use `http` or `https` the client library will append the separator (`://`)
-   * as needed. If empty, the library defaults to `https`.
-   */
+  /// The HTTP proxy scheme (http or https).
   std::string const& scheme() const { return scheme_; }
 
   ///@{

--- a/google/cloud/common_options.h
+++ b/google/cloud/common_options.h
@@ -195,10 +195,12 @@ class ProxyConfig {
  * Configure the HTTP Proxy.
  *
  * Both HTTP and gRPC-based clients can be configured to use an HTTP proxy for
- * requests. Prox
+ * requests. Setting the `ProxyOption` will configure the client to use a
+ * proxy as described by the `ProxyConfig` value.
  *
  * @see https://github.com/grpc/grpc/blob/master/doc/core/default_http_proxy_mapper.md
- * @see https://curl.se/libcurl/c/CURLOPT_PROXYAUTH.html
+ * @see https://curl.se/libcurl/c/CURLOPT_PROXYUSERNAME.html
+ * @see https://curl.se/libcurl/c/CURLOPT_PROXYPASSWORD.html
  * @see https://curl.se/libcurl/c/CURLOPT_PROXY.html
  *
  * @ingroup options

--- a/google/cloud/grpc_options.h
+++ b/google/cloud/grpc_options.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_GRPC_OPTIONS_H
 
 #include "google/cloud/background_threads.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/options.h"
 #include "google/cloud/tracing_options.h"
@@ -216,6 +217,9 @@ void ConfigureContext(grpc::ClientContext& context, Options const& opts);
 
 /// Configure the ClientContext for polling operations using options.
 void ConfigurePollContext(grpc::ClientContext& context, Options const& opts);
+
+/// Creates the value for GRPC_ARG_HTTP_PROXY based on @p config.
+std::string MakeGrpcHttpProxy(ProxyConfig const& config);
 
 /// Creates a new `grpc::ChannelArguments` configured with @p opts.
 grpc::ChannelArguments MakeChannelArguments(Options const& opts);

--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -308,8 +308,6 @@ Status CurlImpl::MakeRequest(HttpMethod method, RestContext& context,
   status =
       handle_.SetOption(CURLOPT_FOLLOWLOCATION, follow_location_ ? 1L : 0L);
   if (!status.ok()) return OnTransferError(context, std::move(status));
-  if (proxy_) status = handle_.SetOption(CURLOPT_PROXY, proxy_->c_str());
-  if (!status.ok()) return OnTransferError(context, std::move(status));
   if (proxy_) {
     status = handle_.SetOption(CURLOPT_PROXY, proxy_->c_str());
     if (!status.ok()) return OnTransferError(context, std::move(status));

--- a/google/cloud/internal/curl_impl.h
+++ b/google/cloud/internal/curl_impl.h
@@ -24,6 +24,7 @@
 #include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
+#include "absl/types/optional.h"
 #include "absl/types/span.h"
 #include <array>
 #include <chrono>
@@ -136,6 +137,10 @@ class CurlImpl {
   std::chrono::seconds download_stall_timeout_;
   std::uint32_t download_stall_minimum_rate_;
 
+  absl::optional<std::string> proxy_;
+  absl::optional<std::string> proxy_username_;
+  absl::optional<std::string> proxy_password_;
+
   CurlReceivedHeaders received_headers_;
   std::string url_;
   HttpStatusCode http_code_;
@@ -171,6 +176,15 @@ class CurlImpl {
   // Store pending data between WriteCallback() calls.
   SpillBuffer spill_;
 };
+
+/// Compute the CURLOPT_PROXY setting from @p options.
+absl::optional<std::string> CurlOptProxy(Options const& options);
+
+/// Compute the CURLOPT_PROXYUSERNAME setting from @p options.
+absl::optional<std::string> CurlOptProxyUsername(Options const& options);
+
+/// Compute the CURLOPT_PROXYPASSWORD setting from @p options.
+absl::optional<std::string> CurlOptProxyPassword(Options const& options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace rest_internal

--- a/google/cloud/internal/curl_impl_test.cc
+++ b/google/cloud/internal/curl_impl_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/internal/curl_impl.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <vector>
@@ -144,6 +145,41 @@ TEST_F(CurlImplTest, SetUrlPathContainsHttp) {
   auto impl = CurlImpl(std::move(handle_), factory_, {});
   impl.SetUrl("https://endpoint.googleapis.com", request, {});
   EXPECT_THAT(impl.url(), Eq("HTTP://endpoint.googleapis.com/resource/verb"));
+}
+
+TEST_F(CurlImplTest, CurlOptProxy) {
+  EXPECT_EQ(CurlOptProxy(Options{}), absl::nullopt);
+  EXPECT_EQ(CurlOptProxy(Options{}.set<ProxyOption>(
+                ProxyConfig().set_hostname("hostname"))),
+            absl::make_optional(std::string("https://hostname")));
+  EXPECT_EQ(
+      CurlOptProxy(Options{}.set<ProxyOption>(ProxyConfig()
+                                                  .set_hostname("hostname")
+                                                  .set_port("1080")
+                                                  .set_scheme("http"))),
+      absl::make_optional(std::string("htt" /*silence*/ "p://hostname:1080")));
+}
+
+TEST_F(CurlImplTest, CurlOptProxyUsername) {
+  EXPECT_EQ(CurlOptProxyUsername(Options{}), absl::nullopt);
+  EXPECT_EQ(CurlOptProxyUsername(Options{}.set<ProxyOption>(
+                ProxyConfig().set_hostname("hostname"))),
+            absl::nullopt);
+  EXPECT_EQ(
+      CurlOptProxyUsername(Options{}.set<ProxyOption>(
+          ProxyConfig().set_hostname("hostname").set_username("username"))),
+      absl::make_optional(std::string("username")));
+}
+
+TEST_F(CurlImplTest, CurlOptProxyPassword) {
+  EXPECT_EQ(CurlOptProxyPassword(Options{}), absl::nullopt);
+  EXPECT_EQ(CurlOptProxyPassword(Options{}.set<ProxyOption>(
+                ProxyConfig().set_hostname("hostname"))),
+            absl::nullopt);
+  EXPECT_EQ(
+      CurlOptProxyPassword(Options{}.set<ProxyOption>(
+          ProxyConfig().set_hostname("hostname").set_password("password"))),
+      absl::make_optional(std::string("password")));
 }
 
 }  // namespace


### PR DESCRIPTION
Applications can use this option to configure the HTTP proxy settings. Some applications need to set the username and password and this cannot be done through environment variables (for `libcurl`).

Fixes #12764 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12766)
<!-- Reviewable:end -->
