### PR TITLE
fix: Fix types of Range class fields.

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/job_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_test.cc
@@ -51,8 +51,8 @@ TEST(JobTest, JobDebugString) {
       R"( destination_table { project_id: "2" dataset_id: "1" table_id: "3" })"
       R"( time_partitioning { type: "tp-field-type" expiration_time { "0" })"
       R"( field: "tp-field-1" } range_partitioning {)"
-      R"( field: "rp-field-1" range { start: "range-start" end: "range-end")"
-      R"( interval: "range-interval" } } clustering { fields: "clustering-field-1")"
+      R"( field: "rp-field-1" range { start: 0 end: 2)"
+      R"( interval: 1 } } clustering { fields: "clustering-field-1")"
       R"( fields: "clustering-field-2" } destination_encryption_configuration {)"
       R"( kms_key_name: "encryption-key-name" } script_options {)"
       R"( statement_timeout { "10ms" } statement_byte_budget: 10)"
@@ -158,8 +158,8 @@ TEST(JobTest, JobDebugString) {
       R"( destination_table { project_id: "2" dataset_id: "1" table_id: "3" })"
       R"( time_partitioning { type: "tp-field-type" expiration_time { "0" })"
       R"( field: "tp-field-1" } range_partitioning {)"
-      R"( field: "rp-field-1" range { start: "range-start" end: "range-end")"
-      R"( interval: "range-interval" } } clustering { fields: "clustering-field-1")"
+      R"( field: "rp-field-1" range { start: 0 end: 2)"
+      R"( interval: 1 } } clustering { fields: "clustering-field-1")"
       R"( fields: "clustering-field-2" } destination_encryption_configuration {)"
       R"( kms_key_name: "encryption-key-name" } script_options {)"
       R"( statement_timeout { "10ms" } statement_byte_budget: 10)"
@@ -309,9 +309,9 @@ TEST(JobTest, JobDebugString) {
       range_partitioning {
         field: "rp-field-1"
         range {
-          start: "range-start"
-          end: "range-end"
-          interval: "range-interval"
+          start: 0
+          end: 2
+          interval: 1
         }
       }
       clustering {
@@ -681,7 +681,7 @@ TEST(JobTest, ListFormatJobDebugString) {
       R"( table_id: "3" } time_partitioning { type: "tp-field-type")"
       R"( expiration_time { "0" } field: "tp-field-1" })"
       R"( range_partitioning { field: "rp-field-1" range {)"
-      R"( start: "range-start" end: "range-end" interval: "range-interval" } })"
+      R"( start: 0 end: 2 interval: 1 } })"
       R"( clustering { fields: "clustering-field-1")"
       R"( fields: "clustering-field-2" } destination_encryption_configuration {)"
       R"( kms_key_name: "encryption-key-name" } script_options {)"
@@ -794,7 +794,7 @@ TEST(JobTest, ListFormatJobDebugString) {
       R"( table_id: "3" } time_partitioning { type: "tp-field-type")"
       R"( expiration_time { "0" } field: "tp-field-1" })"
       R"( range_partitioning { field: "rp-field-1" range {)"
-      R"( start: "range-start" end: "range-end" interval: "range-interval" } })"
+      R"( start: 0 end: 2 interval: 1 } })"
       R"( clustering { fields: "clustering-field-1")"
       R"( fields: "clustering-field-2" } destination_encryption_configuration {)"
       R"( kms_key_name: "encryption-key-name" } script_options {)"
@@ -946,9 +946,9 @@ TEST(JobTest, ListFormatJobDebugString) {
       range_partitioning {
         field: "rp-field-1"
         range {
-          start: "range-start"
-          end: "range-end"
-          interval: "range-interval"
+          start: 0
+          end: 2
+          interval: 1
         }
       }
       clustering {
@@ -1319,8 +1319,8 @@ TEST(JobTest, JobToFromJson) {
       R"(,"structValues":{},"value":"array-val-1"}])"
       R"(,"structValues":{"qp-map-key":{"arrayValues":[],"structValues":{})"
       R"(,"value":"qp-map-value"}},"value":"query-parameter-value"}}])"
-      R"(,"rangePartitioning":{"field":"rp-field-1","range":{"end":"range-end")"
-      R"(,"interval":"range-interval","start":"range-start"}})"
+      R"(,"rangePartitioning":{"field":"rp-field-1","range":{"end":2)"
+      R"(,"interval":1,"start":0}})"
       R"(,"schemaUpdateOptions":["job-update-options"])"
       R"(,"scriptOptions":{"keyResultStatement":"FIRST_SELECT")"
       R"(,"statementByteBudget":10,"statementTimeoutMs":"10"})"
@@ -1442,8 +1442,8 @@ TEST(JobTest, ListFormatJobToFromJson) {
       R"(,"value":"array-map-value"}},"value":"array-val-2"}],"structValues":{})"
       R"(,"value":"array-val-1"}],"structValues":{"qp-map-key":{"arrayValues":[])"
       R"(,"structValues":{},"value":"qp-map-value"}},"value":"query-parameter-value"}}])"
-      R"(,"rangePartitioning":{"field":"rp-field-1","range":{"end":"range-end")"
-      R"(,"interval":"range-interval","start":"range-start"}})"
+      R"(,"rangePartitioning":{"field":"rp-field-1","range":{"end":2)"
+      R"(,"interval":1,"start":0}})"
       R"(,"schemaUpdateOptions":["job-update-options"])"
       R"(,"scriptOptions":{"keyResultStatement":"FIRST_SELECT")"
       R"(,"statementByteBudget":10,"statementTimeoutMs":"10"})"

--- a/google/cloud/bigquery/v2/minimal/internal/table_partition.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/table_partition.cc
@@ -36,9 +36,9 @@ std::string Range::DebugString(absl::string_view name,
                                TracingOptions const& options,
                                int indent) const {
   return internal::DebugFormatter(name, options, indent)
-      .StringField("start", start)
-      .StringField("end", end)
-      .StringField("interval", interval)
+      .Field("start", start)
+      .Field("end", end)
+      .Field("interval", interval)
       .Build();
 }
 

--- a/google/cloud/bigquery/v2/minimal/internal/table_partition.h
+++ b/google/cloud/bigquery/v2/minimal/internal/table_partition.h
@@ -45,9 +45,9 @@ void to_json(nlohmann::json& j, TimePartitioning const& t);
 void from_json(nlohmann::json const& j, TimePartitioning& t);
 
 struct Range {
-  std::string start;
-  std::string end;
-  std::string interval;
+  int start;
+  int end;
+  int interval;
 
   std::string DebugString(absl::string_view name,
                           TracingOptions const& options = {},

--- a/google/cloud/bigquery/v2/minimal/testing/job_test_utils.cc
+++ b/google/cloud/bigquery/v2/minimal/testing/job_test_utils.cc
@@ -260,9 +260,9 @@ Clustering MakeClustering() {
 RangePartitioning MakeRangePartitioning() {
   RangePartitioning rp;
   rp.field = "rp-field-1";
-  rp.range.end = "range-end";
-  rp.range.start = "range-start";
-  rp.range.interval = "range-interval";
+  rp.range.end = 2;
+  rp.range.start = 0;
+  rp.range.interval = 1;
 
   return rp;
 }


### PR DESCRIPTION
Documentation states that it should be `string`.
https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#RangePartitioning However testing REST requests with real instance show that it's `int`. Also it can be tested here by tryng to create a valid json https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/insert

https://screenshot.googleplex.com/SLnKvpUu3uSsv6Q
https://screenshot.googleplex.com/866oUQfjCRmHmC7