### PR TITLE
impl(GCS+gRPC): resumable upload routing header

### DIFF
--- a/google/cloud/storage/internal/grpc/configure_client_context.cc
+++ b/google/cloud/storage/internal/grpc/configure_client_context.cc
@@ -54,13 +54,18 @@ void ApplyRoutingHeaders(
 
 void ApplyRoutingHeaders(grpc::ClientContext& context,
                          storage::internal::UploadChunkRequest const& request) {
+  ApplyResumableUploadRoutingHeader(context, request.upload_session_url());
+}
+
+void ApplyResumableUploadRoutingHeader(grpc::ClientContext& context,
+                                       std::string const& upload_id) {
   static auto* slash_format =
       new std::regex{"(projects/[^/]+/buckets/[^/]+)/.*", std::regex::optimize};
   static auto* colon_format =
       new std::regex{"(projects/[^/]+/buckets/[^:]+):.*", std::regex::optimize};
   for (auto const* re : {slash_format, colon_format}) {
     std::smatch match;
-    if (!std::regex_match(request.upload_session_url(), match, *re)) continue;
+    if (!std::regex_match(upload_id, match, *re)) continue;
     context.AddMetadata(
         "x-goog-request-params",
         "bucket=" + google::cloud::internal::UrlEncode(match[1].str()));

--- a/google/cloud/storage/internal/grpc/configure_client_context.h
+++ b/google/cloud/storage/internal/grpc/configure_client_context.h
@@ -90,6 +90,14 @@ void ApplyRoutingHeaders(
 void ApplyRoutingHeaders(grpc::ClientContext& context,
                          storage::internal::UploadChunkRequest const& request);
 
+/**
+ * The generated `StorageMetadata` stub can not handle dynamic routing headers
+ * for bi-directional streaming. So we manually match and extract the headers in
+ * this function.
+ */
+void ApplyResumableUploadRoutingHeader(grpc::ClientContext& context,
+                                       std::string const& upload_id);
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage_internal
 }  // namespace cloud

--- a/google/cloud/storage/internal/grpc/configure_client_context_test.cc
+++ b/google/cloud/storage/internal/grpc/configure_client_context_test.cc
@@ -192,6 +192,44 @@ TEST_F(GrpcConfigureClientContext, ApplyRoutingHeadersUploadChunkNoMatch) {
   EXPECT_THAT(metadata, Not(Contains(Pair("x-goog-request-params", _))));
 }
 
+TEST_F(GrpcConfigureClientContext, ApplyRoutingHeadersUploadId) {
+  using ::testing::Eq;
+  using ::testing::Matcher;
+
+  struct TestCase {
+    std::string upload_id;
+    ::testing::Matcher<std::string> matcher;
+  } const cases[] = {
+      {"projects/_/buckets/test-bucket/test-upload-id",
+       Eq("bucket=projects%2F_%2Fbuckets%2Ftest-bucket")},
+      {"projects/_/buckets/test-bucket:test-upload-id",
+       Eq("bucket=projects%2F_%2Fbuckets%2Ftest-bucket")},
+      {"projects/_/buckets/test-bucket/test/upload/id",
+       Eq("bucket=projects%2F_%2Fbuckets%2Ftest-bucket")},
+      {"projects/_/buckets/test-bucket:test/upload/id",
+       Eq("bucket=projects%2F_%2Fbuckets%2Ftest-bucket")},
+  };
+
+  for (auto const& test : cases) {
+    SCOPED_TRACE("Testing with " + test.upload_id);
+    grpc::ClientContext context;
+    ApplyResumableUploadRoutingHeader(context, test.upload_id);
+    auto metadata = GetMetadata(context);
+    EXPECT_THAT(metadata,
+                Contains(Pair("x-goog-request-params", test.matcher)));
+  }
+}
+
+TEST_F(GrpcConfigureClientContext, ApplyRoutingHeadersUploadIdNoMatch) {
+  using ::testing::Eq;
+  using ::testing::Matcher;
+
+  grpc::ClientContext context;
+  ApplyResumableUploadRoutingHeader(context, "not-a-match");
+  auto metadata = GetMetadata(context);
+  EXPECT_THAT(metadata, Not(Contains(Pair("x-goog-request-params", _))));
+}
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage_internal

--- a/google/cloud/storage/internal/grpc/configure_client_context_test.cc
+++ b/google/cloud/storage/internal/grpc/configure_client_context_test.cc
@@ -193,21 +193,18 @@ TEST_F(GrpcConfigureClientContext, ApplyRoutingHeadersUploadChunkNoMatch) {
 }
 
 TEST_F(GrpcConfigureClientContext, ApplyRoutingHeadersUploadId) {
-  using ::testing::Eq;
-  using ::testing::Matcher;
-
   struct TestCase {
     std::string upload_id;
-    ::testing::Matcher<std::string> matcher;
+    std::string expected;
   } const cases[] = {
       {"projects/_/buckets/test-bucket/test-upload-id",
-       Eq("bucket=projects%2F_%2Fbuckets%2Ftest-bucket")},
+       "bucket=projects%2F_%2Fbuckets%2Ftest-bucket"},
       {"projects/_/buckets/test-bucket:test-upload-id",
-       Eq("bucket=projects%2F_%2Fbuckets%2Ftest-bucket")},
+       "bucket=projects%2F_%2Fbuckets%2Ftest-bucket"},
       {"projects/_/buckets/test-bucket/test/upload/id",
-       Eq("bucket=projects%2F_%2Fbuckets%2Ftest-bucket")},
+       "bucket=projects%2F_%2Fbuckets%2Ftest-bucket"},
       {"projects/_/buckets/test-bucket:test/upload/id",
-       Eq("bucket=projects%2F_%2Fbuckets%2Ftest-bucket")},
+       "bucket=projects%2F_%2Fbuckets%2Ftest-bucket"},
   };
 
   for (auto const& test : cases) {
@@ -216,7 +213,7 @@ TEST_F(GrpcConfigureClientContext, ApplyRoutingHeadersUploadId) {
     ApplyResumableUploadRoutingHeader(context, test.upload_id);
     auto metadata = GetMetadata(context);
     EXPECT_THAT(metadata,
-                Contains(Pair("x-goog-request-params", test.matcher)));
+                Contains(Pair("x-goog-request-params", test.expected)));
   }
 }
 


### PR DESCRIPTION
We need to populate the routing headers for resumable uploads, as the generator cannot do so for bi-directional streaming RPCs.

Part of the work for #9134

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13025)
<!-- Reviewable:end -->
