### PR TITLE
fix(rest): reuse connections in `sql`, `compute`

### DIFF
--- a/google/cloud/internal/populate_rest_options.cc
+++ b/google/cloud/internal/populate_rest_options.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/rest_options.h"
 #include "absl/strings/match.h"
+#include "absl/strings/strip.h"
 
 namespace google {
 namespace cloud {
@@ -35,9 +36,12 @@ Options PopulateRestOptions(Options opts) {
         "https://longrunning.googleapis.com");
   }
   if (opts.has<EndpointOption>()) {
-    std::string endpoint = opts.get<EndpointOption>();
+    auto& endpoint = opts.lookup<EndpointOption>();
+    // Use an unqualified domain name, because we do not seem to reuse
+    // connections with a fully qualified domain name over REST.
+    if (absl::EndsWith(endpoint, ".googleapis.com.")) endpoint.pop_back();
     if (!absl::StartsWithIgnoreCase(endpoint, "http")) {
-      opts.set<EndpointOption>(absl::StrCat("https://", endpoint));
+      endpoint = absl::StrCat("https://", endpoint);
     }
   }
   if (!opts.has<RestTracingOptionsOption>()) {

--- a/google/cloud/internal/populate_rest_options_test.cc
+++ b/google/cloud/internal/populate_rest_options_test.cc
@@ -39,6 +39,8 @@ TEST(PopulateRestOptions, EndpointOption) {
   };
   std::vector<TestCase> cases = {
       {"example.com", "https://example.com"},
+      {"foo.googleapis.com.", "https://foo.googleapis.com"},
+      {"https://foo.googleapis.com.", "https://foo.googleapis.com"},
       {"http://example.com", "http://example.com"},
       {"https://example.com", "https://example.com"}};
 


### PR DESCRIPTION
Fixes #13393 (although we would prefer a solution that both reuses connections and uses fully qualified domain names)

While it is strange to set the `EndpointOption` to be fully qualified, then strip the ending, note that:
- This way we keep using FQDN over gRPC
- We are already manipulating `EndpointOption` in `PopulateRestOptions` after it is set in `PopulateCommonOptions`.

---

If the application supplies us with a custom FQDN via `EndpointOption`, we might leave it as is, and not reuse connections. :shrug:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13396)
<!-- Reviewable:end -->
