### PR TITLE
cleanup: slightly smarter release notes

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -28,6 +28,8 @@ Set the pre-release version (PROJECT_VERSION_PRE_RELEASE) to the empty string.
 set(PROJECT_VERSION_PRE_RELEASE "")
 ```
 
+Make the corresponding change in `google/cloud/internal/version_info.h`.
+
 ### Update CHANGELOG.md
 
 To update the [`CHANGELOG.md`] file, first change the "TBD" placeholder in the
@@ -36,6 +38,7 @@ latest release header to the current YYYY-MM.
 Then run the script
 
 ```bash
+git fetch upstream
 release/changes.sh
 ```
 
@@ -50,6 +53,12 @@ tweak as needed.
 - Do not list changes for internal components.
 - A change that affects all libraries should only be documented in the
   `Common Libraries` section.
+
+### Run checkers
+
+```bash
+ci/cloudbuild/build.sh -t checkers-pr
+```
 
 ### Send a PR with all these changes
 
@@ -94,11 +103,11 @@ everything looks OK:
 1. Check the latest release checkbox.
 1. Click the update release button.
 
-## Check the published docs on googleapis.dev
+## Check the published reference docs
 
-The `publish-docs` build should start automatically when you create the release
-branch. This build will upload the docs for the new release to the following
-URLs:
+The `publish-docs-release` build should start automatically when you create the
+release branch. This build will upload the docs for the new release to the
+following URLs:
 
 - https://cloud.google.com/cpp/docs/reference/
 

--- a/release/README.md
+++ b/release/README.md
@@ -28,7 +28,11 @@ Set the pre-release version (PROJECT_VERSION_PRE_RELEASE) to the empty string.
 set(PROJECT_VERSION_PRE_RELEASE "")
 ```
 
-Make the corresponding change in `google/cloud/internal/version_info.h`.
+### Update the version info
+
+Run any CMake-based build to update `google/cloud/internal/version_info.h`. If
+you do not feel like waiting for a build, make the corresponding change in
+`google/cloud/internal/version_info.h` manually.
 
 ### Update CHANGELOG.md
 


### PR DESCRIPTION
The instruction update and script updates should probably be split into separate PRs, but eh.

- Only include handwritten libraries in the `sections`
- Only print changes that affect all libraries in "Common Libraries"
- Do not list storage-only changes under "Common Libraries"
  - This is the change from `mapfile` to `IFS`
  - Credit to @devbww for this fix

---


Pre-change:
```
### [Assured Workloads](/google/cloud/assuredworkloads/README.md)

- fix: export headers with top-level Bazel targets ([#12762](https://github.com/googleapis/google-cloud-cpp/pull/12762))
- perf(otel): cache propagator in gRPC tracing stubs ([#12642](https://github.com/googleapis/google-cloud-cpp/pull/12642))
- feat(generator): configurable x-goog-api-client  ([#12571](https://github.com/googleapis/google-cloud-cpp/pull/12571))
-  fix(internal): change url_encode include from .h to .cc ([#12547](https://github.com/googleapis/google-cloud-cpp/pull/12547))
- fix: add implicit routing in GAPICs ([#12544](https://github.com/googleapis/google-cloud-cpp/pull/12544))

### [Batch](/google/cloud/batch/README.md)

- fix: export headers with top-level Bazel targets ([#12762](https://github.com/googleapis/google-cloud-cpp/pull/12762))
- perf(otel): cache propagator in gRPC tracing stubs ([#12642](https://github.com/googleapis/google-cloud-cpp/pull/12642))
- feat(generator): configurable x-goog-api-client  ([#12571](https://github.com/googleapis/google-cloud-cpp/pull/12571))
-  fix(internal): change url_encode include from .h to .cc ([#12547](https://github.com/googleapis/google-cloud-cpp/pull/12547))
- fix: add implicit routing in GAPICs ([#12544](https://github.com/googleapis/google-cloud-cpp/pull/12544))

### [Beyond Corp](/google/cloud/beyondcorp/README.md)

- fix: export headers with top-level Bazel targets ([#12762](https://github.com/googleapis/google-cloud-cpp/pull/12762))
- perf(otel): cache propagator in gRPC tracing stubs ([#12642](https://github.com/googleapis/google-cloud-cpp/pull/12642))
- feat(generator): configurable x-goog-api-client  ([#12571](https://github.com/googleapis/google-cloud-cpp/pull/12571))
-  fix(internal): change url_encode include from .h to .cc ([#12547](https://github.com/googleapis/google-cloud-cpp/pull/12547))
- fix: add implicit routing in GAPICs ([#12544](https://github.com/googleapis/google-cloud-cpp/pull/12544))

### [BigQuery](/google/cloud/bigquery/README.md)

- fix: export headers with top-level Bazel targets ([#12762](https://github.com/googleapis/google-cloud-cpp/pull/12762))
- fix(bigquery): Job Library fixes for InsertJob api ([#12746](https://github.com/googleapis/google-cloud-cpp/pull/12746))
- perf(otel): cache propagator in gRPC tracing stubs ([#12642](https://github.com/googleapis/google-cloud-cpp/pull/12642))
- feat(generator): configurable x-goog-api-client  ([#12571](https://github.com/googleapis/google-cloud-cpp/pull/12571))
-  fix(internal): change url_encode include from .h to .cc ([#12547](https://github.com/googleapis/google-cloud-cpp/pull/12547))
- fix: add implicit routing in GAPICs ([#12544](https://github.com/googleapis/google-cloud-cpp/pull/12544))

### [Bigtable](/google/cloud/bigtable/README.md)

- fix: export headers with top-level Bazel targets ([#12762](https://github.com/googleapis/google-cloud-cpp/pull/12762))
- fix(bigtable): the Location ctor takes project ids ([#12675](https://github.com/googleapis/google-cloud-cpp/pull/12675))
- perf(otel): cache propagator in gRPC tracing stubs ([#12642](https://github.com/googleapis/google-cloud-cpp/pull/12642))
- feat(generator): configurable x-goog-api-client  ([#12571](https://github.com/googleapis/google-cloud-cpp/pull/12571))
-  fix(internal): change url_encode include from .h to .cc ([#12547](https://github.com/googleapis/google-cloud-cpp/pull/12547))
- fix: add implicit routing in GAPICs ([#12544](https://github.com/googleapis/google-cloud-cpp/pull/12544))

### [Cloud Asset](/google/cloud/asset/README.md)

- fix: export headers with top-level Bazel targets ([#12762](https://github.com/googleapis/google-cloud-cpp/pull/12762))
- perf(otel): cache propagator in gRPC tracing stubs ([#12642](https://github.com/googleapis/google-cloud-cpp/pull/12642))
- feat(generator): configurable x-goog-api-client  ([#12571](https://github.com/googleapis/google-cloud-cpp/pull/12571))
-  fix(internal): change url_encode include from .h to .cc ([#12547](https://github.com/googleapis/google-cloud-cpp/pull/12547))
- fix: add implicit routing in GAPICs ([#12544](https://github.com/googleapis/google-cloud-cpp/pull/12544))

### [Cloud Run](/google/cloud/run/README.md)

- fix: export headers with top-level Bazel targets ([#12762](https://github.com/googleapis/google-cloud-cpp/pull/12762))
- perf(otel): cache propagator in gRPC tracing stubs ([#12642](https://github.com/googleapis/google-cloud-cpp/pull/12642))
- feat(generator): configurable x-goog-api-client  ([#12571](https://github.com/googleapis/google-cloud-cpp/pull/12571))
-  fix(internal): change url_encode include from .h to .cc ([#12547](https://github.com/googleapis/google-cloud-cpp/pull/12547))
- fix: add implicit routing in GAPICs ([#12544](https://github.com/googleapis/google-cloud-cpp/pull/12544))

### [IAM](/google/cloud/iam/README.md)

- fix: export headers with top-level Bazel targets ([#12762](https://github.com/googleapis/google-cloud-cpp/pull/12762))
- perf(otel): cache propagator in gRPC tracing stubs ([#12642](https://github.com/googleapis/google-cloud-cpp/pull/12642))
- feat(generator): configurable x-goog-api-client  ([#12571](https://github.com/googleapis/google-cloud-cpp/pull/12571))
-  fix(internal): change url_encode include from .h to .cc ([#12547](https://github.com/googleapis/google-cloud-cpp/pull/12547))
- fix: add implicit routing in GAPICs ([#12544](https://github.com/googleapis/google-cloud-cpp/pull/12544))

### [Pub/Sub](/google/cloud/pubsub/README.md)

- fix: export headers with top-level Bazel targets ([#12762](https://github.com/googleapis/google-cloud-cpp/pull/12762))
- pubsub: add message_batch.h to build ([#12744](https://github.com/googleapis/google-cloud-cpp/pull/12744))
- perf(otel): cache propagator in gRPC tracing stubs ([#12642](https://github.com/googleapis/google-cloud-cpp/pull/12642))
- fix(pubsub): change size_t -> int for otel attribute ([#12633](https://github.com/googleapis/google-cloud-cpp/pull/12633))
- feat(generator): configurable x-goog-api-client  ([#12571](https://github.com/googleapis/google-cloud-cpp/pull/12571))
-  fix(internal): change url_encode include from .h to .cc ([#12547](https://github.com/googleapis/google-cloud-cpp/pull/12547))
- fix: add implicit routing in GAPICs ([#12544](https://github.com/googleapis/google-cloud-cpp/pull/12544))

### [Spanner](/google/cloud/spanner/README.md)

- fix: export headers with top-level Bazel targets ([#12762](https://github.com/googleapis/google-cloud-cpp/pull/12762))
- fix: restore credential logic ([#12690](https://github.com/googleapis/google-cloud-cpp/pull/12690))
- docs(spanner): set max_delay to 16s ([#12680](https://github.com/googleapis/google-cloud-cpp/pull/12680))
- perf(otel): cache propagator in gRPC tracing stubs ([#12642](https://github.com/googleapis/google-cloud-cpp/pull/12642))
- feat(generator): configurable x-goog-api-client  ([#12571](https://github.com/googleapis/google-cloud-cpp/pull/12571))
-  fix(internal): change url_encode include from .h to .cc ([#12547](https://github.com/googleapis/google-cloud-cpp/pull/12547))
- fix: add implicit routing in GAPICs ([#12544](https://github.com/googleapis/google-cloud-cpp/pull/12544))

### [Storage](/google/cloud/storage/README.md)

- fix: export headers with top-level Bazel targets ([#12762](https://github.com/googleapis/google-cloud-cpp/pull/12762))
- fix(GCS+gRPC): race condition in async `Insert()` ([#12715](https://github.com/googleapis/google-cloud-cpp/pull/12715))
- docs(GCS+gRPC): additional `ReadObject()` example ([#12695](https://github.com/googleapis/google-cloud-cpp/pull/12695))
- fix: restore credential logic ([#12690](https://github.com/googleapis/google-cloud-cpp/pull/12690))
- fix(storage): trace auth when default credentials are assumed ([#12672](https://github.com/googleapis/google-cloud-cpp/pull/12672))
- perf(otel): cache propagator in gRPC tracing stubs ([#12642](https://github.com/googleapis/google-cloud-cpp/pull/12642))
- docs(storage): more on InsertObject vs. WriteObject ([#12577](https://github.com/googleapis/google-cloud-cpp/pull/12577))
- feat(generator): configurable x-goog-api-client  ([#12571](https://github.com/googleapis/google-cloud-cpp/pull/12571))
-  fix(internal): change url_encode include from .h to .cc ([#12547](https://github.com/googleapis/google-cloud-cpp/pull/12547))
- fix: add implicit routing in GAPICs ([#12544](https://github.com/googleapis/google-cloud-cpp/pull/12544))

### [Common Libraries](/google/cloud/README.md)

- feat(common): new `*Option` to configure HTTP proxy ([#12766](https://github.com/googleapis/google-cloud-cpp/pull/12766))
- doc(otel): update link ([#12768](https://github.com/googleapis/google-cloud-cpp/pull/12768))
- doc(compute): add create disk and delete disk samples ([#12749](https://github.com/googleapis/google-cloud-cpp/pull/12749))
- fix: export headers with top-level Bazel targets ([#12762](https://github.com/googleapis/google-cloud-cpp/pull/12762))
- doc(compute): update CHANGELOG and other docs for GA ([#12756](https://github.com/googleapis/google-cloud-cpp/pull/12756))
- feat(oauth2): add quickstart, README, etc. ([#12754](https://github.com/googleapis/google-cloud-cpp/pull/12754))
- doc(otel): GA ([#12748](https://github.com/googleapis/google-cloud-cpp/pull/12748))
- feat(otel): GA for cmake ([#12735](https://github.com/googleapis/google-cloud-cpp/pull/12735))
- feat(otel): GA bazel ([#12732](https://github.com/googleapis/google-cloud-cpp/pull/12732))
- feat(otel): promote `OpenTelemetryTracingOption` to GA ([#12728](https://github.com/googleapis/google-cloud-cpp/pull/12728))
- cleanup(otel)!: Drop `Options` from resource detector API. ([#12730](https://github.com/googleapis/google-cloud-cpp/pull/12730))
- fix: gRPC auth logging enabled by "auth" ([#12702](https://github.com/googleapis/google-cloud-cpp/pull/12702))
- fix(GCS+gRPC): race condition in async `Insert()` ([#12715](https://github.com/googleapis/google-cloud-cpp/pull/12715))
- doc(compute): add repo-metadata.json ([#12696](https://github.com/googleapis/google-cloud-cpp/pull/12696))
- docs(GCS+gRPC): additional `ReadObject()` example ([#12695](https://github.com/googleapis/google-cloud-cpp/pull/12695))
- compute: generate as non-experimental ([#12669](https://github.com/googleapis/google-cloud-cpp/pull/12669))
- fix: restore credential logic ([#12690](https://github.com/googleapis/google-cloud-cpp/pull/12690))
- fix(storage): trace auth when default credentials are assumed ([#12672](https://github.com/googleapis/google-cloud-cpp/pull/12672))
- doc(otel): clarify when `OpenTelemetryTracingOption` applies ([#12670](https://github.com/googleapis/google-cloud-cpp/pull/12670))
- perf(otel): cache propagator in gRPC tracing stubs ([#12642](https://github.com/googleapis/google-cloud-cpp/pull/12642))
- docs(storage): more on InsertObject vs. WriteObject ([#12577](https://github.com/googleapis/google-cloud-cpp/pull/12577))
- feat(generator): generate shortname from api id ([#12575](https://github.com/googleapis/google-cloud-cpp/pull/12575))
- feat(generator): configurable x-goog-api-client  ([#12571](https://github.com/googleapis/google-cloud-cpp/pull/12571))
- fix(internal): add url encoding for minimal iam creds ([#12558](https://github.com/googleapis/google-cloud-cpp/pull/12558))
- feat(netapp): generate library ([#12551](https://github.com/googleapis/google-cloud-cpp/pull/12551))
- feat(config): generate library ([#12545](https://github.com/googleapis/google-cloud-cpp/pull/12545))
- fix(discoveryengine): regenerate with latest generator ([#12549](https://github.com/googleapis/google-cloud-cpp/pull/12549))
-  fix(internal): change url_encode include from .h to .cc ([#12547](https://github.com/googleapis/google-cloud-cpp/pull/12547))
- fix(discoveryengine): update generated files ([#12546](https://github.com/googleapis/google-cloud-cpp/pull/12546))
- fix: add implicit routing in GAPICs ([#12544](https://github.com/googleapis/google-cloud-cpp/pull/12544))
- feat(discoveryengine): new *Client ([#12543](https://github.com/googleapis/google-cloud-cpp/pull/12543))
- doc(generator): add documentation links to discovery doc originated method headers ([#12534](https://github.com/googleapis/google-cloud-cpp/pull/12534))
```

Post-change:
```
### [BigQuery](/google/cloud/bigquery/README.md)

- fix(bigquery): Job Library fixes for InsertJob api ([#12746](https://github.com/googleapis/google-cloud-cpp/pull/12746))

### [Bigtable](/google/cloud/bigtable/README.md)

- fix(bigtable): the Location ctor takes project ids ([#12675](https://github.com/googleapis/google-cloud-cpp/pull/12675))

### [OAuth2](/google/cloud/oauth2/README.md)

- feat(oauth2): add quickstart, README, etc. ([#12754](https://github.com/googleapis/google-cloud-cpp/pull/12754))

### [OpenTelemetry](/google/cloud/opentelemetry/README.md)

- doc(otel): update link ([#12768](https://github.com/googleapis/google-cloud-cpp/pull/12768))
- doc(otel): GA ([#12748](https://github.com/googleapis/google-cloud-cpp/pull/12748))
- feat(otel): GA for cmake ([#12735](https://github.com/googleapis/google-cloud-cpp/pull/12735))
- feat(otel): GA bazel ([#12732](https://github.com/googleapis/google-cloud-cpp/pull/12732))
- feat(otel): promote `OpenTelemetryTracingOption` to GA ([#12728](https://github.com/googleapis/google-cloud-cpp/pull/12728))
- cleanup(otel)!: Drop `Options` from resource detector API. ([#12730](https://github.com/googleapis/google-cloud-cpp/pull/12730))

### [Pub/Sub](/google/cloud/pubsub/README.md)

- pubsub: add message_batch.h to build ([#12744](https://github.com/googleapis/google-cloud-cpp/pull/12744))
- fix(pubsub): change size_t -> int for otel attribute ([#12633](https://github.com/googleapis/google-cloud-cpp/pull/12633))

### [Spanner](/google/cloud/spanner/README.md)

- fix: restore credential logic ([#12690](https://github.com/googleapis/google-cloud-cpp/pull/12690))
- docs(spanner): set max_delay to 16s ([#12680](https://github.com/googleapis/google-cloud-cpp/pull/12680))

### [Storage](/google/cloud/storage/README.md)

- fix(GCS+gRPC): race condition in async `Insert()` ([#12715](https://github.com/googleapis/google-cloud-cpp/pull/12715))
- docs(GCS+gRPC): additional `ReadObject()` example ([#12695](https://github.com/googleapis/google-cloud-cpp/pull/12695))
- fix: restore credential logic ([#12690](https://github.com/googleapis/google-cloud-cpp/pull/12690))
- fix(storage): trace auth when default credentials are assumed ([#12672](https://github.com/googleapis/google-cloud-cpp/pull/12672))
- docs(storage): more on InsertObject vs. WriteObject ([#12577](https://github.com/googleapis/google-cloud-cpp/pull/12577))

### [Common Libraries](/google/cloud/README.md)

- feat(common): new `*Option` to configure HTTP proxy ([#12766](https://github.com/googleapis/google-cloud-cpp/pull/12766))
- doc(compute): add create disk and delete disk samples ([#12749](https://github.com/googleapis/google-cloud-cpp/pull/12749))
- fix: export headers with top-level Bazel targets ([#12762](https://github.com/googleapis/google-cloud-cpp/pull/12762))
- doc(compute): update CHANGELOG and other docs for GA ([#12756](https://github.com/googleapis/google-cloud-cpp/pull/12756))
- feat(oauth2): add quickstart, README, etc. ([#12754](https://github.com/googleapis/google-cloud-cpp/pull/12754))
- feat(otel): GA for cmake ([#12735](https://github.com/googleapis/google-cloud-cpp/pull/12735))
- feat(otel): GA bazel ([#12732](https://github.com/googleapis/google-cloud-cpp/pull/12732))
- feat(otel): promote `OpenTelemetryTracingOption` to GA ([#12728](https://github.com/googleapis/google-cloud-cpp/pull/12728))
- fix: gRPC auth logging enabled by "auth" ([#12702](https://github.com/googleapis/google-cloud-cpp/pull/12702))
- doc(compute): add repo-metadata.json ([#12696](https://github.com/googleapis/google-cloud-cpp/pull/12696))
- compute: generate as non-experimental ([#12669](https://github.com/googleapis/google-cloud-cpp/pull/12669))
- fix: restore credential logic ([#12690](https://github.com/googleapis/google-cloud-cpp/pull/12690))
- doc(otel): clarify when `OpenTelemetryTracingOption` applies ([#12670](https://github.com/googleapis/google-cloud-cpp/pull/12670))
- perf(otel): cache propagator in gRPC tracing stubs ([#12642](https://github.com/googleapis/google-cloud-cpp/pull/12642))
- feat(generator): generate shortname from api id ([#12575](https://github.com/googleapis/google-cloud-cpp/pull/12575))
- feat(generator): configurable x-goog-api-client  ([#12571](https://github.com/googleapis/google-cloud-cpp/pull/12571))
- fix(internal): add url encoding for minimal iam creds ([#12558](https://github.com/googleapis/google-cloud-cpp/pull/12558))
- feat(netapp): generate library ([#12551](https://github.com/googleapis/google-cloud-cpp/pull/12551))
- feat(config): generate library ([#12545](https://github.com/googleapis/google-cloud-cpp/pull/12545))
- fix(discoveryengine): regenerate with latest generator ([#12549](https://github.com/googleapis/google-cloud-cpp/pull/12549))
-  fix(internal): change url_encode include from .h to .cc ([#12547](https://github.com/googleapis/google-cloud-cpp/pull/12547))
- fix(discoveryengine): update generated files ([#12546](https://github.com/googleapis/google-cloud-cpp/pull/12546))
- fix: add implicit routing in GAPICs ([#12544](https://github.com/googleapis/google-cloud-cpp/pull/12544))
- feat(discoveryengine): new *Client ([#12543](https://github.com/googleapis/google-cloud-cpp/pull/12543))
- doc(generator): add documentation links to discovery doc originated method headers ([#12534](https://github.com/googleapis/google-cloud-cpp/pull/12534))

```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12800)
<!-- Reviewable:end -->
