### PR TITLE
refactor: generalize name given to TracedAsyncBackoff

### DIFF
--- a/google/cloud/bigtable/internal/async_bulk_apply.cc
+++ b/google/cloud/bigtable/internal/async_bulk_apply.cc
@@ -95,7 +95,7 @@ void AsyncBulkApplier::OnFinish(Status const& status) {
 
   auto self = this->shared_from_this();
   internal::TracedAsyncBackoff(cq_, internal::CurrentOptions(),
-                               backoff_policy_->OnCompletion())
+                               backoff_policy_->OnCompletion(), "Async Backoff")
       .then([self](auto result) {
         if (result.get()) {
           self->StartIteration();

--- a/google/cloud/bigtable/internal/async_row_reader.cc
+++ b/google/cloud/bigtable/internal/async_row_reader.cc
@@ -215,7 +215,7 @@ void AsyncRowReader::OnStreamFinished(Status status) {
   }
   auto self = this->shared_from_this();
   internal::TracedAsyncBackoff(cq_, internal::CurrentOptions(),
-                               backoff_policy_->OnCompletion())
+                               backoff_policy_->OnCompletion(), "Async Backoff")
       .then(
           [self](
               future<StatusOr<std::chrono::system_clock::time_point>> result) {

--- a/google/cloud/bigtable/internal/async_row_sampler.cc
+++ b/google/cloud/bigtable/internal/async_row_sampler.cc
@@ -91,7 +91,7 @@ void AsyncRowSampler::OnFinish(Status status) {
   samples_.clear();
   auto self = this->shared_from_this();
   internal::TracedAsyncBackoff(cq_, internal::CurrentOptions(),
-                               backoff_policy_->OnCompletion())
+                               backoff_policy_->OnCompletion(), "Async Backoff")
       .then([self](TimerFuture result) {
         if (result.get()) {
           self->StartIteration();

--- a/google/cloud/internal/async_polling_loop.cc
+++ b/google/cloud/internal/async_polling_loop.cc
@@ -110,9 +110,8 @@ class AsyncPollingLoopImpl
     GCP_LOG(DEBUG) << location_ << "() polling loop waiting "
                    << duration.count() << "ms";
     auto self = shared_from_this();
-    TracedAsyncBackoff(cq_, *options_, duration).then([self](TimerResult f) {
-      self->OnTimer(std::move(f));
-    });
+    TracedAsyncBackoff(cq_, *options_, duration, "Async Backoff")
+        .then([self](TimerResult f) { self->OnTimer(std::move(f)); });
   }
 
   void OnTimer(TimerResult f) {

--- a/google/cloud/internal/async_rest_polling_loop.h
+++ b/google/cloud/internal/async_rest_polling_loop.h
@@ -348,7 +348,7 @@ class AsyncRestPollingLoopImpl
     GCP_LOG(DEBUG) << location_ << "() polling loop waiting "
                    << duration.count() << "ms";
     auto self = this->shared_from_this();
-    internal::TracedAsyncBackoff(cq_, *options_, duration)
+    internal::TracedAsyncBackoff(cq_, *options_, duration, "Async Backoff")
         .then([self](TimerResult f) { self->OnTimer(std::move(f)); });
   }
 

--- a/google/cloud/internal/async_rest_retry_loop.h
+++ b/google/cloud/internal/async_rest_retry_loop.h
@@ -251,7 +251,8 @@ class AsyncRestRetryLoopImpl
     if (state.cancelled) return;
     SetPending(state.operation,
                internal::TracedAsyncBackoff(cq_, *call_context_.options,
-                                            backoff_policy_->OnCompletion())
+                                            backoff_policy_->OnCompletion(),
+                                            "Async Backoff")
                    .then([self](future<TimerArgType> f) {
                      self->OnBackoff(f.get());
                    }));

--- a/google/cloud/internal/async_retry_loop.h
+++ b/google/cloud/internal/async_retry_loop.h
@@ -247,12 +247,12 @@ class AsyncRetryLoopImpl
     auto self = this->shared_from_this();
     auto state = StartOperation();
     if (state.cancelled) return;
-    SetPending(state.operation,
-               TracedAsyncBackoff(cq_, *call_context_.options,
-                                  backoff_policy_->OnCompletion())
-                   .then([self](future<TimerArgType> f) {
-                     self->OnBackoff(f.get());
-                   }));
+    SetPending(
+        state.operation,
+        TracedAsyncBackoff(cq_, *call_context_.options,
+                           backoff_policy_->OnCompletion(), "Async Backoff")
+            .then(
+                [self](future<TimerArgType> f) { self->OnBackoff(f.get()); }));
   }
 
   void OnAttempt(T result) {

--- a/google/cloud/internal/grpc_opentelemetry.h
+++ b/google/cloud/internal/grpc_opentelemetry.h
@@ -117,6 +117,7 @@ future<StatusOr<std::chrono::system_clock::time_point>> TracedAsyncBackoff(
   }
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
   (void)options;
+  (void)name;
   return cq.MakeRelativeTimer(duration);
 }
 

--- a/google/cloud/internal/grpc_opentelemetry.h
+++ b/google/cloud/internal/grpc_opentelemetry.h
@@ -107,10 +107,10 @@ future<T> EndSpan(
 template <typename Rep, typename Period>
 future<StatusOr<std::chrono::system_clock::time_point>> TracedAsyncBackoff(
     CompletionQueue& cq, Options const& options,
-    std::chrono::duration<Rep, Period> duration) {
+    std::chrono::duration<Rep, Period> duration, std::string const& name) {
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
   if (TracingEnabled(options)) {
-    auto span = MakeSpan("Async Backoff");
+    auto span = MakeSpan(name);
     OTelScope scope(span);
     auto timer = cq.MakeRelativeTimer(duration);
     return EndSpan(std::move(span), std::move(timer));

--- a/google/cloud/internal/grpc_opentelemetry_test.cc
+++ b/google/cloud/internal/grpc_opentelemetry_test.cc
@@ -179,7 +179,8 @@ TEST(OpenTelemetry, TracedAsyncBackoffEnabled) {
           make_status_or(std::chrono::system_clock::now())))));
   CompletionQueue cq(mock_cq);
 
-  auto f = TracedAsyncBackoff(cq, EnableTracing(Options{}), duration);
+  auto f = TracedAsyncBackoff(cq, EnableTracing(Options{}), duration,
+                              "Async Backoff");
   EXPECT_STATUS_OK(f.get());
 
   // Verify that a span was made.
@@ -201,7 +202,8 @@ TEST(OpenTelemetry, TracedAsyncBackoffDisabled) {
               CancelledError("cancelled")))));
   CompletionQueue cq(mock_cq);
 
-  auto f = TracedAsyncBackoff(cq, DisableTracing(Options{}), duration);
+  auto f = TracedAsyncBackoff(cq, DisableTracing(Options{}), duration,
+                              "Async Backoff");
   EXPECT_THAT(f.get(), StatusIs(StatusCode::kCancelled, "cancelled"));
 
   // Verify that no spans were made.
@@ -225,7 +227,8 @@ TEST(OpenTelemetry, TracedAsyncBackoffPreservesContext) {
 
   CompletionQueue cq(mock_cq);
 
-  auto f = TracedAsyncBackoff(cq, EnableTracing(Options{}), duration);
+  auto f = TracedAsyncBackoff(cq, EnableTracing(Options{}), duration,
+                              "Async Backoff");
   EXPECT_STATUS_OK(f.get());
 
   EXPECT_THAT(CurrentOTelContext(), ElementsAre(oc));
@@ -247,7 +250,7 @@ TEST(NoOpenTelemetry, TracedAsyncBackoff) {
           make_status_or(std::chrono::system_clock::now())))));
   CompletionQueue cq(mock_cq);
 
-  auto f = TracedAsyncBackoff(cq, Options{}, duration);
+  auto f = TracedAsyncBackoff(cq, Options{}, duration, "Async Backoff");
   EXPECT_STATUS_OK(f.get());
 }
 


### PR DESCRIPTION
Motivated by #12959 

I want to use a name other than "Async Backoff", so first generalize the function.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13202)
<!-- Reviewable:end -->
