### PR TITLE
feat(otel): capture gRPC response metadata in traces

### DIFF
--- a/generator/integration_tests/tests/golden_kitchen_sink_tracing_stub_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_tracing_stub_test.cc
@@ -467,8 +467,10 @@ TEST(MakeGoldenKitchenSinkTracingStub, OpenTelemetry) {
   auto span_catcher = InstallSpanCatcher();
 
   auto mock = std::make_shared<MockGoldenKitchenSinkStub>();
-  EXPECT_CALL(*mock, DoNothing)
-      .WillOnce(Return(internal::AbortedError("fail")));
+  EXPECT_CALL(*mock, DoNothing).WillOnce([](auto& context, auto const&) {
+    ValidatePropagator(context);
+    return internal::AbortedError("fail");
+  });
 
   auto under_test = MakeGoldenKitchenSinkTracingStub(mock);
   grpc::ClientContext context;

--- a/generator/integration_tests/tests/golden_thing_admin_tracing_stub_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_tracing_stub_test.cc
@@ -667,8 +667,10 @@ TEST(MakeGoldenThingAdminTracingStub, OpenTelemetry) {
   auto span_catcher = InstallSpanCatcher();
 
   auto mock = std::make_shared<MockGoldenThingAdminStub>();
-  EXPECT_CALL(*mock, DropDatabase)
-      .WillOnce(Return(internal::AbortedError("fail")));
+  EXPECT_CALL(*mock, DropDatabase).WillOnce([](auto& context, auto const&) {
+    ValidatePropagator(context);
+    return internal::AbortedError("fail");
+  });
 
   auto under_test = MakeGoldenThingAdminTracingStub(mock);
   grpc::ClientContext context;

--- a/google/cloud/internal/grpc_opentelemetry.cc
+++ b/google/cloud/internal/grpc_opentelemetry.cc
@@ -136,11 +136,11 @@ void ExtractAttributes(grpc::ClientContext& context,
                        opentelemetry::trace::Span& span) {
   auto md = GetRequestMetadataFromContext(context);
   for (auto& kv : md.headers) {
-    auto p = MakeAttribute({std::move(kv.first), std::move(kv.second)});
+    auto p = MakeAttribute(std::move(kv));
     span.SetAttribute(p.first, p.second);
   }
   for (auto& kv : md.trailers) {
-    auto p = MakeAttribute({std::move(kv.first), std::move(kv.second)});
+    auto p = MakeAttribute(std::move(kv));
     span.SetAttribute(p.first, p.second);
   }
 }

--- a/google/cloud/internal/grpc_opentelemetry.cc
+++ b/google/cloud/internal/grpc_opentelemetry.cc
@@ -14,10 +14,12 @@
 
 #include "google/cloud/internal/grpc_opentelemetry.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
+#include "google/cloud/internal/grpc_request_metadata.h"
 #include "google/cloud/internal/noexcept_action.h"
 #include "google/cloud/internal/trace_propagator.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include "absl/strings/match.h"
 #include <grpcpp/grpcpp.h>
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 #include <opentelemetry/context/propagation/global_propagator.h>
@@ -71,6 +73,37 @@ class GrpcClientCarrier
   grpc::ClientContext& context_;
 };
 
+// We translate some keys, and modify binary values to be printable.
+std::pair<std::string, std::string> MakeAttribute(
+    std::pair<std::string, std::string> kv) {
+  if (kv.first == ":grpc-context-peer") {
+    // TODO(#10489): extract IP version, IP address, port from peer URI.
+    // https://github.com/grpc/grpc/blob/master/src/core/lib/address_utils/parse_address.h
+    return {"grpc.peer", std::move(kv.second)};
+  }
+  if (kv.first == ":grpc-context-compression-algorithm") {
+    return {"grpc.compression_algorithm", std::move(kv.second)};
+  }
+  if (!absl::EndsWith(kv.first, "-bin")) {
+    return {"rpc.grpc.response.metadata." + std::move(kv.first),
+            std::move(kv.second)};
+  }
+
+  // The header is in binary format. OpenTelemetry does not really support byte
+  // arrays in their attributes, so let's transform the value into a string that
+  // can be printed and interpreted.
+  std::string value;
+  auto constexpr kDigits = "0123456789ABCDEF";
+  for (unsigned char c : kv.second) {
+    value.push_back('\\');
+    value.push_back('x');
+    value.push_back(kDigits[(c >> 4) & 0xf]);
+    value.push_back(kDigits[c & 0xf]);
+  }
+  return {"rpc.grpc.response.metadata." + std::move(kv.first),
+          std::move(value)};
+}
+
 }  // namespace
 
 opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> MakeSpanGrpc(
@@ -101,9 +134,15 @@ void InjectTraceContext(
 
 void ExtractAttributes(grpc::ClientContext& context,
                        opentelemetry::trace::Span& span) {
-  // TODO(#10489): extract IP version, IP address, port from peer URI.
-  // https://github.com/grpc/grpc/blob/master/src/core/lib/address_utils/parse_address.h
-  span.SetAttribute("grpc.peer", context.peer());
+  auto md = GetRequestMetadataFromContext(context);
+  for (auto& kv : md.headers) {
+    auto p = MakeAttribute({std::move(kv.first), std::move(kv.second)});
+    span.SetAttribute(p.first, p.second);
+  }
+  for (auto& kv : md.trailers) {
+    auto p = MakeAttribute({std::move(kv.first), std::move(kv.second)});
+    span.SetAttribute(p.first, p.second);
+  }
 }
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY

--- a/google/cloud/pubsub/blocking_publisher_connection_test.cc
+++ b/google/cloud/pubsub/blocking_publisher_connection_test.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "google/cloud/testing_util/validate_metadata.h"
+#include "google/cloud/testing_util/validate_propagator.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -184,6 +185,7 @@ using ::google::cloud::testing_util::DisableTracing;
 using ::google::cloud::testing_util::EnableTracing;
 using ::google::cloud::testing_util::InstallSpanCatcher;
 using ::google::cloud::testing_util::SpanNamed;
+using ::google::cloud::testing_util::ValidatePropagator;
 using ::testing::IsEmpty;
 using ::testing::UnorderedElementsAre;
 
@@ -191,8 +193,9 @@ TEST(BlockingPublisherConnectionTest, TracingEnabled) {
   auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
   Topic const topic("test-project", "test-topic");
   EXPECT_CALL(*mock, Publish)
-      .WillOnce([&](grpc::ClientContext&,
+      .WillOnce([&](grpc::ClientContext& context,
                     google::pubsub::v1::PublishRequest const& request) {
+        ValidatePropagator(context);
         EXPECT_EQ(topic.FullName(), request.topic());
         EXPECT_EQ(1, request.messages_size());
         EXPECT_EQ("test-data-0", request.messages(0).data());

--- a/google/cloud/pubsub/publisher_connection_test.cc
+++ b/google/cloud/pubsub/publisher_connection_test.cc
@@ -27,6 +27,7 @@
 #include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "google/cloud/testing_util/validate_metadata.h"
+#include "google/cloud/testing_util/validate_propagator.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -344,6 +345,7 @@ using ::google::cloud::testing_util::DisableTracing;
 using ::google::cloud::testing_util::EnableTracing;
 using ::google::cloud::testing_util::InstallSpanCatcher;
 using ::google::cloud::testing_util::SpanNamed;
+using ::google::cloud::testing_util::ValidatePropagator;
 using ::testing::IsEmpty;
 using ::testing::UnorderedElementsAre;
 
@@ -353,8 +355,9 @@ TEST(MakePublisherConnectionTest, TracingEnabled) {
   Topic const topic("test-project", "test-topic");
 
   EXPECT_CALL(*mock, AsyncPublish)
-      .WillOnce([&](google::cloud::CompletionQueue&, auto,
+      .WillOnce([&](google::cloud::CompletionQueue&, auto context,
                     google::pubsub::v1::PublishRequest const&) {
+        ValidatePropagator(*context);
         google::pubsub::v1::PublishResponse response;
         response.add_message_ids("test-message-id-0");
         return make_ready_future(make_status_or(response));


### PR DESCRIPTION
Fixes #13275 

Capture response metadata over gRPC in traces.

Give special handling to binary headers. I am open to other suggestions on how they should be displayed.

For the tests - note that `ValidatePropagator()` calls `ValidateMetadataFixture::GetMetadata()` under the hood, so it both adds a layer of testing and prevents crashes when trying to access the server metadata stored in the `grpc::ClientContext`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13278)
<!-- Reviewable:end -->
