### PR TITLE
doc(otel): fix fedora install instructions

### DIFF
--- a/ci/cloudbuild/dockerfiles/demo-fedora.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-fedora.Dockerfile
@@ -66,7 +66,7 @@ RUN curl -fsSL https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.
 # default, pkg-config does not search in these directories.
 
 # ```bash
-ENV PKG_CONFIG_PATH=/usr/local/share/pkgconfig:/usr/lib64/pkgconfig
+ENV PKG_CONFIG_PATH=/usr/local/share/pkgconfig:/usr/lib64/pkgconfig:/usr/local/lib64/pkgconfig
 # ```
 
 # #### nlohmann_json library

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -299,7 +299,7 @@ The following steps will install libraries and tools in `/usr/local`. By
 default, pkg-config does not search in these directories.
 
 ```bash
-export PKG_CONFIG_PATH=/usr/local/share/pkgconfig:/usr/lib64/pkgconfig
+export PKG_CONFIG_PATH=/usr/local/share/pkgconfig:/usr/lib64/pkgconfig:/usr/local/lib64/pkgconfig
 ```
 
 #### nlohmann_json library


### PR DESCRIPTION
`opentelemetry-cpp` is installed into `/usr/local/lib64`. Manually update the PKG_CONFIG_PATH to include this path.

Noticed when testing #13177. This is worthy of its own PR though.

* GCB: https://console.cloud.google.com/cloud-build/builds;region=us-east1/f55fe348-dff2-4cba-b602-6ea5b6e4f415;tab=detail?project=cloud-cpp-testing-resources
* Raw: https://storage.googleapis.com/cloud-cpp-community-publiclogs/logs/google-cloud-cpp/13177/6f83e7f67591a66352c9c83809ea3b9450199074/demo-fedora-demo-install/log-f55fe348-dff2-4cba-b602-6ea5b6e4f415.txt

```
2023-11-21T17:46:27Z (+238s): [ Make ]
make: Entering directory '/workspace/google/cloud/bigquery/quickstart'
Package opentelemetry_api was not found in the pkg-config search path.
Perhaps you should add the directory containing `opentelemetry_api.pc'
to the PKG_CONFIG_PATH environment variable
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13180)
<!-- Reviewable:end -->
