### PR TITLE
impl(GCS+gRPC): simplify field mask support

### DIFF
--- a/google/cloud/storage/internal/async/connection_impl.cc
+++ b/google/cloud/storage/internal/async/connection_impl.cc
@@ -340,7 +340,7 @@ AsyncConnectionImpl::WriteObjectImpl(
   auto configure = [current, request = std::move(request),
                     upload =
                         response->upload_id()](grpc::ClientContext& context) {
-    ApplyQueryParameters(context, *current, request, "resource");
+    ApplyQueryParameters(context, *current, request);
     ApplyResumableUploadRoutingHeader(context, upload);
   };
 
@@ -379,7 +379,7 @@ AsyncConnectionImpl::WriteObjectImpl(
           : storage::internal::CreateNullHashFunction();
   auto configure = [current, request = std::move(request),
                     upload = id](grpc::ClientContext& context) {
-    ApplyQueryParameters(context, *current, request, "resource");
+    ApplyQueryParameters(context, *current, request);
     ApplyResumableUploadRoutingHeader(context, upload);
   };
   return WriteObjectImpl(std::move(current), std::move(configure),

--- a/google/cloud/storage/internal/grpc/configure_client_context.h
+++ b/google/cloud/storage/internal/grpc/configure_client_context.h
@@ -43,8 +43,7 @@ void AddIdempotencyToken(grpc::ClientContext& ctx,
  */
 template <typename Request>
 void ApplyQueryParameters(grpc::ClientContext& ctx, Options const& options,
-                          Request const& request,
-                          std::string const& prefix = std::string{}) {
+                          Request const& request) {
   // The gRPC API has a single field for the `QuotaUser` parameter, while the
   // JSON API has two:
   //    https://cloud.google.com/storage/docs/json_api/v1/parameters#quotaUser
@@ -61,9 +60,8 @@ void ApplyQueryParameters(grpc::ClientContext& ctx, Options const& options,
   }
 
   if (request.template HasOption<storage::Fields>()) {
-    auto field_mask = request.template GetOption<storage::Fields>().value();
-    if (!prefix.empty()) field_mask = prefix + "(" + field_mask + ")";
-    ctx.AddMetadata("x-goog-fieldmask", std::move(field_mask));
+    ctx.AddMetadata("x-goog-fieldmask",
+                    request.template GetOption<storage::Fields>().value());
   }
   google::cloud::internal::ConfigureContext(ctx, options);
 }

--- a/google/cloud/storage/internal/grpc/configure_client_context_test.cc
+++ b/google/cloud/storage/internal/grpc/configure_client_context_test.cc
@@ -77,16 +77,15 @@ TEST_F(GrpcConfigureClientContext, ApplyQueryParametersWithFields) {
 
 TEST_F(GrpcConfigureClientContext, ApplyQueryParametersWithFieldsAndPrefix) {
   grpc::ClientContext ctx;
-  ApplyQueryParameters(
-      ctx, Options{},
-      storage::internal::InsertObjectMediaRequest("test-bucket", "test-object",
-                                                  "content")
-          .set_option(storage::Fields("bucket,name,generation,contentType")),
-      "resource");
+  ApplyQueryParameters(ctx, Options{},
+                       storage::internal::InsertObjectMediaRequest(
+                           "test-bucket", "test-object", "content")
+                           .set_option(storage::Fields(
+                               "resource.bucket,resource.content_type")));
   auto metadata = GetMetadata(ctx);
   EXPECT_THAT(metadata,
               Contains(Pair("x-goog-fieldmask",
-                            "resource(bucket,name,generation,contentType)")));
+                            "resource.bucket,resource.content_type")));
 }
 
 TEST_F(GrpcConfigureClientContext, ApplyQueryParametersQuotaUserAndUserIp) {

--- a/google/cloud/storage/internal/grpc/stub.cc
+++ b/google/cloud/storage/internal/grpc/stub.cc
@@ -404,11 +404,7 @@ StatusOr<storage::ObjectMetadata> GrpcStub::InsertObjectMedia(
   };
 
   auto ctx = std::make_shared<grpc::ClientContext>();
-  // The REST response is just the object metadata (aka the "resource"). In the
-  // gRPC response the object metadata is in a "resource" field. Passing an
-  // extra prefix to ApplyQueryParameters sends the right
-  // filtering instructions to the gRPC API.
-  ApplyQueryParameters(*ctx, options, request, "resource");
+  ApplyQueryParameters(*ctx, options, request);
   AddIdempotencyToken(*ctx, context);
   ApplyRoutingHeaders(*ctx, request);
   auto stream = stub_->WriteObject(std::move(ctx), options);
@@ -464,7 +460,7 @@ StatusOr<storage::ObjectMetadata> GrpcStub::CopyObject(
     storage::internal::CopyObjectRequest const& request) {
   auto proto = ToProto(request);
   grpc::ClientContext ctx;
-  ApplyQueryParameters(ctx, options, request, "resource");
+  ApplyQueryParameters(ctx, options, request);
   AddIdempotencyToken(ctx, context);
   auto response = stub_->RewriteObject(ctx, *proto);
   if (!response) return std::move(response).status();
@@ -579,7 +575,7 @@ StatusOr<storage::internal::RewriteObjectResponse> GrpcStub::RewriteObject(
   auto proto = ToProto(request);
   if (!proto) return std::move(proto).status();
   grpc::ClientContext ctx;
-  ApplyQueryParameters(ctx, options, request, "resource");
+  ApplyQueryParameters(ctx, options, request);
   AddIdempotencyToken(ctx, context);
   auto response = stub_->RewriteObject(ctx, *proto);
   if (!response) return std::move(response).status();
@@ -594,7 +590,7 @@ GrpcStub::CreateResumableUpload(
   if (!proto_request) return std::move(proto_request).status();
 
   grpc::ClientContext ctx;
-  ApplyQueryParameters(ctx, options, request, "resource");
+  ApplyQueryParameters(ctx, options, request);
   AddIdempotencyToken(ctx, context);
   auto const timeout = options.get<storage::TransferStallTimeoutOption>();
   if (timeout.count() != 0) {
@@ -612,7 +608,7 @@ GrpcStub::QueryResumableUpload(
     rest_internal::RestContext& context, Options const& options,
     storage::internal::QueryResumableUploadRequest const& request) {
   grpc::ClientContext ctx;
-  ApplyQueryParameters(ctx, options, request, "resource");
+  ApplyQueryParameters(ctx, options, request);
   AddIdempotencyToken(ctx, context);
   auto const timeout = options.get<storage::TransferStallTimeoutOption>();
   if (timeout.count() != 0) {
@@ -627,7 +623,7 @@ StatusOr<storage::internal::EmptyResponse> GrpcStub::DeleteResumableUpload(
     rest_internal::RestContext& context, Options const& options,
     storage::internal::DeleteResumableUploadRequest const& request) {
   grpc::ClientContext ctx;
-  ApplyQueryParameters(ctx, options, request, "");
+  ApplyQueryParameters(ctx, options, request);
   AddIdempotencyToken(ctx, context);
   auto const timeout = options.get<storage::TransferStallTimeoutOption>();
   if (timeout.count() != 0) {
@@ -658,11 +654,7 @@ StatusOr<storage::internal::QueryResumableUploadResponse> GrpcStub::UploadChunk(
   };
 
   auto ctx = std::make_shared<grpc::ClientContext>();
-  // The REST response is just the object metadata (aka the "resource"). In the
-  // gRPC response the object metadata is in a "resource" field. Passing an
-  // extra prefix to ApplyQueryParameters sends the right
-  // filtering instructions to the gRPC API.
-  ApplyQueryParameters(*ctx, options, request, "resource");
+  ApplyQueryParameters(*ctx, options, request);
   AddIdempotencyToken(*ctx, context);
   ApplyRoutingHeaders(*ctx, request);
   auto stream = stub_->WriteObject(std::move(ctx), options);

--- a/google/cloud/storage/internal/grpc/stub_test.cc
+++ b/google/cloud/storage/internal/grpc/stub_test.cc
@@ -150,11 +150,9 @@ TEST_F(GrpcClientTest, QueryResumableUpload) {
       .WillOnce([this](grpc::ClientContext& context,
                        v2::QueryWriteStatusRequest const& request) {
         auto metadata = GetMetadata(context);
-        EXPECT_THAT(metadata,
-                    UnorderedElementsAre(
-                        Pair("x-goog-quota-user", "test-quota-user"),
-                        // Map JSON names to the `resource` subobject
-                        Pair("x-goog-fieldmask", "resource(field1,field2)")));
+        EXPECT_THAT(metadata, UnorderedElementsAre(
+                                  Pair("x-goog-quota-user", "test-quota-user"),
+                                  Pair("x-goog-fieldmask", "field1,field2")));
         EXPECT_EQ(request.upload_id(), "test-only-upload-id");
         return PermanentError();
       });
@@ -202,8 +200,7 @@ TEST_F(GrpcClientTest, UploadChunk) {
         EXPECT_THAT(metadata,
                     UnorderedElementsAre(
                         Pair("x-goog-quota-user", "test-quota-user"),
-                        // Map JSON names to the `resource` subobject
-                        Pair("x-goog-fieldmask", "resource(field1,field2)"),
+                        Pair("x-goog-fieldmask", "field1,field2"),
                         Pair("x-goog-request-params",
                              "bucket=projects%2F_%2Fbuckets%2Ftest-bucket")));
         ::testing::InSequence sequence;
@@ -510,8 +507,7 @@ TEST_F(GrpcClientTest, InsertObjectMedia) {
                     UnorderedElementsAre(
                         Pair(kIdempotencyTokenHeader, "test-token-1234"),
                         Pair("x-goog-quota-user", "test-quota-user"),
-                        // Map JSON names to the `resource` subobject
-                        Pair("x-goog-fieldmask", "resource(field1,field2)"),
+                        Pair("x-goog-fieldmask", "field1,field2"),
                         Pair("x-goog-request-params",
                              "bucket=projects%2F_%2Fbuckets%2Ftest-bucket")));
         ::testing::InSequence sequence;
@@ -541,8 +537,7 @@ TEST_F(GrpcClientTest, CopyObject) {
                     UnorderedElementsAre(
                         Pair(kIdempotencyTokenHeader, "test-token-1234"),
                         Pair("x-goog-quota-user", "test-quota-user"),
-                        // Map JSON names to the `resource` subobject
-                        Pair("x-goog-fieldmask", "resource(field1,field2)")));
+                        Pair("x-goog-fieldmask", "field1,field2")));
         EXPECT_THAT(request.source_bucket(),
                     "projects/_/buckets/test-source-bucket");
         EXPECT_THAT(request.source_object(), "test-source-object");
@@ -573,8 +568,7 @@ TEST_F(GrpcClientTest, CopyObjectTooLarge) {
                     UnorderedElementsAre(
                         Pair(kIdempotencyTokenHeader, "test-token-1234"),
                         Pair("x-goog-quota-user", "test-quota-user"),
-                        // Map JSON names to the `resource` subobject
-                        Pair("x-goog-fieldmask", "resource(field1,field2)")));
+                        Pair("x-goog-fieldmask", "field1,field2")));
         EXPECT_THAT(request.source_bucket(),
                     "projects/_/buckets/test-source-bucket");
         EXPECT_THAT(request.source_object(), "test-source-object");
@@ -796,8 +790,7 @@ TEST_F(GrpcClientTest, RewriteObject) {
                     UnorderedElementsAre(
                         Pair(kIdempotencyTokenHeader, "test-token-1234"),
                         Pair("x-goog-quota-user", "test-quota-user"),
-                        // Map JSON names to the `resource` subobject
-                        Pair("x-goog-fieldmask", "resource(field1,field2)")));
+                        Pair("x-goog-fieldmask", "field1,field2")));
         EXPECT_THAT(request.source_bucket(),
                     "projects/_/buckets/test-source-bucket");
         EXPECT_THAT(request.source_object(), "test-source-object");
@@ -828,8 +821,7 @@ TEST_F(GrpcClientTest, CreateResumableUpload) {
                     UnorderedElementsAre(
                         Pair(kIdempotencyTokenHeader, "test-token-1234"),
                         Pair("x-goog-quota-user", "test-quota-user"),
-                        // Map the JSON field names to the `resource` subobject
-                        Pair("x-goog-fieldmask", "resource(field1,field2)")));
+                        Pair("x-goog-fieldmask", "field1,field2")));
         EXPECT_THAT(request.write_object_spec().resource().bucket(),
                     "projects/_/buckets/test-bucket");
         EXPECT_THAT(request.write_object_spec().resource().name(),

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -565,8 +565,6 @@ TEST_F(BucketIntegrationTest, GetMetadata) {
 }
 
 TEST_F(BucketIntegrationTest, GetMetadataFields) {
-  // TODO(#10991) - using `Fields()` is not working in GCS+gRPC production
-  if (!UsingEmulator() && UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 

--- a/google/cloud/storage/tests/grpc_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_integration_test.cc
@@ -217,8 +217,10 @@ TEST_P(GrpcIntegrationTest, QuotaUser) {
 }
 
 TEST_P(GrpcIntegrationTest, FieldFilter) {
-  // TODO(#10991) - using `Fields()` is not working in GCS+gRPC production
-  if (!UsingEmulator() && UsingGrpc()) GTEST_SKIP();
+  if (UsingEmulator()) GTEST_SKIP();
+  auto const* fields = UsingGrpc() ? "resource.bucket,resource.name,resource."
+                                     "generation,resource.content_type"
+                                   : "bucket,name,generation,contentType";
   auto client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -226,8 +228,7 @@ TEST_P(GrpcIntegrationTest, FieldFilter) {
 
   auto metadata = client->InsertObject(
       bucket_name(), object_name, LoremIpsum(), IfGenerationMatch(0),
-      ContentType("text/plain"), ContentEncoding("utf-8"),
-      Fields("bucket,name,generation,contentType"));
+      ContentType("text/plain"), ContentEncoding("utf-8"), Fields(fields));
   ASSERT_STATUS_OK(metadata);
   ScheduleForDelete(*metadata);
 


### PR DESCRIPTION
`x-goog-fieldmask` does not translate from JSON syntax to gRPC syntax. It is easier to explain how this works than the 
alternatives.

Fixes #10991.  Googlers can see b/232849984 for more details.
