### PR TITLE
cleanup(ci): remove double feature enable from clang-tidy build

### DIFF
--- a/ci/cloudbuild/builds/clang-tidy.sh
+++ b/ci/cloudbuild/builds/clang-tidy.sh
@@ -31,7 +31,6 @@ mapfile -t cmake_args < <(cmake::common_args)
 read -r ENABLED_FEATURES < <(features::always_build_cmake)
 # Add some features that we don't always build, but we want to run clang-tidy
 # over them.
-ENABLED_FEATURES="${ENABLED_FEATURES},experimental-storage_grpc"
 ENABLED_FEATURES="${ENABLED_FEATURES},generator"
 readonly ENABLED_FEATURES
 


### PR DESCRIPTION
Since #12707, when `experimental-storage_grpc` joined the `features::always_build()` list, we have no reason to add it explicitly in the `clang-tidy` build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12965)
<!-- Reviewable:end -->
