### PR TITLE
impl(GCS+gRPC): flush data in `AsyncWriterConnection`

### DIFF
--- a/google/cloud/storage/internal/async/writer_connection_finalized.cc
+++ b/google/cloud/storage/internal/async/writer_connection_finalized.cc
@@ -56,6 +56,15 @@ AsyncWriterConnectionFinalized::Finalize(storage_experimental::WritePayload) {
       StatusOr<storage::ObjectMetadata>(MakeError(GCP_ERROR_INFO())));
 }
 
+future<Status> AsyncWriterConnectionFinalized::Flush(
+    storage_experimental::WritePayload) {
+  return make_ready_future(MakeError(GCP_ERROR_INFO()));
+}
+
+future<StatusOr<std::int64_t>> AsyncWriterConnectionFinalized::Query() {
+  return make_ready_future(StatusOr<std::int64_t>(MakeError(GCP_ERROR_INFO())));
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage_internal
 }  // namespace cloud

--- a/google/cloud/storage/internal/async/writer_connection_finalized.h
+++ b/google/cloud/storage/internal/async/writer_connection_finalized.h
@@ -58,6 +58,8 @@ class AsyncWriterConnectionFinalized
   future<Status> Write(storage_experimental::WritePayload payload) override;
   future<StatusOr<storage::ObjectMetadata>> Finalize(
       storage_experimental::WritePayload) override;
+  future<Status> Flush(storage_experimental::WritePayload payload) override;
+  future<StatusOr<std::int64_t>> Query() override;
 
  private:
   std::string upload_id_;

--- a/google/cloud/storage/internal/async/writer_connection_finalized_test.cc
+++ b/google/cloud/storage/internal/async/writer_connection_finalized_test.cc
@@ -52,6 +52,9 @@ TEST(AsyncWriterConnectionFinalized, Basic) {
               StatusIs(StatusCode::kFailedPrecondition));
   EXPECT_THAT(tested.Finalize({}).get(),
               StatusIs(StatusCode::kFailedPrecondition));
+  EXPECT_THAT(tested.Flush({}).get(),
+              StatusIs(StatusCode::kFailedPrecondition));
+  EXPECT_THAT(tested.Query().get(), StatusIs(StatusCode::kFailedPrecondition));
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/async/writer_connection_impl.cc
+++ b/google/cloud/storage/internal/async/writer_connection_impl.cc
@@ -73,8 +73,8 @@ AsyncWriterConnectionImpl::~AsyncWriterConnectionImpl() {
   impl_->Cancel();
   // It is safe to call Finish() because:
   // (1) this is a no-op if it was already called.
-  // (2) calls to `Write()` and `Finalize()` must have completed by the time the
-  //     destructor is called.
+  // (2) calls to `Write()`, `Finalize()`, and `Query()` must have completed
+  //     by the time the destructor is called
   Finish();
   // When `impl_->Finish()` is satisfied then `finished_` is satisfied too.
   // This extends the lifetime of `impl_` until it is safe to delete.
@@ -118,6 +118,22 @@ future<StatusOr<storage::ObjectMetadata>> AsyncWriterConnectionImpl::Finalize(
     coro.reset();  // breaks the cycle between the completion queue and coro
     return OnFinalUpload(size, f.get());
   });
+}
+
+future<Status> AsyncWriterConnectionImpl::Flush(
+    storage_experimental::WritePayload payload) {
+  auto write = MakeRequest();
+  auto p = WritePayloadImpl::GetImpl(payload);
+  auto size = p.size();
+  auto coro = PartialUpload::Call(impl_, hash_function_, std::move(write),
+                                  std::move(p), PartialUpload::kFlush);
+
+  return coro->Start().then(
+      [coro, size, this](auto f) { return OnPartialUpload(size, f.get()); });
+}
+
+future<StatusOr<std::int64_t>> AsyncWriterConnectionImpl::Query() {
+  return impl_->Read().then([this](auto f) { return OnQuery(f.get()); });
 }
 
 google::storage::v2::BidiWriteObjectRequest

--- a/google/cloud/storage/internal/async/writer_connection_impl.h
+++ b/google/cloud/storage/internal/async/writer_connection_impl.h
@@ -58,6 +58,8 @@ class AsyncWriterConnectionImpl
   future<Status> Write(storage_experimental::WritePayload payload) override;
   future<StatusOr<storage::ObjectMetadata>> Finalize(
       storage_experimental::WritePayload) override;
+  future<Status> Flush(storage_experimental::WritePayload payload) override;
+  future<StatusOr<std::int64_t>> Query() override;
 
  private:
   google::storage::v2::BidiWriteObjectRequest MakeRequest();

--- a/google/cloud/storage/internal/async/writer_connection_tracing_test.cc
+++ b/google/cloud/storage/internal/async/writer_connection_tracing_test.cc
@@ -63,6 +63,19 @@ auto ExpectWrite(std::int64_t id, std::uint64_t size) {
   return AllOf(EventNamed("gl-cpp.write"), ExpectSent(id, size));
 }
 
+auto ExpectFlush(std::int64_t id, std::uint64_t size) {
+  return AllOf(EventNamed("gl-cpp.flush"), ExpectSent(id, size));
+}
+
+auto ExpectQuery(std::int64_t id) {
+  namespace sc = ::opentelemetry::trace::SemanticConventions;
+  return AllOf(EventNamed("gl-cpp.query"),
+               SpanEventAttributesAre(
+                   OTelAttribute<std::string>(sc::kMessageType, "RECEIVE"),
+                   OTelAttribute<std::int64_t>(sc::kMessageId, id),
+                   OTelAttribute<std::string>(sc::kThreadId, _)));
+}
+
 TEST(WriterConnectionTracing, FullCycle) {
   auto span_catcher = InstallSpanCatcher();
 
@@ -72,6 +85,12 @@ TEST(WriterConnectionTracing, FullCycle) {
   EXPECT_CALL(*mock, Write).Times(2).WillRepeatedly([] {
     return make_ready_future(Status{});
   });
+  EXPECT_CALL(*mock, Flush).Times(2).WillRepeatedly([] {
+    return make_ready_future(Status{});
+  });
+  EXPECT_CALL(*mock, Query).Times(2).WillRepeatedly([] {
+    return make_ready_future(StatusOr<std::int64_t>(1024));
+  });
   EXPECT_CALL(*mock, Finalize).WillOnce([] {
     return make_ready_future(make_status_or(storage::ObjectMetadata{}));
   });
@@ -80,7 +99,11 @@ TEST(WriterConnectionTracing, FullCycle) {
   EXPECT_EQ(actual->UploadId(), "test-upload-id");
   EXPECT_THAT(actual->PersistedState(), VariantWith<std::int64_t>(16384));
   EXPECT_STATUS_OK(actual->Write(WritePayload{std::string(1024, 'A')}).get());
+  EXPECT_STATUS_OK(actual->Flush(WritePayload{std::string(1024, 'A')}).get());
+  EXPECT_STATUS_OK(actual->Query().get());
   EXPECT_STATUS_OK(actual->Write(WritePayload{std::string(2048, 'B')}).get());
+  EXPECT_STATUS_OK(actual->Flush(WritePayload{std::string(2048, 'B')}).get());
+  EXPECT_STATUS_OK(actual->Query().get());
   auto response = actual->Finalize({}).get();
   EXPECT_STATUS_OK(response);
 
@@ -91,8 +114,9 @@ TEST(WriterConnectionTracing, FullCycle) {
                  SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
                  SpanHasInstrumentationScope(), SpanKindIsClient(),
                  SpanHasEvents(
-                     ExpectWrite(1, 1024), ExpectWrite(2, 2048),
-                     AllOf(EventNamed("gl-cpp.finalize"), ExpectSent(3, 0))))));
+                     ExpectWrite(1, 1024), ExpectFlush(2, 1024), ExpectQuery(1),
+                     ExpectWrite(3, 2048), ExpectFlush(4, 2048), ExpectQuery(2),
+                     AllOf(EventNamed("gl-cpp.finalize"), ExpectSent(5, 0))))));
 }
 
 TEST(WriterConnectionTracing, FinalizeError) {
@@ -139,6 +163,52 @@ TEST(WriterConnectionTracing, WriteError) {
                                        PermanentError().message()),
                         SpanHasInstrumentationScope(), SpanKindIsClient(),
                         SpanHasEvents(ExpectWrite(1, 1024)))));
+}
+
+TEST(WriterConnectionTracing, FlushError) {
+  namespace sc = ::opentelemetry::trace::SemanticConventions;
+  auto span_catcher = InstallSpanCatcher();
+
+  auto mock = std::make_unique<MockAsyncWriterConnection>();
+  EXPECT_CALL(*mock, Flush).WillOnce([] {
+    return make_ready_future(PermanentError());
+  });
+  auto actual = MakeTracingWriterConnection(
+      internal::MakeSpan("test-span-name"), std::move(mock));
+  auto status = actual->Flush(WritePayload{std::string(1024, 'A')}).get();
+  EXPECT_THAT(status, StatusIs(PermanentError().code()));
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(
+      spans,
+      ElementsAre(AllOf(SpanNamed("test-span-name"),
+                        SpanWithStatus(opentelemetry::trace::StatusCode::kError,
+                                       PermanentError().message()),
+                        SpanHasInstrumentationScope(), SpanKindIsClient(),
+                        SpanHasEvents(ExpectFlush(1, 1024)))));
+}
+
+TEST(WriterConnectionTracing, QueryError) {
+  namespace sc = ::opentelemetry::trace::SemanticConventions;
+  auto span_catcher = InstallSpanCatcher();
+
+  auto mock = std::make_unique<MockAsyncWriterConnection>();
+  EXPECT_CALL(*mock, Query).WillOnce([] {
+    return make_ready_future(StatusOr<std::int64_t>(PermanentError()));
+  });
+  auto actual = MakeTracingWriterConnection(
+      internal::MakeSpan("test-span-name"), std::move(mock));
+  auto status = actual->Query().get();
+  EXPECT_THAT(status, StatusIs(PermanentError().code()));
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(
+      spans,
+      ElementsAre(AllOf(SpanNamed("test-span-name"),
+                        SpanWithStatus(opentelemetry::trace::StatusCode::kError,
+                                       PermanentError().message()),
+                        SpanHasInstrumentationScope(), SpanKindIsClient(),
+                        SpanHasEvents(ExpectQuery(1)))));
 }
 
 TEST(WriterConnectionTracing, Cancel) {

--- a/google/cloud/storage/internal/async/writer_connection_tracing_test.cc
+++ b/google/cloud/storage/internal/async/writer_connection_tracing_test.cc
@@ -166,7 +166,6 @@ TEST(WriterConnectionTracing, WriteError) {
 }
 
 TEST(WriterConnectionTracing, FlushError) {
-  namespace sc = ::opentelemetry::trace::SemanticConventions;
   auto span_catcher = InstallSpanCatcher();
 
   auto mock = std::make_unique<MockAsyncWriterConnection>();
@@ -189,7 +188,6 @@ TEST(WriterConnectionTracing, FlushError) {
 }
 
 TEST(WriterConnectionTracing, QueryError) {
-  namespace sc = ::opentelemetry::trace::SemanticConventions;
   auto span_catcher = InstallSpanCatcher();
 
   auto mock = std::make_unique<MockAsyncWriterConnection>();

--- a/google/cloud/storage/mocks/mock_async_writer_connection.h
+++ b/google/cloud/storage/mocks/mock_async_writer_connection.h
@@ -35,6 +35,9 @@ class MockAsyncWriterConnection
               (override));
   MOCK_METHOD(future<StatusOr<storage::ObjectMetadata>>, Finalize,
               (storage_experimental::WritePayload), (override));
+  MOCK_METHOD(future<Status>, Flush, (storage_experimental::WritePayload),
+              (override));
+  MOCK_METHOD(future<StatusOr<std::int64_t>>, Query, (), (override));
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
This implements `Flush()` and `Query()` member functions in `AsyncWriterConnection` and its implementations. This is needed to fully support uploads for streaming data.

Part of the work for #9134

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13042)
<!-- Reviewable:end -->
