### PR TITLE
ci: refactor ctest:: function to its own module(s)

### DIFF
--- a/ci/cloudbuild/builds/clang-7.0.sh
+++ b/ci/cloudbuild/builds/clang-7.0.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
+source module ci/cloudbuild/builds/lib/ctest.sh
 source module ci/cloudbuild/builds/lib/features.sh
 source module ci/lib/io.sh
 

--- a/ci/cloudbuild/builds/clang-tidy.sh
+++ b/ci/cloudbuild/builds/clang-tidy.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
+source module ci/cloudbuild/builds/lib/ctest.sh
 source module ci/cloudbuild/builds/lib/features.sh
 source module ci/cloudbuild/builds/lib/integration.sh
 source module ci/lib/io.sh

--- a/ci/cloudbuild/builds/cmake-gcs-rest.sh
+++ b/ci/cloudbuild/builds/cmake-gcs-rest.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
+source module ci/cloudbuild/builds/lib/ctest.sh
 source module ci/cloudbuild/builds/lib/features.sh
 source module ci/cloudbuild/builds/lib/integration.sh
 source module ci/lib/io.sh

--- a/ci/cloudbuild/builds/cmake-install.sh
+++ b/ci/cloudbuild/builds/cmake-install.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
+source module ci/cloudbuild/builds/lib/ctest.sh
 source module ci/cloudbuild/builds/lib/features.sh
 source module ci/cloudbuild/builds/lib/quickstart.sh
 source module ci/lib/io.sh

--- a/ci/cloudbuild/builds/cmake-oldest-deps.sh
+++ b/ci/cloudbuild/builds/cmake-oldest-deps.sh
@@ -21,6 +21,7 @@ export CXX=clang++
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
+source module ci/cloudbuild/builds/lib/ctest.sh
 source module ci/cloudbuild/builds/lib/integration.sh
 source module ci/cloudbuild/builds/lib/vcpkg.sh
 source module ci/lib/io.sh

--- a/ci/cloudbuild/builds/cxx14.sh
+++ b/ci/cloudbuild/builds/cxx14.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
+source module ci/cloudbuild/builds/lib/ctest.sh
 source module ci/cloudbuild/builds/lib/features.sh
 source module ci/cloudbuild/builds/lib/integration.sh
 source module ci/lib/io.sh

--- a/ci/cloudbuild/builds/cxx20.sh
+++ b/ci/cloudbuild/builds/cxx20.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
+source module ci/cloudbuild/builds/lib/ctest.sh
 source module ci/cloudbuild/builds/lib/features.sh
 source module ci/cloudbuild/builds/lib/integration.sh
 source module ci/lib/io.sh

--- a/ci/cloudbuild/builds/gcc-7.3.sh
+++ b/ci/cloudbuild/builds/gcc-7.3.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
+source module ci/cloudbuild/builds/lib/ctest.sh
 source module ci/lib/io.sh
 
 # We run this test in a docker image that includes the oldest GCC that we

--- a/ci/cloudbuild/builds/lib/cmake.sh
+++ b/ci/cloudbuild/builds/lib/cmake.sh
@@ -68,16 +68,3 @@ function cmake::common_args() {
   fi
   printf "%s\n" "${args[@]}"
 }
-
-function ctest::common_args() {
-  local args
-  args=(
-    # Print the full output on failures
-    --output-on-failure
-    # Run many tests in parallel, use -j for compatibility with old versions
-    -j "$(nproc)"
-    # Make the output shorter on interactive tests
-    --progress
-  )
-  printf "%s\n" "${args[@]}"
-}

--- a/ci/cloudbuild/builds/lib/ctest.sh
+++ b/ci/cloudbuild/builds/lib/ctest.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This bash library has various helper functions for our cmake-based builds.
+
+# Make our include guard clean against set -o nounset.
+test -n "${CI_CLOUDBUILD_BUILDS_LIB_CTEST_SH__:-}" || declare -i CI_CLOUDBUILD_BUILDS_LIB_CTEST_SH__=0
+if ((CI_CLOUDBUILD_BUILDS_LIB_CTEST_SH__++ != 0)); then
+  return 0
+fi # include guard
+
+function ctest::common_args() {
+  local args
+  args=(
+    # Print the full output on failures
+    --output-on-failure
+    # Run many tests in parallel, use -j for compatibility with old versions
+    -j "$(nproc)"
+    # Make the output shorter on interactive tests
+    --progress
+  )
+  printf "%s\n" "${args[@]}"
+}

--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -23,6 +23,7 @@ if ((CI_CLOUDBUILD_BUILDS_LIB_INTEGRATION_SH__++ != 0)); then
 fi # include guard
 
 source module ci/etc/integration-tests-config.sh
+source module ci/cloudbuild/builds/lib/ctest.sh
 source module ci/cloudbuild/builds/lib/git.sh
 source module ci/lib/io.sh
 

--- a/ci/cloudbuild/builds/m32.sh
+++ b/ci/cloudbuild/builds/m32.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
+source module ci/cloudbuild/builds/lib/ctest.sh
 source module ci/cloudbuild/builds/lib/features.sh
 source module ci/cloudbuild/builds/lib/integration.sh
 source module ci/lib/io.sh

--- a/ci/cloudbuild/builds/noex.sh
+++ b/ci/cloudbuild/builds/noex.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
+source module ci/cloudbuild/builds/lib/ctest.sh
 source module ci/cloudbuild/builds/lib/features.sh
 source module ci/cloudbuild/builds/lib/integration.sh
 source module ci/lib/io.sh

--- a/ci/cloudbuild/builds/quickstart-production.sh
+++ b/ci/cloudbuild/builds/quickstart-production.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
+source module ci/cloudbuild/builds/lib/ctest.sh
 source module ci/cloudbuild/builds/lib/features.sh
 source module ci/cloudbuild/builds/lib/quickstart.sh
 source module ci/lib/io.sh

--- a/ci/cloudbuild/builds/shared.sh
+++ b/ci/cloudbuild/builds/shared.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
+source module ci/cloudbuild/builds/lib/ctest.sh
 source module ci/cloudbuild/builds/lib/features.sh
 source module ci/cloudbuild/builds/lib/quickstart.sh
 source module ci/lib/io.sh

--- a/ci/gha/builds/external-account.sh
+++ b/ci/gha/builds/external-account.sh
@@ -19,6 +19,7 @@ set -euo pipefail
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/gha/builds/lib/linux.sh
 source module ci/gha/builds/lib/cmake.sh
+source module ci/gha/builds/lib/ctest.sh
 
 mapfile -t args < <(cmake::common_args)
 mapfile -t vcpkg_args < <(cmake::vcpkg_args)

--- a/ci/gha/builds/lib/cmake.sh
+++ b/ci/gha/builds/lib/cmake.sh
@@ -71,16 +71,3 @@ function cmake::vcpkg_args() {
   )
   printf "%s\n" "${args[@]}"
 }
-
-function ctest::common_args() {
-  local args
-  args=(
-    # Print the full output on failures
-    --output-on-failure
-    # Run many tests in parallel, use -j for compatibility with old versions
-    -j "$(os::cpus)"
-    # Make the output shorter on interactive tests
-    --progress
-  )
-  printf "%s\n" "${args[@]}"
-}

--- a/ci/gha/builds/lib/ctest.sh
+++ b/ci/gha/builds/lib/ctest.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Make our include guard clean against set -o nounset.
+test -n "${CI_GHA_BUILDS_LIB_CTEST_SH__:-}" || declare -i CI_GHA_BUILDS_LIB_CTEST_SH__=0
+if ((CI_GHA_BUILDS_LIB_CTEST_SH__++ != 0)); then
+  return 0
+fi # include guard
+
+function ctest::common_args() {
+  local args
+  args=(
+    # Print the full output on failures
+    --output-on-failure
+    # Run many tests in parallel, use -j for compatibility with old versions
+    -j "$(os::cpus)"
+    # Make the output shorter on interactive tests
+    --progress
+  )
+  printf "%s\n" "${args[@]}"
+}

--- a/ci/gha/builds/macos-cmake.sh
+++ b/ci/gha/builds/macos-cmake.sh
@@ -19,6 +19,7 @@ set -euo pipefail
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/gha/builds/lib/macos.sh
 source module ci/gha/builds/lib/cmake.sh
+source module ci/gha/builds/lib/ctest.sh
 
 # Usage: macos-cmake.sh <value for GOOGLE_CLOUD_CPP_ENABLE>
 #

--- a/ci/gha/builds/windows-cmake.sh
+++ b/ci/gha/builds/windows-cmake.sh
@@ -19,6 +19,7 @@ set -euo pipefail
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/gha/builds/lib/windows.sh
 source module ci/gha/builds/lib/cmake.sh
+source module ci/gha/builds/lib/ctest.sh
 
 # Usage: macos-cmake.sh <build-type> <value for GOOGLE_CLOUD_CPP_ENABLE>
 #


### PR DESCRIPTION
This will make it possible to use ctest::* without the `cmake.sh` side-effects.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12807)
<!-- Reviewable:end -->
