### PR TITLE
refactor(bigtable): pull auth strategy out of stub factory

### DIFF
--- a/google/cloud/bigtable/data_connection.cc
+++ b/google/cloud/bigtable/data_connection.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/opentelemetry.h"
+#include "google/cloud/internal/unified_grpc_credentials.h"
 #include <memory>
 
 namespace google {
@@ -163,7 +164,10 @@ std::shared_ptr<DataConnection> MakeDataConnection(Options options) {
   options = bigtable::internal::DefaultDataOptions(std::move(options));
   auto background =
       google::cloud::internal::MakeBackgroundThreadsFactory(options)();
-  auto stub = bigtable_internal::CreateBigtableStub(background->cq(), options);
+  auto auth = google::cloud::internal::CreateAuthenticationStrategy(
+      background->cq(), options);
+  auto stub = bigtable_internal::CreateBigtableStub(std::move(auth),
+                                                    background->cq(), options);
   auto limiter =
       bigtable_internal::MakeMutateRowsLimiter(background->cq(), options);
   std::shared_ptr<DataConnection> conn =

--- a/google/cloud/bigtable/internal/bigtable_channel_refresh_test.cc
+++ b/google/cloud/bigtable/internal/bigtable_channel_refresh_test.cc
@@ -17,8 +17,8 @@
 #include "google/cloud/bigtable/options.h"
 #include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/unified_grpc_credentials.h"
 #include "google/cloud/testing_util/mock_completion_queue_impl.h"
+#include "google/cloud/testing_util/mock_grpc_authentication_strategy.h"
 #include <gmock/gmock.h>
 #include <chrono>
 
@@ -28,6 +28,7 @@ namespace bigtable_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+using ::google::cloud::testing_util::MakeStubFactoryMockAuth;
 using ::google::cloud::testing_util::MockCompletionQueueImpl;
 
 auto constexpr kTestChannels = 3;
@@ -52,7 +53,7 @@ TEST(BigtableChannelRefresh, Enabled) {
       });
 
   CompletionQueue cq(mock);
-  auto auth = internal::CreateAuthenticationStrategy(cq, Options{});
+  auto auth = MakeStubFactoryMockAuth();
   auto stub = CreateBigtableStub(
       std::move(auth), cq,
       Options{}
@@ -71,7 +72,7 @@ TEST(BigtableChannelRefresh, Disabled) {
   EXPECT_CALL(*mock, MakeRelativeTimer).Times(0);
 
   CompletionQueue cq(mock);
-  auto auth = internal::CreateAuthenticationStrategy(cq, Options{});
+  auto auth = MakeStubFactoryMockAuth();
   auto stub = CreateBigtableStub(
       std::move(auth), cq,
       Options{}.set<bigtable::MaxConnectionRefreshOption>(ms(0)));
@@ -119,7 +120,7 @@ TEST(BigtableChannelRefresh, Continuations) {
   EXPECT_CALL(*mock_cq, RunAsync).Times(2);
 
   CompletionQueue cq(mock_cq);
-  auto auth = internal::CreateAuthenticationStrategy(cq, Options{});
+  auto auth = MakeStubFactoryMockAuth();
   auto stub = CreateBigtableStub(
       std::move(auth), cq,
       Options{}

--- a/google/cloud/bigtable/internal/bigtable_stub_factory.h
+++ b/google/cloud/bigtable/internal/bigtable_stub_factory.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/bigtable/internal/bigtable_stub.h"
 #include "google/cloud/completion_queue.h"
+#include "google/cloud/internal/unified_grpc_credentials.h"
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
 #include <functional>
@@ -36,12 +37,14 @@ std::shared_ptr<BigtableStub> CreateBigtableStubRoundRobin(
 
 /// Used in testing to create decorated mocks.
 std::shared_ptr<BigtableStub> CreateDecoratedStubs(
-    google::cloud::CompletionQueue cq, Options const& options,
+    std::shared_ptr<internal::GrpcAuthenticationStrategy> auth,
+    CompletionQueue const& cq, Options const& options,
     BaseBigtableStubFactory const& base_factory);
 
 /// Default function used by `DataConnectionImpl`.
 std::shared_ptr<BigtableStub> CreateBigtableStub(
-    google::cloud::CompletionQueue cq, Options const& options);
+    std::shared_ptr<internal::GrpcAuthenticationStrategy> auth,
+    CompletionQueue const& cq, Options const& options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable_internal

--- a/google/cloud/bigtable/internal/bigtable_stub_factory_test.cc
+++ b/google/cloud/bigtable/internal/bigtable_stub_factory_test.cc
@@ -38,7 +38,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::google::cloud::bigtable::testing::MockBigtableStub;
-using ::google::cloud::testing_util::MockAuthenticationStrategy;
+using ::google::cloud::testing_util::MakeStubFactoryMockAuth;
 using ::google::cloud::testing_util::ScopedLog;
 using ::google::cloud::testing_util::StatusIs;
 using ::google::cloud::testing_util::ValidateMetadataFixture;
@@ -85,7 +85,7 @@ TEST(BigtableStubFactory, RoundRobin) {
         Optional(id));
   };
 
-  auto auth = std::make_shared<MockAuthenticationStrategy>();
+  auto auth = MakeStubFactoryMockAuth();
   EXPECT_CALL(*auth, CreateChannel("localhost:1", expect_channel_id(0)));
   EXPECT_CALL(*auth, CreateChannel("localhost:1", expect_channel_id(1)));
   EXPECT_CALL(*auth, CreateChannel("localhost:1", expect_channel_id(2)));
@@ -119,7 +119,7 @@ TEST(BigtableStubFactory, Auth) {
         return mock;
       });
 
-  auto auth = std::make_shared<MockAuthenticationStrategy>();
+  auto auth = MakeStubFactoryMockAuth();
   EXPECT_CALL(*auth, RequiresConfigureContext).WillOnce(Return(true));
   EXPECT_CALL(*auth, CreateChannel("localhost:1", _));
   EXPECT_CALL(*auth, ConfigureContext)
@@ -157,9 +157,7 @@ TEST(BigtableStubFactory, Metadata) {
         return mock;
       });
 
-  auto auth = std::make_shared<MockAuthenticationStrategy>();
-  EXPECT_CALL(*auth, RequiresConfigureContext).WillOnce(Return(false));
-
+  auto auth = MakeStubFactoryMockAuth();
   CompletionQueue cq;
   auto stub = CreateDecoratedStubs(
       std::move(auth), cq,
@@ -186,9 +184,7 @@ TEST(BigtableStubFactory, LoggingEnabled) {
         return mock;
       });
 
-  auto auth = std::make_shared<MockAuthenticationStrategy>();
-  EXPECT_CALL(*auth, RequiresConfigureContext).WillOnce(Return(false));
-
+  auto auth = MakeStubFactoryMockAuth();
   CompletionQueue cq;
   auto stub = CreateDecoratedStubs(
       std::move(auth), cq,
@@ -218,9 +214,7 @@ TEST(BigtableStubFactory, LoggingDisabled) {
         return mock;
       });
 
-  auto auth = std::make_shared<MockAuthenticationStrategy>();
-  EXPECT_CALL(*auth, RequiresConfigureContext).WillOnce(Return(false));
-
+  auto auth = MakeStubFactoryMockAuth();
   CompletionQueue cq;
   auto stub = CreateDecoratedStubs(
       std::move(auth), cq,
@@ -257,9 +251,7 @@ TEST(BigtableStubFactory, FeaturesFlags) {
         return mock;
       });
 
-  auto auth = std::make_shared<MockAuthenticationStrategy>();
-  EXPECT_CALL(*auth, RequiresConfigureContext).WillOnce(Return(false));
-
+  auto auth = MakeStubFactoryMockAuth();
   CompletionQueue cq;
   auto stub = CreateDecoratedStubs(
       std::move(auth), std::move(cq),
@@ -295,9 +287,7 @@ TEST(BigtableStubFactory, TracingEnabled) {
         return mock;
       });
 
-  auto auth = std::make_shared<MockAuthenticationStrategy>();
-  EXPECT_CALL(*auth, RequiresConfigureContext).WillOnce(Return(false));
-
+  auto auth = MakeStubFactoryMockAuth();
   CompletionQueue cq;
   auto stub = CreateDecoratedStubs(
       std::move(auth), std::move(cq),
@@ -328,9 +318,7 @@ TEST(BigtableStubFactory, TracingDisabled) {
         return mock;
       });
 
-  auto auth = std::make_shared<MockAuthenticationStrategy>();
-  EXPECT_CALL(*auth, RequiresConfigureContext).WillOnce(Return(false));
-
+  auto auth = MakeStubFactoryMockAuth();
   CompletionQueue cq;
   auto stub = CreateDecoratedStubs(
       std::move(auth), std::move(cq),

--- a/google/cloud/testing_util/mock_grpc_authentication_strategy.cc
+++ b/google/cloud/testing_util/mock_grpc_authentication_strategy.cc
@@ -20,6 +20,9 @@ namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace testing_util {
 
+using ::testing::NiceMock;
+using ::testing::Return;
+
 std::shared_ptr<MockAuthenticationStrategy> MakeTypicalMockAuth() {
   auto auth = std::make_shared<MockAuthenticationStrategy>();
   EXPECT_CALL(*auth, ConfigureContext)
@@ -47,6 +50,15 @@ std::shared_ptr<MockAuthenticationStrategy> MakeTypicalAsyncMockAuth() {
             grpc::AccessTokenCredentials("test-only-invalid"));
         return make_ready_future(make_status_or(std::move(context)));
       });
+  return auth;
+}
+
+std::shared_ptr<MockAuthenticationStrategy> MakeStubFactoryMockAuth() {
+  auto auth = std::make_shared<NiceMock<MockAuthenticationStrategy>>();
+  ON_CALL(*auth, CreateChannel)
+      .WillByDefault(Return(grpc::CreateCustomChannel(
+          "error:///", grpc::InsecureChannelCredentials(), {})));
+  ON_CALL(*auth, RequiresConfigureContext).WillByDefault(Return(false));
   return auth;
 }
 

--- a/google/cloud/testing_util/mock_grpc_authentication_strategy.h
+++ b/google/cloud/testing_util/mock_grpc_authentication_strategy.h
@@ -36,7 +36,7 @@ class MockAuthenticationStrategy
 };
 
 /**
- * Create and set expectations a mock authentication strategy.
+ * Create and set expectations on a mock authentication strategy.
  *
  * Many of our tests initialize a MockAuthenticationStrategy and set up the same
  * expectations, namely that the test will use the strategy twice, and the
@@ -49,12 +49,20 @@ class MockAuthenticationStrategy
 std::shared_ptr<MockAuthenticationStrategy> MakeTypicalMockAuth();
 
 /**
- * Create and set expectations a mock authentication strategy.
+ * Create and set expectations on a mock authentication strategy.
  *
  * Like MakeTypicalMockAuth() but set the expectations for an asynchronous
  * request.
  */
 std::shared_ptr<MockAuthenticationStrategy> MakeTypicalAsyncMockAuth();
+
+/**
+ * Create a mock authentication strategy with inoffensive default behavior.
+ *
+ * This is useful for testing the stub factory interfaces. If asked, it will
+ * create a channel that is not null.
+ */
+std::shared_ptr<MockAuthenticationStrategy> MakeStubFactoryMockAuth();
 
 }  // namespace testing_util
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
Part of the work for #13300 although not strictly necessary

Move creation of the `GrpcAuthenticationStrategy` outside of the stub factory.

The clearer separation between the interfaces makes our tests a little nicer.

Also introduce a helper to declutter stub factory tests that need to create mock authentication strategies. (I plan to reuse this).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13331)
<!-- Reviewable:end -->
