### PR TITLE
cleanup(compute): shorten target names

### DIFF
--- a/cmake/AddPkgConfig.cmake
+++ b/cmake/AddPkgConfig.cmake
@@ -42,10 +42,15 @@ endmacro ()
 # * ARGN: the names of any pkgconfig modules the generated module depends on
 #
 function (google_cloud_cpp_add_pkgconfig library name description)
-    set(target "google_cloud_cpp_${library}")
+    cmake_parse_arguments(_opt "WITH_SHORT_TARGET" "" "" ${ARGN})
+    if (_opt_WITH_SHORT_TARGET)
+        set(target "${library}")
+    else ()
+        set(target "google_cloud_cpp_${library}")
+    endif ()
     set(GOOGLE_CLOUD_CPP_PC_NAME "${name}")
     set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION "${description}")
-    string(JOIN " " GOOGLE_CLOUD_CPP_PC_REQUIRES ${ARGN})
+    string(JOIN " " GOOGLE_CLOUD_CPP_PC_REQUIRES ${_opt_UNPARSED_ARGUMENTS})
     google_cloud_cpp_set_pkgconfig_paths()
     get_target_property(target_type ${target} TYPE)
     if ("${target_type}" STREQUAL "INTERFACE_LIBRARY")
@@ -53,7 +58,7 @@ function (google_cloud_cpp_add_pkgconfig library name description)
         # files to link against with `-l`.
         set(GOOGLE_CLOUD_CPP_PC_LIBS "")
     else ()
-        set(GOOGLE_CLOUD_CPP_PC_LIBS "-l${target}")
+        set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_${library}")
     endif ()
     get_target_property(target_defs ${target} INTERFACE_COMPILE_DEFINITIONS)
     if (target_defs)
@@ -64,9 +69,9 @@ function (google_cloud_cpp_add_pkgconfig library name description)
 
     # Create and install the pkg-config files.
     configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-                   "${target}.pc" @ONLY)
+                   "google_cloud_cpp_${library}.pc" @ONLY)
     install(
-        FILES "${CMAKE_CURRENT_BINARY_DIR}/${target}.pc"
+        FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_${library}.pc"
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
         COMPONENT google_cloud_cpp_development)
 endfunction ()

--- a/google/cloud/compute/CMakeLists.txt
+++ b/google/cloud/compute/CMakeLists.txt
@@ -70,8 +70,7 @@ include(GoogleCloudCppDoxygen)
 
 foreach (dir IN LISTS service_dirs operation_service_dirs)
     string(REPLACE "/v1/" "" short_dir "${dir}")
-    list(APPEND compute_proto_lib_targets
-         "google_cloud_cpp_compute_${short_dir}_protos")
+    list(APPEND compute_proto_lib_targets "compute_${short_dir}_protos")
 endforeach ()
 
 set(GOOGLE_CLOUD_CPP_DOXYGEN_EXTRA_INCLUDES

--- a/google/cloud/compute/CMakeLists.txt
+++ b/google/cloud/compute/CMakeLists.txt
@@ -24,8 +24,9 @@ function (compute_service_library dir library)
         "${dir}internal/*")
     list(SORT service_source_files)
 
-    string(REPLACE "google_cloud_cpp_" "" alias "${library}")
     add_library(${library} ${service_source_files})
+    set_target_properties(${library} PROPERTIES OUTPUT_NAME
+                                                "google_cloud_cpp_${library}")
     target_include_directories(
         ${library}
         PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
@@ -37,14 +38,14 @@ function (compute_service_library dir library)
     google_cloud_cpp_add_common_options(${library})
     set_target_properties(
         ${library}
-        PROPERTIES EXPORT_NAME google-cloud-cpp::${alias}
+        PROPERTIES EXPORT_NAME google-cloud-cpp::${library}
                    VERSION "${PROJECT_VERSION}"
                    SOVERSION "${PROJECT_VERSION_MAJOR}")
     target_compile_options(${library}
                            PUBLIC ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
     google_cloud_cpp_install_headers(${library} "include/google/cloud/compute")
 
-    add_library(google-cloud-cpp::${alias} ALIAS ${library})
+    add_library(google-cloud-cpp::${library} ALIAS ${library})
 endfunction ()
 
 include(GoogleapisConfig)
@@ -81,25 +82,24 @@ google_cloud_cpp_doxygen_targets("compute" THREADED DEPENDS cloud-docs
 foreach (dir IN LISTS operation_service_dirs)
     string(REPLACE "/v1/" "" short_dir "${dir}")
     compute_service_library(
-        ${dir} google_cloud_cpp_compute_${short_dir} DEPS
+        ${dir} compute_${short_dir} DEPS
         google-cloud-cpp::rest_protobuf_internal
         google-cloud-cpp::compute_${short_dir}_protos)
-    list(APPEND compute_operation_lib_targets
-         "google_cloud_cpp_compute_${short_dir}")
+    list(APPEND compute_operation_lib_targets "compute_${short_dir}")
 endforeach ()
 
 foreach (dir IN LISTS service_dirs)
     string(REPLACE "/v1/" "" short_dir "${dir}")
     compute_service_library(
         ${dir}
-        google_cloud_cpp_compute_${short_dir}
+        compute_${short_dir}
         DEPS
         google-cloud-cpp::compute_${short_dir}_protos
         google-cloud-cpp::compute_global_operations
         google-cloud-cpp::compute_global_organization_operations
         google-cloud-cpp::compute_region_operations
         google-cloud-cpp::compute_zone_operations)
-    list(APPEND compute_lib_targets "google_cloud_cpp_compute_${short_dir}")
+    list(APPEND compute_lib_targets "compute_${short_dir}")
 endforeach ()
 
 add_library(google_cloud_cpp_compute INTERFACE)
@@ -208,6 +208,7 @@ foreach (dir IN LISTS operation_service_dirs)
         "compute_${short_dir}"
         "The Cloud Compute API C++ Client Library"
         "Provides C++ APIs to use the Cloud Compute API."
+        WITH_SHORT_TARGET
         "google_cloud_cpp_rest_internal"
         "google_cloud_cpp_rest_protobuf_internal"
         "google_cloud_cpp_grpc_utils"
@@ -221,6 +222,7 @@ foreach (dir IN LISTS service_dirs)
         "compute_${short_dir}"
         "The Cloud Compute API C++ Client Library"
         "Provides C++ APIs to use the Cloud Compute API."
+        WITH_SHORT_TARGET
         "google_cloud_cpp_compute_global_operations"
         "google_cloud_cpp_compute_global_organization_operations"
         "google_cloud_cpp_compute_region_operations"
@@ -228,6 +230,8 @@ foreach (dir IN LISTS service_dirs)
         "google_cloud_cpp_compute_${short_dir}_protos")
 endforeach ()
 
+set(compute_pc_modules ${compute_lib_targets})
+list(TRANSFORM compute_pc_modules PREPEND "google_cloud_cpp_")
 google_cloud_cpp_add_pkgconfig(
     "compute" "The Cloud Compute API C++ Client Library"
-    "Provides C++ APIs to use the Cloud Compute API." ${compute_lib_targets})
+    "Provides C++ APIs to use the Cloud Compute API." ${compute_pc_modules})

--- a/protos/google/cloud/compute/CMakeLists.txt
+++ b/protos/google/cloud/compute/CMakeLists.txt
@@ -22,13 +22,19 @@ function (compute_proto_library dir library)
         LIST_DIRECTORIES false
         RELATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}" "${dir}*.proto")
     list(SORT proto_files)
-    string(REPLACE "google_cloud_cpp_" "" alias "${library}")
     google_cloud_cpp_proto_library(
         "${library}" "${proto_files}" PROTO_PATH_DIRECTORIES
         "${EXTERNAL_GOOGLEAPIS_SOURCE}" "${PROTO_INCLUDE_DIR}"
         "${PROJECT_SOURCE_DIR}/protos")
-    external_googleapis_set_version_and_alias("${alias}")
-    target_link_libraries("${library}" PUBLIC "${_opt_DEPS}")
+    set_target_properties(${library} PROPERTIES OUTPUT_NAME
+                                                "google_cloud_cpp_${library}")
+    add_library(google-cloud-cpp::${library} ALIAS ${library})
+    set_target_properties(
+        ${library}
+        PROPERTIES EXPORT_NAME google-cloud-cpp::${library}
+                   VERSION "${PROJECT_VERSION}"
+                   SOVERSION "${PROJECT_VERSION_MAJOR}")
+    target_link_libraries(${library} PUBLIC ${_opt_DEPS})
     # Some files are too big for the MSVC defaults.
     if (MSVC)
         target_compile_options("${library}" PRIVATE "/bigobj")
@@ -46,17 +52,14 @@ google_cloud_cpp_find_proto_include_dir(PROTO_INCLUDE_DIR)
 google_cloud_cpp_load_protodeps(
     deps "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/compute.deps")
 
-compute_proto_library("v1/internal/" "google_cloud_cpp_compute_internal_protos"
-                      DEPS "${deps}")
+compute_proto_library("v1/internal/" "compute_internal_protos" DEPS "${deps}")
 
 foreach (dir IN LISTS service_dirs operation_service_dirs)
     string(REPLACE "/v1/" "" short_dir "${dir}")
     compute_proto_library(
-        ${dir} "google_cloud_cpp_compute_${short_dir}_protos" PROTO_FILES
-        "${${short_dir}_proto_files}" DEPS
-        google_cloud_cpp_compute_internal_protos)
-    list(APPEND compute_proto_lib_targets
-         "google_cloud_cpp_compute_${short_dir}_protos")
+        ${dir} "compute_${short_dir}_protos" PROTO_FILES
+        "${${short_dir}_proto_files}" DEPS compute_internal_protos)
+    list(APPEND compute_proto_lib_targets "compute_${short_dir}_protos")
 endforeach ()
 
 # Get the destination directories based on the GNU recommendations.
@@ -71,8 +74,7 @@ install(
 # Install the libraries and headers in the locations determined by
 # GNUInstallDirs
 install(
-    TARGETS ${compute_proto_lib_targets}
-            google_cloud_cpp_compute_internal_protos
+    TARGETS ${compute_proto_lib_targets} compute_internal_protos
     EXPORT google_cloud_cpp_compute_protos-targets
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
             COMPONENT google_cloud_cpp_runtime
@@ -100,7 +102,7 @@ install(
 
 google_cloud_cpp_add_pkgconfig(
     "compute_internal_protos" "The Cloud Compute API C++ Client Library"
-    "Provides C++ APIs to use the Cloud Compute API."
+    "Provides C++ APIs to use the Cloud Compute API." WITH_SHORT_TARGET
     "google_cloud_cpp_cloud_extended_operations_protos")
 
 foreach (dir IN LISTS service_dirs operation_service_dirs)
@@ -109,6 +111,7 @@ foreach (dir IN LISTS service_dirs operation_service_dirs)
         "compute_${short_dir}_protos"
         "The Cloud Compute API C++ Client Library"
         "Provides C++ APIs to use the Cloud Compute API."
+        WITH_SHORT_TARGET
         "google_cloud_cpp_compute_internal_protos"
         "google_cloud_cpp_api_annotations_protos"
         "google_cloud_cpp_api_client_protos"

--- a/protos/google/cloud/compute/CMakeLists.txt
+++ b/protos/google/cloud/compute/CMakeLists.txt
@@ -42,6 +42,12 @@ function (compute_proto_library dir library)
     google_cloud_cpp_install_proto_library_protos(
         "${library}" "${PROJECT_SOURCE_DIR}/protos")
     google_cloud_cpp_install_proto_library_headers("${library}")
+
+    # In some configs we need to only generate the protocol definitions from
+    # `*.proto` files. We achieve this by having this target depend on all proto
+    # libraries. It has to be defined at the top level of the project.
+    add_dependencies(google-cloud-cpp-protos ${library})
+    add_dependencies("${library}" googleapis_download)
 endfunction ()
 
 include(${PROJECT_SOURCE_DIR}/google/cloud/compute/service_dirs.cmake)


### PR DESCRIPTION
Shorting the target names from `google_cloud_cpp_compute_*` to `compute_*` reduces the path length for intermediate artifacts, such as `.o` and `.obj` files. This prevents problems with MSVC, which is limited to 255 characters in file names.

Note that the target name is used as the default name for the output artifact (libraries in this case). This change overrides these defaults to preserve backwards compatibility.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13351)
<!-- Reviewable:end -->
