### PR TITLE
fix(storage): check ReadObject options at runtime

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -1123,22 +1123,6 @@ class Client {
   ObjectReadStream ReadObject(std::string const& bucket_name,
                               std::string const& object_name,
                               Options&&... options) {
-    struct HasReadRange
-        : public absl::disjunction<std::is_same<ReadRange, Options>...> {};
-    struct HasReadFromOffset
-        : public absl::disjunction<std::is_same<ReadFromOffset, Options>...> {};
-    struct HasReadLast
-        : public absl::disjunction<std::is_same<ReadLast, Options>...> {};
-
-    struct HasIncompatibleRangeOptions
-        : public std::integral_constant<bool, HasReadLast::value &&
-                                                  (HasReadFromOffset::value ||
-                                                   HasReadRange::value)> {};
-
-    static_assert(!HasIncompatibleRangeOptions::value,
-                  "Cannot set ReadLast option with either ReadFromOffset or "
-                  "ReadRange.");
-
     google::cloud::internal::OptionsSpan const span(
         SpanOptions(std::forward<Options>(options)...));
     internal::ReadObjectRangeRequest request(bucket_name, object_name);

--- a/google/cloud/storage/internal/grpc/object_request_parser.cc
+++ b/google/cloud/storage/internal/grpc/object_request_parser.cc
@@ -318,11 +318,11 @@ google::storage::v2::GetObjectRequest ToProto(
 
 StatusOr<google::storage::v2::ReadObjectRequest> ToProto(
     storage::internal::ReadObjectRangeRequest const& request) {
-  // With the REST API this condition was detected by the server as an error,
-  // generally we prefer the server to detect errors because its answers are
-  // authoritative. In this case, the server cannot: with gRPC '0' is the same
-  // as "not set" and the server would send back the full file, which was
-  // unlikely to be the customer's intent.
+  // With the REST API this condition was detected by the server as an error.
+  // Generally we prefer the server to detect errors because its answers are
+  // authoritative, but in this case it cannot. With gRPC, '0' is the same as
+  // "not set" so the server would send back the full file, and that is unlikely
+  // to be the customer's intent.
   if (request.HasOption<storage::ReadLast>() &&
       request.GetOption<storage::ReadLast>().value() == 0) {
     return internal::OutOfRangeError(

--- a/google/cloud/storage/internal/grpc/object_request_parser.cc
+++ b/google/cloud/storage/internal/grpc/object_request_parser.cc
@@ -20,6 +20,7 @@
 #include "google/cloud/storage/internal/openssl_util.h"
 #include "google/cloud/storage/internal/patch_builder_details.h"
 #include "google/cloud/internal/invoke_result.h"
+#include "google/cloud/internal/make_status.h"
 #include "google/cloud/internal/time_utils.h"
 #include "google/cloud/log.h"
 
@@ -317,6 +318,31 @@ google::storage::v2::GetObjectRequest ToProto(
 
 StatusOr<google::storage::v2::ReadObjectRequest> ToProto(
     storage::internal::ReadObjectRangeRequest const& request) {
+  // With the REST API this condition was detected by the server as an error,
+  // generally we prefer the server to detect errors because its answers are
+  // authoritative. In this case, the server cannot: with gRPC '0' is the same
+  // as "not set" and the server would send back the full file, which was
+  // unlikely to be the customer's intent.
+  if (request.HasOption<storage::ReadLast>() &&
+      request.GetOption<storage::ReadLast>().value() == 0) {
+    return internal::OutOfRangeError(
+        "ReadLast(0) is invalid in REST and produces incorrect output in gRPC",
+        GCP_ERROR_INFO());
+  }
+  // We should not guess the intent in this case.
+  if (request.HasOption<storage::ReadLast>() &&
+      request.HasOption<storage::ReadRange>()) {
+    return internal::InvalidArgumentError(
+        "Cannot use ReadLast() and ReadRange() at the same time",
+        GCP_ERROR_INFO());
+  }
+  // We should not guess the intent in this case.
+  if (request.HasOption<storage::ReadLast>() &&
+      request.HasOption<storage::ReadFromOffset>()) {
+    return internal::InvalidArgumentError(
+        "Cannot use ReadLast() and ReadFromOffset() at the same time",
+        GCP_ERROR_INFO());
+  }
   google::storage::v2::ReadObjectRequest r;
   auto status = SetCommonObjectParameters(r, request);
   if (!status.ok()) return status;

--- a/google/cloud/storage/internal/grpc/stub.cc
+++ b/google/cloud/storage/internal/grpc/stub.cc
@@ -488,17 +488,6 @@ StatusOr<std::unique_ptr<storage::internal::ObjectReadSource>>
 GrpcStub::ReadObject(rest_internal::RestContext& context,
                      Options const& options,
                      storage::internal::ReadObjectRangeRequest const& request) {
-  // With the REST API this condition was detected by the server as an error,
-  // generally we prefer the server to detect errors because its answers are
-  // authoritative. In this case, the server cannot: with gRPC '0' is the same
-  // as "not set" and the server would send back the full file, which was
-  // unlikely to be the customer's intent.
-  if (request.HasOption<storage::ReadLast>() &&
-      request.GetOption<storage::ReadLast>().value() == 0) {
-    return Status(
-        StatusCode::kOutOfRange,
-        "ReadLast(0) is invalid in REST and produces incorrect output in gRPC");
-  }
   auto ctx = std::make_shared<grpc::ClientContext>();
   ApplyQueryParameters(*ctx, options, request);
   AddIdempotencyToken(*ctx, context);

--- a/google/cloud/storage/internal/rest/stub_test.cc
+++ b/google/cloud/storage/internal/rest/stub_test.cc
@@ -303,6 +303,30 @@ TEST(RestStubTest, ReadObject) {
               StatusIs(PermanentError().code(), PermanentError().message()));
 }
 
+TEST(RestStubTest, ReadObjectReadLastConflictsWithReadFromOffset) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Get(ExpectedContext(), ExpectedRequest())).Times(0);
+  auto tested = std::make_unique<RestStub>(Options{}, mock, mock);
+  auto context = TestContext();
+  auto status = tested->ReadObject(context, TestOptions(),
+                                   ReadObjectRangeRequest()
+                                       .set_option(ReadLast(5))
+                                       .set_option(ReadFromOffset(7)));
+  EXPECT_THAT(status, StatusIs(StatusCode::kInvalidArgument));
+}
+
+TEST(RestStubTest, ReadObjectReadLastConflictsWithReadRange) {
+  auto mock = std::make_shared<MockRestClient>();
+  EXPECT_CALL(*mock, Get(ExpectedContext(), ExpectedRequest())).Times(0);
+  auto tested = std::make_unique<RestStub>(Options{}, mock, mock);
+  auto context = TestContext();
+  auto status = tested->ReadObject(context, TestOptions(),
+                                   ReadObjectRangeRequest()
+                                       .set_option(ReadLast(5))
+                                       .set_option(ReadRange(0, 7)));
+  EXPECT_THAT(status, StatusIs(StatusCode::kInvalidArgument));
+}
+
 TEST(RestStubTest, ListObjects) {
   auto mock = std::make_shared<MockRestClient>();
   EXPECT_CALL(*mock, Get(ExpectedContext(), ExpectedRequest()))


### PR DESCRIPTION
Some options for `ReadObject()` can only be freely combined. The application intent is unclear when somebody says `ReadRange(1, 10)` and `ReadLast(7)`. And it is impossible to represent this as two instructions that the service can disambiguate.

We were checking for the presence of these options in the parameter pack, but that does not work, because the options can be "set" with no value (maybe at runtime choosing to set either `ReadLast()` or `ReadRange()`). Adding insult to injury, I forgot to `std::decay_t` the types in the parameter pack, so the compile-time check did not always work either.

In hindsight we should have represented them by a `absl::variant<>` or some other type that did not allow for illegal combinations, too late to do that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12841)
<!-- Reviewable:end -->
