### PR TITLE
cleanup(otel): rename status attribute

### DIFF
--- a/generator/integration_tests/tests/golden_kitchen_sink_tracing_connection_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_tracing_connection_test.cc
@@ -89,7 +89,7 @@ TEST(GoldenKitchenSinkTracingConnectionTest, GenerateAccessToken) {
               "golden_v1::GoldenKitchenSinkConnection::GenerateAccessToken"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingConnectionTest, GenerateIdToken) {
@@ -114,7 +114,7 @@ TEST(GoldenKitchenSinkTracingConnectionTest, GenerateIdToken) {
           SpanNamed("golden_v1::GoldenKitchenSinkConnection::GenerateIdToken"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingConnectionTest, WriteLogEntries) {
@@ -139,7 +139,7 @@ TEST(GoldenKitchenSinkTracingConnectionTest, WriteLogEntries) {
           SpanNamed("golden_v1::GoldenKitchenSinkConnection::WriteLogEntries"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingConnectionTest, ListLogs) {
@@ -168,7 +168,7 @@ TEST(GoldenKitchenSinkTracingConnectionTest, ListLogs) {
           SpanNamed("golden_v1::GoldenKitchenSinkConnection::ListLogs"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingConnectionTest, ListServiceAccountKeys) {
@@ -194,7 +194,7 @@ TEST(GoldenKitchenSinkTracingConnectionTest, ListServiceAccountKeys) {
               "golden_v1::GoldenKitchenSinkConnection::ListServiceAccountKeys"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingConnectionTest, DoNothing) {
@@ -219,7 +219,7 @@ TEST(GoldenKitchenSinkTracingConnectionTest, DoNothing) {
           SpanNamed("golden_v1::GoldenKitchenSinkConnection::DoNothing"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingConnectionTest, Deprecated2) {
@@ -244,7 +244,7 @@ TEST(GoldenKitchenSinkTracingConnectionTest, Deprecated2) {
           SpanNamed("golden_v1::GoldenKitchenSinkConnection::Deprecated2"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingConnectionTest, StreamingRead) {
@@ -271,7 +271,7 @@ TEST(GoldenKitchenSinkTracingConnectionTest, StreamingRead) {
           SpanNamed("golden_v1::GoldenKitchenSinkConnection::StreamingRead"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingConnectionTest, AsyncStreamingReadWrite) {
@@ -313,7 +313,7 @@ TEST(GoldenKitchenSinkTracingConnectionTest, ExplicitRouting1) {
           SpanNamed("golden_v1::GoldenKitchenSinkConnection::ExplicitRouting1"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingConnectionTest, ExplicitRouting2) {
@@ -338,7 +338,7 @@ TEST(GoldenKitchenSinkTracingConnectionTest, ExplicitRouting2) {
           SpanNamed("golden_v1::GoldenKitchenSinkConnection::ExplicitRouting2"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(MakeGoldenKitchenSinkTracingConnection, TracingEnabled) {

--- a/generator/integration_tests/tests/golden_kitchen_sink_tracing_stub_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_tracing_stub_test.cc
@@ -80,7 +80,7 @@ TEST(GoldenKitchenSinkTracingStubTest, GenerateAccessToken) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingStubTest, GenerateIdToken) {
@@ -109,7 +109,7 @@ TEST(GoldenKitchenSinkTracingStubTest, GenerateIdToken) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingStubTest, WriteLogEntries) {
@@ -138,7 +138,7 @@ TEST(GoldenKitchenSinkTracingStubTest, WriteLogEntries) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingStubTest, ListLogs) {
@@ -166,7 +166,7 @@ TEST(GoldenKitchenSinkTracingStubTest, ListLogs) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingStubTest, StreamingRead) {
@@ -197,7 +197,7 @@ TEST(GoldenKitchenSinkTracingStubTest, StreamingRead) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingStubTest, ListServiceAccountKeys) {
@@ -227,7 +227,7 @@ TEST(GoldenKitchenSinkTracingStubTest, ListServiceAccountKeys) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingStubTest, DoNothing) {
@@ -256,7 +256,7 @@ TEST(GoldenKitchenSinkTracingStubTest, DoNothing) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingStubTest, StreamingWrite) {
@@ -290,7 +290,7 @@ TEST(GoldenKitchenSinkTracingStubTest, StreamingWrite) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingStubTest, AsyncStreamingRead) {
@@ -325,7 +325,7 @@ TEST(GoldenKitchenSinkTracingStubTest, AsyncStreamingRead) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingStubTest, AsyncStreamingWrite) {
@@ -361,7 +361,7 @@ TEST(GoldenKitchenSinkTracingStubTest, AsyncStreamingWrite) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingStubTest, AsyncStreamingReadWrite) {
@@ -397,7 +397,7 @@ TEST(GoldenKitchenSinkTracingStubTest, AsyncStreamingReadWrite) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingStubTest, ExplicitRouting1) {
@@ -426,7 +426,7 @@ TEST(GoldenKitchenSinkTracingStubTest, ExplicitRouting1) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenKitchenSinkTracingStubTest, ExplicitRouting2) {
@@ -455,7 +455,7 @@ TEST(GoldenKitchenSinkTracingStubTest, ExplicitRouting2) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(MakeGoldenKitchenSinkTracingStub, OpenTelemetry) {

--- a/generator/integration_tests/tests/golden_thing_admin_tracing_connection_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_tracing_connection_test.cc
@@ -89,7 +89,7 @@ TEST(GoldenThingAdminTracingConnectionTest, ListDatabases) {
           SpanNamed("golden_v1::GoldenThingAdminConnection::ListDatabases"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, CreateDatabase) {
@@ -115,7 +115,7 @@ TEST(GoldenThingAdminTracingConnectionTest, CreateDatabase) {
           SpanNamed("golden_v1::GoldenThingAdminConnection::CreateDatabase"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, GetDatabase) {
@@ -140,7 +140,7 @@ TEST(GoldenThingAdminTracingConnectionTest, GetDatabase) {
           SpanNamed("golden_v1::GoldenThingAdminConnection::GetDatabase"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, UpdateDatabaseDdl) {
@@ -167,7 +167,7 @@ TEST(GoldenThingAdminTracingConnectionTest, UpdateDatabaseDdl) {
           SpanNamed("golden_v1::GoldenThingAdminConnection::UpdateDatabaseDdl"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, DropDatabase) {
@@ -192,7 +192,7 @@ TEST(GoldenThingAdminTracingConnectionTest, DropDatabase) {
           SpanNamed("golden_v1::GoldenThingAdminConnection::DropDatabase"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, GetDatabaseDdl) {
@@ -217,7 +217,7 @@ TEST(GoldenThingAdminTracingConnectionTest, GetDatabaseDdl) {
           SpanNamed("golden_v1::GoldenThingAdminConnection::GetDatabaseDdl"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, SetIamPolicy) {
@@ -242,7 +242,7 @@ TEST(GoldenThingAdminTracingConnectionTest, SetIamPolicy) {
           SpanNamed("golden_v1::GoldenThingAdminConnection::SetIamPolicy"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, GetIamPolicy) {
@@ -267,7 +267,7 @@ TEST(GoldenThingAdminTracingConnectionTest, GetIamPolicy) {
           SpanNamed("golden_v1::GoldenThingAdminConnection::GetIamPolicy"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, TestIamPermissions) {
@@ -293,7 +293,7 @@ TEST(GoldenThingAdminTracingConnectionTest, TestIamPermissions) {
               "golden_v1::GoldenThingAdminConnection::TestIamPermissions"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, CreateBackup) {
@@ -318,7 +318,7 @@ TEST(GoldenThingAdminTracingConnectionTest, CreateBackup) {
           SpanNamed("golden_v1::GoldenThingAdminConnection::CreateBackup"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, GetBackup) {
@@ -343,7 +343,7 @@ TEST(GoldenThingAdminTracingConnectionTest, GetBackup) {
           SpanNamed("golden_v1::GoldenThingAdminConnection::GetBackup"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, UpdateBackup) {
@@ -368,7 +368,7 @@ TEST(GoldenThingAdminTracingConnectionTest, UpdateBackup) {
           SpanNamed("golden_v1::GoldenThingAdminConnection::UpdateBackup"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, DeleteBackup) {
@@ -393,7 +393,7 @@ TEST(GoldenThingAdminTracingConnectionTest, DeleteBackup) {
           SpanNamed("golden_v1::GoldenThingAdminConnection::DeleteBackup"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, ListBackups) {
@@ -420,7 +420,7 @@ TEST(GoldenThingAdminTracingConnectionTest, ListBackups) {
           SpanNamed("golden_v1::GoldenThingAdminConnection::ListBackups"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, RestoreDatabase) {
@@ -446,7 +446,7 @@ TEST(GoldenThingAdminTracingConnectionTest, RestoreDatabase) {
           SpanNamed("golden_v1::GoldenThingAdminConnection::RestoreDatabase"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, ListDatabaseOperations) {
@@ -475,7 +475,7 @@ TEST(GoldenThingAdminTracingConnectionTest, ListDatabaseOperations) {
               "golden_v1::GoldenThingAdminConnection::ListDatabaseOperations"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, ListBackupOperations) {
@@ -504,7 +504,7 @@ TEST(GoldenThingAdminTracingConnectionTest, ListBackupOperations) {
               "golden_v1::GoldenThingAdminConnection::ListBackupOperations"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, LongRunningWithoutRouting) {
@@ -531,7 +531,7 @@ TEST(GoldenThingAdminTracingConnectionTest, LongRunningWithoutRouting) {
                     "LongRunningWithoutRouting"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, AsyncGetDatabase) {
@@ -557,7 +557,7 @@ TEST(GoldenThingAdminTracingConnectionTest, AsyncGetDatabase) {
           SpanNamed("golden_v1::GoldenThingAdminConnection::AsyncGetDatabase"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingConnectionTest, AsyncDropDatabase) {
@@ -582,7 +582,7 @@ TEST(GoldenThingAdminTracingConnectionTest, AsyncDropDatabase) {
           SpanNamed("golden_v1::GoldenThingAdminConnection::AsyncDropDatabase"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(MakeGoldenThingAdminTracingConnection, TracingEnabled) {

--- a/generator/integration_tests/tests/golden_thing_admin_tracing_stub_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_tracing_stub_test.cc
@@ -80,7 +80,7 @@ TEST(GoldenThingAdminTracingStubTest, ListDatabases) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, AsyncCreateDatabase) {
@@ -106,7 +106,7 @@ TEST(GoldenThingAdminTracingStubTest, AsyncCreateDatabase) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, GetDatabase) {
@@ -135,7 +135,7 @@ TEST(GoldenThingAdminTracingStubTest, GetDatabase) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, AsyncUpdateDatabaseDdl) {
@@ -161,7 +161,7 @@ TEST(GoldenThingAdminTracingStubTest, AsyncUpdateDatabaseDdl) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, DropDatabase) {
@@ -190,7 +190,7 @@ TEST(GoldenThingAdminTracingStubTest, DropDatabase) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, GetDatabaseDdl) {
@@ -219,7 +219,7 @@ TEST(GoldenThingAdminTracingStubTest, GetDatabaseDdl) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, SetIamPolicy) {
@@ -248,7 +248,7 @@ TEST(GoldenThingAdminTracingStubTest, SetIamPolicy) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, GetIamPolicy) {
@@ -277,7 +277,7 @@ TEST(GoldenThingAdminTracingStubTest, GetIamPolicy) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, TestIamPermissions) {
@@ -307,7 +307,7 @@ TEST(GoldenThingAdminTracingStubTest, TestIamPermissions) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, AsyncCreateBackup) {
@@ -333,7 +333,7 @@ TEST(GoldenThingAdminTracingStubTest, AsyncCreateBackup) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, GetBackup) {
@@ -361,7 +361,7 @@ TEST(GoldenThingAdminTracingStubTest, GetBackup) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, UpdateBackup) {
@@ -390,7 +390,7 @@ TEST(GoldenThingAdminTracingStubTest, UpdateBackup) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, DeleteBackup) {
@@ -419,7 +419,7 @@ TEST(GoldenThingAdminTracingStubTest, DeleteBackup) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, ListBackups) {
@@ -448,7 +448,7 @@ TEST(GoldenThingAdminTracingStubTest, ListBackups) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, AsyncRestoreDatabase) {
@@ -474,7 +474,7 @@ TEST(GoldenThingAdminTracingStubTest, AsyncRestoreDatabase) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, ListDatabaseOperations) {
@@ -504,7 +504,7 @@ TEST(GoldenThingAdminTracingStubTest, ListDatabaseOperations) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, ListBackupOperations) {
@@ -534,7 +534,7 @@ TEST(GoldenThingAdminTracingStubTest, ListBackupOperations) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, AsyncGetDatabase) {
@@ -566,7 +566,7 @@ TEST(GoldenThingAdminTracingStubTest, AsyncGetDatabase) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, AsyncDropDatabase) {
@@ -596,7 +596,7 @@ TEST(GoldenThingAdminTracingStubTest, AsyncDropDatabase) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, AsyncGetOperation) {
@@ -621,7 +621,7 @@ TEST(GoldenThingAdminTracingStubTest, AsyncGetOperation) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(GoldenThingAdminTracingStubTest, AsyncCancelOperation) {
@@ -650,7 +650,7 @@ TEST(GoldenThingAdminTracingStubTest, AsyncCancelOperation) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(MakeGoldenThingAdminTracingStub, OpenTelemetry) {

--- a/google/cloud/bigtable/internal/data_tracing_connection_test.cc
+++ b/google/cloud/bigtable/internal/data_tracing_connection_test.cc
@@ -89,7 +89,7 @@ TEST(DataTracingConnection, Apply) {
           SpanNamed("bigtable::Table::Apply"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(DataTracingConnection, AsyncApply) {
@@ -112,7 +112,7 @@ TEST(DataTracingConnection, AsyncApply) {
           SpanNamed("bigtable::Table::AsyncApply"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(DataTracingConnection, BulkApplySuccess) {
@@ -246,7 +246,7 @@ TEST(DataTracingConnection, ReadRows) {
           SpanNamed("bigtable::Table::ReadRows"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(DataTracingConnection, ReadRowsFull) {
@@ -273,7 +273,7 @@ TEST(DataTracingConnection, ReadRowsFull) {
           SpanNamed("bigtable::Table::ReadRows"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(DataTracingConnection, ReadRowFound) {
@@ -295,7 +295,7 @@ TEST(DataTracingConnection, ReadRowFound) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanNamed("bigtable::Table::ReadRow"),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-                  SpanHasAttributes(OTelAttribute<int>("gcloud.status_code", 0),
+                  SpanHasAttributes(OTelAttribute<int>("gl-cpp.status_code", 0),
                                     OTelAttribute<bool>(
                                         "gcloud.bigtable.row_found", true)))));
 }
@@ -319,7 +319,7 @@ TEST(DataTracingConnection, ReadRowNotFound) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanNamed("bigtable::Table::ReadRow"),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-                  SpanHasAttributes(OTelAttribute<int>("gcloud.status_code", 0),
+                  SpanHasAttributes(OTelAttribute<int>("gl-cpp.status_code", 0),
                                     OTelAttribute<bool>(
                                         "gcloud.bigtable.row_found", false)))));
 }
@@ -345,7 +345,7 @@ TEST(DataTracingConnection, ReadRowFailure) {
           SpanNamed("bigtable::Table::ReadRow"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)),
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)),
           Not(SpanHasAttributes(
               OTelAttribute<bool>("gcloud.bigtable.row_found", _))))));
 }
@@ -371,7 +371,7 @@ TEST(DataTracingConnection, CheckAndMutateRow) {
           SpanNamed("bigtable::Table::CheckAndMutateRow"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(DataTracingConnection, AsyncCheckAndMutateRow) {
@@ -396,7 +396,7 @@ TEST(DataTracingConnection, AsyncCheckAndMutateRow) {
           SpanNamed("bigtable::Table::AsyncCheckAndMutateRow"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(DataTracingConnection, SampleRows) {
@@ -419,7 +419,7 @@ TEST(DataTracingConnection, SampleRows) {
           SpanNamed("bigtable::Table::SampleRows"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(DataTracingConnection, AsyncSampleRows) {
@@ -443,7 +443,7 @@ TEST(DataTracingConnection, AsyncSampleRows) {
           SpanNamed("bigtable::Table::AsyncSampleRows"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(DataTracingConnection, ReadModifyWriteRow) {
@@ -466,7 +466,7 @@ TEST(DataTracingConnection, ReadModifyWriteRow) {
           SpanNamed("bigtable::Table::ReadModifyWriteRow"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(DataTracingConnection, AsyncReadModifyWriteRow) {
@@ -490,7 +490,7 @@ TEST(DataTracingConnection, AsyncReadModifyWriteRow) {
           SpanNamed("bigtable::Table::AsyncReadModifyWriteRow"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(DataTracingConnection, AsyncReadRows) {
@@ -538,7 +538,7 @@ TEST(DataTracingConnection, AsyncReadRows) {
           SpanNamed("bigtable::Table::AsyncReadRows"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST(DataTracingConnection, AsyncReadRowFound) {
@@ -561,7 +561,7 @@ TEST(DataTracingConnection, AsyncReadRowFound) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanNamed("bigtable::Table::AsyncReadRow"),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-                  SpanHasAttributes(OTelAttribute<int>("gcloud.status_code", 0),
+                  SpanHasAttributes(OTelAttribute<int>("gl-cpp.status_code", 0),
                                     OTelAttribute<bool>(
                                         "gcloud.bigtable.row_found", true)))));
 }
@@ -586,7 +586,7 @@ TEST(DataTracingConnection, AsyncReadRowNotFound) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanNamed("bigtable::Table::AsyncReadRow"),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-                  SpanHasAttributes(OTelAttribute<int>("gcloud.status_code", 0),
+                  SpanHasAttributes(OTelAttribute<int>("gl-cpp.status_code", 0),
                                     OTelAttribute<bool>(
                                         "gcloud.bigtable.row_found", false)))));
 }
@@ -613,7 +613,7 @@ TEST(DataTracingConnection, AsyncReadRowFailure) {
           SpanNamed("bigtable::Table::AsyncReadRow"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)),
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)),
           Not(SpanHasAttributes(
               OTelAttribute<bool>("gcloud.bigtable.row_found", _))))));
 }

--- a/google/cloud/internal/minimal_iam_credentials_stub_test.cc
+++ b/google/cloud/internal/minimal_iam_credentials_stub_test.cc
@@ -290,7 +290,7 @@ TEST_F(MinimalIamCredentialsStubTest, AsyncGenerateAccessTokenTracing) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 
 TEST_F(MinimalIamCredentialsStubTest, SignBlobNoTracing) {
@@ -339,7 +339,7 @@ TEST_F(MinimalIamCredentialsStubTest, SignBlobTracing) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "fail"),
           SpanHasAttributes(
               OTelAttribute<std::string>("grpc.peer", _),
-              OTelAttribute<int>("gcloud.status_code", kErrorCode)))));
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 

--- a/google/cloud/internal/opentelemetry.cc
+++ b/google/cloud/internal/opentelemetry.cc
@@ -53,12 +53,12 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> MakeSpan(
 void EndSpanImpl(opentelemetry::trace::Span& span, Status const& status) {
   if (status.ok()) {
     span.SetStatus(opentelemetry::trace::StatusCode::kOk);
-    span.SetAttribute("gcloud.status_code", 0);
+    span.SetAttribute("gl-cpp.status_code", 0);
     span.End();
     return;
   }
   span.SetStatus(opentelemetry::trace::StatusCode::kError, status.message());
-  span.SetAttribute("gcloud.status_code", static_cast<int>(status.code()));
+  span.SetAttribute("gl-cpp.status_code", static_cast<int>(status.code()));
   auto const& ei = status.error_info();
   if (!ei.reason().empty()) {
     span.SetAttribute("gcloud.error.reason", ei.reason());

--- a/google/cloud/internal/opentelemetry_test.cc
+++ b/google/cloud/internal/opentelemetry_test.cc
@@ -117,7 +117,7 @@ TEST(OpenTelemetry, EndSpanImplSuccess) {
       spans,
       ElementsAre(AllOf(
           SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-          SpanHasAttributes(OTelAttribute<int>("gcloud.status_code", 0)))));
+          SpanHasAttributes(OTelAttribute<int>("gl-cpp.status_code", 0)))));
 }
 
 TEST(OpenTelemetry, EndSpanImplFail) {
@@ -132,7 +132,7 @@ TEST(OpenTelemetry, EndSpanImplFail) {
       spans,
       ElementsAre(AllOf(
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "not good"),
-          SpanHasAttributes(OTelAttribute<int>("gcloud.status_code", code)))));
+          SpanHasAttributes(OTelAttribute<int>("gl-cpp.status_code", code)))));
 }
 
 TEST(OpenTelemetry, EndSpanImplErrorInfo) {
@@ -148,7 +148,7 @@ TEST(OpenTelemetry, EndSpanImplErrorInfo) {
       ElementsAre(AllOf(
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "not good"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", code),
+              OTelAttribute<int>("gl-cpp.status_code", code),
               OTelAttribute<std::string>("gcloud.error.reason", "reason")))));
 
   span = MakeSpan("domain");
@@ -160,7 +160,7 @@ TEST(OpenTelemetry, EndSpanImplErrorInfo) {
       ElementsAre(AllOf(
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "not good"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", code),
+              OTelAttribute<int>("gl-cpp.status_code", code),
               OTelAttribute<std::string>("gcloud.error.domain", "domain")))));
 
   span = MakeSpan("metadata");
@@ -172,7 +172,7 @@ TEST(OpenTelemetry, EndSpanImplErrorInfo) {
       ElementsAre(AllOf(
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "not good"),
           SpanHasAttributes(
-              OTelAttribute<int>("gcloud.status_code", code),
+              OTelAttribute<int>("gl-cpp.status_code", code),
               OTelAttribute<std::string>("gcloud.error.metadata.k1", "v1"),
               OTelAttribute<std::string>("gcloud.error.metadata.k2", "v2")))));
 }
@@ -280,7 +280,7 @@ TEST(OpenTelemetry, EndSpanVoid) {
       spans,
       ElementsAre(AllOf(
           SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-          SpanHasAttributes(OTelAttribute<int>("gcloud.status_code", 0)))));
+          SpanHasAttributes(OTelAttribute<int>("gl-cpp.status_code", 0)))));
 }
 
 TEST(OpenTelemetry, TracingEnabled) {

--- a/google/cloud/internal/tracing_http_payload_test.cc
+++ b/google/cloud/internal/tracing_http_payload_test.cc
@@ -63,7 +63,7 @@ TEST(TracingHttpPayload, Success) {
     return AllOf(SpanNamed("Read"), SpanHasInstrumentationScope(),
                  SpanKindIsClient(),
                  SpanHasAttributes(
-                     OTelAttribute<std::int32_t>("gcloud.status_code", 0),
+                     OTelAttribute<std::int32_t>("gl-cpp.status_code", 0),
                      OTelAttribute<std::int64_t>("read.buffer.size", bs),
                      OTelAttribute<std::int64_t>("read.returned.size", rs)));
   };
@@ -102,7 +102,7 @@ TEST(TracingHttpPayload, Failure) {
     return AllOf(SpanNamed("Read"), SpanHasInstrumentationScope(),
                  SpanKindIsClient(),
                  SpanHasAttributes(
-                     OTelAttribute<std::int32_t>("gcloud.status_code", 0),
+                     OTelAttribute<std::int32_t>("gl-cpp.status_code", 0),
                      OTelAttribute<std::int64_t>("read.buffer.size", bs),
                      OTelAttribute<std::int64_t>("read.returned.size", rs)));
   };
@@ -111,7 +111,7 @@ TEST(TracingHttpPayload, Failure) {
                  SpanKindIsClient(),
                  SpanHasAttributes(
                      OTelAttribute<std::int32_t>(
-                         "gcloud.status_code", static_cast<std::int32_t>(code)),
+                         "gl-cpp.status_code", static_cast<std::int32_t>(code)),
                      OTelAttribute<std::int64_t>("read.buffer.size", bs)));
   };
   EXPECT_THAT(
@@ -123,7 +123,7 @@ TEST(TracingHttpPayload, Failure) {
                     OTelAttribute<std::string>(sc::kNetTransport,
                                                sc::NetTransportValues::kIpTcp),
                     OTelAttribute<int>(
-                        "gcloud.status_code",
+                        "gl-cpp.status_code",
                         static_cast<int>(StatusCode::kUnavailable)))),
           make_read_success_matcher(16, 16),
           make_read_error_matcher(16, StatusCode::kUnavailable)));

--- a/google/cloud/internal/tracing_rest_response_test.cc
+++ b/google/cloud/internal/tracing_rest_response_test.cc
@@ -75,7 +75,7 @@ TEST(TracingRestResponseTest, Success) {
     return AllOf(SpanNamed("Read"), SpanHasInstrumentationScope(),
                  SpanKindIsClient(),
                  SpanHasAttributes(
-                     OTelAttribute<std::int32_t>("gcloud.status_code", 0),
+                     OTelAttribute<std::int32_t>("gl-cpp.status_code", 0),
                      OTelAttribute<std::int64_t>("read.buffer.size", bs),
                      OTelAttribute<std::int64_t>("read.returned.size", rs)));
   };

--- a/google/cloud/pubsub/internal/batching_publisher_tracing_connection_test.cc
+++ b/google/cloud/pubsub/internal/batching_publisher_tracing_connection_test.cc
@@ -73,7 +73,7 @@ TEST(BatchingPublisherTracingConnectionTest, PublishSpan) {
           SpanHasAttributes(OTelAttribute<std::string>(
                                 sc::kCodeFunction,
                                 "pubsub::BatchingPublisherConnection::Publish"),
-                            OTelAttribute<int>("gcloud.status_code", 0)))));
+                            OTelAttribute<int>("gl-cpp.status_code", 0)))));
 }
 
 TEST(BatchingPublisherTracingConnectionTest, FlushSpan) {
@@ -92,7 +92,7 @@ TEST(BatchingPublisherTracingConnectionTest, FlushSpan) {
           SpanHasInstrumentationScope(), SpanKindIsClient(),
           SpanNamed("pubsub::BatchingPublisherConnection::Flush"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-          SpanHasAttributes(OTelAttribute<int>("gcloud.status_code", 0)))));
+          SpanHasAttributes(OTelAttribute<int>("gl-cpp.status_code", 0)))));
 }
 
 TEST(BatchingPublisherTracingConnectionTest, ResumePublishSpan) {
@@ -112,7 +112,7 @@ TEST(BatchingPublisherTracingConnectionTest, ResumePublishSpan) {
           SpanHasInstrumentationScope(), SpanKindIsClient(),
           SpanNamed("pubsub::BatchingPublisherConnection::ResumePublish"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-          SpanHasAttributes(OTelAttribute<int>("gcloud.status_code", 0)))));
+          SpanHasAttributes(OTelAttribute<int>("gl-cpp.status_code", 0)))));
 }
 
 TEST(MakeBatchingPublisherTracingConnectionTest, CreateTracingConnection) {

--- a/google/cloud/pubsub/internal/flow_controlled_publisher_tracing_connection_test.cc
+++ b/google/cloud/pubsub/internal/flow_controlled_publisher_tracing_connection_test.cc
@@ -76,7 +76,7 @@ TEST(FlowControlledPublisherTracingConnectionTest, PublishSpan) {
                       OTelAttribute<std::string>(
                           sc::kCodeFunction,
                           "pubsub::FlowControlledPublisherConnection::Publish"),
-                      OTelAttribute<int>("gcloud.status_code", 0)))));
+                      OTelAttribute<int>("gl-cpp.status_code", 0)))));
 }
 
 TEST(FlowControlledPublisherTracingConnectionTest, FlushSpan) {
@@ -96,7 +96,7 @@ TEST(FlowControlledPublisherTracingConnectionTest, FlushSpan) {
           SpanHasInstrumentationScope(), SpanKindIsClient(),
           SpanNamed("pubsub::FlowControlledPublisherConnection::Flush"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-          SpanHasAttributes(OTelAttribute<int>("gcloud.status_code", 0)))));
+          SpanHasAttributes(OTelAttribute<int>("gl-cpp.status_code", 0)))));
 }
 
 TEST(FlowControlledPublisher, ResumePublishSpan) {
@@ -116,7 +116,7 @@ TEST(FlowControlledPublisher, ResumePublishSpan) {
           SpanHasInstrumentationScope(), SpanKindIsClient(),
           SpanNamed("pubsub::FlowControlledPublisherConnection::ResumePublish"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-          SpanHasAttributes(OTelAttribute<int>("gcloud.status_code", 0)))));
+          SpanHasAttributes(OTelAttribute<int>("gl-cpp.status_code", 0)))));
 }
 
 TEST(MakeFlowControlledPublisherTracingConnectionTest,

--- a/google/cloud/pubsub/internal/publisher_tracing_connection_test.cc
+++ b/google/cloud/pubsub/internal/publisher_tracing_connection_test.cc
@@ -89,7 +89,7 @@ TEST(PublisherTracingConnectionTest, PublishSpanOnSuccess) {
                                          "topic"),
               OTelAttribute<std::string>("messaging.pubsub.ordering_key",
                                          "ordering-key-0"),
-              OTelAttribute<int>("gcloud.status_code", 0),
+              OTelAttribute<int>("gl-cpp.status_code", 0),
               OTelAttribute<std::int64_t>("messaging.message.total_size_bytes",
                                           45),
               OTelAttribute<std::string>("messaging.message_id", "test-id-0"),
@@ -134,7 +134,7 @@ TEST(PublisherTracingConnectionTest, PublishSpanOnError) {
                         sc::kMessagingDestinationTemplate, "topic"),
                     OTelAttribute<std::string>("messaging.pubsub.ordering_key",
                                                "ordering-key-0"),
-                    OTelAttribute<int>("gcloud.status_code", kErrorCode),
+                    OTelAttribute<int>("gl-cpp.status_code", kErrorCode),
                     OTelAttribute<std::int64_t>(
                         "messaging.message.total_size_bytes", 45)))));
 }
@@ -182,7 +182,7 @@ TEST(PublisherTracingConnectionTest, FlushSpan) {
           SpanHasInstrumentationScope(), SpanKindIsClient(),
           SpanNamed("pubsub::Publisher::Flush"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-          SpanHasAttributes(OTelAttribute<int>("gcloud.status_code", 0)))));
+          SpanHasAttributes(OTelAttribute<int>("gl-cpp.status_code", 0)))));
 }
 
 TEST(PublisherTracingConnectionTest, ResumePublishSpan) {
@@ -200,7 +200,7 @@ TEST(PublisherTracingConnectionTest, ResumePublishSpan) {
           SpanHasInstrumentationScope(), SpanKindIsClient(),
           SpanNamed("pubsub::Publisher::ResumePublish"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-          SpanHasAttributes(OTelAttribute<int>("gcloud.status_code", 0)))));
+          SpanHasAttributes(OTelAttribute<int>("gl-cpp.status_code", 0)))));
 }
 
 TEST(MakePublisherTracingConnectionTest, CreateTracingConnection) {

--- a/google/cloud/storage/internal/async/reader_connection_tracing_test.cc
+++ b/google/cloud/storage/internal/async/reader_connection_tracing_test.cc
@@ -73,7 +73,7 @@ TEST(ReaderConnectionTracing, WithError) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError,
                          PermanentError().message()),
           SpanHasAttributes(
-              OTelAttribute<std::int32_t>("gcloud.status_code", expected_code)),
+              OTelAttribute<std::int32_t>("gl-cpp.status_code", expected_code)),
           SpanHasInstrumentationScope(), SpanKindIsClient(),
           SpanHasEvents(
               AllOf(

--- a/google/cloud/storage/internal/tracing_connection_test.cc
+++ b/google/cloud/storage/internal/tracing_connection_test.cc
@@ -73,7 +73,7 @@ TEST(TracingClientTest, ListBuckets) {
                   SpanNamed("storage::Client::ListBuckets"),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, CreateBucket) {
@@ -95,7 +95,7 @@ TEST(TracingClientTest, CreateBucket) {
                   SpanNamed("storage::Client::CreateBucket"),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, GetBucketMetadata) {
@@ -117,7 +117,7 @@ TEST(TracingClientTest, GetBucketMetadata) {
                   SpanNamed("storage::Client::GetBucketMetadata"),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, DeleteBucket) {
@@ -139,7 +139,7 @@ TEST(TracingClientTest, DeleteBucket) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, UpdateBucket) {
@@ -161,7 +161,7 @@ TEST(TracingClientTest, UpdateBucket) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, PatchBucket) {
@@ -182,7 +182,7 @@ TEST(TracingClientTest, PatchBucket) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, GetNativeBucketIamPolicy) {
@@ -204,7 +204,7 @@ TEST(TracingClientTest, GetNativeBucketIamPolicy) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, SetNativeBucketIamPolicy) {
@@ -228,7 +228,7 @@ TEST(TracingClientTest, SetNativeBucketIamPolicy) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, TestBucketIamPermissions) {
@@ -250,7 +250,7 @@ TEST(TracingClientTest, TestBucketIamPermissions) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, LockBucketRetentionPolicy) {
@@ -272,7 +272,7 @@ TEST(TracingClientTest, LockBucketRetentionPolicy) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, InsertObjectMedia) {
@@ -294,7 +294,7 @@ TEST(TracingClientTest, InsertObjectMedia) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, CopyObject) {
@@ -315,7 +315,7 @@ TEST(TracingClientTest, CopyObject) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, GetObjectMetadata) {
@@ -337,7 +337,7 @@ TEST(TracingClientTest, GetObjectMetadata) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, ReadObject) {
@@ -359,7 +359,7 @@ TEST(TracingClientTest, ReadObject) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, ListObjects) {
@@ -380,7 +380,7 @@ TEST(TracingClientTest, ListObjects) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, DeleteObject) {
@@ -402,7 +402,7 @@ TEST(TracingClientTest, DeleteObject) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, UpdateObject) {
@@ -424,7 +424,7 @@ TEST(TracingClientTest, UpdateObject) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, PatchObject) {
@@ -445,7 +445,7 @@ TEST(TracingClientTest, PatchObject) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, ComposeObject) {
@@ -467,7 +467,7 @@ TEST(TracingClientTest, ComposeObject) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, RewriteObject) {
@@ -489,7 +489,7 @@ TEST(TracingClientTest, RewriteObject) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, CreateResumableUpload) {
@@ -512,7 +512,7 @@ TEST(TracingClientTest, CreateResumableUpload) {
                 SpanHasInstrumentationScope(), SpanKindIsClient(),
                 SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                 SpanHasAttributes(OTelAttribute<int>(
-                    "gcloud.status_code", static_cast<int>(code))))));
+                    "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, QueryResumableUpload) {
@@ -535,7 +535,7 @@ TEST(TracingClientTest, QueryResumableUpload) {
                 SpanHasInstrumentationScope(), SpanKindIsClient(),
                 SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                 SpanHasAttributes(OTelAttribute<int>(
-                    "gcloud.status_code", static_cast<int>(code))))));
+                    "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, DeleteResumableUpload) {
@@ -557,7 +557,7 @@ TEST(TracingClientTest, DeleteResumableUpload) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, UploadChunk) {
@@ -578,7 +578,7 @@ TEST(TracingClientTest, UploadChunk) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, ListBucketAcl) {
@@ -600,7 +600,7 @@ TEST(TracingClientTest, ListBucketAcl) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, CreateBucketAcl) {
@@ -622,7 +622,7 @@ TEST(TracingClientTest, CreateBucketAcl) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, DeleteBucketAcl) {
@@ -644,7 +644,7 @@ TEST(TracingClientTest, DeleteBucketAcl) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, GetBucketAcl) {
@@ -666,7 +666,7 @@ TEST(TracingClientTest, GetBucketAcl) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, UpdateBucketAcl) {
@@ -688,7 +688,7 @@ TEST(TracingClientTest, UpdateBucketAcl) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, PatchBucketAcl) {
@@ -712,7 +712,7 @@ TEST(TracingClientTest, PatchBucketAcl) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, ListObjectAcl) {
@@ -734,7 +734,7 @@ TEST(TracingClientTest, ListObjectAcl) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, CreateObjectAcl) {
@@ -756,7 +756,7 @@ TEST(TracingClientTest, CreateObjectAcl) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, DeleteObjectAcl) {
@@ -778,7 +778,7 @@ TEST(TracingClientTest, DeleteObjectAcl) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, GetObjectAcl) {
@@ -800,7 +800,7 @@ TEST(TracingClientTest, GetObjectAcl) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, UpdateObjectAcl) {
@@ -822,7 +822,7 @@ TEST(TracingClientTest, UpdateObjectAcl) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, PatchObjectAcl) {
@@ -846,7 +846,7 @@ TEST(TracingClientTest, PatchObjectAcl) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, ListDefaultObjectAcl) {
@@ -868,7 +868,7 @@ TEST(TracingClientTest, ListDefaultObjectAcl) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, CreateDefaultObjectAcl) {
@@ -890,7 +890,7 @@ TEST(TracingClientTest, CreateDefaultObjectAcl) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, DeleteDefaultObjectAcl) {
@@ -912,7 +912,7 @@ TEST(TracingClientTest, DeleteDefaultObjectAcl) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, GetDefaultObjectAcl) {
@@ -934,7 +934,7 @@ TEST(TracingClientTest, GetDefaultObjectAcl) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, UpdateDefaultObjectAcl) {
@@ -956,7 +956,7 @@ TEST(TracingClientTest, UpdateDefaultObjectAcl) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, PatchDefaultObjectAcl) {
@@ -980,7 +980,7 @@ TEST(TracingClientTest, PatchDefaultObjectAcl) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, GetServiceAccount) {
@@ -1002,7 +1002,7 @@ TEST(TracingClientTest, GetServiceAccount) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, ListHmacKeys) {
@@ -1024,7 +1024,7 @@ TEST(TracingClientTest, ListHmacKeys) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, CreateHmacKey) {
@@ -1046,7 +1046,7 @@ TEST(TracingClientTest, CreateHmacKey) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, DeleteHmacKey) {
@@ -1069,7 +1069,7 @@ TEST(TracingClientTest, DeleteHmacKey) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, GetHmacKey) {
@@ -1091,7 +1091,7 @@ TEST(TracingClientTest, GetHmacKey) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, UpdateHmacKey) {
@@ -1114,7 +1114,7 @@ TEST(TracingClientTest, UpdateHmacKey) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, SignBlob) {
@@ -1136,7 +1136,7 @@ TEST(TracingClientTest, SignBlob) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, ListNotifications) {
@@ -1158,7 +1158,7 @@ TEST(TracingClientTest, ListNotifications) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, CreateNotification) {
@@ -1180,7 +1180,7 @@ TEST(TracingClientTest, CreateNotification) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, GetNotification) {
@@ -1202,7 +1202,7 @@ TEST(TracingClientTest, GetNotification) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 TEST(TracingClientTest, DeleteNotification) {
@@ -1224,7 +1224,7 @@ TEST(TracingClientTest, DeleteNotification) {
                   SpanHasInstrumentationScope(), SpanKindIsClient(),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kError, msg),
                   SpanHasAttributes(OTelAttribute<int>(
-                      "gcloud.status_code", static_cast<int>(code))))));
+                      "gl-cpp.status_code", static_cast<int>(code))))));
 }
 
 }  // namespace


### PR DESCRIPTION
Follow up to #12835

`google/cloud/internal/opentelemetry.cc` has the real change. The rest are tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12836)
<!-- Reviewable:end -->
