### PR TITLE
impl(otel): detach context from `EndSpan(..., future<>)`

### DIFF
--- a/google/cloud/internal/grpc_opentelemetry.h
+++ b/google/cloud/internal/grpc_opentelemetry.h
@@ -90,9 +90,12 @@ future<T> EndSpan(
     std::shared_ptr<grpc::ClientContext> context,
     opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> span,
     future<T> fut) {
-  return fut.then([c = std::move(context), s = std::move(span)](auto f) {
+  return fut.then([oc = opentelemetry::context::RuntimeContext::GetCurrent(),
+                   c = std::move(context), s = std::move(span)](auto f) {
+    auto t = f.get();
     ExtractAttributes(*c, *s);
-    return EndSpan(*s, f.get());
+    DetachOTelContext(oc);
+    return EndSpan(*s, std::move(t));
   });
 }
 

--- a/google/cloud/internal/grpc_opentelemetry_test.cc
+++ b/google/cloud/internal/grpc_opentelemetry_test.cc
@@ -140,6 +140,33 @@ TEST(OpenTelemetry, EndSpanFuture) {
           SpanHasAttributes(OTelAttribute<std::string>("grpc.peer", _)))));
 }
 
+TEST(OpenTelemetry, EndSpanFutureDetachesContext) {
+  auto span_catcher = InstallSpanCatcher();
+
+  // Set the `OTelContext` like we do in `AsyncOperation`s
+  auto c = opentelemetry::context::Context("key", true);
+  ScopedOTelContext scope({c});
+  EXPECT_EQ(c, opentelemetry::context::RuntimeContext::GetCurrent());
+
+  promise<Status> p;
+  auto f =
+      EndSpan(std::make_shared<grpc::ClientContext>(),
+              MakeSpanGrpc("google.cloud.foo.v1.Foo", "GetBar"), p.get_future())
+          .then([](auto f) {
+            auto s = f.get();
+            // The `OTelContext` should be cleared by the time we exit
+            // `EndSpan()`.
+            EXPECT_EQ(opentelemetry::context::Context{},
+                      opentelemetry::context::RuntimeContext::GetCurrent());
+            return s;
+          });
+
+  p.set_value(Status());
+  EXPECT_STATUS_OK(f.get());
+  EXPECT_THAT(span_catcher->GetSpans(),
+              ElementsAre(SpanNamed("google.cloud.foo.v1.Foo/GetBar")));
+}
+
 TEST(OpenTelemetry, TracedAsyncBackoffEnabled) {
   auto span_catcher = InstallSpanCatcher();
 


### PR DESCRIPTION
Part of the work for #12880 

These `EndSpan(..., future<>)` are mainly a `.then()` which might execute in a different thread than the future is returned in. Detach the context from the original thread in the callback thread.

This change is currently a no-op until we start pushing/popping the context and copying the OTelContext into the callback threads.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12902)
<!-- Reviewable:end -->
