### PR TITLE
cleanup: remove internal GUAC option

### DIFF
--- a/google/cloud/credentials.h
+++ b/google/cloud/credentials.h
@@ -374,19 +374,6 @@ using UnifiedCredentialsOptionList =
                DelegatesOption, ScopesOption, TracingComponentsOption,
                UnifiedCredentialsOption>;
 
-namespace internal {
-
-/**
- * Use an insecure channel for AccessToken authentication.
- *
- * This is useful when testing against emulators, where it is impossible to
- * create a secure channel.
- */
-struct UseInsecureChannelOption {
-  using Type = bool;
-};
-
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/internal/grpc_access_token_authentication.cc
+++ b/google/cloud/internal/grpc_access_token_authentication.cc
@@ -21,17 +21,15 @@ namespace internal {
 
 GrpcAccessTokenAuthentication::GrpcAccessTokenAuthentication(
     AccessToken const& access_token, Options const& opts)
-    : credentials_(grpc::AccessTokenCredentials(access_token.token)),
-      use_insecure_channel_(opts.get<UseInsecureChannelOption>()) {
+    : credentials_(grpc::AccessTokenCredentials(access_token.token)) {
   auto cainfo = LoadCAInfo(opts);
   if (cainfo) ssl_options_.pem_root_certs = std::move(*cainfo);
 }
 
 std::shared_ptr<grpc::Channel> GrpcAccessTokenAuthentication::CreateChannel(
     std::string const& endpoint, grpc::ChannelArguments const& arguments) {
-  auto credentials = use_insecure_channel_ ? grpc::InsecureChannelCredentials()
-                                           : grpc::SslCredentials(ssl_options_);
-  return grpc::CreateCustomChannel(endpoint, credentials, arguments);
+  return grpc::CreateCustomChannel(endpoint, grpc::SslCredentials(ssl_options_),
+                                   arguments);
 }
 
 bool GrpcAccessTokenAuthentication::RequiresConfigureContext() const {

--- a/google/cloud/internal/grpc_access_token_authentication.h
+++ b/google/cloud/internal/grpc_access_token_authentication.h
@@ -42,7 +42,6 @@ class GrpcAccessTokenAuthentication : public GrpcAuthenticationStrategy {
  private:
   std::shared_ptr<grpc::CallCredentials> credentials_;
   grpc::SslCredentialsOptions ssl_options_;
-  bool use_insecure_channel_;
 };
 
 }  // namespace internal

--- a/google/cloud/pubsub/integration_tests/subscriber_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/subscriber_integration_test.cc
@@ -457,22 +457,6 @@ TEST_F(SubscriberIntegrationTest, PublishOrdered) {
   EXPECT_STATUS_OK(result.get());
 }
 
-TEST_F(SubscriberIntegrationTest, UnifiedCredentials) {
-  auto options =
-      Options{}.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials());
-  auto const using_emulator =
-      internal::GetEnv("PUBSUB_EMULATOR_HOST").has_value();
-  if (using_emulator) {
-    options = Options{}
-                  .set<UnifiedCredentialsOption>(MakeInsecureCredentials())
-                  .set<internal::UseInsecureChannelOption>(true);
-  }
-  auto publisher = Publisher(MakePublisherConnection(topic_, options));
-  auto subscriber =
-      Subscriber(MakeSubscriberConnection(subscription_, options));
-  ASSERT_NO_FATAL_FAILURE(TestRoundtrip(publisher, subscriber));
-}
-
 TEST_F(SubscriberIntegrationTest, ExactlyOnce) {
   auto publisher = Publisher(MakePublisherConnection(topic_));
   auto subscriber =

--- a/google/cloud/pubsub/integration_tests/subscription_admin_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/subscription_admin_integration_test.cc
@@ -41,7 +41,6 @@ using ::google::cloud::testing_util::ScopedEnvironment;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::AnyOf;
 using ::testing::Contains;
-using ::testing::IsEmpty;
 using ::testing::Not;
 using ::testing::NotNull;
 
@@ -198,22 +197,6 @@ TEST_F(SubscriptionAdminIntegrationTest, SubscriptionCRUD) {
   names = SubscriptionNames(subscription_admin, project_id);
   ASSERT_STATUS_OK(names);
   EXPECT_THAT(*names, Not(Contains(subscription.FullName())));
-}
-
-TEST_F(SubscriptionAdminIntegrationTest, UnifiedCredentials) {
-  auto project_id =
-      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
-  ASSERT_THAT(project_id, Not(IsEmpty()));
-  auto options =
-      Options{}.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials());
-  if (UsingEmulator()) {
-    options = Options{}
-                  .set<UnifiedCredentialsOption>(MakeInsecureCredentials())
-                  .set<internal::UseInsecureChannelOption>(true);
-  }
-  auto client = SubscriptionAdminClient(
-      MakeSubscriptionAdminConnection(std::move(options)));
-  ASSERT_STATUS_OK(SubscriptionNames(client, project_id));
 }
 
 TEST_F(SubscriptionAdminIntegrationTest, CreateSubscriptionFailure) {

--- a/google/cloud/pubsub/integration_tests/topic_admin_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/topic_admin_integration_test.cc
@@ -107,21 +107,6 @@ TEST_F(TopicAdminIntegrationTest, TopicCRUD) {
   EXPECT_THAT(*names, Not(Contains(topic.FullName())));
 }
 
-TEST_F(TopicAdminIntegrationTest, UnifiedCredentials) {
-  auto project_id =
-      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
-  ASSERT_THAT(project_id, Not(IsEmpty()));
-  auto options =
-      Options{}.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials());
-  if (UsingEmulator()) {
-    options = Options{}
-                  .set<UnifiedCredentialsOption>(MakeInsecureCredentials())
-                  .set<internal::UseInsecureChannelOption>(true);
-  }
-  auto client = TopicAdminClient(MakeTopicAdminConnection(std::move(options)));
-  ASSERT_STATUS_OK(TopicNames(client, project_id));
-}
-
 TEST_F(TopicAdminIntegrationTest, CreateTopicFailure) {
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
   auto publisher = MakeTestTopicAdminClient();

--- a/google/cloud/spanner/integration_tests/client_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/client_integration_test.cc
@@ -1640,27 +1640,6 @@ TEST_F(ClientIntegrationTest, SpannerStatistics) {
   }
 }
 
-/// @test Verify the use of unified credentials.
-TEST_F(ClientIntegrationTest, UnifiedCredentials) {
-  auto options =
-      Options{}.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials());
-  if (UsingEmulator()) {
-    options = Options{}
-                  .set<UnifiedCredentialsOption>(MakeInsecureCredentials())
-                  .set<internal::UseInsecureChannelOption>(true);
-  }
-
-  // Reconnect to the database using the new credentials.
-  auto client = Client(MakeConnection(GetDatabase(), options));
-
-  auto commit_result = client.Commit(Mutations{
-      InsertMutationBuilder("Singers", {"SingerId", "FirstName", "LastName"})
-          .EmplaceRow(1, "test-fname-1", "test-lname-1")
-          .EmplaceRow(2, "test-fname-2", "test-lname-2")
-          .Build()});
-  EXPECT_STATUS_OK(commit_result);
-}
-
 /// @test Verify backwards compatibility for MakeConnection() arguments.
 TEST_F(ClientIntegrationTest, MakeConnectionOverloads) {
   MakeConnection(GetDatabase(), ConnectionOptions());


### PR DESCRIPTION
`UseInsecureChannelOption` seems unnecessary and the builds will either vindicate or embarrass me.

Note that we are not losing coverage for the GUAC integration tests in spanner / pubsub. The `UnifiedCredentialsOption` is defaulted by the library according to the value of the emulator env var. So the other tests in those fixtures exercise the GUAC code paths.

For history, the option was added in #7430 and since #8058, we have not needed the special treatment for gRPC Access Token credentials.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13413)
<!-- Reviewable:end -->
