### PR TITLE
ci(otel): test with minimum version

### DIFF
--- a/ci/cloudbuild/builds/cmake-oldest-deps.sh
+++ b/ci/cloudbuild/builds/cmake-oldest-deps.sh
@@ -22,9 +22,15 @@ export CXX=clang++
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
 source module ci/cloudbuild/builds/lib/ctest.sh
+source module ci/cloudbuild/builds/lib/features.sh
 source module ci/cloudbuild/builds/lib/integration.sh
 source module ci/cloudbuild/builds/lib/vcpkg.sh
 source module ci/lib/io.sh
+
+mapfile -t feature_list < <(features::always_build | grep -v "experimental-")
+ENABLED_FEATURES="$(printf ",%s" "${feature_list[@]}")"
+ENABLED_FEATURES="${ENABLED_FEATURES:1}"
+readonly ENABLED_FEATURES
 
 io::log_h2 "Configuring"
 vcpkg_root="$(vcpkg::root_dir)"
@@ -32,6 +38,7 @@ cmake -GNinja -S . -B cmake-out/build \
   "-DCMAKE_TOOLCHAIN_FILE=${vcpkg_root}/scripts/buildsystems/vcpkg.cmake" \
   "-DVCPKG_MANIFEST_DIR=ci/etc/oldest-deps" \
   "-DVCPKG_FEATURE_FLAGS=versions,manifest" \
+  "-DGOOGLE_CLOUD_CPP_ENABLE=${ENABLED_FEATURES}" \
   "-DGOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND=ON"
 
 io::log_h2 "Building"

--- a/ci/etc/oldest-deps/vcpkg.json
+++ b/ci/etc/oldest-deps/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "name": "google-cloud-cpp",
-    "version": "1.27.0",
+    "version": "2.17.0",
     "description": "C++ Client Libraries for Google Cloud Platform APIs.",
     "homepage": "https://github.com/googleapis/google-cloud-cpp",
     "license": "Apache-2.0",
@@ -27,12 +27,14 @@
         "host": true
       },
       {"name": "grpc", "version>=": "1.33.1"},
+      {"name": "opentelemetry-cpp", "version>=": "1.9.1"},
       {"name": "protobuf", "version>=": "3.15.8"},
       {"name": "nlohmann-json", "version>=": "3.9.1"},
       "benchmark",
       {"name": "gtest", "version>=": "1.11.0", "host":  true}
     ],
     "overrides": [
+      { "name": "opentelemetry-cpp", "version": "1.9.1"},
       { "name": "protobuf", "version": "3.15.8" },
       { "name": "grpc", "version": "1.36.4" },
       { "name": "upb", "version": "2020-12-19" },

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -123,6 +123,13 @@ quickstart guides also cover this use-case.
 | [nlohmann/json][nlohmann-json-gh] |             3.4.0 | JSON for Modern C++                                                                           |
 | [protobuf][protobuf-gh]           |             v21.1 | C++ Micro-generator support                                                                   |
 
+`google-cloud-cpp` also has an **optional** dependency on the following
+libraries:
+
+| Library                           | Minimum version | Description                |
+| --------------------------------- | --------------- | -------------------------- |
+| [OpenTelemetry][opentelemetry-gh] | 1.9.1           | An observability framework |
+
 Note that these libraries may also depend on other libraries. The following
 instructions include steps to install these indirect dependencies too.
 
@@ -1896,6 +1903,7 @@ cmake --build cmake-out --target install
 [ninja-build]: https://ninja-build.org/
 [nlohmann-json-gh]: https://github.com/nlohmann/json
 [openssl-gh]: https://github.com/openssl/openssl
+[opentelemetry-gh]: https://github.com/open-telemetry/opentelemetry-cpp
 [protobuf-gh]: https://github.com/protocolbuffers/protobuf
 [spanner-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/spanner#readme
 [storage-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/storage#readme

--- a/google/cloud/opentelemetry/quickstart/README.md
+++ b/google/cloud/opentelemetry/quickstart/README.md
@@ -49,11 +49,6 @@ Google Cloud client libraries depends on Abseil, which also defines these types
 in the same namespace. In order to avoid ambiguous symbols, we must set certain
 flags when compiling `opentelemetry-cpp`.
 
-### Testing
-
-The client library is only tested against the latest version of
-`opentelemetry-cpp`. As of 2023-05, that is [v1.9.0][opentelemetry-cpp-v1-9-0].
-
 ## Using with Bazel
 
 > :warning: If you are using Windows or macOS there are additional instructions
@@ -230,7 +225,6 @@ set GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=%cd%\roots.pem
 [opentelemetry]: https://opentelemetry.io
 [opentelemetry-cpp]: https://github.com/open-telemetry/opentelemetry-cpp
 [opentelemetry-cpp-install]: https://github.com/open-telemetry/opentelemetry-cpp/INSTALL.md
-[opentelemetry-cpp-v1-9-0]: https://github.com/open-telemetry/opentelemetry-cpp/releases/tag/v1.9.0
 [packaging guide]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging.md
 [quickstart-storage]: https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/storage/quickstart
 [quickstart-trace]: https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/trace/quickstart


### PR DESCRIPTION
Fixes #12991 

Pin OTel to v1.9.1 in our cmake-oldest-deps build. Communicate this in the packaging doc.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13007)
<!-- Reviewable:end -->
