### PR TITLE
ci(spanner): always include Spanner emulator logs in our log

### DIFF
--- a/google/cloud/spanner/ci/lib/spanner_emulator.sh
+++ b/google/cloud/spanner/ci/lib/spanner_emulator.sh
@@ -150,6 +150,9 @@ function spanner_emulator::kill() {
     echo -n "."
     echo " done."
     SPANNER_EMULATOR_PID=0
+    echo "================ emulator.log ================"
+    cat --number --show-nonprinting emulator.log
+    echo "=============================================="
   fi
   if (("${SPANNER_HTTP_EMULATOR_PID}" > 0)); then
     echo -n "Killing Spanner HTTP Emulator [${SPANNER_HTTP_EMULATOR_PID}] "
@@ -158,5 +161,8 @@ function spanner_emulator::kill() {
     echo -n "."
     echo " done."
     SPANNER_HTTP_EMULATOR_PID=0
+    echo "============== http_emulator.log ============="
+    cat --number --show-nonprinting http_emulator.log
+    echo "=============================================="
   fi
 }

--- a/google/cloud/spanner/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/spanner/ci/run_integration_tests_emulator_bazel.sh
@@ -31,13 +31,25 @@ BAZEL_VERB="$1"
 shift
 bazel_test_args=("$@")
 
-# Start the emulator and arranges to kill it, run in $HOME because
-# spanner_emulator::start creates unsightly *.log files in the workspace
-# otherwise. Use a fixed port so Bazel can cache the test results.
-pushd "${HOME}" >/dev/null
-spanner_emulator::start 8787
-popd >/dev/null
-trap spanner_emulator::kill EXIT
+# Run in $HOME because spanner_emulator::start creates unsightly *.log
+# files in the workspace otherwise.
+
+function spanner_emulator_bazel::start() {
+  pushd "${HOME}" >/dev/null
+  spanner_emulator::start "$@"
+  popd >/dev/null
+}
+
+function spanner_emulator_bazel::kill() {
+  pushd "${HOME}" >/dev/null
+  spanner_emulator::kill "$@"
+  popd >/dev/null
+}
+
+# Start the emulator and arrange to kill it. Use a fixed port so
+# Bazel can cache the test results.
+spanner_emulator_bazel::start 8787
+trap spanner_emulator_bazel::kill EXIT
 
 "${BAZEL_BIN}" "${BAZEL_VERB}" "${bazel_test_args[@]}" \
   --test_env="SPANNER_EMULATOR_HOST=${SPANNER_EMULATOR_HOST}" \


### PR DESCRIPTION
Copy the (usually short) Spanner emulator logs into our log after killing the emulator.  This may help diagnose connection failures.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12769)
<!-- Reviewable:end -->
