### PR TITLE
ci: enable `storage_grpc` with oldest deps

### DIFF
--- a/ci/cloudbuild/builds/cmake-oldest-deps.sh
+++ b/ci/cloudbuild/builds/cmake-oldest-deps.sh
@@ -27,7 +27,7 @@ source module ci/cloudbuild/builds/lib/integration.sh
 source module ci/cloudbuild/builds/lib/vcpkg.sh
 source module ci/lib/io.sh
 
-mapfile -t feature_list < <(features::always_build | grep -v "experimental-")
+mapfile -t feature_list < <(features::always_build | grep -v "experimental-bigquery")
 ENABLED_FEATURES="$(printf ",%s" "${feature_list[@]}")"
 ENABLED_FEATURES="${ENABLED_FEATURES:1}"
 readonly ENABLED_FEATURES

--- a/google/cloud/storage/internal/grpc/make_cord_test.cc
+++ b/google/cloud/storage/internal/grpc/make_cord_test.cc
@@ -82,7 +82,8 @@ TYPED_TEST(MakeCordFromVector, MakeCord) {
       reinterpret_cast<char const*>(buffer.data()), buffer.size());
 
   auto const actual = MakeCord(buffer);
-  auto chunks = actual.Chunks();
+  std::vector<absl::string_view> chunks{actual.chunk_begin(),
+                                        actual.chunk_end()};
   EXPECT_THAT(chunks, ElementsAre(view));
 }
 

--- a/google/cloud/storage/internal/grpc/stub.cc
+++ b/google/cloud/storage/internal/grpc/stub.cc
@@ -40,6 +40,7 @@
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/log.h"
 #include "absl/strings/match.h"
+#include "absl/time/time.h"
 #include <grpcpp/grpcpp.h>
 #include <algorithm>
 #include <cinttypes>


### PR DESCRIPTION
Some missing headers in `storage/internal/grpc/stub.cc`. Older versions of `absl::Cord::chunks()` cannot be used with googletests's `ElementsAre()`.

And older versions of gRPC need us to have a thread associated with the completion queue in one of the tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13019)
<!-- Reviewable:end -->
