### PR TITLE
cleanup: URL encode values outside `std::isprint`

### DIFF
--- a/google/cloud/internal/url_encode.cc
+++ b/google/cloud/internal/url_encode.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/internal/url_encode.h"
-#include "google/cloud/internal/absl_str_cat_quiet.h"
+#include <cctype>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/internal/url_encode.cc
+++ b/google/cloud/internal/url_encode.cc
@@ -14,9 +14,7 @@
 
 #include "google/cloud/internal/url_encode.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
-#include <iomanip>
-#include <sstream>
-#include <unordered_map>
+#include <set>
 
 namespace google {
 namespace cloud {
@@ -25,33 +23,12 @@ namespace internal {
 
 namespace {
 
-std::string ToHex(int i) {
-  std::stringstream stream;
-  stream << "%" << std::setfill('0') << std::setw(2) << std::uppercase
-         << std::hex << i;
-  return stream.str();
-}
-
-std::string Escape(char c) {
-  static auto const* const kDict = []() {
-    static std::unordered_map<char, std::string> m;
-    for (auto i = 0; i < 32; ++i) {
-      m[static_cast<char>(i)] = ToHex(i);
-    }
-    for (auto c : {
-             ' ', '\"', '#', '$', '%', '&',  '+', ',', '/', ':', ';', '<',
-             '=', '>',  '?', '@', '[', '\\', ']', '^', '`', '{', '|', '}',
-         }) {
-      m[c] = ToHex(static_cast<int>(c));
-    }
-    for (auto i = 127; i < 256; ++i) {
-      m[static_cast<char>(i)] = ToHex(i);
-    }
-    return &m;
-  }();
-  auto it = kDict->find(c);
-  if (it != kDict->end()) return it->second;
-  return std::string{c};
+bool WeNeedToEscape(unsigned char c) {
+  static auto const* const kSet = new std::set<char>{
+      ' ', '\"', '#', '$', '%', '&',  '+', ',', '/', ':', ';', '<',
+      '=', '>',  '?', '@', '[', '\\', ']', '^', '`', '{', '|', '}',
+  };
+  return std::isprint(c) == 0 || kSet->find(c) != kSet->end();
 }
 
 // Returns 0-15 if c is in [0-9A-Fa-f], and -1 otherwise.
@@ -66,8 +43,15 @@ int ParseDigitHex(char c) {
 
 std::string UrlEncode(absl::string_view value) {
   std::string s;
-  for (auto c : value) {
-    absl::StrAppend(&s, Escape(c));
+  auto constexpr kDigits = "0123456789ABCDEF";
+  for (unsigned char c : value) {
+    if (WeNeedToEscape(c)) {
+      s.push_back('%');
+      s.push_back(kDigits[(c >> 4) & 0xf]);
+      s.push_back(kDigits[c & 0xf]);
+    } else {
+      s.push_back(c);
+    }
   }
   return s;
 }
@@ -75,7 +59,7 @@ std::string UrlEncode(absl::string_view value) {
 std::string UrlDecode(absl::string_view value) {
   std::string s;
   for (std::size_t i = 0; i < value.size(); ++i) {
-    if (value[i] == '%' && i < value.size() - 2) {
+    if (value[i] == '%' && value.size() - i > 2) {
       auto b1 = ParseDigitHex(value[i + 1]);
       auto b0 = ParseDigitHex(value[i + 2]);
       if (b1 != -1 && b0 != -1) {

--- a/google/cloud/internal/url_encode.cc
+++ b/google/cloud/internal/url_encode.cc
@@ -13,9 +13,10 @@
 // limitations under the License.
 
 #include "google/cloud/internal/url_encode.h"
-#include "google/cloud/internal/absl_str_replace_quiet.h"
-#include <array>
-#include <utility>
+#include "google/cloud/internal/absl_str_cat_quiet.h"
+#include <iomanip>
+#include <sstream>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -24,35 +25,68 @@ namespace internal {
 
 namespace {
 
-using UrlMappings =
-    std::array<std::pair<absl::string_view, absl::string_view>, 25>;
+std::string ToHex(int i) {
+  std::stringstream stream;
+  stream << "%" << std::setfill('0') << std::setw(2) << std::uppercase
+         << std::hex << i;
+  return stream.str();
+}
 
-constexpr auto kEncodeMappings = UrlMappings{{
-    {" ", "%20"}, {"\"", "%22"}, {"#", "%23"},  {"$", "%24"}, {"%", "%25"},
-    {"&", "%26"}, {"+", "%2B"},  {",", "%2C"},  {"/", "%2F"}, {":", "%3A"},
-    {";", "%3B"}, {"<", "%3C"},  {"=", "%3D"},  {">", "%3E"}, {"?", "%3F"},
-    {"@", "%40"}, {"[", "%5B"},  {"\\", "%5C"}, {"]", "%5D"}, {"^", "%5E"},
-    {"`", "%60"}, {"{", "%7B"},  {"|", "%7C"},  {"}", "%7D"}, {"\177", "%7F"},
-}};
+std::string Escape(char c) {
+  static auto const* const kDict = []() {
+    static std::unordered_map<char, std::string> m;
+    for (auto i = 0; i < 32; ++i) {
+      m[static_cast<char>(i)] = ToHex(i);
+    }
+    for (auto c : {
+             ' ', '\"', '#', '$', '%', '&',  '+', ',', '/', ':', ';', '<',
+             '=', '>',  '?', '@', '[', '\\', ']', '^', '`', '{', '|', '}',
+         }) {
+      m[c] = ToHex(static_cast<int>(c));
+    }
+    for (auto i = 127; i < 256; ++i) {
+      m[static_cast<char>(i)] = ToHex(i);
+    }
+    return &m;
+  }();
+  auto it = kDict->find(c);
+  if (it != kDict->end()) return it->second;
+  return std::string{c};
+}
 
-// Until we require C++17, it isn't worth trying to eliminate the duplication
-// using a constexpr function to produce kDecodeMappings from kEncodeMappings.
-constexpr auto kDecodeMappings = UrlMappings{{
-    {"%20", " "}, {"%22", "\""}, {"%23", "#"},  {"%24", "$"}, {"%25", "%"},
-    {"%26", "&"}, {"%2B", "+"},  {"%2C", ","},  {"%2F", "/"}, {"%3A", ":"},
-    {"%3B", ";"}, {"%3C", "<"},  {"%3D", "="},  {"%3E", ">"}, {"%3F", "?"},
-    {"%40", "@"}, {"%5B", "["},  {"%5C", "\\"}, {"%5D", "]"}, {"%5E", "^"},
-    {"%60", "`"}, {"%7B", "{"},  {"%7C", "|"},  {"%7D", "}"}, {"%7F", "\177"},
-}};
+// Returns 0-15 if c is in [0-9A-Fa-f], and -1 otherwise.
+int ParseDigitHex(char c) {
+  if ('0' <= c && c <= '9') return c - '0';
+  if ('A' <= c && c <= 'F') return c - 'A' + 0xA;
+  if ('a' <= c && c <= 'f') return c - 'a' + 0xa;
+  return -1;
+}
 
 }  // namespace
 
 std::string UrlEncode(absl::string_view value) {
-  return absl::StrReplaceAll(value, kEncodeMappings);
+  std::string s;
+  for (auto c : value) {
+    absl::StrAppend(&s, Escape(c));
+  }
+  return s;
 }
 
 std::string UrlDecode(absl::string_view value) {
-  return absl::StrReplaceAll(value, kDecodeMappings);
+  std::string s;
+  for (std::size_t i = 0; i < value.size(); ++i) {
+    if (value[i] == '%' && i < value.size() - 2) {
+      auto b1 = ParseDigitHex(value[i + 1]);
+      auto b0 = ParseDigitHex(value[i + 2]);
+      if (b1 != -1 && b0 != -1) {
+        s += static_cast<char>((b1 << 4) + b0);
+        i += 2;
+        continue;
+      }
+    }
+    s += value[i];
+  }
+  return s;
 }
 
 }  // namespace internal

--- a/google/cloud/internal/url_encode_test.cc
+++ b/google/cloud/internal/url_encode_test.cc
@@ -44,6 +44,15 @@ TEST(UrlEncode, MultipleReplacements) {
   EXPECT_THAT(result, encoded_string);
 }
 
+TEST(UrlEncode, NotStdIsPrint) {
+  auto const* unencoded_string = "\t";
+
+  auto result = UrlEncode(unencoded_string);
+
+  auto const* encoded_string = "%09";
+  EXPECT_THAT(result, encoded_string);
+}
+
 TEST(UrlDecode, Simple) {
   auto const* encoded_string = "projects%2F*%2Fresource%2F*";
 


### PR DESCRIPTION
Fixes #13160 

Note that while `UrlEncode()` and `UrlDecode()` do not look like inverse functions, it is always the case that `UrlDecode(UrlEncode(x)) == x`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13224)
<!-- Reviewable:end -->
