### PR TITLE
feat(spanner): control replicas/regions used in non-transactional reads

### DIFF
--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -113,6 +113,7 @@ add_library(
     database_admin_connection.cc
     database_admin_connection.h
     date.h
+    directed_read_replicas.h
     encryption_config.h
     iam_updater.h
     instance.cc

--- a/google/cloud/spanner/connection.h
+++ b/google/cloud/spanner/connection.h
@@ -20,6 +20,7 @@
 #include "google/cloud/spanner/commit_result.h"
 #include "google/cloud/spanner/keys.h"
 #include "google/cloud/spanner/mutations.h"
+#include "google/cloud/spanner/options.h"
 #include "google/cloud/spanner/partition_options.h"
 #include "google/cloud/spanner/partitioned_dml_result.h"
 #include "google/cloud/spanner/query_options.h"
@@ -79,6 +80,7 @@ class Connection {
     ReadOptions read_options;
     absl::optional<std::string> partition_token;
     bool partition_data_boost = false;  // when partition_token
+    DirectedReadOption::Type directed_read_option;
   };
 
   /// Wrap the arguments to `PartitionRead()`.
@@ -95,6 +97,7 @@ class Connection {
     QueryOptions query_options;
     absl::optional<std::string> partition_token;
     bool partition_data_boost = false;  // when partition_token
+    DirectedReadOption::Type directed_read_option;
   };
 
   /// Wrap the arguments to `ExecutePartitionedDml()`.

--- a/google/cloud/spanner/directed_read_replicas.h
+++ b/google/cloud/spanner/directed_read_replicas.h
@@ -1,0 +1,127 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_DIRECTED_READ_REPLICAS_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_DIRECTED_READ_REPLICAS_H
+
+#include "google/cloud/spanner/version.h"
+#include "absl/types/optional.h"
+#include <initializer_list>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+/**
+ * Indicates the type of replica.
+ */
+enum class ReplicaType {
+  kReadWrite,  // Read-write replicas support both reads and writes.
+  kReadOnly,   // Read-only replicas only support reads (not writes).
+};
+
+/**
+ * The directed-read replica selector.
+ *
+ * Callers must provide one or more of the following fields:
+ *   - location: One of the regions within the multi-region configuration
+ *     of your database.
+ *   - type: The type of the replica.
+ */
+class ReplicaSelection {
+ public:
+  // Only replicas in the location and of the given type will be used
+  // to process the request.
+  ReplicaSelection(std::string location, ReplicaType type)
+      : location_(std::move(location)), type_(type) {}
+
+  // Replicas in the location, of any available type, will be used to
+  // process the request.
+  explicit ReplicaSelection(std::string location)
+      : location_(std::move(location)), type_(absl::nullopt) {}
+
+  // Replicas of the given type, in the nearest available location, will
+  // be used to process the request.
+  explicit ReplicaSelection(ReplicaType type)
+      : location_(absl::nullopt), type_(type) {}
+
+  absl::optional<std::string> const& location() const { return location_; }
+  absl::optional<ReplicaType> const& type() const { return type_; }
+
+ private:
+  absl::optional<std::string> location_;
+  absl::optional<ReplicaType> type_;
+};
+
+inline bool operator==(ReplicaSelection const& a, ReplicaSelection const& b) {
+  return a.location() == b.location() && a.type() == b.type();
+}
+
+inline bool operator!=(ReplicaSelection const& a, ReplicaSelection const& b) {
+  return !(a == b);
+}
+
+/**
+ * An `IncludeReplicas` contains an ordered list of `ReplicaSelection`s
+ * that should be considered when serving requests.
+ *
+ * When `auto_failover_disabled` is set, requests will NOT be routed to
+ * a healthy replica outside the list when all replicas in the list are
+ * unavailable/unhealthy.
+ */
+class IncludeReplicas {
+ public:
+  IncludeReplicas(std::initializer_list<ReplicaSelection> replica_selections,
+                  bool auto_failover_disabled = false)
+      : replica_selections_(replica_selections),
+        auto_failover_disabled_(auto_failover_disabled) {}
+
+  std::vector<ReplicaSelection> const& replica_selections() const {
+    return replica_selections_;
+  }
+  bool auto_failover_disabled() const { return auto_failover_disabled_; }
+
+ private:
+  std::vector<ReplicaSelection> replica_selections_;
+  bool auto_failover_disabled_;
+};
+
+/**
+ * An `ExcludeReplicas` contains a list of `ReplicaSelection`s that should
+ * be excluded from serving requests.
+ */
+class ExcludeReplicas {
+ public:
+  ExcludeReplicas(std::initializer_list<ReplicaSelection> replica_selections)
+      : replica_selections_(replica_selections.begin(),
+                            replica_selections.end()) {}
+
+  std::vector<ReplicaSelection> const& replica_selections() const {
+    return replica_selections_;
+  }
+
+ private:
+  std::vector<ReplicaSelection> replica_selections_;
+};
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_DIRECTED_READ_REPLICAS_H

--- a/google/cloud/spanner/google_cloud_cpp_spanner.bzl
+++ b/google/cloud/spanner/google_cloud_cpp_spanner.bzl
@@ -61,6 +61,7 @@ google_cloud_cpp_spanner_hdrs = [
     "database_admin_client.h",
     "database_admin_connection.h",
     "date.h",
+    "directed_read_replicas.h",
     "encryption_config.h",
     "iam_updater.h",
     "instance.h",

--- a/google/cloud/spanner/options.h
+++ b/google/cloud/spanner/options.h
@@ -39,12 +39,14 @@
  */
 
 #include "google/cloud/spanner/backoff_policy.h"
+#include "google/cloud/spanner/directed_read_replicas.h"
 #include "google/cloud/spanner/internal/session.h"
 #include "google/cloud/spanner/polling_policy.h"
 #include "google/cloud/spanner/request_priority.h"
 #include "google/cloud/spanner/retry_policy.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/options.h"
+#include "absl/types/variant.h"
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
@@ -321,6 +323,23 @@ struct PartitionsMaximumOption {
  */
 struct PartitionDataBoostOption {
   using Type = bool;
+};
+
+/**
+ * Option for `google::cloud::Options` to indicate which replicas or regions
+ * should be used for reads/queries in read-only or single-use transactions.
+ * Use of DirectedReadOptions within a read-write transaction will result in
+ * a `kInvalidArgument` error.
+ *
+ * The `IncludeReplicas` variant lists the replicas to try (in order) to
+ * process the request, and what to do if the list is exhausted without
+ * finding a healthy replica.
+ *
+ * Alternately, the `ExcludeReplicas` variant lists replicas that should
+ * be excluded from serving the request.
+ */
+struct DirectedReadOption {
+  using Type = absl::variant<absl::monostate, IncludeReplicas, ExcludeReplicas>;
 };
 
 /**

--- a/google/cloud/spanner/query_partition.h
+++ b/google/cloud/spanner/query_partition.h
@@ -165,13 +165,17 @@ struct QueryPartitionInternals {
 
   static spanner::Connection::SqlParams MakeSqlParams(
       spanner::QueryPartition const& query_partition,
-      spanner::QueryOptions const& query_options) {
+      spanner::QueryOptions const& query_options,
+      spanner::DirectedReadOption::Type directed_read_option) {
     return {MakeTransactionFromIds(query_partition.session_id(),
                                    query_partition.transaction_id(),
                                    query_partition.route_to_leader(),
                                    query_partition.transaction_tag()),
-            query_partition.sql_statement(), query_options,
-            query_partition.partition_token(), query_partition.data_boost()};
+            query_partition.sql_statement(),
+            query_options,
+            query_partition.partition_token(),
+            query_partition.data_boost(),
+            std::move(directed_read_option)};
   }
 };
 
@@ -187,8 +191,10 @@ inline spanner::QueryPartition MakeQueryPartition(
 
 inline spanner::Connection::SqlParams MakeSqlParams(
     spanner::QueryPartition const& query_partition,
-    spanner::QueryOptions const& query_options) {
-  return QueryPartitionInternals::MakeSqlParams(query_partition, query_options);
+    spanner::QueryOptions const& query_options,
+    spanner::DirectedReadOption::Type directed_read_option) {
+  return QueryPartitionInternals::MakeSqlParams(
+      query_partition, query_options, std::move(directed_read_option));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/spanner/read_partition.h
+++ b/google/cloud/spanner/read_partition.h
@@ -173,7 +173,8 @@ struct ReadPartitionInternals {
   }
 
   static spanner::Connection::ReadParams MakeReadParams(
-      spanner::ReadPartition const& read_partition) {
+      spanner::ReadPartition const& read_partition,
+      spanner::DirectedReadOption::Type directed_read_option) {
     return spanner::Connection::ReadParams{
         MakeTransactionFromIds(
             read_partition.SessionId(), read_partition.TransactionId(),
@@ -183,7 +184,8 @@ struct ReadPartitionInternals {
         read_partition.ColumnNames(),
         read_partition.ReadOptions(),
         read_partition.PartitionToken(),
-        read_partition.DataBoost()};
+        read_partition.DataBoost(),
+        std::move(directed_read_option)};
   }
 };
 
@@ -201,8 +203,10 @@ inline spanner::ReadPartition MakeReadPartition(
 }
 
 inline spanner::Connection::ReadParams MakeReadParams(
-    spanner::ReadPartition const& read_partition) {
-  return ReadPartitionInternals::MakeReadParams(read_partition);
+    spanner::ReadPartition const& read_partition,
+    spanner::DirectedReadOption::Type directed_read_option) {
+  return ReadPartitionInternals::MakeReadParams(
+      read_partition, std::move(directed_read_option));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
Add the `DirectedReadOption` to indicate which replicas or regions should be used for `Client::Read()`, `Client::ExecuteQuery()`, and `Client::ProfileQuery()` calls in read-only or single-use transactions.

- The `IncludeReplicas` variant lists the replicas to try (in order) to process the request, and what to do if the list is exhausted without finding a healthy replica.

- The `ExcludeReplicas` variant lists replicas that should be excluded from serving the request.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13031)
<!-- Reviewable:end -->
