### PR TITLE
ci: revert `msan` build to Bazel 6.4.0

### DIFF
--- a/ci/cloudbuild/builds/msan.sh
+++ b/ci/cloudbuild/builds/msan.sh
@@ -16,6 +16,8 @@
 
 set -euo pipefail
 
+export USE_BAZEL_VERSION=6.4.0
+
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/bazel.sh
 source module ci/cloudbuild/builds/lib/integration.sh


### PR DESCRIPTION
Part of the work for #13320

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13420)
<!-- Reviewable:end -->
