### PR TITLE
cleanup(rest): stricter schema checking in `EndpointOption`

### DIFF
--- a/google/cloud/internal/populate_rest_options.cc
+++ b/google/cloud/internal/populate_rest_options.cc
@@ -40,7 +40,8 @@ Options PopulateRestOptions(Options opts) {
     // Use an unqualified domain name, because we do not seem to reuse
     // connections with a fully qualified domain name over REST.
     if (absl::EndsWith(endpoint, ".googleapis.com.")) endpoint.pop_back();
-    if (!absl::StartsWithIgnoreCase(endpoint, "http")) {
+    if (!absl::StartsWithIgnoreCase(endpoint, "http://") &&
+        !absl::StartsWithIgnoreCase(endpoint, "https://")) {
       endpoint = absl::StrCat("https://", endpoint);
     }
   }

--- a/google/cloud/internal/populate_rest_options_test.cc
+++ b/google/cloud/internal/populate_rest_options_test.cc
@@ -39,6 +39,7 @@ TEST(PopulateRestOptions, EndpointOption) {
   };
   std::vector<TestCase> cases = {
       {"example.com", "https://example.com"},
+      {"http-but-not-the-schema.com", "https://http-but-not-the-schema.com"},
       {"foo.googleapis.com.", "https://foo.googleapis.com"},
       {"https://foo.googleapis.com.", "https://foo.googleapis.com"},
       {"http://example.com", "http://example.com"},


### PR DESCRIPTION
If you want me to do something, you have to ask me twice:

https://github.com/googleapis/google-cloud-cpp/pull/13363#discussion_r1436722777
https://github.com/googleapis/google-cloud-cpp/pull/13396#discussion_r1441103622

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13397)
<!-- Reviewable:end -->
