### PR TITLE
ci: `publish-docs` needs its own image

### DIFF
--- a/ci/cloudbuild/dockerfiles/fedora-latest-cmake.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-latest-cmake.Dockerfile
@@ -22,7 +22,7 @@ ARG ARCH=amd64
 RUN dnf makecache && \
     dnf install -y abi-compliance-checker autoconf automake \
         clang clang-analyzer clang-tools-extra \
-        cmake diffutils doxygen findutils gcc-c++ git \
+        cmake diffutils findutils gcc-c++ git \
         libcurl-devel llvm make ninja-build \
         openssl-devel patch python python3 \
         python-pip tar unzip w3m wget which zip zlib-devel
@@ -41,9 +41,6 @@ RUN dnf makecache && dnf debuginfo-install -y libstdc++
 
 # These are used by the docfx tool.
 RUN dnf makecache && dnf install -y pugixml-devel yaml-cpp-devel
-
-# This is used in the `publish-docs` build
-RUN dnf makecache && dnf install -y libxslt
 
 # Sets root's password to the empty string to enable users to get a root shell
 # inside the container with `su -` and no password. Sudo would not work because

--- a/ci/cloudbuild/dockerfiles/fedora-latest-publish-docs.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-latest-publish-docs.Dockerfile
@@ -34,10 +34,10 @@ RUN dnf makecache && \
         openssl-devel \
         protobuf-devel \
         pugixml-devel \
-        yaml-cpp-devel 
+        yaml-cpp-devel
 
 # This is used in the `publish-docs` build
-RUN dnf makecache && dnf install -y libxslt doxygen 
+RUN dnf makecache && dnf install -y libxslt doxygen
 
 # Sets root's password to the empty string to enable users to get a root shell
 # inside the container with `su -` and no password. Sudo would not work because

--- a/ci/cloudbuild/dockerfiles/fedora-latest-publish-docs.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-latest-publish-docs.Dockerfile
@@ -1,0 +1,84 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM fedora:38
+ARG NCPU=4
+ARG ARCH=amd64
+
+# Install the minimum development tools needed to compile `google-cloud-cpp`.
+RUN dnf makecache && \
+    dnf install -y clang cmake diffutils findutils gcc-c++ git \
+        make ninja-build patch python3 python3-devel \
+        python-pip tar unzip which zip
+
+# Then install the development packages for `google-cloud-cpp` dependencies.
+RUN dnf makecache && \
+    dnf install -y \
+        gmock-devel \
+        google-benchmark-devel \
+        google-crc32c-devel \
+        grpc-devel \
+        gtest-devel \
+        libcurl-devel \
+        openssl-devel \
+        protobuf-devel \
+        pugixml-devel \
+        yaml-cpp-devel 
+
+# This is used in the `publish-docs` build
+RUN dnf makecache && dnf install -y libxslt doxygen 
+
+# Sets root's password to the empty string to enable users to get a root shell
+# inside the container with `su -` and no password. Sudo would not work because
+# we run these containers as the invoking user's uid, which does not exist in
+# the container's /etc/passwd file.
+RUN echo 'root:' | chpasswd
+
+WORKDIR /var/tmp/build/json
+RUN curl -fsSL https://github.com/nlohmann/json/archive/v3.11.2.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=yes \
+      -DBUILD_TESTING=OFF \
+      -DJSON_BuildTests=OFF \
+      -G Ninja -S . -B cmake-out && \
+    cmake --build cmake-out --target install && \
+    ldconfig
+
+WORKDIR /var/tmp/build/
+RUN curl -fsSL https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.12.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+        -DCMAKE_CXX_STANDARD=14 \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE \
+        -DBUILD_SHARED_LIBS=ON \
+        -DWITH_EXAMPLES=OFF \
+        -DWITH_ABSEIL=ON \
+        -DBUILD_TESTING=OFF \
+        -DOPENTELEMETRY_INSTALL=ON \
+        -S . -B cmake-out -GNinja && \
+    cmake --build cmake-out --target install && \
+    ldconfig && cd /var/tmp && rm -fr build
+
+WORKDIR /var/tmp/sccache
+RUN curl -fsSL https://github.com/mozilla/sccache/releases/download/v0.5.4/sccache-v0.5.4-x86_64-unknown-linux-musl.tar.gz | \
+    tar -zxf - --strip-components=1 && \
+    mkdir -p /usr/local/bin && \
+    mv sccache /usr/local/bin/sccache && \
+    chmod +x /usr/local/bin/sccache
+
+# Update the ld.conf cache in case any libraries were installed in /usr/local/lib*
+RUN ldconfig /usr/local/lib*

--- a/ci/cloudbuild/triggers/publish-docs-ci.yaml
+++ b/ci/cloudbuild/triggers/publish-docs-ci.yaml
@@ -11,7 +11,7 @@ name: publish-docs-ci
 resourceName: projects/cloud-cpp-testing-resources/locations/global/triggers/ee436bb0-22ab-407d-ab69-2a73aec2566d
 substitutions:
   _BUILD_NAME: publish-docs
-  _DISTRO: fedora-latest-cmake
+  _DISTRO: fedora-latest-publish-docs
   _LIBRARIES: all
   _TRIGGER_TYPE: ci
 tags:

--- a/ci/cloudbuild/triggers/publish-docs-compute-pr.yaml
+++ b/ci/cloudbuild/triggers/publish-docs-compute-pr.yaml
@@ -12,7 +12,7 @@ name: publish-docs-compute-pr
 resourceName: projects/cloud-cpp-testing-resources/locations/global/triggers/30ee0e3e-4eed-4b33-8786-47baae4947c1
 substitutions:
   _BUILD_NAME: publish-docs
-  _DISTRO: fedora-latest-cmake
+  _DISTRO: fedora-latest-publish-docs
   _LIBRARIES: compute
   _TRIGGER_TYPE: pr
 tags:

--- a/ci/cloudbuild/triggers/publish-docs-pr.yaml
+++ b/ci/cloudbuild/triggers/publish-docs-pr.yaml
@@ -12,7 +12,7 @@ name: publish-docs-pr
 resourceName: projects/cloud-cpp-testing-resources/locations/global/triggers/7957a267-70de-4e1b-a6b9-99469602a8af
 substitutions:
   _BUILD_NAME: publish-docs
-  _DISTRO: fedora-latest-cmake
+  _DISTRO: fedora-latest-publish-docs
   _LIBRARIES: all_bar_compute
   _TRIGGER_TYPE: pr
 tags:

--- a/ci/cloudbuild/triggers/publish-docs-release.yaml
+++ b/ci/cloudbuild/triggers/publish-docs-release.yaml
@@ -10,7 +10,7 @@ name: publish-docs-release
 resourceName: projects/cloud-cpp-testing-resources/locations/global/triggers/d8deccfb-08d6-4ab7-b8fe-1d59c2d346ea
 substitutions:
   _BUILD_NAME: publish-docs
-  _DISTRO: fedora-latest-cmake
+  _DISTRO: fedora-latest-publish-docs
   _TRIGGER_TYPE: ci
 tags:
 - release


### PR DESCRIPTION
With the latest Doxygen we generate invalid docfx documents. I don't want to hold back the upgrade to Fedora:39 for most builds.

Part of the work for #13076

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13107)
<!-- Reviewable:end -->
