### PR TITLE
fix: leave arrays in json

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/json_utils.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/json_utils.cc
@@ -109,9 +109,6 @@ nlohmann::json RemoveJsonKeysAndEmptyFields(
         if (event == nlohmann::json::parse_event_t::object_end) {
           return parsed != nullptr && !parsed.empty();
         }
-        if (event == nlohmann::json::parse_event_t::array_end) {
-          return !parsed.empty();
-        }
         return true;
       };
   return nlohmann::json::parse(json_payload, remove_empty_call_back, false);

--- a/google/cloud/bigquery/v2/minimal/internal/json_utils_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/json_utils_test.cc
@@ -229,17 +229,6 @@ TEST(JsonUtilsTest, RemoveKeys) {
   EXPECT_EQ(expected, json.dump());
 }
 
-TEST(JsonUtilsTest, RemoveEmptyArrays) {
-  std::vector<std::string> keys = {"start_time", "query_parameters"};
-  auto constexpr kJsonText =
-      R"({"start_time":"10", "project_id": "1", "query_parameters":[]})";
-
-  auto json = RemoveJsonKeysAndEmptyFields(kJsonText, keys);
-  auto const* expected = R"({"project_id":"1"})";
-
-  EXPECT_EQ(expected, json.dump());
-}
-
 TEST(JsonUtilsTest, RemoveEmptyObjects) {
   std::vector<std::string> keys = {"start_time", "query"};
   auto constexpr kJsonText =


### PR DESCRIPTION
This functionality replaces all arrays with `<discarded>` value, making the json invalid. It happens even if the array is not empty.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13052)
<!-- Reviewable:end -->
