### PR TITLE
cleanup(cmake): use keyword, not global variable

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -47,6 +47,16 @@ additional_commands = {
             "BINARY_DIR": 1,
         },
     },
+    "google_cloud_cpp_add_gapic_library": {
+        "flags": ["EXPERIMENTAL", "TRANSITION"],
+        "kwargs": {
+            "SERVICE_DIRS": "+",
+            "CROSS_LIB_DEPS": "+",
+            "SHARED_PROTO_DEPS": "+",
+            "ADDITIONAL_PROTO_LISTS": "+",
+            "BACKWARDS_COMPAT_PROTO_TARGETS": "+",
+        },
+    },
     "google_cloud_cpp_doxygen_targets": {
         "flags": ["RECURSIVE"],
         "kwargs": {

--- a/cmake/GoogleCloudCppLibrary.cmake
+++ b/cmake/GoogleCloudCppLibrary.cmake
@@ -139,18 +139,18 @@ endfunction ()
 #   libraries for these, which link to the desired proto library. See #8022 for
 #   more details.
 # * CROSS_LIB_DEPS: a list of client libraries which this library depends on.
+# * SERVICE_DIRS: a list of service directories within the library. Use
+#   "__EMPTY__" to represent the empty string in the list.
 # * SHARED_PROTO_DEPS: a list of proto libraries which this library depends on,
 #   e.g. `grafeas`. This function will define the proto library targets if they
 #   do not already exist.
-# * SERVICE_DIRS: a list of service directories within the library. Use
-#   "__EMPTY__" to represent the empty string in the list.
 #
 function (google_cloud_cpp_add_gapic_library library display_name)
     cmake_parse_arguments(
         _opt
         "EXPERIMENTAL;TRANSITION"
         ""
-        "ADDITIONAL_PROTO_LISTS;BACKWARDS_COMPAT_PROTO_TARGETS;CROSS_LIB_DEPS;SHARED_PROTO_DEPS;SERVICE_DIRS"
+        "ADDITIONAL_PROTO_LISTS;BACKWARDS_COMPAT_PROTO_TARGETS;CROSS_LIB_DEPS;SERVICE_DIRS;SHARED_PROTO_DEPS"
         ${ARGN})
     if (_opt_EXPERIMENTAL AND _opt_TRANSITION)
         message(

--- a/cmake/GoogleCloudCppLibrary.cmake
+++ b/cmake/GoogleCloudCppLibrary.cmake
@@ -124,20 +124,13 @@ function (google_cloud_cpp_add_library_protos library)
 endfunction ()
 
 #
-# A function to add targets for GA libraries that use gRPC for transport.
+# A function to add targets for GAPICS - libraries that use gRPC for transport.
 #
 # * library:      the short name of the library, e.g. `kms`.
 # * display_name: the display name of the library, e.g. "Cloud Key Management
 #   Service (KMS) API"
 #
-# Additionally, we must set the following **variable** in the parent scope. We
-# cannot use a `cmake_parse_arguments()` keyword because it will skip the empty
-# string when provided in a list. We often need to use the empty string.
-#
-# * GOOGLE_CLOUD_CPP_SERVICE_DIRS: a list of service directories within the
-#   library.
-#
-# The following **keywords** can be optionally supplied to handle edge cases:
+# The function respects the following keywords:
 #
 # * ADDITIONAL_PROTO_LISTS: a list of proto files that may be used indirectly.
 #   `asset` sets this.
@@ -149,13 +142,15 @@ endfunction ()
 # * SHARED_PROTO_DEPS: a list of proto libraries which this library depends on,
 #   e.g. `grafeas`. This function will define the proto library targets if they
 #   do not already exist.
+# * SERVICE_DIRS: a list of service directories within the library. Use
+#   "__EMPTY__" to represent the empty string in the list.
 #
-function (google_cloud_cpp_add_ga_grpc_library library display_name)
+function (google_cloud_cpp_add_gapic_library library display_name)
     cmake_parse_arguments(
         _opt
         "EXPERIMENTAL;TRANSITION"
         ""
-        "ADDITIONAL_PROTO_LISTS;BACKWARDS_COMPAT_PROTO_TARGETS;CROSS_LIB_DEPS;SHARED_PROTO_DEPS"
+        "ADDITIONAL_PROTO_LISTS;BACKWARDS_COMPAT_PROTO_TARGETS;CROSS_LIB_DEPS;SHARED_PROTO_DEPS;SERVICE_DIRS"
         ${ARGN})
     if (_opt_EXPERIMENTAL AND _opt_TRANSITION)
         message(
@@ -188,7 +183,7 @@ function (google_cloud_cpp_add_ga_grpc_library library display_name)
 
     unset(mocks_globs)
     unset(source_globs)
-    foreach (dir IN LISTS GOOGLE_CLOUD_CPP_SERVICE_DIRS)
+    foreach (dir IN LISTS _opt_SERVICE_DIRS)
         if ("${dir}" STREQUAL "__EMPTY__")
             set(dir "")
         endif ()
@@ -355,7 +350,7 @@ function (google_cloud_cpp_add_ga_grpc_library library display_name)
 
     # ${library_alias} must be defined before we can add the samples.
     if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
-        foreach (dir IN LISTS GOOGLE_CLOUD_CPP_SERVICE_DIRS)
+        foreach (dir IN LISTS _opt_SERVICE_DIRS)
             if ("${dir}" STREQUAL "__EMPTY__")
                 set(dir "")
             endif ()

--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -473,9 +473,8 @@ void GenerateCMakeLists(std::ostream& os,
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "$service_subdirectory$")
-
-google_cloud_cpp_add_ga_grpc_library($library$ "$title$"$experimental$)
+google_cloud_cpp_add_gapic_library($library$ "$title$"$experimental$
+    SERVICE_DIRS "$service_subdirectory$")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable($library$_quickstart "quickstart/quickstart.cc")

--- a/generator/internal/scaffold_generator_test.cc
+++ b/generator/internal/scaffold_generator_test.cc
@@ -229,9 +229,8 @@ TEST_F(ScaffoldGenerator, CMakeLists) {
   EXPECT_THAT(actual, Not(HasSubstr("$experimental$")));
   EXPECT_THAT(actual, HasSubstr(R"""(include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(test "Test Only API")
+google_cloud_cpp_add_gapic_library(test "Test Only API"
+    SERVICE_DIRS "v1/")
 )"""));
 
   EXPECT_THAT(actual, HasSubstr(R"""(add_executable(test_quickstart)"""));

--- a/google/cloud/accessapproval/CMakeLists.txt
+++ b/google/cloud/accessapproval/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(accessapproval "Access Approval API")
+google_cloud_cpp_add_gapic_library(accessapproval "Access Approval API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(accessapproval_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/accesscontextmanager/CMakeLists.txt
+++ b/google/cloud/accesscontextmanager/CMakeLists.txt
@@ -18,7 +18,7 @@ include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(
     accesscontextmanager "Access Context Manager API" SERVICE_DIRS "__EMPTY__"
-    "v1/")
+                                                                   "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(accesscontextmanager_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/accesscontextmanager/CMakeLists.txt
+++ b/google/cloud/accesscontextmanager/CMakeLists.txt
@@ -16,10 +16,9 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(accesscontextmanager
-                                     "Access Context Manager API")
+google_cloud_cpp_add_gapic_library(
+    accesscontextmanager "Access Context Manager API" SERVICE_DIRS "__EMPTY__"
+    "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(accesscontextmanager_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/advisorynotifications/CMakeLists.txt
+++ b/google/cloud/advisorynotifications/CMakeLists.txt
@@ -16,10 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(advisorynotifications
-                                     "Advisory Notifications API")
+google_cloud_cpp_add_gapic_library(
+    advisorynotifications "Advisory Notifications API" SERVICE_DIRS "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(advisorynotifications_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/aiplatform/CMakeLists.txt
+++ b/google/cloud/aiplatform/CMakeLists.txt
@@ -16,8 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-google_cloud_cpp_add_gapic_library(aiplatform "Vertex AI API" SERVICE_DIRS
-                                   "v1/")
+google_cloud_cpp_add_gapic_library(aiplatform "Vertex AI API"
+                                   SERVICE_DIRS "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(aiplatform_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/aiplatform/CMakeLists.txt
+++ b/google/cloud/aiplatform/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(aiplatform "Vertex AI API")
+google_cloud_cpp_add_gapic_library(aiplatform "Vertex AI API" SERVICE_DIRS
+                                   "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(aiplatform_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/alloydb/CMakeLists.txt
+++ b/google/cloud/alloydb/CMakeLists.txt
@@ -16,9 +16,7 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(alloydb "AlloyDB API")
+google_cloud_cpp_add_gapic_library(alloydb "AlloyDB API" SERVICE_DIRS "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(alloydb_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/apigateway/CMakeLists.txt
+++ b/google/cloud/apigateway/CMakeLists.txt
@@ -16,8 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-google_cloud_cpp_add_gapic_library(apigateway "API Gateway API" SERVICE_DIRS
-                                   "__EMPTY__" "v1/")
+google_cloud_cpp_add_gapic_library(apigateway "API Gateway API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(apigateway_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/apigateway/CMakeLists.txt
+++ b/google/cloud/apigateway/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(apigateway "API Gateway API")
+google_cloud_cpp_add_gapic_library(apigateway "API Gateway API" SERVICE_DIRS
+                                   "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(apigateway_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/apigeeconnect/CMakeLists.txt
+++ b/google/cloud/apigeeconnect/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(apigeeconnect "Apigee Connect API")
+google_cloud_cpp_add_gapic_library(apigeeconnect "Apigee Connect API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(apigeeconnect_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/apikeys/CMakeLists.txt
+++ b/google/cloud/apikeys/CMakeLists.txt
@@ -16,8 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-google_cloud_cpp_add_gapic_library(apikeys "API Keys API" SERVICE_DIRS
-                                   "__EMPTY__" "v2/")
+google_cloud_cpp_add_gapic_library(apikeys "API Keys API"
+                                   SERVICE_DIRS "__EMPTY__" "v2/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(apikeys_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/apikeys/CMakeLists.txt
+++ b/google/cloud/apikeys/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v2/")
-
-google_cloud_cpp_add_ga_grpc_library(apikeys "API Keys API")
+google_cloud_cpp_add_gapic_library(apikeys "API Keys API" SERVICE_DIRS
+                                   "__EMPTY__" "v2/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(apikeys_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/appengine/CMakeLists.txt
+++ b/google/cloud/appengine/CMakeLists.txt
@@ -17,13 +17,9 @@
 include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(
-    appengine
-    "App Engine Admin API"
-    SERVICE_DIRS
-    "__EMPTY__"
-    "v1/"
-    SHARED_PROTO_DEPS
-    "logging_type")
+    appengine "App Engine Admin API"
+    SERVICE_DIRS "__EMPTY__" "v1/"
+    SHARED_PROTO_DEPS "logging_type")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(appengine_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/appengine/CMakeLists.txt
+++ b/google/cloud/appengine/CMakeLists.txt
@@ -16,10 +16,14 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(appengine "App Engine Admin API"
-                                     SHARED_PROTO_DEPS "logging_type")
+google_cloud_cpp_add_gapic_library(
+    appengine
+    "App Engine Admin API"
+    SERVICE_DIRS
+    "__EMPTY__"
+    "v1/"
+    SHARED_PROTO_DEPS
+    "logging_type")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(appengine_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/artifactregistry/CMakeLists.txt
+++ b/google/cloud/artifactregistry/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(artifactregistry "Artifact Registry API")
+google_cloud_cpp_add_gapic_library(artifactregistry "Artifact Registry API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(artifactregistry_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/asset/CMakeLists.txt
+++ b/google/cloud/asset/CMakeLists.txt
@@ -17,19 +17,16 @@
 include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(
-    asset
-    "Cloud Asset API"
+    asset "Cloud Asset API"
     SERVICE_DIRS
-    "__EMPTY__"
-    "v1/"
-    # orgpolicy/v**1** is used *indirectly* by google/cloud/asset, therefore it
-    # does not appear in protolists/asset.list. In addition, it is not compiled
-    # by any other library. So, added manually.
+        "__EMPTY__"
+        "v1/"
+        # orgpolicy/v**1** is used *indirectly* by google/cloud/asset, therefore
+        # it does not appear in protolists/asset.list. In addition, it is not
+        # compiled by any other library. So, added manually.
     ADDITIONAL_PROTO_LISTS
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/orgpolicy/v1/orgpolicy.proto"
-    CROSS_LIB_DEPS
-    "accesscontextmanager"
-    "osconfig")
+        "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/orgpolicy/v1/orgpolicy.proto"
+    CROSS_LIB_DEPS "accesscontextmanager" "osconfig")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(asset_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/asset/CMakeLists.txt
+++ b/google/cloud/asset/CMakeLists.txt
@@ -16,11 +16,12 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(
+google_cloud_cpp_add_gapic_library(
     asset
     "Cloud Asset API"
+    SERVICE_DIRS
+    "__EMPTY__"
+    "v1/"
     # orgpolicy/v**1** is used *indirectly* by google/cloud/asset, therefore it
     # does not appear in protolists/asset.list. In addition, it is not compiled
     # by any other library. So, added manually.

--- a/google/cloud/assuredworkloads/CMakeLists.txt
+++ b/google/cloud/assuredworkloads/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(assuredworkloads "Assured Workloads API")
+google_cloud_cpp_add_gapic_library(assuredworkloads "Assured Workloads API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(assuredworkloads_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/automl/CMakeLists.txt
+++ b/google/cloud/automl/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(automl "Cloud AutoML API")
+google_cloud_cpp_add_gapic_library(automl "Cloud AutoML API" SERVICE_DIRS
+                                   "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(automl_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/automl/CMakeLists.txt
+++ b/google/cloud/automl/CMakeLists.txt
@@ -16,8 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-google_cloud_cpp_add_gapic_library(automl "Cloud AutoML API" SERVICE_DIRS
-                                   "__EMPTY__" "v1/")
+google_cloud_cpp_add_gapic_library(automl "Cloud AutoML API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(automl_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/baremetalsolution/CMakeLists.txt
+++ b/google/cloud/baremetalsolution/CMakeLists.txt
@@ -16,10 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v2/")
-
-google_cloud_cpp_add_ga_grpc_library(baremetalsolution
-                                     "Bare Metal Solution API")
+google_cloud_cpp_add_gapic_library(baremetalsolution "Bare Metal Solution API"
+                                   SERVICE_DIRS "__EMPTY__" "v2/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(baremetalsolution_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/batch/CMakeLists.txt
+++ b/google/cloud/batch/CMakeLists.txt
@@ -17,7 +17,7 @@
 include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(batch "Batch API" SERVICE_DIRS "__EMPTY__"
-                                   "v1/")
+                                                                  "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(batch_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/batch/CMakeLists.txt
+++ b/google/cloud/batch/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(batch "Batch API")
+google_cloud_cpp_add_gapic_library(batch "Batch API" SERVICE_DIRS "__EMPTY__"
+                                   "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(batch_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/beyondcorp/CMakeLists.txt
+++ b/google/cloud/beyondcorp/CMakeLists.txt
@@ -17,13 +17,9 @@
 include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(
-    beyondcorp
-    "BeyondCorp API"
-    SERVICE_DIRS
-    "__EMPTY__"
-    "appconnections/v1/"
-    "appconnectors/v1/"
-    "appgateways/v1/")
+    beyondcorp "BeyondCorp API"
+    SERVICE_DIRS "__EMPTY__" "appconnections/v1/" "appconnectors/v1/"
+                 "appgateways/v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(beyondcorp_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/beyondcorp/CMakeLists.txt
+++ b/google/cloud/beyondcorp/CMakeLists.txt
@@ -16,10 +16,14 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "appconnections/v1/" "appconnectors/v1/"
-                                  "appgateways/v1/")
-
-google_cloud_cpp_add_ga_grpc_library(beyondcorp "BeyondCorp API")
+google_cloud_cpp_add_gapic_library(
+    beyondcorp
+    "BeyondCorp API"
+    SERVICE_DIRS
+    "__EMPTY__"
+    "appconnections/v1/"
+    "appconnectors/v1/"
+    "appgateways/v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(beyondcorp_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/bigquery/bigquery_grpc.cmake
+++ b/google/cloud/bigquery/bigquery_grpc.cmake
@@ -17,20 +17,18 @@
 include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(
-    bigquery
-    "Google Cloud BigQuery API"
+    bigquery "Google Cloud BigQuery API"
     SERVICE_DIRS
-    "__EMPTY__"
-    "analyticshub/v1/"
-    "biglake/v1/"
-    "connection/v1/"
-    "datapolicies/v1/"
-    "datatransfer/v1/"
-    "migration/v2/"
-    "reservation/v1/"
-    "storage/v1/"
-    BACKWARDS_COMPAT_PROTO_TARGETS
-    "cloud_bigquery_protos")
+        "__EMPTY__"
+        "analyticshub/v1/"
+        "biglake/v1/"
+        "connection/v1/"
+        "datapolicies/v1/"
+        "datatransfer/v1/"
+        "migration/v2/"
+        "reservation/v1/"
+        "storage/v1/"
+    BACKWARDS_COMPAT_PROTO_TARGETS "cloud_bigquery_protos")
 
 # Examples are enabled if possible, but package maintainers may want to disable
 # compilation to speed up their builds.

--- a/google/cloud/bigquery/bigquery_grpc.cmake
+++ b/google/cloud/bigquery/bigquery_grpc.cmake
@@ -16,8 +16,11 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS
-    ""
+google_cloud_cpp_add_gapic_library(
+    bigquery
+    "Google Cloud BigQuery API"
+    SERVICE_DIRS
+    "__EMPTY__"
     "analyticshub/v1/"
     "biglake/v1/"
     "connection/v1/"
@@ -25,10 +28,8 @@ set(GOOGLE_CLOUD_CPP_SERVICE_DIRS
     "datatransfer/v1/"
     "migration/v2/"
     "reservation/v1/"
-    "storage/v1/")
-
-google_cloud_cpp_add_ga_grpc_library(
-    bigquery "Google Cloud BigQuery API" BACKWARDS_COMPAT_PROTO_TARGETS
+    "storage/v1/"
+    BACKWARDS_COMPAT_PROTO_TARGETS
     "cloud_bigquery_protos")
 
 # Examples are enabled if possible, but package maintainers may want to disable
@@ -49,7 +50,7 @@ if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
 endif ()
 
 # BigQuery has a handwritten sample that demonstrates mocking. The executable is
-# added by `google_cloud_cpp_add_ga_grpc_library()`. We need to manually link it
+# added by `google_cloud_cpp_add_gapic_library()`. We need to manually link it
 # against Google Mock.
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     target_link_libraries(bigquery_samples_mock_bigquery_read

--- a/google/cloud/billing/CMakeLists.txt
+++ b/google/cloud/billing/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "budgets/v1/" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(billing "Cloud Billing Budget API")
+google_cloud_cpp_add_gapic_library(billing "Cloud Billing Budget API"
+                                   SERVICE_DIRS "__EMPTY__" "budgets/v1/" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(billing_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/binaryauthorization/CMakeLists.txt
+++ b/google/cloud/binaryauthorization/CMakeLists.txt
@@ -16,10 +16,14 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(
-    binaryauthorization "Binary Authorization API" SHARED_PROTO_DEPS "grafeas")
+google_cloud_cpp_add_gapic_library(
+    binaryauthorization
+    "Binary Authorization API"
+    SERVICE_DIRS
+    "__EMPTY__"
+    "v1/"
+    SHARED_PROTO_DEPS
+    "grafeas")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(binaryauthorization_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/binaryauthorization/CMakeLists.txt
+++ b/google/cloud/binaryauthorization/CMakeLists.txt
@@ -17,13 +17,9 @@
 include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(
-    binaryauthorization
-    "Binary Authorization API"
-    SERVICE_DIRS
-    "__EMPTY__"
-    "v1/"
-    SHARED_PROTO_DEPS
-    "grafeas")
+    binaryauthorization "Binary Authorization API"
+    SERVICE_DIRS "__EMPTY__" "v1/"
+    SHARED_PROTO_DEPS "grafeas")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(binaryauthorization_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/certificatemanager/CMakeLists.txt
+++ b/google/cloud/certificatemanager/CMakeLists.txt
@@ -16,10 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(certificatemanager
-                                     "Certificate Manager API")
+google_cloud_cpp_add_gapic_library(certificatemanager "Certificate Manager API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(certificatemanager_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/channel/CMakeLists.txt
+++ b/google/cloud/channel/CMakeLists.txt
@@ -29,9 +29,8 @@ endif ()
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(channel "Cloud Channel API")
+google_cloud_cpp_add_gapic_library(channel "Cloud Channel API" SERVICE_DIRS
+                                   "__EMPTY__" "v1/")
 
 # The quickstart is too difficult to run successfully, hence, there is no
 # quickstart runner.

--- a/google/cloud/channel/CMakeLists.txt
+++ b/google/cloud/channel/CMakeLists.txt
@@ -29,8 +29,8 @@ endif ()
 
 include(GoogleCloudCppLibrary)
 
-google_cloud_cpp_add_gapic_library(channel "Cloud Channel API" SERVICE_DIRS
-                                   "__EMPTY__" "v1/")
+google_cloud_cpp_add_gapic_library(channel "Cloud Channel API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 # The quickstart is too difficult to run successfully, hence, there is no
 # quickstart runner.

--- a/google/cloud/cloudbuild/CMakeLists.txt
+++ b/google/cloud/cloudbuild/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/" "v2/")
-
-google_cloud_cpp_add_ga_grpc_library(cloudbuild "Cloud Build API")
+google_cloud_cpp_add_gapic_library(cloudbuild "Cloud Build API" SERVICE_DIRS
+                                   "__EMPTY__" "v1/" "v2/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(cloudbuild_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/cloudbuild/CMakeLists.txt
+++ b/google/cloud/cloudbuild/CMakeLists.txt
@@ -16,8 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-google_cloud_cpp_add_gapic_library(cloudbuild "Cloud Build API" SERVICE_DIRS
-                                   "__EMPTY__" "v1/" "v2/")
+google_cloud_cpp_add_gapic_library(cloudbuild "Cloud Build API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/" "v2/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(cloudbuild_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/commerce/CMakeLists.txt
+++ b/google/cloud/commerce/CMakeLists.txt
@@ -16,10 +16,9 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "consumer/procurement/v1/")
-
-google_cloud_cpp_add_ga_grpc_library(commerce
-                                     "Cloud Commerce Consumer Procurement API")
+google_cloud_cpp_add_gapic_library(
+    commerce "Cloud Commerce Consumer Procurement API" SERVICE_DIRS
+    "consumer/procurement/v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(commerce_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/commerce/CMakeLists.txt
+++ b/google/cloud/commerce/CMakeLists.txt
@@ -17,8 +17,8 @@
 include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(
-    commerce "Cloud Commerce Consumer Procurement API" SERVICE_DIRS
-    "consumer/procurement/v1/")
+    commerce "Cloud Commerce Consumer Procurement API"
+    SERVICE_DIRS "consumer/procurement/v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(commerce_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/composer/CMakeLists.txt
+++ b/google/cloud/composer/CMakeLists.txt
@@ -16,8 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-google_cloud_cpp_add_gapic_library(composer "Cloud Composer API" SERVICE_DIRS
-                                   "__EMPTY__" "v1/")
+google_cloud_cpp_add_gapic_library(composer "Cloud Composer API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(composer_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/composer/CMakeLists.txt
+++ b/google/cloud/composer/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(composer "Cloud Composer API")
+google_cloud_cpp_add_gapic_library(composer "Cloud Composer API" SERVICE_DIRS
+                                   "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(composer_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/confidentialcomputing/CMakeLists.txt
+++ b/google/cloud/confidentialcomputing/CMakeLists.txt
@@ -16,10 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(confidentialcomputing
-                                     "Confidential Computing API")
+google_cloud_cpp_add_gapic_library(
+    confidentialcomputing "Confidential Computing API" SERVICE_DIRS "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(confidentialcomputing_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/config/CMakeLists.txt
+++ b/google/cloud/config/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(config "Infrastructure Manager API")
+google_cloud_cpp_add_gapic_library(config "Infrastructure Manager API"
+                                   SERVICE_DIRS "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(config_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/connectors/CMakeLists.txt
+++ b/google/cloud/connectors/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(connectors "Connectors API")
+google_cloud_cpp_add_gapic_library(connectors "Connectors API" SERVICE_DIRS
+                                   "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(connectors_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/connectors/CMakeLists.txt
+++ b/google/cloud/connectors/CMakeLists.txt
@@ -16,8 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-google_cloud_cpp_add_gapic_library(connectors "Connectors API" SERVICE_DIRS
-                                   "__EMPTY__" "v1/")
+google_cloud_cpp_add_gapic_library(connectors "Connectors API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(connectors_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/contactcenterinsights/CMakeLists.txt
+++ b/google/cloud/contactcenterinsights/CMakeLists.txt
@@ -17,8 +17,8 @@
 include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(
-    contactcenterinsights "Contact Center AI Insights API" SERVICE_DIRS
-    "__EMPTY__" "v1/")
+    contactcenterinsights "Contact Center AI Insights API"
+    SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(contactcenterinsights_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/contactcenterinsights/CMakeLists.txt
+++ b/google/cloud/contactcenterinsights/CMakeLists.txt
@@ -16,10 +16,9 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(contactcenterinsights
-                                     "Contact Center AI Insights API")
+google_cloud_cpp_add_gapic_library(
+    contactcenterinsights "Contact Center AI Insights API" SERVICE_DIRS
+    "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(contactcenterinsights_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/container/CMakeLists.txt
+++ b/google/cloud/container/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(container "Kubernetes Engine API")
+google_cloud_cpp_add_gapic_library(container "Kubernetes Engine API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(container_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/containeranalysis/CMakeLists.txt
+++ b/google/cloud/containeranalysis/CMakeLists.txt
@@ -17,13 +17,9 @@
 include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(
-    containeranalysis
-    "Container Analysis API"
-    SERVICE_DIRS
-    "__EMPTY__"
-    "v1/"
-    SHARED_PROTO_DEPS
-    "grafeas")
+    containeranalysis "Container Analysis API"
+    SERVICE_DIRS "__EMPTY__" "v1/"
+    SHARED_PROTO_DEPS "grafeas")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(containeranalysis_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/containeranalysis/CMakeLists.txt
+++ b/google/cloud/containeranalysis/CMakeLists.txt
@@ -16,10 +16,14 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(containeranalysis "Container Analysis API"
-                                     SHARED_PROTO_DEPS "grafeas")
+google_cloud_cpp_add_gapic_library(
+    containeranalysis
+    "Container Analysis API"
+    SERVICE_DIRS
+    "__EMPTY__"
+    "v1/"
+    SHARED_PROTO_DEPS
+    "grafeas")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(containeranalysis_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/contentwarehouse/CMakeLists.txt
+++ b/google/cloud/contentwarehouse/CMakeLists.txt
@@ -16,10 +16,9 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(
-    contentwarehouse "Document AI Warehouse API" CROSS_LIB_DEPS "documentai")
+google_cloud_cpp_add_gapic_library(
+    contentwarehouse "Document AI Warehouse API" SERVICE_DIRS "v1/"
+    CROSS_LIB_DEPS "documentai")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(contentwarehouse_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/contentwarehouse/CMakeLists.txt
+++ b/google/cloud/contentwarehouse/CMakeLists.txt
@@ -17,7 +17,8 @@
 include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(
-    contentwarehouse "Document AI Warehouse API" SERVICE_DIRS "v1/"
+    contentwarehouse "Document AI Warehouse API"
+    SERVICE_DIRS "v1/"
     CROSS_LIB_DEPS "documentai")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)

--- a/google/cloud/datacatalog/CMakeLists.txt
+++ b/google/cloud/datacatalog/CMakeLists.txt
@@ -16,10 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "lineage/v1/" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(datacatalog
-                                     "Google Cloud Data Catalog API")
+google_cloud_cpp_add_gapic_library(datacatalog "Google Cloud Data Catalog API"
+                                   SERVICE_DIRS "__EMPTY__" "lineage/v1/" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(datacatalog_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/datafusion/CMakeLists.txt
+++ b/google/cloud/datafusion/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(datafusion "Cloud Data Fusion API")
+google_cloud_cpp_add_gapic_library(datafusion "Cloud Data Fusion API"
+                                   SERVICE_DIRS "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(datafusion_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/datamigration/CMakeLists.txt
+++ b/google/cloud/datamigration/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(datamigration "Database Migration API")
+google_cloud_cpp_add_gapic_library(datamigration "Database Migration API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(datamigration_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/dataplex/CMakeLists.txt
+++ b/google/cloud/dataplex/CMakeLists.txt
@@ -16,8 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-google_cloud_cpp_add_gapic_library(dataplex "Cloud Dataplex API" SERVICE_DIRS
-                                   "__EMPTY__" "v1/")
+google_cloud_cpp_add_gapic_library(dataplex "Cloud Dataplex API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(dataplex_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/dataplex/CMakeLists.txt
+++ b/google/cloud/dataplex/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(dataplex "Cloud Dataplex API")
+google_cloud_cpp_add_gapic_library(dataplex "Cloud Dataplex API" SERVICE_DIRS
+                                   "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(dataplex_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/dataproc/CMakeLists.txt
+++ b/google/cloud/dataproc/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(dataproc "Cloud Dataproc API")
+google_cloud_cpp_add_gapic_library(dataproc "Cloud Dataproc API" SERVICE_DIRS
+                                   "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(dataproc_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/dataproc/CMakeLists.txt
+++ b/google/cloud/dataproc/CMakeLists.txt
@@ -16,8 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-google_cloud_cpp_add_gapic_library(dataproc "Cloud Dataproc API" SERVICE_DIRS
-                                   "__EMPTY__" "v1/")
+google_cloud_cpp_add_gapic_library(dataproc "Cloud Dataproc API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(dataproc_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/datastore/CMakeLists.txt
+++ b/google/cloud/datastore/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "admin/v1/" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(datastore "Cloud Datastore API")
+google_cloud_cpp_add_gapic_library(datastore "Cloud Datastore API" SERVICE_DIRS
+                                   "admin/v1/" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(datastore_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/datastore/CMakeLists.txt
+++ b/google/cloud/datastore/CMakeLists.txt
@@ -16,8 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-google_cloud_cpp_add_gapic_library(datastore "Cloud Datastore API" SERVICE_DIRS
-                                   "admin/v1/" "v1/")
+google_cloud_cpp_add_gapic_library(datastore "Cloud Datastore API"
+                                   SERVICE_DIRS "admin/v1/" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(datastore_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/datastream/CMakeLists.txt
+++ b/google/cloud/datastream/CMakeLists.txt
@@ -16,8 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-google_cloud_cpp_add_gapic_library(datastream "Datastream API" SERVICE_DIRS
-                                   "__EMPTY__" "v1/")
+google_cloud_cpp_add_gapic_library(datastream "Datastream API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(datastream_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/datastream/CMakeLists.txt
+++ b/google/cloud/datastream/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(datastream "Datastream API")
+google_cloud_cpp_add_gapic_library(datastream "Datastream API" SERVICE_DIRS
+                                   "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(datastream_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/deploy/CMakeLists.txt
+++ b/google/cloud/deploy/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(deploy "Google Cloud Deploy API")
+google_cloud_cpp_add_gapic_library(deploy "Google Cloud Deploy API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(deploy_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/dialogflow_cx/CMakeLists.txt
+++ b/google/cloud/dialogflow_cx/CMakeLists.txt
@@ -16,8 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-google_cloud_cpp_add_gapic_library(dialogflow_cx "Dialogflow API" SERVICE_DIRS
-                                   "__EMPTY__")
+google_cloud_cpp_add_gapic_library(dialogflow_cx "Dialogflow API"
+                                   SERVICE_DIRS "__EMPTY__")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(dialogflow_cx_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/dialogflow_cx/CMakeLists.txt
+++ b/google/cloud/dialogflow_cx/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "__EMPTY__")
-
-google_cloud_cpp_add_ga_grpc_library(dialogflow_cx "Dialogflow API")
+google_cloud_cpp_add_gapic_library(dialogflow_cx "Dialogflow API" SERVICE_DIRS
+                                   "__EMPTY__")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(dialogflow_cx_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/dialogflow_es/CMakeLists.txt
+++ b/google/cloud/dialogflow_es/CMakeLists.txt
@@ -28,11 +28,9 @@ endif ()
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "__EMPTY__")
-
-google_cloud_cpp_add_ga_grpc_library(
-    dialogflow_es "Dialogflow API" BACKWARDS_COMPAT_PROTO_TARGETS
-    "cloud_dialogflow_v2_protos")
+google_cloud_cpp_add_gapic_library(
+    dialogflow_es "Dialogflow API" SERVICE_DIRS "__EMPTY__"
+    BACKWARDS_COMPAT_PROTO_TARGETS "cloud_dialogflow_v2_protos")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(dialogflow_es_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/dialogflow_es/CMakeLists.txt
+++ b/google/cloud/dialogflow_es/CMakeLists.txt
@@ -29,7 +29,8 @@ endif ()
 include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(
-    dialogflow_es "Dialogflow API" SERVICE_DIRS "__EMPTY__"
+    dialogflow_es "Dialogflow API"
+    SERVICE_DIRS "__EMPTY__"
     BACKWARDS_COMPAT_PROTO_TARGETS "cloud_dialogflow_v2_protos")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)

--- a/google/cloud/discoveryengine/CMakeLists.txt
+++ b/google/cloud/discoveryengine/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(discoveryengine "Discovery Engine API")
+google_cloud_cpp_add_gapic_library(discoveryengine "Discovery Engine API"
+                                   SERVICE_DIRS "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(discoveryengine_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/dlp/CMakeLists.txt
+++ b/google/cloud/dlp/CMakeLists.txt
@@ -26,9 +26,8 @@ endif ()
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v2/")
-
-google_cloud_cpp_add_ga_grpc_library(dlp "Cloud Data Loss Prevention (DLP) API")
+google_cloud_cpp_add_gapic_library(dlp "Cloud Data Loss Prevention (DLP) API"
+                                   SERVICE_DIRS "__EMPTY__" "v2/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(dlp_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/documentai/CMakeLists.txt
+++ b/google/cloud/documentai/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(documentai "Cloud Document AI API")
+google_cloud_cpp_add_gapic_library(documentai "Cloud Document AI API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(documentai_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/domains/CMakeLists.txt
+++ b/google/cloud/domains/CMakeLists.txt
@@ -16,8 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-google_cloud_cpp_add_gapic_library(domains "Cloud Domains API" SERVICE_DIRS
-                                   "v1/")
+google_cloud_cpp_add_gapic_library(domains "Cloud Domains API"
+                                   SERVICE_DIRS "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(domains_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/domains/CMakeLists.txt
+++ b/google/cloud/domains/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(domains "Cloud Domains API")
+google_cloud_cpp_add_gapic_library(domains "Cloud Domains API" SERVICE_DIRS
+                                   "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(domains_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/edgecontainer/CMakeLists.txt
+++ b/google/cloud/edgecontainer/CMakeLists.txt
@@ -16,10 +16,9 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(edgecontainer
-                                     "Distributed Cloud Edge Container API")
+google_cloud_cpp_add_gapic_library(
+    edgecontainer "Distributed Cloud Edge Container API" SERVICE_DIRS
+    "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(edgecontainer_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/edgecontainer/CMakeLists.txt
+++ b/google/cloud/edgecontainer/CMakeLists.txt
@@ -17,8 +17,8 @@
 include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(
-    edgecontainer "Distributed Cloud Edge Container API" SERVICE_DIRS
-    "__EMPTY__" "v1/")
+    edgecontainer "Distributed Cloud Edge Container API"
+    SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(edgecontainer_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/edgenetwork/CMakeLists.txt
+++ b/google/cloud/edgenetwork/CMakeLists.txt
@@ -16,10 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(edgenetwork
-                                     "Distributed Cloud Edge Network API")
+google_cloud_cpp_add_gapic_library(
+    edgenetwork "Distributed Cloud Edge Network API" SERVICE_DIRS "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(edgenetwork_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/essentialcontacts/CMakeLists.txt
+++ b/google/cloud/essentialcontacts/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(essentialcontacts "Essential Contacts API")
+google_cloud_cpp_add_gapic_library(essentialcontacts "Essential Contacts API"
+                                   SERVICE_DIRS "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(essentialcontacts_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/eventarc/CMakeLists.txt
+++ b/google/cloud/eventarc/CMakeLists.txt
@@ -16,8 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-google_cloud_cpp_add_gapic_library(eventarc "Eventarc API" SERVICE_DIRS
-                                   "__EMPTY__" "publishing/v1/" "v1/")
+google_cloud_cpp_add_gapic_library(
+    eventarc "Eventarc API" SERVICE_DIRS "__EMPTY__" "publishing/v1/" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(eventarc_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/eventarc/CMakeLists.txt
+++ b/google/cloud/eventarc/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "publishing/v1/" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(eventarc "Eventarc API")
+google_cloud_cpp_add_gapic_library(eventarc "Eventarc API" SERVICE_DIRS
+                                   "__EMPTY__" "publishing/v1/" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(eventarc_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/filestore/CMakeLists.txt
+++ b/google/cloud/filestore/CMakeLists.txt
@@ -16,8 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-google_cloud_cpp_add_gapic_library(filestore "Cloud Filestore API" SERVICE_DIRS
-                                   "__EMPTY__" "v1/")
+google_cloud_cpp_add_gapic_library(filestore "Cloud Filestore API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(filestore_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/filestore/CMakeLists.txt
+++ b/google/cloud/filestore/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(filestore "Cloud Filestore API")
+google_cloud_cpp_add_gapic_library(filestore "Cloud Filestore API" SERVICE_DIRS
+                                   "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(filestore_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/functions/CMakeLists.txt
+++ b/google/cloud/functions/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/" "v2/")
-
-google_cloud_cpp_add_ga_grpc_library(functions "Cloud Functions API")
+google_cloud_cpp_add_gapic_library(functions "Cloud Functions API" SERVICE_DIRS
+                                   "__EMPTY__" "v1/" "v2/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(functions_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/functions/CMakeLists.txt
+++ b/google/cloud/functions/CMakeLists.txt
@@ -16,8 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-google_cloud_cpp_add_gapic_library(functions "Cloud Functions API" SERVICE_DIRS
-                                   "__EMPTY__" "v1/" "v2/")
+google_cloud_cpp_add_gapic_library(functions "Cloud Functions API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/" "v2/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(functions_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/gkebackup/CMakeLists.txt
+++ b/google/cloud/gkebackup/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(gkebackup "Backup for GKE API")
+google_cloud_cpp_add_gapic_library(gkebackup "Backup for GKE API" SERVICE_DIRS
+                                   "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(gkebackup_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/gkebackup/CMakeLists.txt
+++ b/google/cloud/gkebackup/CMakeLists.txt
@@ -16,8 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-google_cloud_cpp_add_gapic_library(gkebackup "Backup for GKE API" SERVICE_DIRS
-                                   "v1/")
+google_cloud_cpp_add_gapic_library(gkebackup "Backup for GKE API"
+                                   SERVICE_DIRS "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(gkebackup_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/gkehub/CMakeLists.txt
+++ b/google/cloud/gkehub/CMakeLists.txt
@@ -17,7 +17,7 @@
 include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(gkehub "GKE Hub" SERVICE_DIRS "__EMPTY__"
-                                   "v1/")
+                                                                 "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(gkehub_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/gkehub/CMakeLists.txt
+++ b/google/cloud/gkehub/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(gkehub "GKE Hub")
+google_cloud_cpp_add_gapic_library(gkehub "GKE Hub" SERVICE_DIRS "__EMPTY__"
+                                   "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(gkehub_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/gkemulticloud/CMakeLists.txt
+++ b/google/cloud/gkemulticloud/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(gkemulticloud "Anthos Multi-Cloud API")
+google_cloud_cpp_add_gapic_library(gkemulticloud "Anthos Multi-Cloud API"
+                                   SERVICE_DIRS "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(gkemulticloud_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/iam/CMakeLists.txt
+++ b/google/cloud/iam/CMakeLists.txt
@@ -16,10 +16,17 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "admin/v1/" "credentials/v1/" "v1/" "v2/")
-
-google_cloud_cpp_add_ga_grpc_library(iam "Google Cloud IAM API"
-                                     SHARED_PROTO_DEPS "iam_v2")
+google_cloud_cpp_add_gapic_library(
+    iam
+    "Google Cloud IAM API"
+    SERVICE_DIRS
+    "__EMPTY__"
+    "admin/v1/"
+    "credentials/v1/"
+    "v1/"
+    "v2/"
+    SHARED_PROTO_DEPS
+    "iam_v2")
 
 # Examples are enabled if possible, but package maintainers may want to disable
 # compilation to speed up their builds.
@@ -36,8 +43,8 @@ if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
 endif ()
 
 # IAM has some handwritten samples that demonstrate mocking. The executables are
-# added by `google_cloud_cpp_add_ga_grpc_library()`. We need to manually link
-# them against Google Mock.
+# added by `google_cloud_cpp_add_gapic_library()`. We need to manually link them
+# against Google Mock.
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     target_link_libraries(iam_samples_mock_iam PRIVATE GTest::gmock_main)
     target_link_libraries(iam_samples_mock_iam_credentials

--- a/google/cloud/iam/CMakeLists.txt
+++ b/google/cloud/iam/CMakeLists.txt
@@ -17,16 +17,9 @@
 include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(
-    iam
-    "Google Cloud IAM API"
-    SERVICE_DIRS
-    "__EMPTY__"
-    "admin/v1/"
-    "credentials/v1/"
-    "v1/"
-    "v2/"
-    SHARED_PROTO_DEPS
-    "iam_v2")
+    iam "Google Cloud IAM API"
+    SERVICE_DIRS "__EMPTY__" "admin/v1/" "credentials/v1/" "v1/" "v2/"
+    SHARED_PROTO_DEPS "iam_v2")
 
 # Examples are enabled if possible, but package maintainers may want to disable
 # compilation to speed up their builds.

--- a/google/cloud/iap/CMakeLists.txt
+++ b/google/cloud/iap/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(iap "Cloud Identity-Aware Proxy API")
+google_cloud_cpp_add_gapic_library(iap "Cloud Identity-Aware Proxy API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(iap_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/ids/CMakeLists.txt
+++ b/google/cloud/ids/CMakeLists.txt
@@ -17,7 +17,7 @@
 include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(ids "Cloud IDS API" SERVICE_DIRS "__EMPTY__"
-                                   "v1/")
+                                                                    "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(ids_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/ids/CMakeLists.txt
+++ b/google/cloud/ids/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(ids "Cloud IDS API")
+google_cloud_cpp_add_gapic_library(ids "Cloud IDS API" SERVICE_DIRS "__EMPTY__"
+                                   "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(ids_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/kms/CMakeLists.txt
+++ b/google/cloud/kms/CMakeLists.txt
@@ -16,10 +16,9 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "inventory/v1/" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(kms
-                                     "Cloud Key Management Service (KMS) API")
+google_cloud_cpp_add_gapic_library(
+    kms "Cloud Key Management Service (KMS) API" SERVICE_DIRS "__EMPTY__"
+    "inventory/v1/" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(kms_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/kms/CMakeLists.txt
+++ b/google/cloud/kms/CMakeLists.txt
@@ -17,8 +17,8 @@
 include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(
-    kms "Cloud Key Management Service (KMS) API" SERVICE_DIRS "__EMPTY__"
-    "inventory/v1/" "v1/")
+    kms "Cloud Key Management Service (KMS) API"
+    SERVICE_DIRS "__EMPTY__" "inventory/v1/" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(kms_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/language/CMakeLists.txt
+++ b/google/cloud/language/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/" "v2/")
-
-google_cloud_cpp_add_ga_grpc_library(language "Cloud Natural Language API")
+google_cloud_cpp_add_gapic_library(language "Cloud Natural Language API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/" "v2/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(language_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/logging/CMakeLists.txt
+++ b/google/cloud/logging/CMakeLists.txt
@@ -17,15 +17,10 @@
 include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(
-    logging
-    "Cloud Logging API"
-    SERVICE_DIRS
-    "__EMPTY__"
-    "v2/"
-    SHARED_PROTO_DEPS
-    "logging_type"
-    BACKWARDS_COMPAT_PROTO_TARGETS
-    "logging_type_type_protos")
+    logging "Cloud Logging API"
+    SERVICE_DIRS "__EMPTY__" "v2/"
+    SHARED_PROTO_DEPS "logging_type"
+    BACKWARDS_COMPAT_PROTO_TARGETS "logging_type_type_protos")
 
 add_subdirectory(integration_tests)
 

--- a/google/cloud/logging/CMakeLists.txt
+++ b/google/cloud/logging/CMakeLists.txt
@@ -16,11 +16,16 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v2/")
-
-google_cloud_cpp_add_ga_grpc_library(
-    logging "Cloud Logging API" SHARED_PROTO_DEPS "logging_type"
-    BACKWARDS_COMPAT_PROTO_TARGETS "logging_type_type_protos")
+google_cloud_cpp_add_gapic_library(
+    logging
+    "Cloud Logging API"
+    SERVICE_DIRS
+    "__EMPTY__"
+    "v2/"
+    SHARED_PROTO_DEPS
+    "logging_type"
+    BACKWARDS_COMPAT_PROTO_TARGETS
+    "logging_type_type_protos")
 
 add_subdirectory(integration_tests)
 

--- a/google/cloud/managedidentities/CMakeLists.txt
+++ b/google/cloud/managedidentities/CMakeLists.txt
@@ -16,10 +16,9 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(
-    managedidentities "Managed Service for Microsoft Active Directory API")
+google_cloud_cpp_add_gapic_library(
+    managedidentities "Managed Service for Microsoft Active Directory API"
+    SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(managedidentities_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/memcache/CMakeLists.txt
+++ b/google/cloud/memcache/CMakeLists.txt
@@ -18,7 +18,7 @@ include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(
     memcache "Cloud Memorystore for Memcached API" SERVICE_DIRS "__EMPTY__"
-    "v1/")
+                                                                "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(memcache_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/memcache/CMakeLists.txt
+++ b/google/cloud/memcache/CMakeLists.txt
@@ -16,10 +16,9 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(memcache
-                                     "Cloud Memorystore for Memcached API")
+google_cloud_cpp_add_gapic_library(
+    memcache "Cloud Memorystore for Memcached API" SERVICE_DIRS "__EMPTY__"
+    "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(memcache_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/metastore/CMakeLists.txt
+++ b/google/cloud/metastore/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(metastore "Dataproc Metastore API")
+google_cloud_cpp_add_gapic_library(metastore "Dataproc Metastore API"
+                                   SERVICE_DIRS "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(metastore_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/migrationcenter/CMakeLists.txt
+++ b/google/cloud/migrationcenter/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(migrationcenter "Migration Center API")
+google_cloud_cpp_add_gapic_library(migrationcenter "Migration Center API"
+                                   SERVICE_DIRS "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(migrationcenter_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/monitoring/CMakeLists.txt
+++ b/google/cloud/monitoring/CMakeLists.txt
@@ -17,13 +17,8 @@
 include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(
-    monitoring
-    "Cloud Monitoring API"
-    SERVICE_DIRS
-    "__EMPTY__"
-    "dashboard/v1/"
-    "metricsscope/v1/"
-    "v3/")
+    monitoring "Cloud Monitoring API" SERVICE_DIRS "__EMPTY__" "dashboard/v1/"
+                                                   "metricsscope/v1/" "v3/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(monitoring_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/monitoring/CMakeLists.txt
+++ b/google/cloud/monitoring/CMakeLists.txt
@@ -16,9 +16,14 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "dashboard/v1/" "metricsscope/v1/" "v3/")
-
-google_cloud_cpp_add_ga_grpc_library(monitoring "Cloud Monitoring API")
+google_cloud_cpp_add_gapic_library(
+    monitoring
+    "Cloud Monitoring API"
+    SERVICE_DIRS
+    "__EMPTY__"
+    "dashboard/v1/"
+    "metricsscope/v1/"
+    "v3/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(monitoring_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/netapp/CMakeLists.txt
+++ b/google/cloud/netapp/CMakeLists.txt
@@ -16,9 +16,7 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(netapp "NetApp API")
+google_cloud_cpp_add_gapic_library(netapp "NetApp API" SERVICE_DIRS "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(netapp_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/networkconnectivity/CMakeLists.txt
+++ b/google/cloud/networkconnectivity/CMakeLists.txt
@@ -16,10 +16,9 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(networkconnectivity
-                                     "Network Connectivity API")
+google_cloud_cpp_add_gapic_library(
+    networkconnectivity "Network Connectivity API" SERVICE_DIRS "__EMPTY__"
+    "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(networkconnectivity_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/networkconnectivity/CMakeLists.txt
+++ b/google/cloud/networkconnectivity/CMakeLists.txt
@@ -18,7 +18,7 @@ include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(
     networkconnectivity "Network Connectivity API" SERVICE_DIRS "__EMPTY__"
-    "v1/")
+                                                                "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(networkconnectivity_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/networkmanagement/CMakeLists.txt
+++ b/google/cloud/networkmanagement/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(networkmanagement "Network Management API")
+google_cloud_cpp_add_gapic_library(networkmanagement "Network Management API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(networkmanagement_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/networksecurity/CMakeLists.txt
+++ b/google/cloud/networksecurity/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(networksecurity "Network Security API")
+google_cloud_cpp_add_gapic_library(networksecurity "Network Security API"
+                                   SERVICE_DIRS "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(networksecurity_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/networkservices/CMakeLists.txt
+++ b/google/cloud/networkservices/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(networkservices "Network Services API")
+google_cloud_cpp_add_gapic_library(networkservices "Network Services API"
+                                   SERVICE_DIRS "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(networkservices_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/notebooks/CMakeLists.txt
+++ b/google/cloud/notebooks/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/" "v2/")
-
-google_cloud_cpp_add_ga_grpc_library(notebooks "Notebooks API")
+google_cloud_cpp_add_gapic_library(notebooks "Notebooks API" SERVICE_DIRS
+                                   "__EMPTY__" "v1/" "v2/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(notebooks_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/notebooks/CMakeLists.txt
+++ b/google/cloud/notebooks/CMakeLists.txt
@@ -16,8 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-google_cloud_cpp_add_gapic_library(notebooks "Notebooks API" SERVICE_DIRS
-                                   "__EMPTY__" "v1/" "v2/")
+google_cloud_cpp_add_gapic_library(notebooks "Notebooks API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/" "v2/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(notebooks_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/optimization/CMakeLists.txt
+++ b/google/cloud/optimization/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(optimization "Cloud Optimization API")
+google_cloud_cpp_add_gapic_library(optimization "Cloud Optimization API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(optimization_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/orgpolicy/CMakeLists.txt
+++ b/google/cloud/orgpolicy/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v2/")
-
-google_cloud_cpp_add_ga_grpc_library(orgpolicy "Organization Policy API")
+google_cloud_cpp_add_gapic_library(orgpolicy "Organization Policy API"
+                                   SERVICE_DIRS "__EMPTY__" "v2/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(orgpolicy_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/osconfig/CMakeLists.txt
+++ b/google/cloud/osconfig/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "agentendpoint/v1/" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(osconfig "OS Config API")
+google_cloud_cpp_add_gapic_library(osconfig "OS Config API" SERVICE_DIRS
+                                   "__EMPTY__" "agentendpoint/v1/" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(osconfig_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/osconfig/CMakeLists.txt
+++ b/google/cloud/osconfig/CMakeLists.txt
@@ -16,8 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-google_cloud_cpp_add_gapic_library(osconfig "OS Config API" SERVICE_DIRS
-                                   "__EMPTY__" "agentendpoint/v1/" "v1/")
+google_cloud_cpp_add_gapic_library(
+    osconfig "OS Config API" SERVICE_DIRS "__EMPTY__" "agentendpoint/v1/" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(osconfig_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/oslogin/CMakeLists.txt
+++ b/google/cloud/oslogin/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(oslogin "Cloud OS Login API")
+google_cloud_cpp_add_gapic_library(oslogin "Cloud OS Login API" SERVICE_DIRS
+                                   "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(oslogin_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/oslogin/CMakeLists.txt
+++ b/google/cloud/oslogin/CMakeLists.txt
@@ -16,8 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-google_cloud_cpp_add_gapic_library(oslogin "Cloud OS Login API" SERVICE_DIRS
-                                   "__EMPTY__" "v1/")
+google_cloud_cpp_add_gapic_library(oslogin "Cloud OS Login API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(oslogin_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/policysimulator/CMakeLists.txt
+++ b/google/cloud/policysimulator/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(policysimulator "Policy Simulator API")
+google_cloud_cpp_add_gapic_library(policysimulator "Policy Simulator API"
+                                   SERVICE_DIRS "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(policysimulator_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/policytroubleshooter/CMakeLists.txt
+++ b/google/cloud/policytroubleshooter/CMakeLists.txt
@@ -16,10 +16,15 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/" "iam/v3/")
-
-google_cloud_cpp_add_ga_grpc_library(
-    policytroubleshooter "Policy Troubleshooter API" SHARED_PROTO_DEPS "iam_v2")
+google_cloud_cpp_add_gapic_library(
+    policytroubleshooter
+    "Policy Troubleshooter API"
+    SERVICE_DIRS
+    "__EMPTY__"
+    "v1/"
+    "iam/v3/"
+    SHARED_PROTO_DEPS
+    "iam_v2")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(policytroubleshooter_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/policytroubleshooter/CMakeLists.txt
+++ b/google/cloud/policytroubleshooter/CMakeLists.txt
@@ -17,14 +17,9 @@
 include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(
-    policytroubleshooter
-    "Policy Troubleshooter API"
-    SERVICE_DIRS
-    "__EMPTY__"
-    "v1/"
-    "iam/v3/"
-    SHARED_PROTO_DEPS
-    "iam_v2")
+    policytroubleshooter "Policy Troubleshooter API"
+    SERVICE_DIRS "__EMPTY__" "v1/" "iam/v3/"
+    SHARED_PROTO_DEPS "iam_v2")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(policytroubleshooter_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/privateca/CMakeLists.txt
+++ b/google/cloud/privateca/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(privateca "Certificate Authority API")
+google_cloud_cpp_add_gapic_library(privateca "Certificate Authority API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(privateca_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/profiler/CMakeLists.txt
+++ b/google/cloud/profiler/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v2/")
-
-google_cloud_cpp_add_ga_grpc_library(profiler "Cloud Profiler API")
+google_cloud_cpp_add_gapic_library(profiler "Cloud Profiler API" SERVICE_DIRS
+                                   "__EMPTY__" "v2/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(profiler_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/profiler/CMakeLists.txt
+++ b/google/cloud/profiler/CMakeLists.txt
@@ -16,8 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-google_cloud_cpp_add_gapic_library(profiler "Cloud Profiler API" SERVICE_DIRS
-                                   "__EMPTY__" "v2/")
+google_cloud_cpp_add_gapic_library(profiler "Cloud Profiler API"
+                                   SERVICE_DIRS "__EMPTY__" "v2/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(profiler_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/rapidmigrationassessment/CMakeLists.txt
+++ b/google/cloud/rapidmigrationassessment/CMakeLists.txt
@@ -16,10 +16,9 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(rapidmigrationassessment
-                                     "Rapid Migration Assessment API")
+google_cloud_cpp_add_gapic_library(
+    rapidmigrationassessment "Rapid Migration Assessment API" SERVICE_DIRS
+    "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(rapidmigrationassessment_quickstart

--- a/google/cloud/rapidmigrationassessment/CMakeLists.txt
+++ b/google/cloud/rapidmigrationassessment/CMakeLists.txt
@@ -17,8 +17,8 @@
 include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(
-    rapidmigrationassessment "Rapid Migration Assessment API" SERVICE_DIRS
-    "v1/")
+    rapidmigrationassessment "Rapid Migration Assessment API"
+    SERVICE_DIRS "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(rapidmigrationassessment_quickstart

--- a/google/cloud/recaptchaenterprise/CMakeLists.txt
+++ b/google/cloud/recaptchaenterprise/CMakeLists.txt
@@ -16,10 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(recaptchaenterprise
-                                     "reCAPTCHA Enterprise API")
+google_cloud_cpp_add_gapic_library(
+    recaptchaenterprise "reCAPTCHA Enterprise API" SERVICE_DIRS "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(recaptchaenterprise_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/recommender/CMakeLists.txt
+++ b/google/cloud/recommender/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(recommender "Recommender API")
+google_cloud_cpp_add_gapic_library(recommender "Recommender API" SERVICE_DIRS
+                                   "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(recommender_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/recommender/CMakeLists.txt
+++ b/google/cloud/recommender/CMakeLists.txt
@@ -16,8 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-google_cloud_cpp_add_gapic_library(recommender "Recommender API" SERVICE_DIRS
-                                   "__EMPTY__" "v1/")
+google_cloud_cpp_add_gapic_library(recommender "Recommender API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(recommender_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/redis/CMakeLists.txt
+++ b/google/cloud/redis/CMakeLists.txt
@@ -16,10 +16,9 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/" "cluster/v1/")
-
-google_cloud_cpp_add_ga_grpc_library(redis
-                                     "Google Cloud Memorystore for Redis API")
+google_cloud_cpp_add_gapic_library(
+    redis "Google Cloud Memorystore for Redis API" SERVICE_DIRS "__EMPTY__"
+    "v1/" "cluster/v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(redis_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/redis/CMakeLists.txt
+++ b/google/cloud/redis/CMakeLists.txt
@@ -17,8 +17,8 @@
 include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(
-    redis "Google Cloud Memorystore for Redis API" SERVICE_DIRS "__EMPTY__"
-    "v1/" "cluster/v1/")
+    redis "Google Cloud Memorystore for Redis API"
+    SERVICE_DIRS "__EMPTY__" "v1/" "cluster/v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(redis_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/resourcemanager/CMakeLists.txt
+++ b/google/cloud/resourcemanager/CMakeLists.txt
@@ -16,10 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v3/")
-
-google_cloud_cpp_add_ga_grpc_library(resourcemanager
-                                     "Cloud Resource Manager API")
+google_cloud_cpp_add_gapic_library(resourcemanager "Cloud Resource Manager API"
+                                   SERVICE_DIRS "__EMPTY__" "v3/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(resourcemanager_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/resourcesettings/CMakeLists.txt
+++ b/google/cloud/resourcesettings/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(resourcesettings "Resource Settings API")
+google_cloud_cpp_add_gapic_library(resourcesettings "Resource Settings API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(resourcesettings_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/retail/CMakeLists.txt
+++ b/google/cloud/retail/CMakeLists.txt
@@ -17,7 +17,7 @@
 include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(retail "Retail API" SERVICE_DIRS "__EMPTY__"
-                                   "v2/")
+                                                                    "v2/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(retail_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/retail/CMakeLists.txt
+++ b/google/cloud/retail/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v2/")
-
-google_cloud_cpp_add_ga_grpc_library(retail "Retail API")
+google_cloud_cpp_add_gapic_library(retail "Retail API" SERVICE_DIRS "__EMPTY__"
+                                   "v2/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(retail_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/run/CMakeLists.txt
+++ b/google/cloud/run/CMakeLists.txt
@@ -16,8 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-google_cloud_cpp_add_gapic_library(run "Cloud Run Admin API" SERVICE_DIRS
-                                   "__EMPTY__" "v2/")
+google_cloud_cpp_add_gapic_library(run "Cloud Run Admin API"
+                                   SERVICE_DIRS "__EMPTY__" "v2/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(run_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/run/CMakeLists.txt
+++ b/google/cloud/run/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v2/")
-
-google_cloud_cpp_add_ga_grpc_library(run "Cloud Run Admin API")
+google_cloud_cpp_add_gapic_library(run "Cloud Run Admin API" SERVICE_DIRS
+                                   "__EMPTY__" "v2/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(run_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/scheduler/CMakeLists.txt
+++ b/google/cloud/scheduler/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(scheduler "Cloud Scheduler API")
+google_cloud_cpp_add_gapic_library(scheduler "Cloud Scheduler API" SERVICE_DIRS
+                                   "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(scheduler_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/scheduler/CMakeLists.txt
+++ b/google/cloud/scheduler/CMakeLists.txt
@@ -16,8 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-google_cloud_cpp_add_gapic_library(scheduler "Cloud Scheduler API" SERVICE_DIRS
-                                   "__EMPTY__" "v1/")
+google_cloud_cpp_add_gapic_library(scheduler "Cloud Scheduler API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(scheduler_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/secretmanager/CMakeLists.txt
+++ b/google/cloud/secretmanager/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(secretmanager "Secret Manager API")
+google_cloud_cpp_add_gapic_library(secretmanager "Secret Manager API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(secretmanager_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/securesourcemanager/CMakeLists.txt
+++ b/google/cloud/securesourcemanager/CMakeLists.txt
@@ -16,10 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(securesourcemanager
-                                     "Secure Source Manager API")
+google_cloud_cpp_add_gapic_library(
+    securesourcemanager "Secure Source Manager API" SERVICE_DIRS "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(securesourcemanager_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/securitycenter/CMakeLists.txt
+++ b/google/cloud/securitycenter/CMakeLists.txt
@@ -16,10 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(securitycenter
-                                     "Security Command Center API")
+google_cloud_cpp_add_gapic_library(securitycenter "Security Command Center API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(securitycenter_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/servicecontrol/CMakeLists.txt
+++ b/google/cloud/servicecontrol/CMakeLists.txt
@@ -17,14 +17,9 @@
 include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(
-    servicecontrol
-    "Service Control API"
-    SERVICE_DIRS
-    "__EMPTY__"
-    "v1/"
-    "v2/"
-    SHARED_PROTO_DEPS
-    "logging_type")
+    servicecontrol "Service Control API"
+    SERVICE_DIRS "__EMPTY__" "v1/" "v2/"
+    SHARED_PROTO_DEPS "logging_type")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(servicecontrol_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/servicecontrol/CMakeLists.txt
+++ b/google/cloud/servicecontrol/CMakeLists.txt
@@ -16,10 +16,15 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/" "v2/")
-
-google_cloud_cpp_add_ga_grpc_library(servicecontrol "Service Control API"
-                                     SHARED_PROTO_DEPS "logging_type")
+google_cloud_cpp_add_gapic_library(
+    servicecontrol
+    "Service Control API"
+    SERVICE_DIRS
+    "__EMPTY__"
+    "v1/"
+    "v2/"
+    SHARED_PROTO_DEPS
+    "logging_type")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(servicecontrol_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/servicedirectory/CMakeLists.txt
+++ b/google/cloud/servicedirectory/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(servicedirectory "Service Directory API")
+google_cloud_cpp_add_gapic_library(servicedirectory "Service Directory API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(servicedirectory_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/servicemanagement/CMakeLists.txt
+++ b/google/cloud/servicemanagement/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(servicemanagement "Service Management API")
+google_cloud_cpp_add_gapic_library(servicemanagement "Service Management API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(servicemanagement_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/serviceusage/CMakeLists.txt
+++ b/google/cloud/serviceusage/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(serviceusage "Service Usage API")
+google_cloud_cpp_add_gapic_library(serviceusage "Service Usage API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(serviceusage_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/shell/CMakeLists.txt
+++ b/google/cloud/shell/CMakeLists.txt
@@ -16,8 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-google_cloud_cpp_add_gapic_library(shell "Cloud Shell API" SERVICE_DIRS
-                                   "__EMPTY__" "v1/")
+google_cloud_cpp_add_gapic_library(shell "Cloud Shell API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(shell_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/shell/CMakeLists.txt
+++ b/google/cloud/shell/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(shell "Cloud Shell API")
+google_cloud_cpp_add_gapic_library(shell "Cloud Shell API" SERVICE_DIRS
+                                   "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(shell_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/speech/CMakeLists.txt
+++ b/google/cloud/speech/CMakeLists.txt
@@ -17,14 +17,9 @@
 include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(
-    speech
-    "Cloud Speech-to-Text API"
-    SERVICE_DIRS
-    "__EMPTY__"
-    "v1/"
-    "v2/"
-    BACKWARDS_COMPAT_PROTO_TARGETS
-    "cloud_speech_protos")
+    speech "Cloud Speech-to-Text API"
+    SERVICE_DIRS "__EMPTY__" "v1/" "v2/"
+    BACKWARDS_COMPAT_PROTO_TARGETS "cloud_speech_protos")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(speech_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/speech/CMakeLists.txt
+++ b/google/cloud/speech/CMakeLists.txt
@@ -16,10 +16,14 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/" "v2/")
-
-google_cloud_cpp_add_ga_grpc_library(
-    speech "Cloud Speech-to-Text API" BACKWARDS_COMPAT_PROTO_TARGETS
+google_cloud_cpp_add_gapic_library(
+    speech
+    "Cloud Speech-to-Text API"
+    SERVICE_DIRS
+    "__EMPTY__"
+    "v1/"
+    "v2/"
+    BACKWARDS_COMPAT_PROTO_TARGETS
     "cloud_speech_protos")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)

--- a/google/cloud/storageinsights/CMakeLists.txt
+++ b/google/cloud/storageinsights/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(storageinsights "Storage Insights API")
+google_cloud_cpp_add_gapic_library(storageinsights "Storage Insights API"
+                                   SERVICE_DIRS "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(storageinsights_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/storagetransfer/CMakeLists.txt
+++ b/google/cloud/storagetransfer/CMakeLists.txt
@@ -26,9 +26,8 @@ endif ()
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(storagetransfer "Storage Transfer API")
+google_cloud_cpp_add_gapic_library(storagetransfer "Storage Transfer API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(storagetransfer_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/support/CMakeLists.txt
+++ b/google/cloud/support/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "v2/")
-
-google_cloud_cpp_add_ga_grpc_library(support "Google Cloud Support API")
+google_cloud_cpp_add_gapic_library(support "Google Cloud Support API"
+                                   SERVICE_DIRS "v2/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(support_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/talent/CMakeLists.txt
+++ b/google/cloud/talent/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v4/")
-
-google_cloud_cpp_add_ga_grpc_library(talent "Cloud Talent Solution API")
+google_cloud_cpp_add_gapic_library(talent "Cloud Talent Solution API"
+                                   SERVICE_DIRS "__EMPTY__" "v4/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(talent_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/tasks/CMakeLists.txt
+++ b/google/cloud/tasks/CMakeLists.txt
@@ -16,8 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-google_cloud_cpp_add_gapic_library(tasks "Cloud Tasks API" SERVICE_DIRS
-                                   "__EMPTY__" "v2/")
+google_cloud_cpp_add_gapic_library(tasks "Cloud Tasks API"
+                                   SERVICE_DIRS "__EMPTY__" "v2/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(tasks_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/tasks/CMakeLists.txt
+++ b/google/cloud/tasks/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v2/")
-
-google_cloud_cpp_add_ga_grpc_library(tasks "Cloud Tasks API")
+google_cloud_cpp_add_gapic_library(tasks "Cloud Tasks API" SERVICE_DIRS
+                                   "__EMPTY__" "v2/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(tasks_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/telcoautomation/CMakeLists.txt
+++ b/google/cloud/telcoautomation/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(telcoautomation "Telco Automation API")
+google_cloud_cpp_add_gapic_library(telcoautomation "Telco Automation API"
+                                   SERVICE_DIRS "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(telcoautomation_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/texttospeech/CMakeLists.txt
+++ b/google/cloud/texttospeech/CMakeLists.txt
@@ -16,10 +16,13 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(
-    texttospeech "Cloud Text-to-Speech API" BACKWARDS_COMPAT_PROTO_TARGETS
+google_cloud_cpp_add_gapic_library(
+    texttospeech
+    "Cloud Text-to-Speech API"
+    SERVICE_DIRS
+    "__EMPTY__"
+    "v1/"
+    BACKWARDS_COMPAT_PROTO_TARGETS
     "cloud_texttospeech_protos")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)

--- a/google/cloud/texttospeech/CMakeLists.txt
+++ b/google/cloud/texttospeech/CMakeLists.txt
@@ -17,13 +17,9 @@
 include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(
-    texttospeech
-    "Cloud Text-to-Speech API"
-    SERVICE_DIRS
-    "__EMPTY__"
-    "v1/"
-    BACKWARDS_COMPAT_PROTO_TARGETS
-    "cloud_texttospeech_protos")
+    texttospeech "Cloud Text-to-Speech API"
+    SERVICE_DIRS "__EMPTY__" "v1/"
+    BACKWARDS_COMPAT_PROTO_TARGETS "cloud_texttospeech_protos")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(texttospeech_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/timeseriesinsights/CMakeLists.txt
+++ b/google/cloud/timeseriesinsights/CMakeLists.txt
@@ -16,10 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(timeseriesinsights
-                                     "Timeseries Insights API")
+google_cloud_cpp_add_gapic_library(timeseriesinsights "Timeseries Insights API"
+                                   SERVICE_DIRS "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(timeseriesinsights_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/tpu/CMakeLists.txt
+++ b/google/cloud/tpu/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/" "v2/")
-
-google_cloud_cpp_add_ga_grpc_library(tpu "Cloud TPU API")
+google_cloud_cpp_add_gapic_library(tpu "Cloud TPU API" SERVICE_DIRS "__EMPTY__"
+                                   "v1/" "v2/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(tpu_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/tpu/CMakeLists.txt
+++ b/google/cloud/tpu/CMakeLists.txt
@@ -17,7 +17,7 @@
 include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(tpu "Cloud TPU API" SERVICE_DIRS "__EMPTY__"
-                                   "v1/" "v2/")
+                                                                    "v1/" "v2/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(tpu_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/trace/CMakeLists.txt
+++ b/google/cloud/trace/CMakeLists.txt
@@ -16,10 +16,14 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/" "v2/")
-
-google_cloud_cpp_add_ga_grpc_library(
-    trace "Cloud Trace API" BACKWARDS_COMPAT_PROTO_TARGETS
+google_cloud_cpp_add_gapic_library(
+    trace
+    "Cloud Trace API"
+    SERVICE_DIRS
+    "__EMPTY__"
+    "v1/"
+    "v2/"
+    BACKWARDS_COMPAT_PROTO_TARGETS
     "devtools_cloudtrace_v2_trace_protos"
     "devtools_cloudtrace_v2_tracing_protos")
 

--- a/google/cloud/trace/CMakeLists.txt
+++ b/google/cloud/trace/CMakeLists.txt
@@ -17,15 +17,10 @@
 include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(
-    trace
-    "Cloud Trace API"
-    SERVICE_DIRS
-    "__EMPTY__"
-    "v1/"
-    "v2/"
-    BACKWARDS_COMPAT_PROTO_TARGETS
-    "devtools_cloudtrace_v2_trace_protos"
-    "devtools_cloudtrace_v2_tracing_protos")
+    trace "Cloud Trace API"
+    SERVICE_DIRS "__EMPTY__" "v1/" "v2/"
+    BACKWARDS_COMPAT_PROTO_TARGETS "devtools_cloudtrace_v2_trace_protos"
+                                   "devtools_cloudtrace_v2_tracing_protos")
 
 if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
     add_executable(trace_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/translate/CMakeLists.txt
+++ b/google/cloud/translate/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v3/")
-
-google_cloud_cpp_add_ga_grpc_library(translate "Cloud Translation API")
+google_cloud_cpp_add_gapic_library(translate "Cloud Translation API"
+                                   SERVICE_DIRS "__EMPTY__" "v3/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(translate_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/video/CMakeLists.txt
+++ b/google/cloud/video/CMakeLists.txt
@@ -16,11 +16,14 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "livestream/v1/" "stitcher/v1/"
-                                  "transcoder/v1/")
-
-google_cloud_cpp_add_ga_grpc_library(
-    video "A C++ Client Library for several Video Services")
+google_cloud_cpp_add_gapic_library(
+    video
+    "A C++ Client Library for several Video Services"
+    SERVICE_DIRS
+    "__EMPTY__"
+    "livestream/v1/"
+    "stitcher/v1/"
+    "transcoder/v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(video_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/video/CMakeLists.txt
+++ b/google/cloud/video/CMakeLists.txt
@@ -17,13 +17,8 @@
 include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(
-    video
-    "A C++ Client Library for several Video Services"
-    SERVICE_DIRS
-    "__EMPTY__"
-    "livestream/v1/"
-    "stitcher/v1/"
-    "transcoder/v1/")
+    video "A C++ Client Library for several Video Services"
+    SERVICE_DIRS "__EMPTY__" "livestream/v1/" "stitcher/v1/" "transcoder/v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(video_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/videointelligence/CMakeLists.txt
+++ b/google/cloud/videointelligence/CMakeLists.txt
@@ -16,10 +16,9 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(videointelligence
-                                     "Cloud Video Intelligence API")
+google_cloud_cpp_add_gapic_library(
+    videointelligence "Cloud Video Intelligence API" SERVICE_DIRS "__EMPTY__"
+    "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(videointelligence_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/videointelligence/CMakeLists.txt
+++ b/google/cloud/videointelligence/CMakeLists.txt
@@ -18,7 +18,7 @@ include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(
     videointelligence "Cloud Video Intelligence API" SERVICE_DIRS "__EMPTY__"
-    "v1/")
+                                                                  "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(videointelligence_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/vision/CMakeLists.txt
+++ b/google/cloud/vision/CMakeLists.txt
@@ -16,8 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-google_cloud_cpp_add_gapic_library(vision "Cloud Vision API" SERVICE_DIRS
-                                   "__EMPTY__" "v1/")
+google_cloud_cpp_add_gapic_library(vision "Cloud Vision API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(vision_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/vision/CMakeLists.txt
+++ b/google/cloud/vision/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(vision "Cloud Vision API")
+google_cloud_cpp_add_gapic_library(vision "Cloud Vision API" SERVICE_DIRS
+                                   "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(vision_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/vmmigration/CMakeLists.txt
+++ b/google/cloud/vmmigration/CMakeLists.txt
@@ -16,8 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-google_cloud_cpp_add_gapic_library(vmmigration "VM Migration API" SERVICE_DIRS
-                                   "__EMPTY__" "v1/")
+google_cloud_cpp_add_gapic_library(vmmigration "VM Migration API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(vmmigration_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/vmmigration/CMakeLists.txt
+++ b/google/cloud/vmmigration/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(vmmigration "VM Migration API")
+google_cloud_cpp_add_gapic_library(vmmigration "VM Migration API" SERVICE_DIRS
+                                   "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(vmmigration_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/vmwareengine/CMakeLists.txt
+++ b/google/cloud/vmwareengine/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(vmwareengine "VMware Engine API")
+google_cloud_cpp_add_gapic_library(vmwareengine "VMware Engine API"
+                                   SERVICE_DIRS "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(vmwareengine_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/vpcaccess/CMakeLists.txt
+++ b/google/cloud/vpcaccess/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(vpcaccess "Serverless VPC Access API")
+google_cloud_cpp_add_gapic_library(vpcaccess "Serverless VPC Access API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(vpcaccess_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/webrisk/CMakeLists.txt
+++ b/google/cloud/webrisk/CMakeLists.txt
@@ -28,8 +28,8 @@ endif ()
 
 include(GoogleCloudCppLibrary)
 
-google_cloud_cpp_add_gapic_library(webrisk "Web Risk API" SERVICE_DIRS
-                                   "__EMPTY__" "v1/")
+google_cloud_cpp_add_gapic_library(webrisk "Web Risk API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(webrisk_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/webrisk/CMakeLists.txt
+++ b/google/cloud/webrisk/CMakeLists.txt
@@ -28,9 +28,8 @@ endif ()
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(webrisk "Web Risk API")
+google_cloud_cpp_add_gapic_library(webrisk "Web Risk API" SERVICE_DIRS
+                                   "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(webrisk_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/websecurityscanner/CMakeLists.txt
+++ b/google/cloud/websecurityscanner/CMakeLists.txt
@@ -16,10 +16,9 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(websecurityscanner
-                                     "Web Security Scanner API")
+google_cloud_cpp_add_gapic_library(
+    websecurityscanner "Web Security Scanner API" SERVICE_DIRS "__EMPTY__"
+    "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(websecurityscanner_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/websecurityscanner/CMakeLists.txt
+++ b/google/cloud/websecurityscanner/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-google_cloud_cpp_add_gapic_library(
-    websecurityscanner "Web Security Scanner API" SERVICE_DIRS "__EMPTY__"
-    "v1/")
+google_cloud_cpp_add_gapic_library(websecurityscanner "Web Security Scanner API"
+                                   SERVICE_DIRS "__EMPTY__" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(websecurityscanner_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/workflows/CMakeLists.txt
+++ b/google/cloud/workflows/CMakeLists.txt
@@ -16,9 +16,9 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "" "executions/v1/" "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(workflows "Workflow Executions API")
+google_cloud_cpp_add_gapic_library(
+    workflows "Workflow Executions API" SERVICE_DIRS "__EMPTY__"
+    "executions/v1/" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(workflows_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/workflows/CMakeLists.txt
+++ b/google/cloud/workflows/CMakeLists.txt
@@ -18,7 +18,7 @@ include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(
     workflows "Workflow Executions API" SERVICE_DIRS "__EMPTY__"
-    "executions/v1/" "v1/")
+                                                     "executions/v1/" "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(workflows_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/workstations/CMakeLists.txt
+++ b/google/cloud/workstations/CMakeLists.txt
@@ -16,9 +16,8 @@
 
 include(GoogleCloudCppLibrary)
 
-set(GOOGLE_CLOUD_CPP_SERVICE_DIRS "v1/")
-
-google_cloud_cpp_add_ga_grpc_library(workstations "Cloud Workstations API")
+google_cloud_cpp_add_gapic_library(workstations "Cloud Workstations API"
+                                   SERVICE_DIRS "v1/")
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(workstations_quickstart "quickstart/quickstart.cc")


### PR DESCRIPTION
Fixes #12467 

Also renames `ga_grpc` -> `gapic`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13247)
<!-- Reviewable:end -->
