### PR TITLE
ci: skip `storagetransfer` if not buildable

### DIFF
--- a/.github/workflows/macos-cmake.yml
+++ b/.github/workflows/macos-cmake.yml
@@ -98,13 +98,6 @@ jobs:
           skipped_features=("${core_features[@]}")
           skipped_features+=(compute)
           skipped_features+=("${shard1_features[@]}")
-          # Disable `storagetranster` on macOS+CMake because:
-          # - we use vcpkg in this build
-          # - vcpkg ships with Protobuf v21
-          # - GID_MAX is generated in the *.pb.h file
-          # - GID_MAX is a system macro on macOS
-          # - Protobuf v21 does not protect against this macro
-          skipped_features+=(storagetransfer)
           skipped="$(printf ",-%s" "${skipped_features[@]}")"
           echo "features=__ga_libraries__,__experimental_libraries__,${skipped:2}" >> "${GITHUB_OUTPUT}"
         fi

--- a/google/cloud/storagetransfer/CMakeLists.txt
+++ b/google/cloud/storagetransfer/CMakeLists.txt
@@ -14,6 +14,15 @@
 # limitations under the License.
 # ~~~
 
+if (APPLE AND (Protobuf_VERSION VERSION_LESS 23.0))
+    message(WARNING "Cannot build google/cloud/storagetransfer - "
+                    " on macOS GID_MAX is a system macro and is also used as"
+                    " a C++ symbol in this service protos. Protobuf < 23.0"
+                    " does not have the necessary workarounds to handle this"
+                    " conflict.")
+    return()
+endif ()
+
 include(GoogleCloudCppLibrary)
 
 set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")


### PR DESCRIPTION
This library does not build with older versions of Protobuf on macOS (which CMake calls `APPLE`). We still use Protobuf v21 in the macOS builds and our customers may do so too. This simplifies their code and ours.