### PR TITLE
impl(common): statically initialize URL encoding maps

### DIFF
--- a/google/cloud/internal/url_encode.cc
+++ b/google/cloud/internal/url_encode.cc
@@ -15,36 +15,44 @@
 #include "google/cloud/internal/url_encode.h"
 #include "google/cloud/internal/absl_str_replace_quiet.h"
 #include <array>
+#include <utility>
 
 namespace google {
 namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 
+namespace {
+
+using UrlMappings =
+    std::array<std::pair<absl::string_view, absl::string_view>, 25>;
+
+constexpr auto kEncodeMappings = UrlMappings{{
+    {" ", "%20"}, {"\"", "%22"}, {"#", "%23"},  {"$", "%24"}, {"%", "%25"},
+    {"&", "%26"}, {"+", "%2B"},  {",", "%2C"},  {"/", "%2F"}, {":", "%3A"},
+    {";", "%3B"}, {"<", "%3C"},  {"=", "%3D"},  {">", "%3E"}, {"?", "%3F"},
+    {"@", "%40"}, {"[", "%5B"},  {"\\", "%5C"}, {"]", "%5D"}, {"^", "%5E"},
+    {"`", "%60"}, {"{", "%7B"},  {"|", "%7C"},  {"}", "%7D"}, {"\177", "%7F"},
+}};
+
+// Until we require C++17, it isn't worth trying to eliminate the duplication
+// using a constexpr function to produce kDecodeMappings from kEncodeMappings.
+constexpr auto kDecodeMappings = UrlMappings{{
+    {"%20", " "}, {"%22", "\""}, {"%23", "#"},  {"%24", "$"}, {"%25", "%"},
+    {"%26", "&"}, {"%2B", "+"},  {"%2C", ","},  {"%2F", "/"}, {"%3A", ":"},
+    {"%3B", ";"}, {"%3C", "<"},  {"%3D", "="},  {"%3E", ">"}, {"%3F", "?"},
+    {"%40", "@"}, {"%5B", "["},  {"%5C", "\\"}, {"%5D", "]"}, {"%5E", "^"},
+    {"%60", "`"}, {"%7B", "{"},  {"%7C", "|"},  {"%7D", "}"}, {"%7F", "\177"},
+}};
+
+}  // namespace
+
 std::string UrlEncode(absl::string_view value) {
-  using CharMapping = std::pair<absl::string_view, absl::string_view>;
-  auto const mappings = std::array<CharMapping, 25>{
-      {{" ", "%20"},   {"\"", "%22"}, {"#", "%23"}, {"$", "%24"},
-       {"%", "%25"},   {"&", "%26"},  {"+", "%2B"}, {",", "%2C"},
-       {"/", "%2F"},   {":", "%3A"},  {";", "%3B"}, {"<", "%3C"},
-       {"=", "%3D"},   {">", "%3E"},  {"?", "%3F"}, {"@", "%40"},
-       {"[", "%5B"},   {"\\", "%5C"}, {"]", "%5D"}, {"^", "%5E"},
-       {"`", "%60"},   {"{", "%7B"},  {"|", "%7C"}, {"}", "%7D"},
-       {"\177", "%7F"}}};
-  return absl::StrReplaceAll(value, mappings);
+  return absl::StrReplaceAll(value, kEncodeMappings);
 }
 
 std::string UrlDecode(absl::string_view value) {
-  using CharMapping = std::pair<absl::string_view, absl::string_view>;
-  auto const mappings = std::array<CharMapping, 25>{
-      {{"%20", " "},   {"%22", "\""}, {"%23", "#"}, {"%24", "$"},
-       {"%25", "%"},   {"%26", "&"},  {"%2B", "+"}, {"%2C", ","},
-       {"%2F", "/"},   {"%3A", ":"},  {"%3B", ";"}, {"%3C", "<"},
-       {"%3D", "="},   {"%3E", ">"},  {"%3F", "?"}, {"%40", "@"},
-       {"%5B", "["},   {"%5C", "\\"}, {"%5D", "]"}, {"%5E", "^"},
-       {"%60", "`"},   {"%7B", "{"},  {"%7C", "|"}, {"%7D", "}"},
-       {"%7F", "\177"}}};
-  return absl::StrReplaceAll(value, mappings);
+  return absl::StrReplaceAll(value, kDecodeMappings);
 }
 
 }  // namespace internal

--- a/google/cloud/internal/url_encode_test.cc
+++ b/google/cloud/internal/url_encode_test.cc
@@ -31,11 +31,16 @@ TEST(UrlEncode, Simple) {
 }
 
 TEST(UrlEncode, MultipleReplacements) {
-  auto const* unencoded_string = "%>/@";
+  auto const* unencoded_string = R"( "#$%&+,/:;<)"
+                                 R"(=>?@[\]^`{|})"
+                                 "\177abcdABCD123";
 
   auto result = UrlEncode(unencoded_string);
 
-  auto const* encoded_string = "%25%3E%2F%40";
+  auto const* encoded_string =
+      "%20%22%23%24%25%26%2B%2C%2F%3A%3B%3C"
+      "%3D%3E%3F%40%5B%5C%5D%5E%60%7B%7C%7D"
+      "%7FabcdABCD123";
   EXPECT_THAT(result, encoded_string);
 }
 
@@ -49,12 +54,22 @@ TEST(UrlDecode, Simple) {
 }
 
 TEST(UrlDecode, MultipleReplacements) {
-  auto const* encoded_string = "%25%3E%2F%40";
+  auto const* encoded_string =
+      "%20%22%23%24%25%26%2B%2C%2F%3A%3B%3C"
+      "%3D%3E%3F%40%5B%5C%5D%5E%60%7B%7C%7D"
+      "%7FabcdABCD123";
 
   auto result = UrlDecode(encoded_string);
 
-  auto const* unencoded_string = "%>/@";
+  auto const* unencoded_string = R"( "#$%&+,/:;<)"
+                                 R"(=>?@[\]^`{|})"
+                                 "\177abcdABCD123";
   EXPECT_THAT(result, unencoded_string);
+}
+
+TEST(UrlDecode, PercentNoOverlap) {
+  EXPECT_THAT(UrlEncode("%25"), "%2525");
+  EXPECT_THAT(UrlDecode("%2525"), "%25");
 }
 
 }  // namespace


### PR DESCRIPTION
Make the URL encode/decode mappings constexpr and namespace scoped. Leave a note about creating one mapping from the other at compile time once we require C++17.

Extend the "MultipleReplacements" tests to cover all the things. Also add a "PercentNoOverlap" test to check that decoded bytes are not subject to further matching.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12849)
<!-- Reviewable:end -->
