### PR TITLE
feat(spanner): single-RPC, batched commit of mutation groups

### DIFF
--- a/google/cloud/spanner/BUILD.bazel
+++ b/google/cloud/spanner/BUILD.bazel
@@ -130,6 +130,7 @@ cc_library(
         ":google_cloud_cpp_spanner_mocks",
         ":spanner_client_testing",
         "//:common",
+        "//google/cloud:google_cloud_cpp_mocks",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc_private",
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
         "@com_google_absl//absl/numeric:int128",

--- a/google/cloud/spanner/commit_result.h
+++ b/google/cloud/spanner/commit_result.h
@@ -17,8 +17,12 @@
 
 #include "google/cloud/spanner/timestamp.h"
 #include "google/cloud/spanner/version.h"
+#include "google/cloud/status_or.h"
+#include "google/cloud/stream_range.h"
 #include "absl/types/optional.h"
+#include <cstddef>
 #include <cstdint>
+#include <vector>
 
 namespace google {
 namespace cloud {
@@ -42,6 +46,26 @@ struct CommitResult {
   /// Additional statistics about the committed transaction.
   absl::optional<CommitStats> commit_stats;
 };
+
+/**
+ * The result of committing a Transaction containing a batch of mutation
+ * groups.  See the batched form of `Client::CommitAtLeastOnce()`.
+ */
+struct BatchedCommitResult {
+  /// The mutation groups applied in this batch. Each value is an index into
+  /// the `std::vector<Mutations>` passed to `Client::CommitAtLeastOnce()`.
+  std::vector<std::size_t> indexes;
+
+  /// If OK, the Cloud Spanner timestamp at which the transaction committed,
+  /// and otherwise the reason why the commit failed.
+  StatusOr<Timestamp> commit_timestamp;
+};
+
+/**
+ * Represents the stream of `BatchedCommitResult` objects returned from the
+ * batched `Client::CommitAtLeastOnce()`.
+ */
+using BatchedCommitResultStream = StreamRange<BatchedCommitResult>;
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace spanner

--- a/google/cloud/spanner/connection.cc
+++ b/google/cloud/spanner/connection.cc
@@ -105,6 +105,12 @@ Status Connection::Rollback(RollbackParams) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+BatchedCommitResultStream Connection::BatchWrite(BatchWriteParams) {
+  return internal::MakeStreamRange<BatchedCommitResult>(
+      [] { return Status(StatusCode::kUnimplemented, "not implemented"); });
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/connection.h
+++ b/google/cloud/spanner/connection.h
@@ -128,6 +128,12 @@ class Connection {
   struct RollbackParams {
     Transaction transaction;
   };
+
+  /// Wrap the arguments to `BatchWrite()`.
+  struct BatchWriteParams {
+    std::vector<Mutations> mutation_groups;
+    Options options;
+  };
   ///@}
 
   /// Returns the options used by the Connection.
@@ -171,6 +177,9 @@ class Connection {
 
   /// Defines the interface for `Client::Rollback()`
   virtual Status Rollback(RollbackParams);
+
+  /// Defines the interface for batched `Client::CommitAtLeastOnce()`
+  virtual BatchedCommitResultStream BatchWrite(BatchWriteParams);
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/spanner/internal/connection_impl.h
+++ b/google/cloud/spanner/internal/connection_impl.h
@@ -64,6 +64,7 @@ class ConnectionImpl : public spanner::Connection {
       ExecuteBatchDmlParams) override;
   StatusOr<spanner::CommitResult> Commit(CommitParams) override;
   Status Rollback(RollbackParams) override;
+  spanner::BatchedCommitResultStream BatchWrite(BatchWriteParams) override;
 
  private:
   Status PrepareSession(SessionHolder& session,
@@ -132,6 +133,8 @@ class ConnectionImpl : public spanner::Connection {
   Status RollbackImpl(SessionHolder& session,
                       StatusOr<google::spanner::v1::TransactionSelector>& s,
                       TransactionContext const& ctx);
+
+  spanner::BatchedCommitResultStream BatchWriteImpl(BatchWriteParams);
 
   template <typename ResultType>
   StatusOr<ResultType> ExecuteSqlImpl(

--- a/google/cloud/spanner/mocks/mock_spanner_connection.h
+++ b/google/cloud/spanner/mocks/mock_spanner_connection.h
@@ -64,6 +64,8 @@ class MockConnection : public spanner::Connection {
   MOCK_METHOD(StatusOr<spanner::CommitResult>, Commit, (CommitParams),
               (override));
   MOCK_METHOD(Status, Rollback, (RollbackParams), (override));
+  MOCK_METHOD(spanner::BatchedCommitResultStream, BatchWrite,
+              (BatchWriteParams), (override));
 };
 
 /**


### PR DESCRIPTION
`spanner::Client::CommitAtLeastOnce(std::vector<Mutations>)`

Add support for committing mutation groups, batched efficiently into transactions with at-least-once semantics, using a single RPC.

All mutations within a group are committed atomically, but there is no atomicity or ordering between groups, so they must be independent of each other.

Partial failure is possible. That is, some batches can commit while others fail. The results of individual batches are returned via the response stream as their transactions complete.

Mutation groups are not replay protected. That is, it is possible that any mutation group may be applied more than once. They should be idempotent to avoid replay complications.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12930)
<!-- Reviewable:end -->
