### PR TITLE
impl(bigtable): support bigtable cookie in `AsyncSampleRows`

### DIFF
--- a/google/cloud/bigtable/internal/async_row_sampler.h
+++ b/google/cloud/bigtable/internal/async_row_sampler.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/bigtable/completion_queue.h"
 #include "google/cloud/bigtable/internal/bigtable_stub.h"
+#include "google/cloud/bigtable/internal/retry_context.h"
 #include "google/cloud/bigtable/options.h"
 #include "google/cloud/bigtable/row_key_sample.h"
 #include "google/cloud/bigtable/version.h"
@@ -65,6 +66,9 @@ class AsyncRowSampler : public std::enable_shared_from_this<AsyncRowSampler> {
   std::vector<bigtable::RowKeySample> samples_;
   promise<StatusOr<std::vector<bigtable::RowKeySample>>> promise_;
   internal::CallContext call_context_;
+  std::shared_ptr<grpc::ClientContext> context_;
+  std::shared_ptr<RetryContext> retry_context_ =
+      std::make_shared<RetryContext>();
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/internal/async_row_sampler_test.cc
+++ b/google/cloud/bigtable/internal/async_row_sampler_test.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/testing_util/mock_completion_queue_impl.h"
 #include "google/cloud/testing_util/opentelemetry_matchers.h"
 #include "google/cloud/testing_util/status_matchers.h"
+#include "google/cloud/testing_util/validate_metadata.h"
 #include <gmock/gmock.h>
 #include <chrono>
 
@@ -40,9 +41,11 @@ using ::google::cloud::bigtable::testing::MockBigtableStub;
 using ::google::cloud::testing_util::MockBackoffPolicy;
 using ::google::cloud::testing_util::MockCompletionQueueImpl;
 using ::google::cloud::testing_util::StatusIs;
+using ::testing::Contains;
 using ::testing::ElementsAre;
 using ::testing::HasSubstr;
 using ::testing::MockFunction;
+using ::testing::Pair;
 
 auto constexpr kNumRetries = 2;
 auto const* const kTableName =
@@ -71,7 +74,12 @@ absl::optional<v2::SampleRowKeysResponse> MakeResponse(std::string row_key,
   return absl::make_optional(r);
 };
 
-TEST(AsyncSampleRowKeysTest, Simple) {
+class AsyncSampleRowKeysTest : public ::testing::Test {
+ protected:
+  testing_util::ValidateMetadataFixture metadata_fixture_;
+};
+
+TEST_F(AsyncSampleRowKeysTest, Simple) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
       .WillOnce([](CompletionQueue const&, auto,
@@ -119,11 +127,12 @@ TEST(AsyncSampleRowKeysTest, Simple) {
   EXPECT_THAT(samples.offset_bytes, ElementsAre(11, 22));
 }
 
-TEST(AsyncSampleRowKeysTest, RetryResetsSamples) {
+TEST_F(AsyncSampleRowKeysTest, RetryResetsSamples) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
-      .WillOnce([](CompletionQueue const&, auto,
-                   v2::SampleRowKeysRequest const& request) {
+      .WillOnce([this](CompletionQueue const&, auto context,
+                       v2::SampleRowKeysRequest const& request) {
+        metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         auto stream = std::make_unique<MockAsyncSampleRowKeysStream>();
@@ -189,12 +198,13 @@ TEST(AsyncSampleRowKeysTest, RetryResetsSamples) {
   EXPECT_THAT(samples.offset_bytes, ElementsAre(22));
 }
 
-TEST(AsyncSampleRowKeysTest, TooManyFailures) {
+TEST_F(AsyncSampleRowKeysTest, TooManyFailures) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
       .Times(kNumRetries + 1)
-      .WillRepeatedly([](CompletionQueue const&, auto,
-                         v2::SampleRowKeysRequest const& request) {
+      .WillRepeatedly([this](CompletionQueue const&, auto context,
+                             v2::SampleRowKeysRequest const& request) {
+        metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         auto stream = std::make_unique<MockAsyncSampleRowKeysStream>();
@@ -233,11 +243,12 @@ TEST(AsyncSampleRowKeysTest, TooManyFailures) {
   EXPECT_THAT(sor, StatusIs(StatusCode::kUnavailable, HasSubstr("try again")));
 }
 
-TEST(AsyncSampleRowKeysTest, TimerError) {
+TEST_F(AsyncSampleRowKeysTest, TimerError) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
-      .WillOnce([](CompletionQueue const&, auto,
-                   v2::SampleRowKeysRequest const& request) {
+      .WillOnce([this](CompletionQueue const&, auto context,
+                       v2::SampleRowKeysRequest const& request) {
+        metadata_fixture_.SetServerMetadata(*context);
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         auto stream = std::make_unique<MockAsyncSampleRowKeysStream>();
@@ -277,7 +288,7 @@ TEST(AsyncSampleRowKeysTest, TimerError) {
               StatusIs(StatusCode::kCancelled, HasSubstr("call cancelled")));
 }
 
-TEST(AsyncSampleRowKeysTest, CancelAfterSuccess) {
+TEST_F(AsyncSampleRowKeysTest, CancelAfterSuccess) {
   promise<absl::optional<v2::SampleRowKeysResponse>> p;
 
   auto mock = std::make_shared<MockBigtableStub>();
@@ -328,7 +339,7 @@ TEST(AsyncSampleRowKeysTest, CancelAfterSuccess) {
   EXPECT_THAT(samples.offset_bytes, ElementsAre(11));
 }
 
-TEST(AsyncSampleRowKeysTest, CancelMidStream) {
+TEST_F(AsyncSampleRowKeysTest, CancelMidStream) {
   promise<absl::optional<v2::SampleRowKeysResponse>> p;
 
   auto mock = std::make_shared<MockBigtableStub>();
@@ -389,7 +400,7 @@ TEST(AsyncSampleRowKeysTest, CancelMidStream) {
               StatusIs(StatusCode::kCancelled, HasSubstr("User cancelled")));
 }
 
-TEST(AsyncSampleRowKeysTest, CurrentOptionsContinuedOnRetries) {
+TEST_F(AsyncSampleRowKeysTest, CurrentOptionsContinuedOnRetries) {
   struct TestOption {
     using Type = int;
   };
@@ -397,19 +408,20 @@ TEST(AsyncSampleRowKeysTest, CurrentOptionsContinuedOnRetries) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
       .Times(2)
-      .WillRepeatedly(
-          [](CompletionQueue const&, auto, v2::SampleRowKeysRequest const&) {
-            EXPECT_EQ(5, internal::CurrentOptions().get<TestOption>());
-            auto stream = std::make_unique<MockAsyncSampleRowKeysStream>();
-            EXPECT_CALL(*stream, Start).WillOnce([] {
-              return make_ready_future(false);
-            });
-            EXPECT_CALL(*stream, Finish).WillOnce([] {
-              return make_ready_future(
-                  Status(StatusCode::kUnavailable, "try again"));
-            });
-            return stream;
-          });
+      .WillRepeatedly([this](CompletionQueue const&, auto context,
+                             v2::SampleRowKeysRequest const&) {
+        EXPECT_EQ(5, internal::CurrentOptions().get<TestOption>());
+        metadata_fixture_.SetServerMetadata(*context);
+        auto stream = std::make_unique<MockAsyncSampleRowKeysStream>();
+        EXPECT_CALL(*stream, Start).WillOnce([] {
+          return make_ready_future(false);
+        });
+        EXPECT_CALL(*stream, Finish).WillOnce([] {
+          return make_ready_future(
+              Status(StatusCode::kUnavailable, "try again"));
+        });
+        return stream;
+      });
 
   promise<StatusOr<std::chrono::system_clock::time_point>> timer_promise;
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
@@ -438,6 +450,54 @@ TEST(AsyncSampleRowKeysTest, CurrentOptionsContinuedOnRetries) {
   timer_promise.set_value(make_status_or(std::chrono::system_clock::now()));
 }
 
+TEST_F(AsyncSampleRowKeysTest, BigtableCookie) {
+  auto mock = std::make_shared<MockBigtableStub>();
+  EXPECT_CALL(*mock, AsyncSampleRowKeys)
+      .WillOnce([this](CompletionQueue const&, auto context,
+                       v2::SampleRowKeysRequest const&) {
+        metadata_fixture_.SetServerMetadata(
+            *context, {{}, {{"x-goog-cbt-cookie-routing", "routing"}}});
+        auto stream = std::make_unique<MockAsyncSampleRowKeysStream>();
+        EXPECT_CALL(*stream, Start).WillOnce([] {
+          return make_ready_future(false);
+        });
+        EXPECT_CALL(*stream, Finish).WillOnce([] {
+          return make_ready_future(internal::UnavailableError("try again"));
+        });
+        return stream;
+      })
+      .WillOnce([this](CompletionQueue const&, auto context,
+                       v2::SampleRowKeysRequest const&) {
+        auto headers = metadata_fixture_.GetMetadata(*context);
+        EXPECT_THAT(headers,
+                    Contains(Pair("x-goog-cbt-cookie-routing", "routing")));
+        auto stream = std::make_unique<MockAsyncSampleRowKeysStream>();
+        EXPECT_CALL(*stream, Start).WillOnce([] {
+          return make_ready_future(false);
+        });
+        EXPECT_CALL(*stream, Finish).WillOnce([] {
+          return make_ready_future(internal::PermissionDeniedError("fail"));
+        });
+        return stream;
+      });
+
+  auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
+  EXPECT_CALL(*mock_cq, MakeRelativeTimer).WillOnce([] {
+    return make_ready_future(make_status_or(std::chrono::system_clock::now()));
+  });
+  CompletionQueue cq(mock_cq);
+
+  auto retry = DataLimitedErrorCountRetryPolicy(kNumRetries).clone();
+  auto mock_b = std::make_unique<MockBackoffPolicy>();
+  EXPECT_CALL(*mock_b, OnCompletion).Times(1);
+
+  auto sor = AsyncRowSampler::Create(cq, mock, std::move(retry),
+                                     std::move(mock_b), kAppProfile, kTableName)
+                 .get();
+
+  EXPECT_THAT(sor, StatusIs(StatusCode::kPermissionDenied, "fail"));
+}
+
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 using ::google::cloud::testing_util::EnableTracing;
 using ::google::cloud::testing_util::IsActive;
@@ -448,13 +508,14 @@ using ::testing::SizeIs;
 using ErrorStream =
     internal::AsyncStreamingReadRpcError<v2::SampleRowKeysResponse>;
 
-TEST(AsyncSampleRowKeysTest, TracedBackoff) {
+TEST_F(AsyncSampleRowKeysTest, TracedBackoff) {
   auto span_catcher = testing_util::InstallSpanCatcher();
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
       .Times(kNumRetries + 1)
-      .WillRepeatedly([] {
+      .WillRepeatedly([this](auto&, auto context, auto const&) {
+        metadata_fixture_.SetServerMetadata(*context, {});
         return std::make_unique<ErrorStream>(
             internal::UnavailableError("try again"));
       });
@@ -473,7 +534,7 @@ TEST(AsyncSampleRowKeysTest, TracedBackoff) {
               AllOf(SizeIs(kNumRetries), Each(SpanNamed("Async Backoff"))));
 }
 
-TEST(AsyncSampleRowKeysTest, CallSpanActiveThroughout) {
+TEST_F(AsyncSampleRowKeysTest, CallSpanActiveThroughout) {
   auto span_catcher = testing_util::InstallSpanCatcher();
 
   auto span = internal::MakeSpan("span");
@@ -481,7 +542,8 @@ TEST(AsyncSampleRowKeysTest, CallSpanActiveThroughout) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
       .Times(kNumRetries + 1)
-      .WillRepeatedly([span] {
+      .WillRepeatedly([this, span](auto&, auto context, auto const&) {
+        metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_THAT(span, IsActive());
         return std::make_unique<ErrorStream>(
             internal::UnavailableError("try again"));

--- a/google/cloud/bigtable/internal/async_row_sampler_test.cc
+++ b/google/cloud/bigtable/internal/async_row_sampler_test.cc
@@ -455,6 +455,7 @@ TEST_F(AsyncSampleRowKeysTest, BigtableCookie) {
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
       .WillOnce([this](CompletionQueue const&, auto context,
                        v2::SampleRowKeysRequest const&) {
+        // Return a bigtable cookie in the first request.
         metadata_fixture_.SetServerMetadata(
             *context, {{}, {{"x-goog-cbt-cookie-routing", "routing"}}});
         auto stream = std::make_unique<MockAsyncSampleRowKeysStream>();
@@ -468,6 +469,7 @@ TEST_F(AsyncSampleRowKeysTest, BigtableCookie) {
       })
       .WillOnce([this](CompletionQueue const&, auto context,
                        v2::SampleRowKeysRequest const&) {
+        // Verify that the next request includes the bigtable cookie from above.
         auto headers = metadata_fixture_.GetMetadata(*context);
         EXPECT_THAT(headers,
                     Contains(Pair("x-goog-cbt-cookie-routing", "routing")));


### PR DESCRIPTION
Part of the work for #13447 

Again, we need to hold onto the `grpc::ClientContext`. Reset the ptr when we are done with it.

Note that only tests that retry need the `metadata_fixture_.SetServerMetadata(...)` treatment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13479)
<!-- Reviewable:end -->
