### PR TITLE
impl(bigtable): support bigtable cookie in `ReadRow(s)`

### DIFF
--- a/google/cloud/bigtable/internal/default_row_reader.cc
+++ b/google/cloud/bigtable/internal/default_row_reader.cc
@@ -58,9 +58,10 @@ void DefaultRowReader::MakeRequest() {
   }
 
   auto const& options = internal::CurrentOptions();
-  auto context = std::make_shared<grpc::ClientContext>();
-  internal::ConfigureContext(*context, options);
-  stream_ = stub_->ReadRows(std::move(context), options, request);
+  context_ = std::make_shared<grpc::ClientContext>();
+  internal::ConfigureContext(*context_, options);
+  retry_context_.PreCall(*context_);
+  stream_ = stub_->ReadRows(context_, options, request);
   stream_is_open_ = true;
 
   parser_ = bigtable::internal::ReadRowsParserFactory().Create(reverse_);
@@ -74,6 +75,8 @@ bool DefaultRowReader::NextChunk() {
     if (absl::holds_alternative<Status>(v)) {
       last_status_ = absl::get<Status>(std::move(v));
       response_ = {};
+      retry_context_.PostCall(*context_);
+      context_ = nullptr;
       return false;
     }
     response_ = absl::get<google::bigtable::v2::ReadRowsResponse>(std::move(v));
@@ -175,6 +178,7 @@ void DefaultRowReader::Cancel() {
       stream_->Read())) {
   }
 
+  context_ = nullptr;
   stream_is_open_ = false;
 }
 

--- a/google/cloud/bigtable/internal/default_row_reader.cc
+++ b/google/cloud/bigtable/internal/default_row_reader.cc
@@ -76,7 +76,7 @@ bool DefaultRowReader::NextChunk() {
       last_status_ = absl::get<Status>(std::move(v));
       response_ = {};
       retry_context_.PostCall(*context_);
-      context_ = nullptr;
+      context_.reset();
       return false;
     }
     response_ = absl::get<google::bigtable::v2::ReadRowsResponse>(std::move(v));
@@ -178,7 +178,7 @@ void DefaultRowReader::Cancel() {
       stream_->Read())) {
   }
 
-  context_ = nullptr;
+  context_.reset();
   stream_is_open_ = false;
 }
 

--- a/google/cloud/bigtable/internal/default_row_reader.h
+++ b/google/cloud/bigtable/internal/default_row_reader.h
@@ -18,6 +18,7 @@
 #include "google/cloud/bigtable/filters.h"
 #include "google/cloud/bigtable/internal/bigtable_stub.h"
 #include "google/cloud/bigtable/internal/readrowsparser.h"
+#include "google/cloud/bigtable/internal/retry_context.h"
 #include "google/cloud/bigtable/internal/row_reader_impl.h"
 #include "google/cloud/bigtable/metadata_update_policy.h"
 #include "google/cloud/bigtable/options.h"
@@ -92,6 +93,8 @@ class DefaultRowReader : public RowReaderImpl {
   bool reverse_;
   std::unique_ptr<bigtable::DataRetryPolicy> retry_policy_;
   std::unique_ptr<BackoffPolicy> backoff_policy_;
+  std::shared_ptr<grpc::ClientContext> context_;
+  RetryContext retry_context_;
 
   std::unique_ptr<bigtable::internal::ReadRowsParser> parser_;
   std::unique_ptr<


### PR DESCRIPTION
Part of the work for #13447 

This thing is like our `StreamRange` class, for bigtable rows. Before we create the stream, call `RetryContext::PreCall(...)`. When the stream finishes (by returning a variant holding a `Status`), call `RetryContext::PostCall(...)`.

Given the structure of the code, we need to hold the `grpc::ClientContext` in the class. Delete it at our earliest convenience.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13468)
<!-- Reviewable:end -->
