### PR TITLE
fix(otel): restore compatibility with otel 1.9.1

### DIFF
--- a/google/cloud/internal/grpc_opentelemetry.cc
+++ b/google/cloud/internal/grpc_opentelemetry.cc
@@ -85,7 +85,8 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> MakeSpanGrpc(
       {{sc::kRpcSystem, sc::RpcSystemValues::kGrpc},
        {sc::kRpcService, service},
        {sc::kRpcMethod, method},
-       {sc::kNetworkTransport, sc::NetTransportValues::kIpTcp},
+       {/*sc::kNetworkTransport=*/"network.transport",
+        sc::NetTransportValues::kIpTcp},
        {"grpc.version", grpc::Version()}},
       options);
 }

--- a/google/cloud/internal/grpc_opentelemetry_test.cc
+++ b/google/cloud/internal/grpc_opentelemetry_test.cc
@@ -70,8 +70,9 @@ TEST(OpenTelemetry, MakeSpanGrpc) {
               OTelAttribute<std::string>(sc::kRpcService,
                                          "google.cloud.foo.v1.Foo"),
               OTelAttribute<std::string>(sc::kRpcMethod, "GetBar"),
-              OTelAttribute<std::string>(sc::kNetworkTransport,
-                                         sc::NetTransportValues::kIpTcp),
+              OTelAttribute<std::string>(
+                  /*sc::kNetworkTransport=*/"network.transport",
+                  sc::NetTransportValues::kIpTcp),
               OTelAttribute<std::string>("grpc.version", grpc::Version())))));
 }
 

--- a/google/cloud/internal/rest_opentelemetry.cc
+++ b/google/cloud/internal/rest_opentelemetry.cc
@@ -76,9 +76,10 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> MakeSpanHttp(
   options.kind = opentelemetry::trace::SpanKind::kClient;
   auto span = internal::MakeSpan(
       absl::StrCat("HTTP/", absl::string_view{method.data(), method.size()}),
-      {{sc::kNetworkTransport, sc::NetTransportValues::kIpTcp},
-       {sc::kHttpRequestMethod, method},
-       {sc::kUrlFull, request.path()}},
+      {{/*sc::kNetworkTransport=*/"network.transport",
+        sc::NetTransportValues::kIpTcp},
+       {/*sc::kHttpRequestMethod=*/"http.request.method", method},
+       {/*sc::kUrlFull=*/"url.full", request.path()}},
       options);
   for (auto const& kv : request.headers()) {
     auto const name = "http.request.header." + kv.first;

--- a/google/cloud/internal/rest_opentelemetry_test.cc
+++ b/google/cloud/internal/rest_opentelemetry_test.cc
@@ -64,10 +64,12 @@ TEST(RestOpentelemetry, MakeSpanHttp) {
           SpanHasInstrumentationScope(), SpanKindIsClient(),
           SpanNamed("HTTP/GET"),
           SpanHasAttributes(
-              OTelAttribute<std::string>(sc::kNetworkTransport,
-                                         sc::NetTransportValues::kIpTcp),
-              OTelAttribute<std::string>(sc::kHttpRequestMethod, "GET"),
-              OTelAttribute<std::string>(sc::kUrlFull, kUrl),
+              OTelAttribute<std::string>(
+                  /*sc::kNetworkTransport=*/"network.transport",
+                  sc::NetTransportValues::kIpTcp),
+              OTelAttribute<std::string>(
+                  /*sc::kHttpRequestMethod=*/"http.request.method", "GET"),
+              OTelAttribute<std::string>(/*sc::kUrlFull=*/"url.full", kUrl),
               OTelAttribute<std::string>("http.request.header.empty", ""),
               OTelAttribute<std::string>("http.request.header.x-goog-foo",
                                          "bar"),

--- a/google/cloud/internal/tracing_http_payload_test.cc
+++ b/google/cloud/internal/tracing_http_payload_test.cc
@@ -67,15 +67,15 @@ TEST(TracingHttpPayload, Success) {
                      OTelAttribute<std::int64_t>("read.buffer.size", bs),
                      OTelAttribute<std::int64_t>("read.returned.size", rs)));
   };
-  EXPECT_THAT(
-      spans,
-      UnorderedElementsAre(
-          AllOf(SpanNamed("HTTP/GET"), SpanHasInstrumentationScope(),
-                SpanKindIsClient(),
-                SpanHasAttributes(OTelAttribute<std::string>(
-                    sc::kNetworkTransport, sc::NetTransportValues::kIpTcp))),
-          make_read_matcher(16, 16), make_read_matcher(16, 16),
-          make_read_matcher(16, 11), make_read_matcher(16, 0)));
+  EXPECT_THAT(spans,
+              UnorderedElementsAre(
+                  AllOf(SpanNamed("HTTP/GET"), SpanHasInstrumentationScope(),
+                        SpanKindIsClient(),
+                        SpanHasAttributes(OTelAttribute<std::string>(
+                            /*sc::kNetworkTransport=*/"network.transport",
+                            sc::NetTransportValues::kIpTcp))),
+                  make_read_matcher(16, 16), make_read_matcher(16, 16),
+                  make_read_matcher(16, 11), make_read_matcher(16, 0)));
 }
 
 TEST(TracingHttpPayload, Failure) {
@@ -115,19 +115,19 @@ TEST(TracingHttpPayload, Failure) {
                          "gl-cpp.status_code", static_cast<std::int32_t>(code)),
                      OTelAttribute<std::int64_t>("read.buffer.size", bs)));
   };
-  EXPECT_THAT(
-      spans,
-      UnorderedElementsAre(
-          AllOf(SpanNamed("HTTP/GET"), SpanHasInstrumentationScope(),
-                SpanKindIsClient(),
-                SpanHasAttributes(
-                    OTelAttribute<std::string>(sc::kNetworkTransport,
-                                               sc::NetTransportValues::kIpTcp),
-                    OTelAttribute<int>(
-                        "gl-cpp.status_code",
-                        static_cast<int>(StatusCode::kUnavailable)))),
-          make_read_success_matcher(16, 16),
-          make_read_error_matcher(16, StatusCode::kUnavailable)));
+  EXPECT_THAT(spans,
+              UnorderedElementsAre(
+                  AllOf(SpanNamed("HTTP/GET"), SpanHasInstrumentationScope(),
+                        SpanKindIsClient(),
+                        SpanHasAttributes(
+                            OTelAttribute<std::string>(
+                                /*sc::kNetworkTransport=*/"network.transport",
+                                sc::NetTransportValues::kIpTcp),
+                            OTelAttribute<int>(
+                                "gl-cpp.status_code",
+                                static_cast<int>(StatusCode::kUnavailable)))),
+                  make_read_success_matcher(16, 16),
+                  make_read_error_matcher(16, StatusCode::kUnavailable)));
 }
 
 }  // namespace

--- a/google/cloud/internal/tracing_rest_client.cc
+++ b/google/cloud/internal/tracing_rest_client.cc
@@ -23,7 +23,6 @@
 #include "absl/functional/function_ref.h"
 #include "absl/strings/match.h"
 #include "absl/strings/numbers.h"
-#include <opentelemetry/trace/semantic_conventions.h>
 #include <array>
 #include <cstdint>
 
@@ -46,15 +45,18 @@ StatusOr<std::unique_ptr<RestResponse>> EndResponseSpan(
     opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> span,
     RestContext& context,
     StatusOr<std::unique_ptr<RestResponse>> request_result) {
-  namespace sc = opentelemetry::trace::SemanticConventions;
   if (context.primary_ip_address() && context.primary_port()) {
-    span->SetAttribute(sc::kServerAddress, *context.primary_ip_address());
-    span->SetAttribute(sc::kServerPort, *context.primary_port());
+    span->SetAttribute(/*sc::kServerAddress=*/"server.address",
+                       *context.primary_ip_address());
+    span->SetAttribute(/*sc::kServerPort=*/"server.port",
+                       *context.primary_port());
   }
 
   if (context.local_ip_address() && context.local_port()) {
-    span->SetAttribute(sc::kClientAddress, *context.local_ip_address());
-    span->SetAttribute(sc::kClientPort, *context.local_port());
+    span->SetAttribute(/*sc::kClientAddress=*/"client.address",
+                       *context.local_ip_address());
+    span->SetAttribute(/*sc::kClientPort=*/"client.port",
+                       *context.local_port());
   }
   for (auto const& kv : context.headers()) {
     auto const name = "http.request.header." + kv.first;

--- a/google/cloud/internal/tracing_rest_client_test.cc
+++ b/google/cloud/internal/tracing_rest_client_test.cc
@@ -105,10 +105,13 @@ TEST(TracingRestClient, Delete) {
               SpanNamed("HTTP/DELETE"), SpanHasInstrumentationScope(),
               SpanKindIsClient(),
               SpanHasAttributes(
-                  OTelAttribute<std::string>(sc::kNetworkTransport,
-                                             sc::NetTransportValues::kIpTcp),
-                  OTelAttribute<std::string>(sc::kHttpRequestMethod, "DELETE"),
-                  OTelAttribute<std::string>(sc::kUrlFull, kUrl),
+                  OTelAttribute<std::string>(
+                      /*sc::kNetworkTransport=*/"network.transport",
+                      sc::NetTransportValues::kIpTcp),
+                  OTelAttribute<std::string>(
+                      /*sc::kHttpRequestMethod=*/"http.request.method",
+                      "DELETE"),
+                  OTelAttribute<std::string>(/*sc::kUrlFull=*/"url.full", kUrl),
                   OTelAttribute<std::string>(
                       "http.request.header.x-test-header-3", "value3"),
                   OTelAttribute<std::string>(
@@ -249,14 +252,20 @@ TEST(TracingRestClient, WithRestContextDetails) {
           AllOf(
               SpanNamed("HTTP/POST"),
               SpanHasAttributes(
-                  OTelAttribute<std::string>(sc::kNetworkTransport,
-                                             sc::NetTransportValues::kIpTcp),
-                  OTelAttribute<std::string>(sc::kHttpRequestMethod, "POST"),
-                  OTelAttribute<std::string>(sc::kUrlFull, kUrl),
-                  OTelAttribute<std::string>(sc::kServerAddress, "192.168.1.1"),
-                  OTelAttribute<std::int32_t>(sc::kServerPort, 443),
-                  OTelAttribute<std::string>(sc::kClientAddress, "127.0.0.1"),
-                  OTelAttribute<std::int32_t>(sc::kClientPort, 32000))),
+                  OTelAttribute<std::string>(
+                      /*sc::kNetworkTransport=*/"network.transport",
+                      sc::NetTransportValues::kIpTcp),
+                  OTelAttribute<std::string>(
+                      /*sc::kHttpRequestMethod=*/"http.request.method", "POST"),
+                  OTelAttribute<std::string>(/*sc::kUrlFull=*/"url.full", kUrl),
+                  OTelAttribute<std::string>(
+                      /*sc::kServerAddress=*/"server.address", "192.168.1.1"),
+                  OTelAttribute<std::int32_t>(/*sc::kServerPort=*/"server.port",
+                                              443),
+                  OTelAttribute<std::string>(
+                      /*sc::kClientAddress=*/"client.address", "127.0.0.1"),
+                  OTelAttribute<std::int32_t>(/*sc::kClientPort=*/"client.port",
+                                              32000))),
           AllOf(SpanNamed("SendRequest"),
                 SpanHasAttributes(
                     OTelAttribute<bool>("gl-cpp.cached_connection", false)),

--- a/google/cloud/internal/tracing_rest_response_test.cc
+++ b/google/cloud/internal/tracing_rest_response_test.cc
@@ -80,15 +80,15 @@ TEST(TracingRestResponseTest, Success) {
                      OTelAttribute<std::int64_t>("read.returned.size", rs)));
   };
   auto const content_size = static_cast<std::int64_t>(MockContents().size());
-  EXPECT_THAT(
-      spans,
-      UnorderedElementsAre(
-          AllOf(SpanNamed("HTTP/GET"), SpanHasInstrumentationScope(),
-                SpanKindIsClient(),
-                SpanHasAttributes(OTelAttribute<std::string>(
-                    sc::kNetworkTransport, sc::NetTransportValues::kIpTcp))),
-          make_read_event_matcher(kBufferSize, content_size),
-          make_read_event_matcher(kBufferSize, 0)));
+  EXPECT_THAT(spans,
+              UnorderedElementsAre(
+                  AllOf(SpanNamed("HTTP/GET"), SpanHasInstrumentationScope(),
+                        SpanKindIsClient(),
+                        SpanHasAttributes(OTelAttribute<std::string>(
+                            /*sc::kNetworkTransport=*/"network.transport",
+                            sc::NetTransportValues::kIpTcp))),
+                  make_read_event_matcher(kBufferSize, content_size),
+                  make_read_event_matcher(kBufferSize, 0)));
 }
 
 }  // namespace


### PR DESCRIPTION
Part of the work for #12991 

Instead of changing the values of these semantic convention variables, OTel deprecates them, and tells you to use the new name. That is weird, but whatever.

Let's not mess with any `#if OPENTELEMETRY_CPP_VERSION`s. Let's just use the values du jour directly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12992)
<!-- Reviewable:end -->
