### PR TITLE
refactor(pubsub): split attributes for blocking publisher

### DIFF
--- a/google/cloud/pubsub/internal/blocking_publisher_tracing_connection.cc
+++ b/google/cloud/pubsub/internal/blocking_publisher_tracing_connection.cc
@@ -40,7 +40,8 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> StartPublishSpan(
   auto span = internal::MakeSpan(
       topic.topic_id() + " create",
       {{sc::kMessagingSystem, "gcp_pubsub"},
-       {sc::kMessagingDestinationTemplate, topic.FullName()},
+       {sc::kMessagingDestinationName, topic.topic_id()},
+       {"gcp.project_id", topic.project_id()},
        {sc::kMessagingOperation, "create"},
        {/*sc::kMessagingMessageEnvelopeSize=*/"messaging.message.envelope.size",
         static_cast<std::int64_t>(MessageSize(m))},

--- a/google/cloud/pubsub/internal/blocking_publisher_tracing_connection_test.cc
+++ b/google/cloud/pubsub/internal/blocking_publisher_tracing_connection_test.cc
@@ -123,9 +123,9 @@ TEST(BlockingPublisherTracingConnectionTest, PublishSpanOnError) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError),
           SpanHasAttributes(
               OTelAttribute<std::string>(sc::kMessagingSystem, "gcp_pubsub"),
-              OTelAttribute<std::string>(
-                  sc::kMessagingDestinationTemplate,
-                  "projects/test-project/topics/test-topic"),
+              OTelAttribute<std::string>(sc::kMessagingDestinationName,
+                                         "test-topic"),
+              OTelAttribute<std::string>("gcp.project_id", "test-project"),
               OTelAttribute<std::string>(
                   "messaging.gcp_pubsub.message.ordering_key",
                   "ordering-key-0"),

--- a/google/cloud/pubsub/internal/blocking_publisher_tracing_connection_test.cc
+++ b/google/cloud/pubsub/internal/blocking_publisher_tracing_connection_test.cc
@@ -80,9 +80,9 @@ TEST(BlockingPublisherTracingConnectionTest, PublishSpanOnSuccess) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
           SpanHasAttributes(
               OTelAttribute<std::string>(sc::kMessagingSystem, "gcp_pubsub"),
-              OTelAttribute<std::string>(
-                  sc::kMessagingDestinationTemplate,
-                  "projects/test-project/topics/test-topic"),
+              OTelAttribute<std::string>(sc::kMessagingDestinationName,
+                                         "test-topic"),
+              OTelAttribute<std::string>("gcp.project_id", "test-project"),
               OTelAttribute<std::string>(
                   "messaging.gcp_pubsub.message.ordering_key",
                   "ordering-key-0"),


### PR DESCRIPTION
For the blocking pull connection

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13512)
<!-- Reviewable:end -->
