### PR TITLE
fix(compute): add missing bazelrc file

### DIFF
--- a/google/cloud/compute/quickstart/.bazelrc
+++ b/google/cloud/compute/quickstart/.bazelrc
@@ -1,0 +1,30 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use host-OS-specific config lines from bazelrc files.
+build --enable_platform_specific_config=true
+
+# The project requires C++ >= 14. By default Bazel adds `-std=c++0x` which
+# disables C++14 features, even if the compilers defaults to C++ >= 14
+build:linux --cxxopt=-std=c++14
+build:macos --cxxopt=-std=c++14
+# Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
+# targets, such as protoc and the grpc plugin.
+build:linux --host_cxxopt=-std=c++14
+build:macos --host_cxxopt=-std=c++14
+
+# Do not create the convenience links. They are inconvenient when the build
+# runs inside a docker image or if one builds a quickstart and then builds
+# the project separately.
+build --experimental_convenience_symlinks=ignore


### PR DESCRIPTION
This is necessary (but not sufficient) to get the quickstart building.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12856)
<!-- Reviewable:end -->
