### PR TITLE
cleanup(policytroubleshooter): cannot move a `const`

### DIFF
--- a/google/cloud/policytroubleshooter/README.md
+++ b/google/cloud/policytroubleshooter/README.md
@@ -40,7 +40,7 @@ int main(int argc, char* argv[]) try {
   access_tuple.set_principal(argv[1]);
   access_tuple.set_full_resource_name(argv[2]);
   access_tuple.set_permission(argv[3]);
-  auto const response = client.TroubleshootIamPolicy(request);
+  auto response = client.TroubleshootIamPolicy(request);
   if (!response) throw std::move(response).status();
   std::cout << response->DebugString() << "\n";
 

--- a/google/cloud/policytroubleshooter/quickstart/quickstart.cc
+++ b/google/cloud/policytroubleshooter/quickstart/quickstart.cc
@@ -32,7 +32,7 @@ int main(int argc, char* argv[]) try {
   access_tuple.set_principal(argv[1]);
   access_tuple.set_full_resource_name(argv[2]);
   access_tuple.set_permission(argv[3]);
-  auto const response = client.TroubleshootIamPolicy(request);
+  auto response = client.TroubleshootIamPolicy(request);
   if (!response) throw std::move(response).status();
   std::cout << response->DebugString() << "\n";
 


### PR DESCRIPTION
If we are going to write `std::move(r).status()` we cannot make `r` a `const` object.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12953)
<!-- Reviewable:end -->
