### PR TITLE
test(GCS+gRPC): deflake stub factory test

### DIFF
--- a/google/cloud/storage/internal/storage_stub_factory.h
+++ b/google/cloud/storage/internal/storage_stub_factory.h
@@ -21,9 +21,11 @@
 #include "google/cloud/internal/minimal_iam_credentials_stub.h"
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <grpcpp/grpcpp.h>
 #include <functional>
 #include <memory>
 #include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {
@@ -34,7 +36,8 @@ using BaseStorageStubFactory =
     std::function<std::shared_ptr<StorageStub>(std::shared_ptr<grpc::Channel>)>;
 
 /// Used in testing to create decorated mocks.
-std::pair<std::shared_ptr<GrpcChannelRefresh>, std::shared_ptr<StorageStub>>
+std::pair<std::vector<std::shared_ptr<grpc::Channel>>,
+          std::shared_ptr<StorageStub>>
 CreateDecoratedStubs(google::cloud::CompletionQueue cq, Options const& options,
                      BaseStorageStubFactory const& base_factory);
 


### PR DESCRIPTION
Change the factory helpers to avoid race conditions in the test. The `GrpcChannelRefresh` object should be deleted after the stubs and the corresponding channels. The test was destroying them in the opposite order, this results in race conditions with older versions of gRPC.

I solved the problem by *not* creating a `GrpcChannelRefresh` that then goes unused.

I think this was a test-only bug: the library does destroy these things in the right order.

Fixes #13084

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13104)
<!-- Reviewable:end -->
