### PR TITLE
feat(bigtable): throttling for AsyncBulkApply

### DIFF
--- a/google/cloud/bigtable/data_connection.cc
+++ b/google/cloud/bigtable/data_connection.cc
@@ -164,7 +164,8 @@ std::shared_ptr<DataConnection> MakeDataConnection(Options options) {
   auto background =
       google::cloud::internal::MakeBackgroundThreadsFactory(options)();
   auto stub = bigtable_internal::CreateBigtableStub(background->cq(), options);
-  auto limiter = bigtable_internal::MakeMutateRowsLimiter(options);
+  auto limiter =
+      bigtable_internal::MakeMutateRowsLimiter(background->cq(), options);
   std::shared_ptr<DataConnection> conn =
       std::make_shared<bigtable_internal::DataConnectionImpl>(
           std::move(background), std::move(stub), std::move(limiter),

--- a/google/cloud/bigtable/internal/mutate_rows_limiter.cc
+++ b/google/cloud/bigtable/internal/mutate_rows_limiter.cc
@@ -87,7 +87,7 @@ std::shared_ptr<MutateRowsLimiter> MakeMutateRowsLimiter(
   };
   sleeper = internal::MakeTracedSleeper(
       options, std::move(sleeper), "gl-cpp.bigtable.bulk_apply_throttling");
-  auto async_sleeper = [&cq, options](duration d) {
+  auto async_sleeper = [cq = std::move(cq), options](duration d) mutable {
     // Capture `options` by value because the source `options` gets moved from.
     return internal::TracedAsyncBackoff(cq, options, d,
                                         "gl-cpp.bigtable.bulk_apply_throttling")

--- a/google/cloud/bigtable/internal/mutate_rows_limiter.cc
+++ b/google/cloud/bigtable/internal/mutate_rows_limiter.cc
@@ -76,8 +76,8 @@ void ThrottlingMutateRowsLimiter::Update(
   limiter_.set_period(period);
 }
 
-std::shared_ptr<MutateRowsLimiter> MakeMutateRowsLimiter(
-    CompletionQueue cq, Options const& options) {
+std::shared_ptr<MutateRowsLimiter> MakeMutateRowsLimiter(CompletionQueue cq,
+                                                         Options options) {
   if (!options.get<bigtable::experimental::BulkApplyThrottlingOption>()) {
     return std::make_shared<NoopMutateRowsLimiter>();
   }
@@ -87,9 +87,9 @@ std::shared_ptr<MutateRowsLimiter> MakeMutateRowsLimiter(
   };
   sleeper = internal::MakeTracedSleeper(
       options, std::move(sleeper), "gl-cpp.bigtable.bulk_apply_throttling");
-  auto async_sleeper = [cq = std::move(cq), options](duration d) mutable {
-    // Capture `options` by value because the source `options` gets moved from.
-    return internal::TracedAsyncBackoff(cq, options, d,
+  auto async_sleeper = [cq = std::move(cq),
+                        o = std::move(options)](duration d) mutable {
+    return internal::TracedAsyncBackoff(cq, o, d,
                                         "gl-cpp.bigtable.bulk_apply_throttling")
         .then([](auto f) { (void)f.get(); });
   };

--- a/google/cloud/bigtable/internal/mutate_rows_limiter.h
+++ b/google/cloud/bigtable/internal/mutate_rows_limiter.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_MUTATE_ROWS_LIMITER_H
 
 #include "google/cloud/bigtable/internal/rate_limiter.h"
+#include "google/cloud/completion_queue.h"
 #include "google/cloud/future.h"
 #include "google/cloud/internal/clock.h"
 #include "google/cloud/options.h"
@@ -98,7 +99,7 @@ class ThrottlingMutateRowsLimiter : public MutateRowsLimiter {
 };
 
 std::shared_ptr<MutateRowsLimiter> MakeMutateRowsLimiter(
-    Options const& options);
+    CompletionQueue cq, Options const& options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable_internal

--- a/google/cloud/bigtable/internal/mutate_rows_limiter.h
+++ b/google/cloud/bigtable/internal/mutate_rows_limiter.h
@@ -98,8 +98,8 @@ class ThrottlingMutateRowsLimiter : public MutateRowsLimiter {
   double max_factor_;
 };
 
-std::shared_ptr<MutateRowsLimiter> MakeMutateRowsLimiter(
-    CompletionQueue cq, Options const& options);
+std::shared_ptr<MutateRowsLimiter> MakeMutateRowsLimiter(CompletionQueue cq,
+                                                         Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable_internal

--- a/google/cloud/bigtable/internal/mutate_rows_limiter_test.cc
+++ b/google/cloud/bigtable/internal/mutate_rows_limiter_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/bigtable/options.h"
 #include "google/cloud/internal/time_utils.h"
 #include "google/cloud/testing_util/fake_clock.h"
+#include "google/cloud/testing_util/mock_completion_queue_impl.h"
 #include "google/cloud/testing_util/opentelemetry_matchers.h"
 #include <gmock/gmock.h>
 #include <chrono>
@@ -29,6 +30,7 @@ namespace {
 using Clock = ThrottlingMutateRowsLimiter::Clock;
 using ::google::cloud::bigtable::experimental::BulkApplyThrottlingOption;
 using ::google::cloud::testing_util::FakeSteadyClock;
+using ::google::cloud::testing_util::MockCompletionQueueImpl;
 using ::testing::MockFunction;
 using ::testing::NotNull;
 
@@ -229,12 +231,12 @@ TEST(MutateRowsLimiter, AsyncBasicRateLimiting) {
 }
 
 TEST(MutateRowsLimiter, MakeMutateRowsLimiter) {
-  auto noop =
-      MakeMutateRowsLimiter(Options{}.set<BulkApplyThrottlingOption>(false));
+  auto noop = MakeMutateRowsLimiter(
+      CompletionQueue{}, Options{}.set<BulkApplyThrottlingOption>(false));
   EXPECT_THAT(dynamic_cast<NoopMutateRowsLimiter*>(noop.get()), NotNull());
 
-  auto throttling =
-      MakeMutateRowsLimiter(Options{}.set<BulkApplyThrottlingOption>(true));
+  auto throttling = MakeMutateRowsLimiter(
+      CompletionQueue{}, Options{}.set<BulkApplyThrottlingOption>(true));
   EXPECT_THAT(dynamic_cast<ThrottlingMutateRowsLimiter*>(throttling.get()),
               NotNull());
 }
@@ -250,6 +252,7 @@ TEST(MakeMutateRowsLimiter, TracingEnabled) {
   auto span_catcher = testing_util::InstallSpanCatcher();
 
   auto limiter = MakeMutateRowsLimiter(
+      CompletionQueue{},
       EnableTracing(Options{}.set<BulkApplyThrottlingOption>(true)));
   // With the default settings, we should expect throttling by the second
   // request. Still, go up to 100 in case instructions are slow.
@@ -259,19 +262,62 @@ TEST(MakeMutateRowsLimiter, TracingEnabled) {
     if (spans.empty()) continue;
     EXPECT_THAT(spans,
                 Contains(SpanNamed("gl-cpp.bigtable.bulk_apply_throttling")));
-    break;
+    return;
   }
+  GTEST_FAIL() << "No spans created when tracing is enabled.";
 }
 
 TEST(MakeMutateRowsLimiter, TracingDisabled) {
   auto span_catcher = testing_util::InstallSpanCatcher();
 
   auto limiter = MakeMutateRowsLimiter(
+      CompletionQueue{},
       DisableTracing(Options{}.set<BulkApplyThrottlingOption>(true)));
   // We generally expect throttling by the second response. Still, go up to 5 to
   // be a little bit more conclusive.
   for (auto i = 0; i != 5; ++i) {
     limiter->Acquire();
+    EXPECT_THAT(span_catcher->GetSpans(), IsEmpty());
+  }
+}
+
+TEST(MakeMutateRowsLimiter, TracingEnabledAsync) {
+  auto span_catcher = testing_util::InstallSpanCatcher();
+
+  auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
+  EXPECT_CALL(*mock_cq, MakeRelativeTimer).WillRepeatedly([] {
+    return make_ready_future(make_status_or(std::chrono::system_clock::now()));
+  });
+  CompletionQueue cq(mock_cq);
+  auto limiter = MakeMutateRowsLimiter(
+      cq, EnableTracing(Options{}.set<BulkApplyThrottlingOption>(true)));
+  // With the default settings, we should expect throttling by the second
+  // request. Still, go up to 100 in case instructions are slow.
+  for (auto i = 0; i != 100; ++i) {
+    limiter->AsyncAcquire().get();
+    auto spans = span_catcher->GetSpans();
+    if (spans.empty()) continue;
+    EXPECT_THAT(spans,
+                Contains(SpanNamed("gl-cpp.bigtable.bulk_apply_throttling")));
+    return;
+  }
+  GTEST_FAIL() << "No spans created when tracing is enabled.";
+}
+
+TEST(MakeMutateRowsLimiter, TracingDisabledAsync) {
+  auto span_catcher = testing_util::InstallSpanCatcher();
+
+  auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
+  EXPECT_CALL(*mock_cq, MakeRelativeTimer).WillRepeatedly([] {
+    return make_ready_future(make_status_or(std::chrono::system_clock::now()));
+  });
+  CompletionQueue cq(mock_cq);
+  auto limiter = MakeMutateRowsLimiter(
+      cq, DisableTracing(Options{}.set<BulkApplyThrottlingOption>(true)));
+  // We generally expect throttling by the second response. Still, go up to 5 to
+  // be a little bit more conclusive.
+  for (auto i = 0; i != 5; ++i) {
+    limiter->AsyncAcquire().get();
     EXPECT_THAT(span_catcher->GetSpans(), IsEmpty());
   }
 }

--- a/google/cloud/bigtable/options.h
+++ b/google/cloud/bigtable/options.h
@@ -176,10 +176,6 @@ namespace experimental {
  * @note This option must be supplied to `MakeDataConnection()` in order to take
  * effect.
  *
- * @note This feature has only been implemented for the synchronous
- * `Table::BulkApply()`. It does not have an effect on `Table::AsyncBulkApply()`
- * or `MutationBatcher::AsyncApply()`.
- *
  * @see https://cloud.google.com/bigtable/docs/writes#flow-control
  *
  * [autoscaling]: https://cloud.google.com/bigtable/docs/autoscaling


### PR DESCRIPTION
Fixes #12959 

Actually start setting async timers for the `AsyncBulkApply` limiting case.

Correct the record about when the option applies.

Fix the synchronous `TracingEnabled` test, which could succeed if no spans were created at all.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13203)
<!-- Reviewable:end -->
