### PR TITLE
impl(pubsub): use tracing message batch

### DIFF
--- a/google/cloud/pubsub/internal/tracing_message_batch.cc
+++ b/google/cloud/pubsub/internal/tracing_message_batch.cc
@@ -154,10 +154,10 @@ class TracingMessageBatch : public MessageBatch {
     return [oc = opentelemetry::context::RuntimeContext::GetCurrent(),
             next = child_->Flush(),
             spans = std::move(batch_sink_spans)](auto f) mutable {
-      internal::DetachOTelContext(oc);
       for (auto& span : spans) {
         internal::EndSpan(*span);
       }
+      internal::DetachOTelContext(oc);
       next(std::move(f));
     };
   }

--- a/google/cloud/pubsub/publisher_connection.cc
+++ b/google/cloud/pubsub/publisher_connection.cc
@@ -28,6 +28,7 @@
 #include "google/cloud/pubsub/internal/publisher_tracing_connection.h"
 #include "google/cloud/pubsub/internal/rejects_with_ordering_key.h"
 #include "google/cloud/pubsub/internal/sequential_batch_sink.h"
+#include "google/cloud/pubsub/internal/tracing_message_batch.h"
 #include "google/cloud/pubsub/options.h"
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/non_constructible.h"
@@ -44,13 +45,15 @@ namespace {
 std::shared_ptr<pubsub::PublisherConnection> ConnectionFromDecoratedStub(
     pubsub::Topic topic, Options opts,
     std::shared_ptr<BackgroundThreads> background,
-    std::shared_ptr<pubsub_internal::PublisherStub> stub) {
+    std::shared_ptr<pubsub_internal::PublisherStub> stub,
+    std::shared_ptr<pubsub_internal::MessageBatch> message_batch) {
   auto make_connection = [&]() -> std::shared_ptr<pubsub::PublisherConnection> {
     auto cq = background->cq();
     std::shared_ptr<pubsub_internal::BatchSink> sink =
         pubsub_internal::DefaultBatchSink::Create(stub, cq, opts);
-    std::shared_ptr<pubsub_internal::MessageBatch> message_batch =
-        std::make_shared<pubsub_internal::NoOpMessageBatch>();
+    if (google::cloud::internal::TracingEnabled(opts)) {
+      message_batch = MakeTracingMessageBatch(std::move(message_batch));
+    }
     if (opts.get<pubsub::MessageOrderingOption>()) {
       auto factory = [topic, opts, sink, cq,
                       message_batch](std::string const& key) {
@@ -126,8 +129,9 @@ std::shared_ptr<PublisherConnection> MakePublisherConnection(Topic topic,
   auto background = internal::MakeBackgroundThreadsFactory(opts)();
   auto stub =
       pubsub_internal::MakeRoundRobinPublisherStub(background->cq(), opts);
-  return ConnectionFromDecoratedStub(std::move(topic), std::move(opts),
-                                     std::move(background), std::move(stub));
+  return ConnectionFromDecoratedStub(
+      std::move(topic), std::move(opts), std::move(background), std::move(stub),
+      std::make_shared<pubsub_internal::NoOpMessageBatch>());
 }
 
 std::shared_ptr<PublisherConnection> MakePublisherConnection(
@@ -150,13 +154,14 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 std::shared_ptr<pubsub::PublisherConnection> MakeTestPublisherConnection(
     pubsub::Topic topic, Options opts,
-    std::vector<std::shared_ptr<PublisherStub>> stubs) {
+    std::vector<std::shared_ptr<PublisherStub>> stubs,
+    std::shared_ptr<MessageBatch> message_batch) {
   auto background = internal::MakeBackgroundThreadsFactory(opts)();
   auto stub = pubsub_internal::MakeTestPublisherStub(background->cq(), opts,
                                                      std::move(stubs));
-  return pubsub::ConnectionFromDecoratedStub(std::move(topic), std::move(opts),
-                                             std::move(background),
-                                             std::move(stub));
+  return pubsub::ConnectionFromDecoratedStub(
+      std::move(topic), std::move(opts), std::move(background), std::move(stub),
+      std::move(message_batch));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsub/publisher_connection.h
+++ b/google/cloud/pubsub/publisher_connection.h
@@ -17,6 +17,8 @@
 
 #include "google/cloud/pubsub/backoff_policy.h"
 #include "google/cloud/pubsub/connection_options.h"
+#include "google/cloud/pubsub/internal/message_batch.h"
+#include "google/cloud/pubsub/internal/noop_message_batch.h"
 #include "google/cloud/pubsub/internal/publisher_stub.h"
 #include "google/cloud/pubsub/message.h"
 #include "google/cloud/pubsub/publisher_options.h"
@@ -169,7 +171,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 std::shared_ptr<pubsub::PublisherConnection> MakeTestPublisherConnection(
     pubsub::Topic topic, Options opts,
-    std::vector<std::shared_ptr<PublisherStub>> stubs);
+    std::vector<std::shared_ptr<PublisherStub>> stubs,
+    std::shared_ptr<MessageBatch> message_batch);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace pubsub_internal

--- a/google/cloud/pubsub/publisher_connection_test.cc
+++ b/google/cloud/pubsub/publisher_connection_test.cc
@@ -27,9 +27,6 @@
 #include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "google/cloud/testing_util/validate_metadata.h"
-#include "opentelemetry/context/runtime_context.h"
-#include "opentelemetry/trace/context.h"
-#include "opentelemetry/trace/span.h"
 #include <gmock/gmock.h>
 
 namespace google {

--- a/google/cloud/pubsub/publisher_connection_test.cc
+++ b/google/cloud/pubsub/publisher_connection_test.cc
@@ -347,7 +347,6 @@ TEST(PublisherConnectionTest, HandleTransientEnabledRetry) {
 using ::google::cloud::testing_util::DisableTracing;
 using ::google::cloud::testing_util::EnableTracing;
 using ::google::cloud::testing_util::InstallSpanCatcher;
-using ::google::cloud::testing_util::OTelContextCaptured;
 using ::google::cloud::testing_util::SpanNamed;
 using ::google::cloud::testing_util::ThereIsAnActiveSpan;
 using ::testing::IsEmpty;

--- a/google/cloud/pubsub/publisher_connection_test.cc
+++ b/google/cloud/pubsub/publisher_connection_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/pubsub/internal/defaults.h"
 #include "google/cloud/pubsub/message.h"
 #include "google/cloud/pubsub/options.h"
+#include "google/cloud/pubsub/testing/mock_message_batch.h"
 #include "google/cloud/pubsub/testing/mock_publisher_stub.h"
 #include "google/cloud/pubsub/testing/test_retry_policies.h"
 #include "google/cloud/internal/api_client_header.h"
@@ -37,17 +38,21 @@ namespace {
 using ::google::cloud::testing_util::AsyncSequencer;
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
+using ::testing::_;
 using ::testing::AtLeast;
 using ::testing::Contains;
 using ::testing::HasSubstr;
 
 std::shared_ptr<PublisherConnection> MakeTestPublisherConnection(
     Topic topic, std::shared_ptr<pubsub_internal::PublisherStub> mock,
-    Options opts = {}) {
+    Options opts = {},
+    std::shared_ptr<pubsub_internal::MessageBatch> message_batch =
+        std::make_shared<pubsub_internal::NoOpMessageBatch>()) {
   opts = pubsub_internal::DefaultPublisherOptions(
       pubsub_testing::MakeTestOptions(std::move(opts)));
   return pubsub_internal::MakeTestPublisherConnection(
-      std::move(topic), std::move(opts), {std::move(mock)});
+      std::move(topic), std::move(opts), {std::move(mock)},
+      std::move(message_batch));
 }
 
 TEST(PublisherConnectionTest, Basic) {
@@ -350,6 +355,22 @@ TEST(MakePublisherConnectionTest, TracingEnabled) {
   auto span_catcher = InstallSpanCatcher();
   auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
   Topic const topic("test-project", "test-topic");
+
+  auto mock_message_batch =
+      std::make_shared<pubsub_testing::MockMessageBatch>();
+  std::mutex mu;
+  std::condition_variable cv;
+  bool is_publish_complete = false;  // ABSL_GUARDED_BY(mu)
+  EXPECT_CALL(*mock_message_batch, SaveMessage(_)).Times(1);
+  EXPECT_CALL(*mock_message_batch, Flush).WillOnce([&] {
+    {
+      std::lock_guard<std::mutex> lk(mu);
+      is_publish_complete = true;
+    }
+    cv.notify_all();
+    return [](auto) {};
+  });
+
   EXPECT_CALL(*mock, AsyncPublish)
       .WillOnce([&](google::cloud::CompletionQueue&, auto,
                     google::pubsub::v1::PublishRequest const&) {
@@ -357,19 +378,29 @@ TEST(MakePublisherConnectionTest, TracingEnabled) {
         response.add_message_ids("test-message-id-0");
         return make_ready_future(make_status_or(response));
       });
-  auto publisher =
-      MakeTestPublisherConnection(topic, mock, EnableTracing(Options{}));
+  auto publisher = MakeTestPublisherConnection(
+      topic, mock, EnableTracing(Options{}), mock_message_batch);
 
   auto response =
       publisher->Publish({MessageBuilder{}.SetData("test-data-0").Build()})
           .get();
+  publisher->Flush({});
 
+  // Wait until the BatchSink span ends before calling `GetSpans`.
+  std::unique_lock<std::mutex> lk(mu);
+  cv.wait(lk, [&] { return is_publish_complete; });
+
+  auto spans = span_catcher->GetSpans();
   EXPECT_THAT(
-      span_catcher->GetSpans(),
+      spans,
       UnorderedElementsAre(
           SpanNamed("projects/test-project/topics/test-topic send"),
           SpanNamed("publisher flow control"), SpanNamed("publish scheduler"),
-          SpanNamed("google.pubsub.v1.Publisher/Publish")));
+          SpanNamed("BatchSink::AsyncPublish"),
+          SpanNamed("google.pubsub.v1.Publisher/Publish"),
+          SpanNamed("pubsub::BatchingPublisherConnection::Flush"),
+          SpanNamed("pubsub::FlowControlledPublisherConnection::Flush"),
+          SpanNamed("pubsub::Publisher::Flush")));
 }
 
 TEST(MakePublisherConnectionTest, TracingDisabled) {


### PR DESCRIPTION
Closes https://github.com/googleapis/google-cloud-cpp/issues/12528

Third times the charm? 🤞 

This reverts commit 324f331 with fixes (https://github.com/googleapis/google-cloud-cpp/pull/12996)

I was notifying the condition variable in the Flush mocking, not the lambda it returned (like I should have been).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13000)
<!-- Reviewable:end -->
