### PR TITLE
feat(storage): another Bucket CRUD field

### DIFF
--- a/google/cloud/storage/bucket_autoclass.cc
+++ b/google/cloud/storage/bucket_autoclass.cc
@@ -26,7 +26,12 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 std::ostream& operator<<(std::ostream& os, BucketAutoclass const& rhs) {
   google::cloud::internal::IosFlagsSaver flags(os);
   return os << "{enabled=" << std::boolalpha << rhs.enabled << ", toggle_time="
-            << google::cloud::internal::FormatRfc3339(rhs.toggle_time) << "}";
+            << google::cloud::internal::FormatRfc3339(rhs.toggle_time)
+            << ", terminal_storage_class=" << rhs.terminal_storage_class
+            << ", terminal_storage_class_update="
+            << google::cloud::internal::FormatRfc3339(
+                   rhs.terminal_storage_class_update)
+            << "}";
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/bucket_autoclass.h
+++ b/google/cloud/storage/bucket_autoclass.h
@@ -18,7 +18,9 @@
 #include "google/cloud/storage/version.h"
 #include <chrono>
 #include <iosfwd>
+#include <string>
 #include <tuple>
+#include <utility>
 
 namespace google {
 namespace cloud {
@@ -38,16 +40,29 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  */
 struct BucketAutoclass {
   explicit BucketAutoclass(bool e) : enabled(e) {}
+  explicit BucketAutoclass(bool e, std::string tsc)
+      : enabled(e), terminal_storage_class(std::move(tsc)) {}
   explicit BucketAutoclass(bool e, std::chrono::system_clock::time_point tp)
       : enabled(e), toggle_time(tp) {}
+  explicit BucketAutoclass(bool e, std::chrono::system_clock::time_point tp,
+                           std::string tsc,
+                           std::chrono::system_clock::time_point tscu)
+      : enabled(e),
+        toggle_time(tp),
+        terminal_storage_class(std::move(tsc)),
+        terminal_storage_class_update(tscu) {}
 
   bool enabled;
   std::chrono::system_clock::time_point toggle_time;
+  std::string terminal_storage_class;
+  std::chrono::system_clock::time_point terminal_storage_class_update;
 };
 
 inline bool operator==(BucketAutoclass const& lhs, BucketAutoclass const& rhs) {
-  return std::tie(lhs.enabled, lhs.toggle_time) ==
-         std::tie(rhs.enabled, rhs.toggle_time);
+  return std::tie(lhs.enabled, lhs.toggle_time, lhs.terminal_storage_class,
+                  lhs.terminal_storage_class_update) ==
+         std::tie(rhs.enabled, rhs.toggle_time, rhs.terminal_storage_class,
+                  rhs.terminal_storage_class_update);
 }
 
 inline bool operator!=(BucketAutoclass const& lhs, BucketAutoclass const& rhs) {

--- a/google/cloud/storage/bucket_metadata.cc
+++ b/google/cloud/storage/bucket_metadata.cc
@@ -255,8 +255,11 @@ BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::ResetAcl() {
 
 BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::SetAutoclass(
     BucketAutoclass const& v) {
-  impl_.AddSubPatch(
-      "autoclass", internal::PatchBuilder().SetBoolField("enabled", v.enabled));
+  auto builder = internal::PatchBuilder().SetBoolField("enabled", v.enabled);
+  if (!v.terminal_storage_class.empty()) {
+    builder.SetStringField("terminalStorageClass", v.terminal_storage_class);
+  }
+  impl_.AddSubPatch("autoclass", std::move(builder));
   return *this;
 }
 

--- a/google/cloud/storage/examples/storage_bucket_autoclass_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_autoclass_samples.cc
@@ -119,7 +119,7 @@ void RunAll(std::vector<std::string> const& argv) {
   std::cout << "\nCreating buckets to run the example:"
             << "\nEnabled Autoclass: " << bucket_name_enabled
             << "\nDisabled Autoclass: " << bucket_name_disabled
-            << "\nArchive Autclass: " << bucket_name_archive << std::endl;
+            << "\nArchive Autoclass: " << bucket_name_archive << std::endl;
   // In GCS a single project cannot create or delete buckets more often than
   // once every two seconds. We will pause until that time before deleting the
   // bucket.

--- a/google/cloud/storage/examples/storage_bucket_autoclass_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_autoclass_samples.cc
@@ -72,6 +72,30 @@ void SetAutoclass(google::cloud::storage::Client client,
   (std::move(client), argv.at(0), enabled);
 }
 
+void SetAutoclassArchive(google::cloud::storage::Client client,
+                         std::vector<std::string> const& argv) {
+  using ::google::cloud::storage::examples::Usage;
+  //! [set-autoclass-archive]
+  namespace gcs = ::google::cloud::storage;
+  [](gcs::Client client, std::string const& bucket_name) {
+    auto metadata = client.PatchBucket(
+        bucket_name,
+        gcs::BucketMetadataPatchBuilder().SetAutoclass(
+            gcs::BucketAutoclass{true, gcs::storage_class::Archive()}));
+    if (!metadata) throw google::cloud::Status(std::move(metadata).status());
+
+    std::cout << "The autoclass configuration for bucket " << bucket_name
+              << " was successfully updated.";
+    if (!metadata->has_autoclass()) {
+      std::cout << " The bucket no longer has an autoclass configuration.\n";
+      return;
+    }
+    std::cout << " The new configuration is " << metadata->autoclass() << "\n";
+  }
+  //! [set-autoclass-archive]
+  (std::move(client), argv.at(0));
+}
+
 void RunAll(std::vector<std::string> const& argv) {
   namespace examples = ::google::cloud::storage::examples;
   namespace gcs = ::google::cloud::storage;
@@ -83,15 +107,19 @@ void RunAll(std::vector<std::string> const& argv) {
   auto const project_id =
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
+  // We need multiple buckets because in production the autoclass state cannot
+  // be reset until 24 hours have elapsed.
   auto const bucket_name_enabled = examples::MakeRandomBucketName(generator);
   auto const bucket_name_disabled = examples::MakeRandomBucketName(generator);
+  auto const bucket_name_archive = examples::MakeRandomBucketName(generator);
   auto const object_name =
       examples::MakeRandomObjectName(generator, "object-") + ".txt";
   auto client = gcs::Client();
 
   std::cout << "\nCreating buckets to run the example:"
             << "\nEnabled Autoclass: " << bucket_name_enabled
-            << "\nDisabled Autoclass: " << bucket_name_disabled << std::endl;
+            << "\nDisabled Autoclass: " << bucket_name_disabled
+            << "\nArchive Autclass: " << bucket_name_archive << std::endl;
   // In GCS a single project cannot create or delete buckets more often than
   // once every two seconds. We will pause until that time before deleting the
   // bucket.
@@ -109,6 +137,13 @@ void RunAll(std::vector<std::string> const& argv) {
           gcs::BucketMetadata{}.set_autoclass(gcs::BucketAutoclass{false}),
           examples::CreateBucketOptions())
       .value();
+  if (!examples::UsingEmulator()) std::this_thread::sleep_for(kBucketPeriod);
+  (void)client
+      .CreateBucketForProject(
+          bucket_name_archive, project_id,
+          gcs::BucketMetadata{}.set_autoclass(gcs::BucketAutoclass{false}),
+          examples::CreateBucketOptions())
+      .value();
   auto const pause = std::chrono::steady_clock::now() + kBucketPeriod;
 
   std::cout << "\nRunning GetAutoclass() example [enabled]" << std::endl;
@@ -120,10 +155,15 @@ void RunAll(std::vector<std::string> const& argv) {
   std::cout << "\nRunning SetAutoclass() example" << std::endl;
   SetAutoclass(client, {bucket_name_enabled, "false"});
 
+  std::cout << "\nRunning SetAutoclassArchive() example" << std::endl;
+  SetAutoclassArchive(client, {bucket_name_archive});
+
   if (!examples::UsingEmulator()) std::this_thread::sleep_until(pause);
   (void)examples::RemoveBucketAndContents(client, bucket_name_enabled);
   if (!examples::UsingEmulator()) std::this_thread::sleep_for(kBucketPeriod);
   (void)examples::RemoveBucketAndContents(client, bucket_name_disabled);
+  if (!examples::UsingEmulator()) std::this_thread::sleep_for(kBucketPeriod);
+  (void)examples::RemoveBucketAndContents(client, bucket_name_archive);
 }
 
 }  // namespace
@@ -135,6 +175,8 @@ int main(int argc, char* argv[]) {
                                    GetAutoclass),
       examples::CreateCommandEntry(
           "set-autoclass", {"<bucket-name>", "<enabled>"}, SetAutoclass),
+      examples::CreateCommandEntry("set-autoclass-archive", {"<bucket-name>"},
+                                   SetAutoclassArchive),
       {"auto", RunAll},
   });
   return example.Run(argc, argv);

--- a/google/cloud/storage/internal/grpc/bucket_metadata_parser.cc
+++ b/google/cloud/storage/internal/grpc/bucket_metadata_parser.cc
@@ -199,6 +199,10 @@ google::storage::v2::Bucket::Autoclass ToProto(
   result.set_enabled(rhs.enabled);
   *result.mutable_toggle_time() =
       google::cloud::internal::ToProtoTimestamp(rhs.toggle_time);
+  result.set_terminal_storage_class(rhs.terminal_storage_class);
+  *result.mutable_terminal_storage_class_update_time() =
+      google::cloud::internal::ToProtoTimestamp(
+          rhs.terminal_storage_class_update);
   return result;
 }
 
@@ -208,6 +212,12 @@ storage::BucketAutoclass FromProto(
   if (rhs.has_toggle_time()) {
     result.toggle_time =
         google::cloud::internal::ToChronoTimePoint(rhs.toggle_time());
+  }
+  result.terminal_storage_class = rhs.terminal_storage_class();
+  if (rhs.has_terminal_storage_class_update_time()) {
+    result.terminal_storage_class_update =
+        google::cloud::internal::ToChronoTimePoint(
+            rhs.terminal_storage_class_update_time());
   }
   return result;
 }

--- a/google/cloud/storage/internal/grpc/bucket_request_parser_test.cc
+++ b/google/cloud/storage/internal/grpc/bucket_request_parser_test.cc
@@ -90,6 +90,8 @@ TEST(GrpcBucketRequestParser, CreateBucketMetadataAllOptions) {
           autoclass {
             enabled: true
             toggle_time {}
+            terminal_storage_class: "NEARLINE"
+            terminal_storage_class_update_time {}
           }
           billing { requester_pays: true }
           default_object_acl {
@@ -137,7 +139,7 @@ TEST(GrpcBucketRequestParser, CreateBucketMetadataAllOptions) {
           .set_name("test-bucket")
           .set_storage_class("NEARLINE")
           .set_location("us-central1")
-          .set_autoclass(storage::BucketAutoclass{true})
+          .set_autoclass(storage::BucketAutoclass{true, "NEARLINE"})
           .set_billing(storage::BucketBilling(true))
           .set_rpo(storage::RpoAsyncTurbo())
           .set_versioning(storage::BucketVersioning(true))


### PR DESCRIPTION
This time, the `Bucket.auto_class()` gains `terminal_storage_class`, and `OUTPUT_ONLY` `terminate_storage_class_update` fields. Only interesting for completeness sake.

Fixes #12658

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12842)
<!-- Reviewable:end -->
