### PR TITLE
impl(pubsub): use tracing message batch

### DIFF
--- a/google/cloud/pubsub/publisher_connection.cc
+++ b/google/cloud/pubsub/publisher_connection.cc
@@ -46,8 +46,7 @@ std::shared_ptr<pubsub::PublisherConnection> ConnectionFromDecoratedStub(
     pubsub::Topic topic, Options opts,
     std::shared_ptr<BackgroundThreads> background,
     std::shared_ptr<pubsub_internal::PublisherStub> stub,
-    std::shared_ptr<pubsub_internal::MessageBatch> message_batch =
-        std::make_shared<pubsub_internal::NoOpMessageBatch>()) {
+    std::shared_ptr<pubsub_internal::MessageBatch> message_batch) {
   auto make_connection = [&]() -> std::shared_ptr<pubsub::PublisherConnection> {
     auto cq = background->cq();
     std::shared_ptr<pubsub_internal::BatchSink> sink =
@@ -130,8 +129,9 @@ std::shared_ptr<PublisherConnection> MakePublisherConnection(Topic topic,
   auto background = internal::MakeBackgroundThreadsFactory(opts)();
   auto stub =
       pubsub_internal::MakeRoundRobinPublisherStub(background->cq(), opts);
-  return ConnectionFromDecoratedStub(std::move(topic), std::move(opts),
-                                     std::move(background), std::move(stub));
+  return ConnectionFromDecoratedStub(
+      std::move(topic), std::move(opts), std::move(background), std::move(stub),
+      std::make_shared<pubsub_internal::NoOpMessageBatch>());
 }
 
 std::shared_ptr<PublisherConnection> MakePublisherConnection(

--- a/google/cloud/pubsub/publisher_connection.cc
+++ b/google/cloud/pubsub/publisher_connection.cc
@@ -28,6 +28,7 @@
 #include "google/cloud/pubsub/internal/publisher_tracing_connection.h"
 #include "google/cloud/pubsub/internal/rejects_with_ordering_key.h"
 #include "google/cloud/pubsub/internal/sequential_batch_sink.h"
+#include "google/cloud/pubsub/internal/tracing_message_batch.h"
 #include "google/cloud/pubsub/options.h"
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/non_constructible.h"
@@ -44,13 +45,16 @@ namespace {
 std::shared_ptr<pubsub::PublisherConnection> ConnectionFromDecoratedStub(
     pubsub::Topic topic, Options opts,
     std::shared_ptr<BackgroundThreads> background,
-    std::shared_ptr<pubsub_internal::PublisherStub> stub) {
+    std::shared_ptr<pubsub_internal::PublisherStub> stub,
+    std::shared_ptr<pubsub_internal::MessageBatch> message_batch =
+        std::make_shared<pubsub_internal::NoOpMessageBatch>()) {
   auto make_connection = [&]() -> std::shared_ptr<pubsub::PublisherConnection> {
     auto cq = background->cq();
     std::shared_ptr<pubsub_internal::BatchSink> sink =
         pubsub_internal::DefaultBatchSink::Create(stub, cq, opts);
-    std::shared_ptr<pubsub_internal::MessageBatch> message_batch =
-        std::make_shared<pubsub_internal::NoOpMessageBatch>();
+    if (google::cloud::internal::TracingEnabled(opts)) {
+      message_batch = MakeTracingMessageBatch(std::move(message_batch));
+    }
     if (opts.get<pubsub::MessageOrderingOption>()) {
       auto factory = [topic, opts, sink, cq,
                       message_batch](std::string const& key) {
@@ -150,13 +154,14 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 std::shared_ptr<pubsub::PublisherConnection> MakeTestPublisherConnection(
     pubsub::Topic topic, Options opts,
-    std::vector<std::shared_ptr<PublisherStub>> stubs) {
+    std::vector<std::shared_ptr<PublisherStub>> stubs,
+    std::shared_ptr<MessageBatch> message_batch) {
   auto background = internal::MakeBackgroundThreadsFactory(opts)();
   auto stub = pubsub_internal::MakeTestPublisherStub(background->cq(), opts,
                                                      std::move(stubs));
-  return pubsub::ConnectionFromDecoratedStub(std::move(topic), std::move(opts),
-                                             std::move(background),
-                                             std::move(stub));
+  return pubsub::ConnectionFromDecoratedStub(
+      std::move(topic), std::move(opts), std::move(background), std::move(stub),
+      std::move(message_batch));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsub/publisher_connection.h
+++ b/google/cloud/pubsub/publisher_connection.h
@@ -17,6 +17,8 @@
 
 #include "google/cloud/pubsub/backoff_policy.h"
 #include "google/cloud/pubsub/connection_options.h"
+#include "google/cloud/pubsub/internal/message_batch.h"
+#include "google/cloud/pubsub/internal/noop_message_batch.h"
 #include "google/cloud/pubsub/internal/publisher_stub.h"
 #include "google/cloud/pubsub/message.h"
 #include "google/cloud/pubsub/publisher_options.h"
@@ -169,7 +171,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 std::shared_ptr<pubsub::PublisherConnection> MakeTestPublisherConnection(
     pubsub::Topic topic, Options opts,
-    std::vector<std::shared_ptr<PublisherStub>> stubs);
+    std::vector<std::shared_ptr<PublisherStub>> stubs,
+    std::shared_ptr<MessageBatch> message_batch =
+        std::make_shared<NoOpMessageBatch>());
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace pubsub_internal

--- a/google/cloud/pubsub/publisher_connection.h
+++ b/google/cloud/pubsub/publisher_connection.h
@@ -172,8 +172,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 std::shared_ptr<pubsub::PublisherConnection> MakeTestPublisherConnection(
     pubsub::Topic topic, Options opts,
     std::vector<std::shared_ptr<PublisherStub>> stubs,
-    std::shared_ptr<MessageBatch> message_batch =
-        std::make_shared<NoOpMessageBatch>());
+    std::shared_ptr<MessageBatch> message_batch);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace pubsub_internal


### PR DESCRIPTION
Closes https://github.com/googleapis/google-cloud-cpp/issues/12528

Second attempt at https://github.com/googleapis/google-cloud-cpp/pull/12969.

- Add an additional param to add a mock'd message batch and then use a condition variable to wait for the spans to complete before checking.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/12996)
<!-- Reviewable:end -->
