### PR TITLE
feat(generator): split discovery doc output

### DIFF
--- a/ci/cloudbuild/builds/generate-libraries.sh
+++ b/ci/cloudbuild/builds/generate-libraries.sh
@@ -42,6 +42,7 @@ if [ -z "${GENERATE_GOLDEN_ONLY}" ]; then
     --googleapis_proto_path="${bazel_output_base}"/external/com_google_googleapis \
     --discovery_proto_path="${PWD}" \
     --output_path="${PROJECT_ROOT}" \
+    --export_output_path="${PROJECT_ROOT}" \
     --check_parameter_comment_substitutions=true \
     --generate_discovery_protos=true \
     --config_file="${PROJECT_ROOT}/generator/generator_config.textproto"

--- a/generator/internal/discovery_to_proto.h
+++ b/generator/internal/discovery_to_proto.h
@@ -79,7 +79,7 @@ AssignResourcesAndTypesToFiles(
     std::map<std::string, DiscoveryResource> const& resources,
     std::map<std::string, DiscoveryTypeVertex>& types,
     DiscoveryDocumentProperties const& document_properties,
-    std::string const& output_path);
+    std::string const& output_path, std::string const& export_output_path);
 
 // Extract hostname typically found in Discovery Documents in the form:
 // https://hostname/
@@ -93,6 +93,7 @@ Status GenerateProtosFromDiscoveryDoc(
     nlohmann::json const& discovery_doc, std::string const& discovery_doc_url,
     std::string const& protobuf_proto_path,
     std::string const& googleapis_proto_path, std::string const& output_path,
+    std::string const& export_output_path,
     std::set<std::string> operation_services = {});
 
 // Recurses through the json accumulating the values of any $ref fields

--- a/generator/internal/discovery_to_proto_test.cc
+++ b/generator/internal/discovery_to_proto_test.cc
@@ -990,7 +990,8 @@ TEST(GenerateProtosFromDiscoveryDocTest, MissingDocumentProperty) {
   auto const document_json =
       nlohmann::json::parse(kDocumentJson, nullptr, false);
   ASSERT_TRUE(document_json.is_object());
-  auto result = GenerateProtosFromDiscoveryDoc(document_json, "", "", "", "");
+  auto result =
+      GenerateProtosFromDiscoveryDoc(document_json, "", "", "", "", "");
   EXPECT_THAT(result,
               StatusIs(StatusCode::kInvalidArgument,
                        HasSubstr("Missing one or more document properties")));
@@ -1006,7 +1007,8 @@ TEST(GenerateProtosFromDiscoveryDocTest, ExtractTypesFromSchemaFailure) {
   auto const document_json =
       nlohmann::json::parse(kDocumentJson, nullptr, false);
   ASSERT_TRUE(document_json.is_object());
-  auto result = GenerateProtosFromDiscoveryDoc(document_json, "", "", "", "");
+  auto result =
+      GenerateProtosFromDiscoveryDoc(document_json, "", "", "", "", "");
   EXPECT_THAT(
       result,
       StatusIs(
@@ -1030,7 +1032,8 @@ TEST(GenerateProtosFromDiscoveryDocTest, EmptyResourcesFailure) {
   auto const document_json =
       nlohmann::json::parse(kDocumentJson, nullptr, false);
   ASSERT_TRUE(document_json.is_object());
-  auto result = GenerateProtosFromDiscoveryDoc(document_json, "", "", "", "");
+  auto result =
+      GenerateProtosFromDiscoveryDoc(document_json, "", "", "", "", "");
   EXPECT_THAT(result,
               StatusIs(StatusCode::kInvalidArgument,
                        HasSubstr("No resources found in Discovery Document")));
@@ -1064,7 +1067,8 @@ TEST(GenerateProtosFromDiscoveryDocTest, ProcessRequestResponseFailure) {
   auto const document_json =
       nlohmann::json::parse(kDocumentJson, nullptr, false);
   ASSERT_TRUE(document_json.is_object());
-  auto result = GenerateProtosFromDiscoveryDoc(document_json, "", "", "", "");
+  auto result =
+      GenerateProtosFromDiscoveryDoc(document_json, "", "", "", "", "");
   EXPECT_THAT(result,
               StatusIs(StatusCode::kInvalidArgument,
                        HasSubstr("Response name=baz not found in types")));
@@ -1648,8 +1652,8 @@ TEST_F(AssignResourcesAndTypesToFilesTest,
                                                  operation_type_json, &pool()));
   DiscoveryDocumentProperties props{"", "", "product_name", "version", "",
                                     "", {}};
-  auto result =
-      AssignResourcesAndTypesToFiles(resources, types, props, "output_path");
+  auto result = AssignResourcesAndTypesToFiles(
+      resources, types, props, "output_path", "export_output_path");
   ASSERT_STATUS_OK(result);
   ASSERT_THAT(result->first.size(), Eq(2));
   EXPECT_THAT(
@@ -2333,8 +2337,9 @@ TEST_F(AssignResourcesAndTypesToFilesTest, ResourceAndCommonFilesWithImports) {
   ASSERT_STATUS_OK(method_status);
   EstablishTypeDependencies(*types);
   ApplyResourceLabelsToTypes(resources);
-  auto files = AssignResourcesAndTypesToFiles(
-      resources, *types, document_properties, "output_path");
+  auto files =
+      AssignResourcesAndTypesToFiles(resources, *types, document_properties,
+                                     "output_path", "export_output_path");
   ASSERT_STATUS_OK(files);
 
   //  The resulting set of proto files contains one file per resource as well as

--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -46,6 +46,8 @@ ABSL_FLAG(std::string, discovery_proto_path, "",
           "Path to root dir of protos created from discovery documents.");
 ABSL_FLAG(std::string, output_path, ".",
           "Path to root dir where code is emitted.");
+ABSL_FLAG(std::string, export_output_path, ".",
+          "Path to root dir where *_export.h files are emitted.");
 ABSL_FLAG(std::string, scaffold_templates_path, ".",
           "Path to directory where we store scaffold templates.");
 ABSL_FLAG(std::string, scaffold, "",
@@ -75,6 +77,7 @@ struct CommandLineArgs {
   std::string golden_proto_path;
   std::string discovery_proto_path;
   std::string output_path;
+  std::string export_output_path;
   std::string scaffold_templates_path;
   std::string scaffold;
   bool experimental_scaffold;
@@ -191,6 +194,7 @@ google::cloud::Status GenerateProtosForRestProducts(
             *doc, p.discovery_document_url(),
             generator_args.protobuf_proto_path,
             generator_args.googleapis_proto_path, generator_args.output_path,
+            generator_args.export_output_path,
             std::set<std::string>(p.operation_services().begin(),
                                   p.operation_services().end()));
     if (!status.ok()) return status;
@@ -396,6 +400,7 @@ int main(int argc, char** argv) {
                              absl::GetFlag(FLAGS_golden_proto_path),
                              absl::GetFlag(FLAGS_discovery_proto_path),
                              absl::GetFlag(FLAGS_output_path),
+                             absl::GetFlag(FLAGS_export_output_path),
                              absl::GetFlag(FLAGS_scaffold_templates_path),
                              absl::GetFlag(FLAGS_scaffold),
                              absl::GetFlag(FLAGS_experimental_scaffold),
@@ -406,6 +411,7 @@ int main(int argc, char** argv) {
   GCP_LOG(INFO) << "googleapis_path = " << args.googleapis_proto_path << "\n";
   GCP_LOG(INFO) << "config_file = " << args.config_file << "\n";
   GCP_LOG(INFO) << "output_path = " << args.output_path << "\n";
+  GCP_LOG(INFO) << "export_output_path = " << args.export_output_path << "\n";
 
   auto config = GetConfig(args.config_file);
   if (!config.ok()) {


### PR DESCRIPTION
Sometimes we need the `*_proto_export.h` files to go to a different directory vs. the `*.proto` files.

Part of the work for #12854

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12866)
<!-- Reviewable:end -->
