### PR TITLE
cleanup: use `std::decay_t` over `absl::decay_t`

### DIFF
--- a/google/cloud/completion_queue.h
+++ b/google/cloud/completion_queue.h
@@ -21,8 +21,8 @@
 #include "google/cloud/internal/completion_queue_impl.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include "absl/meta/type_traits.h"
 #include <chrono>
+#include <type_traits>
 
 namespace google {
 namespace cloud {
@@ -227,7 +227,7 @@ class CompletionQueue {
 
      private:
       std::weak_ptr<internal::CompletionQueueImpl> impl_;
-      absl::decay_t<Functor> fun_;
+      std::decay_t<Functor> fun_;
     };
     impl_->RunAsync(
         std::make_unique<Wrapper>(impl_, std::forward<Functor>(functor)));
@@ -253,7 +253,7 @@ class CompletionQueue {
       void exec() override { fun_(); }
 
      private:
-      absl::decay_t<Functor> fun_;
+      std::decay_t<Functor> fun_;
     };
     impl_->RunAsync(std::make_unique<Wrapper>(std::forward<Functor>(functor)));
   }

--- a/google/cloud/internal/async_rest_retry_loop.h
+++ b/google/cloud/internal/async_rest_retry_loop.h
@@ -27,9 +27,9 @@
 #include "google/cloud/retry_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include "absl/meta/type_traits.h"
 #include <grpcpp/grpcpp.h>
 #include <chrono>
+#include <type_traits>
 
 namespace google {
 namespace cloud {
@@ -330,7 +330,7 @@ class AsyncRestRetryLoopImpl
   std::unique_ptr<BackoffPolicy> backoff_policy_;
   Idempotency idempotency_ = Idempotency::kNonIdempotent;
   CompletionQueue cq_;
-  absl::decay_t<Functor> functor_;
+  std::decay_t<Functor> functor_;
   Request request_;
   char const* location_ = "unknown";
   internal::CallContext call_context_;

--- a/google/cloud/internal/async_retry_loop.h
+++ b/google/cloud/internal/async_retry_loop.h
@@ -28,9 +28,9 @@
 #include "google/cloud/options.h"
 #include "google/cloud/retry_policy.h"
 #include "google/cloud/version.h"
-#include "absl/meta/type_traits.h"
 #include <grpcpp/grpcpp.h>
 #include <chrono>
+#include <type_traits>
 
 namespace google {
 namespace cloud {
@@ -324,7 +324,7 @@ class AsyncRetryLoopImpl
   std::unique_ptr<BackoffPolicy> backoff_policy_;
   Idempotency idempotency_ = Idempotency::kNonIdempotent;
   google::cloud::CompletionQueue cq_;
-  absl::decay_t<Functor> functor_;
+  std::decay_t<Functor> functor_;
   Request request_;
   char const* location_ = "unknown";
   CallContext call_context_;

--- a/google/cloud/internal/resumable_streaming_read_rpc.h
+++ b/google/cloud/internal/resumable_streaming_read_rpc.h
@@ -20,6 +20,7 @@
 #include <chrono>
 #include <memory>
 #include <thread>
+#include <type_traits>
 
 namespace google {
 namespace cloud {
@@ -152,7 +153,7 @@ std::shared_ptr<StreamingReadRpc<ResponseType>> MakeResumableStreamingReadRpc(
     RequestUpdater<ResponseType, RequestType> updater, RequestType request) {
   return std::make_shared<
       ResumableStreamingReadRpc<ResponseType, RequestType, RetryPolicy,
-                                BackoffPolicy, absl::decay_t<Sleeper>>>(
+                                BackoffPolicy, std::decay_t<Sleeper>>>(
       std::move(retry_policy), std::move(backoff_policy),
       std::forward<Sleeper>(sleeper), std::move(stream_factory),
       std::move(updater), std::forward<RequestType>(request));


### PR DESCRIPTION
This was added in C++14

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13457)
<!-- Reviewable:end -->
