### PR TITLE
impl(bigtable): authority respects UniverseDomainOption

### DIFF
--- a/google/cloud/bigtable/internal/defaults.cc
+++ b/google/cloud/bigtable/internal/defaults.cc
@@ -226,7 +226,9 @@ Options DefaultDataOptions(Options opts) {
     opts.set<UserProjectOption>(*std::move(user_project));
   }
   if (!opts.has<AuthorityOption>()) {
-    opts.set<AuthorityOption>("bigtable.googleapis.com");
+    auto ep = google::cloud::internal::UniverseDomainEndpoint(
+        "bigtable.googleapis.com", opts);
+    opts.set<AuthorityOption>(std::move(ep));
   }
   if (!opts.has<bigtable::DataRetryPolicyOption>()) {
     opts.set<bigtable::DataRetryPolicyOption>(

--- a/google/cloud/bigtable/internal/defaults_test.cc
+++ b/google/cloud/bigtable/internal/defaults_test.cc
@@ -221,8 +221,10 @@ TEST(OptionsTest, UniverseDomain) {
   auto options =
       Options{}.set<google::cloud::internal::UniverseDomainOption>("ud.net");
 
-  EXPECT_EQ(DefaultDataOptions(options).get<EndpointOption>(),
-            "bigtable.ud.net");
+  auto data_options = DefaultDataOptions(options);
+  EXPECT_EQ(data_options.get<EndpointOption>(), "bigtable.ud.net");
+  EXPECT_EQ(data_options.get<AuthorityOption>(), "bigtable.ud.net");
+
   EXPECT_EQ(DefaultTableAdminOptions(options).get<EndpointOption>(),
             "bigtableadmin.ud.net");
   EXPECT_EQ(DefaultInstanceAdminOptions(options).get<EndpointOption>(),
@@ -233,9 +235,12 @@ TEST(OptionsTest, EndpointOptionsOverrideUniverseDomain) {
   auto options =
       Options{}
           .set<google::cloud::internal::UniverseDomainOption>("ud.net")
-          .set<EndpointOption>("data.googleapis.com");
-  EXPECT_EQ(DefaultDataOptions(options).get<EndpointOption>(),
-            "data.googleapis.com");
+          .set<EndpointOption>("data-endpoint.googleapis.com")
+          .set<AuthorityOption>("data-authority.googleapis.com");
+  auto data_options = DefaultDataOptions(options);
+  EXPECT_EQ(data_options.get<EndpointOption>(), "data-endpoint.googleapis.com");
+  EXPECT_EQ(data_options.get<AuthorityOption>(),
+            "data-authority.googleapis.com");
 }
 
 TEST(OptionsTest, BigtableEndpointOptionsOverrideUniverseDomain) {


### PR DESCRIPTION
Follow up to #13335 

The `AuthorityOption` default also needs to respect the `UniverseDomainOption`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13485)
<!-- Reviewable:end -->
