### PR TITLE
refactor: always exchange metadata in test helper

### DIFF
--- a/google/cloud/testing_util/validate_metadata.h
+++ b/google/cloud/testing_util/validate_metadata.h
@@ -68,7 +68,7 @@ class ValidateMetadataFixture {
    *   cannot reuse @p context for other RPCs or other calls to this function.
    */
   std::multimap<std::string, std::string> GetMetadata(
-      grpc::ClientContext& context);
+      grpc::ClientContext& client_context);
 
   /**
    * Set server metadata on a `ClientContext`.
@@ -76,7 +76,7 @@ class ValidateMetadataFixture {
    * @note A `grpc::ClientContext` can be used in only one gRPC. The caller
    *   cannot reuse @p context for other RPCs or other calls to this function.
    */
-  void SetServerMetadata(grpc::ClientContext& context,
+  void SetServerMetadata(grpc::ClientContext& client_context,
                          RpcMetadata const& server_metadata = {});
 
   /**
@@ -105,6 +105,13 @@ class ValidateMetadataFixture {
       absl::optional<std::string> const& resource_prefix_header = {});
 
  private:
+  /**
+   * Performs a fake call, leaving the client's metadata accessible from the
+   * server context, and vice versa.
+   */
+  void ExchangeMetadata(grpc::ClientContext& client_context,
+                        grpc::GenericServerContext& server_context);
+
   grpc::CompletionQueue cli_cq_;
   grpc::AsyncGenericService generic_service_;
   std::unique_ptr<grpc::ServerCompletionQueue> srv_cq_;


### PR DESCRIPTION
Part of the work for #13275 

Apologies for the churn. This is what #13276 should have looked like. I hadn't prepared the next PR when I sent that for review.

I have since learned that it is convenient for `GetMetadata()` to leave the `grpc::ClientContext` in a state where calling `GetServerInitialMetadata()` does not crash our tests. Now we complete the call, instead of cutting and running the second we get our hands on the metadata.

This also reduces some duplication, which is good, and damning of #13276

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13277)
<!-- Reviewable:end -->
