### PR TITLE
impl(bigquery): return empty list if BQ API doesn't populate datasets

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/dataset_response_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset_response_test.cc
@@ -170,16 +170,18 @@ TEST(ListDatasetsResponseTest, InvalidJson) {
                        HasSubstr("Error parsing Json from response payload")));
 }
 
-TEST(ListDatasetsResponseTest, InvalidDatasetList) {
+TEST(ListDatasetsResponseTest, EmptyDatasetList) {
   BigQueryHttpResponse http_response;
   http_response.payload =
       R"({"kind": "dkind",
           "etag": "dtag"})";
   auto const response =
       ListDatasetsResponse::BuildFromHttpResponse(http_response);
-  EXPECT_THAT(response,
-              StatusIs(StatusCode::kInternal,
-                       HasSubstr("Not a valid Json DatasetList object")));
+  ASSERT_STATUS_OK(response);
+  EXPECT_FALSE(response->http_response.payload.empty());
+  EXPECT_EQ(response->kind, "dkind");
+  EXPECT_EQ(response->etag, "dtag");
+  EXPECT_THAT(response->datasets, IsEmpty());
 }
 
 TEST(ListDatasetsResponseTest, InvalidListFormatDataset) {

--- a/google/cloud/bigquery/v2/minimal/internal/dataset_response_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset_response_test.cc
@@ -178,7 +178,7 @@ TEST(ListDatasetsResponseTest, EmptyDatasetList) {
   auto const response =
       ListDatasetsResponse::BuildFromHttpResponse(http_response);
   ASSERT_STATUS_OK(response);
-  EXPECT_FALSE(response->http_response.payload.empty());
+  EXPECT_THAT(response->http_response.payload, Not(IsEmpty()));
   EXPECT_EQ(response->kind, "dkind");
   EXPECT_EQ(response->etag, "dtag");
   EXPECT_THAT(response->datasets, IsEmpty());


### PR DESCRIPTION
If a user doesn't have permissions to datasets or there are no datasets in a project, BQ API returns only 'kind' and 'etag' field. The response status is 200. We shouldn't fail such response.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13061)
<!-- Reviewable:end -->
