### PR TITLE
ci(bigtable): change bigtable zone

### DIFF
--- a/ci/etc/integration-tests-config.sh
+++ b/ci/etc/integration-tests-config.sh
@@ -57,8 +57,8 @@ export CLOUD_STORAGE_ENABLE_TRACING="raw-client,rpc,rpc-streams"
 # Cloud Bigtable configuration parameters
 export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID="test-instance"
 export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_CLUSTER_ID="test-instance-c1"
-export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_A="us-west2-b"
-export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_B="us-west2-c"
+export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_A="us-central1-b"
+export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_B="us-central1-c"
 export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_SERVICE_ACCOUNT="bigtable-test-iam-sa@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com"
 export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_QUICKSTART_TABLE="quickstart"
 


### PR DESCRIPTION
Try to resolve https://github.com/googleapis/google-cloud-cpp/issues/12661

Picked us-central1 since @coryan says it is usually the largest zone

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12784)
<!-- Reviewable:end -->
