### PR TITLE
impl: add `RetryInfo` to `Status`

### DIFF
--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -71,6 +71,7 @@ google_cloud_cpp_common_hdrs = [
     "internal/populate_common_options.h",
     "internal/port_platform.h",
     "internal/random.h",
+    "internal/retry_info.h",
     "internal/retry_loop_helpers.h",
     "internal/retry_policy_impl.h",
     "internal/service_endpoint.h",

--- a/google/cloud/google_cloud_cpp_common.cmake
+++ b/google/cloud/google_cloud_cpp_common.cmake
@@ -108,6 +108,7 @@ add_library(
     internal/port_platform.h
     internal/random.cc
     internal/random.h
+    internal/retry_info.h
     internal/retry_loop_helpers.cc
     internal/retry_loop_helpers.h
     internal/retry_policy_impl.cc

--- a/google/cloud/internal/retry_info.h
+++ b/google/cloud/internal/retry_info.h
@@ -1,0 +1,57 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_RETRY_INFO_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_RETRY_INFO_H
+
+#include "google/cloud/version.h"
+#include <chrono>
+
+namespace google {
+namespace cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+
+/**
+ * Recommendation for backoff from the server.
+ *
+ * This class is internal, because it is only relevant to the client library.
+ *
+ * @see https://cloud.google.com/apis/design/errors#retry_info
+ */
+class RetryInfo {
+ public:
+  explicit RetryInfo(std::chrono::nanoseconds retry_delay)
+      : retry_delay_(retry_delay) {}
+
+  std::chrono::nanoseconds retry_delay() const { return retry_delay_; }
+
+  friend inline bool operator==(RetryInfo const& a, RetryInfo const& b) {
+    return a.retry_delay_ == b.retry_delay_;
+  }
+
+  friend inline bool operator!=(RetryInfo const& a, RetryInfo const& b) {
+    return !(a == b);
+  }
+
+ private:
+  std::chrono::nanoseconds retry_delay_;
+};
+
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_RETRY_INFO_H

--- a/google/cloud/status.h
+++ b/google/cloud/status.h
@@ -284,12 +284,6 @@ class ErrorInfo {
   std::unordered_map<std::string, std::string> metadata_;
 };
 
-class Status;
-namespace internal {
-Status MakeStatus(StatusCode code, std::string message, ErrorInfo error_info,
-                  absl::optional<internal::RetryInfo> retry_info);
-}
-
 /**
  * Represents success or an error with info about the error.
  *

--- a/google/cloud/status.h
+++ b/google/cloud/status.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STATUS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STATUS_H
 
+#include "google/cloud/internal/retry_info.h"
 #include "google/cloud/version.h"
 #include "absl/types/optional.h"
 #include <iostream>
@@ -197,6 +198,8 @@ class Status;
 class ErrorInfo;
 namespace internal {
 void AddMetadata(ErrorInfo&, std::string const& key, std::string value);
+void SetRetryInfo(Status& status, absl::optional<RetryInfo> retry_info);
+absl::optional<RetryInfo> GetRetryInfo(Status const& status);
 void SetPayload(Status&, std::string key, std::string payload);
 absl::optional<std::string> GetPayload(Status const&, std::string const& key);
 }  // namespace internal
@@ -281,6 +284,12 @@ class ErrorInfo {
   std::unordered_map<std::string, std::string> metadata_;
 };
 
+class Status;
+namespace internal {
+Status MakeStatus(StatusCode code, std::string message, ErrorInfo error_info,
+                  absl::optional<internal::RetryInfo> retry_info);
+}
+
 /**
  * Represents success or an error with info about the error.
  *
@@ -325,7 +334,7 @@ class Status {
    * @param message the message for the new `Status`, ignored if @p code is
    *     `StatusCode::kOk`.
    * @param info the `ErrorInfo` for the new `Status`, ignored if @p code is
-   *     `SStatusCode::kOk`.
+   *     `StatusCode::kOk`.
    */
   explicit Status(StatusCode code, std::string message, ErrorInfo info = {});
 
@@ -359,6 +368,10 @@ class Status {
 
  private:
   static bool Equals(Status const& a, Status const& b);
+  friend void internal::SetRetryInfo(Status&,
+                                     absl::optional<internal::RetryInfo>);
+  friend absl::optional<internal::RetryInfo> internal::GetRetryInfo(
+      Status const&);
   friend void internal::SetPayload(Status&, std::string, std::string);
   friend absl::optional<std::string> internal::GetPayload(Status const&,
                                                           std::string const&);


### PR DESCRIPTION
Part of the work for #13514 

Store and provide an accessor for `google.rpc.RetryInfo` in our `google::cloud::Status`es.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13515)
<!-- Reviewable:end -->
