### PR TITLE
cleanup: explicit options for LRO polling loop

### DIFF
--- a/google/cloud/internal/async_long_running_operation.h
+++ b/google/cloud/internal/async_long_running_operation.h
@@ -118,8 +118,8 @@ template <typename ReturnType, typename RequestType, typename StartFunctor,
           typename RetryPolicyType>
 future<StatusOr<ReturnType>> AsyncLongRunningOperation(
     google::cloud::CompletionQueue cq, RequestType&& request,
-    StartFunctor&& start, AsyncPollLongRunningOperation poll,
-    AsyncCancelLongRunningOperation cancel,
+    StartFunctor&& start, AsyncPollLongRunningOperationImplicitOptions poll,
+    AsyncCancelLongRunningOperationImplicitOptions cancel,
     LongRunningOperationValueExtractor<ReturnType> value_extractor,
     std::unique_ptr<RetryPolicyType> retry_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy, Idempotency idempotent,

--- a/google/cloud/internal/async_long_running_operation_test.cc
+++ b/google/cloud/internal/async_long_running_operation_test.cc
@@ -95,14 +95,16 @@ StartOperation MakeStart(std::shared_ptr<MockStub> const& m) {
   };
 }
 
-AsyncPollLongRunningOperation MakePoll(std::shared_ptr<MockStub> const& m) {
+AsyncPollLongRunningOperationImplicitOptions MakePoll(
+    std::shared_ptr<MockStub> const& m) {
   return [m](CompletionQueue& cq, auto context,
              google::longrunning::GetOperationRequest const& request) {
     return m->AsyncGetOperation(cq, std::move(context), request);
   };
 }
 
-AsyncCancelLongRunningOperation MakeCancel(std::shared_ptr<MockStub> const& m) {
+AsyncCancelLongRunningOperationImplicitOptions MakeCancel(
+    std::shared_ptr<MockStub> const& m) {
   return [m](CompletionQueue& cq, auto context,
              google::longrunning::CancelOperationRequest const& request) {
     return m->AsyncCancelOperation(cq, std::move(context), request);


### PR DESCRIPTION
Part of the work for #12359

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13049)
<!-- Reviewable:end -->
