### PR TITLE
impl(bigtable): flip throttling flag(s)

### DIFF
--- a/google/cloud/bigtable/internal/bigtable_stub_factory.cc
+++ b/google/cloud/bigtable/internal/bigtable_stub_factory.cc
@@ -51,6 +51,8 @@ std::string FeaturesMetadata() {
     google::bigtable::v2::FeatureFlags proto;
     proto.set_reverse_scans(true);
     proto.set_last_scanned_row_responses(true);
+    proto.set_mutate_rows_rate_limit(true);
+    proto.set_mutate_rows_rate_limit2(true);
     return internal::UrlsafeBase64Encode(proto.SerializeAsString());
   }());
   return *kFeatures;


### PR DESCRIPTION
Part of the work for #12959 

Yes, we really need to set both of these, even though `mutate_rows_rate_limit` means "I have implemented the feature with a bug" and `mutate_rows_rate_limit2` means "I have implemented the feature correctly". The server must be doing an `&&`. :facepalm:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13086)
<!-- Reviewable:end -->
