### PR TITLE
refactor(otel): use makespan instead of start span

### DIFF
--- a/google/cloud/internal/grpc_opentelemetry.cc
+++ b/google/cloud/internal/grpc_opentelemetry.cc
@@ -79,16 +79,15 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> MakeSpanGrpc(
   namespace sc = opentelemetry::trace::SemanticConventions;
   opentelemetry::trace::StartSpanOptions options;
   options.kind = opentelemetry::trace::SpanKind::kClient;
-  return GetTracer(internal::CurrentOptions())
-      ->StartSpan(
-          absl::StrCat(absl::string_view{service.data(), service.size()}, "/",
-                       absl::string_view{method.data(), method.size()}),
-          {{sc::kRpcSystem, sc::RpcSystemValues::kGrpc},
-           {sc::kRpcService, service},
-           {sc::kRpcMethod, method},
-           {sc::kNetworkTransport, sc::NetTransportValues::kIpTcp},
-           {"grpc.version", grpc::Version()}},
-          options);
+  return internal::MakeSpan(
+      absl::StrCat(absl::string_view{service.data(), service.size()}, "/",
+                   absl::string_view{method.data(), method.size()}),
+      {{sc::kRpcSystem, sc::RpcSystemValues::kGrpc},
+       {sc::kRpcService, service},
+       {sc::kRpcMethod, method},
+       {sc::kNetworkTransport, sc::NetTransportValues::kIpTcp},
+       {"grpc.version", grpc::Version()}},
+      options);
 }
 
 void InjectTraceContext(

--- a/google/cloud/internal/rest_opentelemetry.cc
+++ b/google/cloud/internal/rest_opentelemetry.cc
@@ -74,14 +74,12 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> MakeSpanHttp(
   namespace sc = opentelemetry::trace::SemanticConventions;
   opentelemetry::trace::StartSpanOptions options;
   options.kind = opentelemetry::trace::SpanKind::kClient;
-  auto span =
-      internal::GetTracer(internal::CurrentOptions())
-          ->StartSpan(absl::StrCat("HTTP/", absl::string_view{method.data(),
-                                                              method.size()}),
-                      {{sc::kNetworkTransport, sc::NetTransportValues::kIpTcp},
-                       {sc::kHttpRequestMethod, method},
-                       {sc::kUrlFull, request.path()}},
-                      options);
+  auto span = internal::MakeSpan(
+      absl::StrCat("HTTP/", absl::string_view{method.data(), method.size()}),
+      {{sc::kNetworkTransport, sc::NetTransportValues::kIpTcp},
+       {sc::kHttpRequestMethod, method},
+       {sc::kUrlFull, request.path()}},
+      options);
   for (auto const& kv : request.headers()) {
     auto const name = "http.request.header." + kv.first;
     if (kv.second.empty()) {

--- a/google/cloud/internal/tracing_rest_client.cc
+++ b/google/cloud/internal/tracing_rest_client.cc
@@ -94,7 +94,7 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> HttpStart(
   opentelemetry::trace::StartSpanOptions span_options;
   span_options.kind = opentelemetry::trace::SpanKind::kClient;
   span_options.start_system_time = start;
-  return internal::GetTracer(options)->StartSpan("SendRequest", span_options);
+  return internal::MakeSpan("SendRequest", span_options);
 }
 
 StatusOr<std::unique_ptr<RestResponse>> EndStartSpan(

--- a/google/cloud/internal/tracing_rest_client.cc
+++ b/google/cloud/internal/tracing_rest_client.cc
@@ -90,7 +90,7 @@ StatusOr<std::unique_ptr<RestResponse>> EndResponseSpan(
 }
 
 opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> HttpStart(
-    std::chrono::system_clock::time_point start, Options const& options) {
+    std::chrono::system_clock::time_point start) {
   opentelemetry::trace::StartSpanOptions span_options;
   span_options.kind = opentelemetry::trace::SpanKind::kClient;
   span_options.start_system_time = start;
@@ -127,7 +127,7 @@ StatusOr<std::unique_ptr<RestResponse>> WrappedRequest(
   auto scope = opentelemetry::trace::Scope(span);
   InjectTraceContext(context, propagator);
   auto start = std::chrono::system_clock::now();
-  auto start_span = HttpStart(start, internal::CurrentOptions());
+  auto start_span = HttpStart(start);
   auto response =
       EndStartSpan(*start_span, start, context, make_request(context, request));
   return EndResponseSpan(std::move(span), context, std::move(response));

--- a/google/cloud/pubsub/internal/publisher_tracing_connection.cc
+++ b/google/cloud/pubsub/internal/publisher_tracing_connection.cc
@@ -47,17 +47,15 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> StartPublishSpan(
   namespace sc = opentelemetry::trace::SemanticConventions;
   opentelemetry::trace::StartSpanOptions options;
   options.kind = opentelemetry::trace::SpanKind::kProducer;
-  auto span =
-      internal::GetTracer(internal::CurrentOptions())
-          ->StartSpan(
-              topic + " send",
-              {{sc::kMessagingSystem, "pubsub"},
-               {sc::kMessagingDestinationName, topic},
-               {sc::kMessagingDestinationTemplate, "topic"},
-               {"messaging.message.total_size_bytes",
-                static_cast<std::int64_t>(MessageSize(m))},
-               {sc::kCodeFunction, "pubsub::PublisherConnection::Publish"}},
-              options);
+  auto span = internal::MakeSpan(
+      topic + " send",
+      {{sc::kMessagingSystem, "pubsub"},
+       {sc::kMessagingDestinationName, topic},
+       {sc::kMessagingDestinationTemplate, "topic"},
+       {"messaging.message.total_size_bytes",
+        static_cast<std::int64_t>(MessageSize(m))},
+       {sc::kCodeFunction, "pubsub::PublisherConnection::Publish"}},
+      options);
   if (!m.ordering_key().empty()) {
     span->SetAttribute("messaging.pubsub.ordering_key", m.ordering_key());
   }


### PR DESCRIPTION
Now that the function is overloaded, we can use it instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12946)
<!-- Reviewable:end -->
