### PR TITLE
cleanup(common): remove misleading text from request-message log

### DIFF
--- a/google/cloud/internal/log_wrapper.cc
+++ b/google/cloud/internal/log_wrapper.cc
@@ -21,7 +21,7 @@ namespace internal {
 
 void LogRequest(absl::string_view where, absl::string_view args,
                 absl::string_view message) {
-  GCP_LOG(DEBUG) << where << '(' << args << ')' << " << status=" << message;
+  GCP_LOG(DEBUG) << where << '(' << args << ')' << " << " << message;
 }
 
 Status LogResponse(Status response, absl::string_view where,


### PR DESCRIPTION
The last argument to `LogRequest()` is (the debug string of) a request message, so don't prefix it with "status=".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13126)
<!-- Reviewable:end -->
