### PR TITLE
impl: make external/googleapis/renovate.sh a little smarter

### DIFF
--- a/external/googleapis/renovate.sh
+++ b/external/googleapis/renovate.sh
@@ -55,6 +55,12 @@ sed -i -f - cmake/GoogleapisConfig.cmake <<EOT
   }
 EOT
 
+if git diff --quiet bazel/google_cloud_cpp_deps.bzl \
+  cmake/GoogleapisConfig.cmake; then
+  echo "No updates"
+  exit 0
+fi
+
 banner "Updating the protodeps/protolists"
 external/googleapis/update_libraries.sh
 
@@ -70,7 +76,9 @@ if ! git diff --quiet external/googleapis/protodeps \
   git commit -m"Update the protodeps/protolists" \
     external/googleapis/protodeps external/googleapis/protolists
 fi
-git commit -m"Regenerate libraries" .
+if ! git diff --quiet .; then
+  git commit -m"Regenerate libraries" .
+fi
 
 banner "Showing git state"
 git status --untracked-files=no


### PR DESCRIPTION
In addition to #12647, where we recognized that there may be nothing to update in the protodeps/protolists, we now allow for:
- there being no updates to perform at all (i.e., we are already at googleapis HEAD), and
- generate-libraries creating no edits (e.g., if we are updating to facilitate generation of a new library).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12980)
<!-- Reviewable:end -->
