### PR TITLE
refactor(pubsub): hide tracing message batch class definition

### DIFF
--- a/google/cloud/pubsub/internal/tracing_message_batch.cc
+++ b/google/cloud/pubsub/internal/tracing_message_batch.cc
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 #include "google/cloud/pubsub/internal/tracing_message_batch.h"
-#include "google/cloud/pubsub/internal/message_batch.h"
-#include "google/cloud/version.h"
-#include <memory>
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 #include "google/cloud/pubsub/internal/publisher_stub.h"
 #include "google/cloud/future.h"

--- a/google/cloud/pubsub/internal/tracing_message_batch.h
+++ b/google/cloud/pubsub/internal/tracing_message_batch.h
@@ -15,14 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_TRACING_MESSAGE_BATCH_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_TRACING_MESSAGE_BATCH_H
 
-#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
-
 #include "google/cloud/pubsub/internal/message_batch.h"
-#include "google/cloud/pubsub/internal/publisher_stub.h"
-#include "google/cloud/pubsub/version.h"
-#include "google/cloud/future.h"
-#include "google/cloud/internal/opentelemetry.h"
-#include <functional>
+#include "google/cloud/version.h"
 #include <memory>
 
 namespace google {
@@ -30,45 +24,12 @@ namespace cloud {
 namespace pubsub_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-class TracingMessageBatchPeer;
-
-/**
- * Records spans related to a batch messages across calls and
- * callbacks in the `BatchingPublisherConnection`.
- */
-class TracingMessageBatch : public MessageBatch {
- public:
-  explicit TracingMessageBatch(std::unique_ptr<MessageBatch> child)
-      : child_(std::move(child)) {}
-  // For testing only.
-  TracingMessageBatch(
-      std::unique_ptr<MessageBatch> child,
-      std::vector<opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span>>
-          message_spans)
-      : child_(std::move(child)), message_spans_(std::move(message_spans)) {}
-
-  ~TracingMessageBatch() override = default;
-
-  void SaveMessage(pubsub::Message m) override;
-
-  std::function<void(future<void>)> Flush() override;
-
-  // For testing only.
-  std::vector<opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span>>
-  GetMessageSpans() const;
-
- private:
-  std::unique_ptr<MessageBatch> child_;
-  std::mutex mu_;
-  std::vector<opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span>>
-      message_spans_;  // ABSL_GUARDED_BY(mu_)
-};
+std::shared_ptr<MessageBatch> MakeTracingMessageBatch(
+    std::shared_ptr<MessageBatch> message_batch);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace pubsub_internal
 }  // namespace cloud
 }  // namespace google
-
-#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_TRACING_MESSAGE_BATCH_H

--- a/google/cloud/pubsub/internal/tracing_message_batch_test.cc
+++ b/google/cloud/pubsub/internal/tracing_message_batch_test.cc
@@ -33,8 +33,8 @@ using ::google::cloud::testing_util::EventNamed;
 using ::google::cloud::testing_util::InstallSpanCatcher;
 using ::google::cloud::testing_util::LinkHasSpanContext;
 using ::google::cloud::testing_util::OTelAttribute;
-using ::google::cloud::testing_util::SpanHasAttributes;
 using ::google::cloud::testing_util::OTelContextCaptured;
+using ::google::cloud::testing_util::SpanHasAttributes;
 using ::google::cloud::testing_util::SpanHasEvents;
 using ::google::cloud::testing_util::SpanHasInstrumentationScope;
 using ::google::cloud::testing_util::SpanKindIsClient;
@@ -70,7 +70,7 @@ auto CreateSpans(int n) {
 void SaveMessages(
     std::vector<opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span>>
         spans,
-   std::shared_ptr<MessageBatch> const& message_batch, bool end_spans = true) {
+    std::shared_ptr<MessageBatch> const& message_batch, bool end_spans = true) {
   for (size_t i = 0; i < spans.size(); i++) {
     auto message =
         pubsub::MessageBuilder().SetData("test" + std::to_string(i)).Build();
@@ -262,8 +262,7 @@ TEST(TracingMessageBatch, FlushSpanAddsEvent) {
   EXPECT_THAT(
       span_catcher->GetSpans(),
       Contains(AllOf(SpanNamed("test span 0"),
-                     SpanHasEvents(
-                                   EventNamed("gl-cpp.batch_flushed")))));
+                     SpanHasEvents(EventNamed("gl-cpp.batch_flushed")))));
 }
 
 TEST(TracingMessageBatch, FlushAddsEventForMultipleMessages) {

--- a/google/cloud/pubsub/internal/tracing_message_batch_test.cc
+++ b/google/cloud/pubsub/internal/tracing_message_batch_test.cc
@@ -33,8 +33,8 @@ using ::google::cloud::testing_util::EventNamed;
 using ::google::cloud::testing_util::InstallSpanCatcher;
 using ::google::cloud::testing_util::LinkHasSpanContext;
 using ::google::cloud::testing_util::OTelAttribute;
-using ::google::cloud::testing_util::OTelContextCaptured;
 using ::google::cloud::testing_util::SpanHasAttributes;
+using ::google::cloud::testing_util::OTelContextCaptured;
 using ::google::cloud::testing_util::SpanHasEvents;
 using ::google::cloud::testing_util::SpanHasInstrumentationScope;
 using ::google::cloud::testing_util::SpanKindIsClient;
@@ -45,8 +45,6 @@ using ::google::cloud::testing_util::ThereIsAnActiveSpan;
 using ::testing::_;
 using ::testing::AllOf;
 using ::testing::Contains;
-using ::testing::ElementsAre;
-using ::testing::IsEmpty;
 
 namespace {
 
@@ -67,56 +65,35 @@ auto CreateSpans(int n) {
   return spans;
 }
 
-TEST(TracingMessageBatch, SaveMessage) {
-  auto span = MakeSpan("test span");
-  opentelemetry::trace::Scope scope(span);
-  auto mock = std::make_unique<pubsub_testing::MockMessageBatch>();
-  EXPECT_CALL(*mock, SaveMessage);
-  auto message_batch = std::make_unique<TracingMessageBatch>(std::move(mock));
-  auto message = pubsub::MessageBuilder().SetData("test").Build();
-
-  message_batch->SaveMessage(message);
-
-  span->End();
-  auto spans = message_batch->GetMessageSpans();
-  EXPECT_THAT(spans, ElementsAre(span));
-}
-
-TEST(TracingMessageBatch, SaveMultipleMessages) {
-  auto mock = std::make_unique<pubsub_testing::MockMessageBatch>();
-  EXPECT_CALL(*mock, SaveMessage).Times(2);
-  auto message_batch = std::make_unique<TracingMessageBatch>(std::move(mock));
-  auto message = pubsub::MessageBuilder().SetData("test").Build();
-
-  // Save the first span.
-  auto span1 = MakeSpan("test span");
-  opentelemetry::trace::Scope scope1(span1);
-  message_batch->SaveMessage(message);
-  span1->End();
-  // Save the second span.
-  auto span2 = MakeSpan("test span");
-  opentelemetry::trace::Scope scope2(span2);
-  message_batch->SaveMessage(message);
-  span2->End();
-
-  auto spans = message_batch->GetMessageSpans();
-  EXPECT_THAT(spans, ElementsAre(span1, span2));
+/// Saves a message for each span and ends @p spans. If @p end_spans is true, it
+/// will end the spans.
+void SaveMessages(
+    std::vector<opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span>>
+        spans,
+   std::shared_ptr<MessageBatch> const& message_batch, bool end_spans = true) {
+  for (size_t i = 0; i < spans.size(); i++) {
+    auto message =
+        pubsub::MessageBuilder().SetData("test" + std::to_string(i)).Build();
+    auto scope = opentelemetry::trace::Scope(spans[i]);
+    message_batch->SaveMessage(message);
+    if (end_spans) {
+      spans[i]->End();
+    }
+  }
 }
 
 TEST(TracingMessageBatch, SaveMessageAddsEvent) {
   auto span_catcher = InstallSpanCatcher();
   auto span = MakeSpan("test span");
   opentelemetry::trace::Scope scope(span);
-  auto mock = std::make_unique<pubsub_testing::MockMessageBatch>();
-  EXPECT_CALL(*mock, SaveMessage);
-  auto message_batch = std::make_unique<TracingMessageBatch>(std::move(mock));
+  auto mock = std::make_shared<pubsub_testing::MockMessageBatch>();
+  EXPECT_CALL(*mock, SaveMessage(_));
+  auto message_batch = MakeTracingMessageBatch(std::move(mock));
   auto message = pubsub::MessageBuilder().SetData("test").Build();
 
   message_batch->SaveMessage(message);
 
   span->End();
-  auto spans = message_batch->GetMessageSpans();
-  EXPECT_THAT(spans, ElementsAre(span));
 
   EXPECT_THAT(
       span_catcher->GetSpans(),
@@ -128,19 +105,18 @@ TEST(TracingMessageBatch, Flush) {
   auto message_span = MakeSpan("test span");
   auto span_catcher = InstallSpanCatcher();
   auto mock = std::make_unique<pubsub_testing::MockMessageBatch>();
+  EXPECT_CALL(*mock, SaveMessage(_));
   EXPECT_CALL(*mock, Flush).WillOnce([] {
     EXPECT_TRUE(ThereIsAnActiveSpan());
     EXPECT_TRUE(OTelContextCaptured());
     return [](auto) { EXPECT_FALSE(OTelContextCaptured()); };
   });
+  auto message_batch = MakeTracingMessageBatch(std::move(mock));
   auto initial_spans = {message_span};
-  auto message_batch =
-      std::make_unique<TracingMessageBatch>(std::move(mock), initial_spans);
+  SaveMessages(initial_spans, message_batch);
 
   auto end_spans = message_batch->Flush();
   end_spans(make_ready_future());
-
-  EXPECT_THAT(message_batch->GetMessageSpans(), IsEmpty());
 
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(spans,
@@ -159,19 +135,18 @@ TEST(TracingMessageBatch, FlushSmallBatch) {
   auto message_span1 = MakeSpan("test span 1");
   auto message_span2 = MakeSpan("test span 2");
   auto span_catcher = InstallSpanCatcher();
-  auto mock = std::make_unique<pubsub_testing::MockMessageBatch>();
+  auto mock = std::make_shared<pubsub_testing::MockMessageBatch>();
+  EXPECT_CALL(*mock, SaveMessage(_)).Times(2);
   EXPECT_CALL(*mock, Flush).WillOnce([] {
     EXPECT_TRUE(ThereIsAnActiveSpan());
     return [](auto) {};
   });
+  auto message_batch = MakeTracingMessageBatch(std::move(mock));
   auto initial_spans = {message_span1, message_span2};
-  auto message_batch =
-      std::make_unique<TracingMessageBatch>(std::move(mock), initial_spans);
+  SaveMessages(initial_spans, message_batch);
 
   auto end_spans = message_batch->Flush();
   end_spans(make_ready_future());
-
-  EXPECT_THAT(message_batch->GetMessageSpans(), IsEmpty());
 
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(
@@ -192,20 +167,19 @@ TEST(TracingMessageBatch, FlushSmallBatch) {
 TEST(TracingMessageBatch, FlushBatchWithOtelLimit) {
   namespace sc = ::opentelemetry::trace::SemanticConventions;
   auto constexpr kBatchSize = 128;
-  auto initial_spans = CreateSpans(kBatchSize);
-  auto span_catcher = InstallSpanCatcher();
   auto mock = std::make_unique<pubsub_testing::MockMessageBatch>();
+  EXPECT_CALL(*mock, SaveMessage(_)).Times(kBatchSize);
   EXPECT_CALL(*mock, Flush).WillOnce([] {
     EXPECT_TRUE(ThereIsAnActiveSpan());
     return [](auto) {};
   });
-  auto message_batch =
-      std::make_unique<TracingMessageBatch>(std::move(mock), initial_spans);
+  auto message_batch = MakeTracingMessageBatch(std::move(mock));
+  SaveMessages(CreateSpans(kBatchSize), message_batch);
+  // Only catch the batch sink spans.
+  auto span_catcher = InstallSpanCatcher();
 
   auto end_spans = message_batch->Flush();
   end_spans(make_ready_future());
-
-  EXPECT_THAT(message_batch->GetMessageSpans(), IsEmpty());
 
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(spans,
@@ -219,20 +193,19 @@ TEST(TracingMessageBatch, FlushBatchWithOtelLimit) {
 TEST(TracingMessageBatch, FlushLargeBatch) {
   namespace sc = ::opentelemetry::trace::SemanticConventions;
   auto constexpr kBatchSize = 129;
-  auto initial_spans = CreateSpans(kBatchSize);
-  auto span_catcher = InstallSpanCatcher();
-  auto mock = std::make_unique<pubsub_testing::MockMessageBatch>();
+  auto mock = std::make_shared<pubsub_testing::MockMessageBatch>();
+  EXPECT_CALL(*mock, SaveMessage(_)).Times(kBatchSize);
   EXPECT_CALL(*mock, Flush).WillOnce([] {
     EXPECT_TRUE(ThereIsAnActiveSpan());
     return [](auto) {};
   });
-  auto message_batch =
-      std::make_unique<TracingMessageBatch>(std::move(mock), initial_spans);
+  auto message_batch = MakeTracingMessageBatch(std::move(mock));
+  SaveMessages(CreateSpans(kBatchSize), message_batch);
+  // Only catch the batch sink spans.
+  auto span_catcher = InstallSpanCatcher();
 
   auto end_spans = message_batch->Flush();
   end_spans(make_ready_future());
-
-  EXPECT_THAT(message_batch->GetMessageSpans(), IsEmpty());
 
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(spans, Contains(AllOf(
@@ -250,73 +223,69 @@ TEST(TracingMessageBatch, FlushLargeBatch) {
 TEST(TracingMessageBatch, FlushAddsSpanIdAndTraceIdAttribute) {
   // The span catcher must be installed before the message span is created.
   auto span_catcher = InstallSpanCatcher();
-  auto message_span = MakeSpan("test message span");
   auto mock = std::make_unique<pubsub_testing::MockMessageBatch>();
+  EXPECT_CALL(*mock, SaveMessage(_));
   EXPECT_CALL(*mock, Flush).WillOnce([] { return [](auto) {}; });
-  auto initial_spans = {message_span};
-  auto message_batch =
-      std::make_unique<TracingMessageBatch>(std::move(mock), initial_spans);
+  auto message_batch = MakeTracingMessageBatch(std::move(mock));
+  auto message_spans = CreateSpans(1);
+  SaveMessages(message_spans, message_batch, /*end_spans=*/false);
 
   auto end_spans = message_batch->Flush();
   end_spans(make_ready_future());
 
-  // The span must end before it can be processed by the span catcher.
-  EndSpans(initial_spans);
+  EndSpans(message_spans);
 
   EXPECT_THAT(
       span_catcher->GetSpans(),
       Contains(AllOf(
-          SpanNamed("test message span"),
+          SpanNamed("test span 0"),
           SpanHasAttributes(
               OTelAttribute<std::string>("pubsub.batch_sink.trace_id", _),
               OTelAttribute<std::string>("pubsub.batch_sink.span_id", _)))));
 }
 
-TEST(TracingMessageBatch, FlushSpanMetadataAddsEvent) {
+TEST(TracingMessageBatch, FlushSpanAddsEvent) {
   // The span catcher must be installed before the message span is created.
   auto span_catcher = InstallSpanCatcher();
-  auto message_span = MakeSpan("test message span");
   auto mock = std::make_unique<pubsub_testing::MockMessageBatch>();
   EXPECT_CALL(*mock, Flush).WillOnce([] { return [](auto) {}; });
-  auto initial_spans = {message_span};
-  auto message_batch =
-      std::make_unique<TracingMessageBatch>(std::move(mock), initial_spans);
+  EXPECT_CALL(*mock, SaveMessage(_));
+  auto message_batch = MakeTracingMessageBatch(std::move(mock));
+  auto message_spans = CreateSpans(1);
+  SaveMessages(message_spans, message_batch, /*end_spans=*/false);
 
   auto end_spans = message_batch->Flush();
   end_spans(make_ready_future());
 
-  // The span must end before it can be processed by the span catcher.
-  EndSpans(initial_spans);
+  EndSpans(message_spans);
 
   EXPECT_THAT(
       span_catcher->GetSpans(),
-      Contains(AllOf(SpanNamed("test message span"),
-                     SpanHasEvents(EventNamed("gl-cpp.batch_flushed")))));
+      Contains(AllOf(SpanNamed("test span 0"),
+                     SpanHasEvents(
+                                   EventNamed("gl-cpp.batch_flushed")))));
 }
 
 TEST(TracingMessageBatch, FlushAddsEventForMultipleMessages) {
   // The span catcher must be installed before the message span is created.
   auto span_catcher = InstallSpanCatcher();
-  auto span1 = MakeSpan("test message span1");
-  auto span2 = MakeSpan("test message span2");
   auto mock = std::make_unique<pubsub_testing::MockMessageBatch>();
   EXPECT_CALL(*mock, Flush).WillOnce([] { return [](auto) {}; });
-  auto initial_spans = {span1, span2};
-  auto message_batch =
-      std::make_unique<TracingMessageBatch>(std::move(mock), initial_spans);
+  EXPECT_CALL(*mock, SaveMessage(_)).Times(2);
+  auto message_batch = MakeTracingMessageBatch(std::move(mock));
+  auto message_spans = CreateSpans(2);
+  SaveMessages(message_spans, message_batch, /*end_spans=*/false);
 
   auto end_spans = message_batch->Flush();
   end_spans(make_ready_future());
 
-  // The span must end before it can be processed by the span catcher.
-  EndSpans(initial_spans);
-
+  EndSpans(message_spans);
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(spans, Contains(AllOf(
-                         SpanNamed("test message span1"),
+                         SpanNamed("test span 0"),
                          SpanHasEvents(EventNamed("gl-cpp.batch_flushed")))));
   EXPECT_THAT(spans, Contains(AllOf(
-                         SpanNamed("test message span2"),
+                         SpanNamed("test span 1"),
                          SpanHasEvents(EventNamed("gl-cpp.batch_flushed")))));
 }
 


### PR DESCRIPTION
- Move the tracing message batch class declaration into the .cc
- Add MakeTracingMessageBatch interface with one definition when GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY is defined and one when not
- Remove test only constructor and `GetMessageSpans` and refactor corresponding tests.
- Remove SaveMessage and SaveMultipleMessages tests since they are not helpful without the `GetMessageSpans` helper

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12995)
<!-- Reviewable:end -->
