### PR TITLE
impl(GCS+gRPC): `AsyncWriteObject()`, part 1/2

### DIFF
--- a/google/cloud/storage/async_connection.h
+++ b/google/cloud/storage/async_connection.h
@@ -30,6 +30,7 @@ namespace cloud {
 namespace storage_experimental {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AsyncReaderConnection;
+class AsyncWriterConnection;
 
 /**
  * The `*Connection` object for `AsyncClient`.
@@ -76,7 +77,8 @@ class AsyncConnection {
    * prevent breaking any mocks when additional parameters are needed.
    */
   struct ReadObjectParams {
-    /// The metadata attributes to create the object.
+    /// What object to read, what portion of the object to read, and any
+    /// pre-conditions on the read.
     ReadObjectRequest request;
     /// Any options modifying the RPC behavior, including per-client and
     /// per-connection options.
@@ -90,6 +92,25 @@ class AsyncConnection {
   /// Read a range from an object returning all the contents.
   virtual future<AsyncReadObjectRangeResponse> AsyncReadObjectRange(
       ReadObjectParams p) = 0;
+
+  /**
+   * A thin wrapper around the `WriteObject()` parameters.
+   *
+   * We use a single struct as the input parameter for this function to
+   * prevent breaking any mocks when additional parameters are needed.
+   */
+  struct WriteObjectParams {
+    /// The metadata attributes for the new object.
+    ResumableUploadRequest request;
+    /// Any options modifying the RPC behavior, including per-client and
+    /// per-connection options.
+    Options options;
+  };
+
+  /// Start (or resume) a streaming write.
+  virtual future<
+      StatusOr<std::unique_ptr<storage_experimental::AsyncWriterConnection>>>
+  AsyncWriteObject(WriteObjectParams p) = 0;
 
   /**
    * A thin wrapper around the `ComposeObject()` parameters.

--- a/google/cloud/storage/async_object_requests.h
+++ b/google/cloud/storage/async_object_requests.h
@@ -131,6 +131,51 @@ class InsertObjectRequest {
 };
 
 /**
+ * A request to start or resume a resumable upload.
+ *
+ * This class can hold all the mandatory and optional parameters to start or
+ * resume a resumable upload. Resumable uploads can be used to stream large
+ * objects, as they can recover when the upload is interrupted. This request
+ * does not contain any of the payload for the object, that is provided via a
+ * `storage_experimental::AsyncWriter`.
+ *
+ * This class is in the public API for the library because it is required for
+ * mocking.
+ */
+class ResumableUploadRequest {
+ public:
+  ResumableUploadRequest() = default;
+  ResumableUploadRequest(std::string bucket_name, std::string object_name)
+      : impl_(std::move(bucket_name), std::move(object_name)) {}
+
+  std::string const& bucket_name() const { return impl_.bucket_name(); }
+  std::string const& object_name() const { return impl_.object_name(); }
+
+  template <typename... T>
+  ResumableUploadRequest& set_multiple_options(T&&... o) & {
+    impl_.set_multiple_options(std::forward<T>(o)...);
+    return *this;
+  }
+  template <typename... T>
+  ResumableUploadRequest&& set_multiple_options(T&&... o) && {
+    return std::move(set_multiple_options(std::forward<T>(o)...));
+  }
+
+  template <typename T>
+  bool HasOption() const {
+    return impl_.HasOption<T>();
+  }
+  template <typename T>
+  T GetOption() const {
+    return impl_.GetOption<T>();
+  }
+
+ protected:
+  friend class storage_internal::AsyncConnectionImpl;
+  storage::internal::ResumableUploadRequest impl_;
+};
+
+/**
  * A request to read an object.
  *
  * This class can hold all the mandatory and optional parameters to read an

--- a/google/cloud/storage/async_object_requests.h
+++ b/google/cloud/storage/async_object_requests.h
@@ -135,8 +135,8 @@ class InsertObjectRequest {
  *
  * This class can hold all the mandatory and optional parameters to start or
  * resume a resumable upload. Resumable uploads can be used to stream large
- * objects, as they can recover when the upload is interrupted. This request
- * does not contain any of the payload for the object, that is provided via a
+ * objects as they can recover when the upload is interrupted. This request
+ * does not contain any of the payload for the object; that is provided via a
  * `storage_experimental::AsyncWriter`.
  *
  * This class is in the public API for the library because it is required for

--- a/google/cloud/storage/internal/async/connection_tracing_test.cc
+++ b/google/cloud/storage/internal/async/connection_tracing_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/async_reader_connection.h"
 #include "google/cloud/storage/mocks/mock_async_connection.h"
 #include "google/cloud/storage/mocks/mock_async_reader_connection.h"
+#include "google/cloud/storage/mocks/mock_async_writer_connection.h"
 #include "google/cloud/storage/testing/canonical_errors.h"
 #include "google/cloud/opentelemetry_options.h"
 #include "google/cloud/testing_util/opentelemetry_matchers.h"
@@ -34,6 +35,7 @@ using ::google::cloud::storage::testing::canonical_errors::PermanentError;
 using ::google::cloud::storage_experimental::AsyncConnection;
 using ::google::cloud::storage_mocks::MockAsyncConnection;
 using ::google::cloud::storage_mocks::MockAsyncReaderConnection;
+using ::google::cloud::storage_mocks::MockAsyncWriterConnection;
 using ::google::cloud::testing_util::InstallSpanCatcher;
 using ::google::cloud::testing_util::OTelContextCaptured;
 using ::google::cloud::testing_util::PromiseWithOTelContext;
@@ -185,6 +187,68 @@ TEST(ConnectionTracing, AsyncReadObjectRange) {
                   SpanNamed("storage::AsyncConnection::AsyncReadObjectRange"),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
                   SpanHasInstrumentationScope(), SpanKindIsClient())));
+}
+
+TEST(ConnectionTracing, AsyncWriteObjectError) {
+  auto span_catcher = InstallSpanCatcher();
+  PromiseWithOTelContext<
+      StatusOr<std::unique_ptr<storage_experimental::AsyncWriterConnection>>>
+      p;
+
+  auto mock = std::make_unique<MockAsyncConnection>();
+  EXPECT_CALL(*mock, options).WillOnce(Return(TracingEnabled()));
+  EXPECT_CALL(*mock, AsyncWriteObject).WillOnce(expect_context(p));
+  auto actual = MakeTracingAsyncConnection(std::move(mock));
+  auto result = actual->AsyncWriteObject(AsyncConnection::WriteObjectParams{})
+                    .then(expect_no_context);
+
+  p.set_value(
+      StatusOr<std::unique_ptr<storage_experimental::AsyncWriterConnection>>(
+          PermanentError()));
+  EXPECT_THAT(result.get(), StatusIs(PermanentError().code()));
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(
+      spans, ElementsAre(
+                 AllOf(SpanNamed("storage::AsyncConnection::AsyncWriteObject"),
+                       SpanWithStatus(opentelemetry::trace::StatusCode::kError),
+                       SpanHasInstrumentationScope(), SpanKindIsClient())));
+}
+
+TEST(ConnectionTracing, AsyncWriteObjectSuccess) {
+  auto span_catcher = InstallSpanCatcher();
+  PromiseWithOTelContext<
+      StatusOr<std::unique_ptr<storage_experimental::AsyncWriterConnection>>>
+      p;
+
+  auto mock = std::make_unique<MockAsyncConnection>();
+  EXPECT_CALL(*mock, options).WillOnce(Return(TracingEnabled()));
+
+  EXPECT_CALL(*mock, AsyncWriteObject).WillOnce(expect_context(p));
+  auto actual = MakeTracingAsyncConnection(std::move(mock));
+  auto f = actual->AsyncWriteObject(AsyncConnection::WriteObjectParams{})
+               .then(expect_no_context);
+
+  auto mock_reader = std::make_unique<MockAsyncWriterConnection>();
+  EXPECT_CALL(*mock_reader, Finalize)
+      .WillOnce(Return(ByMove(
+          make_ready_future(make_status_or(storage::ObjectMetadata{})))));
+  p.set_value(
+      StatusOr<std::unique_ptr<storage_experimental::AsyncWriterConnection>>(
+          std::move(mock_reader)));
+
+  auto result = f.get();
+  ASSERT_STATUS_OK(result);
+  auto reader = *std::move(result);
+  auto r = reader->Finalize(storage_experimental::WritePayload{}).get();
+  EXPECT_STATUS_OK(r);
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(
+      spans,
+      ElementsAre(AllOf(SpanNamed("storage::AsyncConnection::AsyncWriteObject"),
+                        SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
+                        SpanHasInstrumentationScope(), SpanKindIsClient())));
 }
 
 TEST(ConnectionTracing, AsyncComposeObject) {

--- a/google/cloud/storage/mocks/mock_async_connection.h
+++ b/google/cloud/storage/mocks/mock_async_connection.h
@@ -40,6 +40,10 @@ class MockAsyncConnection : public storage_experimental::AsyncConnection {
       AsyncReadObject, (ReadObjectParams), (override));
   MOCK_METHOD(future<storage_experimental::AsyncReadObjectRangeResponse>,
               AsyncReadObjectRange, (ReadObjectParams), (override));
+  MOCK_METHOD(
+      future<StatusOr<
+          std::unique_ptr<storage_experimental::AsyncWriterConnection>>>,
+      AsyncWriteObject, (WriteObjectParams), (override));
   MOCK_METHOD(future<StatusOr<storage::ObjectMetadata>>, AsyncComposeObject,
               (ComposeObjectParams), (override));
   MOCK_METHOD(future<Status>, AsyncDeleteObject, (DeleteObjectParams),

--- a/google/cloud/storage/testing/mock_storage_stub.h
+++ b/google/cloud/storage/testing/mock_storage_stub.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_TESTING_MOCK_STORAGE_STUB_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_TESTING_MOCK_STORAGE_STUB_H
 
+#include "google/cloud/mocks/mock_async_streaming_read_write_rpc.h"
 #include "google/cloud/storage/internal/storage_stub.h"
 #include "google/cloud/testing_util/mock_async_streaming_read_rpc.h"
 #include <gmock/gmock.h>
@@ -253,6 +254,11 @@ class MockAsyncInsertStream
 using MockAsyncObjectMediaStream =
     google::cloud::testing_util::MockAsyncStreamingReadRpc<
         google::storage::v2::ReadObjectResponse>;
+
+using MockAsyncBidiWriteObjectStream =
+    google::cloud::mocks::MockAsyncStreamingReadWriteRpc<
+        google::storage::v2::BidiWriteObjectRequest,
+        google::storage::v2::BidiWriteObjectResponse>;
 
 }  // namespace testing
 }  // namespace storage


### PR DESCRIPTION
Introduce a member function in the `AsyncConnection` interface (and its implementations) to use resumable uploads. This is the only reasonable way to stream data too, but it requires additional features to fully support recovering from interrupted uploads.

Part of the work for #9134 

I apologize for sending so many large PRs.  This one I can break a little bit, but the additional pieces will look unmotivated. Unfortunately adding a member function to `AsyncConnection` requires changes in all the implementations and requires tests for all of them too.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13030)
<!-- Reviewable:end -->
