### PR TITLE
feat(storage): `MatchGlob` for `ListObjects()`

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -1017,7 +1017,7 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `MaxResults`, `Prefix`,
    *     `Delimiter`, `IncludeTrailingDelimiter`, `StartOffset`, `EndOffset`,
-   *     `Projection`, `UserProject`, and `Versions`.
+   *     `MatchGlob`, `Projection`, `UserProject`, and `Versions`.
    *
    * @par Idempotency
    * This is a read-only operation and is always idempotent.
@@ -1049,7 +1049,7 @@ class Client {
    *     Valid types for this operation include
    *     `IfMetagenerationMatch`, `IfMetagenerationNotMatch`, `UserProject`,
    *     `Projection`, `Prefix`, `Delimiter`, `IncludeTrailingDelimiter`,
-   *     `StartOffset`, `EndOffset`, and `Versions`.
+   *     `StartOffset`, `EndOffset`, `MatchGlob`, and `Versions`.
    *
    * @par Idempotency
    * This is a read-only operation and is always idempotent.

--- a/google/cloud/storage/internal/grpc/object_request_parser.cc
+++ b/google/cloud/storage/internal/grpc/object_request_parser.cc
@@ -525,6 +525,7 @@ google::storage::v2::ListObjectsRequest ToProto(
       request.GetOption<storage::StartOffset>().value_or(""));
   result.set_lexicographic_end(
       request.GetOption<storage::EndOffset>().value_or(""));
+  result.set_match_glob(request.GetOption<storage::MatchGlob>().value_or(""));
   return result;
 }
 

--- a/google/cloud/storage/internal/grpc/object_request_parser_test.cc
+++ b/google/cloud/storage/internal/grpc/object_request_parser_test.cc
@@ -860,6 +860,7 @@ TEST(GrpcObjectRequestParser, ListObjectsRequestAllFields) {
         versions: true
         lexicographic_start: "test/prefix/a"
         lexicographic_end: "test/prefix/abc"
+        match_glob: "**/*.cc"
       )pb",
       &expected));
 
@@ -869,7 +870,7 @@ TEST(GrpcObjectRequestParser, ListObjectsRequestAllFields) {
       storage::MaxResults(10), storage::Delimiter("/"),
       storage::IncludeTrailingDelimiter(true), storage::Prefix("test/prefix"),
       storage::Versions(true), storage::StartOffset("test/prefix/a"),
-      storage::EndOffset("test/prefix/abc"),
+      storage::EndOffset("test/prefix/abc"), storage::MatchGlob("**/*.cc"),
       storage::UserProject("test-user-project"),
       storage::QuotaUser("test-quota-user"), storage::UserIp("test-user-ip"));
 

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -47,7 +47,7 @@ namespace internal {
 class ListObjectsRequest
     : public GenericRequest<ListObjectsRequest, MaxResults, Prefix, Delimiter,
                             IncludeTrailingDelimiter, StartOffset, EndOffset,
-                            Projection, UserProject, Versions> {
+                            MatchGlob, Projection, UserProject, Versions> {
  public:
   ListObjectsRequest() = default;
   explicit ListObjectsRequest(std::string bucket_name)

--- a/google/cloud/storage/well_known_parameters.h
+++ b/google/cloud/storage/well_known_parameters.h
@@ -494,6 +494,20 @@ struct EndOffset : public internal::WellKnownParameter<EndOffset, std::string> {
 };
 
 /**
+ * Restrict list operations to entries matching a glob pattern.
+ *
+ * This optional parameter applies to both the request to list objects. Setting
+ * a value for this option returns only the entries that match the given glob.
+ *
+ * @see https://cloud.google.com/storage/docs/json_api/v1/objects/list#list-object-glob
+ *     for details on the glob pattern.
+ */
+struct MatchGlob : public internal::WellKnownParameter<MatchGlob, std::string> {
+  using WellKnownParameter<MatchGlob, std::string>::WellKnownParameter;
+  static char const* well_known_parameter_name() { return "matchGlob"; }
+};
+
+/**
  * Controls what metadata fields are included in the response.
  *
  * For those operations that return the metadata of an Object or Bucket, this


### PR DESCRIPTION
Support globs to filter object listing operations.

Fixes #1227

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12840)
<!-- Reviewable:end -->
