### PR TITLE
impl(otel): no spans if no sleeps

### DIFF
--- a/google/cloud/internal/opentelemetry.h
+++ b/google/cloud/internal/opentelemetry.h
@@ -229,6 +229,8 @@ std::function<void(std::chrono::duration<Rep, Period>)> MakeTracedSleeper(
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
   if (TracingEnabled(options)) {
     return [=](std::chrono::duration<Rep, Period> d) {
+      // A sleep of 0 is not an interesting event worth tracing.
+      if (d == std::chrono::duration<Rep, Period>::zero()) return sleeper(d);
       auto span = MakeSpan(name);
       sleeper(d);
       span->End();

--- a/google/cloud/internal/opentelemetry_test.cc
+++ b/google/cloud/internal/opentelemetry_test.cc
@@ -405,6 +405,21 @@ TEST(OpenTelemetry, MakeTracedSleeperDisabled) {
   EXPECT_THAT(spans, IsEmpty());
 }
 
+TEST(OpenTelemetry, MakeTracedSleeperNoSpansIfNoSleep) {
+  auto span_catcher = InstallSpanCatcher();
+
+  MockFunction<void(ms)> mock_sleeper;
+  EXPECT_CALL(mock_sleeper, Call(ms(0)));
+
+  auto sleeper = mock_sleeper.AsStdFunction();
+  auto result = MakeTracedSleeper(EnableTracing(Options{}), sleeper, "Backoff");
+  result(ms(0));
+
+  // Verify that no spans were made.
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(spans, IsEmpty());
+}
+
 TEST(OpenTelemetry, AddSpanAttributeEnabled) {
   auto span_catcher = InstallSpanCatcher();
 

--- a/google/cloud/internal/rest_retry_loop_test.cc
+++ b/google/cloud/internal/rest_retry_loop_test.cc
@@ -58,8 +58,8 @@ std::unique_ptr<RetryPolicy> TestRetryPolicy() {
 }
 
 std::unique_ptr<BackoffPolicy> TestBackoffPolicy() {
-  return ExponentialBackoffPolicy(std::chrono::microseconds(1),
-                                  std::chrono::microseconds(5), 2.0)
+  return ExponentialBackoffPolicy(std::chrono::milliseconds(1),
+                                  std::chrono::milliseconds(5), 2.0)
       .clone();
 }
 

--- a/google/cloud/internal/retry_loop_test.cc
+++ b/google/cloud/internal/retry_loop_test.cc
@@ -54,8 +54,8 @@ std::unique_ptr<RetryPolicy> TestRetryPolicy() {
 }
 
 std::unique_ptr<BackoffPolicy> TestBackoffPolicy() {
-  return ExponentialBackoffPolicy(std::chrono::microseconds(1),
-                                  std::chrono::microseconds(5), 2.0)
+  return ExponentialBackoffPolicy(std::chrono::milliseconds(1),
+                                  std::chrono::milliseconds(5), 2.0)
       .clone();
 }
 

--- a/google/cloud/storage/internal/connection_impl_test.cc
+++ b/google/cloud/storage/internal/connection_impl_test.cc
@@ -44,12 +44,12 @@ using ::testing::Property;
 using ::testing::Return;
 
 Options BasicTestPolicies() {
-  using us = std::chrono::microseconds;
+  using ms = std::chrono::milliseconds;
   return Options{}
       .set<RetryPolicyOption>(LimitedErrorCountRetryPolicy(3).clone())
       .set<BackoffPolicyOption>(
           // Make the tests faster.
-          ExponentialBackoffPolicy(us(1), us(2), 2).clone())
+          ExponentialBackoffPolicy(ms(1), ms(2), 2).clone())
       .set<IdempotencyPolicyOption>(AlwaysRetryIdempotencyPolicy{}.clone());
 }
 


### PR DESCRIPTION
Motivated by #12959 

I still like invoking the `sleeper` even when the duration is 0.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13125)
<!-- Reviewable:end -->
