### PR TITLE
impl(pubsub): add addlink api if otel version 2

### DIFF
--- a/google/cloud/pubsub/internal/tracing_message_batch.cc
+++ b/google/cloud/pubsub/internal/tracing_message_batch.cc
@@ -74,9 +74,14 @@ auto MakeParent(Links const& links, Spans const& message_spans) {
   auto trace_id = internal::ToString(context.trace_id());
   auto span_id = internal::ToString(context.span_id());
   for (auto const& message_span : message_spans) {
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+    message_span->AddEvent("gl-cpp.batch_flushed");
+    message_span->AddLink(context, {{}});
+#else
     message_span->AddEvent("gl-cpp.batch_flushed",
                            Attributes{{"pubsub.batch_sink.trace_id", trace_id},
                                       {"pubsub.batch_sink.span_id", span_id}});
+#endif
   }
   return batch_sink_parent;
 }

--- a/google/cloud/pubsub/internal/tracing_message_batch_test.cc
+++ b/google/cloud/pubsub/internal/tracing_message_batch_test.cc
@@ -386,7 +386,8 @@ TEST(TracingMessageBatch, FlushAddsLink) {
 
   EXPECT_THAT(span_catcher->GetSpans(),
               Contains(AllOf(SpanNamed("test span 0"),
-                             SpanHasLinks(AllOf(LinkHasSpanContext(_))))));
+                             SpanHasLinks(AllOf(LinkHasSpanContext(_)),
+                     SpanHasEvents(EventNamed("gl-cpp.batch_flushed")))));
 }
 #else
 


### PR DESCRIPTION
Closes https://github.com/googleapis/google-cloud-cpp/issues/12976

Follows what Otel does with the include guard (https://github.com/open-telemetry/opentelemetry-cpp/blob/35a9362732216c00a24bdd4c98ebb5f9bbaab2c5/sdk/src/trace/span.cc#L149-L176)

Lmk if I need to add a separate build to test this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13078)
<!-- Reviewable:end -->
