### PR TITLE
impl(pubsub): add links to tracing pull ack handler

### DIFF
--- a/google/cloud/pubsub/internal/tracing_pull_ack_handler.cc
+++ b/google/cloud/pubsub/internal/tracing_pull_ack_handler.cc
@@ -17,6 +17,8 @@
 #include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/status.h"
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+#include "opentelemetry/context/runtime_context.h"
+#include "opentelemetry/trace/context.h"
 #include "opentelemetry/trace/semantic_conventions.h"
 #include "opentelemetry/trace/span.h"
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
@@ -30,11 +32,43 @@ namespace pubsub_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
-
 using Attributes =
     std::vector<std::pair<opentelemetry::nostd::string_view,
                           opentelemetry::common::AttributeValue>>;
+using Links =
+    std::vector<std::pair<opentelemetry::trace::SpanContext, Attributes>>;
 
+namespace {
+Links CreateLinks() {
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+  auto consumer_span_context =
+      opentelemetry::trace::GetSpan(
+          opentelemetry::context::RuntimeContext::GetCurrent())
+          ->GetContext();
+  if (consumer_span_context.IsSampled() && consumer_span_context.IsValid()) {
+    return Links{{consumer_span_context, Attributes{}}};
+  }
+#endif
+  return Links{};
+}
+
+void MaybeAddLinkAttributes(
+    opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> const& span) {
+#if OPENTELEMETRY_ABI_VERSION_NO < 2
+  auto consumer_span_context =
+      opentelemetry::trace::GetSpan(
+          opentelemetry::context::RuntimeContext::GetCurrent())
+          ->GetContext();
+  if (consumer_span_context.IsSampled() && consumer_span_context.IsValid()) {
+    span->SetAttribute("gcp_pubsub.receive.trace_id",
+                       internal::ToString(consumer_span_context.trace_id()));
+    span->SetAttribute("gcp_pubsub.receive.span_id",
+                       internal::ToString(consumer_span_context.span_id()));
+  }
+#endif
+}
+
+}  // namespace
 class TracingPullAckHandler : public pubsub::PullAckHandler::Impl {
  public:
   explicit TracingPullAckHandler(
@@ -65,7 +99,8 @@ class TracingPullAckHandler : public pubsub::PullAckHandler::Impl {
     attributes.emplace_back(
         std::make_pair(sc::kCodeFunction, "pubsub::PullAckHandler::ack"));
     auto span = internal::MakeSpan(subscription.subscription_id() + " settle",
-                                   attributes, options);
+                                   attributes, CreateLinks(), options);
+    MaybeAddLinkAttributes(span);
     auto scope = internal::OTelScope(span);
 
     return child_->ack().then(
@@ -88,7 +123,8 @@ class TracingPullAckHandler : public pubsub::PullAckHandler::Impl {
     attributes.emplace_back(
         std::make_pair(sc::kCodeFunction, "pubsub::PullAckHandler::nack"));
     auto span = internal::MakeSpan(subscription.subscription_id() + " settle",
-                                   attributes, options);
+                                   attributes, CreateLinks(), options);
+    MaybeAddLinkAttributes(span);
     auto scope = internal::OTelScope(span);
 
     return child_->nack().then(

--- a/google/cloud/pubsub/internal/tracing_pull_ack_handler.cc
+++ b/google/cloud/pubsub/internal/tracing_pull_ack_handler.cc
@@ -35,11 +35,12 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 using Attributes =
     std::vector<std::pair<opentelemetry::nostd::string_view,
                           opentelemetry::common::AttributeValue>>;
-using Links =
-    std::vector<std::pair<opentelemetry::trace::SpanContext, Attributes>>;
 
 namespace {
-Links CreateLinks() {
+
+auto CreateLinks() {
+  using Links =
+      std::vector<std::pair<opentelemetry::trace::SpanContext, Attributes>>;
 #if OPENTELEMETRY_ABI_VERSION_NO >= 2
   auto consumer_span_context =
       opentelemetry::trace::GetSpan(

--- a/google/cloud/pubsub/internal/tracing_pull_ack_handler.cc
+++ b/google/cloud/pubsub/internal/tracing_pull_ack_handler.cc
@@ -72,6 +72,7 @@ void MaybeAddLinkAttributes(
 }
 
 }  // namespace
+
 class TracingPullAckHandler : public pubsub::PullAckHandler::Impl {
  public:
   explicit TracingPullAckHandler(

--- a/google/cloud/pubsub/internal/tracing_pull_ack_handler.cc
+++ b/google/cloud/pubsub/internal/tracing_pull_ack_handler.cc
@@ -66,6 +66,8 @@ void MaybeAddLinkAttributes(
     span->SetAttribute("gcp_pubsub.receive.span_id",
                        internal::ToString(consumer_span_context.span_id()));
   }
+#else
+  (void)span;
 #endif
 }
 


### PR DESCRIPTION
Part of https://github.com/googleapis/google-cloud-cpp/issues/13265

3/5 in a chain of PRs to add tracing for the settle span for the unary pull

1. https://github.com/googleapis/google-cloud-cpp/pull/13350
2. https://github.com/googleapis/google-cloud-cpp/pull/13353
3. https://github.com/googleapis/google-cloud-cpp/pull/13354
4. https://github.com/googleapis/google-cloud-cpp/pull/13358
5. https://github.com/googleapis/google-cloud-cpp/pull/13360

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13354)
<!-- Reviewable:end -->
