### PR TITLE
impl(GCS+gRPC): support `UniverseDomainOption`

### DIFF
--- a/google/cloud/storage/internal/grpc/stub.cc
+++ b/google/cloud/storage/internal/grpc/stub.cc
@@ -38,6 +38,7 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/invoke_result.h"
 #include "google/cloud/internal/populate_common_options.h"
+#include "google/cloud/internal/service_endpoint.h"
 #include "google/cloud/log.h"
 #include "absl/strings/match.h"
 #include "absl/time/time.h"
@@ -231,9 +232,11 @@ Options DefaultOptionsGrpc(Options options) {
     options.set<UnifiedCredentialsOption>(MakeInsecureCredentials());
   }
 
+  auto const default_endpoint = google::cloud::internal::UniverseDomainEndpoint(
+      "storage.googleapis.com.", options);
   options = google::cloud::internal::MergeOptions(
       std::move(options), Options{}
-                              .set<EndpointOption>("storage.googleapis.com")
+                              .set<EndpointOption>(std::move(default_endpoint))
                               .set<AuthorityOption>("storage.googleapis.com"));
   // We can only compute this once the endpoint is known, so take an additional
   // step.

--- a/google/cloud/storage/internal/grpc/stub.cc
+++ b/google/cloud/storage/internal/grpc/stub.cc
@@ -232,7 +232,7 @@ Options DefaultOptionsGrpc(Options options) {
     options.set<UnifiedCredentialsOption>(MakeInsecureCredentials());
   }
 
-  auto const default_endpoint = google::cloud::internal::UniverseDomainEndpoint(
+  auto default_endpoint = google::cloud::internal::UniverseDomainEndpoint(
       "storage.googleapis.com.", options);
   options = google::cloud::internal::MergeOptions(
       std::move(options), Options{}


### PR DESCRIPTION
Fixes #13343 Fixes #13344 

Support `UniverseDomainOption` for GCS+gRPC. While we're here, use the FQDN.

Unroll the unit test for `EndpointOption` because I generally do not like branching in unit tests. Also, while we're here, set expectations on `AuthorityOption`.

---

For GCS+gRPC there is some example code to demonstrate direct path usage. It has hardcoded: `"google-c2p:///storage.googleapis.com"`. I don't think we should take any action w.r.t. `UniverseDomainOption` at this time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13346)
<!-- Reviewable:end -->
