### PR TITLE
impl(pubsub): add default pull ack handler impls 

### DIFF
--- a/google/cloud/pubsub/internal/default_pull_ack_handler.cc
+++ b/google/cloud/pubsub/internal/default_pull_ack_handler.cc
@@ -81,6 +81,12 @@ std::int32_t DefaultPullAckHandler::delivery_attempt() const {
   return delivery_attempt_;
 }
 
+std::string DefaultPullAckHandler::ack_id() const { return ack_id_; }
+
+pubsub::Subscription DefaultPullAckHandler::subscription() const {
+  return subscription_;
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace pubsub_internal
 }  // namespace cloud

--- a/google/cloud/pubsub/internal/default_pull_ack_handler.h
+++ b/google/cloud/pubsub/internal/default_pull_ack_handler.h
@@ -49,6 +49,8 @@ class DefaultPullAckHandler : public pubsub::PullAckHandler::Impl {
   future<Status> ack() override;
   future<Status> nack() override;
   std::int32_t delivery_attempt() const override;
+  std::string ack_id() const override;
+  pubsub::Subscription subscription() const override;
 
  private:
   CompletionQueue cq_;

--- a/google/cloud/pubsub/internal/default_pull_ack_handler_test.cc
+++ b/google/cloud/pubsub/internal/default_pull_ack_handler_test.cc
@@ -177,6 +177,29 @@ TEST(PullAckHandlerTest, NackPermanentError) {
               StatusIs(StatusCode::kPermissionDenied, HasSubstr("uh-oh")));
 }
 
+TEST(AckHandlerTest, Subscription) {
+  auto subscription = pubsub::Subscription("test-project", "test-subscription");
+  auto mock = std::make_shared<MockSubscriberStub>();
+  AsyncSequencer<bool> aseq;
+  auto cq = MakeMockCompletionQueue(aseq);
+  auto handler = std::make_unique<DefaultPullAckHandler>(
+      cq, mock, MakeTestOptions(), subscription, "test-ack-id", 42);
+
+  EXPECT_EQ(handler->subscription(), subscription);
+}
+
+TEST(AckHandlerTest, AckId) {
+  auto mock = std::make_shared<MockSubscriberStub>();
+  AsyncSequencer<bool> aseq;
+  auto cq = MakeMockCompletionQueue(aseq);
+  auto handler = std::make_unique<DefaultPullAckHandler>(
+      cq, mock, MakeTestOptions(),
+      pubsub::Subscription("test-project", "test-subscription"), "test-ack-id",
+      42);
+
+  EXPECT_EQ(handler->ack_id(), "test-ack-id");
+}
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace pubsub_internal


### PR DESCRIPTION
Part of https://github.com/googleapis/google-cloud-cpp/issues/13265

1/5 in a chain of PRs to add tracing for the settle span for the unary pull

1. https://github.com/googleapis/google-cloud-cpp/pull/13350
2. https://github.com/googleapis/google-cloud-cpp/pull/13353
3. https://github.com/googleapis/google-cloud-cpp/pull/13354
4. https://github.com/googleapis/google-cloud-cpp/pull/13358
5. https://github.com/googleapis/google-cloud-cpp/pull/13360

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13350)
<!-- Reviewable:end -->
