### PR TITLE
impl(GCS+gRPC): capture metadata in async reader

### DIFF
--- a/google/cloud/storage/async_reader.cc
+++ b/google/cloud/storage/async_reader.cc
@@ -55,7 +55,7 @@ class Discard : public std::enable_shared_from_this<Discard> {
 }  // namespace
 
 AsyncReader::~AsyncReader() {
-  if (!impl_) return;
+  if (!impl_ || finished_) return;
   impl_->Cancel();
   auto discard = std::make_shared<Discard>(std::move(impl_));
   discard->Loop();
@@ -80,9 +80,14 @@ future<StatusOr<std::pair<ReadPayload, AsyncToken>>> AsyncReader::Read(
   };
   return impl_->Read().then([this, v = Visitor{std::move(t)}](auto f) mutable {
     auto response = f.get();
-    if (absl::holds_alternative<Status>(response)) impl_.reset();
+    if (absl::holds_alternative<Status>(response)) finished_ = true;
     return absl::visit(std::move(v), std::move(response));
   });
+}
+
+RpcMetadata AsyncReader::GetRequestMetadata() {
+  if (!finished_) return {};
+  return impl_->GetRequestMetadata();
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/async_reader.h
+++ b/google/cloud/storage/async_reader.h
@@ -90,8 +90,12 @@ class AsyncReader {
    */
   future<StatusOr<std::pair<ReadPayload, AsyncToken>>> Read(AsyncToken);
 
+  /// Returns request metadata for troubleshooting / debugging purposes.
+  RpcMetadata GetRequestMetadata();
+
  private:
   std::unique_ptr<AsyncReaderConnection> impl_;
+  bool finished_ = false;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/async_reader_connection.h
+++ b/google/cloud/storage/async_reader_connection.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/storage/async_object_responses.h"
 #include "google/cloud/future.h"
+#include "google/cloud/rpc_metadata.h"
 #include "google/cloud/status.h"
 #include "google/cloud/version.h"
 #include "absl/types/variant.h"
@@ -77,6 +78,9 @@ class AsyncReaderConnection {
    * complicated.
    */
   virtual future<ReadResponse> Read() = 0;
+
+  /// Return the request metadata.
+  virtual RpcMetadata GetRequestMetadata() = 0;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/async/reader_connection_impl.cc
+++ b/google/cloud/storage/internal/async/reader_connection_impl.cc
@@ -27,6 +27,10 @@ AsyncReaderConnectionImpl::Read() {
   return impl_->Read().then([this](auto f) { return OnRead(f.get()); });
 }
 
+RpcMetadata AsyncReaderConnectionImpl::GetRequestMetadata() {
+  return impl_->GetRequestMetadata();
+}
+
 future<AsyncReaderConnectionImpl::ReadResponse>
 AsyncReaderConnectionImpl::OnRead(absl::optional<ProtoPayload> r) {
   if (!r) return DoFinish();

--- a/google/cloud/storage/internal/async/reader_connection_impl.h
+++ b/google/cloud/storage/internal/async/reader_connection_impl.h
@@ -44,6 +44,7 @@ class AsyncReaderConnectionImpl
   void Cancel() override { return impl_->Cancel(); }
 
   future<ReadResponse> Read() override;
+  RpcMetadata GetRequestMetadata() override;
 
  private:
   future<ReadResponse> OnRead(absl::optional<ProtoPayload> r);

--- a/google/cloud/storage/internal/async/reader_connection_tracing.cc
+++ b/google/cloud/storage/internal/async/reader_connection_tracing.cc
@@ -78,6 +78,10 @@ class AsyncReaderConnectionTracing
         });
   }
 
+  RpcMetadata GetRequestMetadata() override {
+    return impl_->GetRequestMetadata();
+  }
+
  private:
   opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> span_;
   std::unique_ptr<storage_experimental::AsyncReaderConnection> impl_;

--- a/google/cloud/storage/mocks/mock_async_reader_connection.h
+++ b/google/cloud/storage/mocks/mock_async_reader_connection.h
@@ -29,6 +29,7 @@ class MockAsyncReaderConnection
  public:
   MOCK_METHOD(void, Cancel, (), (override));
   MOCK_METHOD(future<ReadResponse>, Read, (), (override));
+  MOCK_METHOD(RpcMetadata, GetRequestMetadata, (), (override));
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
The request metadata provides troubleshooting information to applications. It is also helpful in benchmarks to verify the right network path was used.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13231)
<!-- Reviewable:end -->
