### PR TITLE
cleanup(GCS+gRPC): `AsyncConnection::Async*` is overkill

### DIFF
--- a/google/cloud/storage/async/client.h
+++ b/google/cloud/storage/async/client.h
@@ -146,7 +146,7 @@ class AsyncClient {
       std::string bucket_name, std::string object_name, Collection&& contents,
       Args&&... args) {
     auto options = SpanOptions(std::forward<Args>(args)...);
-    return connection_->AsyncInsertObject(
+    return connection_->InsertObject(
         {/*.request=*/InsertObjectRequest(std::move(bucket_name),
                                           std::move(object_name))
              .set_multiple_options(std::forward<Args>(args)...),
@@ -180,7 +180,7 @@ class AsyncClient {
       std::string bucket_name, std::string object_name, Args&&... args) {
     auto options = SpanOptions(std::forward<Args>(args)...);
     return connection_
-        ->AsyncReadObject(
+        ->ReadObject(
             {ReadObjectRequest(std::move(bucket_name), std::move(object_name))
                  .set_multiple_options(std::forward<Args>(args)...),
              std::move(options)})
@@ -245,7 +245,7 @@ class AsyncClient {
                   "parameters instead.");
 
     auto options = SpanOptions(std::forward<Args>(args)...);
-    return connection_->AsyncReadObjectRange(
+    return connection_->ReadObjectRange(
         {ReadObjectRequest(std::move(bucket_name), std::move(object_name))
              .set_multiple_options(std::forward<Args>(args)...,
                                    storage::ReadRange(offset, offset + limit)),
@@ -317,11 +317,10 @@ class AsyncClient {
       std::string bucket_name, std::string object_name, Args&&... args) {
     auto options = SpanOptions(std::forward<Args>(args)...);
     return connection_
-        ->AsyncWriteObject(
-            {ResumableUploadRequest(std::move(bucket_name),
-                                    std::move(object_name))
-                 .set_multiple_options(std::forward<Args>(args)...),
-             std::move(options)})
+        ->WriteObject({ResumableUploadRequest(std::move(bucket_name),
+                                              std::move(object_name))
+                           .set_multiple_options(std::forward<Args>(args)...),
+                       std::move(options)})
         .then([](auto f) -> StatusOr<std::pair<AsyncWriter, AsyncToken>> {
           auto impl = f.get();
           if (!impl) return std::move(impl).status();
@@ -356,7 +355,7 @@ class AsyncClient {
       std::vector<storage::ComposeSourceObject> source_objects,
       std::string destination_object_name, Args&&... args) {
     auto options = SpanOptions(std::forward<Args>(args)...);
-    return connection_->AsyncComposeObject(
+    return connection_->ComposeObject(
         {ComposeObjectRequest(std::move(bucket_name), std::move(source_objects),
                               std::move(destination_object_name))
              .set_multiple_options(std::forward<Args>(args)...),
@@ -386,7 +385,7 @@ class AsyncClient {
   future<Status> DeleteObject(std::string bucket_name, std::string object_name,
                               Args&&... args) {
     auto options = SpanOptions(std::forward<Args>(args)...);
-    return connection_->AsyncDeleteObject(
+    return connection_->DeleteObject(
         {DeleteObjectRequest(std::move(bucket_name), std::move(object_name))
              .set_multiple_options(std::forward<Args>(args)...),
          /*.options=*/std::move(options)});

--- a/google/cloud/storage/async/connection.h
+++ b/google/cloud/storage/async/connection.h
@@ -67,7 +67,7 @@ class AsyncConnection {
   };
 
   /// Insert a new object.
-  virtual future<StatusOr<storage::ObjectMetadata>> AsyncInsertObject(
+  virtual future<StatusOr<storage::ObjectMetadata>> InsertObject(
       InsertObjectParams p) = 0;
 
   /**
@@ -86,12 +86,11 @@ class AsyncConnection {
   };
 
   /// Asynchronously create a stream to read object contents.
-  virtual future<StatusOr<std::unique_ptr<AsyncReaderConnection>>>
-  AsyncReadObject(ReadObjectParams p) = 0;
+  virtual future<StatusOr<std::unique_ptr<AsyncReaderConnection>>> ReadObject(
+      ReadObjectParams p) = 0;
 
   /// Read a range from an object returning all the contents.
-  virtual future<StatusOr<ReadPayload>> AsyncReadObjectRange(
-      ReadObjectParams p) = 0;
+  virtual future<StatusOr<ReadPayload>> ReadObjectRange(ReadObjectParams p) = 0;
 
   /**
    * A thin wrapper around the `WriteObject()` parameters.
@@ -110,7 +109,7 @@ class AsyncConnection {
   /// Start (or resume) a streaming write.
   virtual future<
       StatusOr<std::unique_ptr<storage_experimental::AsyncWriterConnection>>>
-  AsyncWriteObject(WriteObjectParams p) = 0;
+  WriteObject(WriteObjectParams p) = 0;
 
   /**
    * A thin wrapper around the `ComposeObject()` parameters.
@@ -128,7 +127,7 @@ class AsyncConnection {
 
   /// Create a new object by composing (concatenating) the contents of existing
   /// objects.
-  virtual future<StatusOr<storage::ObjectMetadata>> AsyncComposeObject(
+  virtual future<StatusOr<storage::ObjectMetadata>> ComposeObject(
       ComposeObjectParams p) = 0;
 
   /**
@@ -146,7 +145,7 @@ class AsyncConnection {
   };
 
   /// Delete an object.
-  virtual future<Status> AsyncDeleteObject(DeleteObjectParams p) = 0;
+  virtual future<Status> DeleteObject(DeleteObjectParams p) = 0;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/examples/storage_async_mock_samples.cc
+++ b/google/cloud/storage/examples/storage_async_mock_samples.cc
@@ -33,7 +33,7 @@ TEST(StorageAsyncMockingSamples, MockDeleteObject) {
   auto mock =
       std::make_shared<google::cloud::storage_mocks::MockAsyncConnection>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, AsyncDeleteObject)
+  EXPECT_CALL(*mock, DeleteObject)
       .WillOnce(Return(ByMove(gc::make_ready_future(gc::Status{}))));
 
   auto client = gcs_ex::AsyncClient(mock);
@@ -50,7 +50,7 @@ TEST(StorageAsyncMockingSamples, MockReadObject) {
   auto mock =
       std::make_shared<google::cloud::storage_mocks::MockAsyncConnection>();
   EXPECT_CALL(*mock, options);
-  EXPECT_CALL(*mock, AsyncReadObject).WillOnce([] {
+  EXPECT_CALL(*mock, ReadObject).WillOnce([] {
     using ReadResponse = gcs_ex::AsyncReaderConnection::ReadResponse;
     using ReadPayload = gcs_ex::ReadPayload;
     auto reader = std::make_unique<

--- a/google/cloud/storage/examples/storage_async_samples.cc
+++ b/google/cloud/storage/examples/storage_async_samples.cc
@@ -340,8 +340,8 @@ void ComposeObject(google::cloud::storage_experimental::AsyncClient& client,
 
 // We would like to call this function `DeleteObject()`, but that conflicts with
 // a global `DeleteObject()` function on Windows.
-void AsyncDeleteObject(google::cloud::storage_experimental::AsyncClient& client,
-                       std::vector<std::string> const& argv) {
+void DeleteObject(google::cloud::storage_experimental::AsyncClient& client,
+                  std::vector<std::string> const& argv) {
   //! [delete-object]
   namespace g = google::cloud;
   namespace gcs_ex = google::cloud::storage_experimental;
@@ -458,7 +458,7 @@ void AutoRun(std::vector<std::string> const& argv) {
   }
 
   std::cout << "Running DeleteObject() example" << std::endl;
-  AsyncDeleteObject(client, {bucket_name, object_name});
+  DeleteObject(client, {bucket_name, object_name});
 
   namespace g = ::google::cloud;
   std::vector<g::future<g::Status>> pending;
@@ -507,7 +507,7 @@ int main(int argc, char* argv[]) try {
       make_entry("read-object-with-options", {"<generation>"},
                  ReadObjectWithOptions),
       make_entry("compose-object", {"<o1> <o2>"}, ComposeObject),
-      make_entry("delete-object", {}, AsyncDeleteObject),
+      make_entry("delete-object", {}, DeleteObject),
       make_entry("write-object", {"<filename>"}, WriteObject),
       make_entry("write-object-with-retry", {"<filename>"},
                  WriteObjectWithRetry),

--- a/google/cloud/storage/internal/async/connection_impl.h
+++ b/google/cloud/storage/internal/async/connection_impl.h
@@ -54,22 +54,22 @@ class AsyncConnectionImpl
 
   Options options() const override { return options_; }
 
-  future<StatusOr<storage::ObjectMetadata>> AsyncInsertObject(
+  future<StatusOr<storage::ObjectMetadata>> InsertObject(
       InsertObjectParams p) override;
 
   future<StatusOr<std::unique_ptr<storage_experimental::AsyncReaderConnection>>>
-  AsyncReadObject(ReadObjectParams p) override;
+  ReadObject(ReadObjectParams p) override;
 
-  future<StatusOr<storage_experimental::ReadPayload>> AsyncReadObjectRange(
+  future<StatusOr<storage_experimental::ReadPayload>> ReadObjectRange(
       ReadObjectParams p) override;
 
   future<StatusOr<std::unique_ptr<storage_experimental::AsyncWriterConnection>>>
-  AsyncWriteObject(WriteObjectParams p) override;
+  WriteObject(WriteObjectParams p) override;
 
-  future<StatusOr<storage::ObjectMetadata>> AsyncComposeObject(
+  future<StatusOr<storage::ObjectMetadata>> ComposeObject(
       ComposeObjectParams p) override;
 
-  future<Status> AsyncDeleteObject(DeleteObjectParams p) override;
+  future<Status> DeleteObject(DeleteObjectParams p) override;
 
  private:
   std::weak_ptr<AsyncConnectionImpl> WeakFromThis() {
@@ -77,12 +77,12 @@ class AsyncConnectionImpl
   }
 
   future<StatusOr<google::storage::v2::StartResumableWriteResponse>>
-  AsyncStartResumableWrite(internal::ImmutableOptions current,
-                           storage::internal::ResumableUploadRequest request);
+  StartResumableWrite(internal::ImmutableOptions current,
+                      storage::internal::ResumableUploadRequest request);
 
   future<StatusOr<google::storage::v2::QueryWriteStatusResponse>>
-  AsyncQueryWriteStatus(internal::ImmutableOptions current,
-                        storage::internal::QueryResumableUploadRequest request);
+  QueryWriteStatus(internal::ImmutableOptions current,
+                   storage::internal::QueryResumableUploadRequest request);
 
   future<StatusOr<std::unique_ptr<storage_experimental::AsyncWriterConnection>>>
   WriteObjectImpl(

--- a/google/cloud/storage/internal/async/connection_tracing.cc
+++ b/google/cloud/storage/internal/async/connection_tracing.cc
@@ -37,18 +37,17 @@ class AsyncConnectionTracing : public storage_experimental::AsyncConnection {
 
   Options options() const override { return impl_->options(); }
 
-  future<StatusOr<storage::ObjectMetadata>> AsyncInsertObject(
+  future<StatusOr<storage::ObjectMetadata>> InsertObject(
       InsertObjectParams p) override {
-    auto span =
-        internal::MakeSpan("storage::AsyncConnection::AsyncInsertObject");
+    auto span = internal::MakeSpan("storage::AsyncConnection::InsertObject");
     internal::OTelScope scope(span);
     return internal::EndSpan(std::move(span),
-                             impl_->AsyncInsertObject(std::move(p)));
+                             impl_->InsertObject(std::move(p)));
   }
 
   future<StatusOr<std::unique_ptr<storage_experimental::AsyncReaderConnection>>>
-  AsyncReadObject(ReadObjectParams p) override {
-    auto span = internal::MakeSpan("storage::AsyncConnection::AsyncReadObject");
+  ReadObject(ReadObjectParams p) override {
+    auto span = internal::MakeSpan("storage::AsyncConnection::ReadObject");
     internal::OTelScope scope(span);
     auto wrap = [oc = opentelemetry::context::RuntimeContext::GetCurrent(),
                  span = std::move(span)](auto f)
@@ -59,15 +58,14 @@ class AsyncConnectionTracing : public storage_experimental::AsyncConnection {
       if (!reader) return internal::EndSpan(*span, std::move(reader).status());
       return MakeTracingReaderConnection(std::move(span), *std::move(reader));
     };
-    return impl_->AsyncReadObject(std::move(p)).then(std::move(wrap));
+    return impl_->ReadObject(std::move(p)).then(std::move(wrap));
   }
 
-  future<StatusOr<storage_experimental::ReadPayload>> AsyncReadObjectRange(
+  future<StatusOr<storage_experimental::ReadPayload>> ReadObjectRange(
       ReadObjectParams p) override {
-    auto span =
-        internal::MakeSpan("storage::AsyncConnection::AsyncReadObjectRange");
+    auto span = internal::MakeSpan("storage::AsyncConnection::ReadObjectRange");
     internal::OTelScope scope(span);
-    return impl_->AsyncReadObjectRange(std::move(p))
+    return impl_->ReadObjectRange(std::move(p))
         .then([oc = opentelemetry::context::RuntimeContext::GetCurrent(),
                span = std::move(span)](auto f) {
           auto result = f.get();
@@ -77,11 +75,10 @@ class AsyncConnectionTracing : public storage_experimental::AsyncConnection {
   }
 
   future<StatusOr<std::unique_ptr<storage_experimental::AsyncWriterConnection>>>
-  AsyncWriteObject(WriteObjectParams p) override {
-    auto span =
-        internal::MakeSpan("storage::AsyncConnection::AsyncWriteObject");
+  WriteObject(WriteObjectParams p) override {
+    auto span = internal::MakeSpan("storage::AsyncConnection::WriteObject");
     internal::OTelScope scope(span);
-    return impl_->AsyncWriteObject(std::move(p))
+    return impl_->WriteObject(std::move(p))
         .then([oc = opentelemetry::context::RuntimeContext::GetCurrent(),
                span = std::move(span)](auto f)
                   -> StatusOr<std::unique_ptr<
@@ -93,21 +90,19 @@ class AsyncConnectionTracing : public storage_experimental::AsyncConnection {
         });
   }
 
-  future<StatusOr<storage::ObjectMetadata>> AsyncComposeObject(
+  future<StatusOr<storage::ObjectMetadata>> ComposeObject(
       ComposeObjectParams p) override {
-    auto span =
-        internal::MakeSpan("storage::AsyncConnection::AsyncComposeObject");
+    auto span = internal::MakeSpan("storage::AsyncConnection::ComposeObject");
     internal::OTelScope scope(span);
     return internal::EndSpan(std::move(span),
-                             impl_->AsyncComposeObject(std::move(p)));
+                             impl_->ComposeObject(std::move(p)));
   }
 
-  future<Status> AsyncDeleteObject(DeleteObjectParams p) override {
-    auto span =
-        internal::MakeSpan("storage::AsyncConnection::AsyncDeleteObject");
+  future<Status> DeleteObject(DeleteObjectParams p) override {
+    auto span = internal::MakeSpan("storage::AsyncConnection::DeleteObject");
     internal::OTelScope scope(span);
     return internal::EndSpan(std::move(span),
-                             impl_->AsyncDeleteObject(std::move(p)));
+                             impl_->DeleteObject(std::move(p)));
   }
 
  private:

--- a/google/cloud/storage/internal/async/connection_tracing_test.cc
+++ b/google/cloud/storage/internal/async/connection_tracing_test.cc
@@ -85,29 +85,28 @@ TEST(ConnectionTracing, Enabled) {
   EXPECT_NE(actual.get(), mock.get());
 }
 
-TEST(ConnectionTracing, AsyncInsertObject) {
+TEST(ConnectionTracing, InsertObject) {
   auto span_catcher = InstallSpanCatcher();
   PromiseWithOTelContext<StatusOr<storage::ObjectMetadata>> p;
 
   auto mock = std::make_unique<MockAsyncConnection>();
   EXPECT_CALL(*mock, options).WillOnce(Return(TracingEnabled()));
-  EXPECT_CALL(*mock, AsyncInsertObject).WillOnce(expect_context(p));
+  EXPECT_CALL(*mock, InsertObject).WillOnce(expect_context(p));
   auto actual = MakeTracingAsyncConnection(std::move(mock));
-  auto result = actual->AsyncInsertObject(AsyncConnection::InsertObjectParams{})
+  auto result = actual->InsertObject(AsyncConnection::InsertObjectParams{})
                     .then(expect_no_context);
 
   p.set_value(make_status_or(storage::ObjectMetadata{}));
   ASSERT_STATUS_OK(result.get());
 
   auto spans = span_catcher->GetSpans();
-  EXPECT_THAT(
-      spans, ElementsAre(
-                 AllOf(SpanNamed("storage::AsyncConnection::AsyncInsertObject"),
-                       SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-                       SpanHasInstrumentationScope(), SpanKindIsClient())));
+  EXPECT_THAT(spans, ElementsAre(AllOf(
+                         SpanNamed("storage::AsyncConnection::InsertObject"),
+                         SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
+                         SpanHasInstrumentationScope(), SpanKindIsClient())));
 }
 
-TEST(ConnectionTracing, AsyncReadObjectError) {
+TEST(ConnectionTracing, ReadObjectError) {
   auto span_catcher = InstallSpanCatcher();
   PromiseWithOTelContext<
       StatusOr<std::unique_ptr<storage_experimental::AsyncReaderConnection>>>
@@ -115,9 +114,9 @@ TEST(ConnectionTracing, AsyncReadObjectError) {
 
   auto mock = std::make_unique<MockAsyncConnection>();
   EXPECT_CALL(*mock, options).WillOnce(Return(TracingEnabled()));
-  EXPECT_CALL(*mock, AsyncReadObject).WillOnce(expect_context(p));
+  EXPECT_CALL(*mock, ReadObject).WillOnce(expect_context(p));
   auto actual = MakeTracingAsyncConnection(std::move(mock));
-  auto result = actual->AsyncReadObject(AsyncConnection::ReadObjectParams{})
+  auto result = actual->ReadObject(AsyncConnection::ReadObjectParams{})
                     .then(expect_no_context);
 
   p.set_value(
@@ -128,12 +127,12 @@ TEST(ConnectionTracing, AsyncReadObjectError) {
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(
       spans, ElementsAre(
-                 AllOf(SpanNamed("storage::AsyncConnection::AsyncReadObject"),
+                 AllOf(SpanNamed("storage::AsyncConnection::ReadObject"),
                        SpanWithStatus(opentelemetry::trace::StatusCode::kError),
                        SpanHasInstrumentationScope(), SpanKindIsClient())));
 }
 
-TEST(ConnectionTracing, AsyncReadObjectSuccess) {
+TEST(ConnectionTracing, ReadObjectSuccess) {
   auto span_catcher = InstallSpanCatcher();
   PromiseWithOTelContext<
       StatusOr<std::unique_ptr<storage_experimental::AsyncReaderConnection>>>
@@ -142,9 +141,9 @@ TEST(ConnectionTracing, AsyncReadObjectSuccess) {
   auto mock = std::make_unique<MockAsyncConnection>();
   EXPECT_CALL(*mock, options).WillOnce(Return(TracingEnabled()));
 
-  EXPECT_CALL(*mock, AsyncReadObject).WillOnce(expect_context(p));
+  EXPECT_CALL(*mock, ReadObject).WillOnce(expect_context(p));
   auto actual = MakeTracingAsyncConnection(std::move(mock));
-  auto f = actual->AsyncReadObject(AsyncConnection::ReadObjectParams{})
+  auto f = actual->ReadObject(AsyncConnection::ReadObjectParams{})
                .then(expect_no_context);
 
   using Response = ::google::cloud::storage_experimental::
@@ -163,34 +162,32 @@ TEST(ConnectionTracing, AsyncReadObjectSuccess) {
 
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(spans, ElementsAre(AllOf(
-                         SpanNamed("storage::AsyncConnection::AsyncReadObject"),
+                         SpanNamed("storage::AsyncConnection::ReadObject"),
                          SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
                          SpanHasInstrumentationScope(), SpanKindIsClient())));
 }
 
-TEST(ConnectionTracing, AsyncReadObjectRange) {
+TEST(ConnectionTracing, ReadObjectRange) {
   auto span_catcher = InstallSpanCatcher();
   PromiseWithOTelContext<StatusOr<storage_experimental::ReadPayload>> p;
 
   auto mock = std::make_unique<MockAsyncConnection>();
   EXPECT_CALL(*mock, options).WillOnce(Return(TracingEnabled()));
-  EXPECT_CALL(*mock, AsyncReadObjectRange).WillOnce(expect_context(p));
+  EXPECT_CALL(*mock, ReadObjectRange).WillOnce(expect_context(p));
   auto actual = MakeTracingAsyncConnection(std::move(mock));
-  auto result =
-      actual->AsyncReadObjectRange(AsyncConnection::ReadObjectParams{})
-          .then(expect_no_context);
+  auto result = actual->ReadObjectRange(AsyncConnection::ReadObjectParams{})
+                    .then(expect_no_context);
   p.set_value(storage_experimental::ReadPayload{});
   ASSERT_STATUS_OK(result.get());
 
   auto spans = span_catcher->GetSpans();
-  EXPECT_THAT(spans,
-              ElementsAre(AllOf(
-                  SpanNamed("storage::AsyncConnection::AsyncReadObjectRange"),
-                  SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-                  SpanHasInstrumentationScope(), SpanKindIsClient())));
+  EXPECT_THAT(spans, ElementsAre(AllOf(
+                         SpanNamed("storage::AsyncConnection::ReadObjectRange"),
+                         SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
+                         SpanHasInstrumentationScope(), SpanKindIsClient())));
 }
 
-TEST(ConnectionTracing, AsyncWriteObjectError) {
+TEST(ConnectionTracing, WriteObjectError) {
   auto span_catcher = InstallSpanCatcher();
   PromiseWithOTelContext<
       StatusOr<std::unique_ptr<storage_experimental::AsyncWriterConnection>>>
@@ -198,9 +195,9 @@ TEST(ConnectionTracing, AsyncWriteObjectError) {
 
   auto mock = std::make_unique<MockAsyncConnection>();
   EXPECT_CALL(*mock, options).WillOnce(Return(TracingEnabled()));
-  EXPECT_CALL(*mock, AsyncWriteObject).WillOnce(expect_context(p));
+  EXPECT_CALL(*mock, WriteObject).WillOnce(expect_context(p));
   auto actual = MakeTracingAsyncConnection(std::move(mock));
-  auto result = actual->AsyncWriteObject(AsyncConnection::WriteObjectParams{})
+  auto result = actual->WriteObject(AsyncConnection::WriteObjectParams{})
                     .then(expect_no_context);
 
   p.set_value(
@@ -211,12 +208,12 @@ TEST(ConnectionTracing, AsyncWriteObjectError) {
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(
       spans, ElementsAre(
-                 AllOf(SpanNamed("storage::AsyncConnection::AsyncWriteObject"),
+                 AllOf(SpanNamed("storage::AsyncConnection::WriteObject"),
                        SpanWithStatus(opentelemetry::trace::StatusCode::kError),
                        SpanHasInstrumentationScope(), SpanKindIsClient())));
 }
 
-TEST(ConnectionTracing, AsyncWriteObjectSuccess) {
+TEST(ConnectionTracing, WriteObjectSuccess) {
   auto span_catcher = InstallSpanCatcher();
   PromiseWithOTelContext<
       StatusOr<std::unique_ptr<storage_experimental::AsyncWriterConnection>>>
@@ -225,9 +222,9 @@ TEST(ConnectionTracing, AsyncWriteObjectSuccess) {
   auto mock = std::make_unique<MockAsyncConnection>();
   EXPECT_CALL(*mock, options).WillOnce(Return(TracingEnabled()));
 
-  EXPECT_CALL(*mock, AsyncWriteObject).WillOnce(expect_context(p));
+  EXPECT_CALL(*mock, WriteObject).WillOnce(expect_context(p));
   auto actual = MakeTracingAsyncConnection(std::move(mock));
-  auto f = actual->AsyncWriteObject(AsyncConnection::WriteObjectParams{})
+  auto f = actual->WriteObject(AsyncConnection::WriteObjectParams{})
                .then(expect_no_context);
 
   auto mock_reader = std::make_unique<MockAsyncWriterConnection>();
@@ -245,55 +242,51 @@ TEST(ConnectionTracing, AsyncWriteObjectSuccess) {
   EXPECT_STATUS_OK(r);
 
   auto spans = span_catcher->GetSpans();
-  EXPECT_THAT(
-      spans,
-      ElementsAre(AllOf(SpanNamed("storage::AsyncConnection::AsyncWriteObject"),
-                        SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-                        SpanHasInstrumentationScope(), SpanKindIsClient())));
+  EXPECT_THAT(spans, ElementsAre(AllOf(
+                         SpanNamed("storage::AsyncConnection::WriteObject"),
+                         SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
+                         SpanHasInstrumentationScope(), SpanKindIsClient())));
 }
 
-TEST(ConnectionTracing, AsyncComposeObject) {
+TEST(ConnectionTracing, ComposeObject) {
   auto span_catcher = InstallSpanCatcher();
   PromiseWithOTelContext<StatusOr<storage::ObjectMetadata>> p;
 
   auto mock = std::make_unique<MockAsyncConnection>();
   EXPECT_CALL(*mock, options).WillOnce(Return(TracingEnabled()));
-  EXPECT_CALL(*mock, AsyncComposeObject).WillOnce(expect_context(p));
+  EXPECT_CALL(*mock, ComposeObject).WillOnce(expect_context(p));
   auto actual = MakeTracingAsyncConnection(std::move(mock));
-  auto result =
-      actual->AsyncComposeObject(AsyncConnection::ComposeObjectParams{})
-          .then(expect_no_context);
+  auto result = actual->ComposeObject(AsyncConnection::ComposeObjectParams{})
+                    .then(expect_no_context);
 
   p.set_value(make_status_or(storage::ObjectMetadata{}));
   ASSERT_STATUS_OK(result.get());
 
   auto spans = span_catcher->GetSpans();
-  EXPECT_THAT(spans,
-              ElementsAre(AllOf(
-                  SpanNamed("storage::AsyncConnection::AsyncComposeObject"),
-                  SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-                  SpanHasInstrumentationScope(), SpanKindIsClient())));
+  EXPECT_THAT(spans, ElementsAre(AllOf(
+                         SpanNamed("storage::AsyncConnection::ComposeObject"),
+                         SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
+                         SpanHasInstrumentationScope(), SpanKindIsClient())));
 }
 
-TEST(ConnectionTracing, AsyncDeleteObject) {
+TEST(ConnectionTracing, DeleteObject) {
   auto span_catcher = InstallSpanCatcher();
   PromiseWithOTelContext<Status> p;
 
   auto mock = std::make_unique<MockAsyncConnection>();
   EXPECT_CALL(*mock, options).WillOnce(Return(TracingEnabled()));
-  EXPECT_CALL(*mock, AsyncDeleteObject).WillOnce(expect_context(p));
+  EXPECT_CALL(*mock, DeleteObject).WillOnce(expect_context(p));
   auto actual = MakeTracingAsyncConnection(std::move(mock));
-  auto result = actual->AsyncDeleteObject(AsyncConnection::DeleteObjectParams{})
+  auto result = actual->DeleteObject(AsyncConnection::DeleteObjectParams{})
                     .then(expect_no_context);
   p.set_value(Status{});
   ASSERT_STATUS_OK(result.get());
 
   auto spans = span_catcher->GetSpans();
-  EXPECT_THAT(
-      spans, ElementsAre(
-                 AllOf(SpanNamed("storage::AsyncConnection::AsyncDeleteObject"),
-                       SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-                       SpanHasInstrumentationScope(), SpanKindIsClient())));
+  EXPECT_THAT(spans, ElementsAre(AllOf(
+                         SpanNamed("storage::AsyncConnection::DeleteObject"),
+                         SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
+                         SpanHasInstrumentationScope(), SpanKindIsClient())));
 }
 
 }  // namespace

--- a/google/cloud/storage/mocks/mock_async_connection.h
+++ b/google/cloud/storage/mocks/mock_async_connection.h
@@ -32,22 +32,21 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class MockAsyncConnection : public storage_experimental::AsyncConnection {
  public:
   MOCK_METHOD(Options, options, (), (const, override));
-  MOCK_METHOD(future<StatusOr<storage::ObjectMetadata>>, AsyncInsertObject,
+  MOCK_METHOD(future<StatusOr<storage::ObjectMetadata>>, InsertObject,
               (InsertObjectParams), (override));
   MOCK_METHOD(
       future<StatusOr<
           std::unique_ptr<storage_experimental::AsyncReaderConnection>>>,
-      AsyncReadObject, (ReadObjectParams), (override));
+      ReadObject, (ReadObjectParams), (override));
   MOCK_METHOD(future<StatusOr<storage_experimental::ReadPayload>>,
-              AsyncReadObjectRange, (ReadObjectParams), (override));
+              ReadObjectRange, (ReadObjectParams), (override));
   MOCK_METHOD(
       future<StatusOr<
           std::unique_ptr<storage_experimental::AsyncWriterConnection>>>,
-      AsyncWriteObject, (WriteObjectParams), (override));
-  MOCK_METHOD(future<StatusOr<storage::ObjectMetadata>>, AsyncComposeObject,
+      WriteObject, (WriteObjectParams), (override));
+  MOCK_METHOD(future<StatusOr<storage::ObjectMetadata>>, ComposeObject,
               (ComposeObjectParams), (override));
-  MOCK_METHOD(future<Status>, AsyncDeleteObject, (DeleteObjectParams),
-              (override));
+  MOCK_METHOD(future<Status>, DeleteObject, (DeleteObjectParams), (override));
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13395)
<!-- Reviewable:end -->
