### PR TITLE
cleanup(common): explicit options for span attr

### DIFF
--- a/google/cloud/internal/async_polling_loop.cc
+++ b/google/cloud/internal/async_polling_loop.cc
@@ -88,7 +88,7 @@ class AsyncPollingLoopImpl
 
   void OnStart(StatusOr<Operation> op) {
     if (!op) return promise_.set_value(std::move(op));
-    AddSpanAttribute("gcloud.LRO_name", op->name());
+    AddSpanAttribute(CurrentOptions(), "gl-cpp.LRO_name", op->name());
     if (op->done()) return promise_.set_value(std::move(op));
     GCP_LOG(DEBUG) << location_ << "() polling loop starting for "
                    << op->name();

--- a/google/cloud/internal/async_polling_loop_test.cc
+++ b/google/cloud/internal/async_polling_loop_test.cc
@@ -757,7 +757,7 @@ TEST(AsyncPollingLoopTest, TraceCapturesOperationName) {
   EXPECT_THAT(spans,
               ElementsAre(AllOf(SpanNamed("span"),
                                 SpanHasAttributes(OTelAttribute<std::string>(
-                                    "gcloud.LRO_name", "test-op-name")))));
+                                    "gl-cpp.LRO_name", "test-op-name")))));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/internal/async_rest_polling_loop.h
+++ b/google/cloud/internal/async_rest_polling_loop.h
@@ -262,7 +262,8 @@ class AsyncRestPollingLoopImpl
 
   void OnStart(StatusOr<OperationType> op) {
     if (!op) return promise_.set_value(std::move(op));
-    internal::AddSpanAttribute("gcloud.LRO_name", op->name());
+    internal::AddSpanAttribute(internal::CurrentOptions(), "gl-cpp.LRO_name",
+                               op->name());
     if (is_operation_done_(*op)) return promise_.set_value(std::move(op));
     GCP_LOG(DEBUG) << location_ << "() polling loop starting for "
                    << op->name();

--- a/google/cloud/internal/async_rest_polling_loop_test.cc
+++ b/google/cloud/internal/async_rest_polling_loop_test.cc
@@ -816,7 +816,7 @@ TEST(AsyncRestPollingLoopTest, TraceCapturesOperationName) {
   EXPECT_THAT(spans,
               ElementsAre(AllOf(SpanNamed("span"),
                                 SpanHasAttributes(OTelAttribute<std::string>(
-                                    "gcloud.LRO_name", "test-op-name")))));
+                                    "gl-cpp.LRO_name", "test-op-name")))));
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/internal/opentelemetry.cc
+++ b/google/cloud/internal/opentelemetry.cc
@@ -163,14 +163,14 @@ std::function<void(std::chrono::milliseconds)> MakeTracedSleeper(
 }
 
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
-void AddSpanAttribute(std::string const& key, std::string const& value) {
-  if (TracingEnabled(CurrentOptions())) {
-    auto span = opentelemetry::trace::Tracer::GetCurrentSpan();
-    span->SetAttribute(key, value);
-  }
+void AddSpanAttribute(Options const& options, std::string const& key,
+                      std::string const& value) {
+  if (!TracingEnabled(options)) return;
+  auto span = opentelemetry::trace::Tracer::GetCurrentSpan();
+  span->SetAttribute(key, value);
 }
 #else
-void AddSpanAttribute(std::string const&, std::string const&) {}
+void AddSpanAttribute(Options const&, std::string const&, std::string const&) {}
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 
 }  // namespace internal

--- a/google/cloud/internal/opentelemetry.h
+++ b/google/cloud/internal/opentelemetry.h
@@ -226,7 +226,8 @@ std::function<void(std::chrono::milliseconds)> MakeTracedSleeper(
     std::function<void(std::chrono::milliseconds)> const& sleeper);
 
 /// Adds an attribute to the active span, if tracing is enabled.
-void AddSpanAttribute(std::string const& key, std::string const& value);
+void AddSpanAttribute(Options const& options, std::string const& key,
+                      std::string const& value);
 
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/opentelemetry_test.cc
+++ b/google/cloud/internal/opentelemetry_test.cc
@@ -409,8 +409,7 @@ TEST(OpenTelemetry, AddSpanAttributeEnabled) {
 
   auto span = MakeSpan("span");
   auto scope = opentelemetry::trace::Scope(span);
-  OptionsSpan o(EnableTracing(Options{}));
-  AddSpanAttribute("key", "value");
+  AddSpanAttribute(EnableTracing(Options{}), "key", "value");
   span->End();
 
   auto spans = span_catcher->GetSpans();
@@ -425,8 +424,7 @@ TEST(OpenTelemetry, AddSpanAttributeDisabled) {
 
   auto span = MakeSpan("span");
   auto scope = opentelemetry::trace::Scope(span);
-  OptionsSpan o(DisableTracing(Options{}));
-  AddSpanAttribute("key", "value");
+  AddSpanAttribute(DisableTracing(Options{}), "key", "value");
   span->End();
 
   auto spans = span_catcher->GetSpans();


### PR DESCRIPTION
Require explicit options to set attributes in the current span.

Part of the work for #12359 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13048)
<!-- Reviewable:end -->
