### PR TITLE
impl: universe domain endpoint helper

### DIFF
--- a/google/cloud/internal/service_endpoint.cc
+++ b/google/cloud/internal/service_endpoint.cc
@@ -53,6 +53,13 @@ StatusOr<std::string> DetermineServiceEndpoint(
   return default_endpoint;
 }
 
+std::string UniverseDomainEndpoint(std::string gdu_endpoint,
+                                   Options const& options) {
+  if (!options.has<UniverseDomainOption>()) return gdu_endpoint;
+  return absl::StrCat(absl::StripSuffix(gdu_endpoint, ".googleapis.com."), ".",
+                      options.get<UniverseDomainOption>());
+}
+
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud

--- a/google/cloud/internal/service_endpoint.h
+++ b/google/cloud/internal/service_endpoint.h
@@ -40,6 +40,20 @@ StatusOr<std::string> DetermineServiceEndpoint(
     absl::optional<std::string> endpoint_option, std::string default_endpoint,
     Options const& options);
 
+/**
+ * Returns the default endpoint, respecting the `UniverseDomainOption`.
+ *
+ * For example:
+ *
+ * @code
+ * auto options = Options{}.set<UniverseDomainOption>("my-ud.net");
+ * auto endpoint = UniverseDomainEndpoint("foo.googleapis.com.", options);
+ * EXPECT_EQ(endpoint, "foo.my-ud.net");
+ * @endcode
+ */
+std::string UniverseDomainEndpoint(std::string gdu_endpoint,
+                                   Options const& options);
+
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud

--- a/google/cloud/internal/service_endpoint_test.cc
+++ b/google/cloud/internal/service_endpoint_test.cc
@@ -103,6 +103,17 @@ TEST(DetermineServiceEndpoint, DefaultHost) {
   EXPECT_THAT(result, IsOkAndHolds(absl::StrCat(kDefaultEndpoint, ".")));
 }
 
+TEST(UniverseDomainEndpoint, WithoutUniverseDomainOption) {
+  auto ep = UniverseDomainEndpoint("foo.googleapis.com.", Options{});
+  EXPECT_EQ(ep, "foo.googleapis.com.");
+}
+
+TEST(UniverseDomainEndpoint, WithUniverseDomainOption) {
+  auto ep = UniverseDomainEndpoint(
+      "foo.googleapis.com.", Options{}.set<UniverseDomainOption>("my-ud.net"));
+  EXPECT_EQ(ep, "foo.my-ud.net");
+}
+
 }  // namespace
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
Part of the work for #13115 

The approach is to default options in `DefaultFooOptions` instead of defaulting options in the stub factory. This will simplify our internals and we will get universe domain support in `pubsub` and `spanner` for free. yay.

A follow up PR will call this function from `PopulateCommonOptions`.