### PR TITLE
impl: change User-Agent prefix

### DIFF
--- a/google/cloud/bigtable/client_options_test.cc
+++ b/google/cloud/bigtable/client_options_test.cc
@@ -441,7 +441,7 @@ TEST(ClientOptionsTest, SetSslTargetNameOverride) {
 
 TEST(ClientOptionsTest, UserAgentPrefix) {
   std::string const actual = ClientOptions::UserAgentPrefix();
-  EXPECT_THAT(actual, HasSubstr("gcloud-cpp/"));
+  EXPECT_THAT(actual, HasSubstr("gl-cpp/"));
 }
 
 TEST(ClientOptionsTest, RefreshPeriod) {

--- a/google/cloud/internal/curl_rest_client_integration_test.cc
+++ b/google/cloud/internal/curl_rest_client_integration_test.cc
@@ -105,7 +105,7 @@ class RestClientIntegrationTest : public ::testing::Test {
         parsed_response,
         ResultOf(ExtractHeaders,
                  AllOf(Contains(Pair("Content-Type", "application/json")),
-                       Contains(Pair("User-Agent", HasSubstr("gcloud-cpp/"))),
+                       Contains(Pair("User-Agent", HasSubstr("gl-cpp/"))),
                        // The metadata decorator adds this header, the
                        // `CurlRestClient` should not duplicate it.
                        Not(Contains(Pair("X-Goog-Api-Client", _))))));
@@ -307,11 +307,10 @@ TEST_F(RestClientIntegrationTest, AnythingGetVerifyHeaders) {
   ASSERT_FALSE(http_method == parsed_response.end());
   EXPECT_THAT(http_method.value(), Eq("GET"));
 
-  EXPECT_THAT(
-      parsed_response,
-      ResultOf("sent headers are", ExtractHeaders,
-               AllOf(Contains(Pair("User-Agent", HasSubstr("gcloud-cpp"))),
-                     Not(Contains(Pair("X-Goog-Api-Client", _))))));
+  EXPECT_THAT(parsed_response,
+              ResultOf("sent headers are", ExtractHeaders,
+                       AllOf(Contains(Pair("User-Agent", HasSubstr("gl-cpp/"))),
+                             Not(Contains(Pair("X-Goog-Api-Client", _))))));
 }
 
 TEST_F(RestClientIntegrationTest, AnythingGetVerifyHeadersAsIfDecorated) {
@@ -340,7 +339,7 @@ TEST_F(RestClientIntegrationTest, AnythingGetVerifyHeadersAsIfDecorated) {
       parsed_response,
       ResultOf(
           "sent headers are", ExtractHeaders,
-          AllOf(Contains(Pair("User-Agent", HasSubstr("gcloud-cpp"))),
+          AllOf(Contains(Pair("User-Agent", HasSubstr("gl-cpp/"))),
                 Contains(Pair("X-Goog-Api-Client",
                               AllOf(HasSubstr("gl-cpp/"), HasSubstr("gapic/"),
                                     Not(HasSubstr("gccl/"))))))));
@@ -623,7 +622,7 @@ TEST_F(RestClientIntegrationTest, PerRequestOptions) {
   auto const products = std::vector<std::string>(
       absl::StrSplit(headers->value("User-Agent", ""), ' '));
   EXPECT_THAT(products, AllOf(Contains(p1), Contains(p2),
-                              Contains(StartsWith("gcloud-cpp/"))));
+                              Contains(StartsWith("gl-cpp/"))));
 }
 
 }  // namespace

--- a/google/cloud/internal/user_agent_prefix.cc
+++ b/google/cloud/internal/user_agent_prefix.cc
@@ -23,7 +23,7 @@ namespace internal {
 
 std::string UserAgentPrefix() {
   static auto const* const kUserAgentPrefix = new auto(
-      absl::StrCat("gcloud-cpp/", version_string(), " (", CompilerId(), "-",
+      absl::StrCat("gl-cpp/", version_string(), " (", CompilerId(), "-",
                    CompilerVersion(), "; ", CompilerFeatures(), ")"));
   return *kUserAgentPrefix;
 }

--- a/google/cloud/internal/user_agent_prefix_test.cc
+++ b/google/cloud/internal/user_agent_prefix_test.cc
@@ -28,7 +28,7 @@ using ::testing::StartsWith;
 
 TEST(UserAgentPrefix, Format) {
   auto const actual = UserAgentPrefix();
-  EXPECT_THAT(actual, StartsWith("gcloud-cpp/"));
+  EXPECT_THAT(actual, StartsWith("gl-cpp/"));
   EXPECT_THAT(actual, HasSubstr(::google::cloud::version_string()));
   EXPECT_THAT(actual, HasSubstr(::google::cloud::internal::CompilerId()));
 }

--- a/google/cloud/spanner/internal/defaults_test.cc
+++ b/google/cloud/spanner/internal/defaults_test.cc
@@ -36,7 +36,7 @@ using ::testing::StartsWith;
 // Returns a matcher that will match our user-agent string. This is a lambda so
 // we don't have to spell the exact gMock matcher type being returned.
 auto gcloud_user_agent_matcher = [] {
-  return AllOf(StartsWith("gcloud-cpp/" + VersionString()),
+  return AllOf(StartsWith("gl-cpp/" + VersionString()),
                HasSubstr(google::cloud::internal::CompilerId()),
                HasSubstr(google::cloud::internal::CompilerVersion()),
                HasSubstr(google::cloud::internal::CompilerFeatures()));


### PR DESCRIPTION
Using this prefix will let us distinguish between fully generated vs. hand-crafted libraries in Google's telemetry.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13082)
<!-- Reviewable:end -->
