### PR TITLE
impl(generator): use the service name mapping param

### DIFF
--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -635,23 +635,18 @@ bool CheckParameterCommentSubstitutions() {
 /// If a service name mapping exists, return the new name.
 /// Parses a command line argument in the form:
 /// {"service_name_mappings": "service_a:new_service_a,service:new_service"}.
-std::string GetServiceNameMappingOrReturnDefault(VarsDictionary const& vars,
-                                                 std::string const& name) {
+std::string GetEffectiveServiceName(VarsDictionary const& vars,
+                                    std::string const& name) {
   auto service_name_mappings = vars.find("service_name_mappings");
-  if (service_name_mappings == vars.end()) {
-    return name;
-  }
+  if (service_name_mappings == vars.end()) return name;
+
   std::vector<std::string> mappings =
       absl::StrSplit(service_name_mappings->second, ',');
   for (auto& mapping : mappings) {
     std::vector<std::string> kv = absl::StrSplit(mapping, ':');
-    if (kv.size() != 2) {
-      continue;
-    }
-    if (kv[0] == name) {
-      return kv[1];
-    }
-  };
+    if (kv.size() != 2) continue;
+    if (kv[0] == name) return kv[1];
+  }
   return name;
 }
 
@@ -659,8 +654,7 @@ VarsDictionary CreateServiceVars(
     google::protobuf::ServiceDescriptor const& descriptor,
     std::vector<std::pair<std::string, std::string>> const& initial_values) {
   VarsDictionary vars(initial_values.begin(), initial_values.end());
-  auto const& service_name =
-      GetServiceNameMappingOrReturnDefault(vars, descriptor.name());
+  auto const& service_name = GetEffectiveServiceName(vars, descriptor.name());
   vars["product_options_page"] = OptionsGroup(vars["product_path"]);
   vars["additional_pb_header_paths"] = FormatAdditionalPbHeaderPaths(vars);
   vars["class_comment_block"] =

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -632,11 +632,35 @@ bool CheckParameterCommentSubstitutions() {
   return all_substitutions_used;
 }
 
+/// If a service name mapping exists, return the new name.
+/// Parses a command line argument in the form:
+/// {"service_name_mappings": "service_a:new_service_a,service:new_service"}.
+std::string GetServiceNameMappingOrReturnDefault(VarsDictionary const& vars,
+                                                 std::string const& name) {
+  auto service_name_mappings = vars.find("service_name_mappings");
+  if (service_name_mappings == vars.end()) {
+    return name;
+  }
+  std::vector<std::string> mappings =
+      absl::StrSplit(service_name_mappings->second, ',');
+  for (auto& mapping : mappings) {
+    std::vector<std::string> kv = absl::StrSplit(mapping, ':');
+    if (kv.size() != 2) {
+      continue;
+    }
+    if (kv[0] == name) {
+      return kv[1];
+    }
+  };
+  return name;
+}
+
 VarsDictionary CreateServiceVars(
     google::protobuf::ServiceDescriptor const& descriptor,
     std::vector<std::pair<std::string, std::string>> const& initial_values) {
   VarsDictionary vars(initial_values.begin(), initial_values.end());
-  auto const& service_name = descriptor.name();
+  auto const& service_name =
+      GetServiceNameMappingOrReturnDefault(vars, descriptor.name());
   vars["product_options_page"] = OptionsGroup(vars["product_path"]);
   vars["additional_pb_header_paths"] = FormatAdditionalPbHeaderPaths(vars);
   vars["class_comment_block"] =
@@ -783,7 +807,8 @@ VarsDictionary CreateServiceVars(
   if (service_endpoint_env_var.empty()) {
     service_endpoint_env_var = absl::StrCat(
         "GOOGLE_CLOUD_CPP_",
-        absl::AsciiStrToUpper(CamelCaseToSnakeCase(service_name)), "_ENDPOINT");
+        absl::AsciiStrToUpper(CamelCaseToSnakeCase(descriptor.name())),
+        "_ENDPOINT");
   }
   absl::string_view service_endpoint_env_var_prefix = service_endpoint_env_var;
   if (!absl::ConsumeSuffix(&service_endpoint_env_var_prefix, "_ENDPOINT")) {

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -329,6 +329,144 @@ INSTANTIATE_TEST_SUITE_P(
       return std::get<0>(info.param);
     });
 
+class CreateServiceNameMappingTest : public CreateServiceVarsTest {};
+
+TEST_P(CreateServiceNameMappingTest, KeySetCorrectly) {
+  FileDescriptor const* service_file_descriptor =
+      pool_.FindFileByName("google/cloud/frobber/v1/frobber.proto");
+  service_vars_ = CreateServiceVars(
+      *service_file_descriptor->service(0),
+      {std::make_pair("product_path", "google/cloud/frobber/"),
+       std::make_pair("additional_proto_files",
+                      "google/cloud/add1.proto,google/cloud/add2.proto"),
+       std::make_pair("service_name_mappings",
+                      "FrobberService:NewFrobberService")});
+  auto iter = service_vars_.find(GetParam().first);
+  EXPECT_TRUE(iter != service_vars_.end());
+  EXPECT_THAT(iter->second, HasSubstr(GetParam().second));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ServiceVars, CreateServiceNameMappingTest,
+    testing::Values(
+        std::make_pair("product_options_page", "google-cloud-frobber-options"),
+        std::make_pair("additional_pb_header_paths",
+                       "google/cloud/add1.pb.h,google/cloud/add2.pb.h"),
+        std::make_pair("class_comment_block",
+                       "///\n/// Leading comments about service "
+                       "NewFrobberService.\n/// $Delimiter escapes$ $\n///"),
+        std::make_pair("client_class_name", "NewFrobberServiceClient"),
+        std::make_pair("client_cc_path",
+                       "google/cloud/frobber/new_frobber_client.cc"),
+        std::make_pair("client_header_path",
+                       "google/cloud/frobber/"
+                       "new_frobber_client.h"),
+        std::make_pair("connection_class_name", "NewFrobberServiceConnection"),
+        std::make_pair("connection_cc_path",
+                       "google/cloud/frobber/new_frobber_connection.cc"),
+        std::make_pair("connection_header_path",
+                       "google/cloud/frobber/new_frobber_connection.h"),
+        std::make_pair("connection_rest_cc_path",
+                       "google/cloud/frobber/new_frobber_rest_connection.cc"),
+        std::make_pair("connection_rest_header_path",
+                       "google/cloud/frobber/new_frobber_rest_connection.h"),
+        std::make_pair("connection_options_name",
+                       "NewFrobberServiceConnectionOptions"),
+        std::make_pair("connection_options_traits_name",
+                       "NewFrobberServiceConnectionOptionsTraits"),
+        // The grpc service uses the full descriptor name so it does not
+        // change.
+        std::make_pair("grpc_service",
+                       "google.cloud.frobber.v1.FrobberService"),
+        std::make_pair("grpc_stub_fqn",
+                       "google::cloud::frobber::v1::FrobberService"),
+        std::make_pair("idempotency_class_name",
+                       "NewFrobberServiceConnectionIdempotencyPolicy"),
+        std::make_pair("idempotency_policy_cc_path",
+                       "google/cloud/frobber/"
+                       "new_frobber_connection_idempotency_policy.cc"),
+        std::make_pair("idempotency_policy_header_path",
+                       "google/cloud/frobber/"
+                       "new_frobber_connection_idempotency_policy.h"),
+        std::make_pair("limited_error_count_retry_policy_name",
+                       "NewFrobberServiceLimitedErrorCountRetryPolicy"),
+        std::make_pair("limited_time_retry_policy_name",
+                       "NewFrobberServiceLimitedTimeRetryPolicy"),
+        std::make_pair("logging_class_name", "NewFrobberServiceLogging"),
+        std::make_pair("logging_cc_path",
+                       "google/cloud/frobber/internal/"
+                       "new_frobber_logging_decorator.cc"),
+        std::make_pair("logging_header_path",
+                       "google/cloud/frobber/internal/"
+                       "new_frobber_logging_decorator.h"),
+        std::make_pair("metadata_class_name", "NewFrobberServiceMetadata"),
+        std::make_pair("metadata_cc_path",
+                       "google/cloud/frobber/internal/"
+                       "new_frobber_metadata_decorator.cc"),
+        std::make_pair("metadata_header_path",
+                       "google/cloud/frobber/internal/"
+                       "new_frobber_metadata_decorator.h"),
+        std::make_pair("mock_connection_class_name",
+                       "MockNewFrobberServiceConnection"),
+        std::make_pair("mock_connection_header_path",
+                       "google/cloud/frobber/mocks/"
+                       "mock_new_frobber_connection.h"),
+        std::make_pair("option_defaults_cc_path",
+                       "google/cloud/frobber/internal/"
+                       "new_frobber_option_defaults.cc"),
+        std::make_pair("option_defaults_header_path",
+                       "google/cloud/frobber/internal/"
+                       "new_frobber_option_defaults.h"),
+        std::make_pair("options_header_path",
+                       "google/cloud/frobber/new_frobber_options.h"),
+        std::make_pair("product_namespace", "frobber"),
+        // The namespace does not use the mapping.
+        std::make_pair("product_internal_namespace", "frobber_internal"),
+        std::make_pair("proto_file_name",
+                       "google/cloud/frobber/v1/frobber.proto"),
+        std::make_pair("proto_grpc_header_path",
+                       "google/cloud/frobber/v1/frobber.grpc.pb.h"),
+        std::make_pair("retry_policy_name", "NewFrobberServiceRetryPolicy"),
+        std::make_pair("retry_traits_name", "NewFrobberServiceRetryTraits"),
+        std::make_pair(
+            "retry_traits_header_path",
+            "google/cloud/frobber/internal/new_frobber_retry_traits.h"),
+        std::make_pair("service_endpoint", ""),
+        // This uses the same endpoint variable as the existing service.
+        std::make_pair("service_endpoint_env_var",
+                       "GOOGLE_CLOUD_CPP_FROBBER_SERVICE_ENDPOINT"),
+        std::make_pair("service_name", "NewFrobberService"),
+        std::make_pair("stub_class_name", "NewFrobberServiceStub"),
+        std::make_pair("stub_cc_path",
+                       "google/cloud/frobber/internal/new_frobber_stub.cc"),
+        std::make_pair("stub_header_path",
+                       "google/cloud/frobber/internal/new_frobber_stub.h"),
+        std::make_pair(
+            "stub_factory_cc_path",
+            "google/cloud/frobber/internal/new_frobber_stub_factory.cc"),
+        std::make_pair(
+            "stub_factory_header_path",
+            "google/cloud/frobber/internal/new_frobber_stub_factory.h"),
+        std::make_pair("tracing_connection_class_name",
+                       "NewFrobberServiceTracingConnection"),
+        std::make_pair(
+            "tracing_connection_cc_path",
+            "google/cloud/frobber/internal/new_frobber_tracing_connection.cc"),
+        std::make_pair(
+            "tracing_connection_header_path",
+            "google/cloud/frobber/internal/new_frobber_tracing_connection.h"),
+        std::make_pair("tracing_stub_class_name",
+                       "NewFrobberServiceTracingStub"),
+        std::make_pair(
+            "tracing_stub_cc_path",
+            "google/cloud/frobber/internal/new_frobber_tracing_stub.cc"),
+        std::make_pair(
+            "tracing_stub_header_path",
+            "google/cloud/frobber/internal/new_frobber_tracing_stub.h")),
+    [](testing::TestParamInfo<CreateServiceVarsTest::ParamType> const& info) {
+      return std::get<0>(info.param);
+    });
+
 char const* const kIamProto =
     "syntax = \"proto3\";\n"
     "package google.iam.v1;\n"

--- a/generator/internal/format_class_comments.cc
+++ b/generator/internal/format_class_comments.cc
@@ -65,14 +65,13 @@ std::string FormatClassCommentsFromServiceComments(
   } else {
     formatted_comments = absl::StrReplaceAll(
         absl::StripSuffix(service_source_location.leading_comments, "\n"),
-        {
-            {"\n\n", "\n///\n/// "},
-            {"\n", "\n/// "},
-            // This uses a relative link, but we do not know how to resolve
-            // those.  Convert them back to an absolute link.
-            {"[groups](#google.monitoring.v3.Group)",
-             "[groups][google.monitoring.v3.Group]"},
-        });
+        {{"\n\n", "\n///\n/// "},
+         {"\n", "\n/// "},
+         // This uses a relative link, but we do not know how to resolve
+         // those.  Convert them back to an absolute link.
+         {"[groups](#google.monitoring.v3.Group)",
+          "[groups][google.monitoring.v3.Group]"},
+         {service.name(), service_name}});
   }
 
   auto const references =

--- a/generator/internal/format_class_comments_test.cc
+++ b/generator/internal/format_class_comments_test.cc
@@ -173,6 +173,33 @@ service Service {
                     EndsWith("\n///"), Not(EndsWith("\n///\n///"))));
 }
 
+TEST_F(FormatClassCommentsTest, UsesServiceNameParameter) {
+  auto constexpr kContents = R"""(
+syntax = "proto3";
+import "test/v1/common.proto";
+package google.monitoring.v3;
+
+message Group {}
+
+// A brief description of the Service.
+//
+// Use a relative link [groups](#google.monitoring.v3.Group).
+service Service {
+    rpc Method(test.v1.Request) returns (test.v1.Response) {}
+}
+)""";
+
+  ASSERT_THAT(FindFile("test/v1/common.proto"), NotNull());
+  ASSERT_TRUE(AddProtoFile("google/monitoring/v3/service.proto", kContents));
+  auto const* service =
+      pool().FindServiceByName("google.monitoring.v3.Service");
+  ASSERT_THAT(service, NotNull());
+
+  auto const actual =
+      FormatClassCommentsFromServiceComments(*service, "NewService");
+  EXPECT_THAT(actual, AllOf(HasSubstr("NewService")));
+}
+
 }  // namespace
 }  // namespace generator_internal
 }  // namespace cloud


### PR DESCRIPTION
Part of https://github.com/googleapis/google-cloud-cpp/issues/12873

Also fixes the format class comments to replace the service name in the comments with the new service name. This is unused for the pubsub library, but I figured if you use the param you would expect this behavior.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12932)
<!-- Reviewable:end -->
