### PR TITLE
impl(pubsub): only add links that are sampled

### DIFF
--- a/google/cloud/pubsub/internal/tracing_message_batch.cc
+++ b/google/cloud/pubsub/internal/tracing_message_batch.cc
@@ -41,10 +41,14 @@ using Attributes =
 using Links =
     std::vector<std::pair<opentelemetry::trace::SpanContext, Attributes>>;
 
-/// Creates a link for each span in the range @p begin to @p end.
+/// Creates a link for each sampled span in the range @p begin to @p end.
 auto MakeLinks(Spans::const_iterator begin, Spans::const_iterator end) {
   Links links;
-  std::transform(begin, end, std::back_inserter(links),
+  Spans sampled_spans;
+  std::copy_if(begin, end, std::back_inserter(sampled_spans),
+               [](auto const& span) { return span->GetContext().IsSampled(); });
+  std::transform(sampled_spans.begin(), sampled_spans.end(),
+                 std::back_inserter(links),
                  [i = static_cast<std::int64_t>(0)](auto const& span) mutable {
                    return std::make_pair(
                        span->GetContext(),

--- a/google/cloud/pubsub/internal/tracing_message_batch_test.cc
+++ b/google/cloud/pubsub/internal/tracing_message_batch_test.cc
@@ -156,7 +156,7 @@ TEST(TracingMessageBatch, FlushOnlyIncludeSampledLink) {
                              SpanNamed("BatchSink::AsyncPublish"),
                              SpanHasAttributes(OTelAttribute<std::int64_t>(
                                  sc::kMessagingBatchMessageCount, 2)),
-                             SpanHasLinks(AllOf(
+                             SpanLinksAre(AllOf(
                                  LinkHasSpanContext(message_span->GetContext()),
                                  SpanLinkAttributesAre(OTelAttribute<int64_t>(
                                      "messaging.pubsub.message.link", 0)))))));

--- a/google/cloud/pubsub/internal/tracing_message_batch_test.cc
+++ b/google/cloud/pubsub/internal/tracing_message_batch_test.cc
@@ -102,8 +102,8 @@ TEST(TracingMessageBatch, SaveMessageAddsEvent) {
 
 TEST(TracingMessageBatch, Flush) {
   namespace sc = ::opentelemetry::trace::SemanticConventions;
-  auto message_span = MakeSpan("test span");
   auto span_catcher = InstallSpanCatcher();
+  auto message_span = MakeSpan("test span");
   auto mock = std::make_unique<pubsub_testing::MockMessageBatch>();
   EXPECT_CALL(*mock, SaveMessage(_));
   EXPECT_CALL(*mock, Flush).WillOnce([] {
@@ -130,11 +130,43 @@ TEST(TracingMessageBatch, Flush) {
                                      "messaging.pubsub.message.link", 0)))))));
 }
 
+TEST(TracingMessageBatch, FlushOnlyIncludeSampledLink) {
+  namespace sc = ::opentelemetry::trace::SemanticConventions;
+  // Create span before the span catcher so it is not sampled.
+  auto unsampled_span = MakeSpan("test skipped span");
+  auto span_catcher = InstallSpanCatcher();
+  auto message_span = MakeSpan("test span");
+  auto mock = std::make_unique<pubsub_testing::MockMessageBatch>();
+  EXPECT_CALL(*mock, SaveMessage(_)).Times(2);
+  EXPECT_CALL(*mock, Flush).WillOnce([] {
+    EXPECT_TRUE(ThereIsAnActiveSpan());
+    EXPECT_TRUE(OTelContextCaptured());
+    return [](auto) { EXPECT_FALSE(OTelContextCaptured()); };
+  });
+  auto message_batch = MakeTracingMessageBatch(std::move(mock));
+  auto initial_spans = {message_span, unsampled_span};
+  SaveMessages(initial_spans, message_batch);
+
+  auto end_spans = message_batch->Flush();
+  end_spans(make_ready_future());
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(spans,
+              Contains(AllOf(SpanHasInstrumentationScope(), SpanKindIsClient(),
+                             SpanNamed("BatchSink::AsyncPublish"),
+                             SpanHasAttributes(OTelAttribute<std::int64_t>(
+                                 sc::kMessagingBatchMessageCount, 2)),
+                             SpanHasLinks(AllOf(
+                                 LinkHasSpanContext(message_span->GetContext()),
+                                 SpanLinkAttributesAre(OTelAttribute<int64_t>(
+                                     "messaging.pubsub.message.link", 0)))))));
+}
+
 TEST(TracingMessageBatch, FlushSmallBatch) {
   namespace sc = ::opentelemetry::trace::SemanticConventions;
+  auto span_catcher = InstallSpanCatcher();
   auto message_span1 = MakeSpan("test span 1");
   auto message_span2 = MakeSpan("test span 2");
-  auto span_catcher = InstallSpanCatcher();
   auto mock = std::make_shared<pubsub_testing::MockMessageBatch>();
   EXPECT_CALL(*mock, SaveMessage(_)).Times(2);
   EXPECT_CALL(*mock, Flush).WillOnce([] {
@@ -173,10 +205,9 @@ TEST(TracingMessageBatch, FlushBatchWithOtelLimit) {
     EXPECT_TRUE(ThereIsAnActiveSpan());
     return [](auto) {};
   });
+  auto span_catcher = InstallSpanCatcher();
   auto message_batch = MakeTracingMessageBatch(std::move(mock));
   SaveMessages(CreateSpans(kBatchSize), message_batch);
-  // Only catch the batch sink spans.
-  auto span_catcher = InstallSpanCatcher();
 
   auto end_spans = message_batch->Flush();
   end_spans(make_ready_future());
@@ -199,10 +230,9 @@ TEST(TracingMessageBatch, FlushLargeBatch) {
     EXPECT_TRUE(ThereIsAnActiveSpan());
     return [](auto) {};
   });
+  auto span_catcher = InstallSpanCatcher();
   auto message_batch = MakeTracingMessageBatch(std::move(mock));
   SaveMessages(CreateSpans(kBatchSize), message_batch);
-  // Only catch the batch sink spans.
-  auto span_catcher = InstallSpanCatcher();
 
   auto end_spans = message_batch->Flush();
   end_spans(make_ready_future());
@@ -287,8 +317,6 @@ TEST(TracingMessageBatch, FlushAddsEventForMultipleMessages) {
                          SpanNamed("test span 1"),
                          SpanHasEvents(EventNamed("gl-cpp.batch_flushed")))));
 }
-
-// TODO(#12528): Add an end to end test.
 
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/testing_util/opentelemetry_matchers.cc
+++ b/google/cloud/testing_util/opentelemetry_matchers.cc
@@ -183,7 +183,8 @@ bool OTelContextCaptured() {
 SpanCatcher::SpanCatcher()
     : previous_(opentelemetry::trace::Provider::GetTracerProvider()) {
   auto exporter =
-      std::make_unique<opentelemetry::exporter::memory::InMemorySpanExporter>();
+      std::make_unique<opentelemetry::exporter::memory::InMemorySpanExporter>(
+          1000);
   span_data_ = exporter->GetData();
   auto processor =
       std::make_unique<opentelemetry::sdk::trace::SimpleSpanProcessor>(


### PR DESCRIPTION
It needs to increase the span catcher buffer size since the default is 100 (https://github.com/open-telemetry/opentelemetry-cpp/blob/ca08c5a34ad4af1b6b392c8bf5fc26a5210a2f2c/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h#L17)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13043)
<!-- Reviewable:end -->
