### PR TITLE
fix(storage): fix tellg() values

### DIFF
--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -70,8 +70,7 @@ ObjectReadStream Client::ReadObjectImpl(
   }
   auto stream =
       ObjectReadStream(std::make_unique<internal::ObjectReadStreambuf>(
-          request, *std::move(source),
-          request.GetOption<ReadFromOffset>().value_or(0)));
+          request, *std::move(source)));
   (void)stream.peek();
 #if !GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   // Without exceptions the streambuf cannot report errors, so we have to

--- a/google/cloud/storage/internal/object_read_streambuf.cc
+++ b/google/cloud/storage/internal/object_read_streambuf.cc
@@ -22,12 +22,22 @@ namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
+namespace {
+
+std::streamoff InitialOffset(ReadObjectRangeRequest const& request) {
+  if (request.HasOption<ReadLast>()) {
+    return -request.GetOption<ReadLast>().value();
+  }
+  return request.StartingByte();
+}
+
+}  // namespace
 
 ObjectReadStreambuf::ObjectReadStreambuf(
     ReadObjectRangeRequest const& request,
-    std::unique_ptr<ObjectReadSource> source, std::streamoff pos_in_stream)
+    std::unique_ptr<ObjectReadSource> source)
     : source_(std::move(source)),
-      source_pos_(pos_in_stream),
+      source_pos_(static_cast<std::streamoff>(InitialOffset(request))),
       hash_function_(CreateHashFunction(request)),
       hash_validator_(CreateHashValidator(request)) {}
 
@@ -51,6 +61,7 @@ ObjectReadStreambuf::pos_type ObjectReadStreambuf::seekoff(
   // recreated in the general case, which doesn't fit the current code
   // organization.  We can, however, at least implement the bare minimum of this
   // function allowing `tellg()` to work.
+  if (source_pos_ < 0) return -1;
   if (which == std::ios_base::in && dir == std::ios_base::cur && off == 0) {
     return source_pos_ - in_avail();
   }
@@ -198,7 +209,6 @@ std::streamsize ObjectReadStreambuf::xsgetn(char* s, std::streamsize count) {
   hash_function_->Update(absl::string_view{s + offset, read->bytes_received});
   hash_validator_->ProcessHashValues(read->hashes);
   offset += static_cast<std::streamsize>(read->bytes_received);
-  source_pos_ += static_cast<std::streamoff>(read->bytes_received);
   for (auto const& kv : read->response.headers) {
     headers_.emplace(kv.first, kv.second);
   }
@@ -207,6 +217,13 @@ std::streamsize ObjectReadStreambuf::xsgetn(char* s, std::streamsize count) {
   if (!storage_class_) storage_class_ = std::move(read->storage_class);
   if (!size_) size_ = std::move(read->size);
   if (!transformation_) transformation_ = std::move(read->transformation);
+
+  if (source_pos_ >= 0) {
+    source_pos_ += static_cast<std::streamoff>(read->bytes_received);
+  } else if (size_) {
+    source_pos_ = *size_ + source_pos_ +
+                  static_cast<std::streamoff>(read->bytes_received);
+  }
   return run_validator_if_closed(Status());
 }
 

--- a/google/cloud/storage/internal/object_read_streambuf.cc
+++ b/google/cloud/storage/internal/object_read_streambuf.cc
@@ -37,7 +37,7 @@ ObjectReadStreambuf::ObjectReadStreambuf(
     ReadObjectRangeRequest const& request,
     std::unique_ptr<ObjectReadSource> source)
     : source_(std::move(source)),
-      source_pos_(static_cast<std::streamoff>(InitialOffset(request))),
+      source_pos_(InitialOffset(request)),
       hash_function_(CreateHashFunction(request)),
       hash_validator_(CreateHashValidator(request)) {}
 
@@ -221,8 +221,7 @@ std::streamsize ObjectReadStreambuf::xsgetn(char* s, std::streamsize count) {
   if (source_pos_ >= 0) {
     source_pos_ += static_cast<std::streamoff>(read->bytes_received);
   } else if (size_) {
-    source_pos_ = *size_ + source_pos_ +
-                  static_cast<std::streamoff>(read->bytes_received);
+    source_pos_ += *size_ + static_cast<std::streamoff>(read->bytes_received);
   }
   return run_validator_if_closed(Status());
 }

--- a/google/cloud/storage/internal/object_read_streambuf.h
+++ b/google/cloud/storage/internal/object_read_streambuf.h
@@ -43,8 +43,7 @@ namespace internal {
 class ObjectReadStreambuf : public std::basic_streambuf<char> {
  public:
   ObjectReadStreambuf(ReadObjectRangeRequest const& request,
-                      std::unique_ptr<ObjectReadSource> source,
-                      std::streamoff pos_in_stream);
+                      std::unique_ptr<ObjectReadSource> source);
 
   /// Create a streambuf in a permanent error status.
   ObjectReadStreambuf(ReadObjectRangeRequest const& request, Status status);


### PR DESCRIPTION
The initial values for `tellg()` were incorrect `ReadRange()` and `ReadLast()` options.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12844)
<!-- Reviewable:end -->
