### PR TITLE
cleanup(bigtable): fix usage string in example

### DIFF
--- a/google/cloud/bigtable/examples/bigtable_hello_instance_admin.cc
+++ b/google/cloud/bigtable/examples/bigtable_hello_instance_admin.cc
@@ -36,8 +36,7 @@ using ::google::cloud::bigtable::examples::Usage;
 void BigtableHelloInstance(std::vector<std::string> const& argv) {
   if (argv.size() != 4) {
     throw Usage{
-        "bigtable-hello-instance <project-id> <instance-id> <cluster-id> "
-        "<zone>"};
+        "hello-instance <project-id> <instance-id> <cluster-id> <zone>"};
   }
 
   std::string const& project_id = argv[0];


### PR DESCRIPTION
https://github.com/googleapis/google-cloud-cpp/blob/79d9455d2decae4c39beffcad33590e8ee1ef753/google/cloud/bigtable/examples/bigtable_hello_instance_admin.cc#L215

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13281)
<!-- Reviewable:end -->
