### PR TITLE
impl(generator): add service_name_mapping flag

### DIFF
--- a/generator/generator_config.proto
+++ b/generator/generator_config.proto
@@ -161,6 +161,10 @@ message ServiceConfiguration {
   // which by style convention is typically snake_case. When false, the field
   // names will be converted to camelCase.
   bool preserve_proto_field_names_in_json = 25;
+
+  // A mapping from the service name as defined in the googleapis repo to the
+  // name that will be used for the library generation.
+  map<string, string> service_name_mapping = 26;
 }
 
 message DiscoveryDocumentDefinedProduct {

--- a/generator/internal/codegen_utils.cc
+++ b/generator/internal/codegen_utils.cc
@@ -33,7 +33,7 @@ namespace generator_internal {
 namespace {
 
 std::vector<std::pair<std::string, std::string>> const& SnakeCaseExceptions() {
-  static const std::vector<std::pair<std::string, std::string>> kExceptions = {
+  static std::vector<std::pair<std::string, std::string>> const kExceptions = {
       {"big_query", "bigquery"}};
   return kExceptions;
 }
@@ -179,6 +179,12 @@ void ProcessArgIdempotencyOverride(
                   command_line_args);
 }
 
+void ProcessArgServiceNameMapping(
+    std::vector<std::pair<std::string, std::string>>& command_line_args) {
+  ProcessRepeated("service_name_mapping", "service_name_mappings",
+                  command_line_args);
+}
+
 }  // namespace
 
 std::string CurrentCopyrightYear() {
@@ -274,6 +280,7 @@ ProcessCommandLineArgs(std::string const& parameters) {
   ProcessArgForwardingProductPath(command_line_args);
   ProcessArgEmitRpc(command_line_args);
   ProcessArgIdempotencyOverride(command_line_args);
+  ProcessArgServiceNameMapping(command_line_args);
   return command_line_args;
 }
 

--- a/generator/internal/codegen_utils_test.cc
+++ b/generator/internal/codegen_utils_test.cc
@@ -344,6 +344,17 @@ TEST(ProcessCommandLineArgs, ProcessArgEmitRpc) {
                                                   HasSubstr("Emitted2")))));
 }
 
+TEST(ProcessCommandLineArgs, ProcessServiceNameMapping) {
+  auto result = ProcessCommandLineArgs(
+      "product_path=google/cloud/pubsub/"
+      ",service_name_mapping=old_name1:new_name1"
+      ",service_name_mapping=old_name2:new_name2");
+  ASSERT_THAT(result, IsOk());
+  EXPECT_THAT(*result, Contains(Pair("service_name_mappings",
+                                     AllOf(HasSubstr("old_name1:new_name1"),
+                                           HasSubstr("old_name2:new_name2")))));
+}
+
 TEST(SafeReplaceAll, Success) {
   EXPECT_EQ("one@two", SafeReplaceAll("one,two", ",", "@"));
 }

--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -335,6 +335,12 @@ std::vector<std::future<google::cloud::Status>> GenerateCodeFromProtos(
           "--cpp_codegen_opt=preserve_proto_field_names_in_json=false");
     }
 
+    // Add the key value pairs as a single parameter with a colon delimiter.
+    for (auto const& [key, value] : service.service_name_mapping()) {
+      args.emplace_back(absl::StrCat(
+          "--cpp_codegen_opt=service_name_mapping=", key, ":", value));
+    }
+
     GCP_LOG(INFO) << "Generating service code using: "
                   << absl::StrJoin(args, ";") << "\n";
 

--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -336,9 +336,9 @@ std::vector<std::future<google::cloud::Status>> GenerateCodeFromProtos(
     }
 
     // Add the key value pairs as a single parameter with a colon delimiter.
-    for (auto const& [key, value] : service.service_name_mapping()) {
+    for (auto const& kv : service.service_name_mapping()) {
       args.emplace_back(absl::StrCat(
-          "--cpp_codegen_opt=service_name_mapping=", key, ":", value));
+          "--cpp_codegen_opt=service_name_mapping=", kv.first, ":", kv.second));
     }
 
     GCP_LOG(INFO) << "Generating service code using: "


### PR DESCRIPTION
Part of [12873](https://github.com/googleapis/google-cloud-cpp/issues/12873)

Adds the service_name_mapping command line flag and parsing

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12923)
<!-- Reviewable:end -->
