### PR TITLE
test(otel): only test the AsyncPollingLoop interface

### DIFF
--- a/google/cloud/internal/async_rest_polling_loop_test.cc
+++ b/google/cloud/internal/async_rest_polling_loop_test.cc
@@ -811,7 +811,7 @@ TEST(AsyncRestPollingLoopTest, TracedAsyncBackoff) {
   EXPECT_THAT(spans, AllOf(SizeIs(4), Each(SpanNamed("Async Backoff"))));
 }
 
-TEST(AsyncRestPollingLoopTest, SpanActiveThroughout) {
+TEST(AsyncRestPollingLoopTest, SpanActiveDuringCancel) {
   auto span_catcher = testing_util::InstallSpanCatcher();
 
   auto span = internal::MakeSpan("span");
@@ -820,23 +820,16 @@ TEST(AsyncRestPollingLoopTest, SpanActiveThroughout) {
 
   AsyncSequencer<TimerType> timer_sequencer;
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
-  EXPECT_CALL(*mock_cq, MakeRelativeTimer)
-      .Times(AtLeast(1))
-      .WillRepeatedly([&](std::chrono::nanoseconds) {
-        EXPECT_THAT(span, IsActive());
-        return timer_sequencer.PushBack();
-      });
+  EXPECT_CALL(*mock_cq, MakeRelativeTimer).Times(2).WillRepeatedly([&] {
+    return timer_sequencer.PushBack();
+  });
   CompletionQueue cq(mock_cq);
 
   AsyncSequencer<StatusOr<google::longrunning::Operation>> get_sequencer;
   auto mock = std::make_shared<MockStub>();
-  EXPECT_CALL(*mock, AsyncGetOperation)
-      .Times(AtLeast(1))
-      .WillRepeatedly([&](CompletionQueue&, auto, Options const&,
-                          google::longrunning::GetOperationRequest const&) {
-        EXPECT_THAT(span, IsActive());
-        return get_sequencer.PushBack();
-      });
+  EXPECT_CALL(*mock, AsyncGetOperation).Times(2).WillRepeatedly([&] {
+    return get_sequencer.PushBack();
+  });
   EXPECT_CALL(*mock, AsyncCancelOperation)
       .WillOnce([&](CompletionQueue&, auto, Options const&,
                     google::longrunning::CancelOperationRequest const&) {


### PR DESCRIPTION
Unblocks #12880 and #13141 

Modify the async polling loop tests to only test the behavior of the class -- that cancels (which happen out of band) are tied to the operation span.

We did a similar thing for the async retry loop in #12915.

Testing that the call span is active throughout requires a lot of setup. (We have to recreate the behavior of async grpc operations in the mock CQ and mock Stubs). A test that the call span is active throughout is more like #13034.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13144)
<!-- Reviewable:end -->
