### PR TITLE
cleanup: explicit options in streaming write RPCs

### DIFF
--- a/generator/integration_tests/benchmarks/client_benchmark.cc
+++ b/generator/integration_tests/benchmarks/client_benchmark.cc
@@ -116,7 +116,8 @@ class TestStub : public GoldenKitchenSinkStub {
   std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
       google::test::admin::database::v1::Request,
       google::test::admin::database::v1::Response>>
-  StreamingWrite(std::shared_ptr<grpc::ClientContext>) override {
+  StreamingWrite(std::shared_ptr<grpc::ClientContext>,
+                 Options const&) override {
     return nullptr;
   }
 

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_auth_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_auth_decorator.cc
@@ -106,12 +106,13 @@ std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
     google::test::admin::database::v1::Request,
     google::test::admin::database::v1::Response>>
 GoldenKitchenSinkAuth::StreamingWrite(
-    std::shared_ptr<grpc::ClientContext> context) {
+    std::shared_ptr<grpc::ClientContext> context,
+    Options const& options) {
   using ErrorStream = ::google::cloud::internal::StreamingWriteRpcError<
       google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>;
   auto status = auth_->ConfigureContext(*context);
   if (!status.ok()) return std::make_unique<ErrorStream>(std::move(status));
-  return child_->StreamingWrite(std::move(context));
+  return child_->StreamingWrite(std::move(context), options);
 }
 
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_auth_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_auth_decorator.h
@@ -74,8 +74,10 @@ class GoldenKitchenSinkAuth : public GoldenKitchenSinkStub {
 
   std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
       google::test::admin::database::v1::Request,
-      google::test::admin::database::v1::Response>> StreamingWrite(
-      std::shared_ptr<grpc::ClientContext> context) override;
+      google::test::admin::database::v1::Response>>
+  StreamingWrite(
+      std::shared_ptr<grpc::ClientContext> context,
+      Options const& options) override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::test::admin::database::v1::Request,

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_logging_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_logging_decorator.cc
@@ -152,13 +152,14 @@ std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
     google::test::admin::database::v1::Request,
     google::test::admin::database::v1::Response>>
 GoldenKitchenSinkLogging::StreamingWrite(
-    std::shared_ptr<grpc::ClientContext> context) {
+    std::shared_ptr<grpc::ClientContext> context,
+    Options const& options) {
   using LoggingStream = ::google::cloud::internal::StreamingWriteRpcLogging<
       google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>;
 
   auto request_id = google::cloud::internal::RequestIdForLogging();
   GCP_LOG(DEBUG) << __func__ << "(" << request_id << ")";
-  auto stream = child_->StreamingWrite(std::move(context));
+  auto stream = child_->StreamingWrite(std::move(context), options);
   if (stream_logging_) {
     stream = std::make_unique<LoggingStream>(
         std::move(stream), tracing_options_, std::move(request_id));

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_logging_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_logging_decorator.h
@@ -74,8 +74,10 @@ class GoldenKitchenSinkLogging : public GoldenKitchenSinkStub {
 
   std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
       google::test::admin::database::v1::Request,
-      google::test::admin::database::v1::Response>> StreamingWrite(
-      std::shared_ptr<grpc::ClientContext> context) override;
+      google::test::admin::database::v1::Response>>
+  StreamingWrite(
+      std::shared_ptr<grpc::ClientContext> context,
+      Options const& options) override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::test::admin::database::v1::Request,

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.cc
@@ -113,9 +113,10 @@ std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
     google::test::admin::database::v1::Request,
     google::test::admin::database::v1::Response>>
 GoldenKitchenSinkMetadata::StreamingWrite(
-    std::shared_ptr<grpc::ClientContext> context) {
-  SetMetadata(*context, internal::CurrentOptions());
-  return child_->StreamingWrite(std::move(context));
+    std::shared_ptr<grpc::ClientContext> context,
+    Options const& options) {
+  SetMetadata(*context, options);
+  return child_->StreamingWrite(std::move(context), options);
 }
 
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.h
@@ -75,8 +75,10 @@ class GoldenKitchenSinkMetadata : public GoldenKitchenSinkStub {
 
   std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
       google::test::admin::database::v1::Request,
-      google::test::admin::database::v1::Response>> StreamingWrite(
-      std::shared_ptr<grpc::ClientContext> context) override;
+      google::test::admin::database::v1::Response>>
+  StreamingWrite(
+      std::shared_ptr<grpc::ClientContext> context,
+      Options const& options) override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::test::admin::database::v1::Request,

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_round_robin_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_round_robin_decorator.cc
@@ -80,8 +80,9 @@ GoldenKitchenSinkRoundRobin::StreamingRead(
 std::unique_ptr<google::cloud::internal::StreamingWriteRpc<
     google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>>
 GoldenKitchenSinkRoundRobin::StreamingWrite(
-    std::shared_ptr<grpc::ClientContext> context) {
-  return Child()->StreamingWrite(std::move(context));
+    std::shared_ptr<grpc::ClientContext> context,
+    Options const& options) {
+  return Child()->StreamingWrite(std::move(context), options);
 }
 
 std::unique_ptr<google::cloud::AsyncStreamingReadWriteRpc<

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_round_robin_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_round_robin_decorator.h
@@ -72,8 +72,10 @@ class GoldenKitchenSinkRoundRobin : public GoldenKitchenSinkStub {
 
   std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
       google::test::admin::database::v1::Request,
-      google::test::admin::database::v1::Response>> StreamingWrite(
-      std::shared_ptr<grpc::ClientContext> context) override;
+      google::test::admin::database::v1::Response>>
+  StreamingWrite(
+      std::shared_ptr<grpc::ClientContext> context,
+      Options const& options) override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::test::admin::database::v1::Request,

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.cc
@@ -139,7 +139,8 @@ std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
     google::test::admin::database::v1::Request,
     google::test::admin::database::v1::Response>>
 DefaultGoldenKitchenSinkStub::StreamingWrite(
-    std::shared_ptr<grpc::ClientContext> context) {
+    std::shared_ptr<grpc::ClientContext> context,
+    Options const&) {
   auto response = std::make_unique<google::test::admin::database::v1::Response>();
   auto stream = grpc_stub_->StreamingWrite(context.get(), response.get());
   return std::make_unique<::google::cloud::internal::StreamingWriteRpcImpl<

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.h
@@ -80,7 +80,8 @@ class GoldenKitchenSinkStub {
       google::test::admin::database::v1::Request,
       google::test::admin::database::v1::Response>>
   StreamingWrite(
-      std::shared_ptr<grpc::ClientContext> context) = 0;
+      std::shared_ptr<grpc::ClientContext> context,
+      Options const& options) = 0;
 
   virtual std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::test::admin::database::v1::Request,
@@ -153,8 +154,10 @@ class DefaultGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
 
   std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
       google::test::admin::database::v1::Request,
-      google::test::admin::database::v1::Response>> StreamingWrite(
-      std::shared_ptr<grpc::ClientContext> context) override;
+      google::test::admin::database::v1::Response>>
+  StreamingWrite(
+      std::shared_ptr<grpc::ClientContext> context,
+      Options const& options) override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::test::admin::database::v1::Request,

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_stub.cc
@@ -120,11 +120,12 @@ GoldenKitchenSinkTracingStub::StreamingRead(
 
 std::unique_ptr<internal::StreamingWriteRpc<google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>>
 GoldenKitchenSinkTracingStub::StreamingWrite(
-    std::shared_ptr<grpc::ClientContext> context) {
+    std::shared_ptr<grpc::ClientContext> context,
+    Options const& options) {
   auto span = internal::MakeSpanGrpc("google.test.admin.database.v1.GoldenKitchenSink", "StreamingWrite");
   auto scope = opentelemetry::trace::Scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto stream = child_->StreamingWrite(context);
+  auto stream = child_->StreamingWrite(context, options);
   return std::make_unique<
       internal::StreamingWriteRpcTracing<google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>>(
       std::move(context), std::move(stream), std::move(span));

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_stub.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_stub.h
@@ -73,8 +73,10 @@ class GoldenKitchenSinkTracingStub : public GoldenKitchenSinkStub {
 
   std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
       google::test::admin::database::v1::Request,
-      google::test::admin::database::v1::Response>> StreamingWrite(
-      std::shared_ptr<grpc::ClientContext> context) override;
+      google::test::admin::database::v1::Response>>
+  StreamingWrite(
+      std::shared_ptr<grpc::ClientContext> context,
+      Options const& options) override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::test::admin::database::v1::Request,

--- a/generator/integration_tests/tests/golden_kitchen_sink_auth_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_auth_decorator_test.cc
@@ -158,7 +158,7 @@ TEST(GoldenKitchenSinkAuthDecoratorTest, ListServiceAccountKeys) {
 
 TEST(GoldenKitchenSinkAuthDecoratorTest, StreamingWrite) {
   auto mock = std::make_shared<MockGoldenKitchenSinkStub>();
-  EXPECT_CALL(*mock, StreamingWrite).WillOnce([](auto) {
+  EXPECT_CALL(*mock, StreamingWrite).WillOnce([] {
     auto stream = std::make_unique<MockStreamingWriteRpc>();
     EXPECT_CALL(*stream, Write).WillOnce(Return(true)).WillOnce(Return(false));
     EXPECT_CALL(*stream, Close)
@@ -168,13 +168,14 @@ TEST(GoldenKitchenSinkAuthDecoratorTest, StreamingWrite) {
   });
 
   auto under_test = GoldenKitchenSinkAuth(MakeTypicalMockAuth(), mock);
-  auto stream =
-      under_test.StreamingWrite(std::make_shared<grpc::ClientContext>());
+  auto stream = under_test.StreamingWrite(
+      std::make_shared<grpc::ClientContext>(), Options{});
   EXPECT_FALSE(stream->Write(Request{}, grpc::WriteOptions()));
   auto response = stream->Close();
   EXPECT_THAT(response, StatusIs(StatusCode::kInvalidArgument));
 
-  stream = under_test.StreamingWrite(std::make_shared<grpc::ClientContext>());
+  stream = under_test.StreamingWrite(std::make_shared<grpc::ClientContext>(),
+                                     Options{});
   EXPECT_TRUE(stream->Write(Request{}, grpc::WriteOptions()));
   EXPECT_FALSE(stream->Write(Request{}, grpc::WriteOptions()));
   response = stream->Close();

--- a/generator/integration_tests/tests/golden_kitchen_sink_logging_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_logging_decorator_test.cc
@@ -221,7 +221,7 @@ TEST_F(LoggingDecoratorTest, StreamingReadRpcWithRpcStreams) {
 }
 
 TEST_F(LoggingDecoratorTest, StreamingWrite) {
-  EXPECT_CALL(*mock_, StreamingWrite).WillOnce([](auto) {
+  EXPECT_CALL(*mock_, StreamingWrite).WillOnce([] {
     auto stream = std::make_unique<MockStreamingWriteRpc>();
     EXPECT_CALL(*stream, Write).WillOnce(Return(true)).WillOnce(Return(false));
     auto response = Response{};
@@ -230,7 +230,8 @@ TEST_F(LoggingDecoratorTest, StreamingWrite) {
     return stream;
   });
   GoldenKitchenSinkLogging stub(mock_, TracingOptions{}, {});
-  auto stream = stub.StreamingWrite(std::make_shared<grpc::ClientContext>());
+  auto stream =
+      stub.StreamingWrite(std::make_shared<grpc::ClientContext>(), Options{});
   EXPECT_TRUE(stream->Write(Request{}, grpc::WriteOptions()));
   EXPECT_FALSE(stream->Write(Request{}, grpc::WriteOptions()));
   auto response = stream->Close();
@@ -246,7 +247,7 @@ TEST_F(LoggingDecoratorTest, StreamingWrite) {
 }
 
 TEST_F(LoggingDecoratorTest, StreamingWriteFullTracing) {
-  EXPECT_CALL(*mock_, StreamingWrite).WillOnce([](auto) {
+  EXPECT_CALL(*mock_, StreamingWrite).WillOnce([] {
     auto stream = std::make_unique<MockStreamingWriteRpc>();
     EXPECT_CALL(*stream, Write).WillOnce(Return(true)).WillOnce(Return(false));
     auto response = Response{};
@@ -255,7 +256,8 @@ TEST_F(LoggingDecoratorTest, StreamingWriteFullTracing) {
     return stream;
   });
   GoldenKitchenSinkLogging stub(mock_, TracingOptions{}, {"rpc-streams"});
-  auto stream = stub.StreamingWrite(std::make_shared<grpc::ClientContext>());
+  auto stream =
+      stub.StreamingWrite(std::make_shared<grpc::ClientContext>(), Options{});
   EXPECT_TRUE(stream->Write(Request{}, grpc::WriteOptions()));
   EXPECT_FALSE(stream->Write(Request{}, grpc::WriteOptions()));
   auto response = stream->Close();

--- a/generator/integration_tests/tests/golden_kitchen_sink_metadata_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_metadata_decorator_test.cc
@@ -253,22 +253,26 @@ TEST_F(MetadataDecoratorTest, StreamingRead) {
 }
 
 TEST_F(MetadataDecoratorTest, StreamingWrite) {
-  EXPECT_CALL(*mock_, StreamingWrite).WillOnce([this](auto context) {
-    IsContextMDValid(
-        *context,
-        "google.test.admin.database.v1.GoldenKitchenSink.StreamingWrite",
-        Request{});
+  EXPECT_CALL(*mock_, StreamingWrite)
+      .WillOnce([this](auto context, Options const&) {
+        IsContextMDValid(
+            *context,
+            "google.test.admin.database.v1.GoldenKitchenSink.StreamingWrite",
+            Request{});
 
-    auto stream = std::make_unique<MockStreamingWriteRpc>();
-    EXPECT_CALL(*stream, Write).WillOnce(Return(true)).WillOnce(Return(false));
-    auto response = Response{};
-    response.set_response("test-only");
-    EXPECT_CALL(*stream, Close).WillOnce(Return(make_status_or(response)));
-    return stream;
-  });
+        auto stream = std::make_unique<MockStreamingWriteRpc>();
+        EXPECT_CALL(*stream, Write)
+            .WillOnce(Return(true))
+            .WillOnce(Return(false));
+        auto response = Response{};
+        response.set_response("test-only");
+        EXPECT_CALL(*stream, Close).WillOnce(Return(make_status_or(response)));
+        return stream;
+      });
 
   GoldenKitchenSinkMetadata stub(mock_, {});
-  auto stream = stub.StreamingWrite(std::make_shared<grpc::ClientContext>());
+  auto stream =
+      stub.StreamingWrite(std::make_shared<grpc::ClientContext>(), Options{});
   EXPECT_TRUE(stream->Write(Request{}, grpc::WriteOptions()));
   EXPECT_FALSE(stream->Write(Request{}, grpc::WriteOptions()));
   auto response = stream->Close();

--- a/generator/integration_tests/tests/golden_kitchen_sink_round_robin_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_round_robin_decorator_test.cc
@@ -92,7 +92,7 @@ TEST(GoldenKitchenSinkRoundRobinDecoratorTest, StreamingWrite) {
   InSequence sequence;
   for (int i = 0; i != kRepeats; ++i) {
     for (auto& m : mocks) {
-      EXPECT_CALL(*m, StreamingWrite).WillOnce([](auto) {
+      EXPECT_CALL(*m, StreamingWrite).WillOnce([] {
         return std::make_unique<MockStreamingWriteRpc>();
       });
     }
@@ -100,7 +100,8 @@ TEST(GoldenKitchenSinkRoundRobinDecoratorTest, StreamingWrite) {
 
   GoldenKitchenSinkRoundRobin stub(AsPlainStubs(mocks));
   for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
-    auto stream = stub.StreamingWrite(std::make_shared<grpc::ClientContext>());
+    auto stream =
+        stub.StreamingWrite(std::make_shared<grpc::ClientContext>(), Options{});
     EXPECT_THAT(stream, NotNull());
   }
 }

--- a/generator/integration_tests/tests/golden_kitchen_sink_stub_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_stub_test.cc
@@ -488,7 +488,7 @@ TEST_F(GoldenKitchenSinkStubTest, StreamingWrite) {
         return stream.release();
       });
   DefaultGoldenKitchenSinkStub stub(std::move(grpc_stub_));
-  auto stream = stub.StreamingWrite(std::move(context));
+  auto stream = stub.StreamingWrite(std::move(context), Options{});
   EXPECT_TRUE(stream->Write(Request{}, grpc::WriteOptions()));
   EXPECT_THAT(stream->Close(), StatusIs(StatusCode::kOk));
 }

--- a/generator/integration_tests/tests/golden_kitchen_sink_tracing_stub_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_tracing_stub_test.cc
@@ -265,7 +265,7 @@ TEST(GoldenKitchenSinkTracingStubTest, StreamingWrite) {
   auto span_catcher = InstallSpanCatcher();
 
   auto mock = std::make_shared<MockGoldenKitchenSinkStub>();
-  EXPECT_CALL(*mock, StreamingWrite).WillOnce([](auto context) {
+  EXPECT_CALL(*mock, StreamingWrite).WillOnce([](auto context, Options const&) {
     ValidatePropagator(*context);
     EXPECT_TRUE(ThereIsAnActiveSpan());
     auto stream = std::make_unique<MockStreamingWriteRpc>();
@@ -276,8 +276,8 @@ TEST(GoldenKitchenSinkTracingStubTest, StreamingWrite) {
   });
 
   auto under_test = GoldenKitchenSinkTracingStub(mock);
-  auto stream =
-      under_test.StreamingWrite(std::make_shared<grpc::ClientContext>());
+  auto stream = under_test.StreamingWrite(
+      std::make_shared<grpc::ClientContext>(), Options{});
   EXPECT_FALSE(stream->Write(Request{}, grpc::WriteOptions()));
   auto response = stream->Close();
   EXPECT_THAT(response, StatusIs(StatusCode::kAborted));

--- a/generator/integration_tests/tests/mock_golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/tests/mock_golden_kitchen_sink_stub.h
@@ -81,7 +81,8 @@ class MockGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
   MOCK_METHOD((std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
                    ::google::test::admin::database::v1::Request,
                    ::google::test::admin::database::v1::Response>>),
-              StreamingWrite, (std::shared_ptr<grpc::ClientContext>),
+              StreamingWrite,
+              (std::shared_ptr<grpc::ClientContext>, Options const&),
               (override));
 
   MOCK_METHOD((std::unique_ptr<::google::cloud::internal::StreamingReadRpc<

--- a/generator/internal/auth_decorator_generator.cc
+++ b/generator/internal/auth_decorator_generator.cc
@@ -131,12 +131,13 @@ std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
     $request_type$,
     $response_type$>>
 $auth_class_name$::$method_name$(
-    std::shared_ptr<grpc::ClientContext> context) {
+    std::shared_ptr<grpc::ClientContext> context,
+    Options const& options) {
   using ErrorStream = ::google::cloud::internal::StreamingWriteRpcError<
       $request_type$, $response_type$>;
   auto status = auth_->ConfigureContext(*context);
   if (!status.ok()) return std::make_unique<ErrorStream>(std::move(status));
-  return child_->$method_name$(std::move(context));
+  return child_->$method_name$(std::move(context), options);
 }
 )""");
       continue;

--- a/generator/internal/logging_decorator_generator.cc
+++ b/generator/internal/logging_decorator_generator.cc
@@ -140,13 +140,14 @@ std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
     $request_type$,
     $response_type$>>
 $logging_class_name$::$method_name$(
-    std::shared_ptr<grpc::ClientContext> context) {
+    std::shared_ptr<grpc::ClientContext> context,
+    Options const& options) {
   using LoggingStream = ::google::cloud::internal::StreamingWriteRpcLogging<
       $request_type$, $response_type$>;
 
   auto request_id = google::cloud::internal::RequestIdForLogging();
   GCP_LOG(DEBUG) << __func__ << "(" << request_id << ")";
-  auto stream = child_->$method_name$(std::move(context));
+  auto stream = child_->$method_name$(std::move(context), options);
   if (stream_logging_) {
     stream = std::make_unique<LoggingStream>(
         std::move(stream), tracing_options_, std::move(request_id));

--- a/generator/internal/metadata_decorator_generator.cc
+++ b/generator/internal/metadata_decorator_generator.cc
@@ -216,9 +216,10 @@ std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
     $request_type$,
     $response_type$>>
 $metadata_class_name$::$method_name$(
-    std::shared_ptr<grpc::ClientContext> context) {
-  SetMetadata(*context, internal::CurrentOptions());
-  return child_->$method_name$(std::move(context));
+    std::shared_ptr<grpc::ClientContext> context,
+    Options const& options) {
+  SetMetadata(*context, options);
+  return child_->$method_name$(std::move(context), options);
 }
 )""");
       continue;

--- a/generator/internal/round_robin_decorator_generator.cc
+++ b/generator/internal/round_robin_decorator_generator.cc
@@ -126,8 +126,9 @@ $round_robin_class_name$::$method_name$(
 std::unique_ptr<google::cloud::internal::StreamingWriteRpc<
     $request_type$, $response_type$>>
 $round_robin_class_name$::$method_name$(
-    std::shared_ptr<grpc::ClientContext> context) {
-  return Child()->$method_name$(std::move(context));
+    std::shared_ptr<grpc::ClientContext> context,
+    Options const& options) {
+  return Child()->$method_name$(std::move(context), options);
 }
 )""");
       continue;

--- a/generator/internal/stub_generator.cc
+++ b/generator/internal/stub_generator.cc
@@ -51,7 +51,9 @@ Status StubGenerator::GenerateHeader() {
   HeaderPrint("\n");
   auto const needs_completion_queue =
       HasAsyncMethod() || HasBidirStreamingMethod();
-  auto const needs_options = HasLongrunningMethod() || HasStreamingReadMethod();
+  auto const needs_options = HasLongrunningMethod() ||
+                             HasStreamingWriteMethod() ||
+                             HasStreamingReadMethod();
   HeaderLocalIncludes(
       {HasBidirStreamingMethod()
            ? "google/cloud/async_streaming_read_write_rpc.h"
@@ -97,7 +99,8 @@ Status StubGenerator::GenerateHeader() {
       $request_type$,
       $response_type$>>
   $method_name$(
-      std::shared_ptr<grpc::ClientContext> context) = 0;
+      std::shared_ptr<grpc::ClientContext> context,
+      Options const& options) = 0;
 )""");
       continue;
     }
@@ -304,7 +307,8 @@ std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
     $request_type$,
     $response_type$>>
 Default$stub_class_name$::$method_name$(
-    std::shared_ptr<grpc::ClientContext> context) {
+    std::shared_ptr<grpc::ClientContext> context,
+    Options const&) {
   auto response = std::make_unique<$response_type$>();
   auto stream = grpc_stub_->$method_name$(context.get(), response.get());
   return std::make_unique<::google::cloud::internal::StreamingWriteRpcImpl<

--- a/generator/internal/stub_generator_base.cc
+++ b/generator/internal/stub_generator_base.cc
@@ -37,8 +37,10 @@ void StubGeneratorBase::HeaderPrintPublicMethods() {
       HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
   std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
       $request_type$,
-      $response_type$>> $method_name$(
-      std::shared_ptr<grpc::ClientContext> context) override;
+      $response_type$>>
+  $method_name$(
+      std::shared_ptr<grpc::ClientContext> context,
+      Options const& options) override;
 )""");
       continue;
     }

--- a/generator/internal/tracing_stub_generator.cc
+++ b/generator/internal/tracing_stub_generator.cc
@@ -138,11 +138,12 @@ $tracing_stub_class_name$::$tracing_stub_class_name$(
       CcPrintMethod(method, __FILE__, __LINE__, R"""(
 std::unique_ptr<internal::StreamingWriteRpc<$request_type$, $response_type$>>
 $tracing_stub_class_name$::$method_name$(
-    std::shared_ptr<grpc::ClientContext> context) {
+    std::shared_ptr<grpc::ClientContext> context,
+    Options const& options) {
   auto span = internal::MakeSpanGrpc("$grpc_service$", "$method_name$");
   auto scope = opentelemetry::trace::Scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto stream = child_->$method_name$(context);
+  auto stream = child_->$method_name$(context, options);
   return std::make_unique<
       internal::StreamingWriteRpcTracing<$request_type$, $response_type$>>(
       std::move(context), std::move(stream), std::move(span));

--- a/google/cloud/storage/internal/grpc/stub.cc
+++ b/google/cloud/storage/internal/grpc/stub.cc
@@ -411,7 +411,7 @@ StatusOr<storage::ObjectMetadata> GrpcStub::InsertObjectMedia(
   ApplyQueryParameters(*ctx, options, request, "resource");
   AddIdempotencyToken(*ctx, context);
   ApplyRoutingHeaders(*ctx, request);
-  auto stream = stub_->WriteObject(std::move(ctx));
+  auto stream = stub_->WriteObject(std::move(ctx), options);
 
   auto splitter = SplitObjectWriteData<ContentType>(request.payload());
   std::int64_t offset = 0;
@@ -665,7 +665,7 @@ StatusOr<storage::internal::QueryResumableUploadResponse> GrpcStub::UploadChunk(
   ApplyQueryParameters(*ctx, options, request, "resource");
   AddIdempotencyToken(*ctx, context);
   ApplyRoutingHeaders(*ctx, request);
-  auto stream = stub_->WriteObject(std::move(ctx));
+  auto stream = stub_->WriteObject(std::move(ctx), options);
 
   auto splitter = SplitObjectWriteData<ContentType>(request.payload());
   auto offset = request.offset();

--- a/google/cloud/storage/internal/grpc/stub_insert_object_media_test.cc
+++ b/google/cloud/storage/internal/grpc/stub_insert_object_media_test.cc
@@ -72,7 +72,7 @@ TEST(GrpcClientInsertObjectMediaTest, Small) {
   ASSERT_TRUE(TextFormat::ParseFromString(kWriteRequestText, &write_request));
 
   auto mock = std::make_shared<MockStorageStub>();
-  EXPECT_CALL(*mock, WriteObject).WillOnce([&](auto) {
+  EXPECT_CALL(*mock, WriteObject).WillOnce([&] {
     ::testing::InSequence sequence;
     auto stream = std::make_unique<MockInsertStream>();
     EXPECT_CALL(*stream, Write(IsProtoEqual(write_request), _))
@@ -97,7 +97,7 @@ TEST(GrpcClientInsertObjectMediaTest, Small) {
 /// @verify that stall timeouts are reported correctly.
 TEST(GrpcClientInsertObjectMediaTest, StallTimeoutWrite) {
   auto mock = std::make_shared<MockStorageStub>();
-  EXPECT_CALL(*mock, WriteObject).WillOnce([&](auto) {
+  EXPECT_CALL(*mock, WriteObject).WillOnce([&] {
     ::testing::InSequence sequence;
     auto stream = std::make_unique<MockInsertStream>();
     EXPECT_CALL(*stream, Cancel).Times(1);
@@ -132,7 +132,7 @@ TEST(GrpcClientInsertObjectMediaTest, StallTimeoutWrite) {
 /// @verify that stall timeouts are reported correctly.
 TEST(GrpcClientInsertObjectMediaTest, StallTimeoutClose) {
   auto mock = std::make_shared<MockStorageStub>();
-  EXPECT_CALL(*mock, WriteObject).WillOnce([&](auto) {
+  EXPECT_CALL(*mock, WriteObject).WillOnce([&] {
     ::testing::InSequence sequence;
     auto stream = std::make_unique<MockInsertStream>();
     EXPECT_CALL(*stream, Write).WillOnce(Return(false));

--- a/google/cloud/storage/internal/grpc/stub_test.cc
+++ b/google/cloud/storage/internal/grpc/stub_test.cc
@@ -196,21 +196,22 @@ TEST_F(GrpcClientTest, DeleteResumableUpload) {
 
 TEST_F(GrpcClientTest, UploadChunk) {
   auto mock = std::make_shared<MockStorageStub>();
-  EXPECT_CALL(*mock, WriteObject).WillOnce([this](auto context) {
-    auto metadata = GetMetadata(*context);
-    EXPECT_THAT(metadata,
-                UnorderedElementsAre(
-                    Pair("x-goog-quota-user", "test-quota-user"),
-                    // Map JSON names to the `resource` subobject
-                    Pair("x-goog-fieldmask", "resource(field1,field2)"),
-                    Pair("x-goog-request-params",
-                         "bucket=projects%2F_%2Fbuckets%2Ftest-bucket")));
-    ::testing::InSequence sequence;
-    auto stream = std::make_unique<MockInsertStream>();
-    EXPECT_CALL(*stream, Write).WillOnce(Return(false));
-    EXPECT_CALL(*stream, Close).WillOnce(Return(PermanentError()));
-    return stream;
-  });
+  EXPECT_CALL(*mock, WriteObject)
+      .WillOnce([this](auto context, Options const&) {
+        auto metadata = GetMetadata(*context);
+        EXPECT_THAT(metadata,
+                    UnorderedElementsAre(
+                        Pair("x-goog-quota-user", "test-quota-user"),
+                        // Map JSON names to the `resource` subobject
+                        Pair("x-goog-fieldmask", "resource(field1,field2)"),
+                        Pair("x-goog-request-params",
+                             "bucket=projects%2F_%2Fbuckets%2Ftest-bucket")));
+        ::testing::InSequence sequence;
+        auto stream = std::make_unique<MockInsertStream>();
+        EXPECT_CALL(*stream, Write).WillOnce(Return(false));
+        EXPECT_CALL(*stream, Close).WillOnce(Return(PermanentError()));
+        return stream;
+      });
   auto client = CreateTestClient(mock);
   auto context = rest_internal::RestContext(TestOptions());
   auto response = client->UploadChunk(
@@ -502,22 +503,23 @@ TEST_F(GrpcClientTest, TestBucketIamPermissions) {
 
 TEST_F(GrpcClientTest, InsertObjectMedia) {
   auto mock = std::make_shared<MockStorageStub>();
-  EXPECT_CALL(*mock, WriteObject).WillOnce([this](auto context) {
-    auto metadata = GetMetadata(*context);
-    EXPECT_THAT(metadata,
-                UnorderedElementsAre(
-                    Pair(kIdempotencyTokenHeader, "test-token-1234"),
-                    Pair("x-goog-quota-user", "test-quota-user"),
-                    // Map JSON names to the `resource` subobject
-                    Pair("x-goog-fieldmask", "resource(field1,field2)"),
-                    Pair("x-goog-request-params",
-                         "bucket=projects%2F_%2Fbuckets%2Ftest-bucket")));
-    ::testing::InSequence sequence;
-    auto stream = std::make_unique<MockInsertStream>();
-    EXPECT_CALL(*stream, Write).WillOnce(Return(false));
-    EXPECT_CALL(*stream, Close).WillOnce(Return(PermanentError()));
-    return stream;
-  });
+  EXPECT_CALL(*mock, WriteObject)
+      .WillOnce([this](auto context, Options const&) {
+        auto metadata = GetMetadata(*context);
+        EXPECT_THAT(metadata,
+                    UnorderedElementsAre(
+                        Pair(kIdempotencyTokenHeader, "test-token-1234"),
+                        Pair("x-goog-quota-user", "test-quota-user"),
+                        // Map JSON names to the `resource` subobject
+                        Pair("x-goog-fieldmask", "resource(field1,field2)"),
+                        Pair("x-goog-request-params",
+                             "bucket=projects%2F_%2Fbuckets%2Ftest-bucket")));
+        ::testing::InSequence sequence;
+        auto stream = std::make_unique<MockInsertStream>();
+        EXPECT_CALL(*stream, Write).WillOnce(Return(false));
+        EXPECT_CALL(*stream, Close).WillOnce(Return(PermanentError()));
+        return stream;
+      });
   auto client = CreateTestClient(mock);
   auto context = TestContext();
   auto response = client->InsertObjectMedia(

--- a/google/cloud/storage/internal/grpc/stub_upload_chunk_test.cc
+++ b/google/cloud/storage/internal/grpc/stub_upload_chunk_test.cc
@@ -48,7 +48,7 @@ static_assert(
 /// @verify that stall timeouts are reported correctly.
 TEST(GrpcClientUploadChunkTest, StallTimeoutWrite) {
   auto mock = std::make_shared<MockStorageStub>();
-  EXPECT_CALL(*mock, WriteObject).WillOnce([&](auto) {
+  EXPECT_CALL(*mock, WriteObject).WillOnce([&] {
     ::testing::InSequence sequence;
     auto stream = std::make_unique<MockInsertStream>();
     EXPECT_CALL(*stream, Cancel).Times(1);
@@ -87,7 +87,7 @@ TEST(GrpcClientUploadChunkTest, StallTimeoutWrite) {
 /// @verify that stall timeouts are reported correctly.
 TEST(GrpcClientUploadChunkTest, StallTimeoutWritesDone) {
   auto mock = std::make_shared<MockStorageStub>();
-  EXPECT_CALL(*mock, WriteObject).WillOnce([&](auto) {
+  EXPECT_CALL(*mock, WriteObject).WillOnce([&] {
     ::testing::InSequence sequence;
     auto stream = std::make_unique<MockInsertStream>();
     EXPECT_CALL(*stream, Write).WillOnce(Return(true));
@@ -130,7 +130,7 @@ TEST(GrpcClientUploadChunkTest, StallTimeoutWritesDone) {
 /// @verify that stall timeouts are reported correctly.
 TEST(GrpcClientUploadChunkTest, StallTimeoutClose) {
   auto mock = std::make_shared<MockStorageStub>();
-  EXPECT_CALL(*mock, WriteObject).WillOnce([&](auto) {
+  EXPECT_CALL(*mock, WriteObject).WillOnce([&] {
     ::testing::InSequence sequence;
     auto stream = std::make_unique<MockInsertStream>();
     EXPECT_CALL(*stream, Write).Times(2).WillRepeatedly(Return(true));

--- a/google/cloud/storage/internal/storage_auth_decorator.cc
+++ b/google/cloud/storage/internal/storage_auth_decorator.cc
@@ -206,13 +206,14 @@ StatusOr<google::storage::v2::Object> StorageAuth::UpdateObject(
 std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
     google::storage::v2::WriteObjectRequest,
     google::storage::v2::WriteObjectResponse>>
-StorageAuth::WriteObject(std::shared_ptr<grpc::ClientContext> context) {
+StorageAuth::WriteObject(std::shared_ptr<grpc::ClientContext> context,
+                         Options const& options) {
   using ErrorStream = ::google::cloud::internal::StreamingWriteRpcError<
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>;
   auto status = auth_->ConfigureContext(*context);
   if (!status.ok()) return std::make_unique<ErrorStream>(std::move(status));
-  return child_->WriteObject(std::move(context));
+  return child_->WriteObject(std::move(context), options);
 }
 
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<

--- a/google/cloud/storage/internal/storage_auth_decorator.h
+++ b/google/cloud/storage/internal/storage_auth_decorator.h
@@ -130,7 +130,8 @@ class StorageAuth : public StorageStub {
   std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>>
-  WriteObject(std::shared_ptr<grpc::ClientContext> context) override;
+  WriteObject(std::shared_ptr<grpc::ClientContext> context,
+              Options const& options) override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::storage::v2::BidiWriteObjectRequest,

--- a/google/cloud/storage/internal/storage_logging_decorator.cc
+++ b/google/cloud/storage/internal/storage_logging_decorator.cc
@@ -284,14 +284,15 @@ StatusOr<google::storage::v2::Object> StorageLogging::UpdateObject(
 std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
     google::storage::v2::WriteObjectRequest,
     google::storage::v2::WriteObjectResponse>>
-StorageLogging::WriteObject(std::shared_ptr<grpc::ClientContext> context) {
+StorageLogging::WriteObject(std::shared_ptr<grpc::ClientContext> context,
+                            Options const& options) {
   using LoggingStream = ::google::cloud::internal::StreamingWriteRpcLogging<
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>;
 
   auto request_id = google::cloud::internal::RequestIdForLogging();
   GCP_LOG(DEBUG) << __func__ << "(" << request_id << ")";
-  auto stream = child_->WriteObject(std::move(context));
+  auto stream = child_->WriteObject(std::move(context), options);
   if (stream_logging_) {
     stream = std::make_unique<LoggingStream>(
         std::move(stream), tracing_options_, std::move(request_id));

--- a/google/cloud/storage/internal/storage_logging_decorator.h
+++ b/google/cloud/storage/internal/storage_logging_decorator.h
@@ -130,7 +130,8 @@ class StorageLogging : public StorageStub {
   std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>>
-  WriteObject(std::shared_ptr<grpc::ClientContext> context) override;
+  WriteObject(std::shared_ptr<grpc::ClientContext> context,
+              Options const& options) override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::storage::v2::BidiWriteObjectRequest,

--- a/google/cloud/storage/internal/storage_metadata_decorator.cc
+++ b/google/cloud/storage/internal/storage_metadata_decorator.cc
@@ -514,9 +514,10 @@ StatusOr<google::storage::v2::Object> StorageMetadata::UpdateObject(
 std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
     google::storage::v2::WriteObjectRequest,
     google::storage::v2::WriteObjectResponse>>
-StorageMetadata::WriteObject(std::shared_ptr<grpc::ClientContext> context) {
-  SetMetadata(*context, internal::CurrentOptions());
-  return child_->WriteObject(std::move(context));
+StorageMetadata::WriteObject(std::shared_ptr<grpc::ClientContext> context,
+                             Options const& options) {
+  SetMetadata(*context, options);
+  return child_->WriteObject(std::move(context), options);
 }
 
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<

--- a/google/cloud/storage/internal/storage_metadata_decorator.h
+++ b/google/cloud/storage/internal/storage_metadata_decorator.h
@@ -130,7 +130,8 @@ class StorageMetadata : public StorageStub {
   std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>>
-  WriteObject(std::shared_ptr<grpc::ClientContext> context) override;
+  WriteObject(std::shared_ptr<grpc::ClientContext> context,
+              Options const& options) override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::storage::v2::BidiWriteObjectRequest,

--- a/google/cloud/storage/internal/storage_round_robin_decorator.cc
+++ b/google/cloud/storage/internal/storage_round_robin_decorator.cc
@@ -159,8 +159,9 @@ StatusOr<google::storage::v2::Object> StorageRoundRobin::UpdateObject(
 std::unique_ptr<google::cloud::internal::StreamingWriteRpc<
     google::storage::v2::WriteObjectRequest,
     google::storage::v2::WriteObjectResponse>>
-StorageRoundRobin::WriteObject(std::shared_ptr<grpc::ClientContext> context) {
-  return Child()->WriteObject(std::move(context));
+StorageRoundRobin::WriteObject(std::shared_ptr<grpc::ClientContext> context,
+                               Options const& options) {
+  return Child()->WriteObject(std::move(context), options);
 }
 
 std::unique_ptr<google::cloud::AsyncStreamingReadWriteRpc<

--- a/google/cloud/storage/internal/storage_round_robin_decorator.h
+++ b/google/cloud/storage/internal/storage_round_robin_decorator.h
@@ -128,7 +128,8 @@ class StorageRoundRobin : public StorageStub {
   std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>>
-  WriteObject(std::shared_ptr<grpc::ClientContext> context) override;
+  WriteObject(std::shared_ptr<grpc::ClientContext> context,
+              Options const& options) override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::storage::v2::BidiWriteObjectRequest,

--- a/google/cloud/storage/internal/storage_stub.cc
+++ b/google/cloud/storage/internal/storage_stub.cc
@@ -267,7 +267,8 @@ StatusOr<google::storage::v2::Object> DefaultStorageStub::UpdateObject(
 std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
     google::storage::v2::WriteObjectRequest,
     google::storage::v2::WriteObjectResponse>>
-DefaultStorageStub::WriteObject(std::shared_ptr<grpc::ClientContext> context) {
+DefaultStorageStub::WriteObject(std::shared_ptr<grpc::ClientContext> context,
+                                Options const&) {
   auto response = std::make_unique<google::storage::v2::WriteObjectResponse>();
   auto stream = grpc_stub_->WriteObject(context.get(), response.get());
   return std::make_unique<::google::cloud::internal::StreamingWriteRpcImpl<

--- a/google/cloud/storage/internal/storage_stub.h
+++ b/google/cloud/storage/internal/storage_stub.h
@@ -131,7 +131,8 @@ class StorageStub {
   virtual std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>>
-  WriteObject(std::shared_ptr<grpc::ClientContext> context) = 0;
+  WriteObject(std::shared_ptr<grpc::ClientContext> context,
+              Options const& options) = 0;
 
   virtual std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::storage::v2::BidiWriteObjectRequest,
@@ -314,7 +315,8 @@ class DefaultStorageStub : public StorageStub {
   std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>>
-  WriteObject(std::shared_ptr<grpc::ClientContext> context) override;
+  WriteObject(std::shared_ptr<grpc::ClientContext> context,
+              Options const& options) override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::storage::v2::BidiWriteObjectRequest,

--- a/google/cloud/storage/internal/storage_tracing_stub.cc
+++ b/google/cloud/storage/internal/storage_tracing_stub.cc
@@ -263,12 +263,13 @@ StatusOr<google::storage::v2::Object> StorageTracingStub::UpdateObject(
 std::unique_ptr<
     internal::StreamingWriteRpc<google::storage::v2::WriteObjectRequest,
                                 google::storage::v2::WriteObjectResponse>>
-StorageTracingStub::WriteObject(std::shared_ptr<grpc::ClientContext> context) {
+StorageTracingStub::WriteObject(std::shared_ptr<grpc::ClientContext> context,
+                                Options const& options) {
   auto span =
       internal::MakeSpanGrpc("google.storage.v2.Storage", "WriteObject");
   auto scope = opentelemetry::trace::Scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto stream = child_->WriteObject(context);
+  auto stream = child_->WriteObject(context, options);
   return std::make_unique<internal::StreamingWriteRpcTracing<
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>>(

--- a/google/cloud/storage/internal/storage_tracing_stub.h
+++ b/google/cloud/storage/internal/storage_tracing_stub.h
@@ -129,7 +129,8 @@ class StorageTracingStub : public StorageStub {
   std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>>
-  WriteObject(std::shared_ptr<grpc::ClientContext> context) override;
+  WriteObject(std::shared_ptr<grpc::ClientContext> context,
+              Options const& options) override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::storage::v2::BidiWriteObjectRequest,

--- a/google/cloud/storage/testing/mock_storage_stub.h
+++ b/google/cloud/storage/testing/mock_storage_stub.h
@@ -117,7 +117,9 @@ class MockStorageStub : public storage_internal::StorageStub {
   MOCK_METHOD((std::unique_ptr<google::cloud::internal::StreamingWriteRpc<
                    google::storage::v2::WriteObjectRequest,
                    google::storage::v2::WriteObjectResponse>>),
-              WriteObject, (std::shared_ptr<grpc::ClientContext>), (override));
+              WriteObject,
+              (std::shared_ptr<grpc::ClientContext>, Options const&),
+              (override));
 
   MOCK_METHOD((std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
                    google::storage::v2::BidiWriteObjectRequest,


### PR DESCRIPTION
Part of the work for #12359

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13129)
<!-- Reviewable:end -->
