### PR TITLE
feat: support `UniverseDomainOption` in gRPC IAM stub

### DIFF
--- a/google/cloud/internal/minimal_iam_credentials_stub.cc
+++ b/google/cloud/internal/minimal_iam_credentials_stub.cc
@@ -20,6 +20,7 @@
 #include "google/cloud/internal/grpc_opentelemetry.h"
 #include "google/cloud/internal/log_wrapper.h"
 #include "google/cloud/internal/opentelemetry.h"
+#include "google/cloud/internal/service_endpoint.h"
 #include "google/cloud/internal/trace_propagator.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"
 #include "google/cloud/internal/url_encode.h"
@@ -228,9 +229,11 @@ std::shared_ptr<MinimalIamCredentialsStub> MakeMinimalIamCredentialsStub(
 }
 
 Options MakeMinimalIamCredentialsOptions(Options options) {
-  return MergeOptions(
-      Options{}.set<EndpointOption>("iamcredentials.googleapis.com"),
-      std::move(options));
+  // The supplied options come from a service. We are overriding the value of
+  // its `EndpointOption`.
+  options.unset<EndpointOption>();
+  auto ep = UniverseDomainEndpoint("iamcredentials.googleapis.com.", options);
+  return options.set<EndpointOption>(std::move(ep));
 }
 
 }  // namespace internal

--- a/google/cloud/internal/minimal_iam_credentials_stub_test.cc
+++ b/google/cloud/internal/minimal_iam_credentials_stub_test.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include "google/cloud/testing_util/validate_metadata.h"
 #include "google/cloud/testing_util/validate_propagator.h"
+#include "google/cloud/universe_domain_options.h"
 #include <google/iam/credentials/v1/iamcredentials.grpc.pb.h>
 #include <gmock/gmock.h>
 
@@ -342,6 +343,26 @@ TEST_F(MinimalIamCredentialsStubTest, SignBlobTracing) {
               OTelAttribute<int>("gl-cpp.status_code", kErrorCode)))));
 }
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+
+TEST(MakeMinimalIamCredentialsOptions, Default) {
+  auto o = MakeMinimalIamCredentialsOptions(
+      Options{}.set<EndpointOption>("storage.googleapis.com."));
+  EXPECT_EQ(o.get<EndpointOption>(), "iamcredentials.googleapis.com.");
+}
+
+TEST(MakeMinimalIamCredentialsOptions, WithoutUniverseDomain) {
+  auto o = MakeMinimalIamCredentialsOptions(
+      Options{}.set<EndpointOption>("storage.googleapis.com."));
+  EXPECT_EQ(o.get<EndpointOption>(), "iamcredentials.googleapis.com.");
+}
+
+TEST(MakeMinimalIamCredentialsOptions, WithUniverseDomain) {
+  auto o = MakeMinimalIamCredentialsOptions(
+      Options{}
+          .set<EndpointOption>("storage.googleapis.com.")
+          .set<internal::UniverseDomainOption>("my-ud.net"));
+  EXPECT_EQ(o.get<EndpointOption>(), "iamcredentials.my-ud.net");
+}
 
 }  // namespace
 }  // namespace internal


### PR DESCRIPTION
Part of the work for #13115 

GCS+gRPC uses this stub for `SignBlob`. It is also used by gRPC impersonate service account credentials.

Add tests for this function.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13466)
<!-- Reviewable:end -->
