### PR TITLE
ci(gha): set CLOUDSDK_PYTHON env variable

### DIFF
--- a/.github/workflows/windows-cmake.yml
+++ b/.github/workflows/windows-cmake.yml
@@ -70,8 +70,8 @@ jobs:
       with:
         python-version: '3.11'
     - uses: google-github-actions/setup-gcloud@v1
-       env:
-          CLOUDSDK_PYTHON: ${{ steps.py311.outputs.python-path }}
+      env:
+        CLOUDSDK_PYTHON: ${{ steps.py311.outputs.python-path }}
     - name: Dynamic Configuration
       id: dynamic
       shell: bash

--- a/.github/workflows/windows-cmake.yml
+++ b/.github/workflows/windows-cmake.yml
@@ -70,6 +70,8 @@ jobs:
       with:
         python-version: '3.11'
     - uses: google-github-actions/setup-gcloud@v1
+       env:
+          CLOUDSDK_PYTHON: ${{ steps.py311.outputs.python-path }}
     - name: Dynamic Configuration
       id: dynamic
       shell: bash


### PR DESCRIPTION
Fix the error in the cmake builds

```
Error: google-github-actions/setup-gcloud failed with: failed to execute command `gcloud.cmd --quiet auth login --force --cred-file C:\a\google-cloud-cpp\google-cloud-cpp\gha-creds-5220443cfe4db9bc.json`: ERROR: gcloud failed to load. You are running gcloud with Python 3.7, which is no longer supported by gcloud
```

[Failed build](https://github.com/googleapis/google-cloud-cpp/actions/runs/6766491508)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13058)
<!-- Reviewable:end -->
