### PR TITLE
fix: respect logging format env var in `compute`, `sql`

### DIFF
--- a/google/cloud/internal/populate_rest_options.cc
+++ b/google/cloud/internal/populate_rest_options.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
+#include "google/cloud/rest_options.h"
 #include "absl/strings/match.h"
 
 namespace google {
@@ -38,6 +39,9 @@ Options PopulateRestOptions(Options opts) {
     if (!absl::StartsWithIgnoreCase(endpoint, "http")) {
       opts.set<EndpointOption>(absl::StrCat("https://", endpoint));
     }
+  }
+  if (!opts.has<RestTracingOptionsOption>()) {
+    opts.set<RestTracingOptionsOption>(DefaultTracingOptions());
   }
   return opts;
 }

--- a/google/cloud/internal/populate_rest_options_test.cc
+++ b/google/cloud/internal/populate_rest_options_test.cc
@@ -17,6 +17,8 @@
 #include "google/cloud/internal/credentials_impl.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/opentelemetry_options.h"
+#include "google/cloud/rest_options.h"
+#include "google/cloud/testing_util/scoped_environment.h"
 #include "absl/types/optional.h"
 #include <gmock/gmock.h>
 
@@ -25,6 +27,8 @@ namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 namespace {
+
+using ::google::cloud::testing_util::ScopedEnvironment;
 
 struct Visitor : public CredentialsVisitor {
   std::string name;
@@ -112,6 +116,14 @@ TEST(PopulateRestOptions, LongrunningEndpointOption) {
   options = PopulateRestOptions(std::move(options));
   EXPECT_EQ(options.get<LongrunningEndpointOption>(),
             "https://foo.googleapis.com");
+}
+
+TEST(PopulateRestOptions, TracingOptions) {
+  ScopedEnvironment env("GOOGLE_CLOUD_CPP_TRACING_OPTIONS",
+                        "truncate_string_field_longer_than=42");
+  auto actual = PopulateRestOptions(Options{});
+  auto tracing = actual.get<RestTracingOptionsOption>();
+  EXPECT_EQ(tracing.truncate_string_field_longer_than(), 42);
 }
 
 }  // namespace


### PR DESCRIPTION
Part of the work for #13361

We are copying the gRPC implementation. Of course I am just noticing that in the implementation, setting the `*TracingOptionsOption` will override the `GOOGLE_CLOUD_CPP_TRACING_OPTIONS`, which is at odds with our ADR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13368)
<!-- Reviewable:end -->
