### PR TITLE
cleanup(GCS+gRPC): simplify upload_id parsing

### DIFF
--- a/google/cloud/storage/internal/grpc/configure_client_context.cc
+++ b/google/cloud/storage/internal/grpc/configure_client_context.cc
@@ -59,17 +59,13 @@ void ApplyRoutingHeaders(grpc::ClientContext& context,
 
 void ApplyResumableUploadRoutingHeader(grpc::ClientContext& context,
                                        std::string const& upload_id) {
-  static auto* slash_format =
+  static auto* re =
       new std::regex{"(projects/[^/]+/buckets/[^/]+)/.*", std::regex::optimize};
-  static auto* colon_format =
-      new std::regex{"(projects/[^/]+/buckets/[^:]+):.*", std::regex::optimize};
-  for (auto const* re : {slash_format, colon_format}) {
-    std::smatch match;
-    if (!std::regex_match(upload_id, match, *re)) continue;
-    context.AddMetadata(
-        "x-goog-request-params",
-        "bucket=" + google::cloud::internal::UrlEncode(match[1].str()));
-  }
+  std::smatch match;
+  if (!std::regex_match(upload_id, match, *re)) return;
+  context.AddMetadata(
+      "x-goog-request-params",
+      "bucket=" + google::cloud::internal::UrlEncode(match[1].str()));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/grpc/configure_client_context_test.cc
+++ b/google/cloud/storage/internal/grpc/configure_client_context_test.cc
@@ -168,19 +168,6 @@ TEST_F(GrpcConfigureClientContext, ApplyRoutingHeadersUploadChunkMatchSlash) {
                             "bucket=projects%2F_%2Fbuckets%2Ftest-bucket")));
 }
 
-TEST_F(GrpcConfigureClientContext, ApplyRoutingHeadersUploadChunkMatchColon) {
-  storage::internal::UploadChunkRequest req(
-      "projects/_/buckets/test-bucket:blah/blah", 0, {},
-      CreateNullHashFunction());
-
-  grpc::ClientContext context;
-  ApplyRoutingHeaders(context, req);
-  auto metadata = GetMetadata(context);
-  EXPECT_THAT(metadata,
-              Contains(Pair("x-goog-request-params",
-                            "bucket=projects%2F_%2Fbuckets%2Ftest-bucket")));
-}
-
 TEST_F(GrpcConfigureClientContext, ApplyRoutingHeadersUploadChunkNoMatch) {
   storage::internal::UploadChunkRequest req("does-not-match", 0, {},
                                             CreateNullHashFunction());
@@ -198,11 +185,7 @@ TEST_F(GrpcConfigureClientContext, ApplyRoutingHeadersUploadId) {
   } const cases[] = {
       {"projects/_/buckets/test-bucket/test-upload-id",
        "bucket=projects%2F_%2Fbuckets%2Ftest-bucket"},
-      {"projects/_/buckets/test-bucket:test-upload-id",
-       "bucket=projects%2F_%2Fbuckets%2Ftest-bucket"},
       {"projects/_/buckets/test-bucket/test/upload/id",
-       "bucket=projects%2F_%2Fbuckets%2Ftest-bucket"},
-      {"projects/_/buckets/test-bucket:test/upload/id",
        "bucket=projects%2F_%2Fbuckets%2Ftest-bucket"},
   };
 


### PR DESCRIPTION
GCS has settled on `/` as a separator between the bucket name and the upload id name.

Fixes #13026

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13238)
<!-- Reviewable:end -->
