### PR TITLE
impl(GCS+gRPC): capture metadata in async writer

### DIFF
--- a/google/cloud/storage/async_writer.cc
+++ b/google/cloud/storage/async_writer.cc
@@ -81,6 +81,10 @@ future<StatusOr<storage::ObjectMetadata>> AsyncWriter::Finalize(
   return Finalize(std::move(token), WritePayload{});
 }
 
+RpcMetadata AsyncWriter::GetRequestMetadata() const {
+  return impl_->GetRequestMetadata();
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage_experimental
 }  // namespace cloud

--- a/google/cloud/storage/async_writer.h
+++ b/google/cloud/storage/async_writer.h
@@ -117,6 +117,17 @@ class AsyncWriter {
   future<StatusOr<storage::ObjectMetadata>> Finalize(AsyncToken token,
                                                      WritePayload payload);
 
+  /**
+   * The headers (if any) returned by the service. For debugging only.
+   *
+   * @warning The contents of these headers may change without notice. Unless
+   *     documented in the API, headers may be removed or added by the service.
+   *     Furthermore, the headers may change from one version of the library to
+   *     the next, as we find more (or different) opportunities for
+   *     optimization.
+   */
+  RpcMetadata GetRequestMetadata() const;
+
  private:
   std::shared_ptr<AsyncWriterConnection> impl_;
 };

--- a/google/cloud/storage/async_writer_connection.h
+++ b/google/cloud/storage/async_writer_connection.h
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/async_object_requests.h"
 #include "google/cloud/storage/object_metadata.h"
 #include "google/cloud/future.h"
+#include "google/cloud/rpc_metadata.h"
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
@@ -115,6 +116,9 @@ class AsyncWriterConnection {
 
   /// Wait for the result of a `Flush()` call.
   virtual future<StatusOr<std::int64_t>> Query() = 0;
+
+  /// Return the request metadata.
+  virtual RpcMetadata GetRequestMetadata() = 0;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/async_writer_test.cc
+++ b/google/cloud/storage/async_writer_test.cc
@@ -30,8 +30,10 @@ using ::google::cloud::storage_mocks::MockAsyncWriterConnection;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::ElementsAre;
 using ::testing::IsEmpty;
+using ::testing::Pair;
 using ::testing::ResultOf;
 using ::testing::Return;
+using ::testing::UnorderedElementsAre;
 using ::testing::VariantWith;
 
 template <typename Matcher>
@@ -55,6 +57,9 @@ TEST(AsyncWriterTest, Basic) {
       .WillOnce([] {
         return make_ready_future(make_status_or(storage::ObjectMetadata()));
       });
+  EXPECT_CALL(*mock, GetRequestMetadata)
+      .WillOnce(Return(RpcMetadata{{{"hk0", "v0"}, {"hk1", "v1"}},
+                                   {{"tk0", "v0"}, {"tk1", "v1"}}}));
 
   auto token = storage_internal::MakeAsyncToken(mock.get());
   AsyncWriter writer(std::move(mock));
@@ -69,6 +74,12 @@ TEST(AsyncWriterTest, Basic) {
   auto const actual =
       writer.Finalize(std::move(token), WritePayload{std::string("ccc")}).get();
   EXPECT_STATUS_OK(actual);
+
+  auto const metadata = writer.GetRequestMetadata();
+  EXPECT_THAT(metadata.headers,
+              UnorderedElementsAre(Pair("hk0", "v0"), Pair("hk1", "v1")));
+  EXPECT_THAT(metadata.trailers,
+              UnorderedElementsAre(Pair("tk0", "v0"), Pair("tk1", "v1")));
 }
 
 TEST(AsyncWriterTest, FinalizeEmpty) {

--- a/google/cloud/storage/internal/async/writer_connection_finalized.cc
+++ b/google/cloud/storage/internal/async/writer_connection_finalized.cc
@@ -65,6 +65,8 @@ future<StatusOr<std::int64_t>> AsyncWriterConnectionFinalized::Query() {
   return make_ready_future(StatusOr<std::int64_t>(MakeError(GCP_ERROR_INFO())));
 }
 
+RpcMetadata AsyncWriterConnectionFinalized::GetRequestMetadata() { return {}; }
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage_internal
 }  // namespace cloud

--- a/google/cloud/storage/internal/async/writer_connection_finalized.h
+++ b/google/cloud/storage/internal/async/writer_connection_finalized.h
@@ -60,6 +60,7 @@ class AsyncWriterConnectionFinalized
       storage_experimental::WritePayload) override;
   future<Status> Flush(storage_experimental::WritePayload payload) override;
   future<StatusOr<std::int64_t>> Query() override;
+  RpcMetadata GetRequestMetadata() override;
 
  private:
   std::string upload_id_;

--- a/google/cloud/storage/internal/async/writer_connection_finalized_test.cc
+++ b/google/cloud/storage/internal/async/writer_connection_finalized_test.cc
@@ -23,6 +23,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::google::cloud::testing_util::StatusIs;
+using ::testing::IsEmpty;
 using ::testing::VariantWith;
 
 auto MakeTestObject() {
@@ -55,6 +56,8 @@ TEST(AsyncWriterConnectionFinalized, Basic) {
   EXPECT_THAT(tested.Flush({}).get(),
               StatusIs(StatusCode::kFailedPrecondition));
   EXPECT_THAT(tested.Query().get(), StatusIs(StatusCode::kFailedPrecondition));
+  EXPECT_THAT(tested.GetRequestMetadata().headers, IsEmpty());
+  EXPECT_THAT(tested.GetRequestMetadata().trailers, IsEmpty());
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/async/writer_connection_impl.cc
+++ b/google/cloud/storage/internal/async/writer_connection_impl.cc
@@ -138,6 +138,10 @@ future<StatusOr<std::int64_t>> AsyncWriterConnectionImpl::Query() {
   return impl_->Read().then([this](auto f) { return OnQuery(f.get()); });
 }
 
+RpcMetadata AsyncWriterConnectionImpl::GetRequestMetadata() {
+  return impl_->GetRequestMetadata();
+}
+
 google::storage::v2::BidiWriteObjectRequest
 AsyncWriterConnectionImpl::MakeRequest() {
   auto request = google::storage::v2::BidiWriteObjectRequest{};

--- a/google/cloud/storage/internal/async/writer_connection_impl.h
+++ b/google/cloud/storage/internal/async/writer_connection_impl.h
@@ -60,6 +60,7 @@ class AsyncWriterConnectionImpl
       storage_experimental::WritePayload) override;
   future<Status> Flush(storage_experimental::WritePayload payload) override;
   future<StatusOr<std::int64_t>> Query() override;
+  RpcMetadata GetRequestMetadata() override;
 
  private:
   google::storage::v2::BidiWriteObjectRequest MakeRequest();

--- a/google/cloud/storage/internal/async/writer_connection_tracing.cc
+++ b/google/cloud/storage/internal/async/writer_connection_tracing.cc
@@ -124,6 +124,10 @@ class AsyncWriterConnectionTracing
     });
   }
 
+  RpcMetadata GetRequestMetadata() override {
+    return impl_->GetRequestMetadata();
+  }
+
  private:
   opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> span_;
   std::unique_ptr<storage_experimental::AsyncWriterConnection> impl_;

--- a/google/cloud/storage/mocks/mock_async_writer_connection.h
+++ b/google/cloud/storage/mocks/mock_async_writer_connection.h
@@ -38,6 +38,7 @@ class MockAsyncWriterConnection
   MOCK_METHOD(future<Status>, Flush, (storage_experimental::WritePayload),
               (override));
   MOCK_METHOD(future<StatusOr<std::int64_t>>, Query, (), (override));
+  MOCK_METHOD(RpcMetadata, GetRequestMetadata, (), (override));
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
The request metadata is useful when troubleshooting upload problems.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13232)
<!-- Reviewable:end -->
