### PR TITLE
fix(generator): do not override default sleeper in streaming-read RPCs

### DIFF
--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_connection_impl.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_connection_impl.cc
@@ -173,8 +173,7 @@ GoldenKitchenSinkConnectionImpl::StreamingRead(google::test::admin::database::v1
   };
   auto resumable =
       internal::MakeResumableStreamingReadRpc<google::test::admin::database::v1::Response, google::test::admin::database::v1::Request>(
-          retry_policy(*current), backoff_policy(*current),
-          [](std::chrono::milliseconds) {}, factory,
+          retry_policy(*current), backoff_policy(*current), factory,
           GoldenKitchenSinkStreamingReadStreamingUpdater, request);
   return internal::MakeStreamRange(internal::StreamReader<google::test::admin::database::v1::Response>(
       [resumable] { return resumable->Read(); }));

--- a/generator/internal/connection_impl_generator.cc
+++ b/generator/internal/connection_impl_generator.cc
@@ -310,8 +310,7 @@ $connection_class_name$Impl::$method_name$($request_type$ const& request) {
   };
   auto resumable =
       internal::MakeResumableStreamingReadRpc<$response_type$, $request_type$>(
-          retry_policy(*current), backoff_policy(*current),
-          [](std::chrono::milliseconds) {}, factory,
+          retry_policy(*current), backoff_policy(*current), factory,
           $service_name$$method_name$StreamingUpdater, request);
   return internal::MakeStreamRange(internal::StreamReader<$response_type$>(
       [resumable] { return resumable->Read(); }));

--- a/google/cloud/aiplatform/v1/internal/featurestore_online_serving_connection_impl.cc
+++ b/google/cloud/aiplatform/v1/internal/featurestore_online_serving_connection_impl.cc
@@ -99,8 +99,7 @@ FeaturestoreOnlineServingServiceConnectionImpl::StreamingReadFeatureValues(
   auto resumable = internal::MakeResumableStreamingReadRpc<
       google::cloud::aiplatform::v1::ReadFeatureValuesResponse,
       google::cloud::aiplatform::v1::StreamingReadFeatureValuesRequest>(
-      retry_policy(*current), backoff_policy(*current),
-      [](std::chrono::milliseconds) {}, factory,
+      retry_policy(*current), backoff_policy(*current), factory,
       FeaturestoreOnlineServingServiceStreamingReadFeatureValuesStreamingUpdater,
       request);
   return internal::MakeStreamRange(

--- a/google/cloud/aiplatform/v1/internal/prediction_connection_impl.cc
+++ b/google/cloud/aiplatform/v1/internal/prediction_connection_impl.cc
@@ -102,8 +102,7 @@ PredictionServiceConnectionImpl::ServerStreamingPredict(
   auto resumable = internal::MakeResumableStreamingReadRpc<
       google::cloud::aiplatform::v1::StreamingPredictResponse,
       google::cloud::aiplatform::v1::StreamingPredictRequest>(
-      retry_policy(*current), backoff_policy(*current),
-      [](std::chrono::milliseconds) {}, factory,
+      retry_policy(*current), backoff_policy(*current), factory,
       PredictionServiceServerStreamingPredictStreamingUpdater, request);
   return internal::MakeStreamRange(
       internal::StreamReader<

--- a/google/cloud/aiplatform/v1/internal/tensorboard_connection_impl.cc
+++ b/google/cloud/aiplatform/v1/internal/tensorboard_connection_impl.cc
@@ -668,8 +668,7 @@ TensorboardServiceConnectionImpl::ReadTensorboardBlobData(
   auto resumable = internal::MakeResumableStreamingReadRpc<
       google::cloud::aiplatform::v1::ReadTensorboardBlobDataResponse,
       google::cloud::aiplatform::v1::ReadTensorboardBlobDataRequest>(
-      retry_policy(*current), backoff_policy(*current),
-      [](std::chrono::milliseconds) {}, factory,
+      retry_policy(*current), backoff_policy(*current), factory,
       TensorboardServiceReadTensorboardBlobDataStreamingUpdater, request);
   return internal::MakeStreamRange(
       internal::StreamReader<

--- a/google/cloud/bigquery/storage/v1/internal/bigquery_read_connection_impl.cc
+++ b/google/cloud/bigquery/storage/v1/internal/bigquery_read_connection_impl.cc
@@ -89,8 +89,7 @@ BigQueryReadConnectionImpl::ReadRows(
   auto resumable = internal::MakeResumableStreamingReadRpc<
       google::cloud::bigquery::storage::v1::ReadRowsResponse,
       google::cloud::bigquery::storage::v1::ReadRowsRequest>(
-      retry_policy(*current), backoff_policy(*current),
-      [](std::chrono::milliseconds) {}, factory,
+      retry_policy(*current), backoff_policy(*current), factory,
       BigQueryReadReadRowsStreamingUpdater, request);
   return internal::MakeStreamRange(
       internal::StreamReader<

--- a/google/cloud/osconfig/agentendpoint/v1/internal/agent_endpoint_connection_impl.cc
+++ b/google/cloud/osconfig/agentendpoint/v1/internal/agent_endpoint_connection_impl.cc
@@ -84,8 +84,7 @@ AgentEndpointServiceConnectionImpl::ReceiveTaskNotification(
           ReceiveTaskNotificationResponse,
       google::cloud::osconfig::agentendpoint::v1::
           ReceiveTaskNotificationRequest>(
-      retry_policy(*current), backoff_policy(*current),
-      [](std::chrono::milliseconds) {}, factory,
+      retry_policy(*current), backoff_policy(*current), factory,
       AgentEndpointServiceReceiveTaskNotificationStreamingUpdater, request);
   return internal::MakeStreamRange(
       internal::StreamReader<google::cloud::osconfig::agentendpoint::v1::


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12920)
<!-- Reviewable:end -->
