### PR TITLE
fix(pubsub): add missing default capture

### DIFF
--- a/google/cloud/pubsub/internal/tracing_message_batch.cc
+++ b/google/cloud/pubsub/internal/tracing_message_batch.cc
@@ -110,7 +110,7 @@ Spans MakeBatchSinkSpans(Spans message_spans) {
   batch_sink_spans.push_back(MakeParent({{}}, message_spans));
   auto batch_sink_parent = batch_sink_spans.front();
 
-  auto cut = [&message_spans](auto i) {
+  auto cut = [&message_spans, &kMaxOtelLinks](auto i) {
     auto const batch_size = static_cast<std::ptrdiff_t>(kMaxOtelLinks);
     return std::next(
         i, std::min(batch_size, std::distance(i, message_spans.end())));

--- a/google/cloud/pubsub/internal/tracing_message_batch.cc
+++ b/google/cloud/pubsub/internal/tracing_message_batch.cc
@@ -97,12 +97,12 @@ auto MakeChild(
 }
 
 Spans MakeBatchSinkSpans(Spans message_spans) {
-  int constexpr kMaxOtelLinks = 128;
+  int64_t max_otel_links = 128;
   Spans batch_sink_spans;
   // If the batch size is less than the max size, add the links to a single
   // span. If the batch size is greater than the max size, create a parent
   // span with no links and each child spans will contain links.
-  if (message_spans.size() <= kMaxOtelLinks) {
+  if (static_cast<int64_t>(message_spans.size()) <= max_otel_links) {
     batch_sink_spans.push_back(MakeParent(
         MakeLinks(message_spans.begin(), message_spans.end()), message_spans));
     return batch_sink_spans;
@@ -110,8 +110,8 @@ Spans MakeBatchSinkSpans(Spans message_spans) {
   batch_sink_spans.push_back(MakeParent({{}}, message_spans));
   auto batch_sink_parent = batch_sink_spans.front();
 
-  auto cut = [&message_spans, &kMaxOtelLinks](auto i) {
-    auto const batch_size = static_cast<std::ptrdiff_t>(kMaxOtelLinks);
+  auto cut = [&message_spans, max_otel_links](auto i) {
+    auto const batch_size = static_cast<std::ptrdiff_t>(max_otel_links);
     return std::next(
         i, std::min(batch_size, std::distance(i, message_spans.end())));
   };


### PR DESCRIPTION
Getting

```
google/cloud/pubsub/internal/tracing_message_batch.cc(112): error C3493: 'kMaxOtelLinks' cannot be implicitly captured because no default capture mode has been specified
google/cloud/pubsub/internal/tracing_message_batch.cc(117): error C2064: term does not evaluate to a function taking 1 arguments
google/cloud/pubsub/internal/tracing_message_batch.cc(121): error C2064: term does not evaluate to a function taking 1 arguments
google/cloud/pubsub/internal/tracing_message_batch.cc(121): error C2660: 'google::cloud::pubsub_internal::v2_18::`anonymous-namespace'::MakeLinks': function does not take 1 arguments
google/cloud/pubsub/internal/tracing_message_batch.cc(55): note: see declaration of 'google::cloud::pubsub_internal::v2_18::`anonymous-namespace'::MakeLinks'
google/cloud/pubsub/internal/tracing_message_batch.cc(121): error C2660: 'google::cloud::pubsub_internal::v2_18::`anonymous-namespace'::MakeChild': function does not take 2 arguments
google/cloud/pubsub/internal/tracing_message_batch.cc(86): note: see declaration of 'google::cloud::pubsub_internal::v2_18::`anonymous-namespace'::MakeChild'
```
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12984)
<!-- Reviewable:end -->
