### PR TITLE
refactor(pubsub): modify attributes according to otel spec

### DIFF
--- a/google/cloud/pubsub/internal/publisher_tracing_connection.cc
+++ b/google/cloud/pubsub/internal/publisher_tracing_connection.cc
@@ -50,7 +50,6 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> StartPublishSpan(
   auto span = internal::MakeSpan(
       topic.topic_id() + " create",
       {{sc::kMessagingSystem, "gcp_pubsub"},
-       {sc::kMessagingDestinationName, topic.topic_id()},
        {sc::kMessagingDestinationTemplate, topic.FullName()},
        {sc::kMessagingOperation, "create"},
        {/*sc::kMessagingMessageEnvelopeSize=*/"messaging.message.envelope.size",

--- a/google/cloud/pubsub/internal/publisher_tracing_connection_test.cc
+++ b/google/cloud/pubsub/internal/publisher_tracing_connection_test.cc
@@ -85,8 +85,6 @@ TEST(PublisherTracingConnectionTest, PublishSpanOnSuccess) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
           SpanHasAttributes(
               OTelAttribute<std::string>(sc::kMessagingSystem, "gcp_pubsub"),
-              OTelAttribute<std::string>(sc::kMessagingDestinationName,
-                                         "test-topic"),
               OTelAttribute<std::string>(
                   sc::kMessagingDestinationTemplate,
                   "projects/test-project/topics/test-topic"),
@@ -133,8 +131,6 @@ TEST(PublisherTracingConnectionTest, PublishSpanOnError) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError),
           SpanHasAttributes(
               OTelAttribute<std::string>(sc::kMessagingSystem, "gcp_pubsub"),
-              OTelAttribute<std::string>(sc::kMessagingDestinationName,
-                                         "test-topic"),
               OTelAttribute<std::string>(
                   sc::kMessagingDestinationTemplate,
                   "projects/test-project/topics/test-topic"),

--- a/google/cloud/pubsub/internal/tracing_batch_sink_test.cc
+++ b/google/cloud/pubsub/internal/tracing_batch_sink_test.cc
@@ -44,7 +44,6 @@ using ::google::cloud::testing_util::SpanHasAttributes;
 using ::google::cloud::testing_util::SpanHasEvents;
 using ::google::cloud::testing_util::SpanHasInstrumentationScope;
 using ::google::cloud::testing_util::SpanKindIsClient;
-using ::google::cloud::testing_util::SpanLinkAttributesAre;
 using ::google::cloud::testing_util::SpanLinksSizeIs;
 using ::google::cloud::testing_util::SpanNamed;
 using ::google::cloud::testing_util::ThereIsAnActiveSpan;

--- a/google/cloud/pubsub/internal/tracing_batch_sink_test.cc
+++ b/google/cloud/pubsub/internal/tracing_batch_sink_test.cc
@@ -44,7 +44,6 @@ using ::google::cloud::testing_util::SpanHasAttributes;
 using ::google::cloud::testing_util::SpanHasEvents;
 using ::google::cloud::testing_util::SpanHasInstrumentationScope;
 using ::google::cloud::testing_util::SpanKindIsClient;
-using ::google::cloud::testing_util::SpanKindIsProducer;
 using ::google::cloud::testing_util::SpanLinkAttributesAre;
 using ::google::cloud::testing_util::SpanLinksSizeIs;
 using ::google::cloud::testing_util::SpanNamed;
@@ -167,16 +166,13 @@ TEST(TracingBatchSink, AsyncPublish) {
   EXPECT_THAT(response, IsOk());
 
   auto spans = span_catcher->GetSpans();
-  EXPECT_THAT(
-      spans,
-      Contains(AllOf(
-          SpanHasInstrumentationScope(), SpanKindIsProducer(),
-          SpanNamed("test-topic publish"),
-          SpanHasAttributes(
-              OTelAttribute<std::int64_t>(sc::kMessagingBatchMessageCount, 1)),
-          SpanHasLinks(AllOf(LinkHasSpanContext(message_span->GetContext()),
-                             SpanLinkAttributesAre(OTelAttribute<int64_t>(
-                                 "messaging.gcp_pubsub.message.link", 0)))))));
+  EXPECT_THAT(spans,
+              Contains(AllOf(SpanHasInstrumentationScope(), SpanKindIsClient(),
+                             SpanNamed("test-topic publish"),
+                             SpanHasAttributes(OTelAttribute<std::int64_t>(
+                                 sc::kMessagingBatchMessageCount, 1)),
+                             SpanHasLinks(AllOf(LinkHasSpanContext(
+                                 message_span->GetContext()))))));
 }
 
 TEST(TracingBatchSink, PublishSpanHasAttributes) {
@@ -210,6 +206,15 @@ TEST(TracingBatchSink, PublishSpanHasAttributes) {
               Contains(AllOf(SpanNamed("test-topic publish"),
                              SpanHasAttributes(OTelAttribute<std::string>(
                                  sc::kMessagingOperation, "publish")))));
+  EXPECT_THAT(spans,
+              Contains(AllOf(SpanNamed("test-topic publish"),
+                             SpanHasAttributes(OTelAttribute<std::string>(
+                                 sc::kMessagingSystem, "gcp_pubsub")))));
+  EXPECT_THAT(spans,
+              Contains(AllOf(SpanNamed("test-topic publish"),
+                             SpanHasAttributes(OTelAttribute<std::string>(
+                                 sc::kMessagingDestinationTemplate,
+                                 TestTopic().FullName())))));
 }
 
 TEST(TracingBatchSink, AsyncPublishOnlyIncludeSampledLink) {
@@ -233,16 +238,13 @@ TEST(TracingBatchSink, AsyncPublishOnlyIncludeSampledLink) {
   EXPECT_THAT(response, IsOk());
 
   auto spans = span_catcher->GetSpans();
-  EXPECT_THAT(
-      spans,
-      Contains(AllOf(
-          SpanHasInstrumentationScope(), SpanKindIsProducer(),
-          SpanNamed("test-topic publish"),
-          SpanHasAttributes(
-              OTelAttribute<std::int64_t>(sc::kMessagingBatchMessageCount, 2)),
-          SpanLinksAre(AllOf(LinkHasSpanContext(message_span->GetContext()),
-                             SpanLinkAttributesAre(OTelAttribute<int64_t>(
-                                 "messaging.gcp_pubsub.message.link", 0)))))));
+  EXPECT_THAT(spans,
+              Contains(AllOf(SpanHasInstrumentationScope(), SpanKindIsClient(),
+                             SpanNamed("test-topic publish"),
+                             SpanHasAttributes(OTelAttribute<std::int64_t>(
+                                 sc::kMessagingBatchMessageCount, 2)),
+                             SpanLinksAre(AllOf(LinkHasSpanContext(
+                                 message_span->GetContext()))))));
 }
 
 TEST(TracingBatchSink, AsyncPublishSmallBatch) {
@@ -267,16 +269,12 @@ TEST(TracingBatchSink, AsyncPublishSmallBatch) {
   EXPECT_THAT(
       spans,
       Contains(AllOf(
-          SpanHasInstrumentationScope(), SpanKindIsProducer(),
+          SpanHasInstrumentationScope(), SpanKindIsClient(),
           SpanNamed("test-topic publish"),
           SpanHasAttributes(
               OTelAttribute<std::int64_t>(sc::kMessagingBatchMessageCount, 2)),
-          SpanHasLinks(AllOf(LinkHasSpanContext(message_span1->GetContext()),
-                             SpanLinkAttributesAre(OTelAttribute<int64_t>(
-                                 "messaging.gcp_pubsub.message.link", 0))),
-                       AllOf(LinkHasSpanContext(message_span2->GetContext()),
-                             SpanLinkAttributesAre(OTelAttribute<int64_t>(
-                                 "messaging.gcp_pubsub.message.link", 1)))))));
+          SpanHasLinks(LinkHasSpanContext(message_span1->GetContext()),
+                       LinkHasSpanContext(message_span2->GetContext())))));
 }
 
 TEST(TracingBatchSink, AsyncPublishBatchWithOtelLimit) {
@@ -297,7 +295,7 @@ TEST(TracingBatchSink, AsyncPublishBatchWithOtelLimit) {
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(
       spans,
-      Contains(AllOf(SpanHasInstrumentationScope(), SpanKindIsProducer(),
+      Contains(AllOf(SpanHasInstrumentationScope(), SpanKindIsClient(),
                      SpanNamed("test-topic publish"),
                      SpanHasAttributes(OTelAttribute<std::int64_t>(
                          sc::kMessagingBatchMessageCount, kDefaultMaxLinks)),
@@ -354,7 +352,7 @@ TEST(TracingBatchSink, AsyncPublishBatchWithCustomLimit) {
 
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(spans, Contains(AllOf(
-                         SpanHasInstrumentationScope(), SpanKindIsProducer(),
+                         SpanHasInstrumentationScope(), SpanKindIsClient(),
                          SpanNamed("test-topic publish"),
                          SpanHasAttributes(OTelAttribute<std::int64_t>(
                              sc::kMessagingBatchMessageCount, kBatchSize)))));
@@ -446,16 +444,13 @@ TEST(TracingBatchSink, Scope) {
   EXPECT_THAT(response, IsOk());
 
   auto spans = span_catcher->GetSpans();
-  EXPECT_THAT(
-      spans,
-      Contains(AllOf(
-          SpanHasInstrumentationScope(), SpanKindIsProducer(),
-          SpanNamed("test-topic publish"),
-          SpanHasAttributes(
-              OTelAttribute<std::int64_t>(sc::kMessagingBatchMessageCount, 1)),
-          SpanHasLinks(AllOf(LinkHasSpanContext(message_span->GetContext()),
-                             SpanLinkAttributesAre(OTelAttribute<int64_t>(
-                                 "messaging.gcp_pubsub.message.link", 0)))))));
+  EXPECT_THAT(spans,
+              Contains(AllOf(SpanHasInstrumentationScope(), SpanKindIsClient(),
+                             SpanNamed("test-topic publish"),
+                             SpanHasAttributes(OTelAttribute<std::int64_t>(
+                                 sc::kMessagingBatchMessageCount, 1)),
+                             SpanHasLinks(AllOf(LinkHasSpanContext(
+                                 message_span->GetContext()))))));
 }
 
 TEST(TracingBatchSink, ResumePublish) {


### PR DESCRIPTION
Changes in https://github.com/open-telemetry/semantic-conventions/pull/545

- Fixes for the publisher
Publish span
- Remove the link # attribute
- Add a full name topic attribute
- Add a gcp_pubsub attribute
- Change publish to client not producer
Create span
- Remove topic attribute

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13263)
<!-- Reviewable:end -->
