### PR TITLE
cleanup(pubsub): no const for std::move

### DIFF
--- a/google/cloud/pubsub/options.cc
+++ b/google/cloud/pubsub/options.cc
@@ -22,7 +22,7 @@ namespace pubsub {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 Options IAMPolicyOptions(Options opts) {
-  auto const default_endpoint =
+  auto default_endpoint =
       internal::UniverseDomainEndpoint("pubsub.googleapis.com.", opts);
   return internal::MergeOptions(
       std::move(opts), Options{}


### PR DESCRIPTION
Cleanup after #13341

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13347)
<!-- Reviewable:end -->
