### PR TITLE
ci: upgrade `checkers` build to Fedora:39

### DIFF
--- a/ci/cloudbuild/dockerfiles/checkers.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/checkers.Dockerfile
@@ -17,7 +17,7 @@
 # than to the extent that certain distros offer certain versions of software
 # that the build needs. It's fine to add more deps that are needed by the
 # `checkers.sh` build.
-FROM fedora:38
+FROM fedora:39
 ARG NCPU=4
 ARG ARCH=amd64
 

--- a/google/cloud/spanner/internal/transaction_impl_test.cc
+++ b/google/cloud/spanner/internal/transaction_impl_test.cc
@@ -116,7 +116,7 @@ ResultSet Client::Read(SessionHolder& session,
                        std::string const&, KeySet const&,
                        std::vector<std::string> const&) {
   // when we mark a transaction invalid, we use this Status.
-  const Status failed_txn_status(StatusCode::kInternal, "Bad transaction");
+  Status const failed_txn_status(StatusCode::kInternal, "Bad transaction");
 
   bool fail_with_throw = false;
   EXPECT_THAT(tag, IsEmpty());

--- a/google/cloud/spanner/results_test.cc
+++ b/google/cloud/spanner/results_test.cc
@@ -190,7 +190,7 @@ TEST(ProfileQueryResult, ExecutionStats) {
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &stats));
   EXPECT_CALL(*mock_source, Stats()).WillOnce(Return(stats));
 
-  std::vector<std::pair<const std::string, std::string>> expected;
+  std::vector<std::pair<std::string const, std::string>> expected;
   expected.emplace_back("elapsed_time", "42 secs");
   ProfileQueryResult query_result(std::move(mock_source));
   EXPECT_THAT(*query_result.ExecutionStats(),
@@ -250,7 +250,7 @@ TEST(ProfileDmlResult, ExecutionStats) {
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &stats));
   EXPECT_CALL(*mock_source, Stats()).WillOnce(Return(stats));
 
-  std::vector<std::pair<const std::string, std::string>> expected;
+  std::vector<std::pair<std::string const, std::string>> expected;
   expected.emplace_back("elapsed_time", "42 secs");
   ProfileDmlResult dml_result(std::move(mock_source));
   EXPECT_THAT(*dml_result.ExecutionStats(), UnorderedPointwise(Eq(), expected));

--- a/google/cloud/spanner/row.cc
+++ b/google/cloud/spanner/row.cc
@@ -48,7 +48,7 @@ Row MakeTestRow(std::vector<std::pair<std::string, Value>> pairs) {
 Row::Row() : Row({}, std::make_shared<std::vector<std::string>>()) {}
 
 Row::Row(std::vector<Value> values,
-         std::shared_ptr<const std::vector<std::string>> columns)
+         std::shared_ptr<std::vector<std::string> const> columns)
     : values_(std::move(values)), columns_(std::move(columns)) {
   if (values_.size() != columns_->size()) {
     GCP_LOG(FATAL) << "Row's value and column sizes do not match: "

--- a/google/cloud/terminate_handler_test.cc
+++ b/google/cloud/terminate_handler_test.cc
@@ -58,14 +58,14 @@ TEST(TerminateHandler, OldHandlerIsReturned) {
 
 TEST(TerminateHandler, TerminateTerminates) {
   auto orig = SetTerminateHandler(&CustomHandler);
-  const std::string expected = std::string(kHandlerMsg) + "details";
+  std::string const expected = std::string(kHandlerMsg) + "details";
   EXPECT_DEATH_IF_SUPPORTED(Terminate("details"), expected);
   SetTerminateHandler(orig);
 }
 
 TEST(TerminateHandler, NoAbortAborts) {
   auto orig = SetTerminateHandler([](char const*) {});
-  const std::string expected =
+  std::string const expected =
       "Aborting because the installed terminate "
       "handler returned. Error details: details";
   EXPECT_DEATH_IF_SUPPORTED(Terminate("details"), expected);

--- a/google/cloud/testing_util/mock_http_payload.h
+++ b/google/cloud/testing_util/mock_http_payload.h
@@ -33,7 +33,7 @@ class MockHttpPayload : public rest_internal::HttpPayload {
   MOCK_METHOD(StatusOr<std::size_t>, Read, (absl::Span<char> buffer),
               (override));
   MOCK_METHOD((std::multimap<std::string, std::string>), DebugHeaders, (),
-              (const override));
+              (override const));
 };
 
 template <typename Collection>

--- a/google/cloud/testing_util/mock_http_payload.h
+++ b/google/cloud/testing_util/mock_http_payload.h
@@ -33,7 +33,7 @@ class MockHttpPayload : public rest_internal::HttpPayload {
   MOCK_METHOD(StatusOr<std::size_t>, Read, (absl::Span<char> buffer),
               (override));
   MOCK_METHOD((std::multimap<std::string, std::string>), DebugHeaders, (),
-              (override const));
+              (const, override));
 };
 
 template <typename Collection>


### PR DESCRIPTION
New version of `clang-format` with (better ?) east-const enforcement.

Part of the work for #13076

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13101)
<!-- Reviewable:end -->
