### PR TITLE
impl(bigtable): support bigtable cookie in `AsyncReadRow(s)`

### DIFF
--- a/google/cloud/bigtable/internal/async_row_reader.h
+++ b/google/cloud/bigtable/internal/async_row_reader.h
@@ -19,6 +19,7 @@
 #include "google/cloud/bigtable/internal/async_streaming_read.h"
 #include "google/cloud/bigtable/internal/bigtable_stub.h"
 #include "google/cloud/bigtable/internal/readrowsparser.h"
+#include "google/cloud/bigtable/internal/retry_context.h"
 #include "google/cloud/bigtable/options.h"
 #include "google/cloud/bigtable/row.h"
 #include "google/cloud/bigtable/row_set.h"
@@ -163,6 +164,9 @@ class AsyncRowReader : public std::enable_shared_from_this<AsyncRowReader> {
   /// Tracks the level of recursion of TryGiveRowToUser
   int recursion_level_ = 0;
   internal::CallContext call_context_;
+  std::shared_ptr<grpc::ClientContext> context_;
+  std::shared_ptr<RetryContext> retry_context_ =
+      std::make_shared<RetryContext>();
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
Part of the work for #13447 

Very similar to #13479...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13480)
<!-- Reviewable:end -->
