### PR TITLE
fix(oauth2): do not require `id_token` in creds

### DIFF
--- a/google/cloud/internal/oauth2_authorized_user_credentials.cc
+++ b/google/cloud/internal/oauth2_authorized_user_credentials.cc
@@ -68,12 +68,11 @@ StatusOr<AccessToken> ParseAuthorizedUserRefreshResponse(
   auto access_token = nlohmann::json::parse(*payload, nullptr, false);
   if (access_token.is_discarded() || access_token.count("access_token") == 0 ||
       access_token.count("expires_in") == 0 ||
-      access_token.count("id_token") == 0 ||
       access_token.count("token_type") == 0) {
     auto error_payload =
         *payload +
         "Could not find all required fields in response (access_token,"
-        " id_token, expires_in, token_type) while trying to obtain an access"
+        " expires_in, token_type) while trying to obtain an access"
         " token for service account credentials.";
     return AsStatus(status_code, error_payload);
   }

--- a/google/cloud/internal/oauth2_authorized_user_credentials_test.cc
+++ b/google/cloud/internal/oauth2_authorized_user_credentials_test.cc
@@ -62,7 +62,6 @@ TEST_F(AuthorizedUserCredentialsTest, Simple) {
   std::string response_payload = R"""({
     "token_type": "Type",
     "access_token": "access-token-value",
-    "id_token": "id-token-value",
     "expires_in": 1234
 })""";
 
@@ -223,7 +222,6 @@ TEST_F(AuthorizedUserCredentialsTest,
   // Does not have access_token.
   std::string r2 = R"""({
     "token_type": "Type",
-    "id_token": "id-token-value",
     "expires_in": 1000
 })""";
 
@@ -260,7 +258,6 @@ TEST_F(AuthorizedUserCredentialsTest, ParseAuthorizedUserRefreshResponse) {
   std::string r1 = R"""({
     "token_type": "Type",
     "access_token": "access-token-r1",
-    "id_token": "id-token-value",
     "expires_in": 1000
 })""";
 


### PR DESCRIPTION
Only a limited number of scopes returns this field. For the rest of scopes this field is not populated, which is ok.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12867)
<!-- Reviewable:end -->
