### PR TITLE
impl(oauth2): compute credentials query MDS for universe domain

### DIFF
--- a/google/cloud/internal/oauth2_compute_engine_credentials.h
+++ b/google/cloud/internal/oauth2_compute_engine_credentials.h
@@ -32,6 +32,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct ServiceAccountMetadata {
   std::set<std::string> scopes;
   std::string email;
+  std::string universe_domain;
 };
 
 /// Parses a metadata server response JSON string into a ServiceAccountMetadata.
@@ -98,6 +99,18 @@ class ComputeEngineCredentials : public Credentials {
   std::string AccountEmail() const override;
 
   /**
+   * Returns the universe domain from the Metadata Server (MDS).
+   * RPCs are made using `UniverseDomainRetryPolicyOption` and
+   * `UniverseDomainBackoffPolicyOption` if specified,
+   * preferring per call `Options` over `Options` used to construct the
+   * `ComputeEngineCredentials` instance. Otherwise, the default policies are
+   * used.
+   */
+  StatusOr<std::string> universe_domain() const override;
+  StatusOr<std::string> universe_domain(
+      google::cloud::Options const& options) const override;
+
+  /**
    * Returns the email or alias of this credential's service account.
    *
    * @note This class must query the Compute Engine instance's metadata server
@@ -132,9 +145,11 @@ class ComputeEngineCredentials : public Credentials {
   Options options_;
   HttpClientFactory client_factory_;
   mutable std::mutex mu_;
-  mutable bool metadata_retrieved_ = false;
+  mutable bool service_account_retrieved_ = false;
+  mutable bool universe_domain_retrieved_ = false;
   mutable std::set<std::string> scopes_;
   mutable std::string service_account_email_;
+  mutable std::string universe_domain_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/oauth2_compute_engine_credentials.h
+++ b/google/cloud/internal/oauth2_compute_engine_credentials.h
@@ -19,6 +19,7 @@
 #include "google/cloud/internal/oauth2_http_client_factory.h"
 #include "google/cloud/status.h"
 #include "google/cloud/version.h"
+#include "absl/types/optional.h"
 #include <chrono>
 #include <mutex>
 #include <string>
@@ -141,15 +142,16 @@ class ComputeEngineCredentials : public Credentials {
   std::string RetrieveServiceAccountInfo() const;
   std::string RetrieveServiceAccountInfo(
       std::lock_guard<std::mutex> const&) const;
+  StatusOr<std::string> RetrieveUniverseDomain(
+      std::lock_guard<std::mutex> const&, Options const& options) const;
 
   Options options_;
   HttpClientFactory client_factory_;
   mutable std::mutex mu_;
   mutable bool service_account_retrieved_ = false;
-  mutable bool universe_domain_retrieved_ = false;
   mutable std::set<std::string> scopes_;
   mutable std::string service_account_email_;
-  mutable std::string universe_domain_;
+  mutable absl::optional<std::string> universe_domain_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/oauth2_compute_engine_credentials_test.cc
+++ b/google/cloud/internal/oauth2_compute_engine_credentials_test.cc
@@ -206,21 +206,23 @@ TEST(ComputeEngineCredentialsTest, ParseMetadataServerResponse) {
     std::string payload;
     ServiceAccountMetadata expected;
   } cases[] = {
-      {R"js({"email": "foo@bar.baz", "scopes": ["scope1", "scope2"]})js",
-       ServiceAccountMetadata{{"scope1", "scope2"}, "foo@bar.baz", {}}},
+      {R"js({"email": "foo@bar.baz", "scopes": ["scope1", "scope2"], "universe_domain": "test-ud.net"})js",
+       ServiceAccountMetadata{
+           {"scope1", "scope2"}, "foo@bar.baz", "test-ud.net"}},
       {R"js({"email": "foo@bar.baz", "scopes": "scope1\nscope2\n"})js",
-       ServiceAccountMetadata{{"scope1", "scope2"}, "foo@bar.baz", {}}},
+       ServiceAccountMetadata{
+           {"scope1", "scope2"}, "foo@bar.baz", "googleapis.com"}},
       // Ignore invalid formats
-      {R"js({"email": ["1", "2"], "scopes": ["scope1", "scope2"]})js",
+      {R"js({"email": ["1", "2"], "scopes": ["scope1", "scope2"], "universe_domain": true})js",
        ServiceAccountMetadata{{"scope1", "scope2"}, "", {}}},
-      {R"js({"email": "foo@bar", "scopes": {"foo": "bar"}})js",
+      {R"js({"email": "foo@bar", "scopes": {"foo": "bar"}, "universe_domain": 42})js",
        ServiceAccountMetadata{{}, "foo@bar", {}}},
       // Ignore missing fields
       {R"js({"scopes": ["scope1", "scope2"]})js",
-       ServiceAccountMetadata{{"scope1", "scope2"}, "", {}}},
+       ServiceAccountMetadata{{"scope1", "scope2"}, "", "googleapis.com"}},
       {R"js({"email": "foo@bar.baz"})js",
-       ServiceAccountMetadata{{}, "foo@bar.baz", {}}},
-      {R"js({})js", ServiceAccountMetadata{{}, "", {}}},
+       ServiceAccountMetadata{{}, "foo@bar.baz", "googleapis.com"}},
+      {R"js({})js", ServiceAccountMetadata{{}, "", "googleapis.com"}},
   };
 
   for (auto const& test : cases) {
@@ -238,6 +240,7 @@ TEST(ComputeEngineCredentialsTest, ParseMetadataServerResponse) {
     EXPECT_EQ(metadata.email, test.expected.email);
     EXPECT_THAT(metadata.scopes,
                 UnorderedElementsAreArray(test.expected.scopes));
+    EXPECT_EQ(metadata.universe_domain, test.expected.universe_domain);
   }
 }
 

--- a/google/cloud/internal/oauth2_compute_engine_credentials_test.cc
+++ b/google/cloud/internal/oauth2_compute_engine_credentials_test.cc
@@ -14,11 +14,15 @@
 
 #include "google/cloud/internal/oauth2_compute_engine_credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
+#include "google/cloud/internal/backoff_policy.h"
 #include "google/cloud/internal/compute_engine_util.h"
+#include "google/cloud/internal/make_status.h"
+#include "google/cloud/internal/retry_policy_impl.h"
 #include "google/cloud/testing_util/mock_http_payload.h"
 #include "google/cloud/testing_util/mock_rest_client.h"
 #include "google/cloud/testing_util/mock_rest_response.h"
 #include "google/cloud/testing_util/status_matchers.h"
+#include "google/cloud/universe_domain_options.h"
 #include <gmock/gmock.h>
 #include <chrono>
 
@@ -33,6 +37,7 @@ using ::google::cloud::rest_internal::RestContext;
 using ::google::cloud::rest_internal::RestRequest;
 using ::google::cloud::rest_internal::RestResponse;
 using ::google::cloud::testing_util::IsOk;
+using ::google::cloud::testing_util::IsOkAndHolds;
 using ::google::cloud::testing_util::MakeMockHttpPayloadSuccess;
 using ::google::cloud::testing_util::MockRestClient;
 using ::google::cloud::testing_util::MockRestResponse;
@@ -202,20 +207,20 @@ TEST(ComputeEngineCredentialsTest, ParseMetadataServerResponse) {
     ServiceAccountMetadata expected;
   } cases[] = {
       {R"js({"email": "foo@bar.baz", "scopes": ["scope1", "scope2"]})js",
-       ServiceAccountMetadata{{"scope1", "scope2"}, "foo@bar.baz"}},
+       ServiceAccountMetadata{{"scope1", "scope2"}, "foo@bar.baz", {}}},
       {R"js({"email": "foo@bar.baz", "scopes": "scope1\nscope2\n"})js",
-       ServiceAccountMetadata{{"scope1", "scope2"}, "foo@bar.baz"}},
+       ServiceAccountMetadata{{"scope1", "scope2"}, "foo@bar.baz", {}}},
       // Ignore invalid formats
       {R"js({"email": ["1", "2"], "scopes": ["scope1", "scope2"]})js",
-       ServiceAccountMetadata{{"scope1", "scope2"}, ""}},
+       ServiceAccountMetadata{{"scope1", "scope2"}, "", {}}},
       {R"js({"email": "foo@bar", "scopes": {"foo": "bar"}})js",
-       ServiceAccountMetadata{{}, "foo@bar"}},
+       ServiceAccountMetadata{{}, "foo@bar", {}}},
       // Ignore missing fields
       {R"js({"scopes": ["scope1", "scope2"]})js",
-       ServiceAccountMetadata{{"scope1", "scope2"}, ""}},
+       ServiceAccountMetadata{{"scope1", "scope2"}, "", {}}},
       {R"js({"email": "foo@bar.baz"})js",
-       ServiceAccountMetadata{{}, "foo@bar.baz"}},
-      {R"js({})js", ServiceAccountMetadata{{}, ""}},
+       ServiceAccountMetadata{{}, "foo@bar.baz", {}}},
+      {R"js({})js", ServiceAccountMetadata{{}, "", {}}},
   };
 
   for (auto const& test : cases) {
@@ -408,6 +413,137 @@ TEST(ComputeEngineCredentialsTest, AccountEmail) {
   auto refreshed_email = credentials.AccountEmail();
   EXPECT_EQ(email, refreshed_email);
   EXPECT_EQ(credentials.service_account_email(), refreshed_email);
+}
+
+auto expected_universe_domain_request = []() {
+  auto const expected_path = absl::StrCat(
+      internal::GceMetadataScheme(), "://", internal::GceMetadataHostname(),
+      "/computeMetadata/v1/universe/universe_domain");
+  return AllOf(
+      Property(&RestRequest::path, expected_path),
+      Property(&RestRequest::headers,
+               Contains(Pair("metadata-flavor", Contains("Google")))),
+      Property(&RestRequest::parameters, Contains(Pair("recursive", "true"))));
+};
+
+TEST(ComputeEngineCredentialsTest, UniverseDomainSuccess) {
+  auto const universe_domain_resp = std::string{R"""({
+      "universe_domain": "my-ud.net"
+  })"""};
+
+  auto client = std::make_unique<MockRestClient>();
+  EXPECT_CALL(*client, Get(_, expected_universe_domain_request()))
+      .WillOnce([&](RestContext&, RestRequest const&) {
+        return internal::UnavailableError("Transient Error");
+      })
+      .WillOnce([&](RestContext&, RestRequest const&) {
+        auto response = std::make_unique<MockRestResponse>();
+        EXPECT_CALL(*response, StatusCode)
+            .WillRepeatedly(Return(HttpStatusCode::kOk));
+        EXPECT_CALL(std::move(*response), ExtractPayload).WillOnce([&] {
+          return MakeMockHttpPayloadSuccess(universe_domain_resp);
+        });
+        return std::unique_ptr<RestResponse>(std::move(response));
+      });
+
+  MockHttpClientFactory client_factory;
+  EXPECT_CALL(client_factory, Call).WillOnce(Return(ByMove(std::move(client))));
+  ComputeEngineCredentials credentials(Options{},
+                                       client_factory.AsStdFunction());
+  EXPECT_THAT(credentials.universe_domain(), IsOkAndHolds("my-ud.net"));
+}
+
+TEST(ComputeEngineCredentialsTest, UniverseDomainPermanentFailure) {
+  auto client = std::make_unique<MockRestClient>();
+  EXPECT_CALL(*client, Get(_, expected_universe_domain_request()))
+      .WillOnce([&](RestContext&, RestRequest const&) {
+        return internal::UnavailableError("Transient Error");
+      })
+      .WillOnce([&](RestContext&, RestRequest const&) {
+        return internal::NotFoundError("Permanent Error");
+      });
+
+  MockHttpClientFactory client_factory;
+  EXPECT_CALL(client_factory, Call).WillOnce(Return(ByMove(std::move(client))));
+  ComputeEngineCredentials credentials(Options{},
+                                       client_factory.AsStdFunction());
+  EXPECT_THAT(credentials.universe_domain(), StatusIs(StatusCode::kNotFound));
+}
+
+struct TestUniverseDomainRetryTraits {
+  static bool IsPermanentFailure(Status const& status) {
+    return !status.ok() && status.code() != StatusCode::kUnavailable;
+  }
+};
+
+class TestUniverseDomainRetryPolicy
+    : public internal::UniverseDomainRetryPolicy {
+ public:
+  ~TestUniverseDomainRetryPolicy() override = default;
+
+  explicit TestUniverseDomainRetryPolicy(int maximum_failures)
+      : impl_(maximum_failures) {}
+  TestUniverseDomainRetryPolicy(TestUniverseDomainRetryPolicy&& rhs) noexcept
+      : TestUniverseDomainRetryPolicy(rhs.maximum_failures()) {}
+  TestUniverseDomainRetryPolicy(
+      TestUniverseDomainRetryPolicy const& rhs) noexcept
+      : TestUniverseDomainRetryPolicy(rhs.maximum_failures()) {}
+
+  bool OnFailure(Status const& status) override {
+    return impl_.OnFailure(status);
+  }
+  bool IsExhausted() const override { return impl_.IsExhausted(); }
+  bool IsPermanentFailure(Status const& status) const override {
+    return impl_.IsPermanentFailure(status);
+  }
+  int maximum_failures() const { return impl_.maximum_failures(); }
+  std::unique_ptr<internal::UniverseDomainRetryPolicy> clone() const override {
+    return std::make_unique<TestUniverseDomainRetryPolicy>(maximum_failures());
+  }
+
+ private:
+  internal::LimitedErrorCountRetryPolicy<TestUniverseDomainRetryTraits> impl_;
+};
+
+TEST(ComputeEngineCredentialsTest,
+     UniverseDomainCredentialsOptionsCustomRetryPolicy) {
+  auto client = std::make_unique<MockRestClient>();
+  EXPECT_CALL(*client, Get(_, expected_universe_domain_request()))
+      .Times(3)
+      .WillRepeatedly([&](RestContext&, RestRequest const&) {
+        return internal::UnavailableError("Transient Error");
+      });
+
+  auto credentials_options =
+      Options{}.set<internal::UniverseDomainRetryPolicyOption>(
+          std::make_unique<TestUniverseDomainRetryPolicy>(2)->clone());
+  MockHttpClientFactory client_factory;
+  EXPECT_CALL(client_factory, Call).WillOnce(Return(ByMove(std::move(client))));
+  ComputeEngineCredentials credentials(credentials_options,
+                                       client_factory.AsStdFunction());
+  EXPECT_THAT(credentials.universe_domain(),
+              StatusIs(StatusCode::kUnavailable));
+}
+
+TEST(ComputeEngineCredentialsTest, UniverseDomainCallOptionsCustomRetryPolicy) {
+  auto client = std::make_unique<MockRestClient>();
+  EXPECT_CALL(*client, Get(_, expected_universe_domain_request()))
+      .Times(4)
+      .WillRepeatedly([&](RestContext&, RestRequest const&) {
+        return internal::UnavailableError("Transient Error");
+      });
+
+  auto call_options = Options{}.set<internal::UniverseDomainRetryPolicyOption>(
+      std::make_unique<TestUniverseDomainRetryPolicy>(3)->clone());
+  auto credentials_options =
+      Options{}.set<internal::UniverseDomainRetryPolicyOption>(
+          std::make_unique<TestUniverseDomainRetryPolicy>(2)->clone());
+  MockHttpClientFactory client_factory;
+  EXPECT_CALL(client_factory, Call).WillOnce(Return(ByMove(std::move(client))));
+  ComputeEngineCredentials credentials(credentials_options,
+                                       client_factory.AsStdFunction());
+  EXPECT_THAT(credentials.universe_domain(call_options),
+              StatusIs(StatusCode::kUnavailable));
 }
 
 }  // namespace

--- a/google/cloud/internal/oauth2_credentials.cc
+++ b/google/cloud/internal/oauth2_credentials.cc
@@ -27,11 +27,12 @@ StatusOr<std::vector<std::uint8_t>> Credentials::SignBlob(
                 "The current credentials cannot sign blobs locally");
 }
 
-std::string Credentials::universe_domain() const {
+StatusOr<std::string> Credentials::universe_domain() const {
   return GoogleDefaultUniverseDomain();
 }
 
-std::string Credentials::universe_domain(google::cloud::Options const&) const {
+StatusOr<std::string> Credentials::universe_domain(
+    google::cloud::Options const&) const {
   return universe_domain();
 }
 

--- a/google/cloud/internal/oauth2_credentials.h
+++ b/google/cloud/internal/oauth2_credentials.h
@@ -80,13 +80,13 @@ class Credentials {
   /// Return the universe domain from the credentials. If no explicit value is
   /// present, it is assumed to be "googleapis.com". If additional rpc calls are
   /// required, the default retry policy is used.
-  virtual std::string universe_domain() const;
+  virtual StatusOr<std::string> universe_domain() const;
 
   /// Return the universe domain from the credentials. If no explicit value is
   /// present, it is assumed to be "googleapis.com". If additional rpc calls are
   /// required, the `UniverseDomainRetryPolicyOption`, if present in the
   /// `Options`, is used. Otherwise the default retry policy is used.
-  virtual std::string universe_domain(
+  virtual StatusOr<std::string> universe_domain(
       google::cloud::Options const& options) const;
 };
 

--- a/google/cloud/internal/oauth2_external_account_credentials.h
+++ b/google/cloud/internal/oauth2_external_account_credentials.h
@@ -84,7 +84,7 @@ class ExternalAccountCredentials : public oauth2_internal::Credentials {
   StatusOr<AccessToken> GetToken(
       std::chrono::system_clock::time_point tp) override;
 
-  std::string universe_domain(Options const&) const override {
+  StatusOr<std::string> universe_domain(Options const&) const override {
     return info_.universe_domain;
   }
 

--- a/google/cloud/internal/oauth2_impersonate_service_account_credentials.h
+++ b/google/cloud/internal/oauth2_impersonate_service_account_credentials.h
@@ -48,7 +48,7 @@ class ImpersonateServiceAccountCredentials
   StatusOr<AccessToken> GetToken(
       std::chrono::system_clock::time_point tp) override;
 
-  std::string universe_domain(Options const& options) const override {
+  StatusOr<std::string> universe_domain(Options const& options) const override {
     return stub_->universe_domain(options);
   }
 

--- a/google/cloud/internal/oauth2_minimal_iam_credentials_rest.h
+++ b/google/cloud/internal/oauth2_minimal_iam_credentials_rest.h
@@ -55,7 +55,8 @@ class MinimalIamCredentialsRest {
   virtual StatusOr<google::cloud::AccessToken> GenerateAccessToken(
       GenerateAccessTokenRequest const& request) = 0;
 
-  virtual std::string universe_domain(Options const& options) const = 0;
+  virtual StatusOr<std::string> universe_domain(
+      Options const& options) const = 0;
 };
 
 /**
@@ -77,7 +78,7 @@ class MinimalIamCredentialsRestStub : public MinimalIamCredentialsRest {
   StatusOr<google::cloud::AccessToken> GenerateAccessToken(
       GenerateAccessTokenRequest const& request) override;
 
-  std::string universe_domain(Options const& options) const override {
+  StatusOr<std::string> universe_domain(Options const& options) const override {
     return credentials_->universe_domain(options);
   }
 
@@ -100,7 +101,7 @@ class MinimalIamCredentialsRestLogging : public MinimalIamCredentialsRest {
   StatusOr<google::cloud::AccessToken> GenerateAccessToken(
       GenerateAccessTokenRequest const& request) override;
 
-  std::string universe_domain(Options const& options) const override {
+  StatusOr<std::string> universe_domain(Options const& options) const override {
     return child_->universe_domain(options);
   }
 

--- a/google/cloud/storage/internal/impersonate_service_account_credentials_test.cc
+++ b/google/cloud/storage/internal/impersonate_service_account_credentials_test.cc
@@ -37,7 +37,7 @@ class MockMinimalIamCredentialsRest
  public:
   MOCK_METHOD(StatusOr<google::cloud::AccessToken>, GenerateAccessToken,
               (oauth2_internal::GenerateAccessTokenRequest const&), (override));
-  MOCK_METHOD(std::string, universe_domain, (Options const& options),
+  MOCK_METHOD(StatusOr<std::string>, universe_domain, (Options const& options),
               (override, const));
 };
 


### PR DESCRIPTION
fixes #13434 
fixes #13433

Also had to update the return type of the `Credentials::universe_domain` accessor from `std::string` to `StatusOr<std::string>`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13435)
<!-- Reviewable:end -->
