### PR TITLE
impl(otel): record more streaming RPC events

### DIFF
--- a/generator/integration_tests/tests/golden_kitchen_sink_tracing_stub_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_tracing_stub_test.cc
@@ -318,7 +318,7 @@ TEST(GoldenKitchenSinkTracingStubTest, AsyncStreamingRead) {
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(
       spans,
-      ElementsAre(AllOf(
+      Contains(AllOf(
           SpanHasInstrumentationScope(), SpanKindIsClient(),
           SpanNamed(
               "google.test.admin.database.v1.GoldenKitchenSink/StreamingRead"),
@@ -354,7 +354,7 @@ TEST(GoldenKitchenSinkTracingStubTest, AsyncStreamingWrite) {
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(
       spans,
-      ElementsAre(AllOf(
+      Contains(AllOf(
           SpanHasInstrumentationScope(), SpanKindIsClient(),
           SpanNamed(
               "google.test.admin.database.v1.GoldenKitchenSink/StreamingWrite"),
@@ -390,7 +390,7 @@ TEST(GoldenKitchenSinkTracingStubTest, AsyncStreamingReadWrite) {
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(
       spans,
-      ElementsAre(AllOf(
+      Contains(AllOf(
           SpanHasInstrumentationScope(), SpanKindIsClient(),
           SpanNamed("google.test.admin.database.v1.GoldenKitchenSink/"
                     "StreamingReadWrite"),

--- a/google/cloud/internal/async_read_write_stream_tracing.h
+++ b/google/cloud/internal/async_read_write_stream_tracing.h
@@ -44,14 +44,18 @@ class AsyncStreamingReadWriteRpcTracing
   }
 
   future<bool> Start() override {
-    return impl_->Start().then([this](future<bool> f) {
-      auto started = f.get();
-      span_->SetAttribute("gl-cpp.stream_started", started);
-      return started;
-    });
+    auto start_span = internal::MakeSpan("Start");
+    return impl_->Start().then(
+        [this, ss = std::move(start_span)](future<bool> f) {
+          EndSpan(*ss);
+          auto started = f.get();
+          span_->SetAttribute("gl-cpp.stream_started", started);
+          return started;
+        });
   }
 
   future<absl::optional<Response>> Read() override {
+    if (read_count_ == 0) span_->AddEvent("gl-cpp.first-read");
     return impl_->Read().then([this](future<absl::optional<Response>> f) {
       auto r = f.get();
       if (r.has_value()) {
@@ -64,6 +68,7 @@ class AsyncStreamingReadWriteRpcTracing
 
   future<bool> Write(Request const& request,
                      grpc::WriteOptions options) override {
+    if (write_count_ == 0) span_->AddEvent("gl-cpp.first-write");
     auto is_last = options.is_last_message();
     return impl_->Write(request, std::move(options))
         .then([this, is_last](future<bool> f) {
@@ -84,8 +89,12 @@ class AsyncStreamingReadWriteRpcTracing
   }
 
   future<Status> Finish() override {
+    auto finish_span = internal::MakeSpan("Finish");
     return impl_->Finish().then(
-        [this](future<Status> f) { return End(f.get()); });
+        [this, fs = std::move(finish_span)](future<Status> f) {
+          EndSpan(*fs);
+          return End(f.get());
+        });
   }
 
  private:


### PR DESCRIPTION
For streaming RPCs the `Start()` and `Finish()` calls need to be spans, as they can take significant time and may involve waiting for the server. It is also using to record the first `Read()` and `Write()` as they may initiate the upload or download.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12837)
<!-- Reviewable:end -->
