### PR TITLE
refactor: clock interface into common

### DIFF
--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -38,6 +38,7 @@ google_cloud_cpp_common_hdrs = [
     "internal/big_endian.h",
     "internal/build_info.h",
     "internal/call_context.h",
+    "internal/clock.h",
     "internal/compiler_info.h",
     "internal/compute_engine_util.h",
     "internal/credentials_impl.h",

--- a/google/cloud/google_cloud_cpp_common.cmake
+++ b/google/cloud/google_cloud_cpp_common.cmake
@@ -56,6 +56,7 @@ add_library(
     internal/big_endian.h
     internal/build_info.h
     internal/call_context.h
+    internal/clock.h
     internal/compiler_info.cc
     internal/compiler_info.h
     internal/compute_engine_util.cc
@@ -334,6 +335,7 @@ if (BUILD_TESTING)
         internal/base64_transforms_test.cc
         internal/big_endian_test.cc
         internal/call_context_test.cc
+        internal/clock_test.cc
         internal/compiler_info_test.cc
         internal/compute_engine_util_test.cc
         internal/credentials_impl_test.cc

--- a/google/cloud/google_cloud_cpp_common_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_common_unit_tests.bzl
@@ -30,6 +30,7 @@ google_cloud_cpp_common_unit_tests = [
     "internal/base64_transforms_test.cc",
     "internal/big_endian_test.cc",
     "internal/call_context_test.cc",
+    "internal/clock_test.cc",
     "internal/compiler_info_test.cc",
     "internal/compute_engine_util_test.cc",
     "internal/credentials_impl_test.cc",

--- a/google/cloud/internal/clock.h
+++ b/google/cloud/internal/clock.h
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_CLOCK_H
-#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_CLOCK_H
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_CLOCK_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_CLOCK_H
 
-#include "google/cloud/spanner/version.h"
+#include "google/cloud/version.h"
 #include <chrono>
 
 namespace google {
 namespace cloud {
-namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
 
 /**
  * A simple `Clock` class that can be overridden for testing.
@@ -45,19 +45,17 @@ class Clock {
  * `SteadyClock` is a monotonic clock where time points cannot decrease as
  * physical time moves forward. It is not related to wall clock time.
  */
-using SteadyClock =
-    ::google::cloud::spanner_internal::Clock<std::chrono::steady_clock>;
+using SteadyClock = ::google::cloud::internal::Clock<std::chrono::steady_clock>;
 
 /**
  * `SystemClock` represents the system-wide real time wall clock.
  * It may not be monotonic.
  */
-using SystemClock =
-    ::google::cloud::spanner_internal::Clock<std::chrono::system_clock>;
+using SystemClock = ::google::cloud::internal::Clock<std::chrono::system_clock>;
 
+}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace spanner_internal
 }  // namespace cloud
 }  // namespace google
 
-#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_CLOCK_H
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_CLOCK_H

--- a/google/cloud/internal/clock_test.cc
+++ b/google/cloud/internal/clock_test.cc
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/spanner/internal/clock.h"
-#include "google/cloud/spanner/testing/fake_clock.h"
+#include "google/cloud/internal/clock.h"
+#include "google/cloud/testing_util/fake_clock.h"
 #include <gmock/gmock.h>
 #include <memory>
 
 namespace google {
 namespace cloud {
-namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
 namespace {
 
-using ::google::cloud::spanner_testing::FakeClock;
+using ::google::cloud::testing_util::FakeClock;
 
 TEST(Clock, SteadyClock) {
   auto clock = std::make_shared<SteadyClock>();
@@ -62,7 +62,7 @@ TEST(Clock, FakeClock) {
 }
 
 }  // namespace
+}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace spanner_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -123,7 +123,6 @@ add_library(
     instance_admin_connection.cc
     instance_admin_connection.h
     internal/channel.h
-    internal/clock.h
     internal/connection_impl.cc
     internal/connection_impl.h
     internal/database_admin_logging.cc
@@ -343,7 +342,6 @@ function (spanner_client_define_tests)
         testing/database_integration_test.h
         testing/debug_log.cc
         testing/debug_log.h
-        testing/fake_clock.h
         testing/instance_location.cc
         testing/instance_location.h
         testing/matchers.h
@@ -394,7 +392,6 @@ function (spanner_client_define_tests)
         instance_admin_client_test.cc
         instance_admin_connection_test.cc
         instance_test.cc
-        internal/clock_test.cc
         internal/connection_impl_test.cc
         internal/database_admin_logging_test.cc
         internal/database_admin_metadata_test.cc

--- a/google/cloud/spanner/google_cloud_cpp_spanner.bzl
+++ b/google/cloud/spanner/google_cloud_cpp_spanner.bzl
@@ -68,7 +68,6 @@ google_cloud_cpp_spanner_hdrs = [
     "instance_admin_client.h",
     "instance_admin_connection.h",
     "internal/channel.h",
-    "internal/clock.h",
     "internal/connection_impl.h",
     "internal/database_admin_logging.h",
     "internal/database_admin_metadata.h",

--- a/google/cloud/spanner/internal/session.h
+++ b/google/cloud/spanner/internal/session.h
@@ -16,8 +16,8 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_SESSION_H
 
 #include "google/cloud/spanner/internal/channel.h"
-#include "google/cloud/spanner/internal/clock.h"
 #include "google/cloud/spanner/version.h"
+#include "google/cloud/internal/clock.h"
 #include <atomic>
 #include <memory>
 #include <string>
@@ -35,7 +35,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  */
 class Session {
  public:
-  using Clock = ::google::cloud::spanner_internal::SteadyClock;
+  using Clock = ::google::cloud::internal::SteadyClock;
   Session(std::string session_name, std::shared_ptr<Channel> channel,
           std::shared_ptr<Clock> clock = std::make_shared<Clock>())
       : session_name_(std::move(session_name)),

--- a/google/cloud/spanner/internal/session_pool_test.cc
+++ b/google/cloud/spanner/internal/session_pool_test.cc
@@ -13,16 +13,16 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/internal/session_pool.h"
-#include "google/cloud/spanner/internal/clock.h"
 #include "google/cloud/spanner/internal/defaults.h"
 #include "google/cloud/spanner/internal/session.h"
 #include "google/cloud/spanner/options.h"
-#include "google/cloud/spanner/testing/fake_clock.h"
 #include "google/cloud/spanner/testing/mock_spanner_stub.h"
 #include "google/cloud/spanner/testing/status_utils.h"
 #include "google/cloud/spanner/timestamp.h"
 #include "google/cloud/internal/background_threads_impl.h"
+#include "google/cloud/internal/clock.h"
 #include "google/cloud/status.h"
+#include "google/cloud/testing_util/fake_clock.h"
 #include "google/cloud/testing_util/fake_completion_queue_impl.h"
 #include "google/cloud/testing_util/mock_async_response_reader.h"
 #include "google/cloud/testing_util/status_matchers.h"
@@ -44,8 +44,8 @@ namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-using ::google::cloud::spanner_testing::FakeSteadyClock;
 using ::google::cloud::testing_util::FakeCompletionQueueImpl;
+using ::google::cloud::testing_util::FakeSteadyClock;
 using ::google::cloud::testing_util::StatusIs;
 using ::google::protobuf::TextFormat;
 using ::testing::_;

--- a/google/cloud/spanner/spanner_client_testing.bzl
+++ b/google/cloud/spanner/spanner_client_testing.bzl
@@ -21,7 +21,6 @@ spanner_client_testing_hdrs = [
     "testing/cleanup_stale_instances.h",
     "testing/database_integration_test.h",
     "testing/debug_log.h",
-    "testing/fake_clock.h",
     "testing/instance_location.h",
     "testing/matchers.h",
     "testing/mock_database_admin_stub.h",

--- a/google/cloud/spanner/spanner_client_unit_tests.bzl
+++ b/google/cloud/spanner/spanner_client_unit_tests.bzl
@@ -30,7 +30,6 @@ spanner_client_unit_tests = [
     "instance_admin_client_test.cc",
     "instance_admin_connection_test.cc",
     "instance_test.cc",
-    "internal/clock_test.cc",
     "internal/connection_impl_test.cc",
     "internal/database_admin_logging_test.cc",
     "internal/database_admin_metadata_test.cc",

--- a/google/cloud/testing_util/CMakeLists.txt
+++ b/google/cloud/testing_util/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(
     example_driver.h
     expect_exception.h
     expect_future_error.h
+    fake_clock.h
     integration_test.cc
     integration_test.h
     mock_async_streaming_read_rpc.h

--- a/google/cloud/testing_util/fake_clock.h
+++ b/google/cloud/testing_util/fake_clock.h
@@ -12,17 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_TESTING_FAKE_CLOCK_H
-#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_TESTING_FAKE_CLOCK_H
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_FAKE_CLOCK_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_FAKE_CLOCK_H
 
-#include "google/cloud/spanner/internal/clock.h"
-#include "google/cloud/spanner/version.h"
+#include "google/cloud/internal/clock.h"
+#include "google/cloud/version.h"
 #include <mutex>
 
 namespace google {
 namespace cloud {
-namespace spanner_testing {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace testing_util {
 
 /**
  * A fake clock intended for use in tests.
@@ -60,13 +60,13 @@ class FakeClock : public RealClock {
   time_point now_;
 };
 
-using FakeSteadyClock = FakeClock<google::cloud::spanner_internal::SteadyClock>;
+using FakeSteadyClock = FakeClock<google::cloud::internal::SteadyClock>;
 
-using FakeSystemClock = FakeClock<google::cloud::spanner_internal::SystemClock>;
+using FakeSystemClock = FakeClock<google::cloud::internal::SystemClock>;
 
+}  // namespace testing_util
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace spanner_testing
 }  // namespace cloud
 }  // namespace google
 
-#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_TESTING_FAKE_CLOCK_H
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_FAKE_CLOCK_H

--- a/google/cloud/testing_util/google_cloud_cpp_testing.bzl
+++ b/google/cloud/testing_util/google_cloud_cpp_testing.bzl
@@ -25,6 +25,7 @@ google_cloud_cpp_testing_hdrs = [
     "example_driver.h",
     "expect_exception.h",
     "expect_future_error.h",
+    "fake_clock.h",
     "integration_test.h",
     "mock_async_streaming_read_rpc.h",
     "mock_async_streaming_write_rpc.h",


### PR DESCRIPTION
Part of the work for #12959 

Move `spanner_internal::Clock` (and its associated classes) into common.

In bigtable, I am going to have a few interfaces (I think 4) that will need to know `Clock::now()`. I could always accept `time_point now` as an argument to all of these interfaces.... but the code would be unnecessarily verbose. I would rather initialize the objects with a generic `Clock` and call `Clock::now()` in the implementation. Hence this refactor.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13057)
<!-- Reviewable:end -->
