### PR TITLE
impl(pubsub): Authority respects UniverseDomainOption for IAM

### DIFF
--- a/google/cloud/pubsub/options.cc
+++ b/google/cloud/pubsub/options.cc
@@ -22,12 +22,14 @@ namespace pubsub {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 Options IAMPolicyOptions(Options opts) {
-  auto default_endpoint =
+  auto default_ep =
       internal::UniverseDomainEndpoint("pubsub.googleapis.com.", opts);
+  auto authority_ep =
+      internal::UniverseDomainEndpoint("pubsub.googleapis.com", opts);
   return internal::MergeOptions(
       std::move(opts), Options{}
-                           .set<EndpointOption>(std::move(default_endpoint))
-                           .set<AuthorityOption>("pubsub.googleapis.com"));
+                           .set<EndpointOption>(std::move(default_ep))
+                           .set<AuthorityOption>(std::move(authority_ep)));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsub/options_test.cc
+++ b/google/cloud/pubsub/options_test.cc
@@ -72,7 +72,7 @@ TEST(IAMPolicyOptions, EndpointOverridesUniverseDomain) {
       IAMPolicyOptions(Options{}
                            .set<internal::UniverseDomainOption>("my-ud.net")
                            .set<EndpointOption>("test-only-endpoint")
-                           .set<EndpointOption>("test-only-authority"));
+                           .set<AuthorityOption>("test-only-authority"));
   EXPECT_EQ(actual.get<EndpointOption>(), "test-only-endpoint");
   EXPECT_EQ(actual.get<AuthorityOption>(), "test-only-authority");
 }

--- a/google/cloud/pubsub/options_test.cc
+++ b/google/cloud/pubsub/options_test.cc
@@ -64,14 +64,17 @@ TEST(IAMPolicyOptions, IncorporatesUniverseDomain) {
   auto const actual = IAMPolicyOptions(
       Options{}.set<internal::UniverseDomainOption>("my-ud.net"));
   EXPECT_EQ(actual.get<EndpointOption>(), "pubsub.my-ud.net");
+  EXPECT_EQ(actual.get<AuthorityOption>(), "pubsub.my-ud.net");
 }
 
 TEST(IAMPolicyOptions, EndpointOverridesUniverseDomain) {
   auto const actual =
       IAMPolicyOptions(Options{}
                            .set<internal::UniverseDomainOption>("my-ud.net")
-                           .set<EndpointOption>("test-only-endpoint"));
+                           .set<EndpointOption>("test-only-endpoint")
+                           .set<EndpointOption>("test-only-authority"));
   EXPECT_EQ(actual.get<EndpointOption>(), "test-only-endpoint");
+  EXPECT_EQ(actual.get<AuthorityOption>(), "test-only-authority");
 }
 
 }  // namespace


### PR DESCRIPTION
Follow up to #13341 

The `AuthorityOption` default also needs to respect the `UniverseDomainOption`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13484)
<!-- Reviewable:end -->
