### PR TITLE
ci: gRPC at HEAD requires Protobuf >= v25

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -29,10 +29,6 @@ switched_rules_by_language(
     grpc = True,
 )
 
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-
-protobuf_deps()
-
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 
 grpc_deps()
@@ -40,6 +36,11 @@ grpc_deps()
 load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
 
 grpc_extra_deps()
+
+# Protobuf dependencies cannot be loaded before the gRPC dependencies.
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
 
 load("@io_opentelemetry_cpp//bazel:repository.bzl", "opentelemetry_cpp_deps")
 

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -29,6 +29,10 @@ switched_rules_by_language(
     grpc = True,
 )
 
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 
 grpc_deps()

--- a/ci/cloudbuild/builds/grpc-at-head.sh
+++ b/ci/cloudbuild/builds/grpc-at-head.sh
@@ -21,8 +21,8 @@ source module ci/cloudbuild/builds/lib/bazel.sh
 source module ci/cloudbuild/builds/lib/integration.sh
 
 rm -fr /h/grpc && git -C /h clone -q --depth 1 https://github.com/grpc/grpc.git
-rm -fr /h/protobuf && mkdir -p /h/protobuf && \
-  curl -fsSL https://github.com/protocolbuffers/protobuf/archive/v25.0.tar.gz | \
+rm -fr /h/protobuf && mkdir -p /h/protobuf &&
+  curl -fsSL https://github.com/protocolbuffers/protobuf/archive/v25.0.tar.gz |
   tar -C /h/protobuf -xzf - --strip-components=1
 
 mapfile -t args < <(bazel::common_args)

--- a/ci/cloudbuild/builds/grpc-at-head.sh
+++ b/ci/cloudbuild/builds/grpc-at-head.sh
@@ -21,10 +21,14 @@ source module ci/cloudbuild/builds/lib/bazel.sh
 source module ci/cloudbuild/builds/lib/integration.sh
 
 rm -fr /h/grpc && git -C /h clone -q --depth 1 https://github.com/grpc/grpc.git
+rm -fr /h/protobuf && mkdir -p /h/protobuf && \
+  curl -fsSL https://github.com/protocolbuffers/protobuf/archive/v25.0.tar.gz | \
+  tar -C /h/protobuf -xzf - --strip-components=1
 
 mapfile -t args < <(bazel::common_args)
 args+=(
   "--override_repository=com_github_grpc_grpc=/h/grpc"
+  "--override_repository=com_google_protobuf=/h/protobuf"
 )
 bazel test "${args[@]}" --test_tag_filters=-integration-test ...
 


### PR DESCRIPTION
Basically, gRPC used to vendor-in `upb`, but that is now part of Protobuf, so both needed changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13109)
<!-- Reviewable:end -->
