### PR TITLE
impl: heed universe domain in defaults

### DIFF
--- a/google/cloud/internal/populate_common_options.cc
+++ b/google/cloud/internal/populate_common_options.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/common_options.h"
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include "google/cloud/internal/getenv.h"
+#include "google/cloud/internal/service_endpoint.h"
 #include "google/cloud/internal/user_agent_prefix.h"
 #include "google/cloud/opentelemetry_options.h"
 #include "absl/strings/str_split.h"
@@ -39,12 +40,6 @@ Options PopulateCommonOptions(Options opts, std::string const& endpoint_env_var,
     }
   }
 
-  if (!opts.has<EndpointOption>()) {
-    if (!absl::EndsWith(default_endpoint, ".")) {
-      absl::StrAppend(&default_endpoint, ".");
-    }
-    opts.set<EndpointOption>(std::move(default_endpoint));
-  }
   if (!endpoint_env_var.empty()) {
     auto e = GetEnv(endpoint_env_var.c_str());
     if (e && !e->empty()) {
@@ -56,6 +51,11 @@ Options PopulateCommonOptions(Options opts, std::string const& endpoint_env_var,
     if (e && !e->empty()) {
       opts.set<EndpointOption>(*std::move(e));
     }
+  }
+  if (!opts.has<EndpointOption>()) {
+    absl::StrAppend(&default_endpoint, ".");
+    opts.set<EndpointOption>(
+        UniverseDomainEndpoint(std::move(default_endpoint), opts));
   }
 
   auto e = GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");


### PR DESCRIPTION
Part of the work for #13115
Fixes #13301 Fixes #13302 Fixes #13293 Fixes #13295

Factor the `UniverseDomainOption` into the default endpoint in `PopulateCommonOptions`.

`storage` and `bigtable` do not call `PopulateCommonOptions`. They will need manual work, but it is not much.

The gRPC stub factories now have dead code. I will clean that up in a follow up.

---

I am marking the `pubsub` issues as fixed, although there is still this function which we probably want to deal with: https://github.com/googleapis/google-cloud-cpp/blob/3aa4aec44c9500142ec6008e0c79b80e9d47e716/google/cloud/pubsub/options.cc#L24-L28

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13334)
<!-- Reviewable:end -->
