### PR TITLE
fix(bigquery): core job library fixes for Query and GetQueryResults api

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/job_request.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.h
@@ -545,6 +545,9 @@ class PostQueryRequest {
 
   std::string const& project_id() const { return project_id_; }
   QueryRequest const& query_request() const { return query_request_; }
+  std::vector<std::string> json_filter_keys() const {
+    return json_filter_keys_;
+  }
 
   PostQueryRequest& set_project_id(std::string project_id) & {
     project_id_ = std::move(project_id);
@@ -562,6 +565,14 @@ class PostQueryRequest {
     return std::move(set_query_request(std::move(query_request)));
   }
 
+  PostQueryRequest& set_json_filter_keys(std::vector<std::string> keys) & {
+    json_filter_keys_ = std::move(keys);
+    return *this;
+  }
+  PostQueryRequest&& set_json_filter_keys(std::vector<std::string> keys) && {
+    return std::move(set_json_filter_keys(std::move(keys)));
+  }
+
   std::string DebugString(absl::string_view name,
                           TracingOptions const& options = {},
                           int indent = 0) const;
@@ -569,6 +580,7 @@ class PostQueryRequest {
  private:
   std::string project_id_;
   QueryRequest query_request_;
+  std::vector<std::string> json_filter_keys_;
 };
 void to_json(nlohmann::json& j, PostQueryRequest const& q);
 void from_json(nlohmann::json const& j, PostQueryRequest& q);
@@ -588,7 +600,6 @@ class GetQueryResultsRequest {
   std::uint32_t const& max_results() const { return max_results_; }
 
   std::chrono::milliseconds const& timeout() const { return timeout_; }
-  DataFormatOptions const& format_options() const { return format_options_; }
 
   GetQueryResultsRequest& set_project_id(std::string project_id) & {
     project_id_ = std::move(project_id);
@@ -646,16 +657,6 @@ class GetQueryResultsRequest {
     return std::move(set_timeout(std::move(timeout)));
   }
 
-  GetQueryResultsRequest& set_format_options(
-      DataFormatOptions format_options) & {
-    format_options_ = std::move(format_options);
-    return *this;
-  }
-  GetQueryResultsRequest&& set_format_options(
-      DataFormatOptions format_options) && {
-    return std::move(set_format_options(std::move(format_options)));
-  }
-
   std::string DebugString(absl::string_view name,
                           TracingOptions const& options = {},
                           int indent = 0) const;
@@ -670,8 +671,6 @@ class GetQueryResultsRequest {
   std::uint32_t max_results_ = 0;
 
   std::chrono::milliseconds timeout_ = std::chrono::milliseconds(0);
-
-  DataFormatOptions format_options_;
 };
 void to_json(nlohmann::json& j, GetQueryResultsRequest const& q);
 void from_json(nlohmann::json const& j, GetQueryResultsRequest& q);

--- a/google/cloud/bigquery/v2/minimal/internal/job_request_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request_test.cc
@@ -1125,7 +1125,7 @@ TEST(PostQueryRequestTest, DebugString) {
       R"( query: "select 1;" kind: "query-kind" parameter_mode: "parameter-mode")"
       R"( location: "useast1" request_id: "1234" dry_run: true)"
       R"( preserver_nulls: true use_query_cache: true use_legacy_sql: true)"
-      R"( create_session: true max_results: 10 maximum_bytes_biller: 100000)"
+      R"( create_session: true max_results: 10 maximum_bytes_billed: 100000)"
       R"( timeout { "10ms" } connection_properties { key: "conn-prop-key")"
       R"( value: "conn-prop-val" } query_parameters { name: "query-parameter-name")"
       R"( parameter_type { type: "query-parameter-type" struct_types {)"
@@ -1144,7 +1144,7 @@ TEST(PostQueryRequestTest, DebugString) {
       R"( kind: "query-k...<truncated>..." parameter_mode: "paramet...<truncated>...")"
       R"( location: "useast1" request_id: "1234" dry_run: true preserver_nulls: true)"
       R"( use_query_cache: true use_legacy_sql: true create_session: true)"
-      R"( max_results: 10 maximum_bytes_biller: 100000 timeout { "10ms" })"
+      R"( max_results: 10 maximum_bytes_billed: 100000 timeout { "10ms" })"
       R"( connection_properties { key: "conn-pr...<truncated>...")"
       R"( value: "conn-pr...<truncated>..." } query_parameters {)"
       R"( name: "query-p...<truncated>..." parameter_type {)"
@@ -1171,7 +1171,7 @@ TEST(PostQueryRequestTest, DebugString) {
     use_legacy_sql: true
     create_session: true
     max_results: 10
-    maximum_bytes_biller: 100000
+    maximum_bytes_billed: 100000
     timeout {
       "10ms"
     }
@@ -1259,7 +1259,6 @@ TEST(GetQueryResultsRequestTest, SuccessWithQueryParameters) {
   expected.AddQueryParameter("startIndex", "1");
   expected.AddQueryParameter("maxResults", "10");
   expected.AddQueryParameter("timeoutMs", "30");
-  expected.AddQueryParameter("formatOptions", R"({"useInt64Timestamp":true})");
 
   EXPECT_EQ(expected, *actual);
 }
@@ -1278,7 +1277,6 @@ TEST(GetQueryResultsRequestTest, SuccessWithoutQueryParameters) {
   expected.SetPath(
       "https://bigquery.googleapis.com/bigquery/v2/projects/1/queries/2");
   expected.AddQueryParameter("startIndex", "0");
-  expected.AddQueryParameter("formatOptions", R"({"useInt64Timestamp":false})");
 
   EXPECT_EQ(expected, *actual);
 }
@@ -1314,7 +1312,6 @@ TEST(GetQueryResultsRequestTest, DebugString) {
             R"( page_token: "npt123" location: "useast")"
             R"( start_index: 1 max_results: 10)"
             R"( timeout { "30ms" })"
-            R"( format_options { use_int64_timestamp: true })"
             R"( })");
 
   EXPECT_EQ(request.DebugString("GetQueryResultsRequest",
@@ -1324,7 +1321,6 @@ TEST(GetQueryResultsRequestTest, DebugString) {
             R"( project_id: "1" job_id: "2" page_token: "npt123")"
             R"( location: "useast" start_index: 1 max_results: 10)"
             R"( timeout { "30ms" })"
-            R"( format_options { use_int64_timestamp: true })"
             R"( })");
 
   EXPECT_EQ(
@@ -1339,9 +1335,6 @@ TEST(GetQueryResultsRequestTest, DebugString) {
   max_results: 10
   timeout {
     "30ms"
-  }
-  format_options {
-    use_int64_timestamp: true
   }
 })");
 }

--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.cc
@@ -64,10 +64,11 @@ StatusOr<InsertJobResponse> DefaultBigQueryJobRestStub::InsertJob(
   nlohmann::json json_payload;
   to_json(json_payload, request.job());
 
+  // 4) Filter out any keys that are being requested to be removed.
   auto filtered_json = RemoveJsonKeysAndEmptyFields(json_payload.dump(),
                                                     request.json_filter_keys());
 
-  // 4) Call the rest stub and parse the RestResponse.
+  // 5) Call the rest stub and parse the RestResponse.
   rest_internal::RestContext context;
   return ParseFromRestResponse<InsertJobResponse>(
       rest_stub_->Post(context, std::move(*rest_request),
@@ -107,11 +108,15 @@ StatusOr<QueryResponse> DefaultBigQueryJobRestStub::Query(
   nlohmann::json json_payload;
   to_json(json_payload, request.query_request());
 
-  // 4) Call the rest stub and parse the RestResponse.
+  // 4) Filter out any keys that are being requested to be removed.
+  auto filtered_json = RemoveJsonKeysAndEmptyFields(json_payload.dump(),
+                                                    request.json_filter_keys());
+
+  // 5) Call the rest stub and parse the RestResponse.
   rest_internal::RestContext context;
   return ParseFromRestResponse<QueryResponse>(
       rest_stub_->Post(context, std::move(*rest_request),
-                       {absl::MakeConstSpan(json_payload.dump())}));
+                       {absl::MakeConstSpan(filtered_json.dump())}));
 }
 
 StatusOr<GetQueryResultsResponse> DefaultBigQueryJobRestStub::GetQueryResults(

--- a/google/cloud/bigquery/v2/minimal/internal/json_utils.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/json_utils.cc
@@ -50,6 +50,14 @@ void ToJson(std::chrono::milliseconds const& field, nlohmann::json& j,
   j[name] = std::to_string(m);
 }
 
+void ToIntJson(std::chrono::milliseconds const& field, nlohmann::json& j,
+               char const* name) {
+  auto m = static_cast<std::int64_t>(
+      std::chrono::duration_cast<std::chrono::milliseconds>(field).count());
+
+  j[name] = m;
+}
+
 void FromJson(std::chrono::hours& field, nlohmann::json const& j,
               char const* name) {
   auto const m = GetNumberFromJson(j, name);

--- a/google/cloud/bigquery/v2/minimal/internal/json_utils.h
+++ b/google/cloud/bigquery/v2/minimal/internal/json_utils.h
@@ -31,6 +31,8 @@ void FromJson(std::chrono::milliseconds& field, nlohmann::json const& j,
 
 void ToJson(std::chrono::milliseconds const& field, nlohmann::json& j,
             char const* name);
+void ToIntJson(std::chrono::milliseconds const& field, nlohmann::json& j,
+               char const* name);
 
 void FromJson(std::chrono::system_clock::time_point& field,
               nlohmann::json const& j, char const* name);

--- a/google/cloud/bigquery/v2/minimal/internal/json_utils_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/json_utils_test.cc
@@ -62,6 +62,19 @@ TEST(JsonUtilsTest, ToJsonMillisecondsString) {
   EXPECT_EQ(expected_json, actual_json);
 }
 
+TEST(JsonUtilsTest, ToJsonMillisecondsNumber) {
+  auto const* const name = "start_time";
+  auto constexpr kJsonText = R"({"start_time":10})";
+  auto expected_json = nlohmann::json::parse(kJsonText, nullptr, false);
+  EXPECT_TRUE(expected_json.is_object());
+
+  auto field = std::chrono::milliseconds{10};
+  nlohmann::json actual_json;
+  ToIntJson(field, actual_json, name);
+
+  EXPECT_EQ(expected_json, actual_json);
+}
+
 TEST(JsonUtilsTest, FromJsonHoursNumber) {
   auto const* const name = "start_time";
   auto constexpr kJsonText = R"({"start_time":10})";

--- a/google/cloud/bigquery/v2/minimal/testing/job_query_test_utils.cc
+++ b/google/cloud/bigquery/v2/minimal/testing/job_query_test_utils.cc
@@ -98,7 +98,6 @@ GetQueryResultsRequest MakeFullGetQueryResultsRequest() {
       .set_page_token("npt123")
       .set_start_index(1)
       .set_timeout(std::chrono::milliseconds(30))
-      .set_format_options(format_options)
       .set_location("useast");
 
   return request;


### PR DESCRIPTION
This PR includes the following fixes for the core Job library found during benchmark and end to end testing
of the Query and GetQueryResults api

- Added methods to PostQueryRequest() to record json keys that need to be filtered.
- Modified Query() rest stub to filter out json keys from the request, in the json payload.
- Modified “timeoutMs” field to be integer in GetQueryResultsRequest.
- Removed “formatOptions” from GetQueryResultsRequest as the server rejects it even though the documentation mentions it.
- Fixed “maximumBytesBilled” to be string in PostQueryRequest
- Fixed parsing of QueryResponse and GetQueryResultsResponse fields. This includes 64-bit parsing of integer fields, handling absent fields etc.

The above has been tested with a benchmark program. I'll send the benchmark program changes after the above is merged.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12805)
<!-- Reviewable:end -->
