### PR TITLE
cleanup: parent span matcher

### DIFF
--- a/google/cloud/testing_util/opentelemetry_matchers.h
+++ b/google/cloud/testing_util/opentelemetry_matchers.h
@@ -143,11 +143,11 @@ MATCHER(SpanKindIsProducer,
   return kind == opentelemetry::trace::SpanKind::kProducer;
 }
 
-MATCHER_P(SpanWithParentSpanId, parent_span_id,
-          "has parent span id: " + ToString(parent_span_id)) {
+MATCHER_P(SpanWithParent, span,
+          "has parent span id: " + ToString(span->GetContext().span_id())) {
   auto const& actual = arg->GetParentSpanId();
   *result_listener << "has parent span id: " << ToString(actual);
-  return actual == parent_span_id;
+  return actual == span->GetContext().span_id();
 }
 
 MATCHER_P(SpanNamed, name, "has name: " + std::string{name}) {


### PR DESCRIPTION
It is a little bit nicer to match on the span object. Still, the best we can do in the debug string is to just dump the span ID. (We do not have access to the span's name or anything).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13155)
<!-- Reviewable:end -->
