### PR TITLE
chore(otel): update semantic conventions

### DIFF
--- a/google/cloud/internal/grpc_opentelemetry.cc
+++ b/google/cloud/internal/grpc_opentelemetry.cc
@@ -86,7 +86,7 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> MakeSpanGrpc(
           {{sc::kRpcSystem, sc::RpcSystemValues::kGrpc},
            {sc::kRpcService, service},
            {sc::kRpcMethod, method},
-           {sc::kNetTransport, sc::NetTransportValues::kIpTcp},
+           {sc::kNetworkTransport, sc::NetTransportValues::kIpTcp},
            {"grpc.version", grpc::Version()}},
           options);
 }

--- a/google/cloud/internal/grpc_opentelemetry_test.cc
+++ b/google/cloud/internal/grpc_opentelemetry_test.cc
@@ -70,7 +70,7 @@ TEST(OpenTelemetry, MakeSpanGrpc) {
               OTelAttribute<std::string>(sc::kRpcService,
                                          "google.cloud.foo.v1.Foo"),
               OTelAttribute<std::string>(sc::kRpcMethod, "GetBar"),
-              OTelAttribute<std::string>(sc::kNetTransport,
+              OTelAttribute<std::string>(sc::kNetworkTransport,
                                          sc::NetTransportValues::kIpTcp),
               OTelAttribute<std::string>("grpc.version", grpc::Version())))));
 }

--- a/google/cloud/internal/rest_opentelemetry.cc
+++ b/google/cloud/internal/rest_opentelemetry.cc
@@ -78,9 +78,9 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> MakeSpanHttp(
       internal::GetTracer(internal::CurrentOptions())
           ->StartSpan(absl::StrCat("HTTP/", absl::string_view{method.data(),
                                                               method.size()}),
-                      {{sc::kNetTransport, sc::NetTransportValues::kIpTcp},
-                       {sc::kHttpMethod, method},
-                       {sc::kHttpUrl, request.path()}},
+                      {{sc::kNetworkTransport, sc::NetTransportValues::kIpTcp},
+                       {sc::kHttpRequestMethod, method},
+                       {sc::kUrlFull, request.path()}},
                       options);
   for (auto const& kv : request.headers()) {
     auto const name = "http.request.header." + kv.first;

--- a/google/cloud/internal/rest_opentelemetry_test.cc
+++ b/google/cloud/internal/rest_opentelemetry_test.cc
@@ -64,10 +64,10 @@ TEST(RestOpentelemetry, MakeSpanHttp) {
           SpanHasInstrumentationScope(), SpanKindIsClient(),
           SpanNamed("HTTP/GET"),
           SpanHasAttributes(
-              OTelAttribute<std::string>(sc::kNetTransport,
+              OTelAttribute<std::string>(sc::kNetworkTransport,
                                          sc::NetTransportValues::kIpTcp),
-              OTelAttribute<std::string>(sc::kHttpMethod, "GET"),
-              OTelAttribute<std::string>(sc::kHttpUrl, kUrl),
+              OTelAttribute<std::string>(sc::kHttpRequestMethod, "GET"),
+              OTelAttribute<std::string>(sc::kUrlFull, kUrl),
               OTelAttribute<std::string>("http.request.header.empty", ""),
               OTelAttribute<std::string>("http.request.header.x-goog-foo",
                                          "bar"),

--- a/google/cloud/internal/tracing_http_payload_test.cc
+++ b/google/cloud/internal/tracing_http_payload_test.cc
@@ -68,13 +68,14 @@ TEST(TracingHttpPayload, Success) {
                      OTelAttribute<std::int64_t>("read.returned.size", rs)));
   };
   EXPECT_THAT(
-      spans, UnorderedElementsAre(
-                 AllOf(SpanNamed("HTTP/GET"), SpanHasInstrumentationScope(),
-                       SpanKindIsClient(),
-                       SpanHasAttributes(OTelAttribute<std::string>(
-                           sc::kNetTransport, sc::NetTransportValues::kIpTcp))),
-                 make_read_matcher(16, 16), make_read_matcher(16, 16),
-                 make_read_matcher(16, 11), make_read_matcher(16, 0)));
+      spans,
+      UnorderedElementsAre(
+          AllOf(SpanNamed("HTTP/GET"), SpanHasInstrumentationScope(),
+                SpanKindIsClient(),
+                SpanHasAttributes(OTelAttribute<std::string>(
+                    sc::kNetworkTransport, sc::NetTransportValues::kIpTcp))),
+          make_read_matcher(16, 16), make_read_matcher(16, 16),
+          make_read_matcher(16, 11), make_read_matcher(16, 0)));
 }
 
 TEST(TracingHttpPayload, Failure) {
@@ -120,7 +121,7 @@ TEST(TracingHttpPayload, Failure) {
           AllOf(SpanNamed("HTTP/GET"), SpanHasInstrumentationScope(),
                 SpanKindIsClient(),
                 SpanHasAttributes(
-                    OTelAttribute<std::string>(sc::kNetTransport,
+                    OTelAttribute<std::string>(sc::kNetworkTransport,
                                                sc::NetTransportValues::kIpTcp),
                     OTelAttribute<int>(
                         "gl-cpp.status_code",

--- a/google/cloud/internal/tracing_rest_client.cc
+++ b/google/cloud/internal/tracing_rest_client.cc
@@ -48,13 +48,13 @@ StatusOr<std::unique_ptr<RestResponse>> EndResponseSpan(
     StatusOr<std::unique_ptr<RestResponse>> request_result) {
   namespace sc = opentelemetry::trace::SemanticConventions;
   if (context.primary_ip_address() && context.primary_port()) {
-    span->SetAttribute(sc::kNetPeerName, *context.primary_ip_address());
-    span->SetAttribute(sc::kNetPeerPort, *context.primary_port());
+    span->SetAttribute(sc::kServerAddress, *context.primary_ip_address());
+    span->SetAttribute(sc::kServerPort, *context.primary_port());
   }
 
   if (context.local_ip_address() && context.local_port()) {
-    span->SetAttribute(sc::kNetHostName, *context.local_ip_address());
-    span->SetAttribute(sc::kNetHostPort, *context.local_port());
+    span->SetAttribute(sc::kClientAddress, *context.local_ip_address());
+    span->SetAttribute(sc::kClientPort, *context.local_port());
   }
   for (auto const& kv : context.headers()) {
     auto const name = "http.request.header." + kv.first;

--- a/google/cloud/internal/tracing_rest_client_test.cc
+++ b/google/cloud/internal/tracing_rest_client_test.cc
@@ -101,19 +101,20 @@ TEST(TracingRestClient, Delete) {
       spans,
       UnorderedElementsAre(
           // Request span
-          AllOf(SpanNamed("HTTP/DELETE"), SpanHasInstrumentationScope(),
-                SpanKindIsClient(),
-                SpanHasAttributes(
-                    OTelAttribute<std::string>(sc::kNetTransport,
-                                               sc::NetTransportValues::kIpTcp),
-                    OTelAttribute<std::string>(sc::kHttpMethod, "DELETE"),
-                    OTelAttribute<std::string>(sc::kHttpUrl, kUrl),
-                    OTelAttribute<std::string>(
-                        "http.request.header.x-test-header-3", "value3"),
-                    OTelAttribute<std::string>(
-                        "http.response.header.x-test-header-1", "value1"),
-                    OTelAttribute<std::string>(
-                        "http.response.header.x-test-header-2", "value2"))),
+          AllOf(
+              SpanNamed("HTTP/DELETE"), SpanHasInstrumentationScope(),
+              SpanKindIsClient(),
+              SpanHasAttributes(
+                  OTelAttribute<std::string>(sc::kNetworkTransport,
+                                             sc::NetTransportValues::kIpTcp),
+                  OTelAttribute<std::string>(sc::kHttpRequestMethod, "DELETE"),
+                  OTelAttribute<std::string>(sc::kUrlFull, kUrl),
+                  OTelAttribute<std::string>(
+                      "http.request.header.x-test-header-3", "value3"),
+                  OTelAttribute<std::string>(
+                      "http.response.header.x-test-header-1", "value1"),
+                  OTelAttribute<std::string>(
+                      "http.response.header.x-test-header-2", "value2"))),
           SpanNamed("SendRequest"), SpanNamed("Read"), SpanNamed("Read")));
 }
 
@@ -245,16 +246,17 @@ TEST(TracingRestClient, WithRestContextDetails) {
   EXPECT_THAT(
       spans,
       UnorderedElementsAre(
-          AllOf(SpanNamed("HTTP/POST"),
-                SpanHasAttributes(
-                    OTelAttribute<std::string>(sc::kNetTransport,
-                                               sc::NetTransportValues::kIpTcp),
-                    OTelAttribute<std::string>(sc::kHttpMethod, "POST"),
-                    OTelAttribute<std::string>(sc::kHttpUrl, kUrl),
-                    OTelAttribute<std::string>(sc::kNetPeerName, "192.168.1.1"),
-                    OTelAttribute<std::int32_t>(sc::kNetPeerPort, 443),
-                    OTelAttribute<std::string>(sc::kNetHostName, "127.0.0.1"),
-                    OTelAttribute<std::int32_t>(sc::kNetHostPort, 32000))),
+          AllOf(
+              SpanNamed("HTTP/POST"),
+              SpanHasAttributes(
+                  OTelAttribute<std::string>(sc::kNetworkTransport,
+                                             sc::NetTransportValues::kIpTcp),
+                  OTelAttribute<std::string>(sc::kHttpRequestMethod, "POST"),
+                  OTelAttribute<std::string>(sc::kUrlFull, kUrl),
+                  OTelAttribute<std::string>(sc::kServerAddress, "192.168.1.1"),
+                  OTelAttribute<std::int32_t>(sc::kServerPort, 443),
+                  OTelAttribute<std::string>(sc::kClientAddress, "127.0.0.1"),
+                  OTelAttribute<std::int32_t>(sc::kClientPort, 32000))),
           AllOf(SpanNamed("SendRequest"),
                 SpanHasAttributes(
                     OTelAttribute<bool>("gl-cpp.cached_connection", false)),

--- a/google/cloud/internal/tracing_rest_response_test.cc
+++ b/google/cloud/internal/tracing_rest_response_test.cc
@@ -81,13 +81,14 @@ TEST(TracingRestResponseTest, Success) {
   };
   auto const content_size = static_cast<std::int64_t>(MockContents().size());
   EXPECT_THAT(
-      spans, UnorderedElementsAre(
-                 AllOf(SpanNamed("HTTP/GET"), SpanHasInstrumentationScope(),
-                       SpanKindIsClient(),
-                       SpanHasAttributes(OTelAttribute<std::string>(
-                           sc::kNetTransport, sc::NetTransportValues::kIpTcp))),
-                 make_read_event_matcher(kBufferSize, content_size),
-                 make_read_event_matcher(kBufferSize, 0)));
+      spans,
+      UnorderedElementsAre(
+          AllOf(SpanNamed("HTTP/GET"), SpanHasInstrumentationScope(),
+                SpanKindIsClient(),
+                SpanHasAttributes(OTelAttribute<std::string>(
+                    sc::kNetworkTransport, sc::NetTransportValues::kIpTcp))),
+          make_read_event_matcher(kBufferSize, content_size),
+          make_read_event_matcher(kBufferSize, 0)));
 }
 
 }  // namespace


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-cpp/pull/2285 deprecated these names. Update to the new names so we can use the latest OTel version.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12901)
<!-- Reviewable:end -->
