### PR TITLE
impl(common): `future` continuations consume state

### DIFF
--- a/google/cloud/internal/future_base.h
+++ b/google/cloud/internal/future_base.h
@@ -203,9 +203,8 @@ class promise_base {  // NOLINT(readability-identifier-naming)
 };
 
 struct CoroutineSupport {
-  template <typename T>
-  static void set_continuation(future<T>& f,
-                               std::unique_ptr<internal::continuation_base> c) {
+  template <typename T, typename C>
+  static void set_continuation(future<T>& f, std::unique_ptr<C> c) {
     f.shared_state_->set_continuation(std::move(c));
   }
 };

--- a/google/cloud/internal/future_impl_test.cc
+++ b/google/cloud/internal/future_impl_test.cc
@@ -106,10 +106,10 @@ TEST(FutureImplInt, AbandonReady) {
   EXPECT_TRUE(shared_state.is_ready());
 }
 
-class TestContinuation : public continuation_base {
+class TestContinuation : public Continuation<int> {
  public:
   explicit TestContinuation(int* r) : execute_counter(r) {}
-  void execute() override { (*execute_counter)++; }
+  void Execute(SharedStateType<int>&) override { (*execute_counter)++; }
 
   int* execute_counter;
 };
@@ -243,7 +243,7 @@ TEST(FutureImplInt, SetContinuationAlreadySatisfied) {
 TEST(ContinuationIntTest, Constructor) {
   auto functor = [](std::shared_ptr<future_shared_state<int>> const&) {};
 
-  using tested_type = continuation<decltype(functor), int>;
+  using tested_type = SimpleContinuation<decltype(functor), int>;
 
   auto input = std::make_shared<future_shared_state<int>>();
   auto cont = std::make_shared<tested_type>(std::move(functor), input);

--- a/google/cloud/internal/future_then_meta.h
+++ b/google/cloud/internal/future_then_meta.h
@@ -70,17 +70,20 @@ struct unwrap_internal<std::shared_ptr<internal::future_shared_state<U>>> {
 };
 
 template <typename T>
-struct SharedStateTypeImpl {
-  using type = future_shared_state<T>;
+struct SharedStateValueImpl {
+  using type = T;
 };
 
 template <>
-struct SharedStateTypeImpl<void> {
-  using type = future_shared_state<FutureVoid>;
+struct SharedStateValueImpl<void> {
+  using type = FutureVoid;
 };
 
 template <typename T>
-using SharedStateType = typename SharedStateTypeImpl<T>::type;
+using SharedStateValue = typename SharedStateValueImpl<T>::type;
+
+template <typename T>
+using SharedStateType = future_shared_state<SharedStateValue<T>>;
 
 /**
  * A metafunction to implement `internal::continuation<Functor,T>`.


### PR DESCRIPTION
The implementation of futures uses a type-erased version of the continuation provided in `.then()`.  With this change:

- I renamed the class to more closely follow the style guide.
- I changed the class to receive the state of its (satisfied) future as an argument.

Part of the work for #13258

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13282)
<!-- Reviewable:end -->
