### PR TITLE
impl(bigtable): plumb MutateRowsLimiter internally

### DIFF
--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -311,6 +311,7 @@ if (BUILD_TESTING)
         testing/mock_async_failing_rpc_factory.h
         testing/mock_bigtable_stub.h
         testing/mock_data_client.h
+        testing/mock_mutate_rows_limiter.h
         testing/mock_mutate_rows_reader.h
         testing/mock_policies.h
         testing/mock_read_rows_reader.h

--- a/google/cloud/bigtable/bigtable_client_testing.bzl
+++ b/google/cloud/bigtable/bigtable_client_testing.bzl
@@ -23,6 +23,7 @@ bigtable_client_testing_hdrs = [
     "testing/mock_async_failing_rpc_factory.h",
     "testing/mock_bigtable_stub.h",
     "testing/mock_data_client.h",
+    "testing/mock_mutate_rows_limiter.h",
     "testing/mock_mutate_rows_reader.h",
     "testing/mock_policies.h",
     "testing/mock_read_rows_reader.h",

--- a/google/cloud/bigtable/internal/bulk_mutator.h
+++ b/google/cloud/bigtable/internal/bulk_mutator.h
@@ -19,6 +19,7 @@
 #include "google/cloud/bigtable/data_client.h"
 #include "google/cloud/bigtable/idempotent_mutation_policy.h"
 #include "google/cloud/bigtable/internal/bigtable_stub.h"
+#include "google/cloud/bigtable/internal/mutate_rows_limiter.h"
 #include "google/cloud/bigtable/version.h"
 #include "google/cloud/internal/invoke_result.h"
 #include "google/cloud/status.h"
@@ -125,7 +126,7 @@ class BulkMutator {
                               grpc::ClientContext& client_context);
 
   /// Synchronously send one batch request to the given stub.
-  Status MakeOneRequest(BigtableStub& stub);
+  Status MakeOneRequest(BigtableStub& stub, MutateRowsLimiter& limiter);
 
   /// Give up on any pending mutations, move them to the failures array.
   std::vector<bigtable::FailedMutation> OnRetryDone() &&;

--- a/google/cloud/bigtable/internal/bulk_mutator_test.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator_test.cc
@@ -91,8 +91,8 @@ TEST(BulkMutatorTest, Simple) {
                                          std::move(mut));
 
   EXPECT_TRUE(mutator.HasPendingMutations());
-  auto limiter = std::make_shared<bigtable_internal::NoopMutateRowsLimiter>();
-  auto status = mutator.MakeOneRequest(*mock, *limiter);
+  bigtable_internal::NoopMutateRowsLimiter limiter;
+  auto status = mutator.MakeOneRequest(*mock, limiter);
   EXPECT_STATUS_OK(status);
   auto failures = std::move(mutator).OnRetryDone();
   EXPECT_TRUE(failures.empty());
@@ -137,8 +137,8 @@ TEST(BulkMutatorTest, RetryPartialFailure) {
   // isolation, so call MakeOneRequest() twice, for the r1, and the r2 cases.
   for (int i = 0; i != 2; ++i) {
     EXPECT_TRUE(mutator.HasPendingMutations());
-    auto limiter = std::make_shared<bigtable_internal::NoopMutateRowsLimiter>();
-    auto status = mutator.MakeOneRequest(*mock, *limiter);
+    bigtable_internal::NoopMutateRowsLimiter limiter;
+    auto status = mutator.MakeOneRequest(*mock, limiter);
     EXPECT_STATUS_OK(status);
   }
   auto failures = std::move(mutator).OnRetryDone();
@@ -184,8 +184,8 @@ TEST(BulkMutatorTest, PermanentFailure) {
   // isolation, so call MakeOneRequest() twice, for the r1, and the r2 cases.
   for (int i = 0; i != 2; ++i) {
     EXPECT_TRUE(mutator.HasPendingMutations());
-    auto limiter = std::make_shared<bigtable_internal::NoopMutateRowsLimiter>();
-    auto status = mutator.MakeOneRequest(*mock, *limiter);
+    bigtable_internal::NoopMutateRowsLimiter limiter;
+    auto status = mutator.MakeOneRequest(*mock, limiter);
     EXPECT_STATUS_OK(status);
   }
   auto failures = std::move(mutator).OnRetryDone();
@@ -233,8 +233,8 @@ TEST(BulkMutatorTest, PartialStream) {
   // isolation, so call MakeOneRequest() twice: for the r1 and r2 cases.
   for (int i = 0; i != 2; ++i) {
     EXPECT_TRUE(mutator.HasPendingMutations());
-    auto limiter = std::make_shared<bigtable_internal::NoopMutateRowsLimiter>();
-    auto status = mutator.MakeOneRequest(*mock, *limiter);
+    bigtable_internal::NoopMutateRowsLimiter limiter;
+    auto status = mutator.MakeOneRequest(*mock, limiter);
     EXPECT_STATUS_OK(status);
   }
   auto failures = std::move(mutator).OnRetryDone();
@@ -293,8 +293,8 @@ TEST(BulkMutatorTest, RetryOnlyIdempotent) {
   // isolation, so call MakeOneRequest() twice, for the r1, and the r2 cases.
   for (int i = 0; i != 2; ++i) {
     EXPECT_TRUE(mutator.HasPendingMutations());
-    auto limiter = std::make_shared<bigtable_internal::NoopMutateRowsLimiter>();
-    auto status = mutator.MakeOneRequest(*mock, *limiter);
+    bigtable_internal::NoopMutateRowsLimiter limiter;
+    auto status = mutator.MakeOneRequest(*mock, limiter);
     EXPECT_STATUS_OK(status);
   }
   auto failures = std::move(mutator).OnRetryDone();
@@ -333,8 +333,8 @@ TEST(BulkMutatorTest, UnconfirmedAreFailed) {
                                          std::move(mut));
 
   EXPECT_TRUE(mutator.HasPendingMutations());
-  auto limiter = std::make_shared<bigtable_internal::NoopMutateRowsLimiter>();
-  auto status = mutator.MakeOneRequest(*mock, *limiter);
+  bigtable_internal::NoopMutateRowsLimiter limiter;
+  auto status = mutator.MakeOneRequest(*mock, limiter);
   EXPECT_THAT(status, StatusIs(StatusCode::kPermissionDenied));
 
   auto failures = std::move(mutator).OnRetryDone();
@@ -366,8 +366,8 @@ TEST(BulkMutatorTest, ConfiguresContext) {
   google::cloud::internal::OptionsSpan span(
       Options{}.set<google::cloud::internal::GrpcSetupOption>(
           mock_setup.AsStdFunction()));
-  auto limiter = std::make_shared<bigtable_internal::NoopMutateRowsLimiter>();
-  (void)mutator.MakeOneRequest(*mock, *limiter);
+  bigtable_internal::NoopMutateRowsLimiter limiter;
+  (void)mutator.MakeOneRequest(*mock, limiter);
 }
 
 TEST(BulkMutatorTest, MutationStatusReportedOnOkStream) {
@@ -390,8 +390,8 @@ TEST(BulkMutatorTest, MutationStatusReportedOnOkStream) {
   bigtable_internal::BulkMutator mutator(kAppProfile, kTableName, *policy,
                                          std::move(mut));
 
-  auto limiter = std::make_shared<bigtable_internal::NoopMutateRowsLimiter>();
-  auto status = mutator.MakeOneRequest(*mock, *limiter);
+  bigtable_internal::NoopMutateRowsLimiter limiter;
+  auto status = mutator.MakeOneRequest(*mock, limiter);
   EXPECT_STATUS_OK(status);
 
   auto failures = std::move(mutator).OnRetryDone();
@@ -426,8 +426,8 @@ TEST(BulkMutatorTest, ReportEitherRetryableMutationFailOrStreamFail) {
   bigtable_internal::BulkMutator mutator(kAppProfile, kTableName, *policy,
                                          std::move(mut));
 
-  auto limiter = std::make_shared<bigtable_internal::NoopMutateRowsLimiter>();
-  auto status = mutator.MakeOneRequest(*mock, *limiter);
+  bigtable_internal::NoopMutateRowsLimiter limiter;
+  auto status = mutator.MakeOneRequest(*mock, limiter);
   EXPECT_THAT(status, StatusIs(StatusCode::kDataLoss));
 
   auto failures = std::move(mutator).OnRetryDone();
@@ -471,11 +471,11 @@ TEST(BulkMutatorTest, ReportOnlyLatestMutationStatus) {
   bigtable_internal::BulkMutator mutator(kAppProfile, kTableName, *policy,
                                          std::move(mut));
 
-  auto limiter = std::make_shared<bigtable_internal::NoopMutateRowsLimiter>();
-  auto status = mutator.MakeOneRequest(*mock, *limiter);
+  bigtable_internal::NoopMutateRowsLimiter limiter;
+  auto status = mutator.MakeOneRequest(*mock, limiter);
   EXPECT_THAT(status, StatusIs(StatusCode::kUnavailable));
 
-  status = mutator.MakeOneRequest(*mock, *limiter);
+  status = mutator.MakeOneRequest(*mock, limiter);
   EXPECT_THAT(status, StatusIs(StatusCode::kDataLoss));
 
   auto failures = std::move(mutator).OnRetryDone();

--- a/google/cloud/bigtable/internal/bulk_mutator_test.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/bigtable/internal/bulk_mutator.h"
 #include "google/cloud/bigtable/testing/mock_bigtable_stub.h"
+#include "google/cloud/bigtable/testing/mock_mutate_rows_limiter.h"
 #include "google/cloud/testing_util/chrono_literals.h"
 #include "google/cloud/testing_util/status_matchers.h"
 
@@ -26,10 +27,12 @@ namespace {
 namespace v2 = ::google::bigtable::v2;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;  // NOLINT
 using ::google::cloud::bigtable::testing::MockBigtableStub;
+using ::google::cloud::bigtable::testing::MockMutateRowsLimiter;
 using ::google::cloud::bigtable::testing::MockMutateRowsStream;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::AnyOf;
 using ::testing::Eq;
+using ::testing::IsEmpty;
 using ::testing::Matcher;
 using ::testing::MockFunction;
 using ::testing::Property;
@@ -88,7 +91,8 @@ TEST(BulkMutatorTest, Simple) {
                                          std::move(mut));
 
   EXPECT_TRUE(mutator.HasPendingMutations());
-  auto status = mutator.MakeOneRequest(*mock);
+  auto limiter = std::make_shared<bigtable_internal::NoopMutateRowsLimiter>();
+  auto status = mutator.MakeOneRequest(*mock, *limiter);
   EXPECT_STATUS_OK(status);
   auto failures = std::move(mutator).OnRetryDone();
   EXPECT_TRUE(failures.empty());
@@ -133,7 +137,8 @@ TEST(BulkMutatorTest, RetryPartialFailure) {
   // isolation, so call MakeOneRequest() twice, for the r1, and the r2 cases.
   for (int i = 0; i != 2; ++i) {
     EXPECT_TRUE(mutator.HasPendingMutations());
-    auto status = mutator.MakeOneRequest(*mock);
+    auto limiter = std::make_shared<bigtable_internal::NoopMutateRowsLimiter>();
+    auto status = mutator.MakeOneRequest(*mock, *limiter);
     EXPECT_STATUS_OK(status);
   }
   auto failures = std::move(mutator).OnRetryDone();
@@ -179,7 +184,8 @@ TEST(BulkMutatorTest, PermanentFailure) {
   // isolation, so call MakeOneRequest() twice, for the r1, and the r2 cases.
   for (int i = 0; i != 2; ++i) {
     EXPECT_TRUE(mutator.HasPendingMutations());
-    auto status = mutator.MakeOneRequest(*mock);
+    auto limiter = std::make_shared<bigtable_internal::NoopMutateRowsLimiter>();
+    auto status = mutator.MakeOneRequest(*mock, *limiter);
     EXPECT_STATUS_OK(status);
   }
   auto failures = std::move(mutator).OnRetryDone();
@@ -227,7 +233,8 @@ TEST(BulkMutatorTest, PartialStream) {
   // isolation, so call MakeOneRequest() twice: for the r1 and r2 cases.
   for (int i = 0; i != 2; ++i) {
     EXPECT_TRUE(mutator.HasPendingMutations());
-    auto status = mutator.MakeOneRequest(*mock);
+    auto limiter = std::make_shared<bigtable_internal::NoopMutateRowsLimiter>();
+    auto status = mutator.MakeOneRequest(*mock, *limiter);
     EXPECT_STATUS_OK(status);
   }
   auto failures = std::move(mutator).OnRetryDone();
@@ -286,7 +293,8 @@ TEST(BulkMutatorTest, RetryOnlyIdempotent) {
   // isolation, so call MakeOneRequest() twice, for the r1, and the r2 cases.
   for (int i = 0; i != 2; ++i) {
     EXPECT_TRUE(mutator.HasPendingMutations());
-    auto status = mutator.MakeOneRequest(*mock);
+    auto limiter = std::make_shared<bigtable_internal::NoopMutateRowsLimiter>();
+    auto status = mutator.MakeOneRequest(*mock, *limiter);
     EXPECT_STATUS_OK(status);
   }
   auto failures = std::move(mutator).OnRetryDone();
@@ -325,7 +333,8 @@ TEST(BulkMutatorTest, UnconfirmedAreFailed) {
                                          std::move(mut));
 
   EXPECT_TRUE(mutator.HasPendingMutations());
-  auto status = mutator.MakeOneRequest(*mock);
+  auto limiter = std::make_shared<bigtable_internal::NoopMutateRowsLimiter>();
+  auto status = mutator.MakeOneRequest(*mock, *limiter);
   EXPECT_THAT(status, StatusIs(StatusCode::kPermissionDenied));
 
   auto failures = std::move(mutator).OnRetryDone();
@@ -357,7 +366,8 @@ TEST(BulkMutatorTest, ConfiguresContext) {
   google::cloud::internal::OptionsSpan span(
       Options{}.set<google::cloud::internal::GrpcSetupOption>(
           mock_setup.AsStdFunction()));
-  (void)mutator.MakeOneRequest(*mock);
+  auto limiter = std::make_shared<bigtable_internal::NoopMutateRowsLimiter>();
+  (void)mutator.MakeOneRequest(*mock, *limiter);
 }
 
 TEST(BulkMutatorTest, MutationStatusReportedOnOkStream) {
@@ -380,7 +390,8 @@ TEST(BulkMutatorTest, MutationStatusReportedOnOkStream) {
   bigtable_internal::BulkMutator mutator(kAppProfile, kTableName, *policy,
                                          std::move(mut));
 
-  auto status = mutator.MakeOneRequest(*mock);
+  auto limiter = std::make_shared<bigtable_internal::NoopMutateRowsLimiter>();
+  auto status = mutator.MakeOneRequest(*mock, *limiter);
   EXPECT_STATUS_OK(status);
 
   auto failures = std::move(mutator).OnRetryDone();
@@ -415,7 +426,8 @@ TEST(BulkMutatorTest, ReportEitherRetryableMutationFailOrStreamFail) {
   bigtable_internal::BulkMutator mutator(kAppProfile, kTableName, *policy,
                                          std::move(mut));
 
-  auto status = mutator.MakeOneRequest(*mock);
+  auto limiter = std::make_shared<bigtable_internal::NoopMutateRowsLimiter>();
+  auto status = mutator.MakeOneRequest(*mock, *limiter);
   EXPECT_THAT(status, StatusIs(StatusCode::kDataLoss));
 
   auto failures = std::move(mutator).OnRetryDone();
@@ -459,16 +471,51 @@ TEST(BulkMutatorTest, ReportOnlyLatestMutationStatus) {
   bigtable_internal::BulkMutator mutator(kAppProfile, kTableName, *policy,
                                          std::move(mut));
 
-  auto status = mutator.MakeOneRequest(*mock);
+  auto limiter = std::make_shared<bigtable_internal::NoopMutateRowsLimiter>();
+  auto status = mutator.MakeOneRequest(*mock, *limiter);
   EXPECT_THAT(status, StatusIs(StatusCode::kUnavailable));
 
-  status = mutator.MakeOneRequest(*mock);
+  status = mutator.MakeOneRequest(*mock, *limiter);
   EXPECT_THAT(status, StatusIs(StatusCode::kDataLoss));
 
   auto failures = std::move(mutator).OnRetryDone();
   ASSERT_EQ(1UL, failures.size());
   EXPECT_EQ(0, failures[0].original_index());
   EXPECT_THAT(failures[0].status(), StatusIs(StatusCode::kDataLoss));
+}
+
+TEST(BulkMutatorTest, Throttling) {
+  BulkMutation mut(IdempotentMutation("r0"), IdempotentMutation("r1"));
+
+  auto mock_stub = std::make_shared<MockBigtableStub>();
+  auto mock_limiter = std::make_shared<MockMutateRowsLimiter>();
+
+  {
+    ::testing::InSequence seq;
+    EXPECT_CALL(*mock_limiter, Acquire);
+    EXPECT_CALL(*mock_stub, MutateRows)
+        .WillOnce(
+            [](auto, google::bigtable::v2::MutateRowsRequest const& request) {
+              EXPECT_THAT(request, HasCorrectResourceNames());
+              auto stream = std::make_unique<MockMutateRowsStream>();
+              EXPECT_CALL(*stream, Read)
+                  .WillOnce(Return(MakeResponse({{0, grpc::StatusCode::OK}})))
+                  .WillOnce(Return(MakeResponse({{1, grpc::StatusCode::OK}})))
+                  .WillOnce(Return(Status()));
+              return stream;
+            });
+    EXPECT_CALL(*mock_limiter, Update).Times(2);
+  }
+
+  auto policy = DefaultIdempotentMutationPolicy();
+  bigtable_internal::BulkMutator mutator(kAppProfile, kTableName, *policy,
+                                         std::move(mut));
+
+  EXPECT_TRUE(mutator.HasPendingMutations());
+  auto status = mutator.MakeOneRequest(*mock_stub, *mock_limiter);
+  EXPECT_STATUS_OK(status);
+  auto failures = std::move(mutator).OnRetryDone();
+  EXPECT_THAT(failures, IsEmpty());
 }
 
 }  // namespace

--- a/google/cloud/bigtable/internal/data_connection_impl.h
+++ b/google/cloud/bigtable/internal/data_connection_impl.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/bigtable/data_connection.h"
 #include "google/cloud/bigtable/internal/bigtable_stub.h"
+#include "google/cloud/bigtable/internal/mutate_rows_limiter.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
@@ -36,7 +37,9 @@ class DataConnectionImpl : public bigtable::DataConnection {
   ~DataConnectionImpl() override = default;
 
   DataConnectionImpl(std::unique_ptr<BackgroundThreads> background,
-                     std::shared_ptr<BigtableStub> stub, Options options);
+                     std::shared_ptr<BigtableStub> stub,
+                     std::shared_ptr<MutateRowsLimiter> limiter,
+                     Options options);
 
   Options options() override { return options_; }
 
@@ -93,6 +96,7 @@ class DataConnectionImpl : public bigtable::DataConnection {
  private:
   std::unique_ptr<BackgroundThreads> background_;
   std::shared_ptr<BigtableStub> stub_;
+  std::shared_ptr<MutateRowsLimiter> limiter_;
   Options options_;
 };
 

--- a/google/cloud/bigtable/internal/mutate_rows_limiter.cc
+++ b/google/cloud/bigtable/internal/mutate_rows_limiter.cc
@@ -31,8 +31,6 @@ T Clamp(T value, T min, T max) {
 
 }  // namespace
 
-MutateRowsLimiter::~MutateRowsLimiter() = default;
-
 void ThrottlingMutateRowsLimiter::Acquire() {
   auto wait = limiter_.acquire(1);
   throttled_since_last_update_ =

--- a/google/cloud/bigtable/internal/mutate_rows_limiter.cc
+++ b/google/cloud/bigtable/internal/mutate_rows_limiter.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/internal/mutate_rows_limiter.h"
-#include "google/cloud/bigtable/options.h"
 #include "google/cloud/internal/opentelemetry.h"
 #include <algorithm>
 #include <thread>
@@ -31,6 +30,8 @@ T Clamp(T value, T min, T max) {
 }
 
 }  // namespace
+
+MutateRowsLimiter::~MutateRowsLimiter() = default;
 
 void ThrottlingMutateRowsLimiter::Acquire() {
   auto wait = limiter_.acquire(1);

--- a/google/cloud/bigtable/internal/mutate_rows_limiter.h
+++ b/google/cloud/bigtable/internal/mutate_rows_limiter.h
@@ -39,7 +39,6 @@ class MutateRowsLimiter {
 
 class NoopMutateRowsLimiter : public MutateRowsLimiter {
  public:
-  ~NoopMutateRowsLimiter() override = default;
   void Acquire() override {}
   void Update(google::bigtable::v2::MutateRowsResponse const&) override {}
 };
@@ -47,9 +46,6 @@ class NoopMutateRowsLimiter : public MutateRowsLimiter {
 class ThrottlingMutateRowsLimiter : public MutateRowsLimiter {
  public:
   using Clock = RateLimiter::Clock;
-
-  ~ThrottlingMutateRowsLimiter() override = default;
-
   template <typename Rep1, typename Period1, typename Rep2, typename Period2,
             typename Rep3, typename Period3>
   explicit ThrottlingMutateRowsLimiter(

--- a/google/cloud/bigtable/internal/mutate_rows_limiter.h
+++ b/google/cloud/bigtable/internal/mutate_rows_limiter.h
@@ -31,6 +31,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 /// A Bigtable-specific wrapper over the more generic `RateLimiter`
 class MutateRowsLimiter {
  public:
+  virtual ~MutateRowsLimiter() = 0;
   virtual void Acquire() = 0;
   virtual void Update(
       google::bigtable::v2::MutateRowsResponse const& response) = 0;
@@ -38,6 +39,7 @@ class MutateRowsLimiter {
 
 class NoopMutateRowsLimiter : public MutateRowsLimiter {
  public:
+  ~NoopMutateRowsLimiter() override = default;
   void Acquire() override {}
   void Update(google::bigtable::v2::MutateRowsResponse const&) override {}
 };
@@ -45,6 +47,9 @@ class NoopMutateRowsLimiter : public MutateRowsLimiter {
 class ThrottlingMutateRowsLimiter : public MutateRowsLimiter {
  public:
   using Clock = RateLimiter::Clock;
+
+  ~ThrottlingMutateRowsLimiter() override = default;
+
   template <typename Rep1, typename Period1, typename Rep2, typename Period2,
             typename Rep3, typename Period3>
   explicit ThrottlingMutateRowsLimiter(

--- a/google/cloud/bigtable/internal/mutate_rows_limiter.h
+++ b/google/cloud/bigtable/internal/mutate_rows_limiter.h
@@ -31,7 +31,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 /// A Bigtable-specific wrapper over the more generic `RateLimiter`
 class MutateRowsLimiter {
  public:
-  virtual ~MutateRowsLimiter() = 0;
+  virtual ~MutateRowsLimiter() = default;
   virtual void Acquire() = 0;
   virtual void Update(
       google::bigtable::v2::MutateRowsResponse const& response) = 0;

--- a/google/cloud/bigtable/internal/mutate_rows_limiter_test.cc
+++ b/google/cloud/bigtable/internal/mutate_rows_limiter_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/internal/mutate_rows_limiter.h"
+#include "google/cloud/bigtable/options.h"
 #include "google/cloud/internal/time_utils.h"
 #include "google/cloud/testing_util/fake_clock.h"
 #include <gmock/gmock.h>

--- a/google/cloud/bigtable/testing/mock_mutate_rows_limiter.h
+++ b/google/cloud/bigtable/testing/mock_mutate_rows_limiter.h
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/bigtable/testing/mock_mutate_rows_limiter.h
+++ b/google/cloud/bigtable/testing/mock_mutate_rows_limiter.h
@@ -1,0 +1,39 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_MOCK_MUTATE_ROWS_LIMITER_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_MOCK_MUTATE_ROWS_LIMITER_H
+
+#include "google/cloud/bigtable/internal/mutate_rows_limiter.h"
+#include <google/bigtable/v2/bigtable.pb.h>
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace bigtable {
+namespace testing {
+
+class MockMutateRowsLimiter : public bigtable_internal::MutateRowsLimiter {
+ public:
+  MOCK_METHOD(void, Acquire, (), (override));
+  MOCK_METHOD(void, Update, (google::bigtable::v2::MutateRowsResponse const&),
+              (override));
+};
+
+}  // namespace testing
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_MOCK_MUTATE_ROWS_LIMITER_H


### PR DESCRIPTION
Part of the work for #12959 

Create a no-op limiter, and plumb it through the internal layers of the library for `Table::BulkApply()`

Also fix virtual destructor for `MutateRowsLimiter`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13090)
<!-- Reviewable:end -->
