### PR TITLE
impl(bigtable): support bigtable cookie in `BulkApply`

### DIFF
--- a/google/cloud/bigtable/internal/bulk_mutator.h
+++ b/google/cloud/bigtable/internal/bulk_mutator.h
@@ -20,6 +20,7 @@
 #include "google/cloud/bigtable/idempotent_mutation_policy.h"
 #include "google/cloud/bigtable/internal/bigtable_stub.h"
 #include "google/cloud/bigtable/internal/mutate_rows_limiter.h"
+#include "google/cloud/bigtable/internal/retry_context.h"
 #include "google/cloud/bigtable/version.h"
 #include "google/cloud/internal/invoke_result.h"
 #include "google/cloud/status.h"
@@ -133,6 +134,7 @@ class BulkMutator {
 
  protected:
   BulkMutatorState state_;
+  RetryContext retry_context_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/internal/bulk_mutator_test.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator_test.cc
@@ -15,8 +15,10 @@
 #include "google/cloud/bigtable/internal/bulk_mutator.h"
 #include "google/cloud/bigtable/testing/mock_bigtable_stub.h"
 #include "google/cloud/bigtable/testing/mock_mutate_rows_limiter.h"
+#include "google/cloud/internal/make_status.h"
 #include "google/cloud/testing_util/chrono_literals.h"
 #include "google/cloud/testing_util/status_matchers.h"
+#include "google/cloud/testing_util/validate_metadata.h"
 
 namespace google {
 namespace cloud {
@@ -31,10 +33,12 @@ using ::google::cloud::bigtable::testing::MockMutateRowsLimiter;
 using ::google::cloud::bigtable::testing::MockMutateRowsStream;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::AnyOf;
+using ::testing::Contains;
 using ::testing::Eq;
 using ::testing::IsEmpty;
 using ::testing::Matcher;
 using ::testing::MockFunction;
+using ::testing::Pair;
 using ::testing::Property;
 using ::testing::Return;
 
@@ -70,13 +74,19 @@ v2::MutateRowsResponse MakeResponse(
   return resp;
 }
 
-TEST(BulkMutatorTest, Simple) {
+class BulkMutatorTest : public ::testing::Test {
+ protected:
+  testing_util::ValidateMetadataFixture metadata_fixture_;
+};
+
+TEST_F(BulkMutatorTest, Simple) {
   BulkMutation mut(IdempotentMutation("r0"), IdempotentMutation("r1"));
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRows)
-      .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
+      .WillOnce([this](auto context, auto const&,
+                       google::bigtable::v2::MutateRowsRequest const& request) {
+        metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
         EXPECT_CALL(*stream, Read)
@@ -98,7 +108,7 @@ TEST(BulkMutatorTest, Simple) {
   EXPECT_TRUE(failures.empty());
 }
 
-TEST(BulkMutatorTest, RetryPartialFailure) {
+TEST_F(BulkMutatorTest, RetryPartialFailure) {
   // In this test we create a Mutation for two rows, one of which will fail.
   // First create the mutation.
   BulkMutation mut(IdempotentMutation("r0"), IdempotentMutation("r1"));
@@ -107,8 +117,9 @@ TEST(BulkMutatorTest, RetryPartialFailure) {
   EXPECT_CALL(*mock, MutateRows)
       // Prepare the mocks for the request.  First create a stream response
       // which indicates a partial failure.
-      .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
+      .WillOnce([this](auto context, auto const&,
+                       google::bigtable::v2::MutateRowsRequest const& request) {
+        metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
         EXPECT_CALL(*stream, Read)
@@ -119,8 +130,9 @@ TEST(BulkMutatorTest, RetryPartialFailure) {
       })
       // Prepare a second stream response, because the client should retry after
       // the partial failure.
-      .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
+      .WillOnce([this](auto context, auto const&,
+                       google::bigtable::v2::MutateRowsRequest const& request) {
+        metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
         EXPECT_CALL(*stream, Read)
@@ -145,7 +157,7 @@ TEST(BulkMutatorTest, RetryPartialFailure) {
   EXPECT_TRUE(failures.empty());
 }
 
-TEST(BulkMutatorTest, PermanentFailure) {
+TEST_F(BulkMutatorTest, PermanentFailure) {
   // In this test we handle a recoverable and one unrecoverable failures.
   // Create a bulk mutation with two SetCell() mutations.
   BulkMutation mut(IdempotentMutation("r0"), IdempotentMutation("r1"));
@@ -153,8 +165,9 @@ TEST(BulkMutatorTest, PermanentFailure) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRows)
       // The first RPC return one recoverable and one unrecoverable failure.
-      .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
+      .WillOnce([this](auto context, auto const&,
+                       google::bigtable::v2::MutateRowsRequest const& request) {
+        metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
         EXPECT_CALL(*stream, Read)
@@ -166,8 +179,9 @@ TEST(BulkMutatorTest, PermanentFailure) {
       })
       // The BulkMutator should issue a second request, which will return
       // success for the remaining mutation.
-      .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
+      .WillOnce([this](auto context, auto const&,
+                       google::bigtable::v2::MutateRowsRequest const& request) {
+        metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
         EXPECT_CALL(*stream, Read)
@@ -194,7 +208,7 @@ TEST(BulkMutatorTest, PermanentFailure) {
   EXPECT_THAT(failures[0].status(), StatusIs(StatusCode::kOutOfRange));
 }
 
-TEST(BulkMutatorTest, PartialStream) {
+TEST_F(BulkMutatorTest, PartialStream) {
   // We are going to test the case where the stream does not contain a response
   // for all requests.  Create a BulkMutation with two entries.
   BulkMutation mut(IdempotentMutation("r0"), IdempotentMutation("r1"));
@@ -203,8 +217,9 @@ TEST(BulkMutatorTest, PartialStream) {
   EXPECT_CALL(*mock, MutateRows)
       // This will be the stream returned by the first request.  It is missing
       // information about one of the mutations.
-      .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
+      .WillOnce([this](auto context, auto const&,
+                       google::bigtable::v2::MutateRowsRequest const& request) {
+        metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
         EXPECT_CALL(*stream, Read)
@@ -215,8 +230,9 @@ TEST(BulkMutatorTest, PartialStream) {
       // The BulkMutation should issue a second request, this is the stream
       // returned by the second request, which indicates success for the missed
       // mutation on r1.
-      .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
+      .WillOnce([this](auto context, auto const&,
+                       google::bigtable::v2::MutateRowsRequest const& request) {
+        metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
         EXPECT_CALL(*stream, Read)
@@ -241,7 +257,7 @@ TEST(BulkMutatorTest, PartialStream) {
   EXPECT_TRUE(failures.empty());
 }
 
-TEST(BulkMutatorTest, RetryOnlyIdempotent) {
+TEST_F(BulkMutatorTest, RetryOnlyIdempotent) {
   // Create a BulkMutation with a non-idempotent mutation.
   BulkMutation mut(NonIdempotentMutation("r0"),
                    IdempotentMutation("r1-retried"));
@@ -259,8 +275,9 @@ TEST(BulkMutatorTest, RetryOnlyIdempotent) {
   EXPECT_CALL(*mock, MutateRows)
       // We will setup the mock to return recoverable transient errors for all
       // mutations.
-      .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
+      .WillOnce([this](auto context, auto const&,
+                       google::bigtable::v2::MutateRowsRequest const& request) {
+        metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_THAT(request, HasCorrectResourceNames());
         EXPECT_EQ(2, request.entries_size());
         auto stream = std::make_unique<MockMutateRowsStream>();
@@ -274,8 +291,10 @@ TEST(BulkMutatorTest, RetryOnlyIdempotent) {
       // The BulkMutator should issue a second request, with only the
       // idempotent mutation. Make the mock return success for it.
       .WillOnce(
-          [expect_r2](auto, auto const&,
-                      google::bigtable::v2::MutateRowsRequest const& request) {
+          [this, expect_r2](
+              auto context, auto const&,
+              google::bigtable::v2::MutateRowsRequest const& request) {
+            metadata_fixture_.SetServerMetadata(*context, {});
             EXPECT_THAT(request, HasCorrectResourceNames());
             expect_r2(request);
             auto stream = std::make_unique<MockMutateRowsStream>();
@@ -303,7 +322,7 @@ TEST(BulkMutatorTest, RetryOnlyIdempotent) {
   EXPECT_THAT(failures[0].status(), StatusIs(StatusCode::kUnavailable));
 }
 
-TEST(BulkMutatorTest, UnconfirmedAreFailed) {
+TEST_F(BulkMutatorTest, UnconfirmedAreFailed) {
   // Make sure that mutations which are not confirmed are reported as UNKNOWN
   // with the proper index.
   BulkMutation mut(NonIdempotentMutation("r0"),
@@ -314,8 +333,9 @@ TEST(BulkMutatorTest, UnconfirmedAreFailed) {
   EXPECT_CALL(*mock, MutateRows)
       // We will setup the mock to return recoverable failures for idempotent
       // mutations.
-      .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
+      .WillOnce([this](auto context, auto const&,
+                       google::bigtable::v2::MutateRowsRequest const& request) {
+        metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_THAT(request, HasCorrectResourceNames());
         EXPECT_EQ(3, request.entries_size());
         auto stream = std::make_unique<MockMutateRowsStream>();
@@ -343,13 +363,14 @@ TEST(BulkMutatorTest, UnconfirmedAreFailed) {
   EXPECT_THAT(failures[0].status(), StatusIs(StatusCode::kPermissionDenied));
 }
 
-TEST(BulkMutatorTest, ConfiguresContext) {
+TEST_F(BulkMutatorTest, ConfiguresContext) {
   BulkMutation mut(IdempotentMutation("r0"));
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRows)
-      .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
+      .WillOnce([this](auto context, auto const&,
+                       google::bigtable::v2::MutateRowsRequest const& request) {
+        metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
         EXPECT_CALL(*stream, Read).WillOnce(Return(Status()));
@@ -370,13 +391,14 @@ TEST(BulkMutatorTest, ConfiguresContext) {
   (void)mutator.MakeOneRequest(*mock, limiter);
 }
 
-TEST(BulkMutatorTest, MutationStatusReportedOnOkStream) {
+TEST_F(BulkMutatorTest, MutationStatusReportedOnOkStream) {
   BulkMutation mut(IdempotentMutation("r0"), IdempotentMutation("r1"));
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRows)
-      .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
+      .WillOnce([this](auto context, auto const&,
+                       google::bigtable::v2::MutateRowsRequest const& request) {
+        metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
         EXPECT_CALL(*stream, Read)
@@ -406,13 +428,14 @@ TEST(BulkMutatorTest, MutationStatusReportedOnOkStream) {
   EXPECT_THAT(failures[1].status(), StatusIs(StatusCode::kInternal));
 }
 
-TEST(BulkMutatorTest, ReportEitherRetryableMutationFailOrStreamFail) {
+TEST_F(BulkMutatorTest, ReportEitherRetryableMutationFailOrStreamFail) {
   BulkMutation mut(IdempotentMutation("r0"));
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRows)
-      .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
+      .WillOnce([this](auto context, auto const&,
+                       google::bigtable::v2::MutateRowsRequest const& request) {
+        metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
         EXPECT_CALL(*stream, Read)
@@ -440,7 +463,7 @@ TEST(BulkMutatorTest, ReportEitherRetryableMutationFailOrStreamFail) {
               StatusIs(AnyOf(StatusCode::kUnavailable, StatusCode::kDataLoss)));
 }
 
-TEST(BulkMutatorTest, ReportOnlyLatestMutationStatus) {
+TEST_F(BulkMutatorTest, ReportOnlyLatestMutationStatus) {
   // In this test, the mutation fails with an ABORTED status in the first
   // response. It is not included in the second response. We should report the
   // final stream failure for this mutation, as it is the more informative
@@ -449,8 +472,9 @@ TEST(BulkMutatorTest, ReportOnlyLatestMutationStatus) {
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRows)
-      .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
+      .WillOnce([this](auto context, auto const&,
+                       google::bigtable::v2::MutateRowsRequest const& request) {
+        metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
         EXPECT_CALL(*stream, Read)
@@ -458,8 +482,9 @@ TEST(BulkMutatorTest, ReportOnlyLatestMutationStatus) {
             .WillOnce(Return(Status(StatusCode::kUnavailable, "try again")));
         return stream;
       })
-      .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
+      .WillOnce([this](auto context, auto const&,
+                       google::bigtable::v2::MutateRowsRequest const& request) {
+        metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
         EXPECT_CALL(*stream, Read)
@@ -484,7 +509,7 @@ TEST(BulkMutatorTest, ReportOnlyLatestMutationStatus) {
   EXPECT_THAT(failures[0].status(), StatusIs(StatusCode::kDataLoss));
 }
 
-TEST(BulkMutatorTest, Throttling) {
+TEST_F(BulkMutatorTest, Throttling) {
   BulkMutation mut(IdempotentMutation("r0"), IdempotentMutation("r1"));
 
   auto mock_stub = std::make_shared<MockBigtableStub>();
@@ -494,16 +519,18 @@ TEST(BulkMutatorTest, Throttling) {
     ::testing::InSequence seq;
     EXPECT_CALL(*mock_limiter, Acquire);
     EXPECT_CALL(*mock_stub, MutateRows)
-        .WillOnce([](auto, auto const&,
-                     google::bigtable::v2::MutateRowsRequest const& request) {
-          EXPECT_THAT(request, HasCorrectResourceNames());
-          auto stream = std::make_unique<MockMutateRowsStream>();
-          EXPECT_CALL(*stream, Read)
-              .WillOnce(Return(MakeResponse({{0, grpc::StatusCode::OK}})))
-              .WillOnce(Return(MakeResponse({{1, grpc::StatusCode::OK}})))
-              .WillOnce(Return(Status()));
-          return stream;
-        });
+        .WillOnce(
+            [this](auto context, auto const&,
+                   google::bigtable::v2::MutateRowsRequest const& request) {
+              metadata_fixture_.SetServerMetadata(*context, {});
+              EXPECT_THAT(request, HasCorrectResourceNames());
+              auto stream = std::make_unique<MockMutateRowsStream>();
+              EXPECT_CALL(*stream, Read)
+                  .WillOnce(Return(MakeResponse({{0, grpc::StatusCode::OK}})))
+                  .WillOnce(Return(MakeResponse({{1, grpc::StatusCode::OK}})))
+                  .WillOnce(Return(Status()));
+              return stream;
+            });
     EXPECT_CALL(*mock_limiter, Update).Times(2);
   }
 
@@ -516,6 +543,50 @@ TEST(BulkMutatorTest, Throttling) {
   EXPECT_STATUS_OK(status);
   auto failures = std::move(mutator).OnRetryDone();
   EXPECT_THAT(failures, IsEmpty());
+}
+
+TEST_F(BulkMutatorTest, BigtableCookies) {
+  BulkMutation mut(IdempotentMutation("r0"));
+
+  auto mock = std::make_shared<MockBigtableStub>();
+
+  EXPECT_CALL(*mock, MutateRows)
+      .WillOnce([this](auto context, auto const&,
+                       google::bigtable::v2::MutateRowsRequest const&) {
+        // Return a bigtable cookie in the first request.
+        metadata_fixture_.SetServerMetadata(
+            *context, {{}, {{"x-goog-cbt-cookie-routing", "routing"}}});
+        auto stream = std::make_unique<MockMutateRowsStream>();
+        EXPECT_CALL(*stream, Read)
+            .WillOnce(
+                Return(google::cloud::internal::UnavailableError("try again")));
+        return stream;
+      })
+      .WillOnce([this](auto context, auto const&,
+                       google::bigtable::v2::MutateRowsRequest const&) {
+        // Verify that the next request includes the bigtable cookie from above.
+        auto headers = metadata_fixture_.GetMetadata(*context);
+        EXPECT_THAT(headers,
+                    Contains(Pair("x-goog-cbt-cookie-routing", "routing")));
+        auto stream = std::make_unique<MockMutateRowsStream>();
+        EXPECT_CALL(*stream, Read)
+            .WillOnce(
+                Return(google::cloud::internal::PermissionDeniedError("fail")));
+        return stream;
+      });
+
+  auto policy = DefaultIdempotentMutationPolicy();
+  bigtable_internal::BulkMutator mutator(kAppProfile, kTableName, *policy,
+                                         std::move(mut));
+
+  EXPECT_TRUE(mutator.HasPendingMutations());
+  bigtable_internal::NoopMutateRowsLimiter limiter;
+  auto status = mutator.MakeOneRequest(*mock, limiter);
+  EXPECT_THAT(status, StatusIs(StatusCode::kUnavailable));
+
+  EXPECT_TRUE(mutator.HasPendingMutations());
+  status = mutator.MakeOneRequest(*mock, limiter);
+  EXPECT_THAT(status, StatusIs(StatusCode::kPermissionDenied));
 }
 
 }  // namespace


### PR DESCRIPTION
Part of the work for #13447 

This thing holds state for `Table::BulkApply` calls. The `SetServerMetadata(...)` test changes are to avoid asserts in gRPC.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13469)
<!-- Reviewable:end -->
