### PR TITLE
refactor(pubsub): split the messaging destination attributes on receive span

### DIFF
--- a/google/cloud/pubsub/internal/subscriber_tracing_connection.cc
+++ b/google/cloud/pubsub/internal/subscriber_tracing_connection.cc
@@ -44,7 +44,8 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> StartPullSpan() {
       {{sc::kMessagingSystem, "gcp_pubsub"},
        {sc::kMessagingOperation, "receive"},
        {sc::kCodeFunction, "pubsub::SubscriberConnection::Pull"},
-       {sc::kMessagingDestinationTemplate, subscription.FullName()}},
+       {"gcp.project_id", subscription.project_id()},
+       {sc::kMessagingDestinationName, subscription.subscription_id()}},
       options);
   return span;
 }

--- a/google/cloud/pubsub/internal/subscriber_tracing_connection_test.cc
+++ b/google/cloud/pubsub/internal/subscriber_tracing_connection_test.cc
@@ -159,13 +159,13 @@ TEST(SubscriberTracingConnectionTest, PullAttributes) {
   EXPECT_THAT(spans,
               Contains(AllOf(SpanNamed("test-subscription receive"),
                              SpanHasAttributes(OTelAttribute<std::string>(
-                                 sc::kMessagingDestinationTemplate,
-                                 TestSubscription().FullName())))));
-  EXPECT_THAT(spans,
-              Contains(AllOf(SpanNamed("test-subscription receive"),
-                             SpanHasAttributes(OTelAttribute<std::string>(
-                                 sc::kMessagingDestinationTemplate,
-                                 TestSubscription().FullName())))));
+                                 sc::kMessagingDestinationName,
+                                 TestSubscription().subscription_id())))));
+  EXPECT_THAT(
+      spans,
+      Contains(AllOf(SpanNamed("test-subscription receive"),
+                     SpanHasAttributes(OTelAttribute<std::string>(
+                         "gcp.project_id", TestSubscription().project_id())))));
   EXPECT_THAT(spans,
               Contains(AllOf(SpanNamed("test-subscription receive"),
                              SpanHasAttributes(OTelAttribute<std::string>(


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13508)
<!-- Reviewable:end -->
