### PR TITLE
impl(GCS+gRPC): need state lookup on flush

### DIFF
--- a/google/cloud/storage/internal/async/partial_upload.cc
+++ b/google/cloud/storage/internal/async/partial_upload.cc
@@ -56,6 +56,7 @@ void PartialUpload::Write() {
       if (!status.ok()) return WriteError(std::move(status));
     } else if (action_ == LastMessageAction::kFlush) {
       request_.set_flush(true);
+      request_.set_state_lookup(true);
     }
   }
   (void)rpc_->Write(request_, std::move(wopt))


### PR DESCRIPTION
When we send messages with `flush: true` we also want a response with the current status. I also took the opportunity to add additional test cases and other cleanups in the test.

Part of the work for #9134

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13036)
<!-- Reviewable:end -->
