### PR TITLE
ci: build script for developer workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ cmake-build-*/
 # Ignore Visual Studio Code files
 .vsbuild/
 .vscode/
+
+# `google-cloud-cpp` developers use this file to configure the development
+# workflow build.
+.cloudcxxrc

--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -351,7 +351,7 @@ if [[ "${DOCKER_FLAG}" = "true" ]]; then
     # generator dir.
     "--env=GENERATE_GOLDEN_ONLY=${GENERATE_GOLDEN_ONLY-}"
   )
-  if [[ -r "$HOME/.cloudcxxrc" ]]; then
+  if [[ -r "${HOME}/.cloudcxxrc" ]]; then
     run_flags+=(
       "--volume=${HOME}/.cloudcxxrc:/h/.cloudcxxrc:Z"
     )

--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -351,6 +351,11 @@ if [[ "${DOCKER_FLAG}" = "true" ]]; then
     # generator dir.
     "--env=GENERATE_GOLDEN_ONLY=${GENERATE_GOLDEN_ONLY-}"
   )
+  if [[ -r "$HOME/.cloudcxxrc" ]]; then
+    run_flags+=(
+      "--volume=${HOME}/.cloudcxxrc:/h/.cloudcxxrc:Z"
+    )
+  fi
   # All GOOGLE_CLOUD_* env vars will be passed to the docker container.
   for e in $(env); do
     if [[ "${e}" = GOOGLE_CLOUD_* ]]; then

--- a/ci/cloudbuild/builds/development.sh
+++ b/ci/cloudbuild/builds/development.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+#
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+source "$(dirname "$0")/../../lib/init.sh"
+source module ci/cloudbuild/builds/lib/cmake.sh
+source module ci/cloudbuild/builds/lib/features.sh
+source module ci/cloudbuild/builds/lib/integration.sh
+source module ci/lib/io.sh
+
+export CC=clang
+export CXX=clang++
+export CTCACHE_DIR=~/.cache/ctcache
+
+# Load the build configuration. Start with the default, then any settings for
+# all workspaces, then the settings for the current workspace.
+#
+# Developers only need to override what changes, keep a configuration file that
+# applies to all their builds, and have some workspaces with custom settings.
+source module ci/etc/cloudcxxrc
+if [[ -r "${HOME}/.cloudcxxrc" ]]; then
+  source "${HOME}/.cloudcxxrc"
+fi
+if [[ -r "${PROJECT_ROOT}/.cloudcxxrc" ]]; then
+  source "${PROJECT_ROOT}/.cloudcxxrc"
+fi
+
+# Always remove the CMakeCache because it may be invalidated by `cloudcxxrc`
+# changes.
+if [[ "${ALWAYS_RESET_CMAKE_CACHE}" = "YES" ]]; then
+  io::run rm -f cmake-out/CMakeCache.txt
+fi
+
+# Note: we use C++14 for this build because we don't want tidy suggestions that
+# require a newer C++ standard.
+mapfile -t cmake_args < <(cmake::common_args)
+io::run cmake "${cmake_args[@]}" \
+  -DCMAKE_CXX_CLANG_TIDY=/usr/local/bin/clang-tidy-wrapper \
+  -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+  -DCMAKE_CXX_STANDARD=14 \
+  -DGOOGLE_CLOUD_CPP_ENABLE="${ENABLED_FEATURES}"
+io::run cmake --build cmake-out
+
+if [[ "${RUN_CLANG_TIDY_FIX}" = "YES" ]]; then
+  io::bold clang-tidy -p cmake-out -fix
+  git_files -z -- '*.h' '*.cc' |
+    xargs -r -P "$(nproc)" -n 1 -0 clang-tidy -p cmake-out -fix
+  io::run cmake --build cmake-out
+fi
+
+if [[ "${RUN_UNIT_TESTS}" = "YES" ]]; then
+  mapfile -t ctest_args < <(ctest::common_args)
+  io::run ctest --test-dir cmake-out "${ctest_args[@]}" -LE integration-test
+fi
+
+if [[ "${RUN_INTEGRATION_TESTS}" = "YES" ]]; then
+  integration::ctest_with_emulators "cmake-out"
+fi
+
+# This build should fail if any of the above work generated code differences.
+# This may be updated `.bzl` files, or files updated by clang-tidy.
+io::log_h2 "Highlight generated code differences"
+git diff --exit-code

--- a/ci/cloudbuild/builds/lib/ctest.sh
+++ b/ci/cloudbuild/builds/lib/ctest.sh
@@ -34,3 +34,11 @@ function ctest::common_args() {
   )
   printf "%s\n" "${args[@]}"
 }
+
+function ctest::has_no_tests() {
+  local dir="$1"
+  local prefix="$2"
+  shift 2
+  local ctest_args=("$@")
+  ctest --test-dir "${dir}" --show-only -R "${prefix}" "${ctest_args[@]}" 2>&1 | grep -q 'Total Tests: 0'
+}

--- a/ci/etc/cloudcxxrc
+++ b/ci/etc/cloudcxxrc
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Assume the CMakeCache remains valid between runs.
+ALWAYS_RESET_CMAKE_CACHE=NO
+
+# By default compile most features.
+ENABLED_FEATURES=__ga_libraries__,__experimental_libraries__,opentelemetry,experimental-storage_grpc
+
+# Set to `YES` to run the unit tests.
+RUN_UNIT_TESTS=YES
+
+# Set to `YES` to run the clang-tidy fixes.
+RUN_CLANG_TIDY_FIX=YES
+
+# Set to the list of integration tests to run.
+RUN_INTEGRATION_TESTS=YES

--- a/google/cloud/bigtable/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/bigtable/ci/run_integration_tests_emulator_cmake.sh
@@ -17,7 +17,7 @@
 set -euo pipefail
 
 source "$(dirname "$0")/../../../../ci/lib/init.sh"
-source module /ci/cloudbuild/builds/lib/cmake.sh
+source module /ci/cloudbuild/builds/lib/ctest.sh
 source module /ci/etc/integration-tests-config.sh
 
 if [[ $# -lt 1 ]]; then

--- a/google/cloud/bigtable/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/bigtable/ci/run_integration_tests_emulator_cmake.sh
@@ -33,7 +33,7 @@ readonly BINARY_DIR
 shift
 ctest_args=("$@")
 
-if ctest::has_tests "${BINARY_DIR}" "^bigtable_" "${ctest_args[@]}"; then
+if ctest::has_no_tests "${BINARY_DIR}" "^bigtable_" "${ctest_args[@]}"; then
   exit 0
 fi
 

--- a/google/cloud/bigtable/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/bigtable/ci/run_integration_tests_emulator_cmake.sh
@@ -32,6 +32,10 @@ readonly BINARY_DIR
 shift
 ctest_args=("$@")
 
+if ctest --test-dir "${BINARY_DIR}" --show-only -R "^bigtable_" "${ctest_args[@]}" 2>&1 | grep -q 'Total Tests: 0'; then
+  exit 0
+fi
+
 # Configure run_emulators_utils.sh to find the instance admin emulator.
 export CBT_INSTANCE_ADMIN_EMULATOR_CMD="${BINARY_DIR}/google/cloud/bigtable/tests/instance_admin_emulator"
 source module /google/cloud/bigtable/tools/run_emulator_utils.sh

--- a/google/cloud/bigtable/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/bigtable/ci/run_integration_tests_emulator_cmake.sh
@@ -17,6 +17,7 @@
 set -euo pipefail
 
 source "$(dirname "$0")/../../../../ci/lib/init.sh"
+source module /ci/cloudbuild/builds/lib/cmake.sh
 source module /ci/etc/integration-tests-config.sh
 
 if [[ $# -lt 1 ]]; then
@@ -32,7 +33,7 @@ readonly BINARY_DIR
 shift
 ctest_args=("$@")
 
-if ctest --test-dir "${BINARY_DIR}" --show-only -R "^bigtable_" "${ctest_args[@]}" 2>&1 | grep -q 'Total Tests: 0'; then
+if ctest::has_tests "${BINARY_DIR}" "^bigtable_" "${ctest_args[@]}"; then
   exit 0
 fi
 

--- a/google/cloud/internal/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/internal/ci/run_integration_tests_emulator_cmake.sh
@@ -33,6 +33,10 @@ readonly BINARY_DIR
 shift
 ctest_args=("$@")
 
+if ctest --test-dir "${BINARY_DIR}" --show-only -R "^common_" "${ctest_args[@]}" 2>&1 | grep -q 'Total Tests: 0'; then
+  exit 0
+fi
+
 cd "${BINARY_DIR}"
 start_emulator
 

--- a/google/cloud/internal/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/internal/ci/run_integration_tests_emulator_cmake.sh
@@ -17,7 +17,7 @@
 set -euo pipefail
 
 source "$(dirname "$0")/../../../../ci/lib/init.sh"
-source module /ci/cloudbuild/builds/lib/cmake.sh
+source module /ci/cloudbuild/builds/lib/ctest.sh
 source module /ci/etc/integration-tests-config.sh
 source module /ci/lib/run_gcs_httpbin_emulator_utils.sh
 

--- a/google/cloud/internal/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/internal/ci/run_integration_tests_emulator_cmake.sh
@@ -17,6 +17,7 @@
 set -euo pipefail
 
 source "$(dirname "$0")/../../../../ci/lib/init.sh"
+source module /ci/cloudbuild/builds/lib/cmake.sh
 source module /ci/etc/integration-tests-config.sh
 source module /ci/lib/run_gcs_httpbin_emulator_utils.sh
 
@@ -33,7 +34,7 @@ readonly BINARY_DIR
 shift
 ctest_args=("$@")
 
-if ctest --test-dir "${BINARY_DIR}" --show-only -R "^common_" "${ctest_args[@]}" 2>&1 | grep -q 'Total Tests: 0'; then
+if ctest::has_tests "${BINARY_DIR}" "^common_" "${ctest_args[@]}"; then
   exit 0
 fi
 

--- a/google/cloud/internal/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/internal/ci/run_integration_tests_emulator_cmake.sh
@@ -34,7 +34,7 @@ readonly BINARY_DIR
 shift
 ctest_args=("$@")
 
-if ctest::has_tests "${BINARY_DIR}" "^common_" "${ctest_args[@]}"; then
+if ctest::has_no_tests "${BINARY_DIR}" "^common_" "${ctest_args[@]}"; then
   exit 0
 fi
 

--- a/google/cloud/pubsub/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/pubsub/ci/run_integration_tests_emulator_cmake.sh
@@ -34,7 +34,7 @@ readonly BINARY_DIR
 shift
 ctest_args=("$@")
 
-if ctest::has_tests "${BINARY_DIR}" "^pubsub_" "${ctest_args[@]}"; then
+if ctest::has_no_tests "${BINARY_DIR}" "^pubsub_" "${ctest_args[@]}"; then
   exit 0
 fi
 

--- a/google/cloud/pubsub/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/pubsub/ci/run_integration_tests_emulator_cmake.sh
@@ -17,6 +17,7 @@
 set -euo pipefail
 
 source "$(dirname "$0")/../../../../ci/lib/init.sh"
+source module /ci/cloudbuild/builds/lib/cmake.sh
 source module /ci/etc/integration-tests-config.sh
 source module /google/cloud/pubsub/ci/lib/pubsub_emulator.sh
 
@@ -33,7 +34,7 @@ readonly BINARY_DIR
 shift
 ctest_args=("$@")
 
-if ctest --test-dir "${BINARY_DIR}" --show-only -R "^pubsub_" "${ctest_args[@]}" 2>&1 | grep -q 'Total Tests: 0'; then
+if ctest::has_tests "${BINARY_DIR}" "^pubsub_" "${ctest_args[@]}"; then
   exit 0
 fi
 

--- a/google/cloud/pubsub/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/pubsub/ci/run_integration_tests_emulator_cmake.sh
@@ -17,7 +17,7 @@
 set -euo pipefail
 
 source "$(dirname "$0")/../../../../ci/lib/init.sh"
-source module /ci/cloudbuild/builds/lib/cmake.sh
+source module /ci/cloudbuild/builds/lib/ctest.sh
 source module /ci/etc/integration-tests-config.sh
 source module /google/cloud/pubsub/ci/lib/pubsub_emulator.sh
 

--- a/google/cloud/pubsub/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/pubsub/ci/run_integration_tests_emulator_cmake.sh
@@ -33,6 +33,10 @@ readonly BINARY_DIR
 shift
 ctest_args=("$@")
 
+if ctest --test-dir "${BINARY_DIR}" --show-only -R "^pubsub_" "${ctest_args[@]}" 2>&1 | grep -q 'Total Tests: 0'; then
+  exit 0
+fi
+
 cd "${BINARY_DIR}"
 # Start the emulator and arranges to kill it
 pubsub_emulator::start

--- a/google/cloud/spanner/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/spanner/ci/run_integration_tests_emulator_cmake.sh
@@ -17,6 +17,7 @@
 set -euo pipefail
 
 source "$(dirname "$0")/../../../../ci/lib/init.sh"
+source module /ci/cloudbuild/builds/lib/cmake.sh
 source module /ci/etc/integration-tests-config.sh
 source module /ci/lib/io.sh
 source module /google/cloud/spanner/ci/lib/spanner_emulator.sh
@@ -32,7 +33,7 @@ CMAKE_BINARY_DIR="$(realpath "${1}")"
 readonly CMAKE_BINARY_DIR
 shift
 
-if ctest --test-dir "${CMAKE_BINARY_DIR}" --show-only -R "^spanner_" "${ctest_args[@]}" 2>&1 | grep -q 'Total Tests: 0'; then
+if ctest::has_tests "${CMAKE_BINARY_DIR}" "^spanner_" "${ctest_args[@]}"; then
   exit 0
 fi
 

--- a/google/cloud/spanner/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/spanner/ci/run_integration_tests_emulator_cmake.sh
@@ -32,6 +32,10 @@ CMAKE_BINARY_DIR="$(realpath "${1}")"
 readonly CMAKE_BINARY_DIR
 shift
 
+if ctest --test-dir "${CMAKE_BINARY_DIR}" --show-only -R "^spanner_" "${ctest_args[@]}" 2>&1 | grep -q 'Total Tests: 0'; then
+  exit 0
+fi
+
 # Any additional arguments for the ctest invocation.
 ctest_args=("$@")
 

--- a/google/cloud/spanner/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/spanner/ci/run_integration_tests_emulator_cmake.sh
@@ -17,7 +17,7 @@
 set -euo pipefail
 
 source "$(dirname "$0")/../../../../ci/lib/init.sh"
-source module /ci/cloudbuild/builds/lib/cmake.sh
+source module /ci/cloudbuild/builds/lib/ctest.sh
 source module /ci/etc/integration-tests-config.sh
 source module /ci/lib/io.sh
 source module /google/cloud/spanner/ci/lib/spanner_emulator.sh

--- a/google/cloud/spanner/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/spanner/ci/run_integration_tests_emulator_cmake.sh
@@ -33,7 +33,7 @@ CMAKE_BINARY_DIR="$(realpath "${1}")"
 readonly CMAKE_BINARY_DIR
 shift
 
-if ctest::has_tests "${CMAKE_BINARY_DIR}" "^spanner_" "${ctest_args[@]}"; then
+if ctest::has_no_tests "${CMAKE_BINARY_DIR}" "^spanner_" "${ctest_args[@]}"; then
   exit 0
 fi
 

--- a/google/cloud/storage/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/storage/ci/run_integration_tests_emulator_cmake.sh
@@ -17,6 +17,7 @@
 set -euo pipefail
 
 source "$(dirname "$0")/../../../../ci/lib/init.sh"
+source module /ci/cloudbuild/builds/lib/cmake.sh
 source module /ci/etc/integration-tests-config.sh
 source module /ci/lib/run_gcs_httpbin_emulator_utils.sh
 
@@ -33,7 +34,7 @@ readonly BINARY_DIR
 shift
 ctest_args=("$@")
 
-if ctest --test-dir "${BINARY_DIR}" --show-only -R "^storage_" "${ctest_args[@]}" 2>&1 | grep -q 'Total Tests: 0'; then
+if ctest::has_tests "${BINARY_DIR}" "^storage_" "${ctest_args[@]}"; then
   exit 0
 fi
 

--- a/google/cloud/storage/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/storage/ci/run_integration_tests_emulator_cmake.sh
@@ -17,7 +17,7 @@
 set -euo pipefail
 
 source "$(dirname "$0")/../../../../ci/lib/init.sh"
-source module /ci/cloudbuild/builds/lib/cmake.sh
+source module /ci/cloudbuild/builds/lib/ctest.sh
 source module /ci/etc/integration-tests-config.sh
 source module /ci/lib/run_gcs_httpbin_emulator_utils.sh
 

--- a/google/cloud/storage/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/storage/ci/run_integration_tests_emulator_cmake.sh
@@ -33,6 +33,10 @@ readonly BINARY_DIR
 shift
 ctest_args=("$@")
 
+if ctest --test-dir "${BINARY_DIR}" --show-only -R "^storage_" "${ctest_args[@]}" 2>&1 | grep -q 'Total Tests: 0'; then
+  exit 0
+fi
+
 cd "${BINARY_DIR}"
 start_emulator
 

--- a/google/cloud/storage/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/storage/ci/run_integration_tests_emulator_cmake.sh
@@ -34,7 +34,7 @@ readonly BINARY_DIR
 shift
 ctest_args=("$@")
 
-if ctest::has_tests "${BINARY_DIR}" "^storage_" "${ctest_args[@]}"; then
+if ctest::has_no_tests "${BINARY_DIR}" "^storage_" "${ctest_args[@]}"; then
   exit 0
 fi
 


### PR DESCRIPTION
This script is expected to support /most/ developer workflows. We will be able to create a configuration file in $HOME or in the workspace to build only a subset of the code, with clang-tidy, and to run (or not run) the unit and integration tests associated with that code.

I expect this script will grow and be more customizable over time, as the team adds features to match their workflow.

Part of the work for #12801

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12804)
<!-- Reviewable:end -->
