### PR TITLE
refactor: make `StreamingRpcMetadata` public

### DIFF
--- a/generator/integration_tests/tests/mock_golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/tests/mock_golden_kitchen_sink_stub.h
@@ -130,8 +130,7 @@ class MockStreamingReadRpc
   MOCK_METHOD(
       (absl::variant<Status, ::google::test::admin::database::v1::Response>),
       Read, (), (override));
-  MOCK_METHOD(internal::StreamingRpcMetadata, GetRequestMetadata, (),
-              (const, override));
+  MOCK_METHOD(RpcMetadata, GetRequestMetadata, (), (const, override));
 };
 
 class MockStreamingWriteRpc
@@ -146,8 +145,7 @@ class MockStreamingWriteRpc
               (override));
   MOCK_METHOD(StatusOr<::google::test::admin::database::v1::Response>, Close,
               (), (override));
-  MOCK_METHOD(internal::StreamingRpcMetadata, GetRequestMetadata, (),
-              (const, override));
+  MOCK_METHOD(RpcMetadata, GetRequestMetadata, (), (const, override));
 };
 
 using MockAsyncStreamingReadWriteRpc =

--- a/google/cloud/bigtable/testing/mock_bigtable_stub.h
+++ b/google/cloud/bigtable/testing/mock_bigtable_stub.h
@@ -110,8 +110,8 @@ class MockMutateRowsStream : public google::cloud::internal::StreamingReadRpc<
   using MutateRowsResultType =
       absl::variant<Status, google::bigtable::v2::MutateRowsResponse>;
   MOCK_METHOD(MutateRowsResultType, Read, (), (override));
-  MOCK_METHOD(google::cloud::internal::StreamingRpcMetadata, GetRequestMetadata,
-              (), (const, override));
+  MOCK_METHOD(google::cloud::RpcMetadata, GetRequestMetadata, (),
+              (const, override));
 };
 
 class MockReadRowsStream : public google::cloud::internal::StreamingReadRpc<
@@ -121,8 +121,8 @@ class MockReadRowsStream : public google::cloud::internal::StreamingReadRpc<
   using ReadRowsResultType =
       absl::variant<Status, google::bigtable::v2::ReadRowsResponse>;
   MOCK_METHOD(ReadRowsResultType, Read, (), (override));
-  MOCK_METHOD(google::cloud::internal::StreamingRpcMetadata, GetRequestMetadata,
-              (), (const, override));
+  MOCK_METHOD(google::cloud::RpcMetadata, GetRequestMetadata, (),
+              (const, override));
 };
 
 class MockSampleRowKeysStream
@@ -133,8 +133,8 @@ class MockSampleRowKeysStream
   using SampleRowKeysResultType =
       absl::variant<Status, google::bigtable::v2::SampleRowKeysResponse>;
   MOCK_METHOD(SampleRowKeysResultType, Read, (), (override));
-  MOCK_METHOD(google::cloud::internal::StreamingRpcMetadata, GetRequestMetadata,
-              (), (const, override));
+  MOCK_METHOD(google::cloud::RpcMetadata, GetRequestMetadata, (),
+              (const, override));
 };
 
 using MockAsyncMutateRowsStream =

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -101,6 +101,7 @@ google_cloud_cpp_common_hdrs = [
     "polling_policy.h",
     "project.h",
     "retry_policy.h",
+    "rpc_metadata.h",
     "status.h",
     "status_or.h",
     "stream_range.h",

--- a/google/cloud/google_cloud_cpp_common.cmake
+++ b/google/cloud/google_cloud_cpp_common.cmake
@@ -155,6 +155,7 @@ add_library(
     project.cc
     project.h
     retry_policy.h
+    rpc_metadata.h
     status.cc
     status.h
     status_or.h

--- a/google/cloud/internal/async_streaming_read_rpc.h
+++ b/google/cloud/internal/async_streaming_read_rpc.h
@@ -16,7 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_ASYNC_STREAMING_READ_RPC_H
 
 #include "google/cloud/future.h"
-#include "google/cloud/internal/grpc_request_metadata.h"
+#include "google/cloud/rpc_metadata.h"
 #include "google/cloud/status.h"
 #include "google/cloud/version.h"
 #include "absl/types/optional.h"
@@ -97,7 +97,7 @@ class AsyncStreamingReadRpc {
    *
    * @note Only call this function once, and only after `Finish()` completes.
    */
-  virtual StreamingRpcMetadata GetRequestMetadata() const = 0;
+  virtual RpcMetadata GetRequestMetadata() const = 0;
 };
 
 }  // namespace internal

--- a/google/cloud/internal/async_streaming_read_rpc_auth.h
+++ b/google/cloud/internal/async_streaming_read_rpc_auth.h
@@ -62,7 +62,7 @@ class AsyncStreamingReadRpcAuth : public AsyncStreamingReadRpc<Response> {
 
   future<Status> Finish() override { return state_->Finish(); }
 
-  StreamingRpcMetadata GetRequestMetadata() const override {
+  RpcMetadata GetRequestMetadata() const override {
     return state_->GetRequestMetadata();
   }
 
@@ -99,7 +99,7 @@ class AsyncStreamingReadRpcAuth : public AsyncStreamingReadRpc<Response> {
       return stream->Finish();
     }
 
-    StreamingRpcMetadata GetRequestMetadata() {
+    RpcMetadata GetRequestMetadata() {
       std::lock_guard<std::mutex> g{mu};
       return stream->GetRequestMetadata();
     }

--- a/google/cloud/internal/async_streaming_read_rpc_auth_test.cc
+++ b/google/cloud/internal/async_streaming_read_rpc_auth_test.cc
@@ -55,7 +55,7 @@ TEST(AsyncStreamReadWriteAuth, Start) {
       return make_ready_future(Status{});
     });
     EXPECT_CALL(*mock, GetRequestMetadata).WillOnce([] {
-      return StreamingRpcMetadata({{"test-only", "value"}});
+      return RpcMetadata{{{"test-only", "value"}}, {{"t2", "v2"}}};
     });
     return std::unique_ptr<BaseStream>(std::move(mock));
   });
@@ -71,7 +71,9 @@ TEST(AsyncStreamReadWriteAuth, Start) {
   EXPECT_EQ(response->key, "k0");
   EXPECT_EQ(response->value, "v0");
   EXPECT_THAT(uut->Finish().get(), IsOk());
-  EXPECT_THAT(uut->GetRequestMetadata(), Contains(Pair("test-only", "value")));
+  auto metadata = uut->GetRequestMetadata();
+  EXPECT_THAT(metadata.headers, Contains(Pair("test-only", "value")));
+  EXPECT_THAT(metadata.trailers, Contains(Pair("t2", "v2")));
 }
 
 TEST(AsyncStreamReadWriteAuth, AuthFails) {

--- a/google/cloud/internal/async_streaming_read_rpc_impl.h
+++ b/google/cloud/internal/async_streaming_read_rpc_impl.h
@@ -20,6 +20,7 @@
 #include "google/cloud/internal/async_streaming_read_rpc.h"
 #include "google/cloud/internal/call_context.h"
 #include "google/cloud/internal/completion_queue_impl.h"
+#include "google/cloud/internal/grpc_request_metadata.h"
 #include "google/cloud/version.h"
 #include "absl/functional/function_ref.h"
 #include "absl/types/optional.h"
@@ -107,7 +108,7 @@ class AsyncStreamingReadRpcImpl : public AsyncStreamingReadRpc<Response> {
     return op->p.get_future();
   }
 
-  StreamingRpcMetadata GetRequestMetadata() const override {
+  RpcMetadata GetRequestMetadata() const override {
     return GetRequestMetadataFromContext(*context_);
   }
 
@@ -164,7 +165,7 @@ class AsyncStreamingReadRpcError : public AsyncStreamingReadRpc<Response> {
     return make_ready_future<absl::optional<Response>>(absl::nullopt);
   }
   future<Status> Finish() override { return make_ready_future(status_); }
-  StreamingRpcMetadata GetRequestMetadata() const override { return {}; }
+  RpcMetadata GetRequestMetadata() const override { return {}; }
 
  private:
   Status status_;

--- a/google/cloud/internal/async_streaming_read_rpc_logging.h
+++ b/google/cloud/internal/async_streaming_read_rpc_logging.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include "google/cloud/internal/async_streaming_read_rpc.h"
+#include "google/cloud/internal/grpc_request_metadata.h"
 #include "google/cloud/internal/log_wrapper.h"
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
@@ -78,7 +79,7 @@ class AsyncStreamingReadRpcLogging : public AsyncStreamingReadRpc<Response> {
     });
   }
 
-  StreamingRpcMetadata GetRequestMetadata() const override {
+  RpcMetadata GetRequestMetadata() const override {
     auto prefix = std::string(__func__) + "(" + request_id_ + ")";
     GCP_LOG(DEBUG) << prefix << " <<";
     auto metadata = child_->GetRequestMetadata();

--- a/google/cloud/internal/async_streaming_read_rpc_logging_test.cc
+++ b/google/cloud/internal/async_streaming_read_rpc_logging_test.cc
@@ -107,10 +107,10 @@ TEST(StreamingReadRpcLoggingTest, GetRequestMetadata) {
 
   auto mock = std::make_unique<MockStream>();
   EXPECT_CALL(*mock, GetRequestMetadata).WillOnce([] {
-    return StreamingRpcMetadata({{":test-only", "value"}});
+    return RpcMetadata{{{":test-only", "value"}}, {}};
   });
   TestedStream stream(std::move(mock), TracingOptions{}, "test-id");
-  EXPECT_THAT(stream.GetRequestMetadata(),
+  EXPECT_THAT(stream.GetRequestMetadata().headers,
               Contains(Pair(":test-only", "value")));
   EXPECT_THAT(log.ExtractLines(),
               Contains(AllOf(HasSubstr("GetRequestMetadata(test-id)"),

--- a/google/cloud/internal/async_streaming_read_rpc_timeout.h
+++ b/google/cloud/internal/async_streaming_read_rpc_timeout.h
@@ -66,7 +66,7 @@ class AsyncStreamingReadRpcTimeout : public AsyncStreamingReadRpc<Response> {
 
   future<Status> Finish() override { return state_->child->Finish(); }
 
-  StreamingRpcMetadata GetRequestMetadata() const override {
+  RpcMetadata GetRequestMetadata() const override {
     return state_->child->GetRequestMetadata();
   }
 

--- a/google/cloud/internal/async_streaming_read_rpc_timeout_test.cc
+++ b/google/cloud/internal/async_streaming_read_rpc_timeout_test.cc
@@ -206,7 +206,8 @@ TEST(AsyncStreamingReadRpcTimeout, Finish) {
 }
 
 TEST(AsyncStreamingReadRpcTimeout, GetRequestMetadata) {
-  auto const expected = StreamingRpcMetadata{{"k1", "v1"}, {"k2", "v2"}};
+  auto const expected =
+      RpcMetadata{{{"k1", "v1"}, {"k2", "v2"}}, {{"t1", "tv1"}}};
   AsyncSequencer<bool> sequencer;
   auto mock = std::make_unique<MockStream>();
   EXPECT_CALL(*mock, GetRequestMetadata).WillOnce(Return(expected));
@@ -218,7 +219,8 @@ TEST(AsyncStreamingReadRpcTimeout, GetRequestMetadata) {
 
   TestedStream uut(cq, kStartTimeout, kReadTimeout, std::move(mock));
   auto const actual = uut.GetRequestMetadata();
-  EXPECT_THAT(actual, ElementsAreArray(expected));
+  EXPECT_THAT(actual.headers, ElementsAreArray(expected.headers));
+  EXPECT_THAT(actual.trailers, ElementsAreArray(expected.trailers));
 }
 
 }  // namespace

--- a/google/cloud/internal/async_streaming_read_rpc_tracing.h
+++ b/google/cloud/internal/async_streaming_read_rpc_tracing.h
@@ -74,7 +74,7 @@ class AsyncStreamingReadRpcTracing : public AsyncStreamingReadRpc<Response> {
         });
   }
 
-  StreamingRpcMetadata GetRequestMetadata() const override {
+  RpcMetadata GetRequestMetadata() const override {
     return impl_->GetRequestMetadata();
   }
 

--- a/google/cloud/internal/async_streaming_read_rpc_tracing_test.cc
+++ b/google/cloud/internal/async_streaming_read_rpc_tracing_test.cc
@@ -170,12 +170,12 @@ TEST(AsyncStreamingReadRpcTracing, Finish) {
 TEST(AsyncStreamingReadRpcTracing, GetRequestMetadata) {
   auto mock = std::make_unique<MockStream>();
   EXPECT_CALL(*mock, GetRequestMetadata)
-      .WillOnce(Return(StreamingRpcMetadata{{"key", "value"}}));
+      .WillOnce(Return(RpcMetadata{{{"key", "value"}}, {}}));
 
   auto span = MakeSpan("span");
   TestedStream stream(std::make_shared<grpc::ClientContext>(), std::move(mock),
                       span);
-  auto md = stream.GetRequestMetadata();
+  auto md = stream.GetRequestMetadata().headers;
   EXPECT_THAT(md, ElementsAre(Pair("key", "value")));
 }
 

--- a/google/cloud/internal/async_streaming_write_rpc.h
+++ b/google/cloud/internal/async_streaming_write_rpc.h
@@ -16,9 +16,10 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_ASYNC_STREAMING_WRITE_RPC_H
 
 #include "google/cloud/future.h"
-#include "google/cloud/internal/grpc_request_metadata.h"
+#include "google/cloud/rpc_metadata.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
+#include <grpcpp/grpcpp.h>
 
 namespace google {
 namespace cloud {
@@ -126,7 +127,7 @@ class AsyncStreamingWriteRpc {
    *
    * @note Only call this function once, and only after `Finish()` completes.
    */
-  virtual StreamingRpcMetadata GetRequestMetadata() const = 0;
+  virtual RpcMetadata GetRequestMetadata() const = 0;
 };
 
 }  // namespace internal

--- a/google/cloud/internal/async_streaming_write_rpc_auth.h
+++ b/google/cloud/internal/async_streaming_write_rpc_auth.h
@@ -69,7 +69,7 @@ class AsyncStreamingWriteRpcAuth
 
   future<StatusOr<Response>> Finish() override { return state_->Finish(); }
 
-  StreamingRpcMetadata GetRequestMetadata() const override {
+  RpcMetadata GetRequestMetadata() const override {
     return state_->GetRequestMetadata();
   }
 
@@ -109,7 +109,7 @@ class AsyncStreamingWriteRpcAuth
       return stream->Finish();
     }
 
-    StreamingRpcMetadata GetRequestMetadata() {
+    RpcMetadata GetRequestMetadata() {
       std::lock_guard<std::mutex> g{mu};
       return stream->GetRequestMetadata();
     }

--- a/google/cloud/internal/async_streaming_write_rpc_auth_test.cc
+++ b/google/cloud/internal/async_streaming_write_rpc_auth_test.cc
@@ -53,7 +53,7 @@ class MockStream : public BaseStream {
               (override));
   MOCK_METHOD(future<bool>, WritesDone, (), (override));
   MOCK_METHOD(future<StatusOr<FakeResponse>>, Finish, (), (override));
-  MOCK_METHOD(StreamingRpcMetadata, GetRequestMetadata, (), (const, override));
+  MOCK_METHOD(RpcMetadata, GetRequestMetadata, (), (const, override));
 };
 
 TEST(AsyncStreamingWriteRpcAuth, Start) {
@@ -68,7 +68,7 @@ TEST(AsyncStreamingWriteRpcAuth, Start) {
       return make_ready_future(make_status_or(FakeResponse{"key0", "value0"}));
     });
     EXPECT_CALL(*mock, GetRequestMetadata).WillOnce([] {
-      return StreamingRpcMetadata({{"test-only", "value"}});
+      return RpcMetadata{{{"test-only", "value"}}, {}};
     });
     return std::unique_ptr<BaseStream>(std::move(mock));
   });
@@ -86,7 +86,8 @@ TEST(AsyncStreamingWriteRpcAuth, Start) {
   ASSERT_THAT(response, IsOk());
   EXPECT_EQ(response->key, "key0");
   EXPECT_EQ(response->value, "value0");
-  EXPECT_THAT(uut->GetRequestMetadata(), Contains(Pair("test-only", "value")));
+  EXPECT_THAT(uut->GetRequestMetadata().headers,
+              Contains(Pair("test-only", "value")));
 }
 
 TEST(AsyncStreamingWriteRpcAuth, AuthFails) {

--- a/google/cloud/internal/async_streaming_write_rpc_impl.h
+++ b/google/cloud/internal/async_streaming_write_rpc_impl.h
@@ -20,6 +20,7 @@
 #include "google/cloud/internal/async_streaming_write_rpc.h"
 #include "google/cloud/internal/call_context.h"
 #include "google/cloud/internal/completion_queue_impl.h"
+#include "google/cloud/internal/grpc_request_metadata.h"
 #include "google/cloud/version.h"
 #include "absl/functional/function_ref.h"
 #include "absl/types/optional.h"
@@ -129,7 +130,7 @@ class AsyncStreamingWriteRpcImpl
     return op->p.get_future();
   }
 
-  StreamingRpcMetadata GetRequestMetadata() const override {
+  RpcMetadata GetRequestMetadata() const override {
     return GetRequestMetadataFromContext(*context_);
   }
 
@@ -194,7 +195,7 @@ class AsyncStreamingWriteRpcError
   future<StatusOr<Response>> Finish() override {
     return make_ready_future(StatusOr<Response>(status_));
   }
-  StreamingRpcMetadata GetRequestMetadata() const override { return {}; }
+  RpcMetadata GetRequestMetadata() const override { return {}; }
 
  private:
   Status status_;

--- a/google/cloud/internal/async_streaming_write_rpc_logging.h
+++ b/google/cloud/internal/async_streaming_write_rpc_logging.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include "google/cloud/internal/async_streaming_write_rpc.h"
+#include "google/cloud/internal/grpc_request_metadata.h"
 #include "google/cloud/internal/log_wrapper.h"
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
@@ -90,7 +91,7 @@ class AsyncStreamingWriteRpcLogging
     });
   }
 
-  StreamingRpcMetadata GetRequestMetadata() const override {
+  RpcMetadata GetRequestMetadata() const override {
     auto prefix = std::string(__func__) + "(" + request_id_ + ")";
     GCP_LOG(DEBUG) << prefix << " <<";
     auto metadata = child_->GetRequestMetadata();

--- a/google/cloud/internal/async_streaming_write_rpc_logging_test.cc
+++ b/google/cloud/internal/async_streaming_write_rpc_logging_test.cc
@@ -126,10 +126,10 @@ TEST(StreamingWriteRpcLoggingTest, GetRequestMetadata) {
 
   auto mock = std::make_unique<MockStream>();
   EXPECT_CALL(*mock, GetRequestMetadata).WillOnce([] {
-    return StreamingRpcMetadata({{":test-only", "value"}});
+    return RpcMetadata{{{":test-only", "value"}}, {}};
   });
   TestedStream stream(std::move(mock), TracingOptions{}, "test-id");
-  EXPECT_THAT(stream.GetRequestMetadata(),
+  EXPECT_THAT(stream.GetRequestMetadata().headers,
               Contains(Pair(":test-only", "value")));
   EXPECT_THAT(log.ExtractLines(),
               Contains(AllOf(HasSubstr("GetRequestMetadata(test-id)"),

--- a/google/cloud/internal/async_streaming_write_rpc_timeout.h
+++ b/google/cloud/internal/async_streaming_write_rpc_timeout.h
@@ -74,7 +74,7 @@ class AsyncStreamingWriteRpcTimeout
     return state_->child->Finish();
   }
 
-  StreamingRpcMetadata GetRequestMetadata() const override {
+  RpcMetadata GetRequestMetadata() const override {
     return state_->child->GetRequestMetadata();
   }
 

--- a/google/cloud/internal/async_streaming_write_rpc_timeout_test.cc
+++ b/google/cloud/internal/async_streaming_write_rpc_timeout_test.cc
@@ -261,7 +261,8 @@ TEST(AsyncStreamingWriteRpcTimeout, Finish) {
 }
 
 TEST(AsyncStreamingWriteRpcTimeout, GetRequestMetadata) {
-  auto const expected = StreamingRpcMetadata{{"k1", "v1"}, {"k2", "v2"}};
+  auto const expected =
+      RpcMetadata{{{"k1", "v1"}, {"k2", "v2"}}, {{"t1", "tv1"}}};
   AsyncSequencer<bool> sequencer;
   auto mock = std::make_unique<MockStream>();
   EXPECT_CALL(*mock, GetRequestMetadata).WillOnce(Return(expected));
@@ -273,7 +274,8 @@ TEST(AsyncStreamingWriteRpcTimeout, GetRequestMetadata) {
 
   TestedStream uut(cq, kStartTimeout, kWriteTimeout, std::move(mock));
   auto const actual = uut.GetRequestMetadata();
-  EXPECT_THAT(actual, ElementsAreArray(expected));
+  EXPECT_THAT(actual.headers, ElementsAreArray(expected.headers));
+  EXPECT_THAT(actual.trailers, ElementsAreArray(expected.trailers));
 }
 
 }  // namespace

--- a/google/cloud/internal/async_streaming_write_rpc_tracing.h
+++ b/google/cloud/internal/async_streaming_write_rpc_tracing.h
@@ -93,7 +93,7 @@ class AsyncStreamingWriteRpcTracing
         });
   }
 
-  StreamingRpcMetadata GetRequestMetadata() const override {
+  RpcMetadata GetRequestMetadata() const override {
     return impl_->GetRequestMetadata();
   }
 

--- a/google/cloud/internal/async_streaming_write_rpc_tracing_test.cc
+++ b/google/cloud/internal/async_streaming_write_rpc_tracing_test.cc
@@ -197,13 +197,13 @@ TEST(AsyncStreamingWriteRpcTracing, Finish) {
 TEST(AsyncStreamingWriteRpcTracing, GetRequestMetadata) {
   auto mock = std::make_unique<MockStream>();
   EXPECT_CALL(*mock, GetRequestMetadata)
-      .WillOnce(Return(StreamingRpcMetadata{{"key", "value"}}));
+      .WillOnce(Return(RpcMetadata{{{"key", "value"}}, {}}));
 
   auto span = MakeSpan("span");
   TestedStream stream(std::make_shared<grpc::ClientContext>(), std::move(mock),
                       span);
   auto md = stream.GetRequestMetadata();
-  EXPECT_THAT(md, ElementsAre(Pair("key", "value")));
+  EXPECT_THAT(md.headers, ElementsAre(Pair("key", "value")));
 }
 
 TEST(AsyncStreamingWriteRpcTracing, SpanEndsOnDestruction) {

--- a/google/cloud/internal/grpc_request_metadata.h
+++ b/google/cloud/internal/grpc_request_metadata.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_GRPC_REQUEST_METADATA_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_GRPC_REQUEST_METADATA_H
 
+#include "google/cloud/rpc_metadata.h"
 #include "google/cloud/version.h"
 #include <grpcpp/grpcpp.h>
 #include <map>
@@ -25,15 +26,11 @@ namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 
-/// A simple representation of request metadata.
-using StreamingRpcMetadata = std::multimap<std::string, std::string>;
-
 /// Return interesting bits of metadata stored in the client context.
-StreamingRpcMetadata GetRequestMetadataFromContext(
-    grpc::ClientContext const& context);
+RpcMetadata GetRequestMetadataFromContext(grpc::ClientContext const& context);
 
 /// Format metadata for logging decorators.
-std::string FormatForLoggingDecorator(StreamingRpcMetadata const& metadata);
+std::string FormatForLoggingDecorator(RpcMetadata const& metadata);
 
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/grpc_request_metadata_test.cc
+++ b/google/cloud/internal/grpc_request_metadata_test.cc
@@ -24,12 +24,14 @@ namespace {
 
 TEST(GrpcRequestMetadata, FormatForLoggingDecorator) {
   struct Test {
-    StreamingRpcMetadata metadata;
+    RpcMetadata metadata;
     std::string expected;
-  } cases[] = {
-      {{}, ""},
-      {{{"a", "b"}}, "{a: b}"},
-      {{{"a", "b"}, {"k", "v"}}, "{a: b}, {k: v}"},
+  } const cases[] = {
+      {RpcMetadata{{}, {}}, "headers={}, trailers={}"},
+      {RpcMetadata{{{"a", "b"}}, {}}, "headers={{a: b}}, trailers={}"},
+      {RpcMetadata{{}, {{"a", "b"}}}, "headers={}, trailers={{a: b}}"},
+      {RpcMetadata{{{"a", "b"}, {"k", "v"}}, {{"d", "e"}, {"h", "f"}}},
+       "headers={{a: b}, {k: v}}, trailers={{d: e}, {h: f}}"},
   };
   for (auto const& test : cases) {
     auto const actual = FormatForLoggingDecorator(test.metadata);

--- a/google/cloud/internal/resumable_streaming_read_rpc.h
+++ b/google/cloud/internal/resumable_streaming_read_rpc.h
@@ -127,8 +127,8 @@ class ResumableStreamingReadRpc : public StreamingReadRpc<ResponseType> {
     return last_status;
   }
 
-  StreamingRpcMetadata GetRequestMetadata() const override {
-    return impl_ ? impl_->GetRequestMetadata() : StreamingRpcMetadata{};
+  RpcMetadata GetRequestMetadata() const override {
+    return impl_ ? impl_->GetRequestMetadata() : RpcMetadata{};
   }
 
  private:

--- a/google/cloud/internal/resumable_streaming_read_rpc_test.cc
+++ b/google/cloud/internal/resumable_streaming_read_rpc_test.cc
@@ -47,7 +47,7 @@ class MockStreamingReadRpc : public StreamingReadRpc<FakeResponse> {
  public:
   MOCK_METHOD(void, Cancel, (), (override));
   MOCK_METHOD(ReadReturn, Read, (), (override));
-  MOCK_METHOD(StreamingRpcMetadata, GetRequestMetadata, (), (const, override));
+  MOCK_METHOD(RpcMetadata, GetRequestMetadata, (), (const, override));
 };
 
 struct TestRetryablePolicy {

--- a/google/cloud/internal/streaming_read_rpc.h
+++ b/google/cloud/internal/streaming_read_rpc.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/grpc_error_delegate.h"
 #include "google/cloud/internal/grpc_request_metadata.h"
+#include "google/cloud/rpc_metadata.h"
 #include "google/cloud/status.h"
 #include "google/cloud/version.h"
 #include "absl/types/variant.h"
@@ -60,7 +61,7 @@ class StreamingReadRpc {
    * expensive to extract.  Library developers should avoid this function in
    * the critical path.
    */
-  virtual StreamingRpcMetadata GetRequestMetadata() const = 0;
+  virtual RpcMetadata GetRequestMetadata() const = 0;
 };
 
 /// Report the errors in a standalone function to minimize includes
@@ -96,7 +97,7 @@ class StreamingReadRpcImpl : public StreamingReadRpc<ResponseType> {
     return Finish();
   }
 
-  StreamingRpcMetadata GetRequestMetadata() const override {
+  RpcMetadata GetRequestMetadata() const override {
     if (!context_) return {};
     return GetRequestMetadataFromContext(*context_);
   }
@@ -133,7 +134,7 @@ class StreamingReadRpcError : public StreamingReadRpc<ResponseType> {
 
   absl::variant<Status, ResponseType> Read() override { return status_; }
 
-  StreamingRpcMetadata GetRequestMetadata() const override { return {}; }
+  RpcMetadata GetRequestMetadata() const override { return {}; }
 
  private:
   Status status_;

--- a/google/cloud/internal/streaming_read_rpc_logging.h
+++ b/google/cloud/internal/streaming_read_rpc_logging.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_STREAMING_READ_RPC_LOGGING_H
 
 #include "google/cloud/internal/absl_str_cat_quiet.h"
+#include "google/cloud/internal/grpc_request_metadata.h"
 #include "google/cloud/internal/log_wrapper.h"
 #include "google/cloud/internal/streaming_read_rpc.h"
 #include "google/cloud/status.h"
@@ -61,7 +62,7 @@ class StreamingReadRpcLogging : public StreamingReadRpc<ResponseType> {
                    << absl::visit(ResultVisitor(tracing_options_), result);
     return result;
   }
-  StreamingRpcMetadata GetRequestMetadata() const override {
+  RpcMetadata GetRequestMetadata() const override {
     auto metadata = reader_->GetRequestMetadata();
     GCP_LOG(DEBUG) << __func__ << "() >> metadata={"
                    << FormatForLoggingDecorator(metadata) << "}";

--- a/google/cloud/internal/streaming_read_rpc_logging_test.cc
+++ b/google/cloud/internal/streaming_read_rpc_logging_test.cc
@@ -35,7 +35,7 @@ class MockStreamingReadRpc : public StreamingReadRpc<ResponseType> {
   ~MockStreamingReadRpc() override = default;
   MOCK_METHOD(void, Cancel, (), (override));
   MOCK_METHOD((absl::variant<Status, ResponseType>), Read, (), (override));
-  MOCK_METHOD(StreamingRpcMetadata, GetRequestMetadata, (), (const, override));
+  MOCK_METHOD(RpcMetadata, GetRequestMetadata, (), (const, override));
 };
 
 class StreamingReadRpcLoggingTest : public ::testing::Test {

--- a/google/cloud/internal/streaming_read_rpc_tracing.h
+++ b/google/cloud/internal/streaming_read_rpc_tracing.h
@@ -57,7 +57,7 @@ class StreamingReadRpcTracing : public StreamingReadRpc<ResponseType> {
     return result;
   }
 
-  StreamingRpcMetadata GetRequestMetadata() const override {
+  RpcMetadata GetRequestMetadata() const override {
     return impl_->GetRequestMetadata();
   }
 

--- a/google/cloud/internal/streaming_write_rpc.h
+++ b/google/cloud/internal/streaming_write_rpc.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_STREAMING_WRITE_RPC_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_STREAMING_WRITE_RPC_H
 
-#include "google/cloud/internal/grpc_request_metadata.h"
+#include "google/cloud/rpc_metadata.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <grpcpp/grpcpp.h>
@@ -65,7 +65,7 @@ class StreamingWriteRpc {
    *
    * @note Only call this function once, and only after `Finish()` completes.
    */
-  virtual StreamingRpcMetadata GetRequestMetadata() const = 0;
+  virtual RpcMetadata GetRequestMetadata() const = 0;
 };
 
 }  // namespace internal

--- a/google/cloud/internal/streaming_write_rpc_impl.h
+++ b/google/cloud/internal/streaming_write_rpc_impl.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_STREAMING_WRITE_RPC_IMPL_H
 
 #include "google/cloud/grpc_error_delegate.h"
+#include "google/cloud/internal/grpc_request_metadata.h"
 #include "google/cloud/internal/streaming_write_rpc.h"
 #include "google/cloud/status.h"
 #include "google/cloud/version.h"
@@ -73,7 +74,7 @@ class StreamingWriteRpcImpl
     return std::move(*response_);
   }
 
-  StreamingRpcMetadata GetRequestMetadata() const override {
+  RpcMetadata GetRequestMetadata() const override {
     return GetRequestMetadataFromContext(*context_);
   }
 
@@ -113,7 +114,7 @@ class StreamingWriteRpcError
 
   StatusOr<ResponseType> Close() override { return status_; }
 
-  StreamingRpcMetadata GetRequestMetadata() const override { return {}; }
+  RpcMetadata GetRequestMetadata() const override { return {}; }
 
  private:
   Status status_;

--- a/google/cloud/internal/streaming_write_rpc_logging.h
+++ b/google/cloud/internal/streaming_write_rpc_logging.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_STREAMING_WRITE_RPC_LOGGING_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_STREAMING_WRITE_RPC_LOGGING_H
 
+#include "google/cloud/internal/grpc_request_metadata.h"
 #include "google/cloud/internal/log_wrapper.h"
 #include "google/cloud/internal/streaming_write_rpc.h"
 #include "google/cloud/log.h"
@@ -73,7 +74,7 @@ class StreamingWriteRpcLogging
     return result;
   }
 
-  StreamingRpcMetadata GetRequestMetadata() const override {
+  RpcMetadata GetRequestMetadata() const override {
     auto prefix = std::string(__func__) + "(" + request_id_ + ")";
     GCP_LOG(DEBUG) << prefix << " <<";
     auto metadata = stream_->GetRequestMetadata();

--- a/google/cloud/internal/streaming_write_rpc_logging_test.cc
+++ b/google/cloud/internal/streaming_write_rpc_logging_test.cc
@@ -44,7 +44,7 @@ class MockStreamingWriteRpc
   MOCK_METHOD(bool, Write, (RequestType const&, grpc::WriteOptions),
               (override));
   MOCK_METHOD(StatusOr<ResponseType>, Close, (), (override));
-  MOCK_METHOD(StreamingRpcMetadata, GetRequestMetadata, (), (const, override));
+  MOCK_METHOD(RpcMetadata, GetRequestMetadata, (), (const, override));
 };
 
 class StreamingWriteRpcLoggingTest : public ::testing::Test {
@@ -115,10 +115,10 @@ TEST_F(StreamingWriteRpcLoggingTest, CloseWithError) {
 TEST_F(StreamingWriteRpcLoggingTest, GetRequestMetadata) {
   auto mock = std::make_unique<MockStream>();
   EXPECT_CALL(*mock, GetRequestMetadata).WillOnce([] {
-    return StreamingRpcMetadata({{":test-only", "value"}});
+    return RpcMetadata{{{":test-only", "value"}}, {}};
   });
   TestedStream stream(std::move(mock), TracingOptions{}, "test-id");
-  EXPECT_THAT(stream.GetRequestMetadata(),
+  EXPECT_THAT(stream.GetRequestMetadata().headers,
               Contains(Pair(":test-only", "value")));
   EXPECT_THAT(log_.ExtractLines(),
               Contains(AllOf(HasSubstr("GetRequestMetadata(test-id)"),

--- a/google/cloud/internal/streaming_write_rpc_tracing.h
+++ b/google/cloud/internal/streaming_write_rpc_tracing.h
@@ -67,7 +67,7 @@ class StreamingWriteRpcTracing
     return EndSpan(*std::move(context_), *std::move(span_), impl_->Close());
   }
 
-  StreamingRpcMetadata GetRequestMetadata() const override {
+  RpcMetadata GetRequestMetadata() const override {
     return impl_->GetRequestMetadata();
   }
 

--- a/google/cloud/internal/streaming_write_rpc_tracing_test.cc
+++ b/google/cloud/internal/streaming_write_rpc_tracing_test.cc
@@ -46,7 +46,7 @@ class MockStreamingWriteRpc
   MOCK_METHOD(bool, Write, (RequestType const&, grpc::WriteOptions),
               (override));
   MOCK_METHOD(StatusOr<ResponseType>, Close, (), (override));
-  MOCK_METHOD(StreamingRpcMetadata, GetRequestMetadata, (), (const, override));
+  MOCK_METHOD(RpcMetadata, GetRequestMetadata, (), (const, override));
 };
 
 using MockStream = MockStreamingWriteRpc<int, int>;
@@ -145,13 +145,14 @@ TEST(StreamingWriteRpcTracingTest, Close) {
 TEST(StreamingWriteRpcTracingTest, GetRequestMetadata) {
   auto mock = std::make_unique<MockStream>();
   EXPECT_CALL(*mock, GetRequestMetadata)
-      .WillOnce(Return(StreamingRpcMetadata{{"key", "value"}}));
+      .WillOnce(Return(RpcMetadata{{{"key", "value"}}, {{"tk", "tv"}}}));
 
   auto span = MakeSpan("span");
   TestedStream stream(std::make_shared<grpc::ClientContext>(), std::move(mock),
                       span);
   auto md = stream.GetRequestMetadata();
-  EXPECT_THAT(md, ElementsAre(Pair("key", "value")));
+  EXPECT_THAT(md.headers, ElementsAre(Pair("key", "value")));
+  EXPECT_THAT(md.trailers, ElementsAre(Pair("tk", "tv")));
 }
 
 TEST(StreamingWriteRpcTracingTest, SpanEndsOnDestruction) {

--- a/google/cloud/rpc_metadata.h
+++ b/google/cloud/rpc_metadata.h
@@ -1,0 +1,47 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RPC_METADATA_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RPC_METADATA_H
+
+#include "google/cloud/version.h"
+#include <map>
+#include <string>
+
+namespace google {
+namespace cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+/**
+ * RPC request metadata.
+ *
+ * Once a RPC completes the underlying transport (gRPC or HTTP) may make some
+ * metadata attributes about the request available. For the moment we just
+ * capture headers, trailers, and tunnel some low-level socket information as
+ * fake headers.
+ *
+ * @note When available to applications this information is intended only for
+ *   debugging and troubleshooting.  There is no guarantee that the header names
+ *   will always be available, or remain stable.
+ */
+struct RpcMetadata {
+  std::multimap<std::string, std::string> headers;
+  std::multimap<std::string, std::string> trailers;
+};
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RPC_METADATA_H

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -304,8 +304,7 @@ class MockStreamingReadRpc : public internal::StreamingReadRpc<ResponseType> {
  public:
   MOCK_METHOD(void, Cancel, (), (override));
   MOCK_METHOD((absl::variant<Status, ResponseType>), Read, (), (override));
-  MOCK_METHOD(internal::StreamingRpcMetadata, GetRequestMetadata, (),
-              (const, override));
+  MOCK_METHOD(RpcMetadata, GetRequestMetadata, (), (const, override));
 };
 
 // Creates a MockStreamingReadRpc that yields the specified `responses`

--- a/google/cloud/storage/internal/async/accumulate_read_object.h
+++ b/google/cloud/storage/internal/async/accumulate_read_object.h
@@ -21,6 +21,7 @@
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/future.h"
 #include "google/cloud/internal/async_streaming_read_rpc.h"
+#include "google/cloud/rpc_metadata.h"
 #include "google/cloud/version.h"
 #include <google/storage/v2/storage.pb.h>
 #include <chrono>
@@ -45,7 +46,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  */
 struct AsyncAccumulateReadObjectResult {
   std::vector<google::storage::v2::ReadObjectResponse> payload;
-  google::cloud::internal::StreamingRpcMetadata metadata;
+  google::cloud::RpcMetadata metadata;
   Status status;
 };
 

--- a/google/cloud/storage/internal/grpc/object_read_source.cc
+++ b/google/cloud/storage/internal/grpc/object_read_source.cc
@@ -64,7 +64,10 @@ StatusOr<storage::internal::ReadSourceResult> GrpcObjectReadSource::Read(
     if (absl::holds_alternative<Status>(data)) {
       status_ = absl::get<Status>(std::move(data));
       auto metadata = stream_->GetRequestMetadata();
-      result.response.headers.insert(metadata.begin(), metadata.end());
+      result.response.headers.insert(metadata.headers.begin(),
+                                     metadata.headers.end());
+      result.response.headers.insert(metadata.trailers.begin(),
+                                     metadata.trailers.end());
       stream_.reset();
       if (!status_.ok()) return status_;
       return result;

--- a/google/cloud/storage/internal/grpc/object_read_source_test.cc
+++ b/google/cloud/storage/internal/grpc/object_read_source_test.cc
@@ -28,7 +28,7 @@ namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-using ::google::cloud::internal::StreamingRpcMetadata;
+using ::google::cloud::RpcMetadata;
 using ::google::cloud::storage::testing::MockObjectMediaStream;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::HasSubstr;
@@ -60,8 +60,7 @@ TEST(GrpcObjectReadSource, Simple) {
         return response;
       })
       .WillOnce(Return(Status{}));
-  EXPECT_CALL(*mock, GetRequestMetadata)
-      .WillOnce(Return(StreamingRpcMetadata{}));
+  EXPECT_CALL(*mock, GetRequestMetadata).WillOnce(Return(RpcMetadata{}));
   GrpcObjectReadSource tested(MakeSimpleTimerSource(), std::move(mock));
   std::string expected =
       "0123456789 The quick brown fox jumps over the lazy dog";
@@ -84,8 +83,7 @@ TEST(GrpcObjectReadSource, EmptyWithError) {
   ::testing::InSequence sequence;
   EXPECT_CALL(*mock, Read)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
-  EXPECT_CALL(*mock, GetRequestMetadata)
-      .WillOnce(Return(StreamingRpcMetadata{}));
+  EXPECT_CALL(*mock, GetRequestMetadata).WillOnce(Return(RpcMetadata{}));
   GrpcObjectReadSource tested(MakeSimpleTimerSource(), std::move(mock));
   std::vector<char> buffer(1024);
   EXPECT_THAT(tested.Read(buffer.data(), buffer.size()),
@@ -106,8 +104,7 @@ TEST(GrpcObjectReadSource, DataWithError) {
         return response;
       })
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
-  EXPECT_CALL(*mock, GetRequestMetadata)
-      .WillOnce(Return(StreamingRpcMetadata{}));
+  EXPECT_CALL(*mock, GetRequestMetadata).WillOnce(Return(RpcMetadata{}));
   GrpcObjectReadSource tested(MakeSimpleTimerSource(), std::move(mock));
   std::string expected = "0123456789";
   std::vector<char> buffer(1024);
@@ -136,8 +133,7 @@ TEST(GrpcObjectReadSource, UseSpillBuffer) {
         return response;
       })
       .WillOnce(Return(Status{}));
-  EXPECT_CALL(*mock, GetRequestMetadata)
-      .WillOnce(Return(StreamingRpcMetadata{}));
+  EXPECT_CALL(*mock, GetRequestMetadata).WillOnce(Return(RpcMetadata{}));
   GrpcObjectReadSource tested(MakeSimpleTimerSource(), std::move(mock));
   std::vector<char> buffer(trailer_size);
   auto response = tested.Read(buffer.data(), expected_1.size());
@@ -172,8 +168,7 @@ TEST(GrpcObjectReadSource, UseSpillBufferMany) {
         return response;
       })
       .WillOnce(Return(Status{}));
-  EXPECT_CALL(*mock, GetRequestMetadata)
-      .WillOnce(Return(StreamingRpcMetadata{}));
+  EXPECT_CALL(*mock, GetRequestMetadata).WillOnce(Return(RpcMetadata{}));
   GrpcObjectReadSource tested(MakeSimpleTimerSource(), std::move(mock));
   std::vector<char> buffer(1024);
   auto response = tested.Read(buffer.data(), 3);
@@ -232,8 +227,7 @@ TEST(GrpcObjectReadSource, CaptureChecksums) {
         return response;
       })
       .WillOnce(Return(Status{}));
-  EXPECT_CALL(*mock, GetRequestMetadata)
-      .WillOnce(Return(StreamingRpcMetadata{}));
+  EXPECT_CALL(*mock, GetRequestMetadata).WillOnce(Return(RpcMetadata{}));
   GrpcObjectReadSource tested(MakeSimpleTimerSource(), std::move(mock));
   std::vector<char> buffer(1024);
   auto response = tested.Read(buffer.data(), buffer.size());
@@ -270,8 +264,7 @@ TEST(GrpcObjectReadSource, CaptureGeneration) {
         return response;
       })
       .WillOnce(Return(Status{}));
-  EXPECT_CALL(*mock, GetRequestMetadata)
-      .WillOnce(Return(StreamingRpcMetadata{}));
+  EXPECT_CALL(*mock, GetRequestMetadata).WillOnce(Return(RpcMetadata{}));
 
   GrpcObjectReadSource tested(MakeSimpleTimerSource(), std::move(mock));
   std::vector<char> buffer(1024);
@@ -305,8 +298,7 @@ TEST(GrpcObjectReadSource, HandleEmptyResponses) {
         return response;
       })
       .WillOnce(Return(Status{}));
-  EXPECT_CALL(*mock, GetRequestMetadata)
-      .WillOnce(Return(StreamingRpcMetadata{}));
+  EXPECT_CALL(*mock, GetRequestMetadata).WillOnce(Return(RpcMetadata{}));
   GrpcObjectReadSource tested(MakeSimpleTimerSource(), std::move(mock));
   std::string const expected = "The quick brown fox jumps over the lazy dog";
   std::vector<char> buffer(1024);
@@ -331,8 +323,7 @@ TEST(GrpcObjectReadSource, HandleExtraRead) {
         return response;
       })
       .WillOnce(Return(Status{}));
-  EXPECT_CALL(*mock, GetRequestMetadata)
-      .WillOnce(Return(StreamingRpcMetadata{}));
+  EXPECT_CALL(*mock, GetRequestMetadata).WillOnce(Return(RpcMetadata{}));
   GrpcObjectReadSource tested(MakeSimpleTimerSource(), std::move(mock));
   std::string const expected = "The quick brown fox jumps over the lazy dog";
   std::vector<char> buffer(1024);

--- a/google/cloud/storage/internal/grpc/object_request_parser.cc
+++ b/google/cloud/storage/internal/grpc/object_request_parser.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/internal/make_status.h"
 #include "google/cloud/internal/time_utils.h"
 #include "google/cloud/log.h"
+#include <iterator>
 
 namespace google {
 namespace cloud {
@@ -538,7 +539,7 @@ StatusOr<google::storage::v2::WriteObjectRequest> ToProto(
 
 storage::internal::QueryResumableUploadResponse FromProto(
     google::storage::v2::WriteObjectResponse const& p, Options const& options,
-    google::cloud::internal::StreamingRpcMetadata metadata) {
+    google::cloud::RpcMetadata metadata) {
   storage::internal::QueryResumableUploadResponse response;
   if (p.has_persisted_size()) {
     response.committed_size = static_cast<std::uint64_t>(p.persisted_size());
@@ -546,7 +547,10 @@ storage::internal::QueryResumableUploadResponse FromProto(
   if (p.has_resource()) {
     response.payload = storage_internal::FromProto(p.resource(), options);
   }
-  response.request_metadata = std::move(metadata);
+  response.request_metadata = std::move(metadata.headers);
+  response.request_metadata.insert(
+      std::make_move_iterator(metadata.trailers.begin()),
+      std::make_move_iterator(metadata.trailers.end()));
   return response;
 }
 

--- a/google/cloud/storage/internal/grpc/object_request_parser.h
+++ b/google/cloud/storage/internal/grpc/object_request_parser.h
@@ -18,8 +18,9 @@
 #include "google/cloud/storage/async_object_requests.h"
 #include "google/cloud/storage/internal/storage_connection.h"
 #include "google/cloud/storage/version.h"
-#include "google/cloud/internal/grpc_request_metadata.h"
+#include "google/cloud/rpc_metadata.h"
 #include <google/storage/v2/storage.pb.h>
+#include <grpcpp/grpcpp.h>
 
 namespace google {
 namespace cloud {
@@ -49,7 +50,7 @@ StatusOr<google::storage::v2::WriteObjectRequest> ToProto(
     storage::internal::InsertObjectMediaRequest const& request);
 storage::internal::QueryResumableUploadResponse FromProto(
     google::storage::v2::WriteObjectResponse const& p, Options const& options,
-    google::cloud::internal::StreamingRpcMetadata metadata);
+    google::cloud::RpcMetadata metadata);
 
 google::storage::v2::ListObjectsRequest ToProto(
     storage::internal::ListObjectsRequest const& request);

--- a/google/cloud/storage/internal/grpc/object_request_parser_test.cc
+++ b/google/cloud/storage/internal/grpc/object_request_parser_test.cc
@@ -859,7 +859,8 @@ TEST(GrpcObjectRequestParser, WriteObjectResponseWithResource) {
       &input));
 
   auto const actual = FromProto(
-      input, Options{}, {{"header", "value"}, {"other-header", "other-value"}});
+      input, Options{},
+      RpcMetadata{{{"header", "value"}, {"other-header", "other-value"}}, {}});
   EXPECT_FALSE(actual.committed_size.has_value());
   ASSERT_TRUE(actual.payload.has_value());
   EXPECT_EQ(actual.payload->name(), "test-object-name");

--- a/google/cloud/storage/testing/mock_storage_stub.h
+++ b/google/cloud/storage/testing/mock_storage_stub.h
@@ -221,8 +221,8 @@ class MockInsertStream : public google::cloud::internal::StreamingWriteRpc<
               (override));
   MOCK_METHOD(StatusOr<google::storage::v2::WriteObjectResponse>, Close, (),
               (override));
-  MOCK_METHOD(google::cloud::internal::StreamingRpcMetadata, GetRequestMetadata,
-              (), (const, override));
+  MOCK_METHOD(google::cloud::RpcMetadata, GetRequestMetadata, (),
+              (const, override));
 };
 
 class MockObjectMediaStream : public google::cloud::internal::StreamingReadRpc<
@@ -231,8 +231,8 @@ class MockObjectMediaStream : public google::cloud::internal::StreamingReadRpc<
   MOCK_METHOD(void, Cancel, (), (override));
   MOCK_METHOD((absl::variant<Status, google::storage::v2::ReadObjectResponse>),
               Read, (), (override));
-  MOCK_METHOD(google::cloud::internal::StreamingRpcMetadata, GetRequestMetadata,
-              (), (const, override));
+  MOCK_METHOD(google::cloud::RpcMetadata, GetRequestMetadata, (),
+              (const, override));
 };
 
 class MockAsyncInsertStream
@@ -249,8 +249,8 @@ class MockAsyncInsertStream
   MOCK_METHOD(future<bool>, WritesDone, (), (override));
   MOCK_METHOD(future<StatusOr<google::storage::v2::WriteObjectResponse>>,
               Finish, (), (override));
-  MOCK_METHOD(google::cloud::internal::StreamingRpcMetadata, GetRequestMetadata,
-              (), (const, override));
+  MOCK_METHOD(google::cloud::RpcMetadata, GetRequestMetadata, (),
+              (const, override));
 };
 
 using MockAsyncObjectMediaStream =

--- a/google/cloud/testing_util/mock_async_streaming_read_rpc.h
+++ b/google/cloud/testing_util/mock_async_streaming_read_rpc.h
@@ -34,8 +34,7 @@ class MockAsyncStreamingReadRpc
   MOCK_METHOD(future<bool>, Start, (), (override));
   MOCK_METHOD(future<absl::optional<Response>>, Read, (), (override));
   MOCK_METHOD(future<Status>, Finish, (), (override));
-  MOCK_METHOD(internal::StreamingRpcMetadata, GetRequestMetadata, (),
-              (const, override));
+  MOCK_METHOD(RpcMetadata, GetRequestMetadata, (), (const, override));
 };
 
 }  // namespace testing_util

--- a/google/cloud/testing_util/mock_async_streaming_write_rpc.h
+++ b/google/cloud/testing_util/mock_async_streaming_write_rpc.h
@@ -36,8 +36,7 @@ class MockAsyncStreamingWriteRpc
               (override));
   MOCK_METHOD(future<bool>, WritesDone, (), (override));
   MOCK_METHOD(future<StatusOr<Response>>, Finish, (), (override));
-  MOCK_METHOD(internal::StreamingRpcMetadata, GetRequestMetadata, (),
-              (const, override));
+  MOCK_METHOD(RpcMetadata, GetRequestMetadata, (), (const, override));
 };
 
 }  // namespace testing_util


### PR DESCRIPTION
This type is used to return the per-request metadata on streaming RPCs. So far it was only used in non-public APIs. I am planning to now use it in `google::cloud::AsyncStreamingReadWriteStreamingRpc<>` which is public and therefore the type must now become public too.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13185)
<!-- Reviewable:end -->
