### PR TITLE
fix(oauth2): only enable via GOOGLE_CLOUD_CPP_ENABLE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,11 @@ the APIs in these libraries are stable, and are ready for production use.
 
 ### Other Changes
 
-* fix(oauth2): only enable via `GOOGLE_CLOUD_CPP_ENABLE`
-  ([#12911](https://github.com/googleapis/google-cloud-cpp/pull/12911))
-  When compiling with CMake, the `oauth2` used to be automatically enabled if
+- fix(oauth2): only enable via `GOOGLE_CLOUD_CPP_ENABLE`
+  ([#12911](https://github.com/googleapis/google-cloud-cpp/pull/12911)) When
+  compiling with CMake, the `oauth2` used to be automatically enabled if
   `GOOGLE_CLOUD_CPP_REST` was manually enabled or enabled by a separate library.
-  That made it impossible to shard a build with separate builds for `oauth2`, 
+  That made it impossible to shard a build with separate builds for `oauth2`,
   `storage` and `compute`.
 
 ## v2.17.0 - 2023-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ the APIs in these libraries are stable, and are ready for production use.
 
 - [Secure Source Manager](/google/cloud/securesourcemanager/README.md)
 
+### Other Changes
+
+* fix(oauth2): only enable via `GOOGLE_CLOUD_CPP_ENABLE`
+  ([#12911](https://github.com/googleapis/google-cloud-cpp/pull/12911))
+  When compiling with CMake, the `oauth2` used to be automatically enabled if
+  `GOOGLE_CLOUD_CPP_REST` was manually enabled or enabled by a separate library.
+  That made it impossible to shard a build with separate builds for `oauth2`, 
+  `storage` and `compute`.
+
 ## v2.17.0 - 2023-10
 
 ### [Compute Engine](/google/cloud/compute/README.md)

--- a/cmake/GoogleCloudCppFeatures.cmake
+++ b/cmake/GoogleCloudCppFeatures.cmake
@@ -362,9 +362,6 @@ macro (google_cloud_cpp_enable_cleanup)
         OR (sql IN_LIST GOOGLE_CLOUD_CPP_ENABLE)
         OR (generator IN_LIST GOOGLE_CLOUD_CPP_ENABLE))
         set(GOOGLE_CLOUD_CPP_ENABLE_REST ON)
-        # Backwards compatibility. In the original release of `oauth2` we
-        # automatically compiled the library if REST was enabled
-        list(APPEND GOOGLE_CLOUD_CPP_ENABLE oauth2)
     endif ()
 
     list(REMOVE_DUPLICATES GOOGLE_CLOUD_CPP_ENABLE)


### PR DESCRIPTION
Enabling `oauth2` if `GOOGLE_CLOUD_CPPP_ENABLE_REST` is set is a bug: it introduces a cycle in the dependencies of the library, and makes it impossible to compile `oauth2`, `storage`, and `compute` in different shards.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12911)
<!-- Reviewable:end -->
