### PR TITLE
feat(common): mock for `AsyncStreamingReadWriteRpc`

### DIFF
--- a/generator/integration_tests/tests/mock_golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/tests/mock_golden_kitchen_sink_stub.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_TESTS_MOCK_GOLDEN_KITCHEN_SINK_STUB_H
 
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.h"
+#include "google/cloud/mocks/mock_async_streaming_read_write_rpc.h"
 #include "google/cloud/testing_util/mock_async_streaming_read_rpc.h"
 #include "google/cloud/testing_util/mock_async_streaming_write_rpc.h"
 #include <gmock/gmock.h>
@@ -148,23 +149,10 @@ class MockStreamingWriteRpc
               (const, override));
 };
 
-class MockAsyncStreamingReadWriteRpc
-    : public AsyncStreamingReadWriteRpc<
-          ::google::test::admin::database::v1::Request,
-          ::google::test::admin::database::v1::Response> {
- public:
-  MOCK_METHOD(void, Cancel, (), (override));
-  MOCK_METHOD(future<bool>, Start, (), (override));
-  MOCK_METHOD(
-      future<absl::optional<::google::test::admin::database::v1::Response>>,
-      Read, (), (override));
-  MOCK_METHOD(future<bool>, Write,
-              (::google::test::admin::database::v1::Request const&,
-               grpc::WriteOptions),
-              (override));
-  MOCK_METHOD(future<bool>, WritesDone, (), (override));
-  MOCK_METHOD(future<Status>, Finish, (), (override));
-};
+using MockAsyncStreamingReadWriteRpc =
+    google::cloud::mocks::MockAsyncStreamingReadWriteRpc<
+        ::google::test::admin::database::v1::Request,
+        ::google::test::admin::database::v1::Response>;
 
 using MockAsyncStreamingReadRpc =
     google::cloud::testing_util::MockAsyncStreamingReadRpc<

--- a/google/cloud/BUILD.bazel
+++ b/google/cloud/BUILD.bazel
@@ -199,6 +199,7 @@ cc_library(
     deps = [
         ":google_cloud_cpp_common",
         ":google_cloud_cpp_grpc_utils",
+        ":google_cloud_cpp_mocks",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc_private",
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
         "@com_google_googleapis//google/bigtable/admin/v2:admin_cc_grpc",

--- a/google/cloud/google_cloud_cpp_common.cmake
+++ b/google/cloud/google_cloud_cpp_common.cmake
@@ -263,7 +263,8 @@ install(
 add_library(google_cloud_cpp_mocks INTERFACE)
 set(google_cloud_cpp_mocks_hdrs
     # cmake-format: sort
-    mocks/current_options.h mocks/mock_stream_range.h)
+    mocks/current_options.h mocks/mock_async_streaming_read_write_rpc.h
+    mocks/mock_stream_range.h)
 export_list_to_bazel("google_cloud_cpp_mocks.bzl" "google_cloud_cpp_mocks_hdrs"
                      YEAR "2022")
 target_link_libraries(

--- a/google/cloud/google_cloud_cpp_mocks.bzl
+++ b/google/cloud/google_cloud_cpp_mocks.bzl
@@ -18,5 +18,6 @@
 
 google_cloud_cpp_mocks_hdrs = [
     "mocks/current_options.h",
+    "mocks/mock_async_streaming_read_write_rpc.h",
     "mocks/mock_stream_range.h",
 ]

--- a/google/cloud/internal/async_read_write_stream_logging_test.cc
+++ b/google/cloud/internal/async_read_write_stream_logging_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/internal/async_read_write_stream_logging.h"
+#include "google/cloud/mocks/mock_async_streaming_read_write_rpc.h"
 #include "google/cloud/log.h"
 #include "google/cloud/status.h"
 #include "google/cloud/testing_util/scoped_log.h"
@@ -32,28 +33,13 @@ using ::google::cloud::testing_util::StatusIs;
 using ::testing::Contains;
 using ::testing::HasSubstr;
 
-template <typename Request, typename Response>
-class MockAsyncStreamingReadWriteRpc
-    : public AsyncStreamingReadWriteRpc<Request, Response> {
- public:
-  ~MockAsyncStreamingReadWriteRpc() override = default;
-
-  MOCK_METHOD(void, Cancel, (), (override));
-  MOCK_METHOD(future<bool>, Start, (), (override));
-  MOCK_METHOD(future<absl::optional<Response>>, Read, (), (override));
-  MOCK_METHOD(future<bool>, Write, (Request const&, grpc::WriteOptions),
-              (override));
-  MOCK_METHOD(future<bool>, WritesDone, (), (override));
-  MOCK_METHOD(future<Status>, Finish, (), (override));
-};
-
 class StreamingReadRpcLoggingTest : public ::testing::Test {
  protected:
   testing_util::ScopedLog log_;
 };
 
-using MockStream = MockAsyncStreamingReadWriteRpc<google::protobuf::Timestamp,
-                                                  google::protobuf::Duration>;
+using MockStream = google::cloud::mocks::MockAsyncStreamingReadWriteRpc<
+    google::protobuf::Timestamp, google::protobuf::Duration>;
 using TestedStream =
     AsyncStreamingReadWriteRpcLogging<google::protobuf::Timestamp,
                                       google::protobuf::Duration>;

--- a/google/cloud/internal/async_read_write_stream_tracing_test.cc
+++ b/google/cloud/internal/async_read_write_stream_tracing_test.cc
@@ -14,6 +14,7 @@
 
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 #include "google/cloud/internal/async_read_write_stream_tracing.h"
+#include "google/cloud/mocks/mock_async_streaming_read_write_rpc.h"
 #include "google/cloud/internal/make_status.h"
 #include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/testing_util/opentelemetry_matchers.h"
@@ -41,22 +42,8 @@ using ::testing::IsEmpty;
 using ::testing::Optional;
 using ::testing::Return;
 
-template <typename Request, typename Response>
-class MockAsyncStreamingReadWriteRpc
-    : public AsyncStreamingReadWriteRpc<Request, Response> {
- public:
-  ~MockAsyncStreamingReadWriteRpc() override = default;
-
-  MOCK_METHOD(void, Cancel, (), (override));
-  MOCK_METHOD(future<bool>, Start, (), (override));
-  MOCK_METHOD(future<absl::optional<Response>>, Read, (), (override));
-  MOCK_METHOD(future<bool>, Write, (Request const&, grpc::WriteOptions),
-              (override));
-  MOCK_METHOD(future<bool>, WritesDone, (), (override));
-  MOCK_METHOD(future<Status>, Finish, (), (override));
-};
-
-using MockStream = MockAsyncStreamingReadWriteRpc<int, int>;
+using MockStream =
+    google::cloud::mocks::MockAsyncStreamingReadWriteRpc<int, int>;
 using TestedStream = AsyncStreamingReadWriteRpcTracing<int, int>;
 
 TEST(AsyncStreamingReadWriteRpcTracing, Cancel) {

--- a/google/cloud/mocks/mock_async_streaming_read_write_rpc.h
+++ b/google/cloud/mocks/mock_async_streaming_read_write_rpc.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUBLITE_TESTING_MOCK_ASYNC_READER_WRITER_H
-#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUBLITE_TESTING_MOCK_ASYNC_READER_WRITER_H
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_MOCKS_MOCK_ASYNC_STREAMING_READ_WRITE_RPC_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_MOCKS_MOCK_ASYNC_STREAMING_READ_WRITE_RPC_H
 
 #include "google/cloud/async_streaming_read_write_rpc.h"
 #include "google/cloud/version.h"
@@ -21,11 +21,11 @@
 
 namespace google {
 namespace cloud {
-namespace pubsublite_testing {
+namespace mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 template <typename RequestType, typename ResponseType>
-class MockAsyncReaderWriter
+class MockAsyncStreamingReadWriteRpc
     : public google::cloud::AsyncStreamingReadWriteRpc<RequestType,
                                                        ResponseType> {
  public:
@@ -39,8 +39,8 @@ class MockAsyncReaderWriter
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace pubsublite_testing
+}  // namespace mocks
 }  // namespace cloud
 }  // namespace google
 
-#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUBLITE_TESTING_MOCK_ASYNC_READER_WRITER_H
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_MOCKS_MOCK_ASYNC_STREAMING_READ_WRITE_RPC_H

--- a/google/cloud/pubsublite/BUILD.bazel
+++ b/google/cloud/pubsublite/BUILD.bazel
@@ -82,6 +82,7 @@ cc_library(
             ":google_cloud_cpp_pubsublite_mocks",
             ":pubsublite_testing",
             "//:common",
+            "//:mocks",
             "//google/cloud/testing_util:google_cloud_cpp_testing_grpc_private",
             "//google/cloud/testing_util:google_cloud_cpp_testing_private",
             "@com_google_absl//absl/memory",

--- a/google/cloud/pubsublite/CMakeLists.txt
+++ b/google/cloud/pubsublite/CMakeLists.txt
@@ -235,7 +235,6 @@ function (google_cloud_cpp_pubsublite_client_define_tests)
         pubsublite_testing
         INTERFACE
             ${CMAKE_CURRENT_SOURCE_DIR}/testing/mock_alarm_registry.h
-            ${CMAKE_CURRENT_SOURCE_DIR}/testing/mock_async_reader_writer.h
             ${CMAKE_CURRENT_SOURCE_DIR}/testing/mock_publisher.h
             ${CMAKE_CURRENT_SOURCE_DIR}/testing/mock_resumable_async_reader_writer_stream.h
             ${CMAKE_CURRENT_SOURCE_DIR}/testing/mock_retry_policy.h

--- a/google/cloud/pubsublite/internal/partition_publisher_test.cc
+++ b/google/cloud/pubsublite/internal/partition_publisher_test.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/pubsublite/internal/partition_publisher.h"
+#include "google/cloud/mocks/mock_async_streaming_read_write_rpc.h"
 #include "google/cloud/pubsublite/testing/mock_alarm_registry.h"
-#include "google/cloud/pubsublite/testing/mock_async_reader_writer.h"
 #include "google/cloud/pubsublite/testing/mock_resumable_async_reader_writer_stream.h"
 #include "google/cloud/future.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
@@ -52,11 +52,11 @@ using google::cloud::pubsublite::v1::PubSubMessage;
 
 using ::google::cloud::pubsublite_testing::MockAlarmRegistry;
 using ::google::cloud::pubsublite_testing::MockAlarmRegistryCancelToken;
-using ::google::cloud::pubsublite_testing::MockAsyncReaderWriter;
 using ::google::cloud::pubsublite_testing::MockResumableAsyncReaderWriter;
 
 using AsyncReaderWriter =
-    MockAsyncReaderWriter<PublishRequest, PublishResponse>;
+    google::cloud::mocks::MockAsyncStreamingReadWriteRpc<PublishRequest,
+                                                         PublishResponse>;
 
 using AsyncReadWriteStreamReturnType = std::unique_ptr<
     AsyncStreamingReadWriteRpc<PublishRequest, PublishResponse>>;

--- a/google/cloud/pubsublite/internal/resumable_async_streaming_read_write_rpc_test.cc
+++ b/google/cloud/pubsublite/internal/resumable_async_streaming_read_write_rpc_test.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/pubsublite/internal/resumable_async_streaming_read_write_rpc.h"
-#include "google/cloud/pubsublite/testing/mock_async_reader_writer.h"
+#include "google/cloud/mocks/mock_async_streaming_read_write_rpc.h"
 #include "google/cloud/pubsublite/testing/mock_retry_policy.h"
 #include "google/cloud/future.h"
 #include "google/cloud/status_or.h"
@@ -63,8 +63,8 @@ bool operator==(FakeResponse const& lhs, FakeResponse const& rhs) {
 }
 
 using AsyncReaderWriter =
-    ::google::cloud::pubsublite_testing::MockAsyncReaderWriter<FakeRequest,
-                                                               FakeResponse>;
+    ::google::cloud::mocks::MockAsyncStreamingReadWriteRpc<FakeRequest,
+                                                           FakeResponse>;
 
 using AsyncReadWriteStreamReturnType =
     std::unique_ptr<AsyncStreamingReadWriteRpc<FakeRequest, FakeResponse>>;

--- a/google/cloud/pubsublite/pubsublite_testing.bzl
+++ b/google/cloud/pubsublite/pubsublite_testing.bzl
@@ -18,7 +18,6 @@
 
 pubsublite_testing_hdrs = [
     "testing/mock_alarm_registry.h",
-    "testing/mock_async_reader_writer.h",
     "testing/mock_publisher.h",
     "testing/mock_resumable_async_reader_writer_stream.h",
     "testing/mock_retry_policy.h",


### PR DESCRIPTION
This class is part of the public API for some `*Connection` and `*Client` classes. Applications may need to mock them, we should provide the mock.

I also refactored existing mocks to a single place.

Part of the work for #9134

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12950)
<!-- Reviewable:end -->
