### PR TITLE
fix(GCS+gRPC): restore build on Windows

### DIFF
--- a/google/cloud/storage/examples/storage_async_samples.cc
+++ b/google/cloud/storage/examples/storage_async_samples.cc
@@ -340,8 +340,8 @@ void ComposeObject(google::cloud::storage_experimental::AsyncClient& client,
 
 // We would like to call this function `DeleteObject()`, but that conflicts with
 // a global `DeleteObject()` function on Windows.
-void DeleteObject(google::cloud::storage_experimental::AsyncClient& client,
-                  std::vector<std::string> const& argv) {
+void AsyncDeleteObject(google::cloud::storage_experimental::AsyncClient& client,
+                       std::vector<std::string> const& argv) {
   //! [delete-object]
   namespace g = google::cloud;
   namespace gcs_ex = google::cloud::storage_experimental;
@@ -458,7 +458,7 @@ void AutoRun(std::vector<std::string> const& argv) {
   }
 
   std::cout << "Running DeleteObject() example" << std::endl;
-  DeleteObject(client, {bucket_name, object_name});
+  AsyncDeleteObject(client, {bucket_name, object_name});
 
   namespace g = ::google::cloud;
   std::vector<g::future<g::Status>> pending;
@@ -507,7 +507,7 @@ int main(int argc, char* argv[]) try {
       make_entry("read-object-with-options", {"<generation>"},
                  ReadObjectWithOptions),
       make_entry("compose-object", {"<o1> <o2>"}, ComposeObject),
-      make_entry("delete-object", {}, DeleteObject),
+      make_entry("delete-object", {}, AsyncDeleteObject),
       make_entry("write-object", {"<filename>"}, WriteObject),
       make_entry("write-object-with-retry", {"<filename>"},
                  WriteObjectWithRetry),


### PR DESCRIPTION
See https://github.com/googleapis/google-cloud-cpp/actions/runs/7405693533/job/20149036049#step:5:2692

I obviously missed my own comments in the last refactor:

https://github.com/googleapis/google-cloud-cpp/blob/800121693bc5608af67b0efdbb47c4aff56f8fa7/google/cloud/storage/examples/storage_async_samples.cc#L341-L343

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13398)
<!-- Reviewable:end -->
