### PR TITLE
cleanup: use real endpoints in common options test

### DIFF
--- a/google/cloud/internal/populate_common_options_test.cc
+++ b/google/cloud/internal/populate_common_options_test.cc
@@ -36,11 +36,12 @@ TEST(PopulateCommonOptions, Simple) {
   // Unset all the relevant environment variables.
   ScopedEnvironment user("GOOGLE_CLOUD_CPP_USER_PROJECT", absl::nullopt);
   ScopedEnvironment tracing("GOOGLE_CLOUD_CPP_ENABLE_TRACING", absl::nullopt);
-  auto actual = PopulateCommonOptions(Options{}, {}, {}, {}, "default");
+  auto actual =
+      PopulateCommonOptions(Options{}, {}, {}, {}, "default.googleapis.com");
   EXPECT_TRUE(actual.has<EndpointOption>());
-  EXPECT_THAT(actual.get<EndpointOption>(), Eq("default."));
+  EXPECT_THAT(actual.get<EndpointOption>(), Eq("default.googleapis.com."));
   EXPECT_TRUE(actual.has<AuthorityOption>());
-  EXPECT_THAT(actual.get<AuthorityOption>(), Eq("default"));
+  EXPECT_THAT(actual.get<AuthorityOption>(), Eq("default.googleapis.com"));
   EXPECT_FALSE(actual.has<UserProjectOption>());
   EXPECT_TRUE(actual.has<TracingComponentsOption>());
   EXPECT_THAT(actual.get<TracingComponentsOption>(), IsEmpty());
@@ -51,25 +52,27 @@ TEST(PopulateCommonOptions, Simple) {
 
 TEST(PopulateCommonOptions, EmptyEndpointOption) {
   auto actual = PopulateCommonOptions(Options{}.set<EndpointOption>(""), {}, {},
-                                      {}, "default");
+                                      {}, "default.googleapis.com");
   EXPECT_TRUE(actual.has<EndpointOption>());
   EXPECT_THAT(actual.get<EndpointOption>(), Eq(""));
 }
 
 TEST(PopulateCommonOptions, EmptyEndpointEnvVar) {
   ScopedEnvironment endpoint("GOOGLE_CLOUD_CPP_SERVICE_ENDPOINT", "");
-  auto actual = PopulateCommonOptions(
-      Options{}, "GOOGLE_CLOUD_CPP_SERVICE_ENDPOINT", {}, {}, "default");
+  auto actual =
+      PopulateCommonOptions(Options{}, "GOOGLE_CLOUD_CPP_SERVICE_ENDPOINT", {},
+                            {}, "default.googleapis.com");
   EXPECT_TRUE(actual.has<EndpointOption>());
-  EXPECT_THAT(actual.get<EndpointOption>(), Eq("default."));
+  EXPECT_THAT(actual.get<EndpointOption>(), Eq("default.googleapis.com."));
 }
 
 TEST(PopulateCommonOptions, EmptyEmulatorEnvVar) {
   ScopedEnvironment endpoint("GOOGLE_CLOUD_CPP_EMULATOR_ENDPOINT", "");
-  auto actual = PopulateCommonOptions(
-      Options{}, {}, "GOOGLE_CLOUD_CPP_EMULATOR_ENDPOINT", {}, "default");
+  auto actual =
+      PopulateCommonOptions(Options{}, {}, "GOOGLE_CLOUD_CPP_EMULATOR_ENDPOINT",
+                            {}, "default.googleapis.com");
   EXPECT_TRUE(actual.has<EndpointOption>());
-  EXPECT_THAT(actual.get<EndpointOption>(), Eq("default."));
+  EXPECT_THAT(actual.get<EndpointOption>(), Eq("default.googleapis.com."));
 }
 
 // TODO(#13191): Simplify into multiple tests.
@@ -93,9 +96,9 @@ TEST(PopulateCommonOptions, EndpointAuthority) {
           ScopedEnvironment emulator("SERVICE_EMULATOR", emulator_env);
           ScopedEnvironment authority("SERVICE_AUTHORITY", authority_env);
 
-          auto actual = PopulateCommonOptions(options, "SERVICE_ENDPOINT",
-                                              "SERVICE_EMULATOR",
-                                              "SERVICE_AUTHORITY", "default");
+          auto actual = PopulateCommonOptions(
+              options, "SERVICE_ENDPOINT", "SERVICE_EMULATOR",
+              "SERVICE_AUTHORITY", "default.googleapis.com");
 
           ASSERT_TRUE(actual.has<EndpointOption>());
           auto const& actual_endpoint = actual.get<EndpointOption>();
@@ -106,7 +109,7 @@ TEST(PopulateCommonOptions, EndpointAuthority) {
           } else if (options.has<EndpointOption>()) {
             EXPECT_THAT(actual_endpoint, Eq(options.get<EndpointOption>()));
           } else {
-            EXPECT_THAT(actual_endpoint, Eq("default."));
+            EXPECT_THAT(actual_endpoint, Eq("default.googleapis.com."));
           }
 
           ASSERT_TRUE(actual.has<AuthorityOption>());
@@ -116,7 +119,7 @@ TEST(PopulateCommonOptions, EndpointAuthority) {
           } else if (options.has<AuthorityOption>()) {
             EXPECT_THAT(actual_authority, Eq(options.get<AuthorityOption>()));
           } else {
-            EXPECT_THAT(actual_authority, Eq("default"));
+            EXPECT_THAT(actual_authority, Eq("default.googleapis.com"));
           }
         }
       }
@@ -133,7 +136,8 @@ TEST(PopulateCommonOptions, UserProject) {
   for (auto const& options : optionses) {
     for (auto const& project_env : projects) {
       ScopedEnvironment projects("GOOGLE_CLOUD_CPP_USER_PROJECT", project_env);
-      auto actual = PopulateCommonOptions(options, {}, {}, {}, "default");
+      auto actual =
+          PopulateCommonOptions(options, {}, {}, {}, "default.googleapis.com");
       if (project_env.has_value() && !project_env->empty()) {
         EXPECT_THAT(actual.get<UserProjectOption>(), Eq(*project_env));
       } else if (options.has<UserProjectOption>()) {


### PR DESCRIPTION
Use a more realistic endpoint in our test

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13330)
<!-- Reviewable:end -->
