### PR TITLE
internal(bigquery): cast time without 'time_since_epoch()'

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/job_request.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.cc
@@ -139,8 +139,6 @@ StatusOr<rest_internal::RestRequest> BuildRestRequest(GetJobRequest const& r) {
   return request;
 }
 
-// Assuming that std::chrono::system_clock epoch is the Unix Time epoch.
-// It's not guaranteed, but de-facto works for most of the platforms
 auto TimePointToUnixMilliseconds(std::chrono::system_clock::time_point tp) {
   return std::chrono::duration_cast<std::chrono::milliseconds>(
              tp - std::chrono::system_clock::from_time_t(0))

--- a/google/cloud/bigquery/v2/minimal/internal/job_request.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.cc
@@ -141,9 +141,9 @@ StatusOr<rest_internal::RestRequest> BuildRestRequest(GetJobRequest const& r) {
 
 // Assuming that std::chrono::system_clock epoch is the Unix Time epoch.
 // It's not guaranteed, but de-facto works for most of the platforms
-auto CastTimeToMilliseconds(std::chrono::system_clock::time_point time) {
+auto TimePointToUnixMilliseconds(std::chrono::system_clock::time_point tp) {
   return std::chrono::duration_cast<std::chrono::milliseconds>(
-             time.time_since_epoch())
+             tp - std::chrono::system_clock::from_time_t(0))
       .count();
 }
 
@@ -173,12 +173,12 @@ StatusOr<rest_internal::RestRequest> BuildRestRequest(
   if (r.min_creation_time()) {
     request.AddQueryParameter(
         "minCreationTime",
-        std::to_string(CastTimeToMilliseconds(*r.min_creation_time())));
+        std::to_string(TimePointToUnixMilliseconds(*r.min_creation_time())));
   }
   if (r.max_creation_time()) {
     request.AddQueryParameter(
         "maxCreationTime",
-        std::to_string(CastTimeToMilliseconds(*r.max_creation_time())));
+        std::to_string(TimePointToUnixMilliseconds(*r.max_creation_time())));
   }
 
   auto if_not_empty_add = [&](char const* key, auto const& v) {

--- a/google/cloud/bigquery/v2/minimal/internal/job_request_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request_test.cc
@@ -36,23 +36,19 @@ using ::google::cloud::bigquery_v2_minimal_testing::MakePostQueryRequest;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::HasSubstr;
 
-auto static const kMin = std::chrono::system_clock::now();
-auto static const kMax = kMin + std::chrono::milliseconds(100);
-auto static const kMinInt =
-    std::chrono::duration_cast<std::chrono::milliseconds>(
-        kMin.time_since_epoch())
-        .count();
-auto static const kMaxInt =
-    std::chrono::duration_cast<std::chrono::milliseconds>(
-        kMax.time_since_epoch())
-        .count();
+auto static const kMinCreationTime = 1111111111111;
+auto static const kMaxCreationTime = 1111111111211;
+std::chrono::system_clock::time_point static const kMinTime{
+    std::chrono::milliseconds{kMinCreationTime}};
+std::chrono::system_clock::time_point static const kMaxTime{
+    std::chrono::milliseconds{kMaxCreationTime}};
 
 ListJobsRequest GetListJobsRequest() {
   ListJobsRequest request("1");
   request.set_all_users(true)
       .set_max_results(10)
-      .set_min_creation_time(kMin)
-      .set_max_creation_time(kMax)
+      .set_min_creation_time(kMinTime)
+      .set_max_creation_time(kMaxTime)
       .set_parent_job_id("1")
       .set_page_token("123")
       .set_projection(Projection::Full())
@@ -167,8 +163,10 @@ TEST(ListJobsRequestTest, Success) {
       "https://bigquery.googleapis.com/bigquery/v2/projects/1/jobs");
   expected.AddQueryParameter("allUsers", "true");
   expected.AddQueryParameter("maxResults", "10");
-  expected.AddQueryParameter("minCreationTime", std::to_string(kMinInt));
-  expected.AddQueryParameter("maxCreationTime", std::to_string(kMaxInt));
+  expected.AddQueryParameter("minCreationTime",
+                             std::to_string(kMinCreationTime));
+  expected.AddQueryParameter("maxCreationTime",
+                             std::to_string(kMaxCreationTime));
   expected.AddQueryParameter("pageToken", "123");
   expected.AddQueryParameter("projection", "FULL");
   expected.AddQueryParameter("stateFilter", "RUNNING");

--- a/google/cloud/bigquery/v2/minimal/internal/job_request_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request_test.cc
@@ -36,12 +36,12 @@ using ::google::cloud::bigquery_v2_minimal_testing::MakePostQueryRequest;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::HasSubstr;
 
-auto static const kMinCreationTime = 1111111111111;
-auto static const kMaxCreationTime = 1111111111211;
-std::chrono::system_clock::time_point static const kMinTime{
-    std::chrono::milliseconds{kMinCreationTime}};
-std::chrono::system_clock::time_point static const kMaxTime{
-    std::chrono::milliseconds{kMaxCreationTime}};
+auto static const kMinCreationTimeMs = 1111111111111;
+auto static const kMaxCreationTimeMs = 1111111111211;
+auto static const kMinTime = std::chrono::system_clock::from_time_t(0) +
+                             std::chrono::milliseconds{kMinCreationTimeMs};
+auto static const kMaxTime = std::chrono::system_clock::from_time_t(0) +
+                             std::chrono::milliseconds{kMaxCreationTimeMs};
 
 ListJobsRequest GetListJobsRequest() {
   ListJobsRequest request("1");
@@ -164,9 +164,9 @@ TEST(ListJobsRequestTest, Success) {
   expected.AddQueryParameter("allUsers", "true");
   expected.AddQueryParameter("maxResults", "10");
   expected.AddQueryParameter("minCreationTime",
-                             std::to_string(kMinCreationTime));
+                             std::to_string(kMinCreationTimeMs));
   expected.AddQueryParameter("maxCreationTime",
-                             std::to_string(kMaxCreationTime));
+                             std::to_string(kMaxCreationTimeMs));
   expected.AddQueryParameter("pageToken", "123");
   expected.AddQueryParameter("projection", "FULL");
   expected.AddQueryParameter("stateFilter", "RUNNING");


### PR DESCRIPTION
Based on comments for already merged PR
https://github.com/googleapis/google-cloud-cpp/pull/13103

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13140)
<!-- Reviewable:end -->
