### PR TITLE
impl: accept non-FQDN in `UniverseDomainEndpoint(...)`

### DIFF
--- a/google/cloud/internal/service_endpoint.cc
+++ b/google/cloud/internal/service_endpoint.cc
@@ -57,9 +57,9 @@ std::string UniverseDomainEndpoint(std::string gdu_endpoint,
                                    Options const& options) {
   if (!options.has<UniverseDomainOption>()) return gdu_endpoint;
   // Support both "foo.googleapis.com" and "foo.googleapis.com."
-  auto e = absl::StripSuffix(gdu_endpoint, ".");
-  return absl::StrCat(absl::StripSuffix(e, ".googleapis.com"), ".",
-                      options.get<UniverseDomainOption>());
+  return absl::StrCat(absl::StripSuffix(absl::StripSuffix(gdu_endpoint, "."),
+                                        ".googleapis.com"),
+                      ".", options.get<UniverseDomainOption>());
 }
 
 }  // namespace internal

--- a/google/cloud/internal/service_endpoint.cc
+++ b/google/cloud/internal/service_endpoint.cc
@@ -56,7 +56,9 @@ StatusOr<std::string> DetermineServiceEndpoint(
 std::string UniverseDomainEndpoint(std::string gdu_endpoint,
                                    Options const& options) {
   if (!options.has<UniverseDomainOption>()) return gdu_endpoint;
-  return absl::StrCat(absl::StripSuffix(gdu_endpoint, ".googleapis.com."), ".",
+  // Support both "foo.googleapis.com" and "foo.googleapis.com."
+  auto e = absl::StripSuffix(gdu_endpoint, ".");
+  return absl::StrCat(absl::StripSuffix(e, ".googleapis.com"), ".",
                       options.get<UniverseDomainOption>());
 }
 

--- a/google/cloud/internal/service_endpoint_test.cc
+++ b/google/cloud/internal/service_endpoint_test.cc
@@ -106,11 +106,18 @@ TEST(DetermineServiceEndpoint, DefaultHost) {
 TEST(UniverseDomainEndpoint, WithoutUniverseDomainOption) {
   auto ep = UniverseDomainEndpoint("foo.googleapis.com.", Options{});
   EXPECT_EQ(ep, "foo.googleapis.com.");
+
+  ep = UniverseDomainEndpoint("foo.googleapis.com", Options{});
+  EXPECT_EQ(ep, "foo.googleapis.com");
 }
 
 TEST(UniverseDomainEndpoint, WithUniverseDomainOption) {
   auto ep = UniverseDomainEndpoint(
       "foo.googleapis.com.", Options{}.set<UniverseDomainOption>("my-ud.net"));
+  EXPECT_EQ(ep, "foo.my-ud.net");
+
+  ep = UniverseDomainEndpoint(
+      "foo.googleapis.com", Options{}.set<UniverseDomainOption>("my-ud.net"));
   EXPECT_EQ(ep, "foo.my-ud.net");
 }
 

--- a/google/cloud/internal/service_endpoint_test.cc
+++ b/google/cloud/internal/service_endpoint_test.cc
@@ -116,8 +116,8 @@ TEST(UniverseDomainEndpoint, WithUniverseDomainOption) {
       "foo.googleapis.com.", Options{}.set<UniverseDomainOption>("my-ud.net"));
   EXPECT_EQ(ep, "foo.my-ud.net");
 
-  ep = UniverseDomainEndpoint(
-      "foo.googleapis.com", Options{}.set<UniverseDomainOption>("my-ud.net"));
+  ep = UniverseDomainEndpoint("foo.googleapis.com",
+                              Options{}.set<UniverseDomainOption>("my-ud.net"));
   EXPECT_EQ(ep, "foo.my-ud.net");
 }
 


### PR DESCRIPTION
Part of the work for #13345 

In light of #13357, accept non-FQDN in our universe domain helper.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13465)
<!-- Reviewable:end -->
