### PR TITLE
fix(otel): detach context when single-threaded

### DIFF
--- a/google/cloud/internal/opentelemetry_context.h
+++ b/google/cloud/internal/opentelemetry_context.h
@@ -87,7 +87,8 @@ class OTelScope {
   ~OTelScope();
 
  private:
-  opentelemetry::trace::Scope scope_;
+  opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> span_;
+  opentelemetry::context::Context context_;
 };
 
 /**


### PR DESCRIPTION
Part of the work (and fix the implementation of) #12880 

We write code like:
```cc
{
  auto span = MakeSpan("span");
  OTelScope scope(span);
  return AsyncFoo().then([oc = opentelemetry::context::RuntimeContext::GetCurrent(), span] {
    DetachOTelContext(oc);
    EndSpan(span);
    // We do not want `span` to be active at this point
  }).then([] { AsyncBar(); });
}
```

A problem occurs when the future returns immediately. Then the code looks more like:
```cc
{
  auto span = MakeSpan("span");
  OTelScope scope(span);
  AsyncFoo();
  DetachOTelContext(opentelemetry::context::RuntimeContext::GetCurrent()));
  EndSpan(span);
  // We do not want `span` to be active at this point, but it is.
  AsyncBar();
}
```

---

To make sure `DetachOTelContext()` ends the active context, we want to own the token associated with that context.

If the code to set the active span is unfamiliar, look at the implementation of `opentelemetry::trace::Scope`:
https://github.com/open-telemetry/opentelemetry-cpp/blob/3dfcf93c41bb1d487b3d4d1291791ea21a2a38ce/api/include/opentelemetry/trace/scope.h#L32-L34

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13154)
<!-- Reviewable:end -->
