### PR TITLE
fix(pubsub): fix merge conflict causing bad unit test

### DIFF
--- a/google/cloud/pubsub/internal/tracing_message_batch_test.cc
+++ b/google/cloud/pubsub/internal/tracing_message_batch_test.cc
@@ -155,15 +155,18 @@ TEST(TracingMessageBatch, FlushOnlyIncludeSampledLink) {
   end_spans(make_ready_future());
 
   auto spans = span_catcher->GetSpans();
-  EXPECT_THAT(spans,
-              Contains(AllOf(SpanHasInstrumentationScope(), SpanKindIsClient(),
-                             SpanNamed("BatchSink::AsyncPublish"),
-                             SpanHasAttributes(OTelAttribute<std::int64_t>(
-                                 sc::kMessagingBatchMessageCount, 2)),
-                             SpanLinksAre(AllOf(
-                                 LinkHasSpanContext(message_span->GetContext()),
-                                 SpanLinkAttributesAre(OTelAttribute<int64_t>(
-                                     "messaging.pubsub.message.link", 0)))))));
+  EXPECT_THAT(
+      spans,
+      Contains(AllOf(
+          SpanHasInstrumentationScope(), SpanKindIsClient(),
+          SpanNamed("publish"),
+          SpanHasAttributes(
+              OTelAttribute<std::int64_t>(sc::kMessagingBatchMessageCount, 2),
+              OTelAttribute<std::string>(sc::kCodeFunction,
+                                         "BatchSink::AsyncPublish")),
+          SpanLinksAre(AllOf(LinkHasSpanContext(message_span->GetContext()),
+                             SpanLinkAttributesAre(OTelAttribute<int64_t>(
+                                 "messaging.pubsub.message.link", 0)))))));
 }
 
 TEST(TracingMessageBatch, FlushSmallBatch) {


### PR DESCRIPTION
https://github.com/googleapis/google-cloud-cpp/pull/13039 went in before https://github.com/googleapis/google-cloud-cpp/pull/13043 so the names were not updated in the unit test 😮 

Causing all our CI builds to fail 🙃 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13046)
<!-- Reviewable:end -->
