### PR TITLE
refactor(pubsub): change naming to use topic id not full name

### DIFF
--- a/google/cloud/pubsub/blocking_publisher_connection_test.cc
+++ b/google/cloud/pubsub/blocking_publisher_connection_test.cc
@@ -209,10 +209,10 @@ TEST(BlockingPublisherConnectionTest, TracingEnabled) {
   auto response = publisher->Publish(
       {topic, MessageBuilder{}.SetData("test-data-0").Build()});
 
-  EXPECT_THAT(span_catcher->GetSpans(),
-              UnorderedElementsAre(
-                  SpanNamed("projects/test-project/topics/test-topic create"),
-                  SpanNamed("google.pubsub.v1.Publisher/Publish")));
+  EXPECT_THAT(
+      span_catcher->GetSpans(),
+      UnorderedElementsAre(SpanNamed("test-topic create"),
+                           SpanNamed("google.pubsub.v1.Publisher/Publish")));
 }
 
 TEST(BlockingPublisherConnectionTest, TracingDisabled) {

--- a/google/cloud/pubsub/internal/blocking_publisher_tracing_connection.cc
+++ b/google/cloud/pubsub/internal/blocking_publisher_tracing_connection.cc
@@ -38,11 +38,11 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> StartPublishSpan(
   opentelemetry::trace::StartSpanOptions options;
   options.kind = opentelemetry::trace::SpanKind::kProducer;
   auto span = internal::MakeSpan(
-      topic.FullName() + " create",
+      topic.topic_id() + " create",
       {{sc::kMessagingSystem, "gcp_pubsub"},
+       {sc::kMessagingDestinationName, topic.topic_id()},
+       {sc::kMessagingDestinationTemplate, topic.FullName()},
        {sc::kMessagingOperation, "create"},
-       {sc::kMessagingDestinationName, topic.FullName()},
-       {sc::kMessagingDestinationTemplate, "topic"},
        {/*sc::kMessagingMessageEnvelopeSize=*/"messaging.message.envelope.size",
         static_cast<std::int64_t>(MessageSize(m))},
        {sc::kCodeFunction, "pubsub::BlockingPublisher::Publish"}},

--- a/google/cloud/pubsub/internal/blocking_publisher_tracing_connection_test.cc
+++ b/google/cloud/pubsub/internal/blocking_publisher_tracing_connection_test.cc
@@ -76,15 +76,16 @@ TEST(BlockingPublisherTracingConnectionTest, PublishSpanOnSuccess) {
       span_catcher->GetSpans(),
       ElementsAre(AllOf(
           SpanHasInstrumentationScope(), SpanKindIsProducer(),
- 
-         SpanNamed("test-topic create"),
+
+          SpanNamed("test-topic create"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
           SpanHasAttributes(
               OTelAttribute<std::string>(sc::kMessagingSystem, "gcp_pubsub"),
+              OTelAttribute<std::string>(sc::kMessagingDestinationName,
+                                         "test-topic"),
               OTelAttribute<std::string>(
-                  sc::kMessagingDestinationName, "test-topic"),
-              OTelAttribute<std::string>(sc::kMessagingDestinationTemplate,
-                                         "projects/test-project/topics/test-topic"),
+                  sc::kMessagingDestinationTemplate,
+                  "projects/test-project/topics/test-topic"),
               OTelAttribute<std::string>("messaging.pubsub.ordering_key",
                                          "ordering-key-0"),
               OTelAttribute<int>("gl-cpp.status_code", 0),
@@ -119,15 +120,16 @@ TEST(BlockingPublisherTracingConnectionTest, PublishSpanOnError) {
       span_catcher->GetSpans(),
       ElementsAre(AllOf(
           SpanHasInstrumentationScope(), SpanKindIsProducer(),
- 
-         SpanNamed("test-topic create"),
+
+          SpanNamed("test-topic create"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError),
           SpanHasAttributes(
               OTelAttribute<std::string>(sc::kMessagingSystem, "gcp_pubsub"),
+              OTelAttribute<std::string>(sc::kMessagingDestinationName,
+                                         "test-topic"),
               OTelAttribute<std::string>(
-                  sc::kMessagingDestinationName, "test-topic"),
-              OTelAttribute<std::string>(sc::kMessagingDestinationTemplate,
-                                         "projects/test-project/topics/test-topic"),
+                  sc::kMessagingDestinationTemplate,
+                  "projects/test-project/topics/test-topic"),
               OTelAttribute<std::string>("messaging.pubsub.ordering_key",
                                          "ordering-key-0"),
               OTelAttribute<int>("gl-cpp.status_code", kErrorCode),
@@ -152,14 +154,14 @@ TEST(BlockingPublisherTracingConnectionTest, PublishSpanOmitsOrderingKey) {
                                                   .Build()});
 
   EXPECT_STATUS_OK(response);
-  EXPECT_THAT(span_catcher->GetSpans(),
-              ElementsAre(AllOf(
-                  SpanHasInstrumentationScope(), SpanKindIsProducer(),
-         
-         SpanNamed("test-topic create"),
-                  SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-                  Not(SpanHasAttributes(OTelAttribute<std::string>(
-                      "messaging.pubsub.ordering_key", _))))));
+  EXPECT_THAT(
+      span_catcher->GetSpans(),
+      ElementsAre(AllOf(SpanHasInstrumentationScope(), SpanKindIsProducer(),
+
+                        SpanNamed("test-topic create"),
+                        SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
+                        Not(SpanHasAttributes(OTelAttribute<std::string>(
+                            "messaging.pubsub.ordering_key", _))))));
 }
 
 TEST(BlockingPublisherTracingConnectionTest, OptionsSpan) {

--- a/google/cloud/pubsub/internal/blocking_publisher_tracing_connection_test.cc
+++ b/google/cloud/pubsub/internal/blocking_publisher_tracing_connection_test.cc
@@ -76,15 +76,15 @@ TEST(BlockingPublisherTracingConnectionTest, PublishSpanOnSuccess) {
       span_catcher->GetSpans(),
       ElementsAre(AllOf(
           SpanHasInstrumentationScope(), SpanKindIsProducer(),
-          SpanNamed("projects/test-project/topics/test-topic create"),
+ 
+         SpanNamed("test-topic create"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
           SpanHasAttributes(
               OTelAttribute<std::string>(sc::kMessagingSystem, "gcp_pubsub"),
               OTelAttribute<std::string>(
-                  sc::kMessagingDestinationName,
-                  "projects/test-project/topics/test-topic"),
+                  sc::kMessagingDestinationName, "test-topic"),
               OTelAttribute<std::string>(sc::kMessagingDestinationTemplate,
-                                         "topic"),
+                                         "projects/test-project/topics/test-topic"),
               OTelAttribute<std::string>("messaging.pubsub.ordering_key",
                                          "ordering-key-0"),
               OTelAttribute<int>("gl-cpp.status_code", 0),
@@ -119,15 +119,15 @@ TEST(BlockingPublisherTracingConnectionTest, PublishSpanOnError) {
       span_catcher->GetSpans(),
       ElementsAre(AllOf(
           SpanHasInstrumentationScope(), SpanKindIsProducer(),
-          SpanNamed("projects/test-project/topics/test-topic create"),
+ 
+         SpanNamed("test-topic create"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError),
           SpanHasAttributes(
               OTelAttribute<std::string>(sc::kMessagingSystem, "gcp_pubsub"),
               OTelAttribute<std::string>(
-                  sc::kMessagingDestinationName,
-                  "projects/test-project/topics/test-topic"),
+                  sc::kMessagingDestinationName, "test-topic"),
               OTelAttribute<std::string>(sc::kMessagingDestinationTemplate,
-                                         "topic"),
+                                         "projects/test-project/topics/test-topic"),
               OTelAttribute<std::string>("messaging.pubsub.ordering_key",
                                          "ordering-key-0"),
               OTelAttribute<int>("gl-cpp.status_code", kErrorCode),
@@ -155,7 +155,8 @@ TEST(BlockingPublisherTracingConnectionTest, PublishSpanOmitsOrderingKey) {
   EXPECT_THAT(span_catcher->GetSpans(),
               ElementsAre(AllOf(
                   SpanHasInstrumentationScope(), SpanKindIsProducer(),
-                  SpanNamed("projects/test-project/topics/test-topic create"),
+         
+         SpanNamed("test-topic create"),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
                   Not(SpanHasAttributes(OTelAttribute<std::string>(
                       "messaging.pubsub.ordering_key", _))))));

--- a/google/cloud/pubsub/internal/blocking_publisher_tracing_connection_test.cc
+++ b/google/cloud/pubsub/internal/blocking_publisher_tracing_connection_test.cc
@@ -156,14 +156,14 @@ TEST(BlockingPublisherTracingConnectionTest, PublishSpanOmitsOrderingKey) {
                                                   .Build()});
 
   EXPECT_STATUS_OK(response);
-  EXPECT_THAT(
-      span_catcher->GetSpans(),
-      ElementsAre(AllOf(SpanHasInstrumentationScope(), SpanKindIsProducer(),
+  EXPECT_THAT(span_catcher->GetSpans(),
+              ElementsAre(AllOf(
+                  SpanHasInstrumentationScope(), SpanKindIsProducer(),
 
-                        SpanNamed("test-topic create"),
-                        SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-                        Not(SpanHasAttributes(OTelAttribute<std::string>(
-                             "messaging.gcp_pubsub.message.ordering_key", _))))));
+                  SpanNamed("test-topic create"),
+                  SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
+                  Not(SpanHasAttributes(OTelAttribute<std::string>(
+                      "messaging.gcp_pubsub.message.ordering_key", _))))));
 }
 
 TEST(BlockingPublisherTracingConnectionTest, OptionsSpan) {

--- a/google/cloud/pubsub/internal/publisher_tracing_connection.cc
+++ b/google/cloud/pubsub/internal/publisher_tracing_connection.cc
@@ -43,7 +43,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> StartPublishSpan(
-     pubsub::Topic const& topic, pubsub::Message const& m) {
+    pubsub::Topic const& topic, pubsub::Message const& m) {
   namespace sc = opentelemetry::trace::SemanticConventions;
   opentelemetry::trace::StartSpanOptions options;
   options.kind = opentelemetry::trace::SpanKind::kProducer;

--- a/google/cloud/pubsub/internal/publisher_tracing_connection_test.cc
+++ b/google/cloud/pubsub/internal/publisher_tracing_connection_test.cc
@@ -90,8 +90,9 @@ TEST(PublisherTracingConnectionTest, PublishSpanOnSuccess) {
               OTelAttribute<std::string>(
                   sc::kMessagingDestinationTemplate,
                   "projects/test-project/topics/test-topic"),
-              OTelAttribute<std::string>("messaging.gcp_pubsub.message.ordering_key",
-                                         "ordering-key-0"),
+              OTelAttribute<std::string>(
+                  "messaging.gcp_pubsub.message.ordering_key",
+                  "ordering-key-0"),
               OTelAttribute<int>("gl-cpp.status_code", 0),
               OTelAttribute<std::int64_t>(/*sc::kMessagingMessageEnvelopeSize=*/
                                           "messaging.message.envelope.size",
@@ -137,8 +138,9 @@ TEST(PublisherTracingConnectionTest, PublishSpanOnError) {
               OTelAttribute<std::string>(
                   sc::kMessagingDestinationTemplate,
                   "projects/test-project/topics/test-topic"),
-              OTelAttribute<std::string>( "messaging.gcp_pubsub.message.ordering_key",
-                                         "ordering-key-0"),
+              OTelAttribute<std::string>(
+                  "messaging.gcp_pubsub.message.ordering_key",
+                  "ordering-key-0"),
               OTelAttribute<std::string>(sc::kMessagingOperation, "create"),
               OTelAttribute<int>("gl-cpp.status_code", kErrorCode),
               OTelAttribute<std::int64_t>(/*sc::kMessagingMessageEnvelopeSize=*/
@@ -188,13 +190,13 @@ TEST(PublisherTracingConnectionTest, PublishSpanOmitsOrderingKey) {
                       .get();
 
   EXPECT_STATUS_OK(response);
-  EXPECT_THAT(
-      span_catcher->GetSpans(),
-      ElementsAre(AllOf(SpanHasInstrumentationScope(), SpanKindIsProducer(),
-                        SpanNamed("test-topic create"),
-                        SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-                        Not(SpanHasAttributes(OTelAttribute<std::string>(
-                             "messaging.gcp_pubsub.message.ordering_key", _))))));
+  EXPECT_THAT(span_catcher->GetSpans(),
+              ElementsAre(AllOf(
+                  SpanHasInstrumentationScope(), SpanKindIsProducer(),
+                  SpanNamed("test-topic create"),
+                  SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
+                  Not(SpanHasAttributes(OTelAttribute<std::string>(
+                      "messaging.gcp_pubsub.message.ordering_key", _))))));
 }
 
 TEST(PublisherTracingConnectionTest, FlushSpan) {

--- a/google/cloud/pubsub/internal/publisher_tracing_connection_test.cc
+++ b/google/cloud/pubsub/internal/publisher_tracing_connection_test.cc
@@ -81,15 +81,14 @@ TEST(PublisherTracingConnectionTest, PublishSpanOnSuccess) {
       span_catcher->GetSpans(),
       ElementsAre(AllOf(
           SpanHasInstrumentationScope(), SpanKindIsProducer(),
-          SpanNamed("projects/test-project/topics/test-topic create"),
+          SpanNamed("test-topic create"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
           SpanHasAttributes(
               OTelAttribute<std::string>(sc::kMessagingSystem, "gcp_pubsub"),
               OTelAttribute<std::string>(
-                  sc::kMessagingDestinationName,
-                  "projects/test-project/topics/test-topic"),
+                  sc::kMessagingDestinationName, "test-topic"),
               OTelAttribute<std::string>(sc::kMessagingDestinationTemplate,
-                                         "topic"),
+                                         "projects/test-project/topics/test-topic"),
               OTelAttribute<std::string>("messaging.pubsub.ordering_key",
                                          "ordering-key-0"),
               OTelAttribute<int>("gl-cpp.status_code", 0),
@@ -128,15 +127,14 @@ TEST(PublisherTracingConnectionTest, PublishSpanOnError) {
       span_catcher->GetSpans(),
       ElementsAre(AllOf(
           SpanHasInstrumentationScope(), SpanKindIsProducer(),
-          SpanNamed("projects/test-project/topics/test-topic create"),
+          SpanNamed("test-topic create"),
           SpanWithStatus(opentelemetry::trace::StatusCode::kError),
           SpanHasAttributes(
               OTelAttribute<std::string>(sc::kMessagingSystem, "gcp_pubsub"),
               OTelAttribute<std::string>(
-                  sc::kMessagingDestinationName,
-                  "projects/test-project/topics/test-topic"),
+                  sc::kMessagingDestinationName, "test-topic"),
               OTelAttribute<std::string>(sc::kMessagingDestinationTemplate,
-                                         "topic"),
+                                         "projects/test-project/topics/test-topic"),
               OTelAttribute<std::string>("messaging.pubsub.ordering_key",
                                          "ordering-key-0"),
               OTelAttribute<std::string>(sc::kMessagingOperation, "create"),
@@ -191,7 +189,7 @@ TEST(PublisherTracingConnectionTest, PublishSpanOmitsOrderingKey) {
   EXPECT_THAT(span_catcher->GetSpans(),
               ElementsAre(AllOf(
                   SpanHasInstrumentationScope(), SpanKindIsProducer(),
-                  SpanNamed("projects/test-project/topics/test-topic create"),
+                  SpanNamed("test-topic create"),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
                   Not(SpanHasAttributes(OTelAttribute<std::string>(
                       "messaging.pubsub.ordering_key", _))))));

--- a/google/cloud/pubsub/internal/publisher_tracing_connection_test.cc
+++ b/google/cloud/pubsub/internal/publisher_tracing_connection_test.cc
@@ -85,10 +85,11 @@ TEST(PublisherTracingConnectionTest, PublishSpanOnSuccess) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
           SpanHasAttributes(
               OTelAttribute<std::string>(sc::kMessagingSystem, "gcp_pubsub"),
+              OTelAttribute<std::string>(sc::kMessagingDestinationName,
+                                         "test-topic"),
               OTelAttribute<std::string>(
-                  sc::kMessagingDestinationName, "test-topic"),
-              OTelAttribute<std::string>(sc::kMessagingDestinationTemplate,
-                                         "projects/test-project/topics/test-topic"),
+                  sc::kMessagingDestinationTemplate,
+                  "projects/test-project/topics/test-topic"),
               OTelAttribute<std::string>("messaging.pubsub.ordering_key",
                                          "ordering-key-0"),
               OTelAttribute<int>("gl-cpp.status_code", 0),
@@ -131,10 +132,11 @@ TEST(PublisherTracingConnectionTest, PublishSpanOnError) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError),
           SpanHasAttributes(
               OTelAttribute<std::string>(sc::kMessagingSystem, "gcp_pubsub"),
+              OTelAttribute<std::string>(sc::kMessagingDestinationName,
+                                         "test-topic"),
               OTelAttribute<std::string>(
-                  sc::kMessagingDestinationName, "test-topic"),
-              OTelAttribute<std::string>(sc::kMessagingDestinationTemplate,
-                                         "projects/test-project/topics/test-topic"),
+                  sc::kMessagingDestinationTemplate,
+                  "projects/test-project/topics/test-topic"),
               OTelAttribute<std::string>("messaging.pubsub.ordering_key",
                                          "ordering-key-0"),
               OTelAttribute<std::string>(sc::kMessagingOperation, "create"),
@@ -186,13 +188,13 @@ TEST(PublisherTracingConnectionTest, PublishSpanOmitsOrderingKey) {
                       .get();
 
   EXPECT_STATUS_OK(response);
-  EXPECT_THAT(span_catcher->GetSpans(),
-              ElementsAre(AllOf(
-                  SpanHasInstrumentationScope(), SpanKindIsProducer(),
-                  SpanNamed("test-topic create"),
-                  SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-                  Not(SpanHasAttributes(OTelAttribute<std::string>(
-                      "messaging.pubsub.ordering_key", _))))));
+  EXPECT_THAT(
+      span_catcher->GetSpans(),
+      ElementsAre(AllOf(SpanHasInstrumentationScope(), SpanKindIsProducer(),
+                        SpanNamed("test-topic create"),
+                        SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
+                        Not(SpanHasAttributes(OTelAttribute<std::string>(
+                            "messaging.pubsub.ordering_key", _))))));
 }
 
 TEST(PublisherTracingConnectionTest, FlushSpan) {

--- a/google/cloud/pubsub/publisher_connection_test.cc
+++ b/google/cloud/pubsub/publisher_connection_test.cc
@@ -393,9 +393,9 @@ TEST(MakePublisherConnectionTest, TracingEnabled) {
   EXPECT_THAT(
       spans,
       UnorderedElementsAre(
-          SpanNamed("test-topic create"),
-          SpanNamed("publisher flow control"), SpanNamed("publish scheduler"),
-          SpanNamed("publish"), SpanNamed("google.pubsub.v1.Publisher/Publish"),
+          SpanNamed("test-topic create"), SpanNamed("publisher flow control"),
+          SpanNamed("publish scheduler"), SpanNamed("publish"),
+          SpanNamed("google.pubsub.v1.Publisher/Publish"),
           SpanNamed("pubsub::BatchingPublisherConnection::Flush"),
           SpanNamed("pubsub::FlowControlledPublisherConnection::Flush"),
           SpanNamed("pubsub::Publisher::Flush")));

--- a/google/cloud/pubsub/publisher_connection_test.cc
+++ b/google/cloud/pubsub/publisher_connection_test.cc
@@ -393,7 +393,7 @@ TEST(MakePublisherConnectionTest, TracingEnabled) {
   EXPECT_THAT(
       spans,
       UnorderedElementsAre(
-          SpanNamed("projects/test-project/topics/test-topic create"),
+          SpanNamed("test-topic create"),
           SpanNamed("publisher flow control"), SpanNamed("publish scheduler"),
           SpanNamed("publish"), SpanNamed("google.pubsub.v1.Publisher/Publish"),
           SpanNamed("pubsub::BatchingPublisherConnection::Flush"),


### PR DESCRIPTION
- Change topic.FullName() + " create" -> topic.topic_id() + " create"
- sc::kMessagingDestinationName, topic.FullName() ->  sc::kMessagingDestinationName, topic.topic_id() 
- sc::kMessagingDestinationTemplate, "topic" -> sc::kMessagingDestinationName, topic.FullName()

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13178)
<!-- Reviewable:end -->
