### PR TITLE
ci: try to deflake Bazel 7 remote cache

### DIFF
--- a/ci/cloudbuild/builds/lib/bazel.sh
+++ b/ci/cloudbuild/builds/lib/bazel.sh
@@ -68,6 +68,7 @@ function bazel::common_args() {
     "--cache_test_results=$(should_cache_test_results)"
   )
   if [[ -n "${BAZEL_REMOTE_CACHE:-}" ]]; then
+    args+=("--remote_download_minimal")
     args+=("--remote_cache=${BAZEL_REMOTE_CACHE}")
     args+=("--google_default_credentials")
     # See https://docs.bazel.build/versions/main/remote-caching.html#known-issues

--- a/ci/cloudbuild/builds/msan.sh
+++ b/ci/cloudbuild/builds/msan.sh
@@ -16,8 +16,6 @@
 
 set -euo pipefail
 
-export USE_BAZEL_VERSION=6.4.0
-
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/bazel.sh
 source module ci/cloudbuild/builds/lib/integration.sh


### PR DESCRIPTION
Related to #13315

We might as well move `msan` back to 7.0.0. If we see a flake, we will at least know this is not the fix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13441)
<!-- Reviewable:end -->
