### PR TITLE
ci(bigtable): no connection refreshing with emulator

### DIFF
--- a/google/cloud/bigtable/internal/defaults.cc
+++ b/google/cloud/bigtable/internal/defaults.cc
@@ -183,7 +183,7 @@ Options DefaultOptions(Options opts) {
   opts = google::cloud::internal::MergeOptions(std::move(opts),
                                                std::move(defaults));
 
-  opts = DefaultConnectionRefreshOptions(std::move(opts));
+  if (!emulator) opts = DefaultConnectionRefreshOptions(std::move(opts));
   opts = DefaultChannelArgumentOptions(std::move(opts));
 
   // Inserts our user-agent string at the front.

--- a/google/cloud/bigtable/internal/defaults_test.cc
+++ b/google/cloud/bigtable/internal/defaults_test.cc
@@ -19,9 +19,9 @@
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/background_threads_impl.h"
 #include "google/cloud/status.h"
+#include "google/cloud/testing_util/chrono_output.h"
 #include "google/cloud/testing_util/scoped_environment.h"
 #include "google/cloud/testing_util/status_matchers.h"
-#include "absl/time/time.h"
 #include "absl/types/optional.h"
 #include <gmock/gmock.h>
 #include <thread>
@@ -344,11 +344,9 @@ TEST(ConnectionRefreshRange, BothUnset) {
   auto opts = DefaultOptions();
 
   // See `kDefaultMinRefreshPeriod`
-  EXPECT_LT(absl::FromChrono(secs(15)),
-            absl::FromChrono(opts.get<MinConnectionRefreshOption>()));
+  EXPECT_LT(secs(15), opts.get<MinConnectionRefreshOption>());
   // See `kDefaultMaxRefreshPeriod`
-  EXPECT_GT(absl::FromChrono(mins(4)),
-            absl::FromChrono(opts.get<MaxConnectionRefreshOption>()));
+  EXPECT_GT(mins(4), opts.get<MaxConnectionRefreshOption>());
 }
 
 TEST(ConnectionRefreshRange, MinSetAboveMaxDefault) {
@@ -356,10 +354,8 @@ TEST(ConnectionRefreshRange, MinSetAboveMaxDefault) {
   auto opts =
       DefaultOptions(Options{}.set<MinConnectionRefreshOption>(mins(10)));
 
-  EXPECT_EQ(absl::FromChrono(mins(10)),
-            absl::FromChrono(opts.get<MinConnectionRefreshOption>()));
-  EXPECT_EQ(absl::FromChrono(mins(10)),
-            absl::FromChrono(opts.get<MaxConnectionRefreshOption>()));
+  EXPECT_EQ(mins(10), opts.get<MinConnectionRefreshOption>());
+  EXPECT_EQ(mins(10), opts.get<MaxConnectionRefreshOption>());
 }
 
 TEST(ConnectionRefreshRange, MaxSetBelowMinDefault) {
@@ -367,10 +363,8 @@ TEST(ConnectionRefreshRange, MaxSetBelowMinDefault) {
   auto opts =
       DefaultOptions(Options{}.set<MaxConnectionRefreshOption>(secs(1)));
 
-  EXPECT_EQ(absl::FromChrono(secs(1)),
-            absl::FromChrono(opts.get<MinConnectionRefreshOption>()));
-  EXPECT_EQ(absl::FromChrono(secs(1)),
-            absl::FromChrono(opts.get<MaxConnectionRefreshOption>()));
+  EXPECT_EQ(secs(1), opts.get<MinConnectionRefreshOption>());
+  EXPECT_EQ(secs(1), opts.get<MaxConnectionRefreshOption>());
 }
 
 TEST(ConnectionRefreshRange, BothSetValid) {
@@ -379,10 +373,8 @@ TEST(ConnectionRefreshRange, BothSetValid) {
                                  .set<MinConnectionRefreshOption>(secs(30))
                                  .set<MaxConnectionRefreshOption>(mins(2)));
 
-  EXPECT_EQ(absl::FromChrono(secs(30)),
-            absl::FromChrono(opts.get<MinConnectionRefreshOption>()));
-  EXPECT_EQ(absl::FromChrono(mins(2)),
-            absl::FromChrono(opts.get<MaxConnectionRefreshOption>()));
+  EXPECT_EQ(secs(30), opts.get<MinConnectionRefreshOption>());
+  EXPECT_EQ(mins(2), opts.get<MaxConnectionRefreshOption>());
 }
 
 TEST(ConnectionRefreshRange, BothSetInvalidUsesMax) {
@@ -391,10 +383,8 @@ TEST(ConnectionRefreshRange, BothSetInvalidUsesMax) {
                                  .set<MinConnectionRefreshOption>(mins(2))
                                  .set<MaxConnectionRefreshOption>(secs(30)));
 
-  EXPECT_EQ(absl::FromChrono(mins(2)),
-            absl::FromChrono(opts.get<MinConnectionRefreshOption>()));
-  EXPECT_EQ(absl::FromChrono(mins(2)),
-            absl::FromChrono(opts.get<MaxConnectionRefreshOption>()));
+  EXPECT_EQ(mins(2), opts.get<MinConnectionRefreshOption>());
+  EXPECT_EQ(mins(2), opts.get<MaxConnectionRefreshOption>());
 }
 
 TEST(ConnectionRefreshRange, DisabledIfEmulator) {
@@ -402,8 +392,7 @@ TEST(ConnectionRefreshRange, DisabledIfEmulator) {
   auto opts = DefaultOptions();
 
   // Zero duration means connection refreshing is disabled.
-  EXPECT_EQ(absl::ZeroDuration(),
-            absl::FromChrono(opts.get<MaxConnectionRefreshOption>()));
+  EXPECT_EQ(secs(0), opts.get<MaxConnectionRefreshOption>());
 }
 
 }  // namespace

--- a/google/cloud/bigtable/internal/defaults_test.cc
+++ b/google/cloud/bigtable/internal/defaults_test.cc
@@ -340,6 +340,7 @@ TEST(EndpointEnvTest, EmulatorOverridesDirectPath) {
 }
 
 TEST(ConnectionRefreshRange, BothUnset) {
+  ScopedEnvironment emulator("BIGTABLE_EMULATOR_HOST", absl::nullopt);
   auto opts = DefaultOptions();
 
   // See `kDefaultMinRefreshPeriod`
@@ -351,6 +352,7 @@ TEST(ConnectionRefreshRange, BothUnset) {
 }
 
 TEST(ConnectionRefreshRange, MinSetAboveMaxDefault) {
+  ScopedEnvironment emulator("BIGTABLE_EMULATOR_HOST", absl::nullopt);
   auto opts =
       DefaultOptions(Options{}.set<MinConnectionRefreshOption>(mins(10)));
 
@@ -361,6 +363,7 @@ TEST(ConnectionRefreshRange, MinSetAboveMaxDefault) {
 }
 
 TEST(ConnectionRefreshRange, MaxSetBelowMinDefault) {
+  ScopedEnvironment emulator("BIGTABLE_EMULATOR_HOST", absl::nullopt);
   auto opts =
       DefaultOptions(Options{}.set<MaxConnectionRefreshOption>(secs(1)));
 
@@ -371,6 +374,7 @@ TEST(ConnectionRefreshRange, MaxSetBelowMinDefault) {
 }
 
 TEST(ConnectionRefreshRange, BothSetValid) {
+  ScopedEnvironment emulator("BIGTABLE_EMULATOR_HOST", absl::nullopt);
   auto opts = DefaultOptions(Options{}
                                  .set<MinConnectionRefreshOption>(secs(30))
                                  .set<MaxConnectionRefreshOption>(mins(2)));
@@ -382,6 +386,7 @@ TEST(ConnectionRefreshRange, BothSetValid) {
 }
 
 TEST(ConnectionRefreshRange, BothSetInvalidUsesMax) {
+  ScopedEnvironment emulator("BIGTABLE_EMULATOR_HOST", absl::nullopt);
   auto opts = DefaultOptions(Options{}
                                  .set<MinConnectionRefreshOption>(mins(2))
                                  .set<MaxConnectionRefreshOption>(secs(30)));
@@ -389,6 +394,15 @@ TEST(ConnectionRefreshRange, BothSetInvalidUsesMax) {
   EXPECT_EQ(absl::FromChrono(mins(2)),
             absl::FromChrono(opts.get<MinConnectionRefreshOption>()));
   EXPECT_EQ(absl::FromChrono(mins(2)),
+            absl::FromChrono(opts.get<MaxConnectionRefreshOption>()));
+}
+
+TEST(ConnectionRefreshRange, DisabledIfEmulator) {
+  ScopedEnvironment emulator("BIGTABLE_EMULATOR_HOST", "emulator-host:8000");
+  auto opts = DefaultOptions();
+
+  // Zero duration means connection refreshing is disabled.
+  EXPECT_EQ(absl::ZeroDuration(),
             absl::FromChrono(opts.get<MaxConnectionRefreshOption>()));
 }
 


### PR DESCRIPTION
Motivated by #8331 / #12354

Connection refreshing only makes sense when running against production. We do not need it when running integration tests against the emulator.

While I doubt this will prevent any crashes, I know that attempting to refresh the connections after the emulator crashes produces a ton of logs. This PR will at least help with that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13327)
<!-- Reviewable:end -->
