### PR TITLE
cleanup(otel): handle empty in ScopedOTelContext

### DIFF
--- a/google/cloud/internal/opentelemetry_context.h
+++ b/google/cloud/internal/opentelemetry_context.h
@@ -71,16 +71,17 @@ class ScopedOTelContext {
  public:
   explicit ScopedOTelContext(OTelContext contexts)
       : contexts_(std::move(contexts)),
-        same_thread_(contexts_.back() ==
-                     opentelemetry::context::RuntimeContext::GetCurrent()) {
-    if (same_thread_) return;
+        noop_(contexts_.empty() ||
+              contexts_.back() ==
+                  opentelemetry::context::RuntimeContext::GetCurrent()) {
+    if (noop_) return;
     for (auto const& c : contexts_) {
       AttachOTelContext(c);
     }
   }
 
   ~ScopedOTelContext() {
-    if (same_thread_) return;
+    if (noop_) return;
     for (auto it = contexts_.rbegin(); it != contexts_.rend(); ++it) {
       DetachOTelContext(*it);
     }
@@ -88,7 +89,7 @@ class ScopedOTelContext {
 
  private:
   OTelContext contexts_;
-  bool same_thread_;
+  bool noop_;
 };
 
 }  // namespace internal

--- a/google/cloud/internal/opentelemetry_context_test.cc
+++ b/google/cloud/internal/opentelemetry_context_test.cc
@@ -102,6 +102,11 @@ TEST_F(OTelContextTest, Scope) {
   EXPECT_THAT(CurrentOTelContext(), IsEmpty());
 }
 
+TEST_F(OTelContextTest, ScopeHandlesEmpty) {
+  ScopedOTelContext scope({});
+  EXPECT_THAT(CurrentOTelContext(), IsEmpty());
+}
+
 TEST_F(OTelContextTest, ScopeNoopWhenContextIsAlreadyActive) {
   auto c1 = MakeNewContext();
   auto c2 = MakeNewContext();


### PR DESCRIPTION
https://github.com/googleapis/google-cloud-cpp/pull/12887#discussion_r1358695983

> (don't forget the empty collection case)

D'oh.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12893)
<!-- Reviewable:end -->
