### PR TITLE
fix(common): call continuation on abandoned future

### DIFF
--- a/google/cloud/future_generic_then_test.cc
+++ b/google/cloud/future_generic_then_test.cc
@@ -188,6 +188,19 @@ TEST(FutureTestInt, CancelThroughContinuation) {
   EXPECT_EQ(84, f1.get());
 }
 
+/// @test Verify that `.then()` continuations are notified on abandoned futures.
+TEST(FutureTestInt, AbandonNotifiesContinuation) {
+  future<int> f;
+  {
+    promise<int> p;
+    f = p.get_future().then([](auto g) {
+      ExpectFutureError([&g] { g.get(); }, std::future_errc::broken_promise);
+      return 42;
+    });
+  }
+  EXPECT_EQ(f.get(), 42);
+}
+
 // The following tests reference the technical specification:
 //   http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0159r0.html
 // The test names match the section and paragraph from the TS.

--- a/google/cloud/future_void_then_test.cc
+++ b/google/cloud/future_void_then_test.cc
@@ -179,6 +179,19 @@ TEST(FutureTestVoid, CancelThroughContinuation) {
   EXPECT_EQ(7, f1.get());
 }
 
+/// @test Verify that `.then()` continuations are notified on abandoned futures.
+TEST(FutureTestVoid, AbandonNotifiesContinuation) {
+  future<int> f;
+  {
+    promise<void> p;
+    f = p.get_future().then([](auto g) {
+      ExpectFutureError([&g] { g.get(); }, std::future_errc::broken_promise);
+      return 42;
+    });
+  }
+  EXPECT_EQ(f.get(), 42);
+}
+
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
 // NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_2_3_2_a) {

--- a/google/cloud/internal/future_impl.h
+++ b/google/cloud/internal/future_impl.h
@@ -224,7 +224,7 @@ class future_shared_state final {  // NOLINT(readability-identifier-naming)
 #else
     set_exception(nullptr, lk);
 #endif
-    cv_.notify_all();
+    notify_now(std::move(lk));
   }
 
   void set_continuation(std::unique_ptr<Continuation<T>> c) {


### PR DESCRIPTION
I found this while working on #13258, but it is an unrelated bug.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13292)
<!-- Reviewable:end -->
