### PR TITLE
impl: grpc error credentials return non-null channel

### DIFF
--- a/google/cloud/internal/unified_grpc_credentials.cc
+++ b/google/cloud/internal/unified_grpc_credentials.cc
@@ -55,7 +55,8 @@ class GrpcErrorCredentialsAuthentication : public GrpcAuthenticationStrategy {
 
   std::shared_ptr<grpc::Channel> CreateChannel(
       std::string const&, grpc::ChannelArguments const&) override {
-    return {};
+    return grpc::CreateCustomChannel("error:///",
+                                     grpc::InsecureChannelCredentials(), {});
   }
   bool RequiresConfigureContext() const override { return true; }
   Status ConfigureContext(grpc::ClientContext&) override {

--- a/google/cloud/internal/unified_grpc_credentials_test.cc
+++ b/google/cloud/internal/unified_grpc_credentials_test.cc
@@ -35,6 +35,7 @@ using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::ScopedEnvironment;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::IsEmpty;
+using ::testing::IsNull;
 
 TEST(UnifiedGrpcCredentialsTest, GrpcCredentialOption) {
   CompletionQueue cq;
@@ -121,7 +122,7 @@ TEST(UnifiedGrpcCredentialsTest, WithErrorCredentials) {
           .get();
   EXPECT_THAT(async_configured_context, StatusIs(error_status.code()));
   auto channel = result->CreateChannel(std::string{}, grpc::ChannelArguments{});
-  EXPECT_EQ(nullptr, channel.get());
+  EXPECT_THAT(channel.get(), Not(IsNull()));
 }
 
 TEST(UnifiedGrpcCredentialsTest, LoadCAInfoNotSet) {


### PR DESCRIPTION
gRPC assumes `std::shared_ptr<grpc::Channel>` is not NULL when making an rpc call. In order to prevent the program from dereferencing a NULL pointer, the error credentials needs to return a valid, but useless, value. Unfortunately, `grpc::Channel` is declared final, so we cannot derive from it to create a Channel with the behavior we would want.

part of the work for #13170 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13169)
<!-- Reviewable:end -->
