### PR TITLE
refactor(pubsub): dedup internal function

### DIFF
--- a/google/cloud/pubsub/internal/publisher_stub_factory.cc
+++ b/google/cloud/pubsub/internal/publisher_stub_factory.cc
@@ -19,6 +19,9 @@
 #include "google/cloud/pubsub/internal/publisher_metadata_decorator.h"
 #include "google/cloud/pubsub/internal/publisher_round_robin_decorator.h"
 #include "google/cloud/pubsub/internal/publisher_tracing_stub.h"
+#include "google/cloud/common_options.h"
+#include "google/cloud/grpc_options.h"
+#include "google/cloud/internal/algorithm.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/log.h"
@@ -50,18 +53,13 @@ std::shared_ptr<grpc::Channel> CreateGrpcChannel(
 
 }  // namespace
 
-std::shared_ptr<PublisherStub> MakeDefaultPublisherStub(
+std::shared_ptr<PublisherStub> MakeRoundRobinPublisherStub(
     google::cloud::CompletionQueue cq, Options const& options) {
   return CreateDecoratedStubs(
       std::move(cq), options, [](std::shared_ptr<grpc::Channel> c) {
         return std::make_shared<DefaultPublisherStub>(
             google::pubsub::v1::Publisher::NewStub(std::move(c)));
       });
-}
-
-std::shared_ptr<PublisherStub> MakeRoundRobinPublisherStub(
-    google::cloud::CompletionQueue cq, Options const& options) {
-  return MakeDefaultPublisherStub(std::move(cq), std::move(options));
 }
 
 std::shared_ptr<PublisherStub> CreateDecoratedStubs(

--- a/google/cloud/pubsub/internal/publisher_stub_factory.h
+++ b/google/cloud/pubsub/internal/publisher_stub_factory.h
@@ -36,12 +36,6 @@ using BasePublisherStubFactory = std::function<std::shared_ptr<PublisherStub>(
  * By default, a PublisherRoundRobinStub is created using the number of
  * GrpcNumChannelsOption.
  */
-std::shared_ptr<PublisherStub> MakeDefaultPublisherStub(
-    google::cloud::CompletionQueue cq, Options const& options);
-
-/**
- * Creates a PublisherStub configured with @p cq and @p options.
- */
 std::shared_ptr<PublisherStub> MakeRoundRobinPublisherStub(
     google::cloud::CompletionQueue cq, Options const& options);
 

--- a/google/cloud/pubsub/topic_admin_connection.cc
+++ b/google/cloud/pubsub/topic_admin_connection.cc
@@ -295,7 +295,8 @@ std::shared_ptr<TopicAdminConnection> MakeTopicAdminConnection(Options opts) {
   opts = pubsub_internal::DefaultCommonOptions(std::move(opts));
 
   auto background = internal::MakeBackgroundThreadsFactory(opts)();
-  auto stub = pubsub_internal::MakeDefaultPublisherStub(background->cq(), opts);
+  auto stub =
+      pubsub_internal::MakeRoundRobinPublisherStub(background->cq(), opts);
   return std::make_shared<TopicAdminConnectionImpl>(
       std::move(background), std::move(stub), std::move(opts));
 }


### PR DESCRIPTION
`MakeDefaultPublisherStub` and `MakeRoundRobinPublisherStub` were two ways to say the same thing. Remove one.

I notice that the handwritten topic admin connection stub includes the round robin decorator. That predates this PR. It is probably not worth doing anything about, given that we want to move to the generated admin clients anyway.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13388)
<!-- Reviewable:end -->
