### PR TITLE
impl(pubsub): add ack id and subscription to PullAckHandler::Impl

### DIFF
--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -403,6 +403,7 @@ function (google_cloud_cpp_pubsub_client_define_tests)
         publisher_connection_test.cc
         publisher_options_test.cc
         publisher_test.cc
+        pull_ack_handler_test.cc
         schema_test.cc
         snapshot_builder_test.cc
         snapshot_test.cc

--- a/google/cloud/pubsub/mocks/mock_pull_ack_handler.h
+++ b/google/cloud/pubsub/mocks/mock_pull_ack_handler.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_MOCKS_MOCK_PULL_ACK_HANDLER_H
 
 #include "google/cloud/pubsub/pull_ack_handler.h"
+#include "google/cloud/pubsub/subscription.h"
 #include <gmock/gmock.h>
 #include <string>
 
@@ -34,7 +35,9 @@ class MockPullAckHandler : public pubsub::PullAckHandler::Impl {
  public:
   MOCK_METHOD(future<Status>, ack, (), (override));
   MOCK_METHOD(future<Status>, nack, (), (override));
+  MOCK_METHOD(std::string, ack_id, (), (const, override));
   MOCK_METHOD(std::int32_t, delivery_attempt, (), (const, override));
+  MOCK_METHOD(pubsub::Subscription, subscription, (), (const, override));
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsub/mocks/mock_pull_ack_handler.h
+++ b/google/cloud/pubsub/mocks/mock_pull_ack_handler.h
@@ -35,8 +35,8 @@ class MockPullAckHandler : public pubsub::PullAckHandler::Impl {
  public:
   MOCK_METHOD(future<Status>, ack, (), (override));
   MOCK_METHOD(future<Status>, nack, (), (override));
-  MOCK_METHOD(std::string, ack_id, (), (const, override));
   MOCK_METHOD(std::int32_t, delivery_attempt, (), (const, override));
+  MOCK_METHOD(std::string, ack_id, (), (const, override));
   MOCK_METHOD(pubsub::Subscription, subscription, (), (const, override));
 };
 

--- a/google/cloud/pubsub/pubsub_client_unit_tests.bzl
+++ b/google/cloud/pubsub/pubsub_client_unit_tests.bzl
@@ -55,6 +55,7 @@ pubsub_client_unit_tests = [
     "publisher_connection_test.cc",
     "publisher_options_test.cc",
     "publisher_test.cc",
+    "pull_ack_handler_test.cc",
     "schema_test.cc",
     "snapshot_builder_test.cc",
     "snapshot_test.cc",

--- a/google/cloud/pubsub/pull_ack_handler.h
+++ b/google/cloud/pubsub/pull_ack_handler.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_PULL_ACK_HANDLER_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_PULL_ACK_HANDLER_H
 
+#include "google/cloud/pubsub/subscription.h"
 #include "google/cloud/pubsub/version.h"
 #include "google/cloud/future.h"
 #include "google/cloud/status.h"
@@ -122,6 +123,14 @@ class PullAckHandler {
     }
     /// The implementation for `PullAckHandler::delivery_attempt()`
     virtual std::int32_t delivery_attempt() const { return 0; }
+    /// Returns the ack_id for the handler. No public interface for
+    /// `PullAckHandler`.
+    virtual std::string ack_id() const { return ""; }
+    /// Returns the subscription for the handler. No public interface for
+    /// `PullAckHandler`.
+    virtual pubsub::Subscription subscription() const {
+      return pubsub::Subscription{};
+    }
   };
 
   /**

--- a/google/cloud/pubsub/pull_ack_handler.h
+++ b/google/cloud/pubsub/pull_ack_handler.h
@@ -123,11 +123,13 @@ class PullAckHandler {
     }
     /// The implementation for `PullAckHandler::delivery_attempt()`
     virtual std::int32_t delivery_attempt() const { return 0; }
-    /// Returns the ack_id for the handler. No public interface for
-    /// `PullAckHandler`.
+    /// Returns the ack id for the handler. There is no corresponding public
+    /// interface to access the ack id in `PullAckHandler`. This is for internal
+    /// use only.
     virtual std::string ack_id() const { return ""; }
-    /// Returns the subscription for the handler. No public interface for
-    /// `PullAckHandler`.
+    /// Returns the subscription for the handler. There is no corresponding
+    /// public interface to access the subscription id in `PullAckHandler`. This
+    /// is for internal use only.
     virtual pubsub::Subscription subscription() const {
       return pubsub::Subscription{};
     }


### PR DESCRIPTION
Part of https://github.com/googleapis/google-cloud-cpp/issues/13265

- Adds the pull ack handler test to the build files, we can't add any tests directly since we aren't modifying the inerface

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13349)
<!-- Reviewable:end -->
