### PR TITLE
fix(bigquery): use int for creationTime

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/job_request.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.cc
@@ -139,9 +139,11 @@ StatusOr<rest_internal::RestRequest> BuildRestRequest(GetJobRequest const& r) {
   return request;
 }
 
-auto CastTimeToMilliseconds(std::chrono::system_clock::time_point const time) {
-  return std::chrono::time_point_cast<std::chrono::milliseconds>(time)
-      .time_since_epoch()
+// Assuming that std::chrono::system_clock epoch is the Unix Time epoch.
+// It's not guaranteed, but de-facto works for most of the platforms
+auto CastTimeToMilliseconds(std::chrono::system_clock::time_point time) {
+  return std::chrono::duration_cast<std::chrono::milliseconds>(
+             time.time_since_epoch())
       .count();
 }
 
@@ -171,12 +173,12 @@ StatusOr<rest_internal::RestRequest> BuildRestRequest(
   if (r.min_creation_time()) {
     request.AddQueryParameter(
         "minCreationTime",
-        std::to_string(CastTimeToMilliseconds(r.min_creation_time().value())));
+        std::to_string(CastTimeToMilliseconds(*r.min_creation_time())));
   }
   if (r.max_creation_time()) {
     request.AddQueryParameter(
         "maxCreationTime",
-        std::to_string(CastTimeToMilliseconds(r.max_creation_time().value())));
+        std::to_string(CastTimeToMilliseconds(*r.max_creation_time())));
   }
 
   auto if_not_empty_add = [&](char const* key, auto const& v) {

--- a/google/cloud/bigquery/v2/minimal/internal/job_request.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.cc
@@ -19,10 +19,10 @@
 #include "google/cloud/common_options.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/debug_string.h"
-#include "google/cloud/internal/format_time_point.h"
 #include "google/cloud/internal/make_status.h"
 #include "google/cloud/status.h"
 #include "absl/strings/match.h"
+#include <chrono>
 
 namespace google {
 namespace cloud {
@@ -139,6 +139,13 @@ StatusOr<rest_internal::RestRequest> BuildRestRequest(GetJobRequest const& r) {
   return request;
 }
 
+auto CastTimeToMilliseconds(
+    const std::chrono::system_clock::time_point time) {
+  return std::chrono::time_point_cast<std::chrono::milliseconds>(time)
+      .time_since_epoch()
+      .count();
+}
+
 StatusOr<rest_internal::RestRequest> BuildRestRequest(
     ListJobsRequest const& r) {
   rest_internal::RestRequest request;
@@ -165,18 +172,12 @@ StatusOr<rest_internal::RestRequest> BuildRestRequest(
   if (r.min_creation_time()) {
     request.AddQueryParameter(
         "minCreationTime",
-        std::to_string(std::chrono::time_point_cast<std::chrono::milliseconds>(
-                           r.min_creation_time().value())
-                           .time_since_epoch()
-                           .count()));
+        std::to_string(CastTimeToMilliseconds(r.min_creation_time().value())));
   }
   if (r.max_creation_time()) {
     request.AddQueryParameter(
         "maxCreationTime",
-        std::to_string(std::chrono::time_point_cast<std::chrono::milliseconds>(
-                           r.max_creation_time().value())
-                           .time_since_epoch()
-                           .count()));
+        std::to_string(CastTimeToMilliseconds(r.max_creation_time().value())));
   }
 
   auto if_not_empty_add = [&](char const* key, auto const& v) {

--- a/google/cloud/bigquery/v2/minimal/internal/job_request.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.cc
@@ -139,7 +139,7 @@ StatusOr<rest_internal::RestRequest> BuildRestRequest(GetJobRequest const& r) {
   return request;
 }
 
-auto CastTimeToMilliseconds(const std::chrono::system_clock::time_point time) {
+auto CastTimeToMilliseconds(std::chrono::system_clock::time_point const time) {
   return std::chrono::time_point_cast<std::chrono::milliseconds>(time)
       .time_since_epoch()
       .count();

--- a/google/cloud/bigquery/v2/minimal/internal/job_request.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.cc
@@ -139,8 +139,7 @@ StatusOr<rest_internal::RestRequest> BuildRestRequest(GetJobRequest const& r) {
   return request;
 }
 
-auto CastTimeToMilliseconds(
-    const std::chrono::system_clock::time_point time) {
+auto CastTimeToMilliseconds(const std::chrono::system_clock::time_point time) {
   return std::chrono::time_point_cast<std::chrono::milliseconds>(time)
       .time_since_epoch()
       .count();

--- a/google/cloud/bigquery/v2/minimal/internal/job_request.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.cc
@@ -163,12 +163,20 @@ StatusOr<rest_internal::RestRequest> BuildRestRequest(
     request.AddQueryParameter("maxResults", std::to_string(r.max_results()));
   }
   if (r.min_creation_time()) {
-    request.AddQueryParameter("minCreationTime",
-                              internal::FormatRfc3339(*r.min_creation_time()));
+    request.AddQueryParameter(
+        "minCreationTime",
+        std::to_string(std::chrono::time_point_cast<std::chrono::milliseconds>(
+                           r.min_creation_time().value())
+                           .time_since_epoch()
+                           .count()));
   }
   if (r.max_creation_time()) {
-    request.AddQueryParameter("maxCreationTime",
-                              internal::FormatRfc3339(*r.max_creation_time()));
+    request.AddQueryParameter(
+        "maxCreationTime",
+        std::to_string(std::chrono::time_point_cast<std::chrono::milliseconds>(
+                           r.max_creation_time().value())
+                           .time_since_epoch()
+                           .count()));
   }
 
   auto if_not_empty_add = [&](char const* key, auto const& v) {

--- a/google/cloud/bigquery/v2/minimal/internal/job_request_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request_test.cc
@@ -39,12 +39,12 @@ using ::testing::HasSubstr;
 auto static const kMin = std::chrono::system_clock::now();
 auto static const kMax = kMin + std::chrono::milliseconds(100);
 auto static const kMinInt =
-    std::chrono::time_point_cast<std::chrono::milliseconds>(kMin)
-        .time_since_epoch()
+    std::chrono::duration_cast<std::chrono::milliseconds>(
+        kMin.time_since_epoch())
         .count();
 auto static const kMaxInt =
-    std::chrono::time_point_cast<std::chrono::milliseconds>(kMax)
-        .time_since_epoch()
+    std::chrono::duration_cast<std::chrono::milliseconds>(
+        kMax.time_since_epoch())
         .count();
 
 ListJobsRequest GetListJobsRequest() {

--- a/google/cloud/bigquery/v2/minimal/internal/job_request_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request_test.cc
@@ -38,11 +38,11 @@ using ::testing::HasSubstr;
 
 auto static const kMin = std::chrono::system_clock::now();
 auto static const kMax = kMin + std::chrono::milliseconds(100);
-auto static const kMin_int =
+auto static const kMinInt =
     std::chrono::time_point_cast<std::chrono::milliseconds>(kMin)
         .time_since_epoch()
         .count();
-auto static const kMax_int =
+auto static const kMaxInt =
     std::chrono::time_point_cast<std::chrono::milliseconds>(kMax)
         .time_since_epoch()
         .count();
@@ -167,8 +167,8 @@ TEST(ListJobsRequestTest, Success) {
       "https://bigquery.googleapis.com/bigquery/v2/projects/1/jobs");
   expected.AddQueryParameter("allUsers", "true");
   expected.AddQueryParameter("maxResults", "10");
-  expected.AddQueryParameter("minCreationTime", std::to_string(kMin_int));
-  expected.AddQueryParameter("maxCreationTime", std::to_string(kMax_int));
+  expected.AddQueryParameter("minCreationTime", std::to_string(kMinInt));
+  expected.AddQueryParameter("maxCreationTime", std::to_string(kMaxInt));
   expected.AddQueryParameter("pageToken", "123");
   expected.AddQueryParameter("projection", "FULL");
   expected.AddQueryParameter("stateFilter", "RUNNING");

--- a/google/cloud/bigquery/v2/minimal/internal/job_request_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request_test.cc
@@ -36,15 +36,23 @@ using ::google::cloud::bigquery_v2_minimal_testing::MakePostQueryRequest;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::HasSubstr;
 
+auto static const kMin = std::chrono::system_clock::now();
+auto static const kMax = kMin + std::chrono::milliseconds(100);
+auto static const kMin_int =
+    std::chrono::time_point_cast<std::chrono::milliseconds>(kMin)
+        .time_since_epoch()
+        .count();
+auto static const kMax_int =
+    std::chrono::time_point_cast<std::chrono::milliseconds>(kMax)
+        .time_since_epoch()
+        .count();
+
 ListJobsRequest GetListJobsRequest() {
   ListJobsRequest request("1");
-  auto const min = std::chrono::system_clock::now();
-  auto const duration = std::chrono::milliseconds(100);
-  auto const max = min + duration;
   request.set_all_users(true)
       .set_max_results(10)
-      .set_min_creation_time(min)
-      .set_max_creation_time(max)
+      .set_min_creation_time(kMin)
+      .set_max_creation_time(kMax)
       .set_parent_job_id("1")
       .set_page_token("123")
       .set_projection(Projection::Full())
@@ -159,18 +167,8 @@ TEST(ListJobsRequestTest, Success) {
       "https://bigquery.googleapis.com/bigquery/v2/projects/1/jobs");
   expected.AddQueryParameter("allUsers", "true");
   expected.AddQueryParameter("maxResults", "10");
-  expected.AddQueryParameter(
-      "minCreationTime",
-      std::to_string(std::chrono::time_point_cast<std::chrono::milliseconds>(
-                         request.min_creation_time().value())
-                         .time_since_epoch()
-                         .count()));
-  expected.AddQueryParameter(
-      "maxCreationTime",
-      std::to_string(std::chrono::time_point_cast<std::chrono::milliseconds>(
-                         request.max_creation_time().value())
-                         .time_since_epoch()
-                         .count()));
+  expected.AddQueryParameter("minCreationTime", std::to_string(kMin_int));
+  expected.AddQueryParameter("maxCreationTime", std::to_string(kMax_int));
   expected.AddQueryParameter("pageToken", "123");
   expected.AddQueryParameter("projection", "FULL");
   expected.AddQueryParameter("stateFilter", "RUNNING");

--- a/google/cloud/bigquery/v2/minimal/internal/job_request_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request_test.cc
@@ -161,10 +161,16 @@ TEST(ListJobsRequestTest, Success) {
   expected.AddQueryParameter("maxResults", "10");
   expected.AddQueryParameter(
       "minCreationTime",
-      internal::FormatRfc3339(request.min_creation_time().value()));
+      std::to_string(std::chrono::time_point_cast<std::chrono::milliseconds>(
+                         request.min_creation_time().value())
+                         .time_since_epoch()
+                         .count()));
   expected.AddQueryParameter(
       "maxCreationTime",
-      internal::FormatRfc3339(request.max_creation_time().value()));
+      std::to_string(std::chrono::time_point_cast<std::chrono::milliseconds>(
+                         request.max_creation_time().value())
+                         .time_since_epoch()
+                         .count()));
   expected.AddQueryParameter("pageToken", "123");
   expected.AddQueryParameter("projection", "FULL");
   expected.AddQueryParameter("stateFilter", "RUNNING");


### PR DESCRIPTION
Docs states that min/maxCreationTime is a string with `value for job creation time, in milliseconds since the POSIX epoch` 
https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/list#query-parameters
Currently the format is like `2023-11-03T10:33:16.946721928Z` which is not valid for BQ API.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13103)
<!-- Reviewable:end -->
