### PR TITLE
refactor(pubsub): rename s/settle/ack or s/settle/nack

### DIFF
--- a/google/cloud/pubsub/internal/pull_ack_handler_factory_test.cc
+++ b/google/cloud/pubsub/internal/pull_ack_handler_factory_test.cc
@@ -112,7 +112,7 @@ TEST(PullAckHandlerTest, TracingEnabled) {
   EXPECT_THAT(spans, Contains(AllOf(
                          SpanHasInstrumentationScope(), SpanKindIsClient(),
                          SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-                         SpanNamed("test-subscription settle"))));
+                         SpanNamed("test-subscription ack"))));
 }
 
 TEST(PullAckHandlerTest, TracingDisabled) {

--- a/google/cloud/pubsub/internal/tracing_pull_ack_handler.cc
+++ b/google/cloud/pubsub/internal/tracing_pull_ack_handler.cc
@@ -55,7 +55,7 @@ class TracingPullAckHandler : public pubsub::PullAckHandler::Impl {
         {"messaging.gcp_pubsub.message.delivery_attempt",
          child_->delivery_attempt()},
         {"gcp.project_id", subscription.project_id()},
-        {"messaging.destination.name", subscription.subscription_id()}};
+        {sc::kMessagingDestinationName, subscription.subscription_id()}};
   }
 
   future<Status> ack() override {

--- a/google/cloud/pubsub/internal/tracing_pull_ack_handler.cc
+++ b/google/cloud/pubsub/internal/tracing_pull_ack_handler.cc
@@ -46,16 +46,16 @@ class TracingPullAckHandler : public pubsub::PullAckHandler::Impl {
   }
   ~TracingPullAckHandler() override = default;
 
-  TracingAttributes MakeSharedAttributes(std::string const& ack_id,
-                                         std::string const& subscription) {
+  TracingAttributes MakeSharedAttributes(
+      std::string const& ack_id, pubsub::Subscription const& subscription) {
     namespace sc = opentelemetry::trace::SemanticConventions;
     return TracingAttributes{
         {sc::kMessagingSystem, "gcp_pubsub"},
-        {sc::kMessagingOperation, "settle"},
         {"messaging.gcp_pubsub.message.ack_id", ack_id},
         {"messaging.gcp_pubsub.message.delivery_attempt",
          child_->delivery_attempt()},
-        {"messaging.gcp_pubsub.subscription.template", subscription}};
+        {"gcp.project_id", subscription.project_id()},
+        {"messaging.destination.name", subscription.subscription_id()}};
   }
 
   future<Status> ack() override {
@@ -64,14 +64,13 @@ class TracingPullAckHandler : public pubsub::PullAckHandler::Impl {
     options.kind = opentelemetry::trace::SpanKind::kClient;
     auto const ack_id = child_->ack_id();
     auto const subscription = child_->subscription();
-    auto const subscription_name = subscription.FullName();
-    TracingAttributes attributes =
-        MakeSharedAttributes(ack_id, subscription_name);
+    TracingAttributes attributes = MakeSharedAttributes(ack_id, subscription);
     attributes.emplace_back(
         std::make_pair(sc::kCodeFunction, "pubsub::PullAckHandler::ack"));
-    auto span = internal::MakeSpan(
-        subscription.subscription_id() + " settle", attributes,
-        CreateLinks(consumer_span_context_), options);
+    attributes.emplace_back(std::make_pair(sc::kMessagingOperation, "ack"));
+    auto span =
+        internal::MakeSpan(subscription.subscription_id() + " ack", attributes,
+                           CreateLinks(consumer_span_context_), options);
     MaybeAddLinkAttributes(*span, consumer_span_context_, "receive");
     auto scope = internal::OTelScope(span);
 
@@ -90,14 +89,13 @@ class TracingPullAckHandler : public pubsub::PullAckHandler::Impl {
     options.kind = opentelemetry::trace::SpanKind::kClient;
     auto const ack_id = child_->ack_id();
     auto const subscription = child_->subscription();
-    auto const subscription_name = subscription.FullName();
-    TracingAttributes attributes =
-        MakeSharedAttributes(ack_id, subscription_name);
+    TracingAttributes attributes = MakeSharedAttributes(ack_id, subscription);
     attributes.emplace_back(
         std::make_pair(sc::kCodeFunction, "pubsub::PullAckHandler::nack"));
-    auto span = internal::MakeSpan(
-        subscription.subscription_id() + " settle", attributes,
-        CreateLinks(consumer_span_context_), options);
+    attributes.emplace_back(std::make_pair(sc::kMessagingOperation, "nack"));
+    auto span =
+        internal::MakeSpan(subscription.subscription_id() + " nack", attributes,
+                           CreateLinks(consumer_span_context_), options);
     MaybeAddLinkAttributes(*span, consumer_span_context_, "receive");
     auto scope = internal::OTelScope(span);
 

--- a/google/cloud/pubsub/internal/tracing_pull_ack_handler_test.cc
+++ b/google/cloud/pubsub/internal/tracing_pull_ack_handler_test.cc
@@ -126,11 +126,11 @@ TEST(TracingAckHandlerTest, AckAttributes) {
                   SpanNamed("test-subscription ack"),
                   SpanHasAttributes(OTelAttribute<std::int32_t>(
                       "messaging.gcp_pubsub.message.delivery_attempt", 42)))));
-  EXPECT_THAT(
-      spans,
-      Contains(AllOf(SpanNamed("test-subscription ack"),
-                     SpanHasAttributes(OTelAttribute<std::string>(
-                         sc::kMessagingDestinationName, "test-subscription")))));
+  EXPECT_THAT(spans,
+              Contains(AllOf(
+                  SpanNamed("test-subscription ack"),
+                  SpanHasAttributes(OTelAttribute<std::string>(
+                      sc::kMessagingDestinationName, "test-subscription")))));
 }
 
 TEST(TracingAckHandlerTest, NackSuccess) {
@@ -200,11 +200,11 @@ TEST(TracingAckHandlerTest, NackAttributes) {
                   SpanNamed("test-subscription nack"),
                   SpanHasAttributes(OTelAttribute<std::int32_t>(
                       "messaging.gcp_pubsub.message.delivery_attempt", 42)))));
-  EXPECT_THAT(
-      spans,
-      Contains(AllOf(SpanNamed("test-subscription nack"),
-                     SpanHasAttributes(OTelAttribute<std::string>(
-                         sc::kMessagingDestinationName, "test-subscription")))));
+  EXPECT_THAT(spans,
+              Contains(AllOf(
+                  SpanNamed("test-subscription nack"),
+                  SpanHasAttributes(OTelAttribute<std::string>(
+                      sc::kMessagingDestinationName, "test-subscription")))));
 }
 
 TEST(TracingAckHandlerTest, DeliveryAttemptNoSpans) {

--- a/google/cloud/pubsub/internal/tracing_pull_ack_handler_test.cc
+++ b/google/cloud/pubsub/internal/tracing_pull_ack_handler_test.cc
@@ -130,7 +130,7 @@ TEST(TracingAckHandlerTest, AckAttributes) {
       spans,
       Contains(AllOf(SpanNamed("test-subscription ack"),
                      SpanHasAttributes(OTelAttribute<std::string>(
-                         "messaging.destination.name", "test-subscription")))));
+                         sc::kMessagingDestinationName, "test-subscription")))));
 }
 
 TEST(TracingAckHandlerTest, NackSuccess) {
@@ -204,7 +204,7 @@ TEST(TracingAckHandlerTest, NackAttributes) {
       spans,
       Contains(AllOf(SpanNamed("test-subscription nack"),
                      SpanHasAttributes(OTelAttribute<std::string>(
-                         "messaging.destination.name", "test-subscription")))));
+                         sc::kMessagingDestinationName, "test-subscription")))));
 }
 
 TEST(TracingAckHandlerTest, DeliveryAttemptNoSpans) {

--- a/google/cloud/pubsub/internal/tracing_pull_ack_handler_test.cc
+++ b/google/cloud/pubsub/internal/tracing_pull_ack_handler_test.cc
@@ -72,7 +72,7 @@ TEST(TracingAckHandlerTest, AckSuccess) {
   EXPECT_THAT(spans, Contains(AllOf(
                          SpanHasInstrumentationScope(), SpanKindIsClient(),
                          SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-                         SpanNamed("test-subscription settle"))));
+                         SpanNamed("test-subscription ack"))));
 }
 
 TEST(TracingAckHandlerTest, AckError) {
@@ -90,7 +90,7 @@ TEST(TracingAckHandlerTest, AckError) {
   EXPECT_THAT(
       spans,
       Contains(AllOf(SpanWithStatus(opentelemetry::trace::StatusCode::kError),
-                     SpanNamed("test-subscription settle"))));
+                     SpanNamed("test-subscription ack"))));
 }
 
 TEST(TracingAckHandlerTest, AckAttributes) {
@@ -105,30 +105,32 @@ TEST(TracingAckHandlerTest, AckAttributes) {
 
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(spans,
-              Contains(AllOf(SpanNamed("test-subscription settle"),
+              Contains(AllOf(SpanNamed("test-subscription ack"),
                              SpanHasAttributes(OTelAttribute<std::string>(
                                  sc::kMessagingSystem, "gcp_pubsub")))));
   EXPECT_THAT(spans,
-              Contains(AllOf(SpanNamed("test-subscription settle"),
+              Contains(AllOf(SpanNamed("test-subscription ack"),
                              SpanHasAttributes(OTelAttribute<std::string>(
-                                 sc::kMessagingOperation, "settle")))));
+                                 "gcp.project_id", "test-project")))));
+  EXPECT_THAT(spans,
+              Contains(AllOf(SpanNamed("test-subscription ack"),
+                             SpanHasAttributes(OTelAttribute<std::string>(
+                                 sc::kMessagingOperation, "ack")))));
   EXPECT_THAT(
       spans,
-      Contains(AllOf(SpanNamed("test-subscription settle"),
+      Contains(AllOf(SpanNamed("test-subscription ack"),
                      SpanHasAttributes(OTelAttribute<std::string>(
                          sc::kCodeFunction, "pubsub::PullAckHandler::ack")))));
   EXPECT_THAT(spans,
               Contains(AllOf(
-                  SpanNamed("test-subscription settle"),
+                  SpanNamed("test-subscription ack"),
                   SpanHasAttributes(OTelAttribute<std::int32_t>(
                       "messaging.gcp_pubsub.message.delivery_attempt", 42)))));
   EXPECT_THAT(
       spans,
-      Contains(AllOf(
-          SpanNamed("test-subscription settle"),
-          SpanHasAttributes(OTelAttribute<std::string>(
-              "messaging.gcp_pubsub.subscription.template",
-              "projects/test-project/subscriptions/test-subscription")))));
+      Contains(AllOf(SpanNamed("test-subscription ack"),
+                     SpanHasAttributes(OTelAttribute<std::string>(
+                         "messaging.destination.name", "test-subscription")))));
 }
 
 TEST(TracingAckHandlerTest, NackSuccess) {
@@ -144,7 +146,7 @@ TEST(TracingAckHandlerTest, NackSuccess) {
   EXPECT_THAT(spans, Contains(AllOf(
                          SpanHasInstrumentationScope(), SpanKindIsClient(),
                          SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
-                         SpanNamed("test-subscription settle"))));
+                         SpanNamed("test-subscription nack"))));
 }
 
 TEST(TracingAckHandlerTest, NackError) {
@@ -162,7 +164,7 @@ TEST(TracingAckHandlerTest, NackError) {
   EXPECT_THAT(
       spans,
       Contains(AllOf(SpanWithStatus(opentelemetry::trace::StatusCode::kError),
-                     SpanNamed("test-subscription settle"))));
+                     SpanNamed("test-subscription nack"))));
 }
 
 TEST(TracingAckHandlerTest, NackAttributes) {
@@ -177,23 +179,32 @@ TEST(TracingAckHandlerTest, NackAttributes) {
 
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(spans,
-              Contains(AllOf(SpanNamed("test-subscription settle"),
+              Contains(AllOf(SpanNamed("test-subscription nack"),
                              SpanHasAttributes(OTelAttribute<std::string>(
                                  sc::kMessagingSystem, "gcp_pubsub")))));
   EXPECT_THAT(spans,
-              Contains(AllOf(SpanNamed("test-subscription settle"),
+              Contains(AllOf(SpanNamed("test-subscription nack"),
                              SpanHasAttributes(OTelAttribute<std::string>(
-                                 sc::kMessagingOperation, "settle")))));
+                                 sc::kMessagingOperation, "nack")))));
+  EXPECT_THAT(spans,
+              Contains(AllOf(SpanNamed("test-subscription nack"),
+                             SpanHasAttributes(OTelAttribute<std::string>(
+                                 "gcp.project_id", "test-project")))));
   EXPECT_THAT(
       spans,
-      Contains(AllOf(SpanNamed("test-subscription settle"),
+      Contains(AllOf(SpanNamed("test-subscription nack"),
                      SpanHasAttributes(OTelAttribute<std::string>(
                          sc::kCodeFunction, "pubsub::PullAckHandler::nack")))));
   EXPECT_THAT(spans,
               Contains(AllOf(
-                  SpanNamed("test-subscription settle"),
+                  SpanNamed("test-subscription nack"),
                   SpanHasAttributes(OTelAttribute<std::int32_t>(
                       "messaging.gcp_pubsub.message.delivery_attempt", 42)))));
+  EXPECT_THAT(
+      spans,
+      Contains(AllOf(SpanNamed("test-subscription nack"),
+                     SpanHasAttributes(OTelAttribute<std::string>(
+                         "messaging.destination.name", "test-subscription")))));
 }
 
 TEST(TracingAckHandlerTest, DeliveryAttemptNoSpans) {
@@ -246,7 +257,7 @@ TEST(TracingAckHandlerTest, AckAddsLink) {
 
   consumer_span->End();
   auto spans = span_catcher->GetSpans();
-  EXPECT_THAT(spans, Contains(AllOf(SpanNamed("test-subscription settle"),
+  EXPECT_THAT(spans, Contains(AllOf(SpanNamed("test-subscription ack"),
                                     SpanLinksSizeIs(1))));
 }
 
@@ -264,7 +275,7 @@ TEST(TracingAckHandlerTest, AckSkipsLinkForNotSampledSpan) {
 
   consumer_span->End();
   auto spans = span_catcher->GetSpans();
-  EXPECT_THAT(spans, Contains(AllOf(SpanNamed("test-subscription settle"),
+  EXPECT_THAT(spans, Contains(AllOf(SpanNamed("test-subscription ack"),
                                     SpanLinksSizeIs(0))));
 }
 
@@ -286,7 +297,7 @@ TEST(TracingAckHandlerTest, AckAddsSpanIdAndTraceIdAttribute) {
   EXPECT_THAT(
       spans,
       Contains(AllOf(
-          SpanNamed("test-subscription settle"),
+          SpanNamed("test-subscription ack"),
           SpanHasAttributes(
               OTelAttribute<std::string>("gcp_pubsub.receive.trace_id", _),
               OTelAttribute<std::string>("gcp_pubsub.receive.span_id", _)))));

--- a/google/cloud/pubsub/subscriber_connection_test.cc
+++ b/google/cloud/pubsub/subscriber_connection_test.cc
@@ -222,7 +222,7 @@ TEST(MakeSubscriberConnectionTest, TracingEnabledForUnaryPull) {
   EXPECT_THAT(spans, UnorderedElementsAre(
                          SpanNamed("test-subscription receive"),
                          SpanNamed("google.pubsub.v1.Subscriber/Pull"),
-                         SpanNamed("test-subscription settle"),
+                         SpanNamed("test-subscription ack"),
                          SpanNamed("google.pubsub.v1.Subscriber/Acknowledge")));
 }
 


### PR DESCRIPTION
Also add a few attributes to the ack/nack spans based on updated semantic conventions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13506)
<!-- Reviewable:end -->
