### PR TITLE
ci: use Abseil's detection of the compiled ABI

### DIFF
--- a/ci/cloudbuild/dockerfiles/centos-7.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/centos-7.Dockerfile
@@ -65,7 +65,6 @@ ENV PATH=/usr/local/bin:${PATH}
 WORKDIR /var/tmp/build/abseil-cpp
 RUN curl -fsSL https://github.com/abseil/abseil-cpp/archive/20230802.1.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_TESTING=OFF \

--- a/ci/cloudbuild/dockerfiles/demo-centos-7.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-centos-7.Dockerfile
@@ -86,21 +86,10 @@ ENV PATH=/usr/local/bin:${PATH}
 
 # We need a recent version of Abseil.
 
-# :warning: By default, Abseil's ABI changes depending on whether it is used
-# with C++ >= 17 enabled or not. Installing Abseil with the default
-# configuration is error-prone, unless you can guarantee that all the code using
-# Abseil (gRPC, google-cloud-cpp, your own code, etc.) is compiled with the same
-# C++ version. We recommend that you switch the default configuration to pin
-# Abseil's ABI to the version used at compile time. In this case, the compiler
-# defaults to C++14. Therefore, we change `absl/base/options.h` to **always**
-# use `absl::any`, `absl::string_view`, and `absl::variant`. See
-# [abseil/abseil-cpp#696] for more information.
-
 # ```bash
 WORKDIR /var/tmp/build/abseil-cpp
 RUN curl -fsSL https://github.com/abseil/abseil-cpp/archive/20230802.1.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DABSL_BUILD_TESTING=OFF \

--- a/ci/cloudbuild/dockerfiles/demo-debian-bullseye.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-debian-bullseye.Dockerfile
@@ -32,21 +32,10 @@ RUN apt-get update && \
 # Debian 11 ships with Abseil==20200923.3.  Unfortunately, the current gRPC
 # version needs Abseil >= 20210324.
 
-# :warning: By default, Abseil's ABI changes depending on whether it is used
-# with C++ >= 17 enabled or not. Installing Abseil with the default
-# configuration is error-prone, unless you can guarantee that all the code using
-# Abseil (gRPC, google-cloud-cpp, your own code, etc.) is compiled with the same
-# C++ version. We recommend that you switch the default configuration to pin
-# Abseil's ABI to the version used at compile time. In this case, the compiler
-# defaults to C++14. Therefore, we change `absl/base/options.h` to **always**
-# use `absl::any`, `absl::string_view`, and `absl::variant`. See
-# [abseil/abseil-cpp#696] for more information.
-
 # ```bash
 WORKDIR /var/tmp/build/abseil-cpp
 RUN curl -fsSL https://github.com/abseil/abseil-cpp/archive/20230802.1.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DABSL_BUILD_TESTING=OFF \

--- a/ci/cloudbuild/dockerfiles/demo-debian-buster.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-debian-buster.Dockerfile
@@ -31,21 +31,10 @@ RUN apt-get update && \
 
 # We need a recent version of Abseil.
 
-# :warning: By default, Abseil's ABI changes depending on whether it is used
-# with C++ >= 17 enabled or not. Installing Abseil with the default
-# configuration is error-prone, unless you can guarantee that all the code using
-# Abseil (gRPC, google-cloud-cpp, your own code, etc.) is compiled with the same
-# C++ version. We recommend that you switch the default configuration to pin
-# Abseil's ABI to the version used at compile time. In this case, the compiler
-# defaults to C++14. Therefore, we change `absl/base/options.h` to **always**
-# use `absl::any`, `absl::string_view`, and `absl::variant`. See
-# [abseil/abseil-cpp#696] for more information.
-
 # ```bash
 WORKDIR /var/tmp/build/abseil-cpp
 RUN curl -fsSL https://github.com/abseil/abseil-cpp/archive/20230802.1.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DABSL_BUILD_TESTING=OFF \

--- a/ci/cloudbuild/dockerfiles/demo-opensuse-leap.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-opensuse-leap.Dockerfile
@@ -46,21 +46,10 @@ ENV PATH=/usr/local/bin:${PATH}
 
 # We need a recent version of Abseil.
 
-# :warning: By default, Abseil's ABI changes depending on whether it is used
-# with C++ >= 17 enabled or not. Installing Abseil with the default
-# configuration is error-prone, unless you can guarantee that all the code using
-# Abseil (gRPC, google-cloud-cpp, your own code, etc.) is compiled with the same
-# C++ version. We recommend that you switch the default configuration to pin
-# Abseil's ABI to the version used at compile time. In this case, the compiler
-# defaults to C++14. Therefore, we change `absl/base/options.h` to **always**
-# use `absl::any`, `absl::string_view`, and `absl::variant`. See
-# [abseil/abseil-cpp#696] for more information.
-
 # ```bash
 WORKDIR /var/tmp/build/abseil-cpp
 RUN curl -fsSL https://github.com/abseil/abseil-cpp/archive/20230802.1.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DABSL_BUILD_TESTING=OFF \

--- a/ci/cloudbuild/dockerfiles/demo-rockylinux-8.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-rockylinux-8.Dockerfile
@@ -61,21 +61,10 @@ ENV PATH=/usr/local/bin:${PATH}
 
 # We need a recent version of Abseil.
 
-# :warning: By default, Abseil's ABI changes depending on whether it is used
-# with C++ >= 17 enabled or not. Installing Abseil with the default
-# configuration is error-prone, unless you can guarantee that all the code using
-# Abseil (gRPC, google-cloud-cpp, your own code, etc.) is compiled with the same
-# C++ version. We recommend that you switch the default configuration to pin
-# Abseil's ABI to the version used at compile time. In this case, the compiler
-# defaults to C++14. Therefore, we change `absl/base/options.h` to **always**
-# use `absl::any`, `absl::string_view`, and `absl::variant`. See
-# [abseil/abseil-cpp#696] for more information.
-
 # ```bash
 WORKDIR /var/tmp/build/abseil-cpp
 RUN curl -fsSL https://github.com/abseil/abseil-cpp/archive/20230802.1.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DABSL_BUILD_TESTING=OFF \

--- a/ci/cloudbuild/dockerfiles/demo-rockylinux-9.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-rockylinux-9.Dockerfile
@@ -61,23 +61,12 @@ ENV PATH=/usr/local/bin:${PATH}
 
 # Rocky Linux 9 includes a package for Abseil, unfortunately, this package is
 # incomplete, as it lacks the CMake support files for it. We need to compile
-# Abseiil from source.
-
-# :warning: By default, Abseil's ABI changes depending on whether it is used
-# with C++ >= 17 enabled or not. Installing Abseil with the default
-# configuration is error-prone, unless you can guarantee that all the code using
-# Abseil (gRPC, google-cloud-cpp, your own code, etc.) is compiled with the same
-# C++ version. We recommend that you switch the default configuration to pin
-# Abseil's ABI to the version used at compile time. In Rocky Linux 9 the
-# compiler defaults to C++17. Therefore, we change `absl/base/options.h` to
-# **always** use `std::any`, `std::string_view`, and `std::variant`. See
-# [abseil/abseil-cpp#696] for more information.
+# Abseil from source.
 
 # ```bash
 WORKDIR /var/tmp/build/abseil-cpp
 RUN curl -fsSL https://github.com/abseil/abseil-cpp/archive/20230802.1.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 1/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DABSL_BUILD_TESTING=OFF \

--- a/ci/cloudbuild/dockerfiles/demo-ubuntu-focal.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-ubuntu-focal.Dockerfile
@@ -32,21 +32,10 @@ RUN apt-get update && \
 
 # We need a recent version of Abseil.
 
-# :warning: By default, Abseil's ABI changes depending on whether it is used
-# with C++ >= 17 enabled or not. Installing Abseil with the default
-# configuration is error-prone, unless you can guarantee that all the code using
-# Abseil (gRPC, google-cloud-cpp, your own code, etc.) is compiled with the same
-# C++ version. We recommend that you switch the default configuration to pin
-# Abseil's ABI to the version used at compile time. In this case, the compiler
-# defaults to C++14. Therefore, we change `absl/base/options.h` to **always**
-# use `absl::any`, `absl::string_view`, and `absl::variant`. See
-# [abseil/abseil-cpp#696] for more information.
-
 # ```bash
 WORKDIR /var/tmp/build/abseil-cpp
 RUN curl -fsSL https://github.com/abseil/abseil-cpp/archive/20230802.1.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DABSL_BUILD_TESTING=OFF \

--- a/ci/cloudbuild/dockerfiles/demo-ubuntu-jammy.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-ubuntu-jammy.Dockerfile
@@ -32,22 +32,10 @@ RUN apt-get update && \
 
 # We need a recent version of Abseil.
 
-# :warning: By default, Abseil's ABI changes depending on whether it is used
-# with C++ >= 17 enabled or not. Installing Abseil with the default
-# configuration is error-prone, unless you can guarantee that all the code using
-# Abseil (gRPC, google-cloud-cpp, your own code, etc.) is compiled with the same
-# C++ version. We recommend that you switch the default configuration to pin
-# Abseil's ABI to the version used at compile time. In this case, the compiler
-# defaults to C++17. Nevertheless, gRPC compiles with C++11 and depends on
-# some of the Abseil polyfills, such as `absl::string_view`. Therefore, we
-# pin Abseil's ABI to always use the polyfills. See [abseil/abseil-cpp#696]
-# for more information.
-
 # ```bash
 WORKDIR /var/tmp/build/abseil-cpp
 RUN curl -fsSL https://github.com/abseil/abseil-cpp/archive/20230802.1.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DABSL_BUILD_TESTING=OFF \

--- a/ci/cloudbuild/dockerfiles/fedora-latest-cmake.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-latest-cmake.Dockerfile
@@ -68,7 +68,6 @@ ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/lib
 WORKDIR /var/tmp/build
 RUN curl -fsSL https://github.com/abseil/abseil-cpp/archive/20230802.1.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     sed -i 's/^#define ABSL_OPTION_USE_INLINE_NAMESPACE 1$/#define ABSL_OPTION_USE_INLINE_NAMESPACE 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE="Release" \


### PR DESCRIPTION
Abseil has been able to install an options file that reflects the compiled ABI since
https://github.com/abseil/abseil-cpp/commit/308bbf300fe9332130f4784c7a91fa2ad707d6e4.

A more recent Abseil uses a switch based on C++20 availability. The string replacement in the Cloud C++ Dockerfiles does not handle this correctly. Instead rely on the logic from
https://github.com/abseil/abseil-cpp/commit/bcce85ef8d9042794a50e4afbbd2c672121ab0d2.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13476)
<!-- Reviewable:end -->
