### PR TITLE
fix(bigquery): remove requirement to have `configuration` field

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/job_response.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response.cc
@@ -33,7 +33,7 @@ bool valid_job(nlohmann::json const& j) {
 
 bool valid_list_format_job(nlohmann::json const& j) {
   return (j.contains("kind") && j.contains("state") && j.contains("id") &&
-          j.contains("jobReference") && j.contains("configuration"));
+          j.contains("jobReference"));
 }
 
 bool valid_jobs_list(nlohmann::json const& j) {

--- a/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
@@ -253,7 +253,7 @@ TEST(ListJobsResponseTest, InvalidListFormatJob) {
                        HasSubstr("Not a valid Json ListFormatJob object")));
 }
 
-TEST(ListJobsResponseTest, MimimalProjectionJson) {
+TEST(ListJobsResponseTest, MinimalProjectionJson) {
   BigQueryHttpResponse http_response;
   http_response.payload =
       R"({"etag": "tag-1",


### PR DESCRIPTION
BQ returns this field only if `projection:FULL` was chosen during request. If request doesn't have it or `projection:MINIMAL` is chosen, BQ doesn't return this field. Which makes it not mandatory for ALL responses to have it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13102)
<!-- Reviewable:end -->
