### PR TITLE
impl(pubsub): support UniverseDomainOption for IAM

### DIFF
--- a/google/cloud/pubsub/options.cc
+++ b/google/cloud/pubsub/options.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/pubsub/options.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/internal/service_endpoint.h"
 
 namespace google {
 namespace cloud {
@@ -21,9 +22,11 @@ namespace pubsub {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 Options IAMPolicyOptions(Options opts) {
-  return google::cloud::internal::MergeOptions(
+  auto const default_endpoint =
+      internal::UniverseDomainEndpoint("pubsub.googleapis.com.", opts);
+  return internal::MergeOptions(
       std::move(opts), Options{}
-                           .set<EndpointOption>("pubsub.googleapis.com")
+                           .set<EndpointOption>(std::move(default_endpoint))
                            .set<AuthorityOption>("pubsub.googleapis.com"));
 }
 

--- a/google/cloud/pubsub/options_test.cc
+++ b/google/cloud/pubsub/options_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/pubsub/options.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/universe_domain_options.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -22,13 +23,13 @@ namespace pubsub {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-TEST(Options, IAMPolicyOptionsDefault) {
+TEST(IAMPolicyOptions, Default) {
   auto const actual = IAMPolicyOptions();
-  EXPECT_EQ(actual.get<EndpointOption>(), "pubsub.googleapis.com");
+  EXPECT_EQ(actual.get<EndpointOption>(), "pubsub.googleapis.com.");
   EXPECT_EQ(actual.get<AuthorityOption>(), "pubsub.googleapis.com");
 }
 
-TEST(Options, IAMPolicyOptionsOverrideAll) {
+TEST(IAMPolicyOptions, OverrideAll) {
   auto const actual =
       IAMPolicyOptions(Options{}
                            .set<EndpointOption>("test-only-endpoint")
@@ -39,7 +40,7 @@ TEST(Options, IAMPolicyOptionsOverrideAll) {
   EXPECT_EQ(actual.get<UserProjectOption>(), "test-only-user-project");
 }
 
-TEST(Options, IAMPolicyOptionsOverrideEndpoint) {
+TEST(IAMPolicyOptions, OverrideEndpoint) {
   auto const actual =
       IAMPolicyOptions(Options{}
                            .set<EndpointOption>("test-only-endpoint")
@@ -49,14 +50,28 @@ TEST(Options, IAMPolicyOptionsOverrideEndpoint) {
   EXPECT_EQ(actual.get<UserProjectOption>(), "test-only-user-project");
 }
 
-TEST(Options, IAMPolicyOptionsOverrideAuthority) {
+TEST(IAMPolicyOptions, OverrideAuthority) {
   auto const actual =
       IAMPolicyOptions(Options{}
                            .set<AuthorityOption>("test-only-authority")
                            .set<UserProjectOption>("test-only-user-project"));
-  EXPECT_EQ(actual.get<EndpointOption>(), "pubsub.googleapis.com");
+  EXPECT_EQ(actual.get<EndpointOption>(), "pubsub.googleapis.com.");
   EXPECT_EQ(actual.get<AuthorityOption>(), "test-only-authority");
   EXPECT_EQ(actual.get<UserProjectOption>(), "test-only-user-project");
+}
+
+TEST(IAMPolicyOptions, IncorporatesUniverseDomain) {
+  auto const actual = IAMPolicyOptions(
+      Options{}.set<internal::UniverseDomainOption>("my-ud.net"));
+  EXPECT_EQ(actual.get<EndpointOption>(), "pubsub.my-ud.net");
+}
+
+TEST(IAMPolicyOptions, EndpointOverridesUniverseDomain) {
+  auto const actual =
+      IAMPolicyOptions(Options{}
+                           .set<internal::UniverseDomainOption>("my-ud.net")
+                           .set<EndpointOption>("test-only-endpoint"));
+  EXPECT_EQ(actual.get<EndpointOption>(), "test-only-endpoint");
 }
 
 }  // namespace


### PR DESCRIPTION
Part of the work for #13115 

Pub/Sub has a standalone function that creates `Options` for an `IAMPolicyConnection`. Applications write code like:
```cc
Options options;
auto options = pubsub::IAMPolicyOptions(std::move(options));
auto conn = iam::MakeIAMPolicyConnection(options);
```

We need to incorporate the `UniverseDomainOption` in this function. (or else the library will set the `EndpointOption` and `MakeIAMPolicyConnection` will ignore the `UniverseDomainOption`).

Also while we are here, use the FQDN.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13341)
<!-- Reviewable:end -->
