### PR TITLE
cleanup(GCS+gRPC): `ReadPayload` for range downloads

### DIFF
--- a/google/cloud/storage/async/client.h
+++ b/google/cloud/storage/async/client.h
@@ -216,11 +216,11 @@ class AsyncClient {
    * This is a read-only operation and is always idempotent.
    */
   template <typename... Args>
-  future<AsyncReadObjectRangeResponse> ReadObjectRange(std::string bucket_name,
-                                                       std::string object_name,
-                                                       std::int64_t offset,
-                                                       std::int64_t limit,
-                                                       Args&&... args) {
+  future<StatusOr<ReadPayload>> ReadObjectRange(std::string bucket_name,
+                                                std::string object_name,
+                                                std::int64_t offset,
+                                                std::int64_t limit,
+                                                Args&&... args) {
     struct HasReadRange
         : public absl::disjunction<
               std::is_same<storage::ReadRange, std::decay_t<Args>>...> {};

--- a/google/cloud/storage/async/connection.h
+++ b/google/cloud/storage/async/connection.h
@@ -90,7 +90,7 @@ class AsyncConnection {
   AsyncReadObject(ReadObjectParams p) = 0;
 
   /// Read a range from an object returning all the contents.
-  virtual future<AsyncReadObjectRangeResponse> AsyncReadObjectRange(
+  virtual future<StatusOr<ReadPayload>> AsyncReadObjectRange(
       ReadObjectParams p) = 0;
 
   /**

--- a/google/cloud/storage/async/object_responses.h
+++ b/google/cloud/storage/async/object_responses.h
@@ -32,49 +32,8 @@ namespace cloud {
 namespace storage_experimental {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-/// Represents the response from reading a subset of an object.
-struct AsyncReadObjectRangeResponse {
-  /**
-   * The final status of the download.
-   *
-   * Downloads can have partial failures, where only a subset of the data is
-   * successfully downloaded, and then the connection is interrupted. With the
-   * default configuration, the client library resumes the download. If,
-   * however, the `storage::RetryPolicy` is exhausted, only the partial results
-   * are returned, and the last error status is returned here.
-   */
-  Status status;
-
-  /// If available, the full object metadata.
-  absl::optional<storage::ObjectMetadata> object_metadata;
-
-  /**
-   * The object contents.
-   *
-   * The library receives the object contents as a sequence of `std::string`.
-   * To avoid copies the library returns the sequence to the application. If
-   * you need to consolidate the contents use something like:
-   *
-   * @code
-   * AsyncReadObjectRangeResponse response = ...;
-   * auto all = std::accumulate(
-   *     response.contents.begin(), response.contents.end(), std::string{},
-   *     [](auto a, auto b) { a += b; return a; });
-   * @endcode
-   */
-  std::vector<std::string> contents;
-
-  /**
-   * Per-request metadata and annotations.
-   *
-   * These are intended as debugging tools. They are subject to change without
-   * notice.
-   */
-  std::multimap<std::string, std::string> request_metadata;
-};
-
 /**
- * A partial response to a streaming download.
+ * A partial or full response to an asynchronous download.
  */
 class ReadPayload {
  public:

--- a/google/cloud/storage/examples/storage_async_samples.cc
+++ b/google/cloud/storage/examples/storage_async_samples.cc
@@ -317,13 +317,13 @@ void AutoRun(std::vector<std::string> const& argv) {
 
   std::cout << "Retrieving object metadata" << std::endl;
   auto response = client.ReadObjectRange(bucket_name, object_name, 0, 1).get();
-  if (!response.status.ok()) throw std::move(response.status);
+  if (!response.ok()) throw std::move(response).status();
 
-  if (!response.object_metadata.has_value()) {
+  auto const metadata = response->metadata();
+  if (!metadata.has_value()) {
     std::cout << "Running the ReadObjectWithOptions() example" << std::endl;
-    ReadObjectWithOptions(
-        client, {bucket_name, object_name,
-                 std::to_string(response.object_metadata->generation())});
+    ReadObjectWithOptions(client, {bucket_name, object_name,
+                                   std::to_string(metadata->generation())});
   }
 
   std::cout << "Running DeleteObject() example" << std::endl;

--- a/google/cloud/storage/internal/async/accumulate_read_object.h
+++ b/google/cloud/storage/internal/async/accumulate_read_object.h
@@ -172,7 +172,7 @@ future<AsyncAccumulateReadObjectResult> AsyncAccumulateReadObjectFull(
     google::storage::v2::ReadObjectRequest request, Options const& options);
 
 /// Convert the proto into a representation more familiar to our customers.
-storage_experimental::AsyncReadObjectRangeResponse ToResponse(
+StatusOr<storage_experimental::ReadPayload> ToResponse(
     AsyncAccumulateReadObjectResult accumulated, Options const& options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/async/accumulate_read_object_test.cc
+++ b/google/cloud/storage/internal/async/accumulate_read_object_test.cc
@@ -21,6 +21,7 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
+#include <numeric>
 
 namespace google {
 namespace cloud {
@@ -509,9 +510,13 @@ TEST(AsyncAccumulateReadObjectTest, ToResponse) {
       ToResponse(accumulated, Options{}.set<storage::RestEndpointOption>(
                                   "https://storage.googleapis.com"));
   ASSERT_STATUS_OK(actual);
-  EXPECT_THAT(actual->contents(),
-              ElementsAre("The quick brown fox jumps over the lazy dog",
-                          "How vexingly quick daft zebras jump!"));
+  auto const contents = actual->contents();
+  auto const merged =
+      std::accumulate(contents.begin(), contents.end(), std::string{},
+                      [](auto a, auto b) { return a + std::string(b); });
+  EXPECT_EQ(merged,
+            "The quick brown fox jumps over the lazy dog"
+            "How vexingly quick daft zebras jump!");
   EXPECT_THAT(actual->headers(),
               UnorderedElementsAre(Pair("key", "v0"), Pair("key", "v1"),
                                    Pair("tk", "v0"), Pair("tk", "v1")));

--- a/google/cloud/storage/internal/async/connection_impl.cc
+++ b/google/cloud/storage/internal/async/connection_impl.cc
@@ -159,13 +159,12 @@ AsyncConnectionImpl::AsyncReadObject(ReadObjectParams p) {
       .then(std::move(transform));
 }
 
-future<storage_experimental::AsyncReadObjectRangeResponse>
+future<StatusOr<storage_experimental::ReadPayload>>
 AsyncConnectionImpl::AsyncReadObjectRange(ReadObjectParams p) {
   auto proto = ToProto(p.request.impl_);
   if (!proto) {
-    auto response = storage_experimental::AsyncReadObjectRangeResponse{};
-    response.status = std::move(proto).status();
-    return make_ready_future(std::move(response));
+    return make_ready_future(
+        StatusOr<storage_experimental::ReadPayload>(std::move(proto).status()));
   }
 
   auto const current = internal::MakeImmutableOptions(std::move(p.options));

--- a/google/cloud/storage/internal/async/connection_impl.h
+++ b/google/cloud/storage/internal/async/connection_impl.h
@@ -60,8 +60,8 @@ class AsyncConnectionImpl
   future<StatusOr<std::unique_ptr<storage_experimental::AsyncReaderConnection>>>
   AsyncReadObject(ReadObjectParams p) override;
 
-  future<storage_experimental::AsyncReadObjectRangeResponse>
-  AsyncReadObjectRange(ReadObjectParams p) override;
+  future<StatusOr<storage_experimental::ReadPayload>> AsyncReadObjectRange(
+      ReadObjectParams p) override;
 
   future<StatusOr<std::unique_ptr<storage_experimental::AsyncWriterConnection>>>
   AsyncWriteObject(WriteObjectParams p) override;

--- a/google/cloud/storage/internal/async/connection_tracing.cc
+++ b/google/cloud/storage/internal/async/connection_tracing.cc
@@ -62,8 +62,8 @@ class AsyncConnectionTracing : public storage_experimental::AsyncConnection {
     return impl_->AsyncReadObject(std::move(p)).then(std::move(wrap));
   }
 
-  future<storage_experimental::AsyncReadObjectRangeResponse>
-  AsyncReadObjectRange(ReadObjectParams p) override {
+  future<StatusOr<storage_experimental::ReadPayload>> AsyncReadObjectRange(
+      ReadObjectParams p) override {
     auto span =
         internal::MakeSpan("storage::AsyncConnection::AsyncReadObjectRange");
     internal::OTelScope scope(span);
@@ -72,8 +72,7 @@ class AsyncConnectionTracing : public storage_experimental::AsyncConnection {
                span = std::move(span)](auto f) {
           auto result = f.get();
           internal::DetachOTelContext(oc);
-          internal::EndSpan(*span, result.status);
-          return result;
+          return internal::EndSpan(*span, std::move(result));
         });
   }
 

--- a/google/cloud/storage/internal/async/connection_tracing_test.cc
+++ b/google/cloud/storage/internal/async/connection_tracing_test.cc
@@ -170,7 +170,7 @@ TEST(ConnectionTracing, AsyncReadObjectSuccess) {
 
 TEST(ConnectionTracing, AsyncReadObjectRange) {
   auto span_catcher = InstallSpanCatcher();
-  PromiseWithOTelContext<storage_experimental::AsyncReadObjectRangeResponse> p;
+  PromiseWithOTelContext<StatusOr<storage_experimental::ReadPayload>> p;
 
   auto mock = std::make_unique<MockAsyncConnection>();
   EXPECT_CALL(*mock, options).WillOnce(Return(TracingEnabled()));
@@ -179,8 +179,8 @@ TEST(ConnectionTracing, AsyncReadObjectRange) {
   auto result =
       actual->AsyncReadObjectRange(AsyncConnection::ReadObjectParams{})
           .then(expect_no_context);
-  p.set_value(storage_experimental::AsyncReadObjectRangeResponse{});
-  ASSERT_STATUS_OK(result.get().status);
+  p.set_value(storage_experimental::ReadPayload{});
+  ASSERT_STATUS_OK(result.get());
 
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(spans,

--- a/google/cloud/storage/mocks/mock_async_connection.h
+++ b/google/cloud/storage/mocks/mock_async_connection.h
@@ -38,7 +38,7 @@ class MockAsyncConnection : public storage_experimental::AsyncConnection {
       future<StatusOr<
           std::unique_ptr<storage_experimental::AsyncReaderConnection>>>,
       AsyncReadObject, (ReadObjectParams), (override));
-  MOCK_METHOD(future<storage_experimental::AsyncReadObjectRangeResponse>,
+  MOCK_METHOD(future<StatusOr<storage_experimental::ReadPayload>>,
               AsyncReadObjectRange, (ReadObjectParams), (override));
   MOCK_METHOD(
       future<StatusOr<

--- a/google/cloud/storage/tests/async_client_integration_test.cc
+++ b/google/cloud/storage/tests/async_client_integration_test.cc
@@ -34,6 +34,7 @@ using ::google::cloud::testing_util::StatusIs;
 using ::testing::IsEmpty;
 using ::testing::Le;
 using ::testing::Not;
+using ::testing::Optional;
 using ::testing::VariantWith;
 
 class AsyncClientIntegrationTest
@@ -73,9 +74,13 @@ TEST_F(AsyncClientIntegrationTest, ObjectCRUD) {
 
   for (auto* p : {&pending1, &pending0}) {
     auto response = p->get();
-    EXPECT_STATUS_OK(response.status);
-    auto const full = std::accumulate(response.contents.begin(),
-                                      response.contents.end(), std::string{});
+    ASSERT_STATUS_OK(response);
+    auto contents = response->contents();
+    auto const full = std::accumulate(contents.begin(), contents.end(),
+                                      std::string{}, [](auto a, auto b) {
+                                        a += std::string(b);
+                                        return a;
+                                      });
     EXPECT_EQ(full, LoremIpsum());
   }
   auto status = async
@@ -123,12 +128,15 @@ TEST_F(AsyncClientIntegrationTest, ComposeObject) {
                   .ReadObjectRange(bucket_name(), destination, 0,
                                    2 * LoremIpsum().size())
                   .get();
-  ASSERT_STATUS_OK(read.status);
-  auto const full_contents = std::accumulate(
-      read.contents.begin(), read.contents.end(), std::string{});
+  ASSERT_STATUS_OK(read);
+  auto contents = read->contents();
+  auto const full_contents = std::accumulate(contents.begin(), contents.end(),
+                                             std::string{}, [](auto a, auto b) {
+                                               a += std::string(b);
+                                               return a;
+                                             });
   EXPECT_EQ(full_contents, LoremIpsum() + LoremIpsum());
-  ASSERT_TRUE(read.object_metadata.has_value());
-  EXPECT_EQ(*read.object_metadata, *composed);
+  EXPECT_THAT(read->metadata(), Optional(*composed));
 }
 
 TEST_F(AsyncClientIntegrationTest, StreamingRead) {


### PR DESCRIPTION
Use the same class for streaming downloads and range downloads. Fewer classes for us to explain, and fewer classes for customers to learn.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13252)
<!-- Reviewable:end -->
