### PR TITLE
cleanup(bigtable): split out howto_mock_data_api bazel rule

### DIFF
--- a/google/cloud/bigtable/examples/BUILD.bazel
+++ b/google/cloud/bigtable/examples/BUILD.bazel
@@ -36,6 +36,10 @@ cc_library(
 
 load(":bigtable_examples_unit_tests.bzl", "bigtable_examples_unit_tests")
 
+EXCLUDED_UNIT_TESTS = ["howto_mock_data_api.cc"]
+
+filtered_unit_tests = [test for test in bigtable_examples_unit_tests if not test in EXCLUDED_UNIT_TESTS]
+
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
@@ -48,7 +52,17 @@ load(":bigtable_examples_unit_tests.bzl", "bigtable_examples_unit_tests")
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
         "@com_google_googletest//:gtest_main",
     ],
-) for test in bigtable_examples_unit_tests]
+) for test in filtered_unit_tests]
+
+cc_test(
+    name = "howto_mock_data_api",
+    srcs = ["howto_mock_data_api.cc"],
+    deps = [
+        "//google/cloud/bigtable:google_cloud_cpp_bigtable",
+        "//google/cloud/bigtable:google_cloud_cpp_bigtable_mocks",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
 
 load(":bigtable_examples.bzl", "bigtable_examples")
 


### PR DESCRIPTION
Using the same rule for `howto_mock_data_api` as the other `bigtable_examples_unit_tests` means that the union of the dependencies for all test are used by each.  This is causing a problem for an important google_cloud_cpp consumer.

So, split out the `howto_mock_data_api` rule so that we can minimize its dependency count.  This avoids the downstream issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13189)
<!-- Reviewable:end -->
