### PR TITLE
feat: simplify Bazel initialization

### DIFF
--- a/ci/verify_current_targets/WORKSPACE.bazel
+++ b/ci/verify_current_targets/WORKSPACE.bazel
@@ -22,24 +22,26 @@ local_repository(
     path = "../../",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/ci/verify_deprecated_targets/WORKSPACE.bazel
+++ b/ci/verify_deprecated_targets/WORKSPACE.bazel
@@ -24,24 +24,26 @@ local_repository(
     path = "../../",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/generator/templates/WORKSPACE.bazel
+++ b/generator/templates/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/accessapproval/quickstart/WORKSPACE.bazel
+++ b/google/cloud/accessapproval/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/accesscontextmanager/quickstart/WORKSPACE.bazel
+++ b/google/cloud/accesscontextmanager/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/advisorynotifications/quickstart/WORKSPACE.bazel
+++ b/google/cloud/advisorynotifications/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/aiplatform/quickstart/WORKSPACE.bazel
+++ b/google/cloud/aiplatform/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/alloydb/quickstart/WORKSPACE.bazel
+++ b/google/cloud/alloydb/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/apigateway/quickstart/WORKSPACE.bazel
+++ b/google/cloud/apigateway/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/apigeeconnect/quickstart/WORKSPACE.bazel
+++ b/google/cloud/apigeeconnect/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/apikeys/quickstart/WORKSPACE.bazel
+++ b/google/cloud/apikeys/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/appengine/quickstart/WORKSPACE.bazel
+++ b/google/cloud/appengine/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/artifactregistry/quickstart/WORKSPACE.bazel
+++ b/google/cloud/artifactregistry/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/asset/quickstart/WORKSPACE.bazel
+++ b/google/cloud/asset/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/assuredworkloads/quickstart/WORKSPACE.bazel
+++ b/google/cloud/assuredworkloads/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/automl/quickstart/WORKSPACE.bazel
+++ b/google/cloud/automl/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/baremetalsolution/quickstart/WORKSPACE.bazel
+++ b/google/cloud/baremetalsolution/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/batch/quickstart/WORKSPACE.bazel
+++ b/google/cloud/batch/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/beyondcorp/quickstart/WORKSPACE.bazel
+++ b/google/cloud/beyondcorp/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/bigquery/quickstart/WORKSPACE.bazel
+++ b/google/cloud/bigquery/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/bigtable/quickstart/WORKSPACE.bazel
+++ b/google/cloud/bigtable/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/billing/quickstart/WORKSPACE.bazel
+++ b/google/cloud/billing/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/binaryauthorization/quickstart/WORKSPACE.bazel
+++ b/google/cloud/binaryauthorization/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/certificatemanager/quickstart/WORKSPACE.bazel
+++ b/google/cloud/certificatemanager/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/channel/quickstart/WORKSPACE.bazel
+++ b/google/cloud/channel/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/cloudbuild/quickstart/WORKSPACE.bazel
+++ b/google/cloud/cloudbuild/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/cloudquotas/quickstart/WORKSPACE.bazel
+++ b/google/cloud/cloudquotas/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/commerce/quickstart/WORKSPACE.bazel
+++ b/google/cloud/commerce/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/composer/quickstart/WORKSPACE.bazel
+++ b/google/cloud/composer/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/compute/quickstart/WORKSPACE.bazel
+++ b/google/cloud/compute/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/confidentialcomputing/quickstart/WORKSPACE.bazel
+++ b/google/cloud/confidentialcomputing/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/config/quickstart/WORKSPACE.bazel
+++ b/google/cloud/config/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/connectors/quickstart/WORKSPACE.bazel
+++ b/google/cloud/connectors/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/contactcenterinsights/quickstart/WORKSPACE.bazel
+++ b/google/cloud/contactcenterinsights/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/container/quickstart/WORKSPACE.bazel
+++ b/google/cloud/container/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/containeranalysis/quickstart/WORKSPACE.bazel
+++ b/google/cloud/containeranalysis/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/contentwarehouse/quickstart/WORKSPACE.bazel
+++ b/google/cloud/contentwarehouse/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/datacatalog/quickstart/WORKSPACE.bazel
+++ b/google/cloud/datacatalog/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/datafusion/quickstart/WORKSPACE.bazel
+++ b/google/cloud/datafusion/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/datamigration/quickstart/WORKSPACE.bazel
+++ b/google/cloud/datamigration/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/dataplex/quickstart/WORKSPACE.bazel
+++ b/google/cloud/dataplex/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/dataproc/quickstart/WORKSPACE.bazel
+++ b/google/cloud/dataproc/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/datastore/quickstart/WORKSPACE.bazel
+++ b/google/cloud/datastore/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/datastream/quickstart/WORKSPACE.bazel
+++ b/google/cloud/datastream/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/deploy/quickstart/WORKSPACE.bazel
+++ b/google/cloud/deploy/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/dialogflow_cx/quickstart/WORKSPACE.bazel
+++ b/google/cloud/dialogflow_cx/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/dialogflow_es/quickstart/WORKSPACE.bazel
+++ b/google/cloud/dialogflow_es/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/discoveryengine/quickstart/WORKSPACE.bazel
+++ b/google/cloud/discoveryengine/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/dlp/quickstart/WORKSPACE.bazel
+++ b/google/cloud/dlp/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/documentai/quickstart/WORKSPACE.bazel
+++ b/google/cloud/documentai/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/domains/quickstart/WORKSPACE.bazel
+++ b/google/cloud/domains/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/edgecontainer/quickstart/WORKSPACE.bazel
+++ b/google/cloud/edgecontainer/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/edgenetwork/quickstart/WORKSPACE.bazel
+++ b/google/cloud/edgenetwork/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/essentialcontacts/quickstart/WORKSPACE.bazel
+++ b/google/cloud/essentialcontacts/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/eventarc/quickstart/WORKSPACE.bazel
+++ b/google/cloud/eventarc/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/filestore/quickstart/WORKSPACE.bazel
+++ b/google/cloud/filestore/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/functions/quickstart/WORKSPACE.bazel
+++ b/google/cloud/functions/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/gkebackup/quickstart/WORKSPACE.bazel
+++ b/google/cloud/gkebackup/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/gkehub/quickstart/WORKSPACE.bazel
+++ b/google/cloud/gkehub/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/gkemulticloud/quickstart/WORKSPACE.bazel
+++ b/google/cloud/gkemulticloud/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/iam/quickstart/WORKSPACE.bazel
+++ b/google/cloud/iam/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/iap/quickstart/WORKSPACE.bazel
+++ b/google/cloud/iap/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/ids/quickstart/WORKSPACE.bazel
+++ b/google/cloud/ids/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/kms/quickstart/WORKSPACE.bazel
+++ b/google/cloud/kms/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/language/quickstart/WORKSPACE.bazel
+++ b/google/cloud/language/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/logging/quickstart/WORKSPACE.bazel
+++ b/google/cloud/logging/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/managedidentities/quickstart/WORKSPACE.bazel
+++ b/google/cloud/managedidentities/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/memcache/quickstart/WORKSPACE.bazel
+++ b/google/cloud/memcache/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/metastore/quickstart/WORKSPACE.bazel
+++ b/google/cloud/metastore/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/migrationcenter/quickstart/WORKSPACE.bazel
+++ b/google/cloud/migrationcenter/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/monitoring/quickstart/WORKSPACE.bazel
+++ b/google/cloud/monitoring/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/netapp/quickstart/WORKSPACE.bazel
+++ b/google/cloud/netapp/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/networkconnectivity/quickstart/WORKSPACE.bazel
+++ b/google/cloud/networkconnectivity/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/networkmanagement/quickstart/WORKSPACE.bazel
+++ b/google/cloud/networkmanagement/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/networksecurity/quickstart/WORKSPACE.bazel
+++ b/google/cloud/networksecurity/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/networkservices/quickstart/WORKSPACE.bazel
+++ b/google/cloud/networkservices/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/notebooks/quickstart/WORKSPACE.bazel
+++ b/google/cloud/notebooks/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/oauth2/quickstart/WORKSPACE.bazel
+++ b/google/cloud/oauth2/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/opentelemetry/quickstart/WORKSPACE.bazel
+++ b/google/cloud/opentelemetry/quickstart/WORKSPACE.bazel
@@ -28,27 +28,29 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()
 
 load("@io_opentelemetry_cpp//bazel:repository.bzl", "opentelemetry_cpp_deps")
 

--- a/google/cloud/optimization/quickstart/WORKSPACE.bazel
+++ b/google/cloud/optimization/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/orgpolicy/quickstart/WORKSPACE.bazel
+++ b/google/cloud/orgpolicy/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/osconfig/quickstart/WORKSPACE.bazel
+++ b/google/cloud/osconfig/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/oslogin/quickstart/WORKSPACE.bazel
+++ b/google/cloud/oslogin/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/policysimulator/quickstart/WORKSPACE.bazel
+++ b/google/cloud/policysimulator/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/policytroubleshooter/quickstart/WORKSPACE.bazel
+++ b/google/cloud/policytroubleshooter/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/privateca/quickstart/WORKSPACE.bazel
+++ b/google/cloud/privateca/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/profiler/quickstart/WORKSPACE.bazel
+++ b/google/cloud/profiler/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/pubsub/quickstart/WORKSPACE.bazel
+++ b/google/cloud/pubsub/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/pubsublite/quickstart/WORKSPACE.bazel
+++ b/google/cloud/pubsublite/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/rapidmigrationassessment/quickstart/WORKSPACE.bazel
+++ b/google/cloud/rapidmigrationassessment/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/recaptchaenterprise/quickstart/WORKSPACE.bazel
+++ b/google/cloud/recaptchaenterprise/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/recommender/quickstart/WORKSPACE.bazel
+++ b/google/cloud/recommender/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/redis/quickstart/WORKSPACE.bazel
+++ b/google/cloud/redis/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/resourcemanager/quickstart/WORKSPACE.bazel
+++ b/google/cloud/resourcemanager/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/resourcesettings/quickstart/WORKSPACE.bazel
+++ b/google/cloud/resourcesettings/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/retail/quickstart/WORKSPACE.bazel
+++ b/google/cloud/retail/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/run/quickstart/WORKSPACE.bazel
+++ b/google/cloud/run/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/scheduler/quickstart/WORKSPACE.bazel
+++ b/google/cloud/scheduler/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/secretmanager/quickstart/WORKSPACE.bazel
+++ b/google/cloud/secretmanager/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/securesourcemanager/quickstart/WORKSPACE.bazel
+++ b/google/cloud/securesourcemanager/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/securitycenter/quickstart/WORKSPACE.bazel
+++ b/google/cloud/securitycenter/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/servicecontrol/quickstart/WORKSPACE.bazel
+++ b/google/cloud/servicecontrol/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/servicedirectory/quickstart/WORKSPACE.bazel
+++ b/google/cloud/servicedirectory/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/servicemanagement/quickstart/WORKSPACE.bazel
+++ b/google/cloud/servicemanagement/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/serviceusage/quickstart/WORKSPACE.bazel
+++ b/google/cloud/serviceusage/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/shell/quickstart/WORKSPACE.bazel
+++ b/google/cloud/shell/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/spanner/quickstart/WORKSPACE.bazel
+++ b/google/cloud/spanner/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/speech/quickstart/WORKSPACE.bazel
+++ b/google/cloud/speech/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/sql/quickstart/WORKSPACE.bazel
+++ b/google/cloud/sql/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/storage/quickstart/WORKSPACE.bazel
+++ b/google/cloud/storage/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/storageinsights/quickstart/WORKSPACE.bazel
+++ b/google/cloud/storageinsights/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/storagetransfer/quickstart/WORKSPACE.bazel
+++ b/google/cloud/storagetransfer/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/support/quickstart/WORKSPACE.bazel
+++ b/google/cloud/support/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/talent/quickstart/WORKSPACE.bazel
+++ b/google/cloud/talent/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/tasks/quickstart/WORKSPACE.bazel
+++ b/google/cloud/tasks/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/telcoautomation/quickstart/WORKSPACE.bazel
+++ b/google/cloud/telcoautomation/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/texttospeech/quickstart/WORKSPACE.bazel
+++ b/google/cloud/texttospeech/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/timeseriesinsights/quickstart/WORKSPACE.bazel
+++ b/google/cloud/timeseriesinsights/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/tpu/quickstart/WORKSPACE.bazel
+++ b/google/cloud/tpu/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/trace/quickstart/WORKSPACE.bazel
+++ b/google/cloud/trace/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/translate/quickstart/WORKSPACE.bazel
+++ b/google/cloud/translate/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/video/quickstart/WORKSPACE.bazel
+++ b/google/cloud/video/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/videointelligence/quickstart/WORKSPACE.bazel
+++ b/google/cloud/videointelligence/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/vision/quickstart/WORKSPACE.bazel
+++ b/google/cloud/vision/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/vmmigration/quickstart/WORKSPACE.bazel
+++ b/google/cloud/vmmigration/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/vmwareengine/quickstart/WORKSPACE.bazel
+++ b/google/cloud/vmwareengine/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/vpcaccess/quickstart/WORKSPACE.bazel
+++ b/google/cloud/vpcaccess/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/webrisk/quickstart/WORKSPACE.bazel
+++ b/google/cloud/webrisk/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/websecurityscanner/quickstart/WORKSPACE.bazel
+++ b/google/cloud/websecurityscanner/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/workflows/quickstart/WORKSPACE.bazel
+++ b/google/cloud/workflows/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()

--- a/google/cloud/workstations/quickstart/WORKSPACE.bazel
+++ b/google/cloud/workstations/quickstart/WORKSPACE.bazel
@@ -28,24 +28,26 @@ http_archive(
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.20.0.tar.gz",
 )
 
-# Load indirect dependencies due to
-#     https://github.com/bazelbuild/bazel/issues/1943
-load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
-google_cloud_cpp_deps()
+gl_cpp_workspace0()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@google_cloud_cpp//bazel:workspace1.bzl", "gl_cpp_workspace1")
 
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,
-    grpc = True,
-)
+gl_cpp_workspace1()
 
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@google_cloud_cpp//bazel:workspace2.bzl", "gl_cpp_workspace2")
 
-grpc_deps()
+gl_cpp_workspace2()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("@google_cloud_cpp//bazel:workspace3.bzl", "gl_cpp_workspace3")
 
-grpc_extra_deps()
+gl_cpp_workspace3()
+
+load("@google_cloud_cpp//bazel:workspace4.bzl", "gl_cpp_workspace4")
+
+gl_cpp_workspace4()
+
+load("@google_cloud_cpp//bazel:workspace5.bzl", "gl_cpp_workspace5")
+
+gl_cpp_workspace5()


### PR DESCRIPTION
In v2.20.0 we introduced new Bazel WORKSPACE functions that should simplify the transition to Bazel v7. Now that the quickstart directories are using v2.20.0, we can change them to use these functions.

Part of the work for #13320

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13411)
<!-- Reviewable:end -->
