### PR TITLE
cleanup(storage): prepare for `clang-tidy` 17

### DIFF
--- a/google/cloud/storage/bucket_metadata_test.cc
+++ b/google/cloud/storage/bucket_metadata_test.cc
@@ -1064,8 +1064,10 @@ TEST(BucketMetadataPatchBuilder, ResetBilling) {
 TEST(BucketMetadataPatchBuilder, SetCors) {
   BucketMetadataPatchBuilder builder;
   std::vector<CorsEntry> v;
-  v.emplace_back(CorsEntry{{}, {"method1", "method2"}, {}, {"header1"}});
-  v.emplace_back(CorsEntry{86400, {}, {"origin1"}, {}});
+  // NOLINTNEXTLINE(modernize-use-emplace) - brace initialization
+  v.push_back(CorsEntry{{}, {"method1", "method2"}, {}, {"header1"}});
+  // NOLINTNEXTLINE(modernize-use-emplace) - brace initialization
+  v.push_back(CorsEntry{86400, {}, {"origin1"}, {}});
   builder.SetCors(v);
 
   auto actual = builder.BuildPatch();

--- a/google/cloud/storage/examples/storage_object_csek_samples.cc
+++ b/google/cloud/storage/examples/storage_object_csek_samples.cc
@@ -119,7 +119,7 @@ void ComposeObjectFromEncryptedObjects(google::cloud::storage::Client client,
   auto base64_aes256_key = *it++;
   std::vector<google::cloud::storage::ComposeSourceObject> compose_objects;
   do {
-    compose_objects.push_back({*it++, {}, {}});
+    compose_objects.emplace_back(*it++);
   } while (it != argv.cend());
 
   //! [compose object csek]

--- a/google/cloud/storage/examples/storage_object_csek_samples.cc
+++ b/google/cloud/storage/examples/storage_object_csek_samples.cc
@@ -119,7 +119,8 @@ void ComposeObjectFromEncryptedObjects(google::cloud::storage::Client client,
   auto base64_aes256_key = *it++;
   std::vector<google::cloud::storage::ComposeSourceObject> compose_objects;
   do {
-    compose_objects.emplace_back(*it++);
+    // NOLINTNEXTLINE(modernize-use-emplace) - brace initialization
+    compose_objects.push_back({*it++, {}, {}});
   } while (it != argv.cend());
 
   //! [compose object csek]

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -480,7 +480,8 @@ void ComposeObject(google::cloud::storage::Client client,
   auto destination_object_name = *it++;
   std::vector<google::cloud::storage::ComposeSourceObject> compose_objects;
   do {
-    compose_objects.emplace_back(*it++);
+    // NOLINTNEXTLINE(modernize-use-emplace) - brace initialization
+    compose_objects.push_back({*it++, {}, {}});
   } while (it != argv.cend());
 
   //! [compose object] [START storage_compose_file]
@@ -509,7 +510,8 @@ void ComposeObjectFromMany(google::cloud::storage::Client client,
   auto destination_object_name = *it++;
   std::vector<google::cloud::storage::ComposeSourceObject> compose_objects;
   do {
-    compose_objects.emplace_back(*it++);
+    // NOLINTNEXTLINE(modernize-use-emplace) - brace initialization
+    compose_objects.push_back({*it++, {}, {}});
   } while (it != argv.cend());
 
   //! [compose object from many] [START storage_compose_file_from_many]

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -480,7 +480,7 @@ void ComposeObject(google::cloud::storage::Client client,
   auto destination_object_name = *it++;
   std::vector<google::cloud::storage::ComposeSourceObject> compose_objects;
   do {
-    compose_objects.push_back({*it++, {}, {}});
+    compose_objects.emplace_back(*it++);
   } while (it != argv.cend());
 
   //! [compose object] [START storage_compose_file]
@@ -509,7 +509,7 @@ void ComposeObjectFromMany(google::cloud::storage::Client client,
   auto destination_object_name = *it++;
   std::vector<google::cloud::storage::ComposeSourceObject> compose_objects;
   do {
-    compose_objects.push_back({*it++, {}, {}});
+    compose_objects.emplace_back(*it++);
   } while (it != argv.cend());
 
   //! [compose object from many] [START storage_compose_file_from_many]

--- a/google/cloud/storage/internal/generate_message_boundary.h
+++ b/google/cloud/storage/internal/generate_message_boundary.h
@@ -60,9 +60,9 @@ std::string GenerateMessageBoundaryCandidate(
  * @deprecated use another `GenerateMessageBoundary()` overload.
  */
 template <typename RandomStringGenerator,
-          typename std::enable_if<google::cloud::internal::is_invocable<
-                                      RandomStringGenerator, int>::value,
-                                  int>::type = 0>
+          std::enable_if_t<google::cloud::internal::is_invocable<
+                               RandomStringGenerator, int>::value,
+                           int> = 0>
 GOOGLE_CLOUD_CPP_DEPRECATED(
     "deprecated, using the GenerateMessageBoundary(std::string const&, "
     "absl::FunctionRef<std::string()>) overload")

--- a/google/cloud/storage/internal/generic_request.h
+++ b/google/cloud/storage/internal/generic_request.h
@@ -105,8 +105,8 @@ class GenericRequestBase<Derived, Option> {
     return false;
   }
 
-  template <typename O, typename std::enable_if<std::is_same<O, Option>::value,
-                                                int>::type = 0>
+  template <typename O,
+            std::enable_if_t<std::is_same<O, Option>::value, int> = 0>
   O GetOption() const {
     return option_;
   }
@@ -146,9 +146,9 @@ class GenericRequestBase<Derived, OverrideDefaultProject> {
     return false;
   }
 
-  template <typename O,
-            typename std::enable_if<
-                std::is_same<O, OverrideDefaultProject>::value, int>::type = 0>
+  template <
+      typename O,
+      std::enable_if_t<std::is_same<O, OverrideDefaultProject>::value, int> = 0>
   OverrideDefaultProject GetOption() const {
     return OverrideDefaultProject{};
   }
@@ -199,14 +199,14 @@ class GenericRequestBase : public GenericRequestBase<Derived, Options...> {
     return GenericRequestBase<Derived, Options...>::template HasOption<O>();
   }
 
-  template <typename O, typename std::enable_if<std::is_same<O, Option>::value,
-                                                int>::type = 0>
+  template <typename O,
+            std::enable_if_t<std::is_same<O, Option>::value, int> = 0>
   O GetOption() const {
     return option_;
   }
 
-  template <typename O, typename std::enable_if<!std::is_same<O, Option>::value,
-                                                int>::type = 0>
+  template <typename O,
+            std::enable_if_t<!std::is_same<O, Option>::value, int> = 0>
   O GetOption() const {
     return GenericRequestBase<Derived, Options...>::template GetOption<O>();
   }
@@ -257,16 +257,16 @@ class GenericRequestBase<Derived, OverrideDefaultProject, Options...>
     return GenericRequestBase<Derived, Options...>::template HasOption<O>();
   }
 
-  template <typename O,
-            typename std::enable_if<
-                std::is_same<O, OverrideDefaultProject>::value, int>::type = 0>
+  template <
+      typename O,
+      std::enable_if_t<std::is_same<O, OverrideDefaultProject>::value, int> = 0>
   OverrideDefaultProject GetOption() const {
     return OverrideDefaultProject{};
   }
 
   template <typename O,
-            typename std::enable_if<
-                !std::is_same<O, OverrideDefaultProject>::value, int>::type = 0>
+            std::enable_if_t<!std::is_same<O, OverrideDefaultProject>::value,
+                             int> = 0>
   O GetOption() const {
     return GenericRequestBase<Derived, Options...>::template GetOption<O>();
   }

--- a/google/cloud/storage/internal/grpc/make_cord.h
+++ b/google/cloud/storage/internal/grpc/make_cord.h
@@ -49,8 +49,7 @@ absl::Cord MakeCord(std::string p);
 absl::Cord MakeCord(std::vector<std::string> p);
 
 /// Creates an `absl::Cord`, without copying the data in @p p.
-template <typename T,
-          typename std::enable_if<IsPayloadType<T>::value, int>::type = 0>
+template <typename T, std::enable_if_t<IsPayloadType<T>::value, int> = 0>
 absl::Cord MakeCord(std::vector<T> p) {
   static_assert(IsPayloadType<T>::value, "unexpected value type");
   auto holder = std::make_shared<std::vector<T>>(std::move(p));
@@ -61,8 +60,7 @@ absl::Cord MakeCord(std::vector<T> p) {
 }
 
 /// Creates an `absl::Cord`, without copying the data in @p p.
-template <typename T,
-          typename std::enable_if<IsPayloadType<T>::value, int>::type = 0>
+template <typename T, std::enable_if_t<IsPayloadType<T>::value, int> = 0>
 absl::Cord MakeCord(std::vector<std::vector<T>> p) {
   return std::accumulate(std::make_move_iterator(p.begin()),
                          std::make_move_iterator(p.end()), absl::Cord(),

--- a/google/cloud/storage/internal/grpc/object_request_parser.cc
+++ b/google/cloud/storage/internal/grpc/object_request_parser.cc
@@ -60,11 +60,11 @@ struct GetPredefinedAcl {
 
 template <
     typename GrpcRequest, typename StorageRequest,
-    typename std::enable_if<
+    std::enable_if_t<
         std::is_same<std::string const&,
                      google::cloud::internal::invoke_result_t<
                          GetPredefinedAcl<GrpcRequest>, GrpcRequest>>::value,
-        int>::type = 0>
+        int> = 0>
 void SetPredefinedAcl(GrpcRequest& request, StorageRequest const& req) {
   if (req.template HasOption<storage::PredefinedAcl>()) {
     request.set_predefined_acl(

--- a/google/cloud/storage/internal/policy_document_request.cc
+++ b/google/cloud/storage/internal/policy_document_request.cc
@@ -130,6 +130,9 @@ StatusOr<std::string> Escape1(absl::string_view s, std::size_t pos) {
       return std::string("\\t");
     case '\v':
       return std::string("\\v");
+    default:
+      // Having a default case makes clang-tidy happy.
+      break;
   }
   return std::string(s.substr(pos, 1));
 }

--- a/google/cloud/storage/internal/rest/request_builder.h
+++ b/google/cloud/storage/internal/rest/request_builder.h
@@ -82,9 +82,9 @@ class RestRequestBuilder {
   }
 
   /// Adds one of the well-known headers to the request.
-  template <typename P, typename V,
-            typename Enabled = typename std::enable_if<
-                std::is_arithmetic<V>::value, void>::type>
+  template <
+      typename P, typename V,
+      typename Enabled = std::enable_if_t<std::is_arithmetic<V>::value, void>>
   RestRequestBuilder& AddOption(WellKnownHeader<P, V> const& p) {
     if (p.has_value()) {
       request_.AddHeader(p.header_name(), std::to_string(p.value()));

--- a/google/cloud/storage/internal/tuple_filter.h
+++ b/google/cloud/storage/internal/tuple_filter.h
@@ -92,13 +92,12 @@ struct FilteredTupleReturnType {};
  */
 template <template <class> class TPred, typename Head, typename... Tail>
 struct FilteredTupleReturnType<TPred, std::tuple<Head, Tail...>> {
-  using Result = typename std::conditional<
+  using Result = std::conditional_t<
       TPred<Head>::value,
       typename TupleTypePrepend<
           typename FilteredTupleReturnType<TPred, std::tuple<Tail...>>::Result,
           Head>::Result,
-      typename FilteredTupleReturnType<TPred,
-                                       std::tuple<Tail...>>::Result>::type;
+      typename FilteredTupleReturnType<TPred, std::tuple<Tail...>>::Result>;
 };
 
 /**
@@ -134,11 +133,10 @@ struct StaticTupleFilterImpl {
  * @param tuple the tuple to filter elements from
  */
 template <template <class> class TPred, class Tuple>
-typename FilteredTupleReturnType<TPred,
-                                 typename std::decay<Tuple>::type>::Result
+typename FilteredTupleReturnType<TPred, std::decay_t<Tuple>>::Result
 StaticTupleFilter(Tuple&& t) {
   return std::tuple_cat(google::cloud::internal::apply(
-      StaticTupleFilterImpl<TPred, typename std::decay<Tuple>::type>(),
+      StaticTupleFilterImpl<TPred, std::decay_t<Tuple>>(),
       std::forward<Tuple>(t)));
 }
 
@@ -150,8 +148,7 @@ StaticTupleFilter(Tuple&& t) {
 template <typename... Types>
 struct Among {
   template <typename T>
-  using TPred =
-      absl::disjunction<std::is_same<typename std::decay<T>::type, Types>...>;
+  using TPred = absl::disjunction<std::is_same<std::decay_t<T>, Types>...>;
 };
 
 /**
@@ -163,8 +160,7 @@ template <typename... Types>
 struct NotAmong {
   template <typename T>
   using TPred = std::integral_constant<
-      bool, !absl::disjunction<
-                std::is_same<typename std::decay<T>::type, Types>...>::value>;
+      bool, !absl::disjunction<std::is_same<std::decay_t<T>, Types>...>::value>;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/object_read_stream.cc
+++ b/google/cloud/storage/object_read_stream.cc
@@ -45,7 +45,7 @@ ObjectReadStream::ObjectReadStream(ObjectReadStream&& rhs) noexcept
       // In fact, as that page indicates, the base classes are designed such
       // that derived classes can define their own move constructor and move
       // assignment.
-      buf_(std::move(rhs.buf_)) {
+      buf_(std::move(rhs.buf_)) {  // NOLINT(bugprone-use-after-move)
   auto buf = MakeErrorStreambuf();
   rhs.set_rdbuf(buf.get());  // NOLINT(bugprone-use-after-move)
   rhs.buf_ = std::move(buf);

--- a/google/cloud/storage/object_read_stream.h
+++ b/google/cloud/storage/object_read_stream.h
@@ -56,7 +56,7 @@ class ObjectReadStream : public std::basic_istream<char> {
     return *this;
   }
 
-  void swap(ObjectReadStream& rhs) {
+  void swap(ObjectReadStream& rhs) noexcept {
     std::basic_istream<char>::swap(rhs);
     std::swap(buf_, rhs.buf_);
     rhs.set_rdbuf(rhs.buf_.get());

--- a/google/cloud/storage/object_rewriter.h
+++ b/google/cloud/storage/object_rewriter.h
@@ -98,11 +98,10 @@ class ObjectRewriter {
    *
    * @return the object metadata once the copy completes.
    */
-  template <
-      typename Functor,
-      typename std::enable_if<google::cloud::internal::is_invocable<
-                                  Functor, StatusOr<RewriteProgress>>::value,
-                              int>::type = 0>
+  template <typename Functor,
+            std::enable_if_t<google::cloud::internal::is_invocable<
+                                 Functor, StatusOr<RewriteProgress>>::value,
+                             int> = 0>
   StatusOr<ObjectMetadata> ResultWithProgressCallback(Functor cb) {
     while (!progress_.done) {
       cb(Iterate());

--- a/google/cloud/storage/object_write_stream.cc
+++ b/google/cloud/storage/object_write_stream.cc
@@ -53,10 +53,10 @@ ObjectWriteStream::ObjectWriteStream(ObjectWriteStream&& rhs) noexcept
       // In fact, as that page indicates, the base classes are designed such
       // that derived classes can define their own move constructor and move
       // assignment.
-      buf_(std::move(rhs.buf_)),
-      metadata_(std::move(rhs.metadata_)),
-      headers_(std::move(rhs.headers_)),
-      payload_(std::move(rhs.payload_)) {
+      buf_(std::move(rhs.buf_)),            // NOLINT(bugprone-use-after-move)
+      metadata_(std::move(rhs.metadata_)),  // NOLINT(bugprone-use-after-move)
+      headers_(std::move(rhs.headers_)),    // NOLINT(bugprone-use-after-move)
+      payload_(std::move(rhs.payload_)) {   // NOLINT(bugprone-use-after-move)
   auto buf = MakeErrorStreambuf();
   rhs.set_rdbuf(buf.get());  // NOLINT(bugprone-use-after-move)
   rhs.buf_ = std::move(buf);

--- a/google/cloud/storage/object_write_stream.h
+++ b/google/cloud/storage/object_write_stream.h
@@ -156,7 +156,7 @@ class ObjectWriteStream : public std::basic_ostream<char> {
     return *this;
   }
 
-  void swap(ObjectWriteStream& rhs) {
+  void swap(ObjectWriteStream& rhs) noexcept {
     basic_ostream<char>::swap(rhs);
     std::swap(buf_, rhs.buf_);
     rhs.set_rdbuf(rhs.buf_.get());

--- a/google/cloud/storage/parallel_upload.cc
+++ b/google/cloud/storage/parallel_upload.cc
@@ -97,6 +97,7 @@ StatusOr<ObjectWriteStream> ParallelUploadStateImpl::CreateStream(
   auto idx = streams_.size();
   ++num_unfinished_streams_;
   streams_.emplace_back(
+      // NOLINTNEXTLINE(modernize-use-emplace) - brace initialization
       StreamInfo{request.object_name(), create->upload_id, {}, false});
   assert(idx < streams_.size());
   lk.unlock();

--- a/google/cloud/storage/parallel_upload.h
+++ b/google/cloud/storage/parallel_upload.h
@@ -85,9 +85,8 @@ struct ExtractFirstOccurrenceOfTypeImpl {
 template <typename T, typename... Options>
 struct ExtractFirstOccurrenceOfTypeImpl<
     T, std::tuple<Options...>,
-    typename std::enable_if<
-        Among<typename std::decay<Options>::type...>::template TPred<
-            typename std::decay<T>::type>::value>::type> {
+    std::enable_if_t<Among<std::decay_t<Options>...>::template TPred<
+        std::decay_t<T>>::value>> {
   absl::optional<T> operator()(std::tuple<Options...> const& tuple) {
     return std::get<0>(StaticTupleFilter<Among<T>::template TPred>(tuple));
   }
@@ -602,10 +601,10 @@ class ResumableParallelUploadState {
  * on the first request that fails.
  */
 template <typename... Options,
-          typename std::enable_if<
-              NotAmong<typename std::decay<Options>::type...>::template TPred<
-                  UseResumableUploadSession>::value,
-              int>::type EnableIfNotResumable = 0>
+          std::enable_if_t<NotAmong<std::decay_t<Options>...>::template TPred<
+                               UseResumableUploadSession>::value,
+                           int>
+              EnableIfNotResumable = 0>
 StatusOr<NonResumableParallelUploadState> PrepareParallelUpload(
     Client client, std::string const& bucket_name,
     std::string const& object_name, std::size_t num_shards,
@@ -617,10 +616,10 @@ StatusOr<NonResumableParallelUploadState> PrepareParallelUpload(
 }
 
 template <typename... Options,
-          typename std::enable_if<
-              Among<typename std::decay<Options>::type...>::template TPred<
-                  UseResumableUploadSession>::value,
-              int>::type EnableIfResumable = 0>
+          std::enable_if_t<Among<std::decay_t<Options>...>::template TPred<
+                               UseResumableUploadSession>::value,
+                           int>
+              EnableIfResumable = 0>
 StatusOr<ResumableParallelUploadState> PrepareParallelUpload(
     Client client, std::string const& bucket_name,
     std::string const& object_name, std::size_t num_shards,
@@ -990,10 +989,10 @@ StatusOr<std::vector<std::uintmax_t>> ParallelFileUploadSplitPointsFromString(
 struct PrepareParallelUploadApplyHelper {
   // Some gcc versions crash on using decltype for return type here.
   template <typename... Options>
-  StatusOr<typename std::conditional<
-      Among<typename std::decay<Options>::type...>::template TPred<
-          UseResumableUploadSession>::value,
-      ResumableParallelUploadState, NonResumableParallelUploadState>::type>
+  StatusOr<std::conditional_t<Among<std::decay_t<Options>...>::template TPred<
+                                  UseResumableUploadSession>::value,
+                              ResumableParallelUploadState,
+                              NonResumableParallelUploadState>>
   operator()(Options&&... options) {
     return PrepareParallelUpload(std::move(client), bucket_name, object_name,
                                  num_shards, prefix,

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -325,6 +325,7 @@ TEST_F(BucketIntegrationTest, FullPatch) {
   }
 
   // cors()
+  // NOLINTNEXTLINE(modernize-use-emplace) - brace initialization
   desired_state.mutable_cors().push_back(CorsEntry{86400, {"GET"}, {}, {}});
 
   // default_acl()

--- a/google/cloud/storage/tests/object_compose_many_integration_test.cc
+++ b/google/cloud/storage/tests/object_compose_many_integration_test.cc
@@ -52,6 +52,7 @@ TEST_F(ObjectComposeManyIntegrationTest, ComposeMany) {
     StatusOr<ObjectMetadata> insert_meta = client->InsertObject(
         bucket_name_, object_name, std::move(content), IfGenerationMatch(0));
     ASSERT_STATUS_OK(insert_meta);
+    // NOLINTNEXTLINE(modernize-use-emplace) - brace initialization
     source_objs.emplace_back(ComposeSourceObject{
         std::move(object_name), insert_meta->generation(), {}});
   }


### PR DESCRIPTION
`clang-tidy` really wants us to use `emplace_back()`, but that is not possible for brace-initialized `struct`s with C++14.

Also needed to use `std::foo_t<T>` over `typename std::foo<T>::type`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13088)
<!-- Reviewable:end -->
