### PR TITLE
cleanup: fix CQ TimerCancel test

### DIFF
--- a/google/cloud/completion_queue_test.cc
+++ b/google/cloud/completion_queue_test.cc
@@ -107,7 +107,7 @@ TEST(CompletionQueueTest, TimerCancel) {
     }
   };
   std::vector<std::thread> workers;
-  std::generate_n(std::back_inserter(runners), 8,
+  std::generate_n(std::back_inserter(workers), 8,
                   [&] { return std::thread(worker, cq); });
 
   for (auto& t : workers) t.join();


### PR DESCRIPTION
I don't really know what the test is doing, but it seems the intention was to join the `workers` before the `runners`. Adding these threads to the end of `runners` defeats the purpose.

This PR seems to speed up the test 10x, locally. Hopefully we will see less timeouts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13467)
<!-- Reviewable:end -->
