### PR TITLE
cleanup(otel): silence clang-tidy in C++20 mode

### DIFF
--- a/google/cloud/internal/opentelemetry_context.h
+++ b/google/cloud/internal/opentelemetry_context.h
@@ -109,6 +109,7 @@ class ScopedOTelContext {
 
   ~ScopedOTelContext() {
     if (noop_) return;
+    // NOLINTNEXTLINE(modernize-loop-convert)
     for (auto it = contexts_.rbegin(); it != contexts_.rend(); ++it) {
       DetachOTelContext(*it);
     }


### PR DESCRIPTION
As I write more tests and examples in C++20 code in headers gets examined by `clang-tidy` in C++20 mode. In this case, `clang-tidy` would like one to use ranges to perform a reverse iteration.

Motivated by #9134 