### PR TITLE
impl(bigtable): MutateRowsLimiter can do async

### DIFF
--- a/google/cloud/bigtable/internal/mutate_rows_limiter.h
+++ b/google/cloud/bigtable/internal/mutate_rows_limiter.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_MUTATE_ROWS_LIMITER_H
 
 #include "google/cloud/bigtable/internal/rate_limiter.h"
+#include "google/cloud/future.h"
 #include "google/cloud/internal/clock.h"
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
@@ -34,6 +35,7 @@ class MutateRowsLimiter {
  public:
   virtual ~MutateRowsLimiter() = default;
   virtual void Acquire() = 0;
+  virtual future<void> AsyncAcquire() = 0;
   virtual void Update(
       google::bigtable::v2::MutateRowsResponse const& response) = 0;
 };
@@ -41,6 +43,7 @@ class MutateRowsLimiter {
 class NoopMutateRowsLimiter : public MutateRowsLimiter {
  public:
   void Acquire() override {}
+  future<void> AsyncAcquire() override { return make_ready_future(); }
   void Update(google::bigtable::v2::MutateRowsResponse const&) override {}
 };
 
@@ -52,6 +55,7 @@ class ThrottlingMutateRowsLimiter : public MutateRowsLimiter {
   explicit ThrottlingMutateRowsLimiter(
       std::shared_ptr<Clock> clock,
       std::function<void(Clock::duration)> on_wait,
+      std::function<future<void>(Clock::duration)> async_on_wait,
       std::chrono::duration<Rep1, Period1> initial_period,
       std::chrono::duration<Rep2, Period2> min_period,
       std::chrono::duration<Rep3, Period3> max_period, double min_factor,
@@ -59,6 +63,7 @@ class ThrottlingMutateRowsLimiter : public MutateRowsLimiter {
       : clock_(std::move(clock)),
         limiter_(clock_, initial_period),
         on_wait_(std::move(on_wait)),
+        async_on_wait_(std::move(async_on_wait)),
         next_update_(clock_->Now()),
         min_period_(std::chrono::duration_cast<Clock::duration>(min_period)),
         max_period_(std::chrono::duration_cast<Clock::duration>(max_period)),
@@ -66,6 +71,8 @@ class ThrottlingMutateRowsLimiter : public MutateRowsLimiter {
         max_factor_(max_factor) {}
 
   void Acquire() override;
+
+  future<void> AsyncAcquire() override;
 
   /**
    * As specified in:
@@ -81,6 +88,7 @@ class ThrottlingMutateRowsLimiter : public MutateRowsLimiter {
   std::shared_ptr<Clock> clock_;
   RateLimiter limiter_;
   std::function<void(Clock::duration)> on_wait_;
+  std::function<future<void>(Clock::duration)> async_on_wait_;
   bool throttled_since_last_update_ = false;
   Clock::time_point next_update_;
   Clock::duration min_period_;

--- a/google/cloud/bigtable/testing/mock_mutate_rows_limiter.h
+++ b/google/cloud/bigtable/testing/mock_mutate_rows_limiter.h
@@ -27,6 +27,7 @@ namespace testing {
 class MockMutateRowsLimiter : public bigtable_internal::MutateRowsLimiter {
  public:
   MOCK_METHOD(void, Acquire, (), (override));
+  MOCK_METHOD(future<void>, AsyncAcquire, (), (override));
   MOCK_METHOD(void, Update, (google::bigtable::v2::MutateRowsResponse const&),
               (override));
 };


### PR DESCRIPTION
Part of the work for #12959 

I considered having the `ThrottlingMutateRowLimiter` hold a `CompletionQueue` and `Options const&`, but I think it is nicer to just pass the async sleeper (`std::function<future<void>(duration)>`) in.

---

I considered only having an async sleeper, and implementing the following:

```cc
void ThrottlingMutateRowsLimiter::Acquire() {
  AsyncAcquire().get();
}
```

I do not want to do this, because in practice the async sleeper will be implemented by a `CompletionQueue`. I do not want to involve a `CompletionQueue` in the synchronous code paths.

A follow up PR will add a `CompletionQueue` as a parameter to the factory function.

---

Take this opportunity to reorder `MakeMutateRowsLimiter()` to return early from the simpler branch.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13192)
<!-- Reviewable:end -->
