### PR TITLE
impl: fully qualify default hostname for EndpointOption

### DIFF
--- a/generator/integration_tests/tests/golden_kitchen_sink_option_defaults_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_option_defaults_test.cc
@@ -36,7 +36,7 @@ TEST(GoldenKitchenSinkDefaultOptions, DefaultEndpoint) {
   auto env = ScopedEnvironment("GOLDEN_KITCHEN_SINK_ENDPOINT", absl::nullopt);
   Options options;
   auto updated_options = GoldenKitchenSinkDefaultOptions(options);
-  EXPECT_EQ("goldenkitchensink.googleapis.com",
+  EXPECT_EQ("goldenkitchensink.googleapis.com.",
             updated_options.get<EndpointOption>());
 }
 

--- a/generator/integration_tests/tests/golden_thing_admin_option_defaults_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_option_defaults_test.cc
@@ -34,7 +34,7 @@ using ::google::cloud::testing_util::ScopedEnvironment;
 TEST(GoldenThingAdminDefaultOptions, DefaultEndpoint) {
   Options options;
   auto updated_options = GoldenThingAdminDefaultOptions(options);
-  EXPECT_EQ("test.googleapis.com", updated_options.get<EndpointOption>());
+  EXPECT_EQ("test.googleapis.com.", updated_options.get<EndpointOption>());
 }
 
 TEST(GoldenThingAdminDefaultOptions, EnvVarEndpoint) {

--- a/generator/integration_tests/tests/universe_domain_test.cc
+++ b/generator/integration_tests/tests/universe_domain_test.cc
@@ -29,7 +29,7 @@ using ::testing::Eq;
 TEST(GeneratorUniverseDomainTest, ConnectionEndpointOptionUnset) {
   auto connection = MakeGoldenThingAdminConnection();
   EXPECT_THAT(connection->options().get<EndpointOption>(),
-              Eq("test.googleapis.com"));
+              Eq("test.googleapis.com."));
 }
 
 TEST(GeneratorUniverseDomainTest, ConnectionEndpointOptionEmpty) {
@@ -49,7 +49,7 @@ TEST(GeneratorUniverseDomainTest, ConnectionEndpointEnvVarEmpty) {
   ScopedEnvironment endpoint_var("GOLDEN_KITCHEN_SINK_ENDPOINT", "");
   auto connection = MakeGoldenThingAdminConnection();
   EXPECT_THAT(connection->options().get<EndpointOption>(),
-              Eq("test.googleapis.com"));
+              Eq("test.googleapis.com."));
 }
 
 TEST(GeneratorUniverseDomainTest, ConnectionEndpointEnvVarNonEmpty) {

--- a/google/cloud/bigquery/v2/minimal/internal/dataset_options_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset_options_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/bigquery/v2/minimal/internal/dataset_options.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 
@@ -33,7 +34,7 @@ TEST(DatasetOptionstTest, DefaultOptions) {
   auto const* default_endpoint = "bigquery.googleapis.com";
 
   EXPECT_TRUE(actual.has<EndpointOption>());
-  EXPECT_EQ(actual.get<EndpointOption>(), default_endpoint);
+  EXPECT_EQ(actual.get<EndpointOption>(), absl::StrCat(default_endpoint, "."));
 
   EXPECT_TRUE(actual.has<AuthorityOption>());
   EXPECT_EQ(actual.get<AuthorityOption>(), default_endpoint);

--- a/google/cloud/bigquery/v2/minimal/internal/job_options_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_options_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/bigquery/v2/minimal/internal/job_options.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 
@@ -33,7 +34,7 @@ TEST(JobOptionstTest, DefaultOptions) {
   auto const* default_endpoint = "bigquery.googleapis.com";
 
   EXPECT_TRUE(actual.has<EndpointOption>());
-  EXPECT_EQ(actual.get<EndpointOption>(), default_endpoint);
+  EXPECT_EQ(actual.get<EndpointOption>(), absl::StrCat(default_endpoint, "."));
 
   EXPECT_TRUE(actual.has<AuthorityOption>());
   EXPECT_EQ(actual.get<AuthorityOption>(), default_endpoint);

--- a/google/cloud/bigquery/v2/minimal/internal/project_options_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/project_options_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/bigquery/v2/minimal/internal/project_options.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 
@@ -33,7 +34,7 @@ TEST(ProjectOptionsTest, DefaultOptions) {
   auto const* default_endpoint = "bigquery.googleapis.com";
 
   EXPECT_TRUE(actual.has<EndpointOption>());
-  EXPECT_EQ(actual.get<EndpointOption>(), default_endpoint);
+  EXPECT_EQ(actual.get<EndpointOption>(), absl::StrCat(default_endpoint, "."));
 
   EXPECT_TRUE(actual.has<AuthorityOption>());
   EXPECT_EQ(actual.get<AuthorityOption>(), default_endpoint);

--- a/google/cloud/bigquery/v2/minimal/internal/table_options_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/table_options_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/bigquery/v2/minimal/internal/table_options.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 
@@ -33,7 +34,7 @@ TEST(TableOptionsTest, DefaultOptions) {
   auto const* default_endpoint = "bigquery.googleapis.com";
 
   EXPECT_TRUE(actual.has<EndpointOption>());
-  EXPECT_EQ(actual.get<EndpointOption>(), default_endpoint);
+  EXPECT_EQ(actual.get<EndpointOption>(), absl::StrCat(default_endpoint, "."));
 
   EXPECT_TRUE(actual.has<AuthorityOption>());
   EXPECT_EQ(actual.get<AuthorityOption>(), default_endpoint);

--- a/google/cloud/internal/populate_common_options_test.cc
+++ b/google/cloud/internal/populate_common_options_test.cc
@@ -38,7 +38,7 @@ TEST(PopulateCommonOptions, Simple) {
   ScopedEnvironment tracing("GOOGLE_CLOUD_CPP_ENABLE_TRACING", absl::nullopt);
   auto actual = PopulateCommonOptions(Options{}, {}, {}, {}, "default");
   EXPECT_TRUE(actual.has<EndpointOption>());
-  EXPECT_THAT(actual.get<EndpointOption>(), Eq("default"));
+  EXPECT_THAT(actual.get<EndpointOption>(), Eq("default."));
   EXPECT_TRUE(actual.has<AuthorityOption>());
   EXPECT_THAT(actual.get<AuthorityOption>(), Eq("default"));
   EXPECT_FALSE(actual.has<UserProjectOption>());
@@ -61,7 +61,7 @@ TEST(PopulateCommonOptions, EmptyEndpointEnvVar) {
   auto actual = PopulateCommonOptions(
       Options{}, "GOOGLE_CLOUD_CPP_SERVICE_ENDPOINT", {}, {}, "default");
   EXPECT_TRUE(actual.has<EndpointOption>());
-  EXPECT_THAT(actual.get<EndpointOption>(), Eq("default"));
+  EXPECT_THAT(actual.get<EndpointOption>(), Eq("default."));
 }
 
 TEST(PopulateCommonOptions, EmptyEmulatorEnvVar) {
@@ -69,7 +69,7 @@ TEST(PopulateCommonOptions, EmptyEmulatorEnvVar) {
   auto actual = PopulateCommonOptions(
       Options{}, {}, "GOOGLE_CLOUD_CPP_EMULATOR_ENDPOINT", {}, "default");
   EXPECT_TRUE(actual.has<EndpointOption>());
-  EXPECT_THAT(actual.get<EndpointOption>(), Eq("default"));
+  EXPECT_THAT(actual.get<EndpointOption>(), Eq("default."));
 }
 
 // TODO(#13191): Simplify into multiple tests.
@@ -106,7 +106,7 @@ TEST(PopulateCommonOptions, EndpointAuthority) {
           } else if (options.has<EndpointOption>()) {
             EXPECT_THAT(actual_endpoint, Eq(options.get<EndpointOption>()));
           } else {
-            EXPECT_THAT(actual_endpoint, Eq("default"));
+            EXPECT_THAT(actual_endpoint, Eq("default."));
           }
 
           ASSERT_TRUE(actual.has<AuthorityOption>());

--- a/google/cloud/pubsub/internal/defaults_test.cc
+++ b/google/cloud/pubsub/internal/defaults_test.cc
@@ -60,7 +60,7 @@ TEST(OptionsTest, UnsetEmulatorEnv) {
 
 TEST(OptionsTest, CommonDefaults) {
   auto opts = DefaultCommonOptions(Options{});
-  EXPECT_EQ("pubsub.googleapis.com", opts.get<EndpointOption>());
+  EXPECT_EQ("pubsub.googleapis.com.", opts.get<EndpointOption>());
   EXPECT_EQ(typeid(grpc::GoogleDefaultCredentials()),
             typeid(opts.get<GrpcCredentialOption>()));
   EXPECT_EQ(static_cast<int>(DefaultThreadCount()),

--- a/google/cloud/spanner/internal/defaults_test.cc
+++ b/google/cloud/spanner/internal/defaults_test.cc
@@ -59,7 +59,7 @@ TEST(Options, Defaults) {
       "GOOGLE_CLOUD_CPP_SPANNER_ROUTE_TO_LEADER", absl::nullopt);
   auto opts = spanner_internal::DefaultOptions();
 
-  EXPECT_EQ(opts.get<EndpointOption>(), "spanner.googleapis.com");
+  EXPECT_EQ(opts.get<EndpointOption>(), "spanner.googleapis.com.");
   EXPECT_EQ(opts.get<AuthorityOption>(), "spanner.googleapis.com");
   // In Google's testing environment `expected` can be `nullptr`, we just want
   // to verify that both are `nullptr` or neither is `nullptr`.
@@ -103,7 +103,7 @@ TEST(Options, AdminDefaults) {
       "GOOGLE_CLOUD_CPP_USER_PROJECT", absl::nullopt);
   auto opts = spanner_internal::DefaultAdminOptions();
 
-  EXPECT_EQ(opts.get<EndpointOption>(), "spanner.googleapis.com");
+  EXPECT_EQ(opts.get<EndpointOption>(), "spanner.googleapis.com.");
   EXPECT_EQ(opts.get<AuthorityOption>(), "spanner.googleapis.com");
   // In Google's testing environment `expected` can be `nullptr`, we just want
   // to verify that both are `nullptr` or neither is `nullptr`.


### PR DESCRIPTION
As part of implementing `DetermineServiceEndpoint`, it was suggested that default hostnames should be fully qualified. In order to ease the transition of moving defaulting `EndpointOption` from `PopulateCommonOptions` to `DetermineServiecEndpoint`, this PR adds full qualification to `PopulateCommonOptions`.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13254)
<!-- Reviewable:end -->
