### PR TITLE
impl(GCS+gRPC): authority respects UniverseDomainOption

### DIFF
--- a/google/cloud/storage/internal/grpc/stub.cc
+++ b/google/cloud/storage/internal/grpc/stub.cc
@@ -232,12 +232,14 @@ Options DefaultOptionsGrpc(Options options) {
     options.set<UnifiedCredentialsOption>(MakeInsecureCredentials());
   }
 
-  auto default_endpoint = google::cloud::internal::UniverseDomainEndpoint(
+  auto default_ep = google::cloud::internal::UniverseDomainEndpoint(
       "storage.googleapis.com.", options);
+  auto authority_ep = google::cloud::internal::UniverseDomainEndpoint(
+      "storage.googleapis.com", options);
   options = google::cloud::internal::MergeOptions(
       std::move(options), Options{}
-                              .set<EndpointOption>(std::move(default_endpoint))
-                              .set<AuthorityOption>("storage.googleapis.com"));
+                              .set<EndpointOption>(std::move(default_ep))
+                              .set<AuthorityOption>(std::move(authority_ep)));
   // We can only compute this once the endpoint is known, so take an additional
   // step.
   auto const num_channels =

--- a/google/cloud/storage/internal/grpc/stub_test.cc
+++ b/google/cloud/storage/internal/grpc/stub_test.cc
@@ -129,19 +129,19 @@ TEST(DefaultOptionsGrpc, EnvVarsOverrideOptionsAndDefaults) {
   ScopedEnvironment e("CLOUD_STORAGE_EXPERIMENTAL_GRPC_TESTBENCH_ENDPOINT",
                       "from-env");
 
-  auto options = DefaultOptionsGrpc(
-      Options{}
-          .set<EndpointOption>("from-option")
-          .set<internal::UniverseDomainOption>("ignored-ud"));
+  auto options =
+      DefaultOptionsGrpc(Options{}
+                             .set<EndpointOption>("from-option")
+                             .set<internal::UniverseDomainOption>("my-ud.net"));
   EXPECT_EQ(options.get<EndpointOption>(), "from-env");
-  EXPECT_EQ(options.get<AuthorityOption>(), "storage.googleapis.com");
+  EXPECT_EQ(options.get<AuthorityOption>(), "storage.my-ud.net");
 }
 
 TEST(DefaultOptionsGrpc, IncorporatesUniverseDomain) {
   auto options = DefaultOptionsGrpc(
       Options{}.set<internal::UniverseDomainOption>("my-ud.net"));
   EXPECT_EQ(options.get<EndpointOption>(), "storage.my-ud.net");
-  EXPECT_EQ(options.get<AuthorityOption>(), "storage.googleapis.com");
+  EXPECT_EQ(options.get<AuthorityOption>(), "storage.my-ud.net");
 }
 
 TEST(DefaultOptionsGrpc, DefaultOptionsUploadBuffer) {


### PR DESCRIPTION
Follow up to #13346

The `AuthorityOption` default also needs to respect the `UniverseDomainOption`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13486)
<!-- Reviewable:end -->
