### PR TITLE
feat(otel): add Makefile

### DIFF
--- a/ci/verify_quickstart/CMakeLists.txt
+++ b/ci/verify_quickstart/CMakeLists.txt
@@ -105,12 +105,6 @@ foreach (feature IN LISTS FEATURES)
         add_make_quickstart_target("${feature}" storage quickstart_grpc)
         continue()
     endif ()
-    if ("${feature}" STREQUAL "opentelemetry")
-        add_cmake_quickstart_target("${feature}" opentelemetry quickstart)
-        # TODO(#10795) - sort out opentelemetry-cpp pkgconfig
-        # add_make_quickstart_target("${feature}" opentelemetry quickstart)
-        continue()
-    endif ()
     # In vcpkg we cannot use `_` in the name of a feature. We replace that with
     # `-', but then need to convert the feature name back to a valid path.
     if ("${feature}" STREQUAL "dialogflow-cx")

--- a/google/cloud/google_cloud_cpp_common.cmake
+++ b/google/cloud/google_cloud_cpp_common.cmake
@@ -185,11 +185,10 @@ if (opentelemetry IN_LIST GOOGLE_CLOUD_CPP_ENABLE)
         target_compile_definitions(
             google_cloud_cpp_common
             PUBLIC # Enable OpenTelemetry features in google-cloud-cpp
-                   GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
-                   # TODO(#10975) - install separate opentelemetry .pc file
-                   HAVE_ABSEIL)
+                   GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY)
         set(GOOGLE_CLOUD_CPP_FIND_OPTIONAL_DEPENDENCIES
             "find_dependency(opentelemetry-cpp)")
+        set(GOOGLE_CLOUD_CPP_OPENTELEMETRY_API "opentelemetry_api")
     endif ()
 endif ()
 google_cloud_cpp_add_common_options(google_cloud_cpp_common)
@@ -245,7 +244,8 @@ google_cloud_cpp_add_pkgconfig(
     "absl_time"
     "absl_time_zone"
     "absl_variant"
-    "openssl")
+    "openssl"
+    "${GOOGLE_CLOUD_CPP_OPENTELEMETRY_API}")
 
 # Create and install the CMake configuration files.
 configure_file("config.cmake.in" "google_cloud_cpp_common-config.cmake" @ONLY)

--- a/google/cloud/opentelemetry/CMakeLists.txt
+++ b/google/cloud/opentelemetry/CMakeLists.txt
@@ -85,9 +85,13 @@ google_cloud_cpp_install_headers(google_cloud_cpp_opentelemetry
                                  include/google/cloud/opentelemetry)
 
 google_cloud_cpp_add_pkgconfig(
-    opentelemetry "OpenTelemetry Exporters for Google Cloud"
+    opentelemetry
+    "OpenTelemetry Exporters for Google Cloud"
     "Provides exporters for sending telemetry to Google Cloud services."
-    "google_cloud_cpp_rest_internal" " google_cloud_cpp_trace")
+    "google_cloud_cpp_rest_internal"
+    "google_cloud_cpp_trace"
+    "opentelemetry_resources"
+    "opentelemetry_trace")
 
 # Create and install the CMake configuration files.
 configure_file("config.cmake.in" "google_cloud_cpp_opentelemetry-config.cmake"

--- a/google/cloud/opentelemetry/quickstart/Makefile
+++ b/google/cloud/opentelemetry/quickstart/Makefile
@@ -27,10 +27,10 @@ all: $(BIN)/quickstart
 
 # Configuration variables to compile and link against the Google Cloud
 # OpenTelemetry Exporter library and the Google Cloud Storage client.
-CLIENT_MODULE     := google_cloud_cpp_opentelemetry google_cloud_cpp_storage
-CLIENT_CXXFLAGS   := $(shell pkg-config $(CLIENT_MODULE) --cflags)
-CLIENT_CXXLDFLAGS := $(shell pkg-config $(CLIENT_MODULE) --libs-only-L)
-CLIENT_LIBS       := $(shell pkg-config $(CLIENT_MODULE) --libs-only-l)
+EXAMPLE_MODULES    := google_cloud_cpp_opentelemetry google_cloud_cpp_storage
+EXAMPLE_CXXFLAGS   := $(shell pkg-config $(EXAMPLE_MODULES) --cflags)
+EXAMPLE_CXXLDFLAGS := $(shell pkg-config $(EXAMPLE_MODULES) --libs-only-L)
+EXAMPLE_LIBS       := $(shell pkg-config $(EXAMPLE_MODULES) --libs-only-l)
 
 $(BIN)/quickstart: quickstart.cc
-	$(CXXLD) $(CXXFLAGS) $(CLIENT_CXXFLAGS) $(CLIENT_CXXLDFLAGS) -o $@ $^ $(CLIENT_LIBS)
+	$(CXXLD) $(CXXFLAGS) $(EXAMPLE_CXXFLAGS) $(EXAMPLE_CXXLDFLAGS) -o $@ $^ $(EXAMPLE_LIBS)

--- a/google/cloud/opentelemetry/quickstart/Makefile
+++ b/google/cloud/opentelemetry/quickstart/Makefile
@@ -1,0 +1,36 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a minimal Makefile to show how to use the C++ Google Cloud
+# OpenTelemetry Exporter library for developers who use make(1) as their build
+# system.
+
+# The CXX, CXXFLAGS and CXXLD variables are hard-coded. These values work for
+# our tests, but applications would typically make them configurable parameters.
+CXX=g++
+CXXFLAGS=
+CXXLD=$(CXX)
+BIN=.
+
+all: $(BIN)/quickstart
+
+# Configuration variables to compile and link against the Google Cloud
+# OpenTelemetry Exporter library and the Google Cloud Storage client.
+CLIENT_MODULE     := google_cloud_cpp_opentelemetry google_cloud_cpp_storage
+CLIENT_CXXFLAGS   := $(shell pkg-config $(CLIENT_MODULE) --cflags)
+CLIENT_CXXLDFLAGS := $(shell pkg-config $(CLIENT_MODULE) --libs-only-L)
+CLIENT_LIBS       := $(shell pkg-config $(CLIENT_MODULE) --libs-only-l)
+
+$(BIN)/quickstart: quickstart.cc
+	$(CXXLD) $(CXXFLAGS) $(CLIENT_CXXFLAGS) $(CLIENT_CXXLDFLAGS) -o $@ $^ $(CLIENT_LIBS)

--- a/google/cloud/opentelemetry/quickstart/README.md
+++ b/google/cloud/opentelemetry/quickstart/README.md
@@ -125,10 +125,6 @@ is good practice to explicitly set the language standard.
 While OpenTelemetry supports C++>=11, `google-cloud-cpp` requires C++>=14. So
 you can use `-DCMAKE_CXX_STANDARD=14`, `-DCMAKE_CXX_STANDARD=17`, or higher.
 
-OpenTelemetry only works when installed in a location that is on the
-[`find_package()`][find-package] search path. Also, `opentelemetry-cpp` does not
-install `*.pc` files, so it is not yet usable with `make`.
-
 ### Package Managers
 
 #### [`vcpkg`](https://github.com/Microsoft/vcpkg.git)
@@ -197,7 +193,6 @@ set GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=%cd%\roots.pem
 [bazel-install]: https://docs.bazel.build/versions/main/install.html
 [exporter]: https://opentelemetry.io/docs/concepts/signals/traces/#trace-exporters
 [find and view traces]: https://cloud.google.com/trace/docs/trace-overview
-[find-package]: https://cmake.org/cmake/help/latest/command/find_package.html
 [grpc-roots-pem-bug]: https://github.com/grpc/grpc/issues/16571
 [opentelemetry]: https://opentelemetry.io
 [opentelemetry-cpp]: https://github.com/open-telemetry/opentelemetry-cpp


### PR DESCRIPTION
Fixes #10795

Add a Makefile to the OpenTelemetry exporter library quickstart, to show how to build with `make(1)`.

Also, now that `opentelemetry-cpp` installs its own `opentelemetry_*.pc` modules with proper compiler definitions, we no longer need to define `HAVE_ABSEIL` for them in our code. Yay.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13177)
<!-- Reviewable:end -->
