### PR TITLE
cleanup(storage): use `rest_internal` in tests

### DIFF
--- a/google/cloud/storage/testing/retry_http_request.cc
+++ b/google/cloud/storage/testing/retry_http_request.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "google/cloud/storage/testing/retry_http_request.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/make_status.h"
 #include "google/cloud/internal/rest_client.h"
-#include "google/cloud/common_options.h"
 #include <chrono>
 #include <thread>
 #include <utility>
@@ -55,7 +55,8 @@ StatusOr<std::string> Retry(
 StatusOr<std::string> RetryHttpGet(
     std::string const& url,
     std::function<rest_internal::RestRequest()> const& factory) {
-  auto client = rest_internal::MakeDefaultRestClient(url, Options{}.set<TracingComponentsOption>({"http"}));
+  auto client = rest_internal::MakeDefaultRestClient(
+      url, Options{}.set<TracingComponentsOption>({"http"}));
   auto call = [&]() -> StatusOr<std::string> {
     rest_internal::RestContext context;
     return HandleResponse(client->Get(context, factory()));
@@ -65,11 +66,14 @@ StatusOr<std::string> RetryHttpGet(
 
 StatusOr<std::string> RetryHttpPut(
     std::string const& url,
-    std::function<rest_internal::RestRequest()> const& factory) {
-  auto client = rest_internal::MakeDefaultRestClient(url, Options{}.set<TracingComponentsOption>({"http"}));
+    std::function<rest_internal::RestRequest()> const& factory,
+    std::string const& payload) {
+  auto client = rest_internal::MakeDefaultRestClient(
+      url, Options{}.set<TracingComponentsOption>({"http"}));
   auto call = [&]() -> StatusOr<std::string> {
     rest_internal::RestContext context;
-    return HandleResponse(client->Put(context, factory(), {}));
+    return HandleResponse(
+        client->Put(context, factory(), {absl::Span<char const>(payload)}));
   };
   return Retry(call);
 }

--- a/google/cloud/storage/testing/retry_http_request.cc
+++ b/google/cloud/storage/testing/retry_http_request.cc
@@ -13,23 +13,65 @@
 // limitations under the License.
 
 #include "google/cloud/storage/testing/retry_http_request.h"
+#include "google/cloud/internal/make_status.h"
+#include "google/cloud/internal/rest_client.h"
+#include "google/cloud/common_options.h"
 #include <chrono>
 #include <thread>
+#include <utility>
 
 namespace google {
 namespace cloud {
 namespace storage {
 namespace testing {
+namespace {
 
-StatusOr<internal::HttpResponse> RetryHttpRequest(
-    std::function<internal::CurlRequest()> const& factory) {
-  StatusOr<internal::HttpResponse> response;
+StatusOr<std::string> HandleResponse(
+    StatusOr<std::unique_ptr<rest_internal::RestResponse>> r) {
+  if (!r) return std::move(r).status();
+  auto response = *std::move(r);
+  if (response->StatusCode() != 200) {
+    return internal::InternalError(
+        "unexpected status code",
+        GCP_ERROR_INFO().WithMetadata("http.status_code",
+                                      std::to_string(response->StatusCode())));
+  }
+  return rest_internal::ReadAll(std::move(*response).ExtractPayload());
+}
+
+StatusOr<std::string> Retry(
+    std::function<StatusOr<std::string>()> const& call) {
+  StatusOr<std::string> response;
   for (int i = 0; i != 3; ++i) {
-    response = factory().MakeRequest({});
+    response = call();
     if (response) return response;
     std::this_thread::sleep_for(std::chrono::seconds(1));
   }
   return response;
+}
+
+}  // namespace
+
+StatusOr<std::string> RetryHttpGet(
+    std::string const& url,
+    std::function<rest_internal::RestRequest()> const& factory) {
+  auto client = rest_internal::MakeDefaultRestClient(url, Options{}.set<TracingComponentsOption>({"http"}));
+  auto call = [&]() -> StatusOr<std::string> {
+    rest_internal::RestContext context;
+    return HandleResponse(client->Get(context, factory()));
+  };
+  return Retry(call);
+}
+
+StatusOr<std::string> RetryHttpPut(
+    std::string const& url,
+    std::function<rest_internal::RestRequest()> const& factory) {
+  auto client = rest_internal::MakeDefaultRestClient(url, Options{}.set<TracingComponentsOption>({"http"}));
+  auto call = [&]() -> StatusOr<std::string> {
+    rest_internal::RestContext context;
+    return HandleResponse(client->Put(context, factory(), {}));
+  };
+  return Retry(call);
 }
 
 }  // namespace testing

--- a/google/cloud/storage/testing/retry_http_request.h
+++ b/google/cloud/storage/testing/retry_http_request.h
@@ -15,10 +15,10 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_TESTING_RETRY_HTTP_REQUEST_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_TESTING_RETRY_HTTP_REQUEST_H
 
-#include "google/cloud/storage/internal/curl/request.h"
-#include "google/cloud/storage/internal/http_response.h"
+#include "google/cloud/internal/rest_request.h"
 #include "google/cloud/status_or.h"
 #include <functional>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -26,8 +26,14 @@ namespace storage {
 namespace testing {
 
 /// Avoid flakes in integration tests, retry failures 3 times.
-StatusOr<internal::HttpResponse> RetryHttpRequest(
-    std::function<internal::CurlRequest()> const& factory);
+StatusOr<std::string> RetryHttpGet(
+    std::string const& url,
+    std::function<rest_internal::RestRequest()> const& factory);
+
+/// Avoid flakes in integration tests, retry failures 3 times.
+StatusOr<std::string> RetryHttpPut(
+    std::string const& url,
+    std::function<rest_internal::RestRequest()> const& factory);
 
 }  // namespace testing
 }  // namespace storage

--- a/google/cloud/storage/testing/retry_http_request.h
+++ b/google/cloud/storage/testing/retry_http_request.h
@@ -33,7 +33,8 @@ StatusOr<std::string> RetryHttpGet(
 /// Avoid flakes in integration tests, retry failures 3 times.
 StatusOr<std::string> RetryHttpPut(
     std::string const& url,
-    std::function<rest_internal::RestRequest()> const& factory);
+    std::function<rest_internal::RestRequest()> const& factory,
+    std::string const& payload);
 
 }  // namespace testing
 }  // namespace storage

--- a/google/cloud/storage/tests/signed_url_integration_test.cc
+++ b/google/cloud/storage/tests/signed_url_integration_test.cc
@@ -98,7 +98,7 @@ TEST_F(SignedUrlIntegrationTest, CreateV2SignedUrlPut) {
     return rest_internal::RestRequest().AddHeader("content-type",
                                                   "application/octet-stream");
   };
-  auto response = RetryHttpPut(*signed_url, factory);
+  auto response = RetryHttpPut(*signed_url, factory, expected);
   ASSERT_STATUS_OK(response);
 
   auto stream = client->ReadObject(bucket_name_, object_name);
@@ -150,8 +150,11 @@ TEST_F(SignedUrlIntegrationTest, CreateV4SignedUrlPut) {
   ASSERT_STATUS_OK(signed_url);
 
   // Verify the signed URL can be used to upload the object.
-  auto response =
-      RetryHttpPut(*signed_url, [] { return rest_internal::RestRequest(); });
+  auto factory = [] {
+    return rest_internal::RestRequest().AddHeader("content-type",
+                                                  "application/octet-stream");
+  };
+  auto response = RetryHttpPut(*signed_url, factory, expected);
   ASSERT_STATUS_OK(response);
 
   auto stream = client->ReadObject(bucket_name_, object_name);

--- a/google/cloud/storage/tests/signed_url_integration_test.cc
+++ b/google/cloud/storage/tests/signed_url_integration_test.cc
@@ -13,9 +13,10 @@
 // limitations under the License.
 
 #include "google/cloud/storage/client.h"
-#include "google/cloud/storage/internal/curl/request_builder.h"
+#include "google/cloud/storage/testing/retry_http_request.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
 #include "google/cloud/internal/getenv.h"
+#include "google/cloud/internal/rest_request.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <chrono>
@@ -27,6 +28,10 @@ namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
+
+using ::google::cloud::storage::testing::RetryHttpGet;
+using ::google::cloud::storage::testing::RetryHttpPut;
+using ::google::cloud::testing_util::IsOkAndHolds;
 
 class SignedUrlIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {
@@ -45,18 +50,6 @@ class SignedUrlIntegrationTest
 
   std::string bucket_name_;
   std::string service_account_;
-};
-
-StatusOr<internal::HttpResponse> RetryHttpRequest(
-    std::function<internal::CurlRequest()> const& factory,
-    std::string const& payload = {}) {
-  StatusOr<internal::HttpResponse> response;
-  for (int i = 0; i != 3; ++i) {
-    response = factory().MakeRequest(payload);
-    if (response) return response;
-    std::this_thread::sleep_for(std::chrono::seconds(1));
-  }
-  return response;
 };
 
 TEST_F(SignedUrlIntegrationTest, CreateV2SignedUrlGet) {
@@ -80,17 +73,9 @@ TEST_F(SignedUrlIntegrationTest, CreateV2SignedUrlGet) {
   ASSERT_STATUS_OK(signed_url);
 
   // Verify the signed URL can be used to download the object.
-  auto factory = [&] {
-    internal::CurlRequestBuilder builder(
-        *signed_url, storage::internal::GetDefaultCurlHandleFactory());
-    return std::move(builder).BuildRequest();
-  };
-
-  auto response = RetryHttpRequest(factory);
-  ASSERT_STATUS_OK(response);
-  EXPECT_EQ(200, response->status_code);
-
-  EXPECT_EQ(expected, response->payload);
+  auto response =
+      RetryHttpGet(*signed_url, [] { return rest_internal::RestRequest(); });
+  EXPECT_THAT(response, IsOkAndHolds(expected));
 }
 
 TEST_F(SignedUrlIntegrationTest, CreateV2SignedUrlPut) {
@@ -109,17 +94,12 @@ TEST_F(SignedUrlIntegrationTest, CreateV2SignedUrlPut) {
   ASSERT_STATUS_OK(signed_url);
 
   // Verify the signed URL can be used to download the object.
-  auto factory = [&] {
-    internal::CurlRequestBuilder builder(
-        *signed_url, storage::internal::GetDefaultCurlHandleFactory());
-    builder.SetMethod("PUT");
-    builder.AddHeader("content-type: application/octet-stream");
-    return std::move(builder).BuildRequest();
+  auto factory = [] {
+    return rest_internal::RestRequest().AddHeader("content-type",
+                                                  "application/octet-stream");
   };
-
-  auto response = RetryHttpRequest(factory, expected);
+  auto response = RetryHttpPut(*signed_url, factory);
   ASSERT_STATUS_OK(response);
-  EXPECT_EQ(200, response->status_code);
 
   auto stream = client->ReadObject(bucket_name_, object_name);
   std::string actual(std::istreambuf_iterator<char>{stream}, {});
@@ -150,17 +130,9 @@ TEST_F(SignedUrlIntegrationTest, CreateV4SignedUrlGet) {
   ASSERT_STATUS_OK(signed_url);
 
   // Verify the signed URL can be used to download the object.
-  auto factory = [&] {
-    internal::CurlRequestBuilder builder(
-        *signed_url, storage::internal::GetDefaultCurlHandleFactory());
-    return std::move(builder).BuildRequest();
-  };
-
-  auto response = RetryHttpRequest(factory);
-  ASSERT_STATUS_OK(response);
-  EXPECT_EQ(200, response->status_code);
-
-  EXPECT_EQ(expected, response->payload);
+  auto response =
+      RetryHttpGet(*signed_url, [] { return rest_internal::RestRequest(); });
+  EXPECT_THAT(response, IsOkAndHolds(expected));
 }
 
 TEST_F(SignedUrlIntegrationTest, CreateV4SignedUrlPut) {
@@ -177,17 +149,10 @@ TEST_F(SignedUrlIntegrationTest, CreateV4SignedUrlPut) {
       "PUT", bucket_name_, object_name, SigningAccount(service_account_));
   ASSERT_STATUS_OK(signed_url);
 
-  // Verify the signed URL can be used to download the object.
-  auto factory = [&] {
-    internal::CurlRequestBuilder builder(
-        *signed_url, storage::internal::GetDefaultCurlHandleFactory());
-    builder.SetMethod("PUT");
-    return std::move(builder).BuildRequest();
-  };
-
-  auto response = RetryHttpRequest(factory, expected);
+  // Verify the signed URL can be used to upload the object.
+  auto response =
+      RetryHttpPut(*signed_url, [] { return rest_internal::RestRequest(); });
   ASSERT_STATUS_OK(response);
-  EXPECT_EQ(200, response->status_code);
 
   auto stream = client->ReadObject(bucket_name_, object_name);
   std::string actual(std::istreambuf_iterator<char>{stream}, {});


### PR DESCRIPTION
Some integration tests need to make raw HTTP request. Use `rest_internal` types to make these, reducing the dependencies on `storage::internal::Curl*`.

Part of the work for #9659

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12821)
<!-- Reviewable:end -->
