### PR TITLE
test(generator): update expectations on CurrentCopyrightYear()

### DIFF
--- a/generator/internal/discovery_file_test.cc
+++ b/generator/internal/discovery_file_test.cc
@@ -141,7 +141,7 @@ auto constexpr kGetRequestTypeJson = R"""({
 auto constexpr kOperationTypeJson = R"""({})""";
 
 TEST_F(DiscoveryFileTest, FormatFileWithImport) {
-  auto constexpr kExpectedProto = R"""(// Copyright 2023 Google LLC
+  auto constexpr kExpectedProto = R"""(// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -262,7 +262,7 @@ message GetMyResourceRequest {
 }
 
 TEST_F(DiscoveryFileTest, FormatFileWithoutImports) {
-  auto constexpr kExpectedProto = R"""(// Copyright 2023 Google LLC
+  auto constexpr kExpectedProto = R"""(// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -379,7 +379,7 @@ message GetMyResourceRequest {
 }
 
 TEST_F(DiscoveryFileTest, FormatFileNoResource) {
-  auto constexpr kExpectedProto = R"""(// Copyright 2023 Google LLC
+  auto constexpr kExpectedProto = R"""(// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -462,7 +462,7 @@ TEST_F(DiscoveryFileTest, FormatFileNoTypes) {
   }
 })""";
 
-  auto constexpr kExpectedProto = R"""(// Copyright 2023 Google LLC
+  auto constexpr kExpectedProto = R"""(// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/accelerator_types/v1/accelerator_types_proto_export.h
+++ b/google/cloud/compute/accelerator_types/v1/accelerator_types_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/addresses/v1/addresses_proto_export.h
+++ b/google/cloud/compute/addresses/v1/addresses_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/autoscalers/v1/autoscalers_proto_export.h
+++ b/google/cloud/compute/autoscalers/v1/autoscalers_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/backend_buckets/v1/backend_buckets_proto_export.h
+++ b/google/cloud/compute/backend_buckets/v1/backend_buckets_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/backend_services/v1/backend_services_proto_export.h
+++ b/google/cloud/compute/backend_services/v1/backend_services_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/disk_types/v1/disk_types_proto_export.h
+++ b/google/cloud/compute/disk_types/v1/disk_types_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/disks/v1/disks_proto_export.h
+++ b/google/cloud/compute/disks/v1/disks_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/external_vpn_gateways/v1/external_vpn_gateways_proto_export.h
+++ b/google/cloud/compute/external_vpn_gateways/v1/external_vpn_gateways_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/firewall_policies/v1/firewall_policies_proto_export.h
+++ b/google/cloud/compute/firewall_policies/v1/firewall_policies_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/firewalls/v1/firewalls_proto_export.h
+++ b/google/cloud/compute/firewalls/v1/firewalls_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/forwarding_rules/v1/forwarding_rules_proto_export.h
+++ b/google/cloud/compute/forwarding_rules/v1/forwarding_rules_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/global_addresses/v1/global_addresses_proto_export.h
+++ b/google/cloud/compute/global_addresses/v1/global_addresses_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/global_forwarding_rules/v1/global_forwarding_rules_proto_export.h
+++ b/google/cloud/compute/global_forwarding_rules/v1/global_forwarding_rules_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/global_network_endpoint_groups/v1/global_network_endpoint_groups_proto_export.h
+++ b/google/cloud/compute/global_network_endpoint_groups/v1/global_network_endpoint_groups_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/global_operations/v1/global_operations_proto_export.h
+++ b/google/cloud/compute/global_operations/v1/global_operations_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/global_organization_operations/v1/global_organization_operations_proto_export.h
+++ b/google/cloud/compute/global_organization_operations/v1/global_organization_operations_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/global_public_delegated_prefixes/v1/global_public_delegated_prefixes_proto_export.h
+++ b/google/cloud/compute/global_public_delegated_prefixes/v1/global_public_delegated_prefixes_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/health_checks/v1/health_checks_proto_export.h
+++ b/google/cloud/compute/health_checks/v1/health_checks_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/http_health_checks/v1/http_health_checks_proto_export.h
+++ b/google/cloud/compute/http_health_checks/v1/http_health_checks_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/https_health_checks/v1/https_health_checks_proto_export.h
+++ b/google/cloud/compute/https_health_checks/v1/https_health_checks_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/image_family_views/v1/image_family_views_proto_export.h
+++ b/google/cloud/compute/image_family_views/v1/image_family_views_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/images/v1/images_proto_export.h
+++ b/google/cloud/compute/images/v1/images_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/instance_group_managers/v1/instance_group_managers_proto_export.h
+++ b/google/cloud/compute/instance_group_managers/v1/instance_group_managers_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/instance_groups/v1/instance_groups_proto_export.h
+++ b/google/cloud/compute/instance_groups/v1/instance_groups_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/instance_templates/v1/instance_templates_proto_export.h
+++ b/google/cloud/compute/instance_templates/v1/instance_templates_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/instances/v1/instances_proto_export.h
+++ b/google/cloud/compute/instances/v1/instances_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/interconnect_attachments/v1/interconnect_attachments_proto_export.h
+++ b/google/cloud/compute/interconnect_attachments/v1/interconnect_attachments_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/interconnect_locations/v1/interconnect_locations_proto_export.h
+++ b/google/cloud/compute/interconnect_locations/v1/interconnect_locations_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/interconnect_remote_locations/v1/interconnect_remote_locations_proto_export.h
+++ b/google/cloud/compute/interconnect_remote_locations/v1/interconnect_remote_locations_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/interconnects/v1/interconnects_proto_export.h
+++ b/google/cloud/compute/interconnects/v1/interconnects_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/license_codes/v1/license_codes_proto_export.h
+++ b/google/cloud/compute/license_codes/v1/license_codes_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/licenses/v1/licenses_proto_export.h
+++ b/google/cloud/compute/licenses/v1/licenses_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/machine_images/v1/machine_images_proto_export.h
+++ b/google/cloud/compute/machine_images/v1/machine_images_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/machine_types/v1/machine_types_proto_export.h
+++ b/google/cloud/compute/machine_types/v1/machine_types_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/network_attachments/v1/network_attachments_proto_export.h
+++ b/google/cloud/compute/network_attachments/v1/network_attachments_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/network_edge_security_services/v1/network_edge_security_services_proto_export.h
+++ b/google/cloud/compute/network_edge_security_services/v1/network_edge_security_services_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/network_endpoint_groups/v1/network_endpoint_groups_proto_export.h
+++ b/google/cloud/compute/network_endpoint_groups/v1/network_endpoint_groups_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/network_firewall_policies/v1/network_firewall_policies_proto_export.h
+++ b/google/cloud/compute/network_firewall_policies/v1/network_firewall_policies_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/networks/v1/networks_proto_export.h
+++ b/google/cloud/compute/networks/v1/networks_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/node_groups/v1/node_groups_proto_export.h
+++ b/google/cloud/compute/node_groups/v1/node_groups_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/node_templates/v1/node_templates_proto_export.h
+++ b/google/cloud/compute/node_templates/v1/node_templates_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/node_types/v1/node_types_proto_export.h
+++ b/google/cloud/compute/node_types/v1/node_types_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/packet_mirrorings/v1/packet_mirrorings_proto_export.h
+++ b/google/cloud/compute/packet_mirrorings/v1/packet_mirrorings_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/projects/v1/projects_proto_export.h
+++ b/google/cloud/compute/projects/v1/projects_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/public_advertised_prefixes/v1/public_advertised_prefixes_proto_export.h
+++ b/google/cloud/compute/public_advertised_prefixes/v1/public_advertised_prefixes_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/public_delegated_prefixes/v1/public_delegated_prefixes_proto_export.h
+++ b/google/cloud/compute/public_delegated_prefixes/v1/public_delegated_prefixes_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/region_autoscalers/v1/region_autoscalers_proto_export.h
+++ b/google/cloud/compute/region_autoscalers/v1/region_autoscalers_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/region_backend_services/v1/region_backend_services_proto_export.h
+++ b/google/cloud/compute/region_backend_services/v1/region_backend_services_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/region_commitments/v1/region_commitments_proto_export.h
+++ b/google/cloud/compute/region_commitments/v1/region_commitments_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/region_disk_types/v1/region_disk_types_proto_export.h
+++ b/google/cloud/compute/region_disk_types/v1/region_disk_types_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/region_disks/v1/region_disks_proto_export.h
+++ b/google/cloud/compute/region_disks/v1/region_disks_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/region_health_check_services/v1/region_health_check_services_proto_export.h
+++ b/google/cloud/compute/region_health_check_services/v1/region_health_check_services_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/region_health_checks/v1/region_health_checks_proto_export.h
+++ b/google/cloud/compute/region_health_checks/v1/region_health_checks_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/region_instance_group_managers/v1/region_instance_group_managers_proto_export.h
+++ b/google/cloud/compute/region_instance_group_managers/v1/region_instance_group_managers_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/region_instance_groups/v1/region_instance_groups_proto_export.h
+++ b/google/cloud/compute/region_instance_groups/v1/region_instance_groups_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/region_instance_templates/v1/region_instance_templates_proto_export.h
+++ b/google/cloud/compute/region_instance_templates/v1/region_instance_templates_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/region_instances/v1/region_instances_proto_export.h
+++ b/google/cloud/compute/region_instances/v1/region_instances_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/region_network_endpoint_groups/v1/region_network_endpoint_groups_proto_export.h
+++ b/google/cloud/compute/region_network_endpoint_groups/v1/region_network_endpoint_groups_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/region_network_firewall_policies/v1/region_network_firewall_policies_proto_export.h
+++ b/google/cloud/compute/region_network_firewall_policies/v1/region_network_firewall_policies_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/region_notification_endpoints/v1/region_notification_endpoints_proto_export.h
+++ b/google/cloud/compute/region_notification_endpoints/v1/region_notification_endpoints_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/region_operations/v1/region_operations_proto_export.h
+++ b/google/cloud/compute/region_operations/v1/region_operations_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/region_security_policies/v1/region_security_policies_proto_export.h
+++ b/google/cloud/compute/region_security_policies/v1/region_security_policies_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/region_ssl_certificates/v1/region_ssl_certificates_proto_export.h
+++ b/google/cloud/compute/region_ssl_certificates/v1/region_ssl_certificates_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/region_ssl_policies/v1/region_ssl_policies_proto_export.h
+++ b/google/cloud/compute/region_ssl_policies/v1/region_ssl_policies_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/region_target_http_proxies/v1/region_target_http_proxies_proto_export.h
+++ b/google/cloud/compute/region_target_http_proxies/v1/region_target_http_proxies_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/region_target_https_proxies/v1/region_target_https_proxies_proto_export.h
+++ b/google/cloud/compute/region_target_https_proxies/v1/region_target_https_proxies_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/region_target_tcp_proxies/v1/region_target_tcp_proxies_proto_export.h
+++ b/google/cloud/compute/region_target_tcp_proxies/v1/region_target_tcp_proxies_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/region_url_maps/v1/region_url_maps_proto_export.h
+++ b/google/cloud/compute/region_url_maps/v1/region_url_maps_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/regions/v1/regions_proto_export.h
+++ b/google/cloud/compute/regions/v1/regions_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/reservations/v1/reservations_proto_export.h
+++ b/google/cloud/compute/reservations/v1/reservations_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/resource_policies/v1/resource_policies_proto_export.h
+++ b/google/cloud/compute/resource_policies/v1/resource_policies_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/routers/v1/routers_proto_export.h
+++ b/google/cloud/compute/routers/v1/routers_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/routes/v1/routes_proto_export.h
+++ b/google/cloud/compute/routes/v1/routes_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/security_policies/v1/security_policies_proto_export.h
+++ b/google/cloud/compute/security_policies/v1/security_policies_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/service_attachments/v1/service_attachments_proto_export.h
+++ b/google/cloud/compute/service_attachments/v1/service_attachments_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/snapshot_settings/v1/snapshot_settings_proto_export.h
+++ b/google/cloud/compute/snapshot_settings/v1/snapshot_settings_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/snapshots/v1/snapshots_proto_export.h
+++ b/google/cloud/compute/snapshots/v1/snapshots_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/ssl_certificates/v1/ssl_certificates_proto_export.h
+++ b/google/cloud/compute/ssl_certificates/v1/ssl_certificates_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/ssl_policies/v1/ssl_policies_proto_export.h
+++ b/google/cloud/compute/ssl_policies/v1/ssl_policies_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/subnetworks/v1/subnetworks_proto_export.h
+++ b/google/cloud/compute/subnetworks/v1/subnetworks_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/target_grpc_proxies/v1/target_grpc_proxies_proto_export.h
+++ b/google/cloud/compute/target_grpc_proxies/v1/target_grpc_proxies_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/target_http_proxies/v1/target_http_proxies_proto_export.h
+++ b/google/cloud/compute/target_http_proxies/v1/target_http_proxies_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/target_https_proxies/v1/target_https_proxies_proto_export.h
+++ b/google/cloud/compute/target_https_proxies/v1/target_https_proxies_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/target_instances/v1/target_instances_proto_export.h
+++ b/google/cloud/compute/target_instances/v1/target_instances_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/target_pools/v1/target_pools_proto_export.h
+++ b/google/cloud/compute/target_pools/v1/target_pools_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/target_ssl_proxies/v1/target_ssl_proxies_proto_export.h
+++ b/google/cloud/compute/target_ssl_proxies/v1/target_ssl_proxies_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/target_tcp_proxies/v1/target_tcp_proxies_proto_export.h
+++ b/google/cloud/compute/target_tcp_proxies/v1/target_tcp_proxies_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/target_vpn_gateways/v1/target_vpn_gateways_proto_export.h
+++ b/google/cloud/compute/target_vpn_gateways/v1/target_vpn_gateways_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/url_maps/v1/url_maps_proto_export.h
+++ b/google/cloud/compute/url_maps/v1/url_maps_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/vpn_gateways/v1/vpn_gateways_proto_export.h
+++ b/google/cloud/compute/vpn_gateways/v1/vpn_gateways_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/vpn_tunnels/v1/vpn_tunnels_proto_export.h
+++ b/google/cloud/compute/vpn_tunnels/v1/vpn_tunnels_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/zone_operations/v1/zone_operations_proto_export.h
+++ b/google/cloud/compute/zone_operations/v1/zone_operations_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/compute/zones/v1/zones_proto_export.h
+++ b/google/cloud/compute/zones/v1/zones_proto_export.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/accelerator_types/v1/accelerator_types.proto
+++ b/protos/google/cloud/compute/accelerator_types/v1/accelerator_types.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/addresses/v1/addresses.proto
+++ b/protos/google/cloud/compute/addresses/v1/addresses.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/autoscalers/v1/autoscalers.proto
+++ b/protos/google/cloud/compute/autoscalers/v1/autoscalers.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/backend_buckets/v1/backend_buckets.proto
+++ b/protos/google/cloud/compute/backend_buckets/v1/backend_buckets.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/backend_services/v1/backend_services.proto
+++ b/protos/google/cloud/compute/backend_services/v1/backend_services.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/disk_types/v1/disk_types.proto
+++ b/protos/google/cloud/compute/disk_types/v1/disk_types.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/disks/v1/disks.proto
+++ b/protos/google/cloud/compute/disks/v1/disks.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/external_vpn_gateways/v1/external_vpn_gateways.proto
+++ b/protos/google/cloud/compute/external_vpn_gateways/v1/external_vpn_gateways.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/firewall_policies/v1/firewall_policies.proto
+++ b/protos/google/cloud/compute/firewall_policies/v1/firewall_policies.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/firewalls/v1/firewalls.proto
+++ b/protos/google/cloud/compute/firewalls/v1/firewalls.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/forwarding_rules/v1/forwarding_rules.proto
+++ b/protos/google/cloud/compute/forwarding_rules/v1/forwarding_rules.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/global_addresses/v1/global_addresses.proto
+++ b/protos/google/cloud/compute/global_addresses/v1/global_addresses.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/global_forwarding_rules/v1/global_forwarding_rules.proto
+++ b/protos/google/cloud/compute/global_forwarding_rules/v1/global_forwarding_rules.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/global_network_endpoint_groups/v1/global_network_endpoint_groups.proto
+++ b/protos/google/cloud/compute/global_network_endpoint_groups/v1/global_network_endpoint_groups.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/global_operations/v1/global_operations.proto
+++ b/protos/google/cloud/compute/global_operations/v1/global_operations.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/global_organization_operations/v1/global_organization_operations.proto
+++ b/protos/google/cloud/compute/global_organization_operations/v1/global_organization_operations.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/global_public_delegated_prefixes/v1/global_public_delegated_prefixes.proto
+++ b/protos/google/cloud/compute/global_public_delegated_prefixes/v1/global_public_delegated_prefixes.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/health_checks/v1/health_checks.proto
+++ b/protos/google/cloud/compute/health_checks/v1/health_checks.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/http_health_checks/v1/http_health_checks.proto
+++ b/protos/google/cloud/compute/http_health_checks/v1/http_health_checks.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/https_health_checks/v1/https_health_checks.proto
+++ b/protos/google/cloud/compute/https_health_checks/v1/https_health_checks.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/image_family_views/v1/image_family_views.proto
+++ b/protos/google/cloud/compute/image_family_views/v1/image_family_views.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/images/v1/images.proto
+++ b/protos/google/cloud/compute/images/v1/images.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/instance_group_managers/v1/instance_group_managers.proto
+++ b/protos/google/cloud/compute/instance_group_managers/v1/instance_group_managers.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/instance_groups/v1/instance_groups.proto
+++ b/protos/google/cloud/compute/instance_groups/v1/instance_groups.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/instance_templates/v1/instance_templates.proto
+++ b/protos/google/cloud/compute/instance_templates/v1/instance_templates.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/instances/v1/instances.proto
+++ b/protos/google/cloud/compute/instances/v1/instances.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/interconnect_attachments/v1/interconnect_attachments.proto
+++ b/protos/google/cloud/compute/interconnect_attachments/v1/interconnect_attachments.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/interconnect_locations/v1/interconnect_locations.proto
+++ b/protos/google/cloud/compute/interconnect_locations/v1/interconnect_locations.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/interconnect_remote_locations/v1/interconnect_remote_locations.proto
+++ b/protos/google/cloud/compute/interconnect_remote_locations/v1/interconnect_remote_locations.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/interconnects/v1/interconnects.proto
+++ b/protos/google/cloud/compute/interconnects/v1/interconnects.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/license_codes/v1/license_codes.proto
+++ b/protos/google/cloud/compute/license_codes/v1/license_codes.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/licenses/v1/licenses.proto
+++ b/protos/google/cloud/compute/licenses/v1/licenses.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/machine_images/v1/machine_images.proto
+++ b/protos/google/cloud/compute/machine_images/v1/machine_images.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/machine_types/v1/machine_types.proto
+++ b/protos/google/cloud/compute/machine_types/v1/machine_types.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/network_attachments/v1/network_attachments.proto
+++ b/protos/google/cloud/compute/network_attachments/v1/network_attachments.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/network_edge_security_services/v1/network_edge_security_services.proto
+++ b/protos/google/cloud/compute/network_edge_security_services/v1/network_edge_security_services.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/network_endpoint_groups/v1/network_endpoint_groups.proto
+++ b/protos/google/cloud/compute/network_endpoint_groups/v1/network_endpoint_groups.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/network_firewall_policies/v1/network_firewall_policies.proto
+++ b/protos/google/cloud/compute/network_firewall_policies/v1/network_firewall_policies.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/networks/v1/networks.proto
+++ b/protos/google/cloud/compute/networks/v1/networks.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/node_groups/v1/node_groups.proto
+++ b/protos/google/cloud/compute/node_groups/v1/node_groups.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/node_templates/v1/node_templates.proto
+++ b/protos/google/cloud/compute/node_templates/v1/node_templates.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/node_types/v1/node_types.proto
+++ b/protos/google/cloud/compute/node_types/v1/node_types.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/packet_mirrorings/v1/packet_mirrorings.proto
+++ b/protos/google/cloud/compute/packet_mirrorings/v1/packet_mirrorings.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/projects/v1/projects.proto
+++ b/protos/google/cloud/compute/projects/v1/projects.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/public_advertised_prefixes/v1/public_advertised_prefixes.proto
+++ b/protos/google/cloud/compute/public_advertised_prefixes/v1/public_advertised_prefixes.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/public_delegated_prefixes/v1/public_delegated_prefixes.proto
+++ b/protos/google/cloud/compute/public_delegated_prefixes/v1/public_delegated_prefixes.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/region_autoscalers/v1/region_autoscalers.proto
+++ b/protos/google/cloud/compute/region_autoscalers/v1/region_autoscalers.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/region_backend_services/v1/region_backend_services.proto
+++ b/protos/google/cloud/compute/region_backend_services/v1/region_backend_services.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/region_commitments/v1/region_commitments.proto
+++ b/protos/google/cloud/compute/region_commitments/v1/region_commitments.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/region_disk_types/v1/region_disk_types.proto
+++ b/protos/google/cloud/compute/region_disk_types/v1/region_disk_types.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/region_disks/v1/region_disks.proto
+++ b/protos/google/cloud/compute/region_disks/v1/region_disks.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/region_health_check_services/v1/region_health_check_services.proto
+++ b/protos/google/cloud/compute/region_health_check_services/v1/region_health_check_services.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/region_health_checks/v1/region_health_checks.proto
+++ b/protos/google/cloud/compute/region_health_checks/v1/region_health_checks.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/region_instance_group_managers/v1/region_instance_group_managers.proto
+++ b/protos/google/cloud/compute/region_instance_group_managers/v1/region_instance_group_managers.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/region_instance_groups/v1/region_instance_groups.proto
+++ b/protos/google/cloud/compute/region_instance_groups/v1/region_instance_groups.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/region_instance_templates/v1/region_instance_templates.proto
+++ b/protos/google/cloud/compute/region_instance_templates/v1/region_instance_templates.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/region_instances/v1/region_instances.proto
+++ b/protos/google/cloud/compute/region_instances/v1/region_instances.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/region_network_endpoint_groups/v1/region_network_endpoint_groups.proto
+++ b/protos/google/cloud/compute/region_network_endpoint_groups/v1/region_network_endpoint_groups.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/region_network_firewall_policies/v1/region_network_firewall_policies.proto
+++ b/protos/google/cloud/compute/region_network_firewall_policies/v1/region_network_firewall_policies.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/region_notification_endpoints/v1/region_notification_endpoints.proto
+++ b/protos/google/cloud/compute/region_notification_endpoints/v1/region_notification_endpoints.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/region_operations/v1/region_operations.proto
+++ b/protos/google/cloud/compute/region_operations/v1/region_operations.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/region_security_policies/v1/region_security_policies.proto
+++ b/protos/google/cloud/compute/region_security_policies/v1/region_security_policies.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/region_ssl_certificates/v1/region_ssl_certificates.proto
+++ b/protos/google/cloud/compute/region_ssl_certificates/v1/region_ssl_certificates.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/region_ssl_policies/v1/region_ssl_policies.proto
+++ b/protos/google/cloud/compute/region_ssl_policies/v1/region_ssl_policies.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/region_target_http_proxies/v1/region_target_http_proxies.proto
+++ b/protos/google/cloud/compute/region_target_http_proxies/v1/region_target_http_proxies.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/region_target_https_proxies/v1/region_target_https_proxies.proto
+++ b/protos/google/cloud/compute/region_target_https_proxies/v1/region_target_https_proxies.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/region_target_tcp_proxies/v1/region_target_tcp_proxies.proto
+++ b/protos/google/cloud/compute/region_target_tcp_proxies/v1/region_target_tcp_proxies.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/region_url_maps/v1/region_url_maps.proto
+++ b/protos/google/cloud/compute/region_url_maps/v1/region_url_maps.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/regions/v1/regions.proto
+++ b/protos/google/cloud/compute/regions/v1/regions.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/reservations/v1/reservations.proto
+++ b/protos/google/cloud/compute/reservations/v1/reservations.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/resource_policies/v1/resource_policies.proto
+++ b/protos/google/cloud/compute/resource_policies/v1/resource_policies.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/routers/v1/routers.proto
+++ b/protos/google/cloud/compute/routers/v1/routers.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/routes/v1/routes.proto
+++ b/protos/google/cloud/compute/routes/v1/routes.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/security_policies/v1/security_policies.proto
+++ b/protos/google/cloud/compute/security_policies/v1/security_policies.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/service_attachments/v1/service_attachments.proto
+++ b/protos/google/cloud/compute/service_attachments/v1/service_attachments.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/snapshot_settings/v1/snapshot_settings.proto
+++ b/protos/google/cloud/compute/snapshot_settings/v1/snapshot_settings.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/snapshots/v1/snapshots.proto
+++ b/protos/google/cloud/compute/snapshots/v1/snapshots.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/ssl_certificates/v1/ssl_certificates.proto
+++ b/protos/google/cloud/compute/ssl_certificates/v1/ssl_certificates.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/ssl_policies/v1/ssl_policies.proto
+++ b/protos/google/cloud/compute/ssl_policies/v1/ssl_policies.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/subnetworks/v1/subnetworks.proto
+++ b/protos/google/cloud/compute/subnetworks/v1/subnetworks.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/target_grpc_proxies/v1/target_grpc_proxies.proto
+++ b/protos/google/cloud/compute/target_grpc_proxies/v1/target_grpc_proxies.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/target_http_proxies/v1/target_http_proxies.proto
+++ b/protos/google/cloud/compute/target_http_proxies/v1/target_http_proxies.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/target_https_proxies/v1/target_https_proxies.proto
+++ b/protos/google/cloud/compute/target_https_proxies/v1/target_https_proxies.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/target_instances/v1/target_instances.proto
+++ b/protos/google/cloud/compute/target_instances/v1/target_instances.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/target_pools/v1/target_pools.proto
+++ b/protos/google/cloud/compute/target_pools/v1/target_pools.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/target_ssl_proxies/v1/target_ssl_proxies.proto
+++ b/protos/google/cloud/compute/target_ssl_proxies/v1/target_ssl_proxies.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/target_tcp_proxies/v1/target_tcp_proxies.proto
+++ b/protos/google/cloud/compute/target_tcp_proxies/v1/target_tcp_proxies.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/target_vpn_gateways/v1/target_vpn_gateways.proto
+++ b/protos/google/cloud/compute/target_vpn_gateways/v1/target_vpn_gateways.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/url_maps/v1/url_maps.proto
+++ b/protos/google/cloud/compute/url_maps/v1/url_maps.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_000.proto
+++ b/protos/google/cloud/compute/v1/internal/common_000.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_001.proto
+++ b/protos/google/cloud/compute/v1/internal/common_001.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_002.proto
+++ b/protos/google/cloud/compute/v1/internal/common_002.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_003.proto
+++ b/protos/google/cloud/compute/v1/internal/common_003.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_004.proto
+++ b/protos/google/cloud/compute/v1/internal/common_004.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_005.proto
+++ b/protos/google/cloud/compute/v1/internal/common_005.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_006.proto
+++ b/protos/google/cloud/compute/v1/internal/common_006.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_007.proto
+++ b/protos/google/cloud/compute/v1/internal/common_007.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_008.proto
+++ b/protos/google/cloud/compute/v1/internal/common_008.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_009.proto
+++ b/protos/google/cloud/compute/v1/internal/common_009.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_010.proto
+++ b/protos/google/cloud/compute/v1/internal/common_010.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_011.proto
+++ b/protos/google/cloud/compute/v1/internal/common_011.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_012.proto
+++ b/protos/google/cloud/compute/v1/internal/common_012.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_013.proto
+++ b/protos/google/cloud/compute/v1/internal/common_013.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_014.proto
+++ b/protos/google/cloud/compute/v1/internal/common_014.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_015.proto
+++ b/protos/google/cloud/compute/v1/internal/common_015.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_016.proto
+++ b/protos/google/cloud/compute/v1/internal/common_016.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_017.proto
+++ b/protos/google/cloud/compute/v1/internal/common_017.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_018.proto
+++ b/protos/google/cloud/compute/v1/internal/common_018.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_019.proto
+++ b/protos/google/cloud/compute/v1/internal/common_019.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_020.proto
+++ b/protos/google/cloud/compute/v1/internal/common_020.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_021.proto
+++ b/protos/google/cloud/compute/v1/internal/common_021.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_022.proto
+++ b/protos/google/cloud/compute/v1/internal/common_022.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_023.proto
+++ b/protos/google/cloud/compute/v1/internal/common_023.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_024.proto
+++ b/protos/google/cloud/compute/v1/internal/common_024.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_025.proto
+++ b/protos/google/cloud/compute/v1/internal/common_025.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_026.proto
+++ b/protos/google/cloud/compute/v1/internal/common_026.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_027.proto
+++ b/protos/google/cloud/compute/v1/internal/common_027.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_028.proto
+++ b/protos/google/cloud/compute/v1/internal/common_028.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_029.proto
+++ b/protos/google/cloud/compute/v1/internal/common_029.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_030.proto
+++ b/protos/google/cloud/compute/v1/internal/common_030.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_031.proto
+++ b/protos/google/cloud/compute/v1/internal/common_031.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_032.proto
+++ b/protos/google/cloud/compute/v1/internal/common_032.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_033.proto
+++ b/protos/google/cloud/compute/v1/internal/common_033.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_034.proto
+++ b/protos/google/cloud/compute/v1/internal/common_034.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_035.proto
+++ b/protos/google/cloud/compute/v1/internal/common_035.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_036.proto
+++ b/protos/google/cloud/compute/v1/internal/common_036.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_037.proto
+++ b/protos/google/cloud/compute/v1/internal/common_037.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_038.proto
+++ b/protos/google/cloud/compute/v1/internal/common_038.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_039.proto
+++ b/protos/google/cloud/compute/v1/internal/common_039.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_040.proto
+++ b/protos/google/cloud/compute/v1/internal/common_040.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_041.proto
+++ b/protos/google/cloud/compute/v1/internal/common_041.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_042.proto
+++ b/protos/google/cloud/compute/v1/internal/common_042.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_043.proto
+++ b/protos/google/cloud/compute/v1/internal/common_043.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_044.proto
+++ b/protos/google/cloud/compute/v1/internal/common_044.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_045.proto
+++ b/protos/google/cloud/compute/v1/internal/common_045.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_046.proto
+++ b/protos/google/cloud/compute/v1/internal/common_046.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_047.proto
+++ b/protos/google/cloud/compute/v1/internal/common_047.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_048.proto
+++ b/protos/google/cloud/compute/v1/internal/common_048.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_049.proto
+++ b/protos/google/cloud/compute/v1/internal/common_049.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_050.proto
+++ b/protos/google/cloud/compute/v1/internal/common_050.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_051.proto
+++ b/protos/google/cloud/compute/v1/internal/common_051.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_052.proto
+++ b/protos/google/cloud/compute/v1/internal/common_052.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_053.proto
+++ b/protos/google/cloud/compute/v1/internal/common_053.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_054.proto
+++ b/protos/google/cloud/compute/v1/internal/common_054.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_055.proto
+++ b/protos/google/cloud/compute/v1/internal/common_055.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_056.proto
+++ b/protos/google/cloud/compute/v1/internal/common_056.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_057.proto
+++ b/protos/google/cloud/compute/v1/internal/common_057.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_058.proto
+++ b/protos/google/cloud/compute/v1/internal/common_058.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_059.proto
+++ b/protos/google/cloud/compute/v1/internal/common_059.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_060.proto
+++ b/protos/google/cloud/compute/v1/internal/common_060.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_061.proto
+++ b/protos/google/cloud/compute/v1/internal/common_061.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_062.proto
+++ b/protos/google/cloud/compute/v1/internal/common_062.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_063.proto
+++ b/protos/google/cloud/compute/v1/internal/common_063.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_064.proto
+++ b/protos/google/cloud/compute/v1/internal/common_064.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_065.proto
+++ b/protos/google/cloud/compute/v1/internal/common_065.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_066.proto
+++ b/protos/google/cloud/compute/v1/internal/common_066.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_067.proto
+++ b/protos/google/cloud/compute/v1/internal/common_067.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_068.proto
+++ b/protos/google/cloud/compute/v1/internal/common_068.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_069.proto
+++ b/protos/google/cloud/compute/v1/internal/common_069.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_070.proto
+++ b/protos/google/cloud/compute/v1/internal/common_070.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_071.proto
+++ b/protos/google/cloud/compute/v1/internal/common_071.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_072.proto
+++ b/protos/google/cloud/compute/v1/internal/common_072.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_073.proto
+++ b/protos/google/cloud/compute/v1/internal/common_073.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_074.proto
+++ b/protos/google/cloud/compute/v1/internal/common_074.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_075.proto
+++ b/protos/google/cloud/compute/v1/internal/common_075.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_076.proto
+++ b/protos/google/cloud/compute/v1/internal/common_076.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_077.proto
+++ b/protos/google/cloud/compute/v1/internal/common_077.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_078.proto
+++ b/protos/google/cloud/compute/v1/internal/common_078.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_079.proto
+++ b/protos/google/cloud/compute/v1/internal/common_079.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_080.proto
+++ b/protos/google/cloud/compute/v1/internal/common_080.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_081.proto
+++ b/protos/google/cloud/compute/v1/internal/common_081.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_082.proto
+++ b/protos/google/cloud/compute/v1/internal/common_082.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_083.proto
+++ b/protos/google/cloud/compute/v1/internal/common_083.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_084.proto
+++ b/protos/google/cloud/compute/v1/internal/common_084.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_085.proto
+++ b/protos/google/cloud/compute/v1/internal/common_085.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_086.proto
+++ b/protos/google/cloud/compute/v1/internal/common_086.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_087.proto
+++ b/protos/google/cloud/compute/v1/internal/common_087.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_088.proto
+++ b/protos/google/cloud/compute/v1/internal/common_088.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_089.proto
+++ b/protos/google/cloud/compute/v1/internal/common_089.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_090.proto
+++ b/protos/google/cloud/compute/v1/internal/common_090.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_091.proto
+++ b/protos/google/cloud/compute/v1/internal/common_091.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_092.proto
+++ b/protos/google/cloud/compute/v1/internal/common_092.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_093.proto
+++ b/protos/google/cloud/compute/v1/internal/common_093.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_094.proto
+++ b/protos/google/cloud/compute/v1/internal/common_094.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_095.proto
+++ b/protos/google/cloud/compute/v1/internal/common_095.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_096.proto
+++ b/protos/google/cloud/compute/v1/internal/common_096.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_097.proto
+++ b/protos/google/cloud/compute/v1/internal/common_097.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_098.proto
+++ b/protos/google/cloud/compute/v1/internal/common_098.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_099.proto
+++ b/protos/google/cloud/compute/v1/internal/common_099.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_100.proto
+++ b/protos/google/cloud/compute/v1/internal/common_100.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_101.proto
+++ b/protos/google/cloud/compute/v1/internal/common_101.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_102.proto
+++ b/protos/google/cloud/compute/v1/internal/common_102.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_103.proto
+++ b/protos/google/cloud/compute/v1/internal/common_103.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_104.proto
+++ b/protos/google/cloud/compute/v1/internal/common_104.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_105.proto
+++ b/protos/google/cloud/compute/v1/internal/common_105.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_106.proto
+++ b/protos/google/cloud/compute/v1/internal/common_106.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_107.proto
+++ b/protos/google/cloud/compute/v1/internal/common_107.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_108.proto
+++ b/protos/google/cloud/compute/v1/internal/common_108.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_109.proto
+++ b/protos/google/cloud/compute/v1/internal/common_109.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_110.proto
+++ b/protos/google/cloud/compute/v1/internal/common_110.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_111.proto
+++ b/protos/google/cloud/compute/v1/internal/common_111.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_112.proto
+++ b/protos/google/cloud/compute/v1/internal/common_112.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_113.proto
+++ b/protos/google/cloud/compute/v1/internal/common_113.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_114.proto
+++ b/protos/google/cloud/compute/v1/internal/common_114.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_115.proto
+++ b/protos/google/cloud/compute/v1/internal/common_115.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_116.proto
+++ b/protos/google/cloud/compute/v1/internal/common_116.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_117.proto
+++ b/protos/google/cloud/compute/v1/internal/common_117.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_118.proto
+++ b/protos/google/cloud/compute/v1/internal/common_118.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_119.proto
+++ b/protos/google/cloud/compute/v1/internal/common_119.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_120.proto
+++ b/protos/google/cloud/compute/v1/internal/common_120.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_121.proto
+++ b/protos/google/cloud/compute/v1/internal/common_121.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_122.proto
+++ b/protos/google/cloud/compute/v1/internal/common_122.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_123.proto
+++ b/protos/google/cloud/compute/v1/internal/common_123.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_124.proto
+++ b/protos/google/cloud/compute/v1/internal/common_124.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_125.proto
+++ b/protos/google/cloud/compute/v1/internal/common_125.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_126.proto
+++ b/protos/google/cloud/compute/v1/internal/common_126.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_127.proto
+++ b/protos/google/cloud/compute/v1/internal/common_127.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_128.proto
+++ b/protos/google/cloud/compute/v1/internal/common_128.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_129.proto
+++ b/protos/google/cloud/compute/v1/internal/common_129.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_130.proto
+++ b/protos/google/cloud/compute/v1/internal/common_130.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_131.proto
+++ b/protos/google/cloud/compute/v1/internal/common_131.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_132.proto
+++ b/protos/google/cloud/compute/v1/internal/common_132.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_133.proto
+++ b/protos/google/cloud/compute/v1/internal/common_133.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_134.proto
+++ b/protos/google/cloud/compute/v1/internal/common_134.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_135.proto
+++ b/protos/google/cloud/compute/v1/internal/common_135.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/v1/internal/common_136.proto
+++ b/protos/google/cloud/compute/v1/internal/common_136.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/vpn_gateways/v1/vpn_gateways.proto
+++ b/protos/google/cloud/compute/vpn_gateways/v1/vpn_gateways.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/vpn_tunnels/v1/vpn_tunnels.proto
+++ b/protos/google/cloud/compute/vpn_tunnels/v1/vpn_tunnels.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/zone_operations/v1/zone_operations.proto
+++ b/protos/google/cloud/compute/zone_operations/v1/zone_operations.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/google/cloud/compute/zones/v1/zones.proto
+++ b/protos/google/cloud/compute/zones/v1/zones.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Not the best fix, of course, but at least address the breakage. We'll see which comes first---a good fix or 2025.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13382)
<!-- Reviewable:end -->
