### PR TITLE
refactor(GCS+gRPC): reusable `SetContent` for cords

### DIFF
--- a/google/cloud/storage/internal/async/insert_object.cc
+++ b/google/cloud/storage/internal/async/insert_object.cc
@@ -21,28 +21,6 @@ namespace google {
 namespace cloud {
 namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace {
-
-template <typename T>
-struct AsContentType;
-
-template <>
-struct AsContentType<std::string> {
-  // NOLINTNEXTLINE(performance-unnecessary-value-param)
-  std::string operator()(absl::Cord c) { return static_cast<std::string>(c); }
-};
-
-template <>
-struct AsContentType<absl::Cord> {
-  absl::Cord operator()(absl::Cord c) { return c; }
-};
-
-void SetContent(google::storage::v2::ChecksummedData& data,
-                absl::Cord contents) {
-  SetMutableContent(data, AsContentType<ContentType>{}(std::move(contents)));
-}
-
-}  // namespace
 
 future<StatusOr<storage::ObjectMetadata>> InsertObject::Start() {
   auto future = result_.get_future();

--- a/google/cloud/storage/internal/grpc/ctype_cord_workaround.h
+++ b/google/cloud/storage/internal/grpc/ctype_cord_workaround.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/internal/type_traits.h"
 #include "google/cloud/version.h"
+#include "absl/strings/cord.h"
 #include <google/storage/v2/storage.pb.h>
 #include <string>
 #include <type_traits>
@@ -167,6 +168,25 @@ inline ContentType StealMutableContent(
 }
 
 #endif  // GOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND
+
+template <typename T>
+struct AsContentType;
+
+template <>
+struct AsContentType<std::string> {
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)
+  std::string operator()(absl::Cord c) { return static_cast<std::string>(c); }
+};
+
+template <>
+struct AsContentType<absl::Cord> {
+  absl::Cord operator()(absl::Cord c) { return c; }
+};
+
+inline void SetContent(google::storage::v2::ChecksummedData& data,
+                       absl::Cord contents) {
+  SetMutableContent(data, AsContentType<ContentType>{}(std::move(contents)));
+}
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage_internal


### PR DESCRIPTION
I am going to need `SetContent(ChecksummedData&, absl::Cord)` from more than one `.cc` file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12936)
<!-- Reviewable:end -->
