### PR TITLE
impl(pubsub): use ack handler factory

### DIFF
--- a/google/cloud/pubsub/subscriber_connection_test.cc
+++ b/google/cloud/pubsub/subscriber_connection_test.cc
@@ -222,6 +222,7 @@ TEST(MakeSubscriberConnectionTest, TracingEnabledForUnaryPull) {
   EXPECT_THAT(spans, UnorderedElementsAre(
                          SpanNamed("test-subscription receive"),
                          SpanNamed("google.pubsub.v1.Subscriber/Pull"),
+                         SpanNamed("test-subscription settle"),
                          SpanNamed("google.pubsub.v1.Subscriber/Acknowledge")));
 }
 


### PR DESCRIPTION
Part of https://github.com/googleapis/google-cloud-cpp/issues/13265

5/5 in a chain of PRs to add tracing for the settle span for the unary pull

1. https://github.com/googleapis/google-cloud-cpp/pull/13350
2. https://github.com/googleapis/google-cloud-cpp/pull/13353
3. https://github.com/googleapis/google-cloud-cpp/pull/13354
4. https://github.com/googleapis/google-cloud-cpp/pull/13358
5. https://github.com/googleapis/google-cloud-cpp/pull/13360

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13360)
<!-- Reviewable:end -->
