### PR TITLE
cleanup(bigtable): use generic `RowKeyType`

### DIFF
--- a/google/cloud/bigtable/examples/howto_mock_data_api.cc
+++ b/google/cloud/bigtable/examples/howto_mock_data_api.cc
@@ -58,7 +58,7 @@ TEST(MockTableTest, ReadRowsSuccess) {
 
   // Loop over the rows returned by the `RowReader` and verify the results:
   //! [verify-results]
-  std::vector<std::string> row_keys;
+  std::vector<cbt::RowKeyType> row_keys;
   for (gc::StatusOr<cbt::Row> const& row : reader) {
     ASSERT_TRUE(row.ok());
     row_keys.push_back(row->row_key());


### PR DESCRIPTION
This unblocks building the example in google3, where `cbt::RowKeyType != std::string`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13164)
<!-- Reviewable:end -->
