### PR TITLE
refactor(pubsub): rename to match the semantic convention

### DIFF
--- a/google/cloud/pubsub/internal/blocking_publisher_tracing_connection.cc
+++ b/google/cloud/pubsub/internal/blocking_publisher_tracing_connection.cc
@@ -48,7 +48,8 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> StartPublishSpan(
        {sc::kCodeFunction, "pubsub::BlockingPublisher::Publish"}},
       options);
   if (!m.ordering_key().empty()) {
-    span->SetAttribute("messaging.pubsub.ordering_key", m.ordering_key());
+    span->SetAttribute("messaging.gcp_pubsub.message.ordering_key",
+                       m.ordering_key());
   }
   return span;
 }

--- a/google/cloud/pubsub/internal/blocking_publisher_tracing_connection_test.cc
+++ b/google/cloud/pubsub/internal/blocking_publisher_tracing_connection_test.cc
@@ -85,8 +85,9 @@ TEST(BlockingPublisherTracingConnectionTest, PublishSpanOnSuccess) {
                   "projects/test-project/topics/test-topic"),
               OTelAttribute<std::string>(sc::kMessagingDestinationTemplate,
                                          "topic"),
-              OTelAttribute<std::string>("messaging.pubsub.ordering_key",
-                                         "ordering-key-0"),
+              OTelAttribute<std::string>(
+                  "messaging.gcp_pubsub.message.ordering_key",
+                  "ordering-key-0"),
               OTelAttribute<int>("gl-cpp.status_code", 0),
               OTelAttribute<std::int64_t>(/*sc::kMessagingMessageEnvelopeSize=*/
                                           "messaging.message.envelope.size",
@@ -128,8 +129,9 @@ TEST(BlockingPublisherTracingConnectionTest, PublishSpanOnError) {
                   "projects/test-project/topics/test-topic"),
               OTelAttribute<std::string>(sc::kMessagingDestinationTemplate,
                                          "topic"),
-              OTelAttribute<std::string>("messaging.pubsub.ordering_key",
-                                         "ordering-key-0"),
+              OTelAttribute<std::string>(
+                  "messaging.gcp_pubsub.message.ordering_key",
+                  "ordering-key-0"),
               OTelAttribute<int>("gl-cpp.status_code", kErrorCode),
               OTelAttribute<std::int64_t>(/*sc::kMessagingMessageEnvelopeSize=*/
                                           "messaging.message.envelope.size",
@@ -158,7 +160,7 @@ TEST(BlockingPublisherTracingConnectionTest, PublishSpanOmitsOrderingKey) {
                   SpanNamed("projects/test-project/topics/test-topic create"),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
                   Not(SpanHasAttributes(OTelAttribute<std::string>(
-                      "messaging.pubsub.ordering_key", _))))));
+                      "messaging.gcp_pubsub.message.ordering_key", _))))));
 }
 
 TEST(BlockingPublisherTracingConnectionTest, OptionsSpan) {

--- a/google/cloud/pubsub/internal/publisher_tracing_connection.cc
+++ b/google/cloud/pubsub/internal/publisher_tracing_connection.cc
@@ -58,7 +58,8 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> StartPublishSpan(
        {sc::kCodeFunction, "pubsub::PublisherConnection::Publish"}},
       options);
   if (!m.ordering_key().empty()) {
-    span->SetAttribute("messaging.pubsub.ordering_key", m.ordering_key());
+    span->SetAttribute("messaging.gcp_pubsub.message.ordering_key",
+                       m.ordering_key());
   }
   return span;
 }

--- a/google/cloud/pubsub/internal/publisher_tracing_connection_test.cc
+++ b/google/cloud/pubsub/internal/publisher_tracing_connection_test.cc
@@ -90,8 +90,9 @@ TEST(PublisherTracingConnectionTest, PublishSpanOnSuccess) {
                   "projects/test-project/topics/test-topic"),
               OTelAttribute<std::string>(sc::kMessagingDestinationTemplate,
                                          "topic"),
-              OTelAttribute<std::string>("messaging.pubsub.ordering_key",
-                                         "ordering-key-0"),
+              OTelAttribute<std::string>(
+                  "messaging.gcp_pubsub.message.ordering_key",
+                  "ordering-key-0"),
               OTelAttribute<int>("gl-cpp.status_code", 0),
               OTelAttribute<std::int64_t>(/*sc::kMessagingMessageEnvelopeSize=*/
                                           "messaging.message.envelope.size",
@@ -137,8 +138,9 @@ TEST(PublisherTracingConnectionTest, PublishSpanOnError) {
                   "projects/test-project/topics/test-topic"),
               OTelAttribute<std::string>(sc::kMessagingDestinationTemplate,
                                          "topic"),
-              OTelAttribute<std::string>("messaging.pubsub.ordering_key",
-                                         "ordering-key-0"),
+              OTelAttribute<std::string>(
+                  "messaging.gcp_pubsub.message.ordering_key",
+                  "ordering-key-0"),
               OTelAttribute<std::string>(sc::kMessagingOperation, "create"),
               OTelAttribute<int>("gl-cpp.status_code", kErrorCode),
               OTelAttribute<std::int64_t>(/*sc::kMessagingMessageEnvelopeSize=*/
@@ -194,7 +196,7 @@ TEST(PublisherTracingConnectionTest, PublishSpanOmitsOrderingKey) {
                   SpanNamed("projects/test-project/topics/test-topic create"),
                   SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
                   Not(SpanHasAttributes(OTelAttribute<std::string>(
-                      "messaging.pubsub.ordering_key", _))))));
+                      "messaging.gcp_pubsub.message.ordering_key", _))))));
 }
 
 TEST(PublisherTracingConnectionTest, FlushSpan) {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13183)
<!-- Reviewable:end -->
