### PR TITLE
impl(pubsub): start the publish span as a root span

### DIFF
--- a/google/cloud/pubsub/internal/tracing_batch_sink.cc
+++ b/google/cloud/pubsub/internal/tracing_batch_sink.cc
@@ -60,6 +60,9 @@ auto MakeParent(Links const& links, Spans const& message_spans,
                 pubsub::Topic const& topic) {
   namespace sc = ::opentelemetry::trace::SemanticConventions;
   opentelemetry::trace::StartSpanOptions options;
+  opentelemetry::context::Context root_context;
+  root_context = root_context.SetValue(opentelemetry::trace::kIsRootSpanKey, true);
+  options.parent = root_context;
   options.kind = opentelemetry::trace::SpanKind::kClient;
   auto batch_sink_parent = internal::MakeSpan(
       topic.topic_id() + " publish",

--- a/google/cloud/pubsub/internal/tracing_batch_sink.cc
+++ b/google/cloud/pubsub/internal/tracing_batch_sink.cc
@@ -61,7 +61,8 @@ auto MakeParent(Links const& links, Spans const& message_spans,
   namespace sc = ::opentelemetry::trace::SemanticConventions;
   opentelemetry::trace::StartSpanOptions options;
   opentelemetry::context::Context root_context;
-  root_context = root_context.SetValue(opentelemetry::trace::kIsRootSpanKey, true);
+  root_context =
+      root_context.SetValue(opentelemetry::trace::kIsRootSpanKey, true);
   options.parent = root_context;
   options.kind = opentelemetry::trace::SpanKind::kClient;
   auto batch_sink_parent = internal::MakeSpan(

--- a/google/cloud/pubsub/internal/tracing_batch_sink.cc
+++ b/google/cloud/pubsub/internal/tracing_batch_sink.cc
@@ -64,8 +64,8 @@ auto MakeParent(Links const& links, Spans const& message_spans,
   // TODO(#13287): Use the constant instead of the string.
   // Setting a span as a root span was added in OTel v1.13+. It is a no-op for
   // earlier versions.
-  root_context.SetValue(/*opentelemetry::trace::kIsRootSpanKey=*/"is_root_span",
-                        true);
+  root_context = root_context.SetValue(
+      /*opentelemetry::trace::kIsRootSpanKey=*/"is_root_span", true);
   options.parent = root_context;
   options.kind = opentelemetry::trace::SpanKind::kClient;
   auto batch_sink_parent = internal::MakeSpan(
@@ -81,7 +81,6 @@ auto MakeParent(Links const& links, Spans const& message_spans,
        {sc::kMessagingDestinationTemplate, topic.FullName()}},
       /*links*/ std::move(links), options);
 
-  // Add metadata to the message spans about the batch sink span.
   auto context = batch_sink_parent->GetContext();
   auto trace_id = internal::ToString(context.trace_id());
   auto span_id = internal::ToString(context.span_id());

--- a/google/cloud/pubsub/internal/tracing_batch_sink.cc
+++ b/google/cloud/pubsub/internal/tracing_batch_sink.cc
@@ -62,6 +62,8 @@ auto MakeParent(Links const& links, Spans const& message_spans,
   opentelemetry::trace::StartSpanOptions options;
   opentelemetry::context::Context root_context;
   // TODO(#13287): Use the constant instead of the string.
+  // Setting a span as a root span was added in OTel v1.13+. It is a no-op for
+  // earlier versions.
   root_context.SetValue(/*opentelemetry::trace::kIsRootSpanKey=*/"is_root_span",
                         true);
   options.parent = root_context;

--- a/google/cloud/pubsub/internal/tracing_batch_sink.cc
+++ b/google/cloud/pubsub/internal/tracing_batch_sink.cc
@@ -62,7 +62,8 @@ auto MakeParent(Links const& links, Spans const& message_spans,
   opentelemetry::trace::StartSpanOptions options;
   opentelemetry::context::Context root_context;
   // TODO(#13287): Use the constant instead of the string.
-  root_context.SetValue(/*opentelemetry::trace::kIsRootSpanKey=*/"is_root_span", true);
+  root_context.SetValue(/*opentelemetry::trace::kIsRootSpanKey=*/"is_root_span",
+                        true);
   options.parent = root_context;
   options.kind = opentelemetry::trace::SpanKind::kClient;
   auto batch_sink_parent = internal::MakeSpan(

--- a/google/cloud/pubsub/internal/tracing_batch_sink.cc
+++ b/google/cloud/pubsub/internal/tracing_batch_sink.cc
@@ -64,9 +64,8 @@ auto MakeParent(Links const& links, Spans const& message_spans,
   // TODO(#13287): Use the constant instead of the string.
   // Setting a span as a root span was added in OTel v1.13+. It is a no-op for
   // earlier versions.
-  root_context = root_context.SetValue(
+  options.parent = root_context.SetValue(
       /*opentelemetry::trace::kIsRootSpanKey=*/"is_root_span", true);
-  options.parent = root_context;
   options.kind = opentelemetry::trace::SpanKind::kClient;
   auto batch_sink_parent = internal::MakeSpan(
       topic.topic_id() + " publish",

--- a/google/cloud/pubsub/internal/tracing_batch_sink.cc
+++ b/google/cloud/pubsub/internal/tracing_batch_sink.cc
@@ -61,8 +61,8 @@ auto MakeParent(Links const& links, Spans const& message_spans,
   namespace sc = ::opentelemetry::trace::SemanticConventions;
   opentelemetry::trace::StartSpanOptions options;
   opentelemetry::context::Context root_context;
-  root_context =
-      root_context.SetValue(opentelemetry::trace::kIsRootSpanKey, true);
+  // TODO(#13287): Use the constant instead of the string.
+  root_context.SetValue(/*opentelemetry::trace::kIsRootSpanKey=*/"is_root_span", true);
   options.parent = root_context;
   options.kind = opentelemetry::trace::SpanKind::kClient;
   auto batch_sink_parent = internal::MakeSpan(

--- a/google/cloud/pubsub/internal/tracing_batch_sink_test.cc
+++ b/google/cloud/pubsub/internal/tracing_batch_sink_test.cc
@@ -217,11 +217,12 @@ TEST(TracingBatchSink, PublishSpanHasAttributes) {
                                  TestTopic().FullName())))));
 }
 
-#if OPENTELEMETRY_VERSION_MAJOR >= 1
-#if OPENTELEMETRY_VERSION_MINOR >= 13
+#if OPENTELEMETRY_VERSION_MAJOR >= 2 || \
+    (OPENTELEMETRY_VERSION_MAJOR == 1 && OPENTELEMETRY_VERSION_MINOR >= 13)
 TEST(TracingBatchSink, PublishSpanIsRoot) {
   auto span_catcher = InstallSpanCatcher();
   auto message_span = MakeSpan("test span");
+  auto scope = opentelemetry::trace::Scope(message_span);
   auto mock = std::make_unique<pubsub_testing::MockBatchSink>();
   EXPECT_CALL(*mock, AddMessage(_));
   EXPECT_CALL(*mock, AsyncPublish)
@@ -239,9 +240,7 @@ TEST(TracingBatchSink, PublishSpanIsRoot) {
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(spans,
               Contains(AllOf(SpanNamed("test-topic publish"), SpanIsRoot())));
-  EXPECT_THAT(spans, Contains(AllOf(SpanNamed("test span"), SpanIsRoot())));
 }
-#endif
 #endif
 
 TEST(TracingBatchSink, AsyncPublishOnlyIncludeSampledLink) {

--- a/google/cloud/pubsub/internal/tracing_batch_sink_test.cc
+++ b/google/cloud/pubsub/internal/tracing_batch_sink_test.cc
@@ -217,8 +217,7 @@ TEST(TracingBatchSink, PublishSpanHasAttributes) {
                                  TestTopic().FullName())))));
 }
 
-TEST(TracingBatchSink, PublishSpanHasIsRoot) {
-  namespace sc = ::opentelemetry::trace::SemanticConventions;
+TEST(TracingBatchSink, PublishSpanParentIsRoot) {
   auto span_catcher = InstallSpanCatcher();
   auto message_span = MakeSpan("test span");
   auto mock = std::make_unique<pubsub_testing::MockBatchSink>();

--- a/google/cloud/pubsub/internal/tracing_batch_sink_test.cc
+++ b/google/cloud/pubsub/internal/tracing_batch_sink_test.cc
@@ -44,9 +44,9 @@ using ::google::cloud::testing_util::SpanHasAttributes;
 using ::google::cloud::testing_util::SpanHasEvents;
 using ::google::cloud::testing_util::SpanHasInstrumentationScope;
 using ::google::cloud::testing_util::SpanKindIsClient;
-using ::google::cloud::testing_util::SpanParentIsRoot;
 using ::google::cloud::testing_util::SpanLinksSizeIs;
 using ::google::cloud::testing_util::SpanNamed;
+using ::google::cloud::testing_util::SpanParentIsRoot;
 using ::google::cloud::testing_util::ThereIsAnActiveSpan;
 using ::testing::_;
 using ::testing::AllOf;
@@ -236,8 +236,8 @@ TEST(TracingBatchSink, PublishSpanHasIsRoot) {
   EXPECT_THAT(response, IsOk());
 
   auto spans = span_catcher->GetSpans();
-  EXPECT_THAT(spans,
-              Contains(AllOf(SpanNamed("test-topic publish"), SpanParentIsRoot())));
+  EXPECT_THAT(spans, Contains(AllOf(SpanNamed("test-topic publish"),
+                                    SpanParentIsRoot())));
 }
 
 TEST(TracingBatchSink, AsyncPublishOnlyIncludeSampledLink) {

--- a/google/cloud/testing_util/opentelemetry_matchers.h
+++ b/google/cloud/testing_util/opentelemetry_matchers.h
@@ -150,10 +150,10 @@ MATCHER_P(SpanWithParent, span,
   return actual == span->GetContext().span_id();
 }
 
-MATCHER(SpanParentIsRoot, " is root span") {
+MATCHER(SpanIsRoot, " is root span") {
   auto const& actual =
       (arg->GetParentSpanId() == opentelemetry::trace::SpanId());
-  *result_listener << "is root span: " << actual;
+  *result_listener << "is root span: " << (actual ? "true" : "false");
   return actual;
 }
 

--- a/google/cloud/testing_util/opentelemetry_matchers.h
+++ b/google/cloud/testing_util/opentelemetry_matchers.h
@@ -150,9 +150,8 @@ MATCHER_P(SpanWithParent, span,
   return actual == span->GetContext().span_id();
 }
 
-MATCHER(SpanIsRoot, " is root span") {
-  auto const& actual =
-      (arg->GetParentSpanId() == opentelemetry::trace::SpanId());
+MATCHER(SpanIsRoot, "is root span") {
+  auto const actual = arg->GetParentSpanId() == opentelemetry::trace::SpanId();
   *result_listener << "is root span: " << (actual ? "true" : "false");
   return actual;
 }

--- a/google/cloud/testing_util/opentelemetry_matchers.h
+++ b/google/cloud/testing_util/opentelemetry_matchers.h
@@ -150,6 +150,12 @@ MATCHER_P(SpanWithParent, span,
   return actual == span->GetContext().span_id();
 }
 
+MATCHER(SpanParentIsRoot, " is root span") {
+  auto const& actual = (arg->GetParentSpanId() == opentelemetry::trace::SpanId());
+  *result_listener << "is root span: " << actual;
+  return actual;
+}
+
 MATCHER_P(SpanNamed, name, "has name: " + std::string{name}) {
   auto const& actual = arg->GetName();
   *result_listener << "has name: " << actual;

--- a/google/cloud/testing_util/opentelemetry_matchers.h
+++ b/google/cloud/testing_util/opentelemetry_matchers.h
@@ -151,7 +151,8 @@ MATCHER_P(SpanWithParent, span,
 }
 
 MATCHER(SpanParentIsRoot, " is root span") {
-  auto const& actual = (arg->GetParentSpanId() == opentelemetry::trace::SpanId());
+  auto const& actual =
+      (arg->GetParentSpanId() == opentelemetry::trace::SpanId());
   *result_listener << "is root span: " << actual;
   return actual;
 }


### PR DESCRIPTION
Now that https://github.com/open-telemetry/opentelemetry-cpp/pull/2427 is in we can start an async span as a root span

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13285)
<!-- Reviewable:end -->
