### PR TITLE
ci: dedicated build for conformance tests

### DIFF
--- a/ci/cloudbuild/builds/conformance.sh
+++ b/ci/cloudbuild/builds/conformance.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2021 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,15 +18,14 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/bazel.sh
-source module ci/cloudbuild/builds/lib/integration.sh
+source module ci/cloudbuild/builds/lib/conformance.sh
 source module ci/lib/io.sh
 
 export CC=clang
 export CXX=clang++
 
 mapfile -t args < <(bazel::common_args)
-args+=("--config=asan")
-io::run bazel test "${args[@]}" --test_tag_filters=-integration-test ...
+# At the moment, we only have conformance tests for bigtable, so only build that.
+io::run bazel test "${args[@]}" --test_tag_filters=-integration-test //google/cloud/bigtable/...
 
-mapfile -t integration_args < <(integration::bazel_args)
-integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"
+conformance::bazel_with_proxies "${args[@]}"

--- a/ci/cloudbuild/triggers/conformance-ci.yaml
+++ b/ci/cloudbuild/triggers/conformance-ci.yaml
@@ -1,0 +1,17 @@
+createTime: '2023-10-30T21:38:59.771402989Z'
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  push:
+    branch: ^main$
+id: 9858e9c0-2f5a-45ad-9e5b-3af30eaf30af
+includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
+name: conformance-ci
+resourceName: projects/cloud-cpp-testing-resources/locations/global/triggers/9858e9c0-2f5a-45ad-9e5b-3af30eaf30af
+substitutions:
+  _BUILD_NAME: conformance
+  _DISTRO: fedora-latest-bazel
+  _TRIGGER_TYPE: ci
+tags:
+- ci

--- a/ci/cloudbuild/triggers/conformance-pr.yaml
+++ b/ci/cloudbuild/triggers/conformance-pr.yaml
@@ -1,0 +1,18 @@
+createTime: '2023-10-30T21:35:19.557214462Z'
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  pullRequest:
+    branch: ^main$
+    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
+id: 03976e73-5154-457f-813f-4d33bb162e70
+includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
+name: conformance-pr
+resourceName: projects/cloud-cpp-testing-resources/locations/global/triggers/03976e73-5154-457f-813f-4d33bb162e70
+substitutions:
+  _BUILD_NAME: conformance
+  _DISTRO: fedora-latest-bazel
+  _TRIGGER_TYPE: pr
+tags:
+- pr


### PR DESCRIPTION
Fixes #12391

I made the trigger files by:
- copying `asan-*.yaml`
- deleting `createTime`, `id`, `resourceName` fields
- running `ci/cloudbuild/trigger.sh -i triggers/conformance-*.yaml`
- copying that output into the trigger files

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13002)
<!-- Reviewable:end -->
