### PR TITLE
impl: consistently name our OTel events

### DIFF
--- a/google/cloud/bigtable/internal/traced_row_reader.cc
+++ b/google/cloud/bigtable/internal/traced_row_reader.cc
@@ -38,7 +38,7 @@ class TracedRowReader : public bigtable_internal::RowReaderImpl {
 
   /// Skips remaining rows and invalidates current iterator.
   void Cancel() override {
-    span_->AddEvent("cancel");
+    span_->AddEvent("gl-cpp.cancel");
     reader_.Cancel();
   };
 

--- a/google/cloud/bigtable/internal/traced_row_reader_test.cc
+++ b/google/cloud/bigtable/internal/traced_row_reader_test.cc
@@ -143,7 +143,7 @@ TEST(TracedStreamRange, Cancel) {
 
   EXPECT_THAT(span_catcher->GetSpans(),
               ElementsAre(AllOf(SpanNamed("span"),
-                                SpanEventsAre(EventNamed("cancel")))));
+                                SpanEventsAre(EventNamed("gl-cpp.cancel")))));
 }
 
 }  // namespace

--- a/google/cloud/internal/async_read_write_stream_tracing.h
+++ b/google/cloud/internal/async_read_write_stream_tracing.h
@@ -39,14 +39,14 @@ class AsyncStreamingReadWriteRpcTracing
   ~AsyncStreamingReadWriteRpcTracing() override { (void)End(Status()); }
 
   void Cancel() override {
-    span_->AddEvent("cancel");
+    span_->AddEvent("gl-cpp.cancel");
     impl_->Cancel();
   }
 
   future<bool> Start() override {
     return impl_->Start().then([this](future<bool> f) {
       auto started = f.get();
-      span_->SetAttribute("gcloud.stream_started", started);
+      span_->SetAttribute("gl-cpp.stream_started", started);
       return started;
     });
   }
@@ -78,7 +78,7 @@ class AsyncStreamingReadWriteRpcTracing
 
   future<bool> WritesDone() override {
     return impl_->WritesDone().then([this](future<bool> f) {
-      span_->AddEvent("gcloud.writes_done");
+      span_->AddEvent("gl-cpp.writes_done");
       return f.get();
     });
   }

--- a/google/cloud/internal/async_read_write_stream_tracing_test.cc
+++ b/google/cloud/internal/async_read_write_stream_tracing_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/testing_util/opentelemetry_matchers.h"
 #include "google/cloud/testing_util/status_matchers.h"
+#include "google/cloud/testing_util/validate_metadata.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -82,7 +83,7 @@ TEST(AsyncStreamingReadWriteRpcTracing, Cancel) {
       spans,
       ElementsAre(AllOf(
           SpanNamed("span"),
-          SpanEventsAre(EventNamed("cancel"),
+          SpanEventsAre(EventNamed("gl-cpp.cancel"),
                         EventNamed("test-only: underlying stream cancel")))));
 }
 
@@ -103,7 +104,7 @@ TEST(AsyncStreamingReadWriteRpcTracing, Start) {
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(spans, ElementsAre(AllOf(SpanNamed("span"),
                                        SpanHasAttributes(OTelAttribute<bool>(
-                                           "gcloud.stream_started", true)))));
+                                           "gl-cpp.stream_started", true)))));
 }
 
 TEST(AsyncStreamingReadWriteRpcTracing, Read) {
@@ -246,7 +247,7 @@ TEST(AsyncStreamingReadWriteRpcTracing, WritesDone) {
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(spans, ElementsAre(AllOf(
                          SpanNamed("span"),
-                         SpanEventsAre(EventNamed("gcloud.writes_done")))));
+                         SpanEventsAre(EventNamed("gl-cpp.writes_done")))));
 }
 
 TEST(AsyncStreamingReadWriteRpcTracing, Finish) {

--- a/google/cloud/internal/async_streaming_read_rpc_tracing.h
+++ b/google/cloud/internal/async_streaming_read_rpc_tracing.h
@@ -38,14 +38,14 @@ class AsyncStreamingReadRpcTracing : public AsyncStreamingReadRpc<Response> {
   ~AsyncStreamingReadRpcTracing() override { (void)End(Status()); }
 
   void Cancel() override {
-    span_->AddEvent("cancel");
+    span_->AddEvent("gl-cpp.cancel");
     impl_->Cancel();
   }
 
   future<bool> Start() override {
     return impl_->Start().then([this](future<bool> f) {
       auto started = f.get();
-      span_->SetAttribute("gcloud.stream_started", started);
+      span_->SetAttribute("gl-cpp.stream_started", started);
       return started;
     });
   }

--- a/google/cloud/internal/async_streaming_read_rpc_tracing_test.cc
+++ b/google/cloud/internal/async_streaming_read_rpc_tracing_test.cc
@@ -70,7 +70,7 @@ TEST(AsyncStreamingReadRpcTracing, Cancel) {
       spans,
       ElementsAre(AllOf(
           SpanNamed("span"),
-          SpanEventsAre(EventNamed("cancel"),
+          SpanEventsAre(EventNamed("gl-cpp.cancel"),
                         EventNamed("test-only: underlying stream cancel")))));
 }
 
@@ -91,7 +91,7 @@ TEST(AsyncStreamingReadRpcTracing, Start) {
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(spans, ElementsAre(AllOf(SpanNamed("span"),
                                        SpanHasAttributes(OTelAttribute<bool>(
-                                           "gcloud.stream_started", true)))));
+                                           "gl-cpp.stream_started", true)))));
 }
 
 TEST(AsyncStreamingReadRpcTracing, Read) {

--- a/google/cloud/internal/async_streaming_write_rpc_tracing.h
+++ b/google/cloud/internal/async_streaming_write_rpc_tracing.h
@@ -43,14 +43,14 @@ class AsyncStreamingWriteRpcTracing
   }
 
   void Cancel() override {
-    span_->AddEvent("cancel");
+    span_->AddEvent("gl-cpp.cancel");
     impl_->Cancel();
   }
 
   future<bool> Start() override {
     return impl_->Start().then([this](future<bool> f) {
       auto started = f.get();
-      span_->SetAttribute("gcloud.stream_started", started);
+      span_->SetAttribute("gl-cpp.stream_started", started);
       return started;
     });
   }
@@ -71,7 +71,7 @@ class AsyncStreamingWriteRpcTracing
 
   future<bool> WritesDone() override {
     return impl_->WritesDone().then([this](future<bool> f) {
-      span_->AddEvent("gcloud.writes_done");
+      span_->AddEvent("gl-cpp.writes_done");
       return f.get();
     });
   }

--- a/google/cloud/internal/async_streaming_write_rpc_tracing_test.cc
+++ b/google/cloud/internal/async_streaming_write_rpc_tracing_test.cc
@@ -69,7 +69,7 @@ TEST(AsyncStreamingWriteRpcTracing, Cancel) {
       spans,
       ElementsAre(AllOf(
           SpanNamed("span"),
-          SpanEventsAre(EventNamed("cancel"),
+          SpanEventsAre(EventNamed("gl-cpp.cancel"),
                         EventNamed("test-only: underlying stream cancel")))));
 }
 
@@ -91,7 +91,7 @@ TEST(AsyncStreamingWriteRpcTracing, Start) {
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(spans, ElementsAre(AllOf(SpanNamed("span"),
                                        SpanHasAttributes(OTelAttribute<bool>(
-                                           "gcloud.stream_started", true)))));
+                                           "gl-cpp.stream_started", true)))));
 }
 
 TEST(AsyncStreamingWriteRpcTracing, Write) {
@@ -158,7 +158,7 @@ TEST(AsyncStreamingWriteRpcTracing, WritesDone) {
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(spans, ElementsAre(AllOf(
                          SpanNamed("span"),
-                         SpanEventsAre(EventNamed("gcloud.writes_done")))));
+                         SpanEventsAre(EventNamed("gl-cpp.writes_done")))));
 }
 
 TEST(AsyncStreamingWriteRpcTracing, Finish) {

--- a/google/cloud/internal/streaming_read_rpc_tracing.h
+++ b/google/cloud/internal/streaming_read_rpc_tracing.h
@@ -43,7 +43,7 @@ class StreamingReadRpcTracing : public StreamingReadRpc<ResponseType> {
   ~StreamingReadRpcTracing() override { (void)End(Status()); }
 
   void Cancel() override {
-    span_->AddEvent("cancel");
+    span_->AddEvent("gl-cpp.cancel");
     impl_->Cancel();
   }
 

--- a/google/cloud/internal/streaming_read_rpc_tracing_test.cc
+++ b/google/cloud/internal/streaming_read_rpc_tracing_test.cc
@@ -84,7 +84,7 @@ TEST(StreamingReadRpcTracingTest, Cancel) {
       spans,
       ElementsAre(AllOf(
           SpanNamed("span"),
-          SpanEventsAre(EventNamed("cancel"),
+          SpanEventsAre(EventNamed("gl-cpp.cancel"),
                         EventNamed("test-only: underlying stream cancel")))));
 }
 

--- a/google/cloud/internal/streaming_write_rpc_tracing.h
+++ b/google/cloud/internal/streaming_write_rpc_tracing.h
@@ -48,7 +48,7 @@ class StreamingWriteRpcTracing
   }
 
   void Cancel() override {
-    span_->AddEvent("cancel");
+    span_->AddEvent("gl-cpp.cancel");
     impl_->Cancel();
   }
 
@@ -63,7 +63,7 @@ class StreamingWriteRpcTracing
   }
 
   StatusOr<ResponseType> Close() override {
-    span_->AddEvent("close");
+    span_->AddEvent("gl-cpp.close");
     return EndSpan(*std::move(context_), *std::move(span_), impl_->Close());
   }
 

--- a/google/cloud/internal/streaming_write_rpc_tracing_test.cc
+++ b/google/cloud/internal/streaming_write_rpc_tracing_test.cc
@@ -74,9 +74,9 @@ TEST(StreamingWriteRpcTracingTest, Cancel) {
       spans,
       ElementsAre(
           AllOf(SpanNamed("span"),
-                SpanEventsAre(EventNamed("cancel"),
+                SpanEventsAre(EventNamed("gl-cpp.cancel"),
                               EventNamed("test-only: underlying stream cancel"),
-                              EventNamed("close")))));
+                              EventNamed("gl-cpp.close")))));
 }
 
 TEST(StreamingWriteRpcTracingTest, Write) {
@@ -121,7 +121,7 @@ TEST(StreamingWriteRpcTracingTest, Write) {
                         OTelAttribute<int>("message.id", 3),
                         OTelAttribute<bool>("message.is_last", true),
                         OTelAttribute<bool>("message.success", true))),
-              EventNamed("close")))));
+              EventNamed("gl-cpp.close")))));
 }
 
 TEST(StreamingWriteRpcTracingTest, Close) {

--- a/google/cloud/internal/tracing_rest_client.cc
+++ b/google/cloud/internal/tracing_rest_client.cc
@@ -102,15 +102,16 @@ StatusOr<std::unique_ptr<RestResponse>> EndStartSpan(
     std::chrono::system_clock::time_point start, RestContext& context,
     StatusOr<std::unique_ptr<RestResponse>> request_result) {
   if (context.namelookup_time()) {
-    span.AddEvent("curl.namelookup", start + *context.namelookup_time());
+    span.AddEvent("gl-cpp.curl.namelookup", start + *context.namelookup_time());
   }
   if (context.connect_time()) {
-    span.AddEvent("curl.connected", start + *context.connect_time());
-    span.SetAttribute("gcloud-cpp.cached_connection",
+    span.AddEvent("gl-cpp.curl.connected", start + *context.connect_time());
+    span.SetAttribute("gl-cpp.cached_connection",
                       *context.connect_time() == std::chrono::microseconds(0));
   }
   if (context.appconnect_time()) {
-    span.AddEvent("curl.ssl.handshake", start + *context.appconnect_time());
+    span.AddEvent("gl-cpp.curl.ssl.handshake",
+                  start + *context.appconnect_time());
   }
   return internal::EndSpan(span, std::move(request_result));
 }

--- a/google/cloud/internal/tracing_rest_client_test.cc
+++ b/google/cloud/internal/tracing_rest_client_test.cc
@@ -257,10 +257,10 @@ TEST(TracingRestClient, WithRestContextDetails) {
                     OTelAttribute<std::int32_t>(sc::kNetHostPort, 32000))),
           AllOf(SpanNamed("SendRequest"),
                 SpanHasAttributes(
-                    OTelAttribute<bool>("gcloud-cpp.cached_connection", false)),
-                SpanHasEvents(EventNamed("curl.namelookup"),
-                              EventNamed("curl.connected"),
-                              EventNamed("curl.ssl.handshake"))),
+                    OTelAttribute<bool>("gl-cpp.cached_connection", false)),
+                SpanHasEvents(EventNamed("gl-cpp.curl.namelookup"),
+                              EventNamed("gl-cpp.curl.connected"),
+                              EventNamed("gl-cpp.curl.ssl.handshake"))),
           SpanNamed("Read"), SpanNamed("Read")));
 }
 
@@ -295,13 +295,14 @@ TEST(TracingRestClient, CachedConnection) {
   EXPECT_THAT(contents, IsOkAndHolds(MockContents()));
 
   auto spans = span_catcher->GetSpans();
-  EXPECT_THAT(spans, UnorderedElementsAre(
-                         SpanNamed("HTTP/PUT"),
-                         AllOf(SpanNamed("SendRequest"),
-                               SpanHasAttributes(OTelAttribute<bool>(
-                                   "gcloud-cpp.cached_connection", true)),
-                               SpanHasEvents(EventNamed("curl.connected"))),
-                         SpanNamed("Read"), SpanNamed("Read")));
+  EXPECT_THAT(spans,
+              UnorderedElementsAre(
+                  SpanNamed("HTTP/PUT"),
+                  AllOf(SpanNamed("SendRequest"),
+                        SpanHasAttributes(OTelAttribute<bool>(
+                            "gl-cpp.cached_connection", true)),
+                        SpanHasEvents(EventNamed("gl-cpp.curl.connected"))),
+                  SpanNamed("Read"), SpanNamed("Read")));
 }
 
 #else

--- a/google/cloud/storage/internal/async/reader_connection_tracing.cc
+++ b/google/cloud/storage/internal/async/reader_connection_tracing.cc
@@ -47,9 +47,9 @@ class AsyncReaderConnectionTracing
 
   void Cancel() override {
     auto scope = opentelemetry::trace::Scope(span_);
-    span_->AddEvent("Cancel", {
-                                  {sc::kThreadId, CurrentThreadId()},
-                              });
+    span_->AddEvent("gl-cpp.cancel", {
+                                         {sc::kThreadId, CurrentThreadId()},
+                                     });
     return impl_->Cancel();
   }
 
@@ -59,20 +59,21 @@ class AsyncReaderConnectionTracing
                                span = span_](auto f) -> ReadResponse {
       auto r = f.get();
       if (absl::holds_alternative<Status>(r)) {
-        span->AddEvent("Read", {
-                                   {sc::kMessageType, "RECEIVED"},
-                                   {sc::kMessageId, count},
-                                   {sc::kThreadId, CurrentThreadId()},
-                               });
+        span->AddEvent("gl-cpp.read", {
+                                          {sc::kMessageType, "RECEIVED"},
+                                          {sc::kMessageId, count},
+                                          {sc::kThreadId, CurrentThreadId()},
+                                      });
         return internal::EndSpan(*span, absl::get<Status>(std::move(r)));
       }
       auto const& payload = absl::get<storage_experimental::ReadPayload>(r);
-      span->AddEvent("Read", {
-                                 {sc::kMessageType, "RECEIVED"},
-                                 {sc::kMessageId, count},
-                                 {sc::kThreadId, CurrentThreadId()},
-                                 {"message.starting_offset", payload.offset()},
-                             });
+      span->AddEvent("gl-cpp.read",
+                     {
+                         {sc::kMessageType, "RECEIVED"},
+                         {sc::kMessageId, count},
+                         {sc::kThreadId, CurrentThreadId()},
+                         {"message.starting_offset", payload.offset()},
+                     });
       return r;
     });
   }

--- a/google/cloud/storage/internal/async/reader_connection_tracing_test.cc
+++ b/google/cloud/storage/internal/async/reader_connection_tracing_test.cc
@@ -77,14 +77,14 @@ TEST(ReaderConnectionTracing, WithError) {
           SpanHasInstrumentationScope(), SpanKindIsClient(),
           SpanHasEvents(
               AllOf(
-                  EventNamed("Read"),
+                  EventNamed("gl-cpp.read"),
                   SpanEventAttributesAre(
                       OTelAttribute<std::int64_t>(sc::kMessageId, 1),
                       OTelAttribute<std::string>(sc::kMessageType, "RECEIVED"),
                       OTelAttribute<std::int64_t>("message.starting_offset", 0),
                       OTelAttribute<std::string>(sc::kThreadId, _))),
               AllOf(
-                  EventNamed("Read"),
+                  EventNamed("gl-cpp.read"),
                   SpanEventAttributesAre(
                       OTelAttribute<std::int64_t>(sc::kMessageId, 2),
                       OTelAttribute<std::string>(sc::kMessageType, "RECEIVED"),
@@ -119,14 +119,14 @@ TEST(ReaderConnectionTracing, WithSuccess) {
           SpanHasInstrumentationScope(), SpanKindIsClient(),
           SpanHasEvents(
               AllOf(
-                  EventNamed("Read"),
+                  EventNamed("gl-cpp.read"),
                   SpanEventAttributesAre(
                       OTelAttribute<std::int64_t>(sc::kMessageId, 1),
                       OTelAttribute<std::string>(sc::kMessageType, "RECEIVED"),
                       OTelAttribute<std::int64_t>("message.starting_offset", 0),
                       OTelAttribute<std::string>(sc::kThreadId, _))),
               AllOf(
-                  EventNamed("Read"),
+                  EventNamed("gl-cpp.read"),
                   SpanEventAttributesAre(
                       OTelAttribute<std::int64_t>(sc::kMessageId, 2),
                       OTelAttribute<std::string>(sc::kMessageType, "RECEIVED"),
@@ -134,7 +134,7 @@ TEST(ReaderConnectionTracing, WithSuccess) {
                                                   1024),
                       OTelAttribute<std::string>(sc::kThreadId, _))),
               AllOf(
-                  EventNamed("Read"),
+                  EventNamed("gl-cpp.read"),
                   SpanEventAttributesAre(
                       OTelAttribute<std::int64_t>(sc::kMessageId, 3),
                       OTelAttribute<std::string>(sc::kMessageType, "RECEIVED"),


### PR DESCRIPTION
We intrument streaming RPC events that do not have names prescribed by the OTel semantic conventions. Some of these events were of the form `gcloud.*` and some not. This change makes them all consistent.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12835)
<!-- Reviewable:end -->
