### PR TITLE
cleanup(pubsub): custom name to semantic convention for span

### DIFF
--- a/google/cloud/pubsub/internal/publisher_tracing_connection.cc
+++ b/google/cloud/pubsub/internal/publisher_tracing_connection.cc
@@ -53,7 +53,7 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> StartPublishSpan(
                {sc::kMessagingDestinationTemplate, "topic"},
                {"messaging.message.total_size_bytes",
                 static_cast<std::int64_t>(MessageSize(m))},
-               {"cloud-cxx.function", "pubsub::PublisherConnection::Publish"}},
+               {sc::kCodeFunction, "pubsub::PublisherConnection::Publish"}},
               options);
   if (!m.ordering_key().empty()) {
     span->SetAttribute("messaging.pubsub.ordering_key", m.ordering_key());

--- a/google/cloud/pubsub/internal/publisher_tracing_connection_test.cc
+++ b/google/cloud/pubsub/internal/publisher_tracing_connection_test.cc
@@ -94,7 +94,7 @@ TEST(PublisherTracingConnectionTest, PublishSpanOnSuccess) {
                                           45),
               OTelAttribute<std::string>("messaging.message_id", "test-id-0"),
               OTelAttribute<std::string>(
-                  "cloud-cxx.function",
+                  sc::kCodeFunction,
                   "pubsub::PublisherConnection::Publish")))));
 }
 


### PR DESCRIPTION
Cleanup https://github.com/googleapis/google-cloud-cpp/pull/12774

Change from custom attribute to semantic convention

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12782)
<!-- Reviewable:end -->
