### PR TITLE
refactor(bigtable): credential defaults

### DIFF
--- a/google/cloud/bigtable/internal/defaults.cc
+++ b/google/cloud/bigtable/internal/defaults.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/bigtable/options.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/connection_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/service_endpoint.h"
@@ -190,17 +191,19 @@ Options DefaultOptions(Options opts) {
   // options are always set as a result of calling this function.
   opts = HandleUniverseDomain(std::move(opts));
 
+  if (!opts.has<UnifiedCredentialsOption>() &&
+      !opts.has<GrpcCredentialOption>()) {
+    opts.set<UnifiedCredentialsOption>(
+        emulator ? MakeInsecureCredentials() : MakeGoogleDefaultCredentials());
+  }
+
   // Fill any missing default values.
   auto defaults = Options{}
-                      .set<GrpcCredentialOption>(
-                          emulator ? grpc::InsecureChannelCredentials()
-                                   : grpc::GoogleDefaultCredentials())
                       .set<TracingComponentsOption>(
                           ::google::cloud::internal::DefaultTracingComponents())
                       .set<GrpcTracingOptionsOption>(
                           ::google::cloud::internal::DefaultTracingOptions())
                       .set<GrpcNumChannelsOption>(DefaultConnectionPoolSize());
-
   opts = google::cloud::internal::MergeOptions(std::move(opts),
                                                std::move(defaults));
 


### PR DESCRIPTION
We were unconditionally creating a `grpc::GoogleDefaultCredentials()` object. In some environments[^1] this object does not exist and the creation of it can crash code.

Take the opportunity to have the defaults set the `UnifiedCredentialsOption` and bolster the unit tests.

[^1]:  hint: it rhymes with doogle-dee

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13461)
<!-- Reviewable:end -->
