### PR TITLE
chore(deps): use 6.3.2 as the oldest Bazel version

### DIFF
--- a/.github/workflows/macos-cmake.yml
+++ b/.github/workflows/macos-cmake.yml
@@ -122,7 +122,6 @@ jobs:
         export VCPKG_ROOT="${{ runner.temp }}/vcpkg"
         /opt/homebrew/bin/bash ci/gha/builds/macos-cmake.sh ${{ steps.dynamic.outputs.features }}
     env:
-      USE_BAZEL_VERSION: 6.2.1
       BAZEL_REMOTE_CACHE: https://storage.googleapis.com/cloud-cpp-gha-cache/bazel-cache/${{ matrix.os }}
       SCCACHE_GCS_BUCKET: cloud-cpp-gha-cache
       SCCACHE_GCS_KEY_PREFIX: sccache/${{ matrix.os }}

--- a/ci/cloudbuild/builds/bazel-oldest.sh
+++ b/ci/cloudbuild/builds/bazel-oldest.sh
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-export USE_BAZEL_VERSION=6.0.0
+export USE_BAZEL_VERSION=6.3.2
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/bazel.sh


### PR DESCRIPTION
Both gRPC and Protobuf stopped testing with Bazel < 6.3.x, we need to update too.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13133)
<!-- Reviewable:end -->
