### PR TITLE
cleanup(common): prepare for clang-tidy 17

### DIFF
--- a/google/cloud/completion_queue.h
+++ b/google/cloud/completion_queue.h
@@ -139,7 +139,7 @@ class CompletionQueue {
       /// @endcond
       typename Response = typename Sig::type,
       /// @cond implementation_details
-      typename std::enable_if<Sig::value, int>::type = 0
+      std::enable_if_t<Sig::value, int> = 0
       /// @endcond
       >
   future<StatusOr<Response>> MakeUnaryRpc(
@@ -206,12 +206,12 @@ class CompletionQueue {
    * @tparam Functor the type of @p functor. It must satisfy
    *     `std::is_invocable<Functor, #CompletionQueue&>`
    */
-  template <typename Functor,
-            /// @cond implementation_details
-            typename std::enable_if<
-                internal::CheckRunAsyncCallback<Functor>::value, int>::type = 0
-            /// @endcond
-            >
+  template <
+      typename Functor,
+      /// @cond implementation_details
+      std::enable_if_t<internal::CheckRunAsyncCallback<Functor>::value, int> = 0
+      /// @endcond
+      >
   void RunAsync(Functor&& functor) {
     class Wrapper : public internal::RunAsyncBase {
      public:
@@ -242,8 +242,7 @@ class CompletionQueue {
    */
   template <typename Functor,
             /// @cond implementation_details
-            typename std::enable_if<internal::is_invocable<Functor>::value,
-                                    int>::type = 0
+            std::enable_if_t<internal::is_invocable<Functor>::value, int> = 0
             /// @endcond
             >
   void RunAsync(Functor&& functor) {

--- a/google/cloud/future_generic_then_test.cc
+++ b/google/cloud/future_generic_then_test.cc
@@ -682,19 +682,9 @@ TEST(FutureTestString, conform_2_10_4_2_b) {
 //// @test Verify conformance with section 2.10 of the Concurrency TS.
 // NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestString, conform_2_10_4_2_c) {
-#if 1
   using V =
       internal::make_ready_return<std::reference_wrapper<std::string>>::type;
   static_assert(std::is_same<V, std::string&>::value, "Expected std::string&");
-#else
-  // TODO(#1410) - Implement future<R&> specialization.
-  // When T is a reference wrapper get R&.
-  std::string value("42");
-  future<std::string&> f = make_ready_future(std::ref(value));
-  EXPECT_TRUE(f.valid());
-  ASSERT_EQ(std::future_status::ready, f.wait_for(0_ms));
-  EXPECT_EQ("42", f.get());
-#endif  // 1
 }
 
 class MockFunctor {

--- a/google/cloud/internal/async_read_stream_impl.h
+++ b/google/cloud/internal/async_read_stream_impl.h
@@ -315,8 +315,8 @@ class AsyncReadStreamImpl
                                OnFinishHandler&& on_finish)
       : on_read_(std::move(on_read)), on_finish_(std::move(on_finish)) {}
 
-  typename std::decay<OnReadHandler>::type on_read_;
-  typename std::decay<OnFinishHandler>::type on_finish_;
+  std::decay_t<OnReadHandler> on_read_;
+  std::decay_t<OnFinishHandler> on_finish_;
   std::shared_ptr<grpc::ClientContext> context_;
   std::shared_ptr<CompletionQueueImpl> cq_;
   std::unique_ptr<grpc::ClientAsyncReaderInterface<Response>> reader_;
@@ -335,16 +335,19 @@ class AsyncReadStreamImpl
  */
 template <
     typename Response, typename OnReadHandler, typename OnFinishHandler,
-    typename std::enable_if<
+    std::enable_if_t<
         google::cloud::internal::is_invocable<OnReadHandler, Response>::value,
-        int>::type OnReadIsInvocableWithResponse = 0,
-    typename std::enable_if<
+        int>
+        OnReadIsInvocableWithResponse = 0,
+    std::enable_if_t<
         std::is_same<future<bool>, google::cloud::internal::invoke_result_t<
                                        OnReadHandler, Response>>::value,
-        int>::type OnReadReturnsFutureBool = 0,
-    typename std::enable_if<
+        int>
+        OnReadReturnsFutureBool = 0,
+    std::enable_if_t<
         google::cloud::internal::is_invocable<OnFinishHandler, Status>::value,
-        int>::type OnFinishIsInvocableWithStatus = 0>
+        int>
+        OnFinishIsInvocableWithStatus = 0>
 inline std::shared_ptr<
     AsyncReadStreamImpl<Response, OnReadHandler, OnFinishHandler>>
 MakeAsyncReadStreamImpl(OnReadHandler&& on_read, OnFinishHandler&& on_finish) {

--- a/google/cloud/internal/async_rest_retry_loop.h
+++ b/google/cloud/internal/async_rest_retry_loop.h
@@ -350,11 +350,11 @@ class AsyncRestRetryLoopImpl
  * Create the right AsyncRestRetryLoopImpl object and start the retry loop.
  */
 template <typename Functor, typename Request, typename RetryPolicyType,
-          typename std::enable_if<
+          std::enable_if_t<
               google::cloud::internal::is_invocable<
                   Functor, CompletionQueue&, std::unique_ptr<RestContext>,
                   Options const&, Request const&>::value,
-              int>::type = 0>
+              int> = 0>
 auto AsyncRestRetryLoop(std::unique_ptr<RetryPolicyType> retry_policy,
                         std::unique_ptr<BackoffPolicy> backoff_policy,
                         Idempotency idempotency, CompletionQueue cq,
@@ -375,12 +375,12 @@ auto AsyncRestRetryLoop(std::unique_ptr<RetryPolicyType> retry_policy,
 /**
  * Create the right AsyncRestRetryLoopImpl object and start the retry loop.
  */
-template <typename Functor, typename Request, typename RetryPolicyType,
-          typename std::enable_if<
-              google::cloud::internal::is_invocable<
-                  Functor, CompletionQueue&, std::unique_ptr<RestContext>,
-                  Request const&>::value,
-              int>::type = 0>
+template <
+    typename Functor, typename Request, typename RetryPolicyType,
+    std::enable_if_t<google::cloud::internal::is_invocable<
+                         Functor, CompletionQueue&,
+                         std::unique_ptr<RestContext>, Request const&>::value,
+                     int> = 0>
 auto AsyncRestRetryLoop(std::unique_ptr<RetryPolicyType> retry_policy,
                         std::unique_ptr<BackoffPolicy> backoff_policy,
                         Idempotency idempotency, CompletionQueue cq,

--- a/google/cloud/internal/async_retry_loop.h
+++ b/google/cloud/internal/async_retry_loop.h
@@ -345,11 +345,11 @@ class AsyncRetryLoopImpl
  * Create the right AsyncRetryLoopImpl object and start the retry loop on it.
  */
 template <typename Functor, typename Request, typename RetryPolicyType,
-          typename std::enable_if<google::cloud::internal::is_invocable<
-                                      Functor, google::cloud::CompletionQueue&,
-                                      std::shared_ptr<grpc::ClientContext>,
-                                      Options const&, Request const&>::value,
-                                  int>::type = 0>
+          std::enable_if_t<google::cloud::internal::is_invocable<
+                               Functor, google::cloud::CompletionQueue&,
+                               std::shared_ptr<grpc::ClientContext>,
+                               Options const&, Request const&>::value,
+                           int> = 0>
 auto AsyncRetryLoop(std::unique_ptr<RetryPolicyType> retry_policy,
                     std::unique_ptr<BackoffPolicy> backoff_policy,
                     Idempotency idempotency, google::cloud::CompletionQueue cq,
@@ -371,11 +371,11 @@ auto AsyncRetryLoop(std::unique_ptr<RetryPolicyType> retry_policy,
  * Create the right AsyncRetryLoopImpl object and start the retry loop on it.
  */
 template <typename Functor, typename Request, typename RetryPolicyType,
-          typename std::enable_if<
+          std::enable_if_t<
               google::cloud::internal::is_invocable<
                   Functor, google::cloud::CompletionQueue&,
                   std::shared_ptr<grpc::ClientContext>, Request const&>::value,
-              int>::type = 0>
+              int> = 0>
 auto AsyncRetryLoop(std::unique_ptr<RetryPolicyType> retry_policy,
                     std::unique_ptr<BackoffPolicy> backoff_policy,
                     Idempotency idempotency, google::cloud::CompletionQueue cq,

--- a/google/cloud/internal/async_retry_unary_rpc.h
+++ b/google/cloud/internal/async_retry_unary_rpc.h
@@ -198,15 +198,14 @@ class RetryAsyncUnaryRpc {
  *     retryable error, but the request is non-idempotent, or (d) the
  *     retry policy is expired.
  */
-template <
-    typename RPCBackoffPolicy, typename RPCRetryPolicy, typename AsyncCallType,
-    typename RequestType,
-    typename AsyncCallT = typename std::decay<AsyncCallType>::type,
-    typename RequestT = typename std::decay<RequestType>::type,
-    typename std::enable_if<google::cloud::internal::is_invocable<
-                                AsyncCallT, grpc::ClientContext*,
-                                RequestT const&, grpc::CompletionQueue*>::value,
-                            int>::type = 0>
+template <typename RPCBackoffPolicy, typename RPCRetryPolicy,
+          typename AsyncCallType, typename RequestType,
+          typename AsyncCallT = std::decay_t<AsyncCallType>,
+          typename RequestT = std::decay_t<RequestType>,
+          std::enable_if_t<google::cloud::internal::is_invocable<
+                               AsyncCallT, grpc::ClientContext*,
+                               RequestT const&, grpc::CompletionQueue*>::value,
+                           int> = 0>
 future<StatusOr<typename AsyncCallResponseType<AsyncCallT, RequestT>::type>>
 StartRetryAsyncUnaryRpc(CompletionQueue cq, char const* location,
                         std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,

--- a/google/cloud/internal/base64_transforms.cc
+++ b/google/cloud/internal/base64_transforms.cc
@@ -125,7 +125,7 @@ void Base64Encoder::Flush() {
 }
 
 std::string Base64Encoder::FlushAndPad() && {
-  switch (len_) {
+  switch (len_) {  // NOLINT(bugprone-switch-missing-default-case)
     case 2: {
       unsigned int const v = buf_[0] << 16 | buf_[1] << 8;
       rep_.push_back(kIndexToChar[v >> 18]);

--- a/google/cloud/internal/big_endian.h
+++ b/google/cloud/internal/big_endian.h
@@ -35,13 +35,11 @@ namespace internal {
 //   std::string s = EncodeBigEndian(std::int32_t{255});
 //   assert(s == std::string("\0\0\0\xFF", 4));
 //
-template <typename T,
-          typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+template <typename T, std::enable_if_t<std::is_integral<T>::value, int> = 0>
 std::string EncodeBigEndian(T value) {
   static_assert(std::numeric_limits<unsigned char>::digits == 8,
                 "This code assumes an 8-bit char");
-  using unsigned_type = typename std::make_unsigned<T>::type;
-  unsigned_type const n = *reinterpret_cast<unsigned_type*>(&value);
+  auto const n = *reinterpret_cast<std::make_unsigned_t<T>*>(&value);
   auto shift = sizeof(n) * 8;
   std::array<std::uint8_t, sizeof(n)> a;
   for (auto& c : a) {
@@ -59,8 +57,7 @@ std::string EncodeBigEndian(T value) {
 //   StatusOr<std::int32_t> decoded = DecodeBigEndian(s);
 //   if (decoded) assert(*decoded == 255);
 //
-template <typename T,
-          typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+template <typename T, std::enable_if_t<std::is_integral<T>::value, int> = 0>
 StatusOr<T> DecodeBigEndian(std::string const& value) {
   static_assert(std::numeric_limits<unsigned char>::digits == 8,
                 "This code assumes an 8-bit char");
@@ -69,7 +66,7 @@ StatusOr<T> DecodeBigEndian(std::string const& value) {
                      " bytes; expected " + std::to_string(sizeof(T));
     return Status(StatusCode::kInvalidArgument, msg);
   }
-  using unsigned_type = typename std::make_unsigned<T>::type;
+  using unsigned_type = std::make_unsigned_t<T>;
   auto shift = sizeof(T) * 8;
   unsigned_type result = 0;
   for (auto const& c : value) {

--- a/google/cloud/internal/error_context.h
+++ b/google/cloud/internal/error_context.h
@@ -97,7 +97,7 @@ class ErrorContext {
     return !(lhs == rhs);
   }
 
-  void swap(ErrorContext& rhs) { metadata_.swap(rhs.metadata_); }
+  void swap(ErrorContext& rhs) noexcept { metadata_.swap(rhs.metadata_); }
 
   template <typename... A>
   void emplace_back(A&&... a) {

--- a/google/cloud/internal/future_then_impl.h
+++ b/google/cloud/internal/future_then_impl.h
@@ -71,7 +71,7 @@ typename internal::then_helper<F, T>::future_t future<T>::then_impl(
       return functor(future<T>(std::move(state)));
     }
 
-    typename std::decay<F>::type functor;
+    std::decay_t<F> functor;
   };
 
   auto output_shared_state = local_state_type::make_continuation(
@@ -112,7 +112,7 @@ typename internal::then_helper<F, T>::future_t future<T>::then_impl(
       return functor(future<T>(std::move(state))).shared_state_;
     }
 
-    typename std::decay<F>::type functor;
+    std::decay_t<F> functor;
   };
 
   auto output_shared_state = local_state_type::make_continuation(
@@ -154,7 +154,7 @@ typename internal::then_helper<F, void>::future_t future<void>::then_impl(
       return functor(future<void>(std::move(state)));
     }
 
-    typename std::decay<F>::type functor;
+    std::decay_t<F> functor;
   };
 
   auto output_shared_state = shared_state_type::make_continuation(
@@ -194,7 +194,7 @@ typename internal::then_helper<F, void>::future_t future<void>::then_impl(
       return functor(future<void>(std::move(state))).shared_state_;
     }
 
-    typename std::decay<F>::type functor;
+    std::decay_t<F> functor;
   };
 
   auto output_shared_state = local_state_type::make_continuation(

--- a/google/cloud/internal/future_then_meta.h
+++ b/google/cloud/internal/future_then_meta.h
@@ -91,9 +91,9 @@ struct unwrap_internal<std::shared_ptr<internal::future_shared_state<U>>> {
  */
 template <
     typename Functor, typename T,
-    typename std::enable_if<
+    std::enable_if_t<
         is_invocable<Functor, std::shared_ptr<future_shared_state<T>>>::value,
-        int>::type = 0>
+        int> = 0>
 struct continuation_helper {  // NOLINT(readability-identifier-naming)
   /// The type returned by calling the functor with the given future type.
   using functor_result_t =
@@ -142,9 +142,9 @@ struct continuation_helper {  // NOLINT(readability-identifier-naming)
  */
 template <
     typename Functor, typename T,
-    typename std::enable_if<
+    std::enable_if_t<
         is_invocable<Functor, std::shared_ptr<future_shared_state<T>>>::value,
-        int>::type = 0>
+        int> = 0>
 // NOLINTNEXTLINE(readability-identifier-naming)
 struct unwrapping_continuation_helper {
   /// The type returned by calling the functor with the given future type.
@@ -182,8 +182,8 @@ struct unwrapping_continuation_helper {
  * @tparam T the type contained in the input future.
  */
 template <typename Functor, typename T,
-          typename std::enable_if<is_invocable<Functor, future<T>>::value,
-                                  int>::type = 0>
+          std::enable_if_t<is_invocable<Functor, future<T>>::value,
+                           int> = 0>
 struct then_helper {  // NOLINT(readability-identifier-naming)
   /// The type returned by the functor
   using functor_result_t = invoke_result_t<Functor, future<T>>;
@@ -206,7 +206,7 @@ struct then_helper {  // NOLINT(readability-identifier-naming)
 
 template <typename T, typename U>
 struct make_ready_helper {  // NOLINT(readability-identifier-naming)
-  using type = typename std::decay<T>::type;
+  using type = std::decay_t<T>;
 };
 
 template <typename T, typename X>
@@ -219,8 +219,7 @@ struct make_ready_helper<T, std::reference_wrapper<X>> {
  */
 template <typename T>
 struct make_ready_return {  // NOLINT(readability-identifier-naming)
-  using type =
-      typename make_ready_helper<T, typename std::decay<T>::type>::type;
+  using type = typename make_ready_helper<T, std::decay_t<T>>::type;
 };
 
 }  // namespace internal

--- a/google/cloud/internal/invoke_result.h
+++ b/google/cloud/internal/invoke_result.h
@@ -93,7 +93,7 @@ struct invoke_impl<MT B::*> {
    * @return the result of `(t.*f)(a...)`.
    */
   template <class T, class... Args,
-            typename std::enable_if<std::is_function<MT>::value, int>::type = 0>
+            std::enable_if_t<std::is_function<MT>::value, int> = 0>
   static auto call(MT B::*f, T&& t, Args&&... a)
       -> decltype((std::forward<T>(t).*f)(std::forward<Args>(a)...));
 };
@@ -119,7 +119,7 @@ struct invoke_impl<MT B::*> {
  * @see https://en.cppreference.com/w/cpp/types/decay for a discussion of
  *     decaying function types.
  */
-template <class F, class... ArgTypes, class Fd = typename std::decay<F>::type>
+template <class F, class... ArgTypes, class Fd = std::decay_t<F>>
 auto invoker_function(F&& f, ArgTypes&&... a)
     -> decltype(invoke_impl<Fd>::call(std::forward<F>(f),
                                       std::forward<ArgTypes>(a)...));

--- a/google/cloud/internal/pagination_range.h
+++ b/google/cloud/internal/pagination_range.h
@@ -216,10 +216,10 @@ class PagedStreamReader {
  *      MyRequestProto{}, std::move(loader), std::move(extractor));
  * @endcode
  */
-template <typename Range, typename Request, typename Loader, typename Extractor,
-          typename std::enable_if<
-              is_invocable<Loader, Options const&, Request const&>::value,
-              int>::type = 0>
+template <
+    typename Range, typename Request, typename Loader, typename Extractor,
+    std::enable_if_t<
+        is_invocable<Loader, Options const&, Request const&>::value, int> = 0>
 Range MakePaginationRange(ImmutableOptions options, Request request,
                           Loader loader, Extractor extractor) {
   using ValueType = typename Range::value_type::value_type;
@@ -242,9 +242,9 @@ Range MakePaginationRange(ImmutableOptions options, Request request,
                                     });
 }
 
-template <typename Range, typename Request, typename Loader, typename Extractor,
-          typename std::enable_if<is_invocable<Loader, Request const&>::value,
-                                  int>::type = 0>
+template <
+    typename Range, typename Request, typename Loader, typename Extractor,
+    std::enable_if_t<is_invocable<Loader, Request const&>::value, int> = 0>
 Range MakePaginationRange(Request request, Loader&& loader,
                           Extractor&& extractor) {
   auto wrapper = [loader = std::forward<Loader>(loader)](

--- a/google/cloud/internal/random.h
+++ b/google/cloud/internal/random.h
@@ -59,9 +59,9 @@ inline DefaultPRNG MakeDefaultPRNG() {
  */
 std::string Sample(DefaultPRNG& gen, int n, std::string const& population);
 
-template <typename Collection,
-          typename std::enable_if<std::is_same<Collection, std::string>::value,
-                                  int>::type = 0>
+template <
+    typename Collection,
+    std::enable_if_t<std::is_same<Collection, std::string>::value, int> = 0>
 std::string RandomDataToCollection(std::string v) {
   // This is not motivated by a desire to optimize this function (though that is
   // nice). The issue is that I (coryan@) could not figure out how to write a
@@ -70,9 +70,9 @@ std::string RandomDataToCollection(std::string v) {
   return v;
 }
 
-template <typename Collection,
-          typename std::enable_if<!std::is_same<Collection, std::string>::value,
-                                  int>::type = 0>
+template <
+    typename Collection,
+    std::enable_if_t<!std::is_same<Collection, std::string>::value, int> = 0>
 Collection RandomDataToCollection(std::string v) {
   Collection result(v.size());
   std::transform(v.begin(), v.end(), result.begin(), [](auto c) {

--- a/google/cloud/internal/rest_retry_loop.h
+++ b/google/cloud/internal/rest_retry_loop.h
@@ -59,10 +59,10 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  *     `google::cloud::Status` that indicates the final error for this request.
  */
 template <typename Functor, typename Request, typename Sleeper,
-          typename std::enable_if<
+          std::enable_if_t<
               google::cloud::internal::is_invocable<
                   Functor, RestContext&, Options const&, Request const&>::value,
-              int>::type = 0>
+              int> = 0>
 auto RestRetryLoopImpl(RetryPolicy& retry_policy, BackoffPolicy& backoff_policy,
                        Idempotency idempotency, Functor&& functor,
                        Options const& options, Request const& request,
@@ -90,10 +90,10 @@ auto RestRetryLoopImpl(RetryPolicy& retry_policy, BackoffPolicy& backoff_policy,
 
 /// @copydoc RestRetryLoopImpl
 template <typename Functor, typename Request,
-          typename std::enable_if<
+          std::enable_if_t<
               google::cloud::internal::is_invocable<
                   Functor, RestContext&, Options const&, Request const&>::value,
-              int>::type = 0>
+              int> = 0>
 auto RestRetryLoop(std::unique_ptr<RetryPolicy> retry_policy,
                    std::unique_ptr<BackoffPolicy> backoff_policy,
                    Idempotency idempotency, Functor&& functor,
@@ -111,10 +111,10 @@ auto RestRetryLoop(std::unique_ptr<RetryPolicy> retry_policy,
 
 /// @copydoc RestRetryLoopImpl
 template <typename Functor, typename Request,
-          typename std::enable_if<
+          std::enable_if_t<
               google::cloud::internal::is_invocable<
                   Functor, RestContext&, Options const&, Request const&>::value,
-              int>::type = 0>
+              int> = 0>
 auto RestRetryLoop(RetryPolicy& retry_policy, BackoffPolicy& backoff_policy,
                    Idempotency idempotency, Functor&& functor,
                    Options const& options, Request const& request,
@@ -131,11 +131,10 @@ auto RestRetryLoop(RetryPolicy& retry_policy, BackoffPolicy& backoff_policy,
 
 // TODO(#12359) - remove the variants not using Options
 /// @copydoc RestRetryLoopImpl
-template <
-    typename Functor, typename Request,
-    typename std::enable_if<google::cloud::internal::is_invocable<
-                                Functor, RestContext&, Request const&>::value,
-                            int>::type = 0>
+template <typename Functor, typename Request,
+          std::enable_if_t<google::cloud::internal::is_invocable<
+                               Functor, RestContext&, Request const&>::value,
+                           int> = 0>
 auto RestRetryLoop(RetryPolicy& retry_policy, BackoffPolicy& backoff_policy,
                    Idempotency idempotency, Functor&& functor,
                    Request const& request, char const* location)
@@ -152,11 +151,10 @@ auto RestRetryLoop(RetryPolicy& retry_policy, BackoffPolicy& backoff_policy,
 
 // TODO(#12359) - remove the variants not using Options
 /// @copydoc RestRetryLoopImpl
-template <
-    typename Functor, typename Request,
-    typename std::enable_if<google::cloud::internal::is_invocable<
-                                Functor, RestContext&, Request const&>::value,
-                            int>::type = 0>
+template <typename Functor, typename Request,
+          std::enable_if_t<google::cloud::internal::is_invocable<
+                               Functor, RestContext&, Request const&>::value,
+                           int> = 0>
 auto RestRetryLoop(std::unique_ptr<RetryPolicy> retry_policy,
                    std::unique_ptr<BackoffPolicy> backoff_policy,
                    Idempotency idempotency, Functor&& functor,

--- a/google/cloud/internal/retry_loop.h
+++ b/google/cloud/internal/retry_loop.h
@@ -61,10 +61,10 @@ namespace internal {
  *     `google::cloud::Status` that indicates the final error for this request.
  */
 template <typename Functor, typename Request, typename Sleeper,
-          typename std::enable_if<google::cloud::internal::is_invocable<
-                                      Functor, grpc::ClientContext&,
-                                      Options const&, Request const&>::value,
-                                  int>::type = 0>
+          std::enable_if_t<google::cloud::internal::is_invocable<
+                               Functor, grpc::ClientContext&, Options const&,
+                               Request const&>::value,
+                           int> = 0>
 auto RetryLoopImpl(RetryPolicy& retry_policy, BackoffPolicy& backoff_policy,
                    Idempotency idempotency, Functor&& functor,
                    Options const& options, Request const& request,
@@ -94,10 +94,10 @@ auto RetryLoopImpl(RetryPolicy& retry_policy, BackoffPolicy& backoff_policy,
 
 /// @copydoc RetryLoopImpl
 template <typename Functor, typename Request,
-          typename std::enable_if<google::cloud::internal::is_invocable<
-                                      Functor, grpc::ClientContext&,
-                                      Options const&, Request const&>::value,
-                                  int>::type = 0>
+          std::enable_if_t<google::cloud::internal::is_invocable<
+                               Functor, grpc::ClientContext&, Options const&,
+                               Request const&>::value,
+                           int> = 0>
 auto RetryLoop(std::unique_ptr<RetryPolicy> retry_policy,
                std::unique_ptr<BackoffPolicy> backoff_policy,
                Idempotency idempotency, Functor&& functor,
@@ -114,11 +114,11 @@ auto RetryLoop(std::unique_ptr<RetryPolicy> retry_policy,
 }
 
 /// @copydoc RetryLoopImpl
-template <typename Functor, typename Request,
-          typename std::enable_if<
-              google::cloud::internal::is_invocable<
-                  Functor, grpc::ClientContext&, Request const&>::value,
-              int>::type = 0>
+template <
+    typename Functor, typename Request,
+    std::enable_if_t<google::cloud::internal::is_invocable<
+                         Functor, grpc::ClientContext&, Request const&>::value,
+                     int> = 0>
 auto RetryLoop(std::unique_ptr<RetryPolicy> retry_policy,
                std::unique_ptr<BackoffPolicy> backoff_policy,
                Idempotency idempotency, Functor&& functor,

--- a/google/cloud/internal/strerror.cc
+++ b/google/cloud/internal/strerror.cc
@@ -30,8 +30,7 @@ namespace {
 //
 // We use overload resolution to handle all cases, and SFINAE to avoid the
 // "unused function" warnings.
-template <typename T,
-          typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+template <typename T, std::enable_if_t<std::is_integral<T>::value, int> = 0>
 std::string handle_strerror_r_error(char const* msg, int errnum, T result) {
   if (result == 0) return msg;
   std::ostringstream os;
@@ -40,8 +39,7 @@ std::string handle_strerror_r_error(char const* msg, int errnum, T result) {
   return std::move(os).str();
 }
 
-template <typename T,
-          typename std::enable_if<std::is_pointer<T>::value, int>::type = 0>
+template <typename T, std::enable_if_t<std::is_pointer<T>::value, int> = 0>
 std::string handle_strerror_r_error(char const*, int errnum, T result) {
   if (result != nullptr) return result;
   std::ostringstream os;

--- a/google/cloud/internal/tuple.h
+++ b/google/cloud/internal/tuple.h
@@ -51,17 +51,16 @@ struct ApplyRes<F, std::tuple<Args...>> {
  * @tparam I indices 0..(sizeof(Tuple)-1)
  */
 template <class F, class Tuple, std::size_t... I>
-typename ApplyRes<F, typename std::decay<Tuple>::type>::type ApplyImpl(
+typename ApplyRes<F, std::decay_t<Tuple>>::type ApplyImpl(
     F&& f, Tuple&& t, index_sequence<I...>) {
   return std::forward<F>(f)(std::get<I>(std::forward<Tuple>(t))...);
 }
 
 // Re-implementation of `std::apply` from C++14
 template <class F, class Tuple>
-typename ApplyRes<F, typename std::decay<Tuple>::type>::type apply(F&& f,
-                                                                   Tuple&& t) {
-  using Indices = make_index_sequence<
-      std::tuple_size<typename std::decay<Tuple>::type>::value>;
+typename ApplyRes<F, std::decay_t<Tuple>>::type apply(F&& f, Tuple&& t) {
+  using Indices =
+      make_index_sequence<std::tuple_size<std::decay_t<Tuple>>::value>;
   return ApplyImpl(std::forward<F>(f), std::forward<Tuple>(t), Indices());
 }
 

--- a/google/cloud/internal/utility.h
+++ b/google/cloud/internal/utility.h
@@ -64,8 +64,7 @@ struct MakeIndexSequenceImpl {};
  */
 template <typename T, T N, T... I>
 struct MakeIndexSequenceImpl<T, std::integral_constant<T, N>,
-                             typename std::enable_if<(N > 0), void>::type,
-                             I...> {
+                             std::enable_if_t<(N > 0), void>, I...> {
   using result =
       typename MakeIndexSequenceImpl<T, std::integral_constant<T, N - 1>, void,
                                      N - 1, I...>::result;

--- a/google/cloud/status_or.h
+++ b/google/cloud/status_or.h
@@ -155,13 +155,12 @@ class StatusOr final {
    * @return a reference to this object.
    * @tparam U a type convertible to @p T.
    */
-  template <typename U = T,
-            /// @cond implementation_details
-            typename std::enable_if<
-                !std::is_same<StatusOr, typename std::decay<U>::type>::value,
-                int>::type = 0
-            /// @endcond
-            >
+  template <
+      typename U = T,
+      /// @cond implementation_details
+      std::enable_if_t<!std::is_same<StatusOr, std::decay_t<U>>::value, int> = 0
+      /// @endcond
+      >
   StatusOr& operator=(U&& rhs) {
     status_ = Status();
     value_ = std::forward<U>(rhs);

--- a/google/cloud/testing_util/chrono_output.h
+++ b/google/cloud/testing_util/chrono_output.h
@@ -51,19 +51,19 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 namespace std {
 namespace chrono {
 
-template <class Rep, class Period,
-          typename = typename std::enable_if<
-              !google::cloud::internal::kIsChronoDurationOstreamable<
-                  Rep, Period>>::type>
+template <
+    class Rep, class Period,
+    typename = std::enable_if_t<
+        !google::cloud::internal::kIsChronoDurationOstreamable<Rep, Period>>>
 std::ostream& operator<<(  //
     std::ostream& str, std::chrono::duration<Rep, Period> const& value) {
   return str << absl::FromChrono(value);
 }
 
 template <class Clock, class Duration,
-          typename = typename std::enable_if<
+          typename = std::enable_if_t<
               !google::cloud::internal::kIsChronoTimePointOstreamable<
-                  Clock, Duration>>::type>
+                  Clock, Duration>>>
 std::ostream& operator<<(
     std::ostream& str, std::chrono::time_point<Clock, Duration> const& value) {
   return str << absl::FromChrono(value);

--- a/google/cloud/testing_util/status_matchers.h
+++ b/google/cloud/testing_util/status_matchers.h
@@ -74,7 +74,7 @@ class StatusIsMatcher {
 template <typename S>
 class IsOkAndHoldsMatcherImpl : public ::testing::MatcherInterface<S> {
  public:
-  using status_or_type = typename std::remove_reference<S>::type;
+  using status_or_type = std::remove_reference_t<S>;
   using value_type = typename status_or_type::value_type;
 
   template <typename ValueMatcher>
@@ -222,11 +222,10 @@ IsOk() {
  * @endcode
  */
 template <typename ValueMatcher>
-testing_util_internal::IsOkAndHoldsMatcher<
-    typename std::decay<ValueMatcher>::type>
+testing_util_internal::IsOkAndHoldsMatcher<typename std::decay_t<ValueMatcher>>
 IsOkAndHolds(ValueMatcher&& value_matcher) {
   return testing_util_internal::IsOkAndHoldsMatcher<
-      typename std::decay<ValueMatcher>::type>(
+      typename std::decay_t<ValueMatcher>>(
       std::forward<ValueMatcher>(value_matcher));
 }
 


### PR DESCRIPTION
A number of places where `std::foo_t<T>` is a more succint way to say `typename std::foo<T>::type`. `clang-tidy` also recommends a `noexcept` on `swap()` functions, where that is not a lie, it seems like a good idea.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13083)
<!-- Reviewable:end -->
