### PR TITLE
fix(bigquery): Job Library fixes for CancelJob api

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_rest_stub.cc
@@ -81,8 +81,6 @@ StatusOr<CancelJobResponse> DefaultBigQueryJobRestStub::CancelJob(
   auto rest_request =
       PrepareRestRequest<CancelJobRequest>(rest_context, request);
 
-  rest_request->AddHeader("Content-Type", "application/json");
-
   // For cancel jobs, request body is empty:
   // https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/cancel#request-body
   absl::Span<char const> empty_span = absl::MakeConstSpan("");


### PR DESCRIPTION
This PR includes the following fixes for the core Job library found during benchmark and end to end testing
of the CancelJob api

- Removed content-type header from CancelJob api request since the request body
  needs to be empty.

This has been tested end to end with the benchmark program which I'll send in a
follow-up PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12825)
<!-- Reviewable:end -->
