### PR TITLE
feat(bigtable): support bigtable routing cookies

### DIFF
--- a/google/cloud/bigtable/internal/bigtable_stub_factory.cc
+++ b/google/cloud/bigtable/internal/bigtable_stub_factory.cc
@@ -53,6 +53,7 @@ std::string FeaturesMetadata() {
     proto.set_last_scanned_row_responses(true);
     proto.set_mutate_rows_rate_limit(true);
     proto.set_mutate_rows_rate_limit2(true);
+    proto.set_routing_cookie(true);
     return internal::UrlsafeBase64Encode(proto.SerializeAsString());
   }());
   return *kFeatures;


### PR DESCRIPTION
I forgot to do this as part of #13447 

This flag tells the server that our client supports the feature. Welcome to Bigtable.

Note that the feature flags are tested. We just check that the serialized value is non-empty and in the format we expect: https://github.com/googleapis/google-cloud-cpp/blob/9d54f32c812f693bcf86543fc3be8adee5e923c3/google/cloud/bigtable/internal/bigtable_stub_factory_test.cc#L247-L248

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13502)
<!-- Reviewable:end -->
