### PR TITLE
feat(common): add GrpcCompressionAlgorithmOption

### DIFF
--- a/google/cloud/grpc_options.cc
+++ b/google/cloud/grpc_options.cc
@@ -26,6 +26,11 @@ void ConfigureContext(grpc::ClientContext& context, Options const& opts) {
   if (opts.has<GrpcSetupOption>()) {
     opts.get<GrpcSetupOption>()(context);
   }
+  if (opts.has<GrpcCompressionAlgorithmOption>()) {
+    // Overwrites anything set by the GrpcSetupOption.
+    context.set_compression_algorithm(
+        opts.get<GrpcCompressionAlgorithmOption>());
+  }
 }
 
 void ConfigurePollContext(grpc::ClientContext& context, Options const& opts) {

--- a/google/cloud/grpc_options.h
+++ b/google/cloud/grpc_options.h
@@ -39,6 +39,16 @@ struct GrpcCredentialOption {
 };
 
 /**
+ * The gRPC compression algorithm used by clients/operations configured
+ * with this object.
+ *
+ * @ingroup options
+ */
+struct GrpcCompressionAlgorithmOption {
+  using Type = grpc_compression_algorithm;
+};
+
+/**
  * The number of transport channels to create.
  *
  * gRPC limits the number of simultaneous calls in progress on a channel to
@@ -175,10 +185,11 @@ struct GrpcBackgroundThreadsFactoryOption {
  * A list of all the gRPC options.
  */
 using GrpcOptionList =
-    OptionList<GrpcCredentialOption, GrpcNumChannelsOption,
-               GrpcChannelArgumentsOption, GrpcChannelArgumentsNativeOption,
-               GrpcTracingOptionsOption, GrpcBackgroundThreadPoolSizeOption,
-               GrpcCompletionQueueOption, GrpcBackgroundThreadsFactoryOption>;
+    OptionList<GrpcCredentialOption, GrpcCompressionAlgorithmOption,
+               GrpcNumChannelsOption, GrpcChannelArgumentsOption,
+               GrpcChannelArgumentsNativeOption, GrpcTracingOptionsOption,
+               GrpcBackgroundThreadPoolSizeOption, GrpcCompletionQueueOption,
+               GrpcBackgroundThreadsFactoryOption>;
 
 namespace internal {
 
@@ -191,6 +202,9 @@ namespace internal {
  *     `set_credentials()` directly on the context. Instead, use the Google
  *     Unified Auth Credentials library, via
  *     #google::cloud::UnifiedCredentialsOption.
+ *
+ * @warning `MergeOptions()` will simply select the preferred function, rather
+ *     than merging the behavior of the preferred and alternate functions.
  */
 struct GrpcSetupOption {
   using Type = std::function<void(grpc::ClientContext&)>;
@@ -207,6 +221,9 @@ struct GrpcSetupOption {
  *     `set_credentials()` directly on the context. Instead, use the Google
  *     Unified Auth Credentials library, via
  *     #google::cloud::UnifiedCredentialsOption.
+ *
+ * @warning `MergeOptions()` will simply select the preferred function, rather
+ *     than merging the behavior of the preferred and alternate functions.
  */
 struct GrpcSetupPollOption {
   using Type = std::function<void(grpc::ClientContext&)>;


### PR DESCRIPTION
Add a common option to set the gRPC compression algorithm, which can be used at both the client and individual-operation levels. (Previously, users could only affect client-to-server compression at the connection level, using `GrpcChannelArgumentsNativeOption`.)

- It will take precedence over any compression algorithm set by the `internal::GrpcSetupOption` function.

- The `pubsub::CompressionAlgorithmOption` takes precedence over any other settings during `AsyncPublish()` calls when the request-size threshold is met.

Exercise the new option in the Spanner client in two ways:
- A new `ConnectionImpl` test to check that the compression algorithm from the prevailing options is reflected in the `grpc::ClientContext` passed to the stub.
- Setting the compression algorithm used during the client integration tests, but overriding it on a few operations. (We can't directly observe the effect, but we've done our part.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13108)
<!-- Reviewable:end -->
