### PR TITLE
fix(storage): remove unused dependencies

### DIFF
--- a/google/cloud/storage/google_cloud_cpp_storage.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage.cmake
@@ -16,7 +16,6 @@
 
 include(FindCurlWithTargets)
 find_package(OpenSSL REQUIRED)
-find_package(ZLIB REQUIRED)
 
 # the client library
 add_library(
@@ -259,9 +258,7 @@ target_link_libraries(
            Crc32c::crc32c
            CURL::libcurl
            Threads::Threads
-           OpenSSL::SSL
-           OpenSSL::Crypto
-           ZLIB::ZLIB)
+           OpenSSL::Crypto)
 if (WIN32)
     # We use `setsockopt()` directly, which requires the ws2_32 (Winsock2 for
     # Windows32?) library on Windows.

--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
@@ -144,9 +144,7 @@ else ()
                Crc32c::crc32c
                CURL::libcurl
                Threads::Threads
-               OpenSSL::SSL
-               OpenSSL::Crypto
-               ZLIB::ZLIB)
+               OpenSSL::Crypto)
     google_cloud_cpp_add_common_options(google_cloud_cpp_storage_grpc)
     target_include_directories(
         google_cloud_cpp_storage_grpc


### PR DESCRIPTION
We do not directly use `OpenSSL::SSL` or `ZLIB::ZLIB`. Both are used indirectly via `CURL::libcurl`. We should not require the package or link the libraries.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12890)
<!-- Reviewable:end -->
