### PR TITLE
impl: add remaining universe_domain service demos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,13 +231,18 @@ if (BUILD_TESTING)
     include(FindGMockWithTargets)
 endif ()
 
-# The examples use exception handling to simplify the code. Therefore they
-# cannot be compiled when exceptions are disabled, and applications cannot force
-# the flag.
+# The examples and demos use exception handling to simplify the code. Therefore
+# they cannot be compiled when exceptions are disabled, and applications cannot
+# force the flag.
 cmake_dependent_option(
     GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES "Compile the google-cloud-cpp examples."
     ON "GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS;BUILD_TESTING" OFF)
 mark_as_advanced(GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
+
+cmake_dependent_option(
+    GOOGLE_CLOUD_CPP_BUILD_DEMOS "Compile the google-cloud-cpp demos." OFF
+    "GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS;BUILD_TESTING" OFF)
+mark_as_advanced(GOOGLE_CLOUD_CPP_BUILD_DEMOS)
 
 # Add any subdirectories configured in the application.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,7 +231,7 @@ if (BUILD_TESTING)
     include(FindGMockWithTargets)
 endif ()
 
-# The examples  use exception handling to simplify the code. Therefore they
+# The examples use exception handling to simplify the code. Therefore they
 # cannot be compiled when exceptions are disabled, and applications cannot force
 # the flag.
 cmake_dependent_option(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,18 +231,13 @@ if (BUILD_TESTING)
     include(FindGMockWithTargets)
 endif ()
 
-# The examples and demos use exception handling to simplify the code. Therefore
-# they cannot be compiled when exceptions are disabled, and applications cannot
-# force the flag.
+# The examples  use exception handling to simplify the code. Therefore they
+# cannot be compiled when exceptions are disabled, and applications cannot force
+# the flag.
 cmake_dependent_option(
     GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES "Compile the google-cloud-cpp examples."
     ON "GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS;BUILD_TESTING" OFF)
 mark_as_advanced(GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
-
-cmake_dependent_option(
-    GOOGLE_CLOUD_CPP_BUILD_DEMOS "Compile the google-cloud-cpp demos." OFF
-    "GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS;BUILD_TESTING" OFF)
-mark_as_advanced(GOOGLE_CLOUD_CPP_BUILD_DEMOS)
 
 # Add any subdirectories configured in the application.
 

--- a/ci/cloudbuild/builds/quickstart-production.sh
+++ b/ci/cloudbuild/builds/quickstart-production.sh
@@ -37,7 +37,6 @@ io::run cmake "${cmake_args[@]}" \
   -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
   -DCMAKE_INSTALL_MESSAGE=NEVER \
   -DBUILD_SHARED_LIBS=ON \
-  -DGOOGLE_CLOUD_CPP_BUILD_DEMOS=ON \
   -DGOOGLE_CLOUD_CPP_ENABLE="${ENABLED_FEATURES}"
 io::run cmake --build cmake-out
 mapfile -t ctest_args < <(ctest::common_args)

--- a/ci/cloudbuild/builds/quickstart-production.sh
+++ b/ci/cloudbuild/builds/quickstart-production.sh
@@ -29,12 +29,15 @@ export CXX=g++
 mapfile -t cmake_args < <(cmake::common_args)
 readonly INSTALL_PREFIX="/var/tmp/google-cloud-cpp"
 read -r ENABLED_FEATURES < <(features::list_full_cmake)
+# TODO(#13495): Determine how best to include universe_domain in cmake builds.
+ENABLED_FEATURES="${ENABLED_FEATURES},universe_domain"
 readonly ENABLED_FEATURES
 
 io::run cmake "${cmake_args[@]}" \
   -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
   -DCMAKE_INSTALL_MESSAGE=NEVER \
   -DBUILD_SHARED_LIBS=ON \
+  -DGOOGLE_CLOUD_CPP_BUILD_DEMOS=ON \
   -DGOOGLE_CLOUD_CPP_ENABLE="${ENABLED_FEATURES}"
 io::run cmake --build cmake-out
 mapfile -t ctest_args < <(ctest::common_args)

--- a/google/cloud/universe_domain/CMakeLists.txt
+++ b/google/cloud/universe_domain/CMakeLists.txt
@@ -16,55 +16,72 @@
 
 include(GoogleCloudCppLibrary)
 
-if (GOOGLE_CLOUD_CPP_BUILD_DEMOS AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
+if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     set(universe_domain_demos bigquery compute kms pubsub storage)
-    foreach (demo ${universe_domain_demos})
-        add_executable(universe_domain_${demo}_demo "demo/${demo}.cc")
-        target_link_libraries(
-            universe_domain_${demo}_demo
-            PRIVATE google-cloud-cpp::${demo} google-cloud-cpp::universe_domain)
-        google_cloud_cpp_add_common_options(universe_domain_${demo}_demo)
+    foreach (library ${universe_domain_demos})
+        if (${library} IN_LIST GOOGLE_CLOUD_CPP_ENABLE)
+
+            add_executable(universe_domain_${library}_demo "demo/${library}.cc")
+            target_link_libraries(
+                universe_domain_${library}_demo
+                PRIVATE google-cloud-cpp::${library}
+                        google-cloud-cpp::universe_domain)
+            google_cloud_cpp_add_common_options(universe_domain_${library}_demo)
+        endif ()
     endforeach ()
 
-    add_test(
-        NAME universe_domain_bigquery_demo
-        COMMAND
-            cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
-            $<TARGET_FILE:universe_domain_bigquery_demo> GOOGLE_CLOUD_PROJECT
-            GOOGLE_CLOUD_CPP_BIGQUERY_TEST_QUICKSTART_TABLE)
-    set_tests_properties(universe_domain_bigquery_demo
-                         PROPERTIES LABELS "integration-test;quickstart")
+    if (bigquery IN_LIST GOOGLE_CLOUD_CPP_ENABLE)
+        add_test(
+            NAME universe_domain_bigquery_demo
+            COMMAND
+                cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+                $<TARGET_FILE:universe_domain_bigquery_demo>
+                GOOGLE_CLOUD_PROJECT
+                GOOGLE_CLOUD_CPP_BIGQUERY_TEST_QUICKSTART_TABLE)
+        set_tests_properties(universe_domain_bigquery_demo
+                             PROPERTIES LABELS "integration-test;quickstart")
+    endif ()
 
-    add_test(
-        NAME universe_domain_compute_demo
-        COMMAND
-            cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
-            $<TARGET_FILE:universe_domain_compute_demo> GOOGLE_CLOUD_PROJECT
-            GOOGLE_CLOUD_CPP_TEST_ZONE)
-    set_tests_properties(universe_domain_compute_demo
-                         PROPERTIES LABELS "integration-test;quickstart")
+    if (compute IN_LIST GOOGLE_CLOUD_CPP_ENABLE)
+        add_test(
+            NAME universe_domain_compute_demo
+            COMMAND
+                cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+                $<TARGET_FILE:universe_domain_compute_demo>
+                GOOGLE_CLOUD_PROJECT GOOGLE_CLOUD_CPP_TEST_ZONE)
+        set_tests_properties(universe_domain_compute_demo
+                             PROPERTIES LABELS "integration-test;quickstart")
+    endif ()
 
-    add_test(
-        NAME universe_domain_kms_demo
-        COMMAND
-            cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
-            $<TARGET_FILE:universe_domain_kms_demo> GOOGLE_CLOUD_PROJECT
-            GOOGLE_CLOUD_CPP_TEST_REGION)
-    set_tests_properties(universe_domain_kms_demo
-                         PROPERTIES LABELS "integration-test;quickstart")
+    if (kms IN_LIST GOOGLE_CLOUD_CPP_ENABLE)
+        add_test(
+            NAME universe_domain_kms_demo
+            COMMAND
+                cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+                $<TARGET_FILE:universe_domain_kms_demo> GOOGLE_CLOUD_PROJECT
+                GOOGLE_CLOUD_CPP_TEST_REGION)
+        set_tests_properties(universe_domain_kms_demo
+                             PROPERTIES LABELS "integration-test;quickstart")
+    endif ()
 
-    add_test(
-        NAME universe_domain_pubsub_demo
-        COMMAND cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+    if (pubsub IN_LIST GOOGLE_CLOUD_CPP_ENABLE)
+        add_test(
+            NAME universe_domain_pubsub_demo
+            COMMAND
+                cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
                 $<TARGET_FILE:universe_domain_pubsub_demo> GOOGLE_CLOUD_PROJECT)
-    set_tests_properties(universe_domain_pubsub_demo
-                         PROPERTIES LABELS "integration-test;quickstart")
+        set_tests_properties(universe_domain_pubsub_demo
+                             PROPERTIES LABELS "integration-test;quickstart")
+    endif ()
 
-    add_test(
-        NAME universe_domain_storage_demo
-        COMMAND
-            cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
-            $<TARGET_FILE:universe_domain_storage_demo> GOOGLE_CLOUD_PROJECT)
-    set_tests_properties(universe_domain_storage_demo
-                         PROPERTIES LABELS "integration-test;quickstart")
+    if (storage IN_LIST GOOGLE_CLOUD_CPP_ENABLE)
+        add_test(
+            NAME universe_domain_storage_demo
+            COMMAND
+                cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+                $<TARGET_FILE:universe_domain_storage_demo>
+                GOOGLE_CLOUD_PROJECT)
+        set_tests_properties(universe_domain_storage_demo
+                             PROPERTIES LABELS "integration-test;quickstart")
+    endif ()
 endif ()

--- a/google/cloud/universe_domain/CMakeLists.txt
+++ b/google/cloud/universe_domain/CMakeLists.txt
@@ -16,12 +16,34 @@
 
 include(GoogleCloudCppLibrary)
 
-if (BUILD_UNIVERSE_DOMAIN_DEMOS AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
-    add_executable(universe_domain_kms_demo "demo/kms.cc")
-    target_link_libraries(
-        universe_domain_kms_demo PRIVATE google-cloud-cpp::kms
-                                         google-cloud-cpp::universe_domain)
-    google_cloud_cpp_add_common_options(universe_domain_kms_demo)
+if (GOOGLE_CLOUD_CPP_BUILD_DEMOS AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
+    set(universe_domain_demos bigquery compute kms pubsub storage)
+    foreach (demo ${universe_domain_demos})
+        add_executable(universe_domain_${demo}_demo "demo/${demo}.cc")
+        target_link_libraries(
+            universe_domain_${demo}_demo
+            PRIVATE google-cloud-cpp::${demo} google-cloud-cpp::universe_domain)
+        google_cloud_cpp_add_common_options(universe_domain_${demo}_demo)
+    endforeach ()
+
+    add_test(
+        NAME universe_domain_bigquery_demo
+        COMMAND
+            cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+            $<TARGET_FILE:universe_domain_bigquery_demo> GOOGLE_CLOUD_PROJECT
+            GOOGLE_CLOUD_CPP_BIGQUERY_TEST_QUICKSTART_TABLE)
+    set_tests_properties(universe_domain_bigquery_demo
+                         PROPERTIES LABELS "integration-test;quickstart")
+
+    add_test(
+        NAME universe_domain_compute_demo
+        COMMAND
+            cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+            $<TARGET_FILE:universe_domain_compute_demo> GOOGLE_CLOUD_PROJECT
+            GOOGLE_CLOUD_CPP_TEST_ZONE)
+    set_tests_properties(universe_domain_compute_demo
+                         PROPERTIES LABELS "integration-test;quickstart")
+
     add_test(
         NAME universe_domain_kms_demo
         COMMAND
@@ -29,5 +51,20 @@ if (BUILD_UNIVERSE_DOMAIN_DEMOS AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
             $<TARGET_FILE:universe_domain_kms_demo> GOOGLE_CLOUD_PROJECT
             GOOGLE_CLOUD_CPP_TEST_REGION)
     set_tests_properties(universe_domain_kms_demo
+                         PROPERTIES LABELS "integration-test;quickstart")
+
+    add_test(
+        NAME universe_domain_pubsub_demo
+        COMMAND cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+                $<TARGET_FILE:universe_domain_pubsub_demo> GOOGLE_CLOUD_PROJECT)
+    set_tests_properties(universe_domain_pubsub_demo
+                         PROPERTIES LABELS "integration-test;quickstart")
+
+    add_test(
+        NAME universe_domain_storage_demo
+        COMMAND
+            cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+            $<TARGET_FILE:universe_domain_storage_demo> GOOGLE_CLOUD_PROJECT)
+    set_tests_properties(universe_domain_storage_demo
                          PROPERTIES LABELS "integration-test;quickstart")
 endif ()

--- a/google/cloud/universe_domain/CMakeLists.txt
+++ b/google/cloud/universe_domain/CMakeLists.txt
@@ -20,7 +20,6 @@ if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     set(universe_domain_demos bigquery compute kms pubsub storage)
     foreach (library ${universe_domain_demos})
         if (${library} IN_LIST GOOGLE_CLOUD_CPP_ENABLE)
-
             add_executable(universe_domain_${library}_demo "demo/${library}.cc")
             target_link_libraries(
                 universe_domain_${library}_demo

--- a/google/cloud/universe_domain/demo/BUILD.bazel
+++ b/google/cloud/universe_domain/demo/BUILD.bazel
@@ -14,13 +14,21 @@
 
 licenses(["notice"])  # Apache 2.0
 
-cc_binary(
-    name = "kms_demo",
+service_demos = [
+    "bigquery",
+    "compute",
+    "kms",
+    "pubsub",
+    "storage",
+]
+
+[cc_binary(
+    name = demo + "_demo",
     srcs = [
-        "kms.cc",
+        demo + ".cc",
     ],
     deps = [
+        "@google_cloud_cpp//:" + demo,
         "@google_cloud_cpp//:experimental-universe_domain",
-        "@google_cloud_cpp//:kms",
     ],
-)
+) for demo in service_demos]

--- a/google/cloud/universe_domain/demo/CMakeLists.txt
+++ b/google/cloud/universe_domain/demo/CMakeLists.txt
@@ -30,8 +30,8 @@ else ()
 endif ()
 
 set(universe_domain_demos bigquery compute kms pubsub storage)
-foreach (demo ${universe_domain_demos})
-    add_executable(${demo}_demo ${demo}.cc)
-    target_link_libraries(${demo}_demo google-cloud-cpp::${demo}
+foreach (library ${universe_domain_demos})
+    add_executable(${library}_demo ${library}.cc)
+    target_link_libraries(${library}_demo google-cloud-cpp::${library}
                           google-cloud-cpp::universe_domain)
 endforeach ()

--- a/google/cloud/universe_domain/demo/CMakeLists.txt
+++ b/google/cloud/universe_domain/demo/CMakeLists.txt
@@ -15,7 +15,11 @@
 cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-universe-domain-demo CXX)
 
+find_package(google_cloud_cpp_bigquery REQUIRED)
+find_package(google_cloud_cpp_compute REQUIRED)
 find_package(google_cloud_cpp_kms REQUIRED)
+find_package(google_cloud_cpp_pubsub REQUIRED)
+find_package(google_cloud_cpp_storage REQUIRED)
 find_package(google_cloud_cpp_universe_domain REQUIRED)
 
 # MSVC requires some additional code to select the correct runtime library
@@ -25,7 +29,9 @@ else ()
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
 endif ()
 
-# Define your targets.
-add_executable(kms_demo kms.cc)
-target_link_libraries(kms_demo google-cloud-cpp::kms
-                      google-cloud-cpp::universe_domain)
+set(universe_domain_demos bigquery compute kms pubsub storage)
+foreach (demo ${universe_domain_demos})
+    add_executable(${demo}_demo ${demo}.cc)
+    target_link_libraries(${demo}_demo google-cloud-cpp::${demo}
+                          google-cloud-cpp::universe_domain)
+endforeach ()

--- a/google/cloud/universe_domain/demo/bigquery.cc
+++ b/google/cloud/universe_domain/demo/bigquery.cc
@@ -1,0 +1,71 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigquery/storage/v1/bigquery_read_client.h"
+#include "google/cloud/bigquery/storage/v1/bigquery_read_options.h"
+#include "google/cloud/universe_domain.h"
+#include "google/cloud/universe_domain_options.h"
+#include <iostream>
+
+int main(int argc, char* argv[]) try {
+  if (argc != 4 && argc != 3) {
+    std::cerr << "Usage: " << argv[0]
+              << " [<project-id> <dataset-id> <table-id> | "
+                 "<billing-project-id> <full-table-path>]\n";
+    return 1;
+  }
+  std::string const project_name = std::string{"projects/"} + argv[1];
+  std::string const table_path = [&] {
+    if (argc == 3) return std::string{argv[2]};
+    return project_name + "/datasets/" + argv[2] + "/tables/" + argv[3];
+  }();
+
+  // Create a namespace alias to make the code easier to read.
+  namespace bigquery_storage = ::google::cloud::bigquery_storage_v1;
+  constexpr int kMaxReadStreams = 1;
+
+  auto options =
+      google::cloud::AddUniverseDomainOption(google::cloud::ExperimentalTag{});
+  if (!options.ok()) throw std::move(options).status();
+
+  // Override retry policy to quickly exit if there's a failure.
+  options->set<bigquery_storage::BigQueryReadRetryPolicyOption>(
+      std::make_shared<
+          bigquery_storage::BigQueryReadLimitedErrorCountRetryPolicy>(3));
+  auto client = bigquery_storage::BigQueryReadClient(
+      bigquery_storage::MakeBigQueryReadConnection(*options));
+  ::google::cloud::bigquery::storage::v1::ReadSession read_session;
+  read_session.set_data_format(
+      google::cloud::bigquery::storage::v1::DataFormat::AVRO);
+  read_session.set_table(table_path);
+  auto session =
+      client.CreateReadSession(project_name, read_session, kMaxReadStreams);
+  if (!session) throw std::move(session).status();
+
+  constexpr int kRowOffset = 0;
+  auto read_rows = client.ReadRows(session->streams(0).name(), kRowOffset);
+
+  std::int64_t num_rows = 0;
+  for (auto const& row : read_rows) {
+    if (row.ok()) {
+      num_rows += row->row_count();
+    }
+  }
+
+  std::cout << num_rows << " rows read from table: " << table_path << "\n";
+  return 0;
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
+  return 1;
+}

--- a/google/cloud/universe_domain/demo/compute.cc
+++ b/google/cloud/universe_domain/demo/compute.cc
@@ -1,0 +1,67 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/compute/disks/v1/disks_client.h"
+#include "google/cloud/compute/disks/v1/disks_options.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/internal/rest_options.h"
+#include "google/cloud/universe_domain.h"
+#include "google/cloud/universe_domain_options.h"
+#include <iostream>
+
+namespace {
+
+// This is necessary to access alternate compute API.
+void AddTargetApiVersionFromEnvVar(google::cloud::Options& options) {
+  auto compute_api = google::cloud::internal::GetEnv("COMPUTE_TARGET_API");
+  if (compute_api) {
+    options.set<google::cloud::rest_internal::TargetApiVersionOption>(
+        *compute_api);
+  }
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) try {
+  if (argc != 3) {
+    std::cerr << "Usage: " << argv[0] << " project-id zone-id\n";
+    return 1;
+  }
+  std::string const project_id = argv[1];
+  std::string const zone_id = argv[2];
+
+  // Create aliases to make the code easier to read.
+  namespace disks = ::google::cloud::compute_disks_v1;
+  auto options =
+      google::cloud::AddUniverseDomainOption(google::cloud::ExperimentalTag{});
+  if (!options.ok()) throw std::move(options).status();
+
+  // Override retry policy to quickly exit if there's a failure.
+  options->set<disks::DisksRetryPolicyOption>(
+      std::make_shared<disks::DisksLimitedErrorCountRetryPolicy>(3));
+  // set env var COMPUTE_TARGET_API to select api other than "v1".
+  AddTargetApiVersionFromEnvVar(*options);
+  auto client = disks::DisksClient(disks::MakeDisksConnectionRest(*options));
+
+  std::cout << "compute.ListDisks:\n";
+  for (auto disk : client.ListDisks(project_id, zone_id)) {
+    if (!disk) throw std::move(disk).status();
+    std::cout << disk->DebugString() << "\n";
+  }
+
+  return 0;
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
+  return 1;
+}

--- a/google/cloud/universe_domain/demo/pubsub.cc
+++ b/google/cloud/universe_domain/demo/pubsub.cc
@@ -1,0 +1,52 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/pubsub/admin/topic_admin_client.h"
+#include "google/cloud/pubsub/admin/topic_admin_options.h"
+#include "google/cloud/universe_domain.h"
+#include "google/cloud/universe_domain_options.h"
+#include <iostream>
+
+int main(int argc, char* argv[]) try {
+  if (argc != 2) {
+    std::cerr << "Usage: " << argv[0] << " <project-id>\n";
+    return 1;
+  }
+  std::string const project_id = std::string{"projects/"} + argv[1];
+
+  // Create a namespace alias to make the code easier to read.
+  namespace pubsub_admin = ::google::cloud::pubsub_admin;
+
+  auto options =
+      google::cloud::AddUniverseDomainOption(google::cloud::ExperimentalTag{});
+  if (!options.ok()) throw std::move(options).status();
+
+  // Override retry policy to quickly exit if there's a failure.
+  options->set<pubsub_admin::TopicAdminRetryPolicyOption>(
+      std::make_shared<pubsub_admin::TopicAdminLimitedErrorCountRetryPolicy>(
+          3));
+  auto topic_admin_client = pubsub_admin::TopicAdminClient(
+      pubsub_admin::MakeTopicAdminConnection(*options));
+
+  std::cout << "pubsub.ListTopics:\n";
+  for (auto t : topic_admin_client.ListTopics(project_id)) {
+    if (!t) throw std::move(t).status();
+    std::cout << t->DebugString() << "\n";
+  }
+
+  return 0;
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
+  return 1;
+}

--- a/google/cloud/universe_domain/demo/storage.cc
+++ b/google/cloud/universe_domain/demo/storage.cc
@@ -1,0 +1,49 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/client.h"
+#include "google/cloud/universe_domain.h"
+#include "google/cloud/universe_domain_options.h"
+#include <iostream>
+
+int main(int argc, char* argv[]) try {
+  if (argc != 2) {
+    std::cerr << "Usage: " << argv[0] << " <project-id>\n";
+    return 1;
+  }
+  std::string const project_id = argv[1];
+
+  // Create aliases to make the code easier to read.
+  namespace gcs = ::google::cloud::storage;
+
+  auto options =
+      google::cloud::AddUniverseDomainOption(google::cloud::ExperimentalTag{});
+  if (!options.ok()) throw std::move(options).status();
+
+  // Override retry policy to quickly exit if there's a failure.
+  options->set<gcs::RetryPolicyOption>(
+      std::make_shared<gcs::LimitedErrorCountRetryPolicy>(3));
+  auto client = gcs::Client(*options);
+
+  std::cout << "storage.ListBuckets:\n";
+  for (auto b : client.ListBucketsForProject(project_id)) {
+    if (!b) throw std::move(b).status();
+    std::cout << b->name() << "\n";
+  }
+
+  return 0;
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
+  return 1;
+}


### PR DESCRIPTION
This adds the remaining service demos specified for the universe_domain feature. Additional auth related demos are next.

Demos now are built with cmake and execute as part of the quickstart-production builds.

part of the work for #13495

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13496)
<!-- Reviewable:end -->
