### PR TITLE
impl: make external/googleapis/renovate.sh a little smarter

### DIFF
--- a/external/googleapis/renovate.sh
+++ b/external/googleapis/renovate.sh
@@ -66,7 +66,7 @@ banner "Creating commits"
 git commit -m"chore: update googleapis SHA circa $(date +%Y-%m-%d)" \
   bazel/google_cloud_cpp_deps.bzl cmake/GoogleapisConfig.cmake
 if ! git diff --quiet external/googleapis/protodeps \
-                      external/googleapis/protolists; then
+  external/googleapis/protolists; then
   git commit -m"Update the protodeps/protolists" \
     external/googleapis/protodeps external/googleapis/protolists
 fi

--- a/external/googleapis/renovate.sh
+++ b/external/googleapis/renovate.sh
@@ -65,8 +65,11 @@ ci/cloudbuild/build.sh --docker --trigger=generate-libraries-pr || true
 banner "Creating commits"
 git commit -m"chore: update googleapis SHA circa $(date +%Y-%m-%d)" \
   bazel/google_cloud_cpp_deps.bzl cmake/GoogleapisConfig.cmake
-git commit -m"Update the protodeps/protolists" \
-  external/googleapis/protodeps external/googleapis/protolists
+if ! git diff --quiet external/googleapis/protodeps \
+                      external/googleapis/protolists; then
+  git commit -m"Update the protodeps/protolists" \
+    external/googleapis/protodeps external/googleapis/protolists
+fi
 git commit -m"Regenerate libraries" .
 
 banner "Showing git state"


### PR DESCRIPTION
Sometimes the "Updating the protodeps/protolists" phase does nothing, so make the commit generation conditional on seeing edits.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12941)
<!-- Reviewable:end -->
