### PR TITLE
ci: no mdformat for CHANGELOG.md

### DIFF
--- a/ci/cloudbuild/builds/checkers.sh
+++ b/ci/cloudbuild/builds/checkers.sh
@@ -216,7 +216,7 @@ time {
 printf "%-50s" "Running markdown formatter:" >&2
 time {
   # See `.mdformat.toml` for the configuration parameters.
-  git_files -z -- '*.md' | grep -zv CHANGELOG.md | xargs -r -P "$(nproc)" -n 50 -0 mdformat
+  git_files -z -- '*.md' ':!./CHANGELOG.md' | xargs -r -P "$(nproc)" -n 50 -0 mdformat
   git_files -z -- '*.md' | xargs -r -0 chmod go=u-w
 }
 

--- a/ci/cloudbuild/builds/checkers.sh
+++ b/ci/cloudbuild/builds/checkers.sh
@@ -217,7 +217,7 @@ printf "%-50s" "Running markdown formatter:" >&2
 time {
   # See `.mdformat.toml` for the configuration parameters.
   git_files -z -- '*.md' ':!./CHANGELOG.md' | xargs -r -P "$(nproc)" -n 50 -0 mdformat
-  git_files -z -- '*.md' | xargs -r -0 chmod go=u-w
+  git_files -z -- '*.md' ':!./CHANGELOG.md' | xargs -r -0 chmod go=u-w
 }
 
 printf "%-50s" "Running doxygen landing-page updates:" >&2

--- a/ci/cloudbuild/builds/checkers.sh
+++ b/ci/cloudbuild/builds/checkers.sh
@@ -216,7 +216,7 @@ time {
 printf "%-50s" "Running markdown formatter:" >&2
 time {
   # See `.mdformat.toml` for the configuration parameters.
-  git_files -z -- '*.md' | xargs -r -P "$(nproc)" -n 50 -0 mdformat
+  git_files -z -- '*.md' | grep -zv CHANGELOG.md | xargs -r -P "$(nproc)" -n 50 -0 mdformat
   git_files -z -- '*.md' | xargs -r -0 chmod go=u-w
 }
 


### PR DESCRIPTION
Fixes #12785 

Release notes use a different markdown renderer than the rest of GitHub. It preserves line breaks. That bothers me, but I may be alone.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13045)
<!-- Reviewable:end -->
