### PR TITLE
refactor(otel): any duration in traced sleeper

### DIFF
--- a/google/cloud/internal/opentelemetry.cc
+++ b/google/cloud/internal/opentelemetry.cc
@@ -146,22 +146,6 @@ bool TracingEnabled(Options const& options) {
 bool TracingEnabled(Options const&) { return false; }
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 
-std::function<void(std::chrono::milliseconds)> MakeTracedSleeper(
-    Options const& options,
-    std::function<void(std::chrono::milliseconds)> const& sleeper) {
-#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
-  if (TracingEnabled(options)) {
-    return [=](std::chrono::milliseconds p) {
-      auto span = MakeSpan("Backoff");
-      sleeper(p);
-      span->End();
-    };
-  }
-#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
-  (void)options;
-  return sleeper;
-}
-
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 void AddSpanAttribute(Options const& options, std::string const& key,
                       std::string const& value) {

--- a/google/cloud/internal/opentelemetry_test.cc
+++ b/google/cloud/internal/opentelemetry_test.cc
@@ -381,7 +381,7 @@ TEST(OpenTelemetry, MakeTracedSleeperEnabled) {
   EXPECT_CALL(mock_sleeper, Call(ms(42)));
 
   auto sleeper = mock_sleeper.AsStdFunction();
-  auto result = MakeTracedSleeper(EnableTracing(Options{}), sleeper);
+  auto result = MakeTracedSleeper(EnableTracing(Options{}), sleeper, "Backoff");
   result(ms(42));
 
   // Verify that a span was made.
@@ -396,7 +396,8 @@ TEST(OpenTelemetry, MakeTracedSleeperDisabled) {
   EXPECT_CALL(mock_sleeper, Call(ms(42)));
 
   auto sleeper = mock_sleeper.AsStdFunction();
-  auto result = MakeTracedSleeper(DisableTracing(Options{}), sleeper);
+  auto result =
+      MakeTracedSleeper(DisableTracing(Options{}), sleeper, "Backoff");
   result(ms(42));
 
   // Verify that no spans were made.

--- a/google/cloud/internal/opentelemetry_test.cc
+++ b/google/cloud/internal/opentelemetry_test.cc
@@ -447,7 +447,7 @@ TEST(NoOpenTelemetry, MakeTracedSleeper) {
   EXPECT_CALL(mock_sleeper, Call(ms(42)));
 
   auto sleeper = mock_sleeper.AsStdFunction();
-  auto result = MakeTracedSleeper(Options{}, sleeper);
+  auto result = MakeTracedSleeper(Options{}, sleeper, "Backoff");
   result(ms(42));
 }
 

--- a/google/cloud/internal/rest_retry_loop.h
+++ b/google/cloud/internal/rest_retry_loop.h
@@ -103,7 +103,7 @@ auto RestRetryLoop(std::unique_ptr<RetryPolicy> retry_policy,
         Functor, RestContext&, Options const&, Request const&> {
   std::function<void(std::chrono::milliseconds)> sleeper =
       [](std::chrono::milliseconds p) { std::this_thread::sleep_for(p); };
-  sleeper = internal::MakeTracedSleeper(options, std::move(sleeper));
+  sleeper = internal::MakeTracedSleeper(options, std::move(sleeper), "Backoff");
   return RestRetryLoopImpl(*retry_policy, *backoff_policy, idempotency,
                            std::forward<Functor>(functor), options, request,
                            location, std::move(sleeper));
@@ -123,7 +123,7 @@ auto RestRetryLoop(RetryPolicy& retry_policy, BackoffPolicy& backoff_policy,
         Functor, RestContext&, Options const&, Request const&> {
   std::function<void(std::chrono::milliseconds)> sleeper =
       [](std::chrono::milliseconds p) { std::this_thread::sleep_for(p); };
-  sleeper = internal::MakeTracedSleeper(options, std::move(sleeper));
+  sleeper = internal::MakeTracedSleeper(options, std::move(sleeper), "Backoff");
   return RestRetryLoopImpl(retry_policy, backoff_policy, idempotency,
                            std::forward<Functor>(functor), options, request,
                            location, std::move(sleeper));

--- a/google/cloud/internal/retry_loop.h
+++ b/google/cloud/internal/retry_loop.h
@@ -107,7 +107,7 @@ auto RetryLoop(std::unique_ptr<RetryPolicy> retry_policy,
         Functor, grpc::ClientContext&, Options const&, Request const&> {
   std::function<void(std::chrono::milliseconds)> sleeper =
       [](std::chrono::milliseconds p) { std::this_thread::sleep_for(p); };
-  sleeper = MakeTracedSleeper(options, std::move(sleeper));
+  sleeper = MakeTracedSleeper(options, std::move(sleeper), "Backoff");
   return RetryLoopImpl(*retry_policy, *backoff_policy, idempotency,
                        std::forward<Functor>(functor), options, request,
                        location, std::move(sleeper));

--- a/google/cloud/storage/internal/connection_impl.cc
+++ b/google/cloud/storage/internal/connection_impl.cc
@@ -17,6 +17,8 @@
 #include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/internal/rest_retry_loop.h"
 #include "absl/strings/match.h"
+#include <chrono>
+#include <functional>
 #include <sstream>
 #include <thread>
 #include <utility>
@@ -592,10 +594,10 @@ StatusOr<EmptyResponse> StorageConnectionImpl::DeleteResumableUpload(
 StatusOr<QueryResumableUploadResponse> StorageConnectionImpl::UploadChunk(
     UploadChunkRequest const& request) {
   auto const& current = google::cloud::internal::CurrentOptions();
-  auto sleeper = google::cloud::internal::MakeTracedSleeper(
-      current,
-      [](std::chrono::milliseconds d) { std::this_thread::sleep_for(d); },
-      "Backoff");
+  std::function<void(std::chrono::milliseconds)> sleeper =
+      [](std::chrono::milliseconds d) { std::this_thread::sleep_for(d); };
+  sleeper = google::cloud::internal::MakeTracedSleeper(
+      current, std::move(sleeper), "Backoff");
   auto last_status =
       Status(StatusCode::kDeadlineExceeded,
              "Retry policy exhausted before first attempt was made.");

--- a/google/cloud/storage/internal/connection_impl.cc
+++ b/google/cloud/storage/internal/connection_impl.cc
@@ -594,7 +594,8 @@ StatusOr<QueryResumableUploadResponse> StorageConnectionImpl::UploadChunk(
   auto const& current = google::cloud::internal::CurrentOptions();
   auto sleeper = google::cloud::internal::MakeTracedSleeper(
       current,
-      [](std::chrono::milliseconds d) { std::this_thread::sleep_for(d); });
+      [](std::chrono::milliseconds d) { std::this_thread::sleep_for(d); },
+      "Backoff");
   auto last_status =
       Status(StatusCode::kDeadlineExceeded,
              "Retry policy exhausted before first attempt was made.");


### PR DESCRIPTION
Motivated by #12959 

Generalize traced sleeps
- `std::chrono::duration<R,P>` instead of `std::chrono::milliseconds`
- `name` instead of `"Backoff"`

I plan to trace the sleeps when rate limiting in the Bigtable client (when tracing is enabled).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13106)
<!-- Reviewable:end -->
