### PR TITLE
refactor(pubsub): rename messaging system to gcp_pubsub

### DIFF
--- a/google/cloud/pubsub/internal/blocking_publisher_tracing_connection.cc
+++ b/google/cloud/pubsub/internal/blocking_publisher_tracing_connection.cc
@@ -39,7 +39,7 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> StartPublishSpan(
   options.kind = opentelemetry::trace::SpanKind::kProducer;
   auto span = internal::MakeSpan(
       topic.FullName() + " send",
-      {{sc::kMessagingSystem, "pubsub"},
+      {{sc::kMessagingSystem, "gcp_pubsub"},
        {sc::kMessagingDestinationName, topic.FullName()},
        {sc::kMessagingDestinationTemplate, "topic"},
        {"messaging.message.total_size_bytes",

--- a/google/cloud/pubsub/internal/blocking_publisher_tracing_connection_test.cc
+++ b/google/cloud/pubsub/internal/blocking_publisher_tracing_connection_test.cc
@@ -79,7 +79,7 @@ TEST(BlockingPublisherTracingConnectionTest, PublishSpanOnSuccess) {
           SpanNamed("projects/test-project/topics/test-topic send"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
           SpanHasAttributes(
-              OTelAttribute<std::string>(sc::kMessagingSystem, "pubsub"),
+              OTelAttribute<std::string>(sc::kMessagingSystem, "gcp_pubsub"),
               OTelAttribute<std::string>(
                   sc::kMessagingDestinationName,
                   "projects/test-project/topics/test-topic"),

--- a/google/cloud/pubsub/internal/blocking_publisher_tracing_connection_test.cc
+++ b/google/cloud/pubsub/internal/blocking_publisher_tracing_connection_test.cc
@@ -116,22 +116,22 @@ TEST(BlockingPublisherTracingConnectionTest, PublishSpanOnError) {
   EXPECT_THAT(response, StatusIs(StatusCode::kAborted));
   EXPECT_THAT(
       span_catcher->GetSpans(),
-      ElementsAre(
-          AllOf(SpanHasInstrumentationScope(), SpanKindIsProducer(),
-                SpanNamed("projects/test-project/topics/test-topic send"),
-                SpanWithStatus(opentelemetry::trace::StatusCode::kError),
-                SpanHasAttributes(
-                    OTelAttribute<std::string>(sc::kMessagingSystem, "pubsub"),
-                    OTelAttribute<std::string>(
-                        sc::kMessagingDestinationName,
-                        "projects/test-project/topics/test-topic"),
-                    OTelAttribute<std::string>(
-                        sc::kMessagingDestinationTemplate, "topic"),
-                    OTelAttribute<std::string>("messaging.pubsub.ordering_key",
-                                               "ordering-key-0"),
-                    OTelAttribute<int>("gl-cpp.status_code", kErrorCode),
-                    OTelAttribute<std::int64_t>(
-                        "messaging.message.total_size_bytes", 45)))));
+      ElementsAre(AllOf(
+          SpanHasInstrumentationScope(), SpanKindIsProducer(),
+          SpanNamed("projects/test-project/topics/test-topic send"),
+          SpanWithStatus(opentelemetry::trace::StatusCode::kError),
+          SpanHasAttributes(
+              OTelAttribute<std::string>(sc::kMessagingSystem, "gcp_pubsub"),
+              OTelAttribute<std::string>(
+                  sc::kMessagingDestinationName,
+                  "projects/test-project/topics/test-topic"),
+              OTelAttribute<std::string>(sc::kMessagingDestinationTemplate,
+                                         "topic"),
+              OTelAttribute<std::string>("messaging.pubsub.ordering_key",
+                                         "ordering-key-0"),
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode),
+              OTelAttribute<std::int64_t>("messaging.message.total_size_bytes",
+                                          45)))));
 }
 
 TEST(BlockingPublisherTracingConnectionTest, PublishSpanOmitsOrderingKey) {

--- a/google/cloud/pubsub/internal/publisher_tracing_connection.cc
+++ b/google/cloud/pubsub/internal/publisher_tracing_connection.cc
@@ -49,7 +49,7 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> StartPublishSpan(
   options.kind = opentelemetry::trace::SpanKind::kProducer;
   auto span = internal::MakeSpan(
       topic + " send",
-      {{sc::kMessagingSystem, "pubsub"},
+      {{sc::kMessagingSystem, "gcp_pubsub"},
        {sc::kMessagingDestinationName, topic},
        {sc::kMessagingDestinationTemplate, "topic"},
        {"messaging.message.total_size_bytes",

--- a/google/cloud/pubsub/internal/publisher_tracing_connection_test.cc
+++ b/google/cloud/pubsub/internal/publisher_tracing_connection_test.cc
@@ -124,22 +124,22 @@ TEST(PublisherTracingConnectionTest, PublishSpanOnError) {
   EXPECT_THAT(response, StatusIs(StatusCode::kAborted));
   EXPECT_THAT(
       span_catcher->GetSpans(),
-      ElementsAre(
-          AllOf(SpanHasInstrumentationScope(), SpanKindIsProducer(),
-                SpanNamed("projects/test-project/topics/test-topic send"),
-                SpanWithStatus(opentelemetry::trace::StatusCode::kError),
-                SpanHasAttributes(
-                    OTelAttribute<std::string>(sc::kMessagingSystem, "pubsub"),
-                    OTelAttribute<std::string>(
-                        sc::kMessagingDestinationName,
-                        "projects/test-project/topics/test-topic"),
-                    OTelAttribute<std::string>(
-                        sc::kMessagingDestinationTemplate, "topic"),
-                    OTelAttribute<std::string>("messaging.pubsub.ordering_key",
-                                               "ordering-key-0"),
-                    OTelAttribute<int>("gl-cpp.status_code", kErrorCode),
-                    OTelAttribute<std::int64_t>(
-                        "messaging.message.total_size_bytes", 45)))));
+      ElementsAre(AllOf(
+          SpanHasInstrumentationScope(), SpanKindIsProducer(),
+          SpanNamed("projects/test-project/topics/test-topic send"),
+          SpanWithStatus(opentelemetry::trace::StatusCode::kError),
+          SpanHasAttributes(
+              OTelAttribute<std::string>(sc::kMessagingSystem, "gcp_pubsub"),
+              OTelAttribute<std::string>(
+                  sc::kMessagingDestinationName,
+                  "projects/test-project/topics/test-topic"),
+              OTelAttribute<std::string>(sc::kMessagingDestinationTemplate,
+                                         "topic"),
+              OTelAttribute<std::string>("messaging.pubsub.ordering_key",
+                                         "ordering-key-0"),
+              OTelAttribute<int>("gl-cpp.status_code", kErrorCode),
+              OTelAttribute<std::int64_t>("messaging.message.total_size_bytes",
+                                          45)))));
 }
 
 TEST(PublisherTracingConnectionTest, PublishInjectsTraceContext) {

--- a/google/cloud/pubsub/internal/publisher_tracing_connection_test.cc
+++ b/google/cloud/pubsub/internal/publisher_tracing_connection_test.cc
@@ -84,7 +84,7 @@ TEST(PublisherTracingConnectionTest, PublishSpanOnSuccess) {
           SpanNamed("projects/test-project/topics/test-topic send"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
           SpanHasAttributes(
-              OTelAttribute<std::string>(sc::kMessagingSystem, "pubsub"),
+              OTelAttribute<std::string>(sc::kMessagingSystem, "gcp_pubsub"),
               OTelAttribute<std::string>(
                   sc::kMessagingDestinationName,
                   "projects/test-project/topics/test-topic"),


### PR DESCRIPTION
Closes https://github.com/googleapis/google-cloud-cpp/issues/12952

Trying to get this into the otel semconvs (https://github.com/open-telemetry/semantic-conventions/pull/490)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13041)
<!-- Reviewable:end -->
