### PR TITLE
cleanup(otel): manage OTelContext stack with class

### DIFF
--- a/google/cloud/internal/opentelemetry_context_test.cc
+++ b/google/cloud/internal/opentelemetry_context_test.cc
@@ -45,27 +45,23 @@ class OTelContextTest : public ::testing::Test {
   }
 };
 
-TEST_F(OTelContextTest, PushPopOTelContext) {
+TEST_F(OTelContextTest, OTelScope) {
   EXPECT_THAT(CurrentOTelContext(), IsEmpty());
 
-  auto s1 = opentelemetry::trace::Scope(MakeSpan("s1"));
-  auto c1 = opentelemetry::context::RuntimeContext::GetCurrent();
-
-  PushOTelContext();
-  EXPECT_THAT(CurrentOTelContext(), ElementsAre(c1));
-
   {
-    auto s2 = opentelemetry::trace::Scope(MakeSpan("s2"));
-    auto c2 = opentelemetry::context::RuntimeContext::GetCurrent();
+    OTelScope scope1(MakeSpan("s1"));
+    auto c1 = opentelemetry::context::RuntimeContext::GetCurrent();
+    EXPECT_THAT(CurrentOTelContext(), ElementsAre(c1));
 
-    PushOTelContext();
-    EXPECT_THAT(CurrentOTelContext(), ElementsAre(c1, c2));
+    {
+      OTelScope scope2(MakeSpan("s2"));
+      auto c2 = opentelemetry::context::RuntimeContext::GetCurrent();
+      EXPECT_THAT(CurrentOTelContext(), ElementsAre(c1, c2));
+    }
 
-    PopOTelContext();
     EXPECT_THAT(CurrentOTelContext(), ElementsAre(c1));
   }
 
-  PopOTelContext();
   EXPECT_THAT(CurrentOTelContext(), IsEmpty());
 }
 


### PR DESCRIPTION
Motivated by #12880 

Apologies for the churn in the internal interface....

Having code like:

```cc
{
  auto span = MakeSpan("span");
  OTelScope scope(span);
  return child_->AsyncFoo();
}
```

is cleaner than having code like:

```cc
{
  auto span = MakeSpan("span");
  auto scope = opentelemetry::trace::Scope(scope);
  PushOTelContext();
  auto f =  child_->AsyncFoo();
  PopOTelContext();
  return f;
}
```

It is also closer to the code we currently write, so the diffs will be cleaner.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12904)
<!-- Reviewable:end -->
