### PR TITLE
cleanup: GUAC in examples

### DIFF
--- a/google/cloud/bigtable/doc/bigtable-samples-grpc-credentials.dox
+++ b/google/cloud/bigtable/doc/bigtable-samples-grpc-credentials.dox
@@ -69,10 +69,6 @@ The following code shows how to use a JWT access token to connect to an Admin AP
 
 The following code shows how to use a GCE credentials to connect to an Admin API endpoint.
 
-@snippet bigtable_grpc_credentials.cc test gce credentials
-
-One may face "Request had insufficient authentication scopes." error while running above example. This might be due to disabled "Cloud API access scope" for Bigtable. This error can be removed by providing sufficient access as explained [here][api-access-scope].
-
 ## Use of IAM Credentials
 
 ### Check IAM Policy
@@ -90,6 +86,5 @@ One may face "Request had insufficient authentication scopes." error while runni
 [info-google-authentication]: https://cloud.google.com/docs/authentication/getting-started
 [info-root-certificates]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/bigtable/examples#configure-grpc-root-certificates
 [print-access-token]: https://cloud.google.com/sdk/gcloud/reference/beta/auth/application-default/print-access-token
-[api-access-scope]: https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances#changeserviceaccountandscopes
 
 */


### PR DESCRIPTION
Prefer unified credentials in the examples (over `GrpcCredentialOption`).

Also use the versioned IAM credentials client.

Also remove the GCE credentials example from Bigtable, which is not recommended. Customers should be using the default credentials instead.

---

I am not certain that this gets tested in our CI. I think it is skipped most of the time in `integration-production-pr`. (Maybe they run in `integration-daily`? I don't remember).

I ran the bigtable examples, and the two access token examples manually.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13032)
<!-- Reviewable:end -->
