### PR TITLE
cleanup(docs): and fix the mock links

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,16 @@ if (GOOGLE_CLOUD_CPP_ENABLE_CCACHE)
 endif ()
 
 # Search for Doxygen and create the targets for it if found.
-option(GOOGLE_CLOUD_CPP_GENERATE_DOXYGEN "Generate Doxygen documentation" OFF)
+option(
+    GOOGLE_CLOUD_CPP_GENERATE_DOXYGEN
+    "Generate Doxygen documentation. Only google-cloud-cpp developers are expected to use this flag."
+    OFF)
+mark_as_advanced(GOOGLE_CLOUD_CPP_GENERATE_DOXYGEN)
+
+option(
+    GOOGLE_CLOUD_CPP_USE_LATEST_FOR_REFDOC_LINKS
+    "Link to \"latest\" in our reference documentation. Otherwise, link to the project version. Only google-cloud-cpp developers are expected to use this flag."
+    OFF)
 mark_as_advanced(GOOGLE_CLOUD_CPP_GENERATE_DOXYGEN)
 
 # Compile the DocFX tool.
@@ -104,17 +113,6 @@ option(
     "Compile the docfx tool. Only google-cloud-cpp developers are expected to use this flag."
     OFF)
 mark_as_advanced(GOOGLE_CLOUD_CPP_INTERNAL_DOCFX)
-
-# Generate docs with relative URLs matching with the directory structure on
-# googleapis.dev hosting.
-option(GOOGLE_CLOUD_CPP_GEN_DOCS_FOR_GOOGLEAPIS_DEV
-       "Use relative URLs in docs for googleapis.dev" OFF)
-mark_as_advanced(GOOGLE_CLOUD_CPP_GEN_DOCS_FOR_GOOGLEAPIS_DEV)
-
-# Use main as the version part of the relative URLs.
-option(GOOGLE_CLOUD_CPP_USE_MAIN_FOR_REFDOC_LINKS
-       "Use main as the version part for refdoc relative links" OFF)
-mark_as_advanced(GOOGLE_CLOUD_CPP_USE_MAIN_FOR_REFDOC_LINKS)
 
 option(
     GOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,15 +95,16 @@ if (GOOGLE_CLOUD_CPP_ENABLE_CCACHE)
 endif ()
 
 # Search for Doxygen and create the targets for it if found.
-option(
-    GOOGLE_CLOUD_CPP_GENERATE_DOXYGEN
-    "Generate Doxygen documentation. Only google-cloud-cpp developers are expected to use this flag."
-    OFF)
+option(GOOGLE_CLOUD_CPP_GENERATE_DOXYGEN [==[
+Generate Doxygen documentation. Only google-cloud-cpp developers are expected to
+use this flag.]==] OFF)
 mark_as_advanced(GOOGLE_CLOUD_CPP_GENERATE_DOXYGEN)
 
 option(
     GOOGLE_CLOUD_CPP_USE_LATEST_FOR_REFDOC_LINKS
-    "Link to \"latest\" in our reference documentation. Otherwise, link to the project version. Only google-cloud-cpp developers are expected to use this flag."
+    [==[
+Link to "latest" in our reference documentation. Otherwise, link to the project
+version. Only google-cloud-cpp developers are expected to use this flag.]==]
     OFF)
 mark_as_advanced(GOOGLE_CLOUD_CPP_USE_LATEST_FOR_REFDOC_LINKS)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ option(
     GOOGLE_CLOUD_CPP_USE_LATEST_FOR_REFDOC_LINKS
     "Link to \"latest\" in our reference documentation. Otherwise, link to the project version. Only google-cloud-cpp developers are expected to use this flag."
     OFF)
-mark_as_advanced(GOOGLE_CLOUD_CPP_GENERATE_DOXYGEN)
+mark_as_advanced(GOOGLE_CLOUD_CPP_USE_LATEST_FOR_REFDOC_LINKS)
 
 # Compile the DocFX tool.
 option(

--- a/ci/cloudbuild/builds/publish-docs.sh
+++ b/ci/cloudbuild/builds/publish-docs.sh
@@ -38,12 +38,10 @@ else
   ENABLED_FEATURES="compute"
 fi
 
-version=""
 doc_args=(
   "-DCMAKE_BUILD_TYPE=Debug"
   "-DGOOGLE_CLOUD_CPP_GENERATE_DOXYGEN=ON"
   "-DGOOGLE_CLOUD_CPP_INTERNAL_DOCFX=ON"
-  "-DGOOGLE_CLOUD_CPP_GEN_DOCS_FOR_GOOGLEAPIS_DEV=ON"
   "-DGOOGLE_CLOUD_CPP_ENABLE=${ENABLED_FEATURES}"
   "-DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=OFF"
   "-DGOOGLE_CLOUD_CPP_ENABLE_WERROR=ON"
@@ -56,30 +54,15 @@ if command -v /usr/local/bin/sccache >/dev/null 2>&1; then
   )
 fi
 
-# Extract the version number if we're on a release branch.
-if grep -qP 'v\d+\.\d+\..*' <<<"${BRANCH_NAME}"; then
-  version_file="google/cloud/internal/version_info.h"
-  major="$(awk '/GOOGLE_CLOUD_CPP_VERSION_MAJOR/{print $3}' "${version_file}")"
-  minor="$(awk '/GOOGLE_CLOUD_CPP_VERSION_MINOR/{print $3}' "${version_file}")"
-  patch="$(awk '/GOOGLE_CLOUD_CPP_VERSION_PATCH/{print $3}' "${version_file}")"
-  version="${major}.${minor}.${patch}"
-else
-  version="HEAD"
-  doc_args+=("-DGOOGLE_CLOUD_CPP_USE_MASTER_FOR_REFDOC_LINKS=ON")
+# If we're not on a release branch, point our links to "latest".
+if ! grep -qP 'v\d+\.\d+\..*' <<<"${BRANCH_NAME}"; then
+  doc_args+=("-DGOOGLE_CLOUD_CPP_USE_LATEST_FOR_REFDOC_LINKS=ON")
 fi
 
-# |---------------------------------------------|
-# |      Bucket       |           URL           |
-# |-------------------|-------------------------|
-# |   docs-staging    |     googleapis.dev/     |
-# | test-docs-staging | staging.googleapis.dev/ |
-# |---------------------------------------------|
 # For PR and manual builds, publish to the staging site. For CI builds (release
 # and otherwise), publish to the public URL.
-bucket="test-docs-staging"
 docfx_bucket="docs-staging-v2-dev"
 if [[ "${TRIGGER_TYPE}" == "ci" ]]; then
-  bucket="docs-staging"
   docfx_bucket="docs-staging-v2"
 fi
 

--- a/cmake/GoogleCloudCppDoxygen.cmake
+++ b/cmake/GoogleCloudCppDoxygen.cmake
@@ -19,9 +19,8 @@ find_program(XSLTPROC xsltproc)
 
 function (google_cloud_cpp_doxygen_deploy_version VAR)
     set(VERSION "${PROJECT_VERSION}")
-    if ("${GOOGLE_CLOUD_CPP_USE_MASTER_FOR_REFDOC_LINKS}")
-        # Match the version string used in publish-docs.sh
-        set(VERSION "HEAD")
+    if (${GOOGLE_CLOUD_CPP_USE_LATEST_FOR_REFDOC_LINKS})
+        set(VERSION "latest")
     endif ()
     set(${VAR}
         "${VERSION}"
@@ -210,6 +209,6 @@ function (google_cloud_cpp_doxygen_targets library)
         DEPENDS
         ${opt_DEPENDS}
         TAGFILES
-        "${GOOGLE_CLOUD_CPP_COMMON_TAG}=https://googleapis.dev/cpp/google-cloud-common/${VERSION}/"
+        "${GOOGLE_CLOUD_CPP_COMMON_TAG}=https://cloud.google.com/cpp/docs/reference/common/${VERSION}/"
     )
 endfunction ()


### PR DESCRIPTION
e.g. fix the link in here https://cloud.google.com/cpp/docs/reference/kms/latest/classgoogle_1_1cloud_1_1kms__v1__mocks_1_1MockEkmServiceConnection#see-also

cleanup some dead code while we are here. I do not think cmake options to generate documentation need to be preserved.

I did not look at the docs in the staging site. I am relying on logic and reasoning.

---

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12771)
<!-- Reviewable:end -->
