### PR TITLE
impl(bigtable): plumb limiter thru AsyncBulkApply

### DIFF
--- a/google/cloud/bigtable/internal/async_bulk_apply.cc
+++ b/google/cloud/bigtable/internal/async_bulk_apply.cc
@@ -23,6 +23,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 future<std::vector<bigtable::FailedMutation>> AsyncBulkApplier::Create(
     CompletionQueue cq, std::shared_ptr<BigtableStub> stub,
+    std::shared_ptr<MutateRowsLimiter> limiter,
     std::unique_ptr<bigtable::DataRetryPolicy> retry_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy,
     bigtable::IdempotentMutationPolicy& idempotent_policy,
@@ -33,15 +34,16 @@ future<std::vector<bigtable::FailedMutation>> AsyncBulkApplier::Create(
   }
 
   std::shared_ptr<AsyncBulkApplier> bulk_apply(new AsyncBulkApplier(
-      std::move(cq), std::move(stub), std::move(retry_policy),
-      std::move(backoff_policy), idempotent_policy, app_profile_id, table_name,
-      std::move(mut)));
+      std::move(cq), std::move(stub), std::move(limiter),
+      std::move(retry_policy), std::move(backoff_policy), idempotent_policy,
+      app_profile_id, table_name, std::move(mut)));
   bulk_apply->StartIteration();
   return bulk_apply->promise_.get_future();
 }
 
 AsyncBulkApplier::AsyncBulkApplier(
     CompletionQueue cq, std::shared_ptr<BigtableStub> stub,
+    std::shared_ptr<MutateRowsLimiter> limiter,
     std::unique_ptr<bigtable::DataRetryPolicy> retry_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy,
     bigtable::IdempotentMutationPolicy& idempotent_policy,
@@ -49,12 +51,21 @@ AsyncBulkApplier::AsyncBulkApplier(
     bigtable::BulkMutation mut)
     : cq_(std::move(cq)),
       stub_(std::move(stub)),
+      limiter_(std::move(limiter)),
       retry_policy_(std::move(retry_policy)),
       backoff_policy_(std::move(backoff_policy)),
       state_(app_profile_id, table_name, idempotent_policy, std::move(mut)),
       promise_([this] { keep_reading_ = false; }) {}
 
 void AsyncBulkApplier::StartIteration() {
+  auto self = this->shared_from_this();
+  limiter_->AsyncAcquire().then([self](auto f) {
+    f.get();
+    self->MakeRequest();
+  });
+}
+
+void AsyncBulkApplier::MakeRequest() {
   internal::ScopedCallContext scope(call_context_);
   auto context = std::make_shared<grpc::ClientContext>();
   internal::ConfigureContext(*context, internal::CurrentOptions());
@@ -71,6 +82,7 @@ void AsyncBulkApplier::StartIteration() {
 
 void AsyncBulkApplier::OnRead(
     google::bigtable::v2::MutateRowsResponse response) {
+  limiter_->Update(response);
   state_.OnRead(std::move(response));
 }
 

--- a/google/cloud/bigtable/internal/async_bulk_apply.h
+++ b/google/cloud/bigtable/internal/async_bulk_apply.h
@@ -42,6 +42,7 @@ class AsyncBulkApplier : public std::enable_shared_from_this<AsyncBulkApplier> {
  public:
   static future<std::vector<bigtable::FailedMutation>> Create(
       CompletionQueue cq, std::shared_ptr<BigtableStub> stub,
+      std::shared_ptr<MutateRowsLimiter> limiter,
       std::unique_ptr<bigtable::DataRetryPolicy> retry_policy,
       std::unique_ptr<BackoffPolicy> backoff_policy,
       bigtable::IdempotentMutationPolicy& idempotent_policy,
@@ -50,6 +51,7 @@ class AsyncBulkApplier : public std::enable_shared_from_this<AsyncBulkApplier> {
 
  private:
   AsyncBulkApplier(CompletionQueue cq, std::shared_ptr<BigtableStub> stub,
+                   std::shared_ptr<MutateRowsLimiter> limiter,
                    std::unique_ptr<bigtable::DataRetryPolicy> retry_policy,
                    std::unique_ptr<BackoffPolicy> backoff_policy,
                    bigtable::IdempotentMutationPolicy& idempotent_policy,
@@ -57,12 +59,14 @@ class AsyncBulkApplier : public std::enable_shared_from_this<AsyncBulkApplier> {
                    std::string const& table_name, bigtable::BulkMutation mut);
 
   void StartIteration();
+  void MakeRequest();
   void OnRead(google::bigtable::v2::MutateRowsResponse response);
   void OnFinish(Status const& status);
   void SetPromise();
 
   CompletionQueue cq_;
   std::shared_ptr<BigtableStub> stub_;
+  std::shared_ptr<MutateRowsLimiter> limiter_;
   std::unique_ptr<bigtable::DataRetryPolicy> retry_policy_;
   std::unique_ptr<BackoffPolicy> backoff_policy_;
   BulkMutatorState state_;

--- a/google/cloud/bigtable/internal/data_connection_impl.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl.cc
@@ -171,7 +171,7 @@ DataConnectionImpl::AsyncBulkApply(std::string const& table_name,
                                    bigtable::BulkMutation mut) {
   auto current = google::cloud::internal::SaveCurrentOptions();
   return AsyncBulkApplier::Create(
-      background_->cq(), stub_, retry_policy(*current),
+      background_->cq(), stub_, limiter_, retry_policy(*current),
       backoff_policy(*current), *idempotency_policy(*current),
       app_profile_id(*current), table_name, std::move(mut));
 }


### PR DESCRIPTION
Part of the work for #12959 

Plumb the `MutateRowsLimiter` through the layers of `AsyncBulkApply`.

Note that the implementation is not yet complete, as `MakeMutateRowsLimiter`'s async sleeper just returns immediately. That will take another 1 or 2 PRs, then we can call the thing done.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13197)
<!-- Reviewable:end -->
