### PR TITLE
refactor(pubsub): use sc instead of custom attribute

### DIFF
--- a/google/cloud/pubsub/internal/blocking_publisher_tracing_connection.cc
+++ b/google/cloud/pubsub/internal/blocking_publisher_tracing_connection.cc
@@ -42,7 +42,7 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> StartPublishSpan(
       {{sc::kMessagingSystem, "gcp_pubsub"},
        {sc::kMessagingDestinationName, topic.FullName()},
        {sc::kMessagingDestinationTemplate, "topic"},
-       {"messaging.message.total_size_bytes",
+       {sc::kMessagingMessageEnvelopeSize,
         static_cast<std::int64_t>(MessageSize(m))},
        {sc::kCodeFunction, "pubsub::BlockingPublisher::Publish"}},
       options);

--- a/google/cloud/pubsub/internal/blocking_publisher_tracing_connection.cc
+++ b/google/cloud/pubsub/internal/blocking_publisher_tracing_connection.cc
@@ -42,7 +42,7 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> StartPublishSpan(
       {{sc::kMessagingSystem, "gcp_pubsub"},
        {sc::kMessagingDestinationName, topic.FullName()},
        {sc::kMessagingDestinationTemplate, "topic"},
-       {sc::kMessagingMessageEnvelopeSize,
+       {/*sc::kMessagingMessageEnvelopeSize=*/"messaging.message.envelope.size",
         static_cast<std::int64_t>(MessageSize(m))},
        {sc::kCodeFunction, "pubsub::BlockingPublisher::Publish"}},
       options);

--- a/google/cloud/pubsub/internal/blocking_publisher_tracing_connection_test.cc
+++ b/google/cloud/pubsub/internal/blocking_publisher_tracing_connection_test.cc
@@ -88,7 +88,8 @@ TEST(BlockingPublisherTracingConnectionTest, PublishSpanOnSuccess) {
               OTelAttribute<std::string>("messaging.pubsub.ordering_key",
                                          "ordering-key-0"),
               OTelAttribute<int>("gl-cpp.status_code", 0),
-              OTelAttribute<std::int64_t>(sc::kMessagingMessageEnvelopeSize,
+              OTelAttribute<std::int64_t>(/*sc::kMessagingMessageEnvelopeSize=*/
+                                          "messaging.message.envelope.size",
                                           45),
               OTelAttribute<std::string>("messaging.message_id", "test-id-0"),
               OTelAttribute<std::string>(
@@ -130,7 +131,8 @@ TEST(BlockingPublisherTracingConnectionTest, PublishSpanOnError) {
               OTelAttribute<std::string>("messaging.pubsub.ordering_key",
                                          "ordering-key-0"),
               OTelAttribute<int>("gl-cpp.status_code", kErrorCode),
-              OTelAttribute<std::int64_t>(sc::kMessagingMessageEnvelopeSize,
+              OTelAttribute<std::int64_t>(/*sc::kMessagingMessageEnvelopeSize=*/
+                                          "messaging.message.envelope.size",
                                           45)))));
 }
 

--- a/google/cloud/pubsub/internal/blocking_publisher_tracing_connection_test.cc
+++ b/google/cloud/pubsub/internal/blocking_publisher_tracing_connection_test.cc
@@ -88,7 +88,7 @@ TEST(BlockingPublisherTracingConnectionTest, PublishSpanOnSuccess) {
               OTelAttribute<std::string>("messaging.pubsub.ordering_key",
                                          "ordering-key-0"),
               OTelAttribute<int>("gl-cpp.status_code", 0),
-              OTelAttribute<std::int64_t>("messaging.message.total_size_bytes",
+              OTelAttribute<std::int64_t>(sc::kMessagingMessageEnvelopeSize,
                                           45),
               OTelAttribute<std::string>("messaging.message_id", "test-id-0"),
               OTelAttribute<std::string>(
@@ -130,7 +130,7 @@ TEST(BlockingPublisherTracingConnectionTest, PublishSpanOnError) {
               OTelAttribute<std::string>("messaging.pubsub.ordering_key",
                                          "ordering-key-0"),
               OTelAttribute<int>("gl-cpp.status_code", kErrorCode),
-              OTelAttribute<std::int64_t>("messaging.message.total_size_bytes",
+              OTelAttribute<std::int64_t>(sc::kMessagingMessageEnvelopeSize,
                                           45)))));
 }
 

--- a/google/cloud/pubsub/internal/publisher_tracing_connection.cc
+++ b/google/cloud/pubsub/internal/publisher_tracing_connection.cc
@@ -52,7 +52,7 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> StartPublishSpan(
       {{sc::kMessagingSystem, "gcp_pubsub"},
        {sc::kMessagingDestinationName, topic},
        {sc::kMessagingDestinationTemplate, "topic"},
-       {sc::kMessagingMessageEnvelopeSize,
+       {/*sc::kMessagingMessageEnvelopeSize=*/"messaging.message.envelope.size",
         static_cast<std::int64_t>(MessageSize(m))},
        {sc::kCodeFunction, "pubsub::PublisherConnection::Publish"}},
       options);

--- a/google/cloud/pubsub/internal/publisher_tracing_connection.cc
+++ b/google/cloud/pubsub/internal/publisher_tracing_connection.cc
@@ -52,7 +52,7 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> StartPublishSpan(
       {{sc::kMessagingSystem, "gcp_pubsub"},
        {sc::kMessagingDestinationName, topic},
        {sc::kMessagingDestinationTemplate, "topic"},
-       {"messaging.message.total_size_bytes",
+       {sc::kMessagingMessageEnvelopeSize,
         static_cast<std::int64_t>(MessageSize(m))},
        {sc::kCodeFunction, "pubsub::PublisherConnection::Publish"}},
       options);

--- a/google/cloud/pubsub/internal/publisher_tracing_connection_test.cc
+++ b/google/cloud/pubsub/internal/publisher_tracing_connection_test.cc
@@ -93,7 +93,8 @@ TEST(PublisherTracingConnectionTest, PublishSpanOnSuccess) {
               OTelAttribute<std::string>("messaging.pubsub.ordering_key",
                                          "ordering-key-0"),
               OTelAttribute<int>("gl-cpp.status_code", 0),
-              OTelAttribute<std::int64_t>(sc::kMessagingMessageEnvelopeSize,
+              OTelAttribute<std::int64_t>(/*sc::kMessagingMessageEnvelopeSize=*/
+                                          "messaging.message.envelope.size",
                                           45),
               OTelAttribute<std::string>("messaging.message_id", "test-id-0"),
               OTelAttribute<std::string>(
@@ -138,7 +139,8 @@ TEST(PublisherTracingConnectionTest, PublishSpanOnError) {
               OTelAttribute<std::string>("messaging.pubsub.ordering_key",
                                          "ordering-key-0"),
               OTelAttribute<int>("gl-cpp.status_code", kErrorCode),
-              OTelAttribute<std::int64_t>(sc::kMessagingMessageEnvelopeSize,
+              OTelAttribute<std::int64_t>(/*sc::kMessagingMessageEnvelopeSize=*/
+                                          "messaging.message.envelope.size",
                                           45)))));
 }
 

--- a/google/cloud/pubsub/internal/publisher_tracing_connection_test.cc
+++ b/google/cloud/pubsub/internal/publisher_tracing_connection_test.cc
@@ -93,7 +93,7 @@ TEST(PublisherTracingConnectionTest, PublishSpanOnSuccess) {
               OTelAttribute<std::string>("messaging.pubsub.ordering_key",
                                          "ordering-key-0"),
               OTelAttribute<int>("gl-cpp.status_code", 0),
-              OTelAttribute<std::int64_t>("messaging.message.total_size_bytes",
+              OTelAttribute<std::int64_t>(sc::kMessagingMessageEnvelopeSize,
                                           45),
               OTelAttribute<std::string>("messaging.message_id", "test-id-0"),
               OTelAttribute<std::string>(
@@ -138,7 +138,7 @@ TEST(PublisherTracingConnectionTest, PublishSpanOnError) {
               OTelAttribute<std::string>("messaging.pubsub.ordering_key",
                                          "ordering-key-0"),
               OTelAttribute<int>("gl-cpp.status_code", kErrorCode),
-              OTelAttribute<std::int64_t>("messaging.message.total_size_bytes",
+              OTelAttribute<std::int64_t>(sc::kMessagingMessageEnvelopeSize,
                                           45)))));
 }
 


### PR DESCRIPTION
"messaging.message.total_size_bytes" -> sc::kMessagingMessageEnvelopeSize

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13142)
<!-- Reviewable:end -->
