### PR TITLE
fix(otel): support abseil <= 20210324

### DIFF
--- a/google/cloud/internal/trace_propagator.cc
+++ b/google/cloud/internal/trace_propagator.cc
@@ -19,6 +19,7 @@
 #include <opentelemetry/context/propagation/composite_propagator.h>
 #include <opentelemetry/trace/context.h>
 #include <opentelemetry/trace/propagation/http_trace_context.h>
+#include <cstdlib>
 
 namespace google {
 namespace cloud {
@@ -68,6 +69,7 @@ class CloudTraceContext
     span_id[2 * SpanId::kSize] = '\0';
     char* end = nullptr;
     std::uint64_t span_id_dec = std::strtoull(span_id.data(), &end, 16);
+    if (end - span_id.data() != 2 * SpanId::kSize) return;
     carrier.Set(
         "x-cloud-trace-context",
         absl::StrCat(absl::string_view{trace_id.data(), trace_id.size()}, "/",

--- a/google/cloud/internal/trace_propagator.cc
+++ b/google/cloud/internal/trace_propagator.cc
@@ -60,13 +60,14 @@ class CloudTraceContext
     using opentelemetry::trace::TraceId;
     std::array<char, 2 * TraceId::kSize> trace_id;
     span_context.trace_id().ToLowerBase16(trace_id);
-    std::array<char, 2 * SpanId::kSize> span_id;
-    span_context.span_id().ToLowerBase16(span_id);
-    std::uint64_t span_id_dec;
-    if (!absl::SimpleHexAtoi(absl::string_view{span_id.data(), span_id.size()},
-                             &span_id_dec)) {
-      return;
-    }
+    // We would prefer to use `absl::SimpleHexAtoi`, but it is not available in
+    // the oldest version of Abseil we support. So we use `std::strtoull`, which
+    // requires the input to be null-terminated.
+    std::array<char, 2 * SpanId::kSize + 1> span_id;
+    span_context.span_id().ToLowerBase16({span_id.data(), span_id.size() - 1});
+    span_id[2 * SpanId::kSize] = '\0';
+    char* end = nullptr;
+    std::uint64_t span_id_dec = std::strtoull(span_id.data(), &end, 16);
     carrier.Set(
         "x-cloud-trace-context",
         absl::StrCat(absl::string_view{trace_id.data(), trace_id.size()}, "/",


### PR DESCRIPTION
Part of the work for #12991 

`SimpleHexAtoi()` was not added until later.

Updates to `cmake-oldest-deps.sh` revealed this.... but I need to do a few things to update that script. So there is no verification in our CI at this commit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12993)
<!-- Reviewable:end -->
