### PR TITLE
impl: capture the PiperOrigin-RevId from the googleapis commit

### DIFF
--- a/external/googleapis/renovate.sh
+++ b/external/googleapis/renovate.sh
@@ -29,6 +29,8 @@ REPO="googleapis/googleapis"
 BRANCH="master"
 COMMIT=$(curl -fsSL -H "Accept: application/vnd.github.VERSION.sha" \
   "https://api.github.com/repos/${REPO}/commits/${BRANCH}")
+PIPERORIGIN_REVID=$(gh api "repos/${REPO}/commits/${COMMIT}" |
+  jq --raw-output .commit.message | grep PiperOrigin-RevId:)
 DOWNLOAD="$(mktemp)"
 curl -fsSL "https://github.com/${REPO}/archive/${COMMIT}.tar.gz" -o "${DOWNLOAD}"
 gsutil -q cp "${DOWNLOAD}" "gs://cloud-cpp-community-archive/com_google_googleapis/${COMMIT}.tar.gz"
@@ -70,6 +72,7 @@ ci/cloudbuild/build.sh --docker --trigger=generate-libraries-pr || true
 
 banner "Creating commits"
 git commit -m"chore: update googleapis SHA circa $(date +%Y-%m-%d)" \
+  -m "${PIPERORIGIN_REVID}" \
   bazel/google_cloud_cpp_deps.bzl cmake/GoogleapisConfig.cmake
 if ! git diff --quiet external/googleapis/protodeps \
   external/googleapis/protolists; then

--- a/external/googleapis/renovate.sh
+++ b/external/googleapis/renovate.sh
@@ -41,7 +41,6 @@ until grep -q "/googleapis/archive/${REV_COMMIT}\.tar" bazel/workspace0.bzl; do
     grep PiperOrigin-RevId:) && break
   REV_COMMIT=$(jq --raw-output '.parents[0].sha' <"${DOWNLOAD}")
 done
-PIPERORIGIN_REVID=
 rm -f "${DOWNLOAD}"
 
 banner "Updating Bazel/CMake dependencies"

--- a/external/googleapis/renovate.sh
+++ b/external/googleapis/renovate.sh
@@ -29,12 +29,19 @@ REPO="googleapis/googleapis"
 BRANCH="master"
 COMMIT=$(curl -fsSL -H "Accept: application/vnd.github.VERSION.sha" \
   "https://api.github.com/repos/${REPO}/commits/${BRANCH}")
-PIPERORIGIN_REVID=$(gh api "repos/${REPO}/commits/${COMMIT}" |
-  jq --raw-output .commit.message | grep PiperOrigin-RevId:)
 DOWNLOAD="$(mktemp)"
 curl -fsSL "https://github.com/${REPO}/archive/${COMMIT}.tar.gz" -o "${DOWNLOAD}"
 gsutil -q cp "${DOWNLOAD}" "gs://cloud-cpp-community-archive/com_google_googleapis/${COMMIT}.tar.gz"
 SHA256=$(sha256sum "${DOWNLOAD}" | sed "s/ .*//")
+PIPERORIGIN_REVID=
+REV_COMMIT="${COMMIT}"
+until grep -q "/googleapis/archive/${REV_COMMIT}\.tar" bazel/workspace0.bzl; do
+  gh api "repos/${REPO}/commits/${REV_COMMIT}" >"${DOWNLOAD}"
+  PIPERORIGIN_REVID=$(jq --raw-output .commit.message <"${DOWNLOAD}" |
+    grep PiperOrigin-RevId:) && break
+  REV_COMMIT=$(jq --raw-output '.parents[0].sha' <"${DOWNLOAD}")
+done
+PIPERORIGIN_REVID=
 rm -f "${DOWNLOAD}"
 
 banner "Updating Bazel/CMake dependencies"
@@ -72,7 +79,7 @@ ci/cloudbuild/build.sh --docker --trigger=generate-libraries-pr || true
 
 banner "Creating commits"
 git commit -m"chore: update googleapis SHA circa $(date +%Y-%m-%d)" \
-  -m "${PIPERORIGIN_REVID}" \
+  ${PIPERORIGIN_REVID:+-m "${PIPERORIGIN_REVID}"} \
   bazel/google_cloud_cpp_deps.bzl cmake/GoogleapisConfig.cmake
 if ! git diff --quiet external/googleapis/protodeps \
   external/googleapis/protolists; then


### PR DESCRIPTION
To help the internal automation team, copy the PiperOrigin-RevId from the latest googleapis commit into our SHA-update PR message.

Fixes #13402.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13410)
<!-- Reviewable:end -->
