### PR TITLE
impl(GCS+gRPC): `AsyncWriteObject()`, part 2/2

### DIFF
--- a/google/cloud/storage/internal/async/connection_impl.h
+++ b/google/cloud/storage/internal/async/connection_impl.h
@@ -80,11 +80,21 @@ class AsyncConnectionImpl
   AsyncStartResumableWrite(internal::ImmutableOptions current,
                            storage::internal::ResumableUploadRequest request);
 
+  future<StatusOr<google::storage::v2::QueryWriteStatusResponse>>
+  AsyncQueryWriteStatus(internal::ImmutableOptions current,
+                        storage::internal::QueryResumableUploadRequest request);
+
   future<StatusOr<std::unique_ptr<storage_experimental::AsyncWriterConnection>>>
   WriteObjectImpl(
       internal::ImmutableOptions current,
       storage_experimental::ResumableUploadRequest request,
       StatusOr<google::storage::v2::StartResumableWriteResponse> response);
+
+  future<StatusOr<std::unique_ptr<storage_experimental::AsyncWriterConnection>>>
+  WriteObjectImpl(
+      internal::ImmutableOptions current,
+      storage_experimental::ResumableUploadRequest request,
+      StatusOr<google::storage::v2::QueryWriteStatusResponse> response);
 
   future<StatusOr<std::unique_ptr<storage_experimental::AsyncWriterConnection>>>
   WriteObjectImpl(

--- a/google/cloud/storage/internal/async/connection_impl_test.cc
+++ b/google/cloud/storage/internal/async/connection_impl_test.cc
@@ -563,6 +563,189 @@ TEST_F(AsyncConnectionImplTest, AsyncWriteObjectNewUpload) {
   next.first.set_value(true);
 }
 
+TEST_F(AsyncConnectionImplTest, AsyncWriteObjectResumeUpload) {
+  AsyncSequencer<bool> sequencer;
+  auto mock = std::make_shared<storage::testing::MockStorageStub>();
+  EXPECT_CALL(*mock, AsyncQueryWriteStatus)
+      .WillOnce([&] {
+        return sequencer.PushBack("QueryWriteStatus(1)").then([](auto) {
+          return StatusOr<google::storage::v2::QueryWriteStatusResponse>(
+              TransientError());
+        });
+      })
+      .WillOnce(
+          [&](auto&, auto,
+              google::storage::v2::QueryWriteStatusRequest const& request) {
+            EXPECT_EQ(request.upload_id(), "test-upload-id");
+
+            return sequencer.PushBack("QueryWriteStatus(2)").then([](auto) {
+              auto response = google::storage::v2::QueryWriteStatusResponse{};
+              response.set_persisted_size(16384);
+              return make_status_or(response);
+            });
+          });
+  EXPECT_CALL(*mock, AsyncBidiWriteObject)
+      .WillOnce(
+          [&] { return MakeErrorBidiWriteStream(sequencer, TransientError()); })
+      .WillOnce([&]() {
+        auto stream = std::make_unique<MockAsyncBidiWriteObjectStream>();
+        EXPECT_CALL(*stream, Start).WillOnce([&] {
+          return sequencer.PushBack("Start");
+        });
+        EXPECT_CALL(*stream, Write)
+            .WillOnce(
+                [&](google::storage::v2::BidiWriteObjectRequest const& request,
+                    grpc::WriteOptions wopt) {
+                  EXPECT_TRUE(request.has_upload_id());
+                  EXPECT_EQ(request.upload_id(), "test-upload-id");
+                  EXPECT_FALSE(wopt.is_last_message());
+                  return sequencer.PushBack("Write");
+                })
+            .WillOnce(
+                [&](google::storage::v2::BidiWriteObjectRequest const& request,
+                    grpc::WriteOptions wopt) {
+                  EXPECT_FALSE(request.has_upload_id());
+                  EXPECT_TRUE(request.finish_write());
+                  EXPECT_TRUE(request.has_object_checksums());
+                  EXPECT_TRUE(wopt.is_last_message());
+                  return sequencer.PushBack("Write");
+                });
+        EXPECT_CALL(*stream, Read).WillOnce([&] {
+          return sequencer.PushBack("Read").then([](auto) {
+            auto response = google::storage::v2::BidiWriteObjectResponse{};
+            response.mutable_resource()->set_bucket(
+                "projects/_/buckets/test-bucket");
+            response.mutable_resource()->set_name("test-object");
+            response.mutable_resource()->set_generation(123456);
+            return absl::make_optional(std::move(response));
+          });
+        });
+        EXPECT_CALL(*stream, Cancel).Times(1);
+        EXPECT_CALL(*stream, Finish).WillOnce([&] {
+          return sequencer.PushBack("Finish").then(
+              [](auto) { return Status{}; });
+        });
+        return std::unique_ptr<AsyncBidiWriteObjectStream>(std::move(stream));
+      });
+
+  internal::AutomaticallyCreatedBackgroundThreads pool(1);
+  auto connection = MakeTestConnection(pool.cq(), mock);
+  auto pending = connection->AsyncWriteObject(
+      {storage_experimental::ResumableUploadRequest("test-bucket",
+                                                    "test-object")
+           .set_multiple_options(
+               storage::UseResumableUploadSession("test-upload-id")),
+       connection->options()});
+
+  auto next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "QueryWriteStatus(1)");
+  next.first.set_value(true);
+
+  next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "QueryWriteStatus(2)");
+  next.first.set_value(true);
+
+  next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "Start");
+  next.first.set_value(false);  // The first stream fails
+
+  next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "Finish");
+  next.first.set_value(false);
+
+  next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "Start");
+  next.first.set_value(true);
+
+  auto r = pending.get();
+  ASSERT_STATUS_OK(r);
+  auto writer = *std::move(r);
+  EXPECT_EQ(writer->UploadId(), "test-upload-id");
+  EXPECT_EQ(absl::get<std::int64_t>(writer->PersistedState()), 16384);
+
+  auto w1 = writer->Write({});
+  next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "Write");
+  next.first.set_value(true);
+  EXPECT_STATUS_OK(w1.get());
+
+  auto w2 = writer->Finalize({});
+  next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "Write");
+  next.first.set_value(true);
+  next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "Read");
+  next.first.set_value(true);
+
+  auto response = w2.get();
+  ASSERT_STATUS_OK(response);
+  EXPECT_EQ(response->bucket(), "test-bucket");
+  EXPECT_EQ(response->name(), "test-object");
+  EXPECT_EQ(response->generation(), 123456);
+
+  writer.reset();
+  next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "Finish");
+  next.first.set_value(true);
+}
+
+TEST_F(AsyncConnectionImplTest, AsyncWriteObjectResumeFinalizedUpload) {
+  AsyncSequencer<bool> sequencer;
+  auto mock = std::make_shared<storage::testing::MockStorageStub>();
+  EXPECT_CALL(*mock, AsyncQueryWriteStatus)
+      .WillOnce([&] {
+        return sequencer.PushBack("QueryWriteStatus(1)").then([](auto) {
+          return StatusOr<google::storage::v2::QueryWriteStatusResponse>(
+              TransientError());
+        });
+      })
+      .WillOnce(
+          [&](auto&, auto,
+              google::storage::v2::QueryWriteStatusRequest const& request) {
+            EXPECT_EQ(request.upload_id(), "test-upload-id");
+
+            return sequencer.PushBack("QueryWriteStatus(2)").then([](auto) {
+              auto response = google::storage::v2::QueryWriteStatusResponse{};
+              response.mutable_resource()->set_bucket(
+                  "projects/_/buckets/test-bucket");
+              response.mutable_resource()->set_name("test-object");
+              response.mutable_resource()->set_generation(123456);
+              return make_status_or(response);
+            });
+          });
+  EXPECT_CALL(*mock, AsyncBidiWriteObject).Times(0);
+
+  internal::AutomaticallyCreatedBackgroundThreads pool(1);
+  auto connection = MakeTestConnection(pool.cq(), mock);
+  auto pending = connection->AsyncWriteObject(
+      {storage_experimental::ResumableUploadRequest("test-bucket",
+                                                    "test-object")
+           .set_multiple_options(
+               storage::UseResumableUploadSession("test-upload-id")),
+       connection->options()});
+
+  auto next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "QueryWriteStatus(1)");
+  next.first.set_value(true);
+
+  next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "QueryWriteStatus(2)");
+  next.first.set_value(true);
+
+  auto r = pending.get();
+  ASSERT_STATUS_OK(r);
+  auto writer = *std::move(r);
+  EXPECT_EQ(writer->UploadId(), "test-upload-id");
+  ASSERT_TRUE(absl::holds_alternative<storage::ObjectMetadata>(
+      writer->PersistedState()));
+  auto metadata = absl::get<storage::ObjectMetadata>(writer->PersistedState());
+  EXPECT_EQ(metadata.bucket(), "test-bucket");
+  EXPECT_EQ(metadata.name(), "test-object");
+  EXPECT_EQ(metadata.generation(), 123456);
+
+  writer.reset();
+}
+
 TEST_F(AsyncConnectionImplTest,
        AsyncWriteObjectTooManyTransientsOnStartResumableWrite) {
   AsyncSequencer<bool> sequencer;
@@ -635,6 +818,64 @@ TEST_F(AsyncConnectionImplTest, AsyncWriteObjectInvalidRequest) {
 
   auto r = pending.get();
   EXPECT_THAT(r, StatusIs(StatusCode::kInvalidArgument));
+}
+
+TEST_F(AsyncConnectionImplTest,
+       AsyncWriteObjectTooManyTransientsOnQueryWriteStatus) {
+  AsyncSequencer<bool> sequencer;
+  auto mock = std::make_shared<storage::testing::MockStorageStub>();
+  EXPECT_CALL(*mock, AsyncQueryWriteStatus).Times(3).WillRepeatedly([&] {
+    return sequencer.PushBack("QueryWriteStatus").then([](auto) {
+      return StatusOr<google::storage::v2::QueryWriteStatusResponse>(
+          TransientError());
+    });
+  });
+
+  internal::AutomaticallyCreatedBackgroundThreads pool(1);
+  auto connection = MakeTestConnection(pool.cq(), mock);
+  auto pending = connection->AsyncWriteObject(
+      {storage_experimental::ResumableUploadRequest("test-bucket",
+                                                    "test-object")
+           .set_multiple_options(
+               storage::UseResumableUploadSession("test-upload-id")),
+       connection->options()});
+
+  for (int i = 0; i != 3; ++i) {
+    auto next = sequencer.PopFrontWithName();
+    EXPECT_EQ(next.second, "QueryWriteStatus");
+    next.first.set_value(false);
+  }
+
+  auto r = pending.get();
+  EXPECT_THAT(r, StatusIs(TransientError().code()));
+}
+
+TEST_F(AsyncConnectionImplTest,
+       AsyncWriteObjectPermanentErrorOnQueryWriteStatus) {
+  AsyncSequencer<bool> sequencer;
+  auto mock = std::make_shared<storage::testing::MockStorageStub>();
+  EXPECT_CALL(*mock, AsyncQueryWriteStatus).WillOnce([&] {
+    return sequencer.PushBack("QueryWriteStatus").then([](auto) {
+      return StatusOr<google::storage::v2::QueryWriteStatusResponse>(
+          PermanentError());
+    });
+  });
+
+  internal::AutomaticallyCreatedBackgroundThreads pool(1);
+  auto connection = MakeTestConnection(pool.cq(), mock);
+  auto pending = connection->AsyncWriteObject(
+      {storage_experimental::ResumableUploadRequest("test-bucket",
+                                                    "test-object")
+           .set_multiple_options(
+               storage::UseResumableUploadSession("test-upload-id")),
+       connection->options()});
+
+  auto next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "QueryWriteStatus");
+  next.first.set_value(false);
+
+  auto r = pending.get();
+  EXPECT_THAT(r, StatusIs(PermanentError().code()));
 }
 
 TEST_F(AsyncConnectionImplTest, AsyncWriteObjectTooManyTransients) {


### PR DESCRIPTION
Complete the implementation of `AsyncWriteObject()`. This adds support for resuming uploads.

Part of the work for #9134

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13044)
<!-- Reviewable:end -->
