### PR TITLE
impl: apply universe_domain to default_endpoint for AuthorityOption

### DIFF
--- a/google/cloud/internal/populate_common_options.cc
+++ b/google/cloud/internal/populate_common_options.cc
@@ -32,7 +32,7 @@ Options PopulateCommonOptions(Options opts, std::string const& endpoint_env_var,
                               std::string const& authority_env_var,
                               std::string default_endpoint) {
   if (!opts.has<AuthorityOption>()) {
-    opts.set<AuthorityOption>(default_endpoint);
+    opts.set<AuthorityOption>(UniverseDomainEndpoint(default_endpoint, opts));
   }
   if (!authority_env_var.empty()) {
     auto e = GetEnv(authority_env_var.c_str());

--- a/google/cloud/internal/populate_common_options_test.cc
+++ b/google/cloud/internal/populate_common_options_test.cc
@@ -197,6 +197,12 @@ TEST(PopulateCommonOptions, EnvVarsOverridesUniverseDomain) {
       "AUTHORITY_OPTION", "default.googleapis.com");
   EXPECT_EQ(actual.get<EndpointOption>(), "default.test-ud.net");
   EXPECT_EQ(actual.get<AuthorityOption>(), "authority-env.googleapis.com");
+
+  actual = PopulateCommonOptions(
+      Options{}.set<UniverseDomainOption>("test-ud.net"), "SERVICE_ENDPOINT",
+      {}, "AUTHORITY_OPTION", "default.googleapis.com");
+  EXPECT_EQ(actual.get<EndpointOption>(), "endpoint-env.googleapis.com");
+  EXPECT_EQ(actual.get<AuthorityOption>(), "authority-env.googleapis.com");
 }
 
 TEST(PopulateCommonOptions, UserProject) {

--- a/google/cloud/internal/populate_common_options_test.cc
+++ b/google/cloud/internal/populate_common_options_test.cc
@@ -151,30 +151,52 @@ TEST(PopulateCommonOptions, UniverseDomain) {
       PopulateCommonOptions(Options{}.set<UniverseDomainOption>("my-ud.net"),
                             {}, {}, {}, "default.googleapis.com");
   EXPECT_EQ(actual.get<EndpointOption>(), "default.my-ud.net");
+  EXPECT_EQ(actual.get<AuthorityOption>(), "default.my-ud.net");
 }
 
 TEST(PopulateCommonOptions, EndpointOptionOverridesUniverseDomain) {
   auto actual = PopulateCommonOptions(
       Options{}
-          .set<UniverseDomainOption>("ignored-ud.net")
+          .set<UniverseDomainOption>("test-ud.net")
           .set<EndpointOption>("custom-endpoint.googleapis.com"),
       {}, {}, {}, "default.googleapis.com");
   EXPECT_EQ(actual.get<EndpointOption>(), "custom-endpoint.googleapis.com");
+  EXPECT_EQ(actual.get<AuthorityOption>(), "default.test-ud.net");
+}
+
+TEST(PopulateCommonOptions, AuthorityOptionOverridesUniverseDomain) {
+  auto actual = PopulateCommonOptions(
+      Options{}
+          .set<UniverseDomainOption>("test-ud.net")
+          .set<AuthorityOption>("custom-endpoint.googleapis.com"),
+      {}, {}, {}, "default.googleapis.com");
+  EXPECT_EQ(actual.get<EndpointOption>(), "default.test-ud.net");
+  EXPECT_EQ(actual.get<AuthorityOption>(), "custom-endpoint.googleapis.com");
 }
 
 TEST(PopulateCommonOptions, EnvVarsOverridesUniverseDomain) {
+  ScopedEnvironment authority("AUTHORITY_OPTION",
+                              "authority-env.googleapis.com");
   ScopedEnvironment endpoint("SERVICE_ENDPOINT", "endpoint-env.googleapis.com");
   ScopedEnvironment emulator("SERVICE_EMULATOR", "emulator-env.googleapis.com");
 
   auto actual = PopulateCommonOptions(
-      Options{}.set<UniverseDomainOption>("ignored-ud.net"), "SERVICE_ENDPOINT",
+      Options{}.set<UniverseDomainOption>("test-ud.net"), "SERVICE_ENDPOINT",
       {}, {}, "default.googleapis.com");
   EXPECT_EQ(actual.get<EndpointOption>(), "endpoint-env.googleapis.com");
+  EXPECT_EQ(actual.get<AuthorityOption>(), "default.test-ud.net");
 
   actual = PopulateCommonOptions(
-      Options{}.set<UniverseDomainOption>("ignored-ud.net"), {},
+      Options{}.set<UniverseDomainOption>("test-ud.net"), {},
       "SERVICE_EMULATOR", {}, "default.googleapis.com");
   EXPECT_EQ(actual.get<EndpointOption>(), "emulator-env.googleapis.com");
+  EXPECT_EQ(actual.get<AuthorityOption>(), "default.test-ud.net");
+
+  actual = PopulateCommonOptions(
+      Options{}.set<UniverseDomainOption>("test-ud.net"), {}, {},
+      "AUTHORITY_OPTION", "default.googleapis.com");
+  EXPECT_EQ(actual.get<EndpointOption>(), "default.test-ud.net");
+  EXPECT_EQ(actual.get<AuthorityOption>(), "authority-env.googleapis.com");
 }
 
 TEST(PopulateCommonOptions, UserProject) {


### PR DESCRIPTION
This necessary in order for authentication to succeed for gRPC services (at a minimum).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13483)
<!-- Reviewable:end -->
