### PR TITLE
cleanup: stop using FQDN in default endpoints

### DIFF
--- a/generator/integration_tests/tests/golden_kitchen_sink_option_defaults_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_option_defaults_test.cc
@@ -36,7 +36,7 @@ TEST(GoldenKitchenSinkDefaultOptions, DefaultEndpoint) {
   auto env = ScopedEnvironment("GOLDEN_KITCHEN_SINK_ENDPOINT", absl::nullopt);
   Options options;
   auto updated_options = GoldenKitchenSinkDefaultOptions(options);
-  EXPECT_EQ("goldenkitchensink.googleapis.com.",
+  EXPECT_EQ("goldenkitchensink.googleapis.com",
             updated_options.get<EndpointOption>());
 }
 

--- a/generator/integration_tests/tests/golden_thing_admin_option_defaults_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_option_defaults_test.cc
@@ -34,7 +34,7 @@ using ::google::cloud::testing_util::ScopedEnvironment;
 TEST(GoldenThingAdminDefaultOptions, DefaultEndpoint) {
   Options options;
   auto updated_options = GoldenThingAdminDefaultOptions(options);
-  EXPECT_EQ("test.googleapis.com.", updated_options.get<EndpointOption>());
+  EXPECT_EQ("test.googleapis.com", updated_options.get<EndpointOption>());
 }
 
 TEST(GoldenThingAdminDefaultOptions, EnvVarEndpoint) {

--- a/generator/integration_tests/tests/universe_domain_test.cc
+++ b/generator/integration_tests/tests/universe_domain_test.cc
@@ -29,7 +29,7 @@ using ::testing::Eq;
 TEST(GeneratorUniverseDomainTest, ConnectionEndpointOptionUnset) {
   auto connection = MakeGoldenThingAdminConnection();
   EXPECT_THAT(connection->options().get<EndpointOption>(),
-              Eq("test.googleapis.com."));
+              Eq("test.googleapis.com"));
 }
 
 TEST(GeneratorUniverseDomainTest, ConnectionEndpointOptionEmpty) {
@@ -49,7 +49,7 @@ TEST(GeneratorUniverseDomainTest, ConnectionEndpointEnvVarEmpty) {
   ScopedEnvironment endpoint_var("GOLDEN_KITCHEN_SINK_ENDPOINT", "");
   auto connection = MakeGoldenThingAdminConnection();
   EXPECT_THAT(connection->options().get<EndpointOption>(),
-              Eq("test.googleapis.com."));
+              Eq("test.googleapis.com"));
 }
 
 TEST(GeneratorUniverseDomainTest, ConnectionEndpointEnvVarNonEmpty) {

--- a/google/cloud/bigquery/v2/minimal/internal/dataset_options_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset_options_test.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/bigquery/v2/minimal/internal/dataset_options.h"
 #include "google/cloud/common_options.h"
-#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 
@@ -33,10 +32,7 @@ TEST(DatasetOptionstTest, DefaultOptions) {
   auto expected_idempotency = Idempotency::kIdempotent;
   auto const* default_endpoint = "bigquery.googleapis.com";
 
-  EXPECT_TRUE(actual.has<EndpointOption>());
-  EXPECT_EQ(actual.get<EndpointOption>(), absl::StrCat(default_endpoint, "."));
-
-  EXPECT_TRUE(actual.has<AuthorityOption>());
+  EXPECT_EQ(actual.get<EndpointOption>(), default_endpoint);
   EXPECT_EQ(actual.get<AuthorityOption>(), default_endpoint);
 
   GetDatasetRequest request;

--- a/google/cloud/bigquery/v2/minimal/internal/job_options_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_options_test.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/bigquery/v2/minimal/internal/job_options.h"
 #include "google/cloud/common_options.h"
-#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 
@@ -33,10 +32,7 @@ TEST(JobOptionstTest, DefaultOptions) {
   auto expected_idempotency = Idempotency::kIdempotent;
   auto const* default_endpoint = "bigquery.googleapis.com";
 
-  EXPECT_TRUE(actual.has<EndpointOption>());
-  EXPECT_EQ(actual.get<EndpointOption>(), absl::StrCat(default_endpoint, "."));
-
-  EXPECT_TRUE(actual.has<AuthorityOption>());
+  EXPECT_EQ(actual.get<EndpointOption>(), default_endpoint);
   EXPECT_EQ(actual.get<AuthorityOption>(), default_endpoint);
 
   GetJobRequest request;

--- a/google/cloud/bigquery/v2/minimal/internal/project_options_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/project_options_test.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/bigquery/v2/minimal/internal/project_options.h"
 #include "google/cloud/common_options.h"
-#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 
@@ -33,10 +32,7 @@ TEST(ProjectOptionsTest, DefaultOptions) {
   auto expected_idempotency = Idempotency::kIdempotent;
   auto const* default_endpoint = "bigquery.googleapis.com";
 
-  EXPECT_TRUE(actual.has<EndpointOption>());
-  EXPECT_EQ(actual.get<EndpointOption>(), absl::StrCat(default_endpoint, "."));
-
-  EXPECT_TRUE(actual.has<AuthorityOption>());
+  EXPECT_EQ(actual.get<EndpointOption>(), default_endpoint);
   EXPECT_EQ(actual.get<AuthorityOption>(), default_endpoint);
 
   ListProjectsRequest request;

--- a/google/cloud/bigquery/v2/minimal/internal/table_options_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/table_options_test.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/bigquery/v2/minimal/internal/table_options.h"
 #include "google/cloud/common_options.h"
-#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 
@@ -33,10 +32,7 @@ TEST(TableOptionsTest, DefaultOptions) {
   auto expected_idempotency = Idempotency::kIdempotent;
   auto const* default_endpoint = "bigquery.googleapis.com";
 
-  EXPECT_TRUE(actual.has<EndpointOption>());
-  EXPECT_EQ(actual.get<EndpointOption>(), absl::StrCat(default_endpoint, "."));
-
-  EXPECT_TRUE(actual.has<AuthorityOption>());
+  EXPECT_EQ(actual.get<EndpointOption>(), default_endpoint);
   EXPECT_EQ(actual.get<AuthorityOption>(), default_endpoint);
 
   GetTableRequest request;

--- a/google/cloud/internal/populate_common_options.cc
+++ b/google/cloud/internal/populate_common_options.cc
@@ -31,16 +31,7 @@ Options PopulateCommonOptions(Options opts, std::string const& endpoint_env_var,
                               std::string const& emulator_env_var,
                               std::string const& authority_env_var,
                               std::string default_endpoint) {
-  if (!opts.has<AuthorityOption>()) {
-    opts.set<AuthorityOption>(UniverseDomainEndpoint(default_endpoint, opts));
-  }
-  if (!authority_env_var.empty()) {
-    auto e = GetEnv(authority_env_var.c_str());
-    if (e && !e->empty()) {
-      opts.set<AuthorityOption>(*std::move(e));
-    }
-  }
-
+  default_endpoint = UniverseDomainEndpoint(std::move(default_endpoint), opts);
   if (!endpoint_env_var.empty()) {
     auto e = GetEnv(endpoint_env_var.c_str());
     if (e && !e->empty()) {
@@ -55,9 +46,17 @@ Options PopulateCommonOptions(Options opts, std::string const& endpoint_env_var,
     }
   }
   if (!opts.has<EndpointOption>()) {
-    absl::StrAppend(&default_endpoint, ".");
-    opts.set<EndpointOption>(
-        UniverseDomainEndpoint(std::move(default_endpoint), opts));
+    opts.set<EndpointOption>(default_endpoint);
+  }
+
+  if (!authority_env_var.empty()) {
+    auto e = GetEnv(authority_env_var.c_str());
+    if (e && !e->empty()) {
+      opts.set<AuthorityOption>(*std::move(e));
+    }
+  }
+  if (!opts.has<AuthorityOption>()) {
+    opts.set<AuthorityOption>(std::move(default_endpoint));
   }
 
   auto e = GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");

--- a/google/cloud/internal/populate_common_options_test.cc
+++ b/google/cloud/internal/populate_common_options_test.cc
@@ -44,7 +44,7 @@ TEST(PopulateCommonOptions, Simple) {
   auto actual =
       PopulateCommonOptions(Options{}, {}, {}, {}, "default.googleapis.com");
   EXPECT_TRUE(actual.has<EndpointOption>());
-  EXPECT_THAT(actual.get<EndpointOption>(), Eq("default.googleapis.com."));
+  EXPECT_THAT(actual.get<EndpointOption>(), Eq("default.googleapis.com"));
   EXPECT_TRUE(actual.has<AuthorityOption>());
   EXPECT_THAT(actual.get<AuthorityOption>(), Eq("default.googleapis.com"));
   EXPECT_FALSE(actual.has<UserProjectOption>());
@@ -68,7 +68,7 @@ TEST(PopulateCommonOptions, EmptyEndpointEnvVar) {
       PopulateCommonOptions(Options{}, "GOOGLE_CLOUD_CPP_SERVICE_ENDPOINT", {},
                             {}, "default.googleapis.com");
   EXPECT_TRUE(actual.has<EndpointOption>());
-  EXPECT_THAT(actual.get<EndpointOption>(), Eq("default.googleapis.com."));
+  EXPECT_THAT(actual.get<EndpointOption>(), Eq("default.googleapis.com"));
 }
 
 TEST(PopulateCommonOptions, EmptyEmulatorEnvVar) {
@@ -77,7 +77,7 @@ TEST(PopulateCommonOptions, EmptyEmulatorEnvVar) {
       PopulateCommonOptions(Options{}, {}, "GOOGLE_CLOUD_CPP_EMULATOR_ENDPOINT",
                             {}, "default.googleapis.com");
   EXPECT_TRUE(actual.has<EndpointOption>());
-  EXPECT_THAT(actual.get<EndpointOption>(), Eq("default.googleapis.com."));
+  EXPECT_THAT(actual.get<EndpointOption>(), Eq("default.googleapis.com"));
   EXPECT_FALSE(actual.has<UnifiedCredentialsOption>());
 }
 
@@ -128,7 +128,7 @@ TEST(PopulateCommonOptions, EndpointAuthority) {
           } else if (options.has<EndpointOption>()) {
             EXPECT_THAT(actual_endpoint, Eq(options.get<EndpointOption>()));
           } else {
-            EXPECT_THAT(actual_endpoint, Eq("default.googleapis.com."));
+            EXPECT_THAT(actual_endpoint, Eq("default.googleapis.com"));
           }
 
           ASSERT_TRUE(actual.has<AuthorityOption>());

--- a/google/cloud/internal/populate_rest_options.cc
+++ b/google/cloud/internal/populate_rest_options.cc
@@ -37,9 +37,6 @@ Options PopulateRestOptions(Options opts) {
   }
   if (opts.has<EndpointOption>()) {
     auto& endpoint = opts.lookup<EndpointOption>();
-    // Use an unqualified domain name, because we do not seem to reuse
-    // connections with a fully qualified domain name over REST.
-    if (absl::EndsWith(endpoint, ".googleapis.com.")) endpoint.pop_back();
     if (!absl::StartsWithIgnoreCase(endpoint, "http://") &&
         !absl::StartsWithIgnoreCase(endpoint, "https://")) {
       endpoint = absl::StrCat("https://", endpoint);

--- a/google/cloud/internal/populate_rest_options_test.cc
+++ b/google/cloud/internal/populate_rest_options_test.cc
@@ -40,8 +40,6 @@ TEST(PopulateRestOptions, EndpointOption) {
   std::vector<TestCase> cases = {
       {"example.com", "https://example.com"},
       {"http-but-not-the-schema.com", "https://http-but-not-the-schema.com"},
-      {"foo.googleapis.com.", "https://foo.googleapis.com"},
-      {"https://foo.googleapis.com.", "https://foo.googleapis.com"},
       {"http://example.com", "http://example.com"},
       {"https://example.com", "https://example.com"}};
 

--- a/google/cloud/internal/service_endpoint.h
+++ b/google/cloud/internal/service_endpoint.h
@@ -47,7 +47,7 @@ StatusOr<std::string> DetermineServiceEndpoint(
  *
  * @code
  * auto options = Options{}.set<UniverseDomainOption>("my-ud.net");
- * auto endpoint = UniverseDomainEndpoint("foo.googleapis.com.", options);
+ * auto endpoint = UniverseDomainEndpoint("foo.googleapis.com", options);
  * EXPECT_EQ(endpoint, "foo.my-ud.net");
  * @endcode
  */

--- a/google/cloud/pubsub/internal/defaults_test.cc
+++ b/google/cloud/pubsub/internal/defaults_test.cc
@@ -61,7 +61,7 @@ TEST(OptionsTest, UnsetEmulatorEnv) {
 
 TEST(OptionsTest, CommonDefaults) {
   auto opts = DefaultCommonOptions(Options{});
-  EXPECT_EQ("pubsub.googleapis.com.", opts.get<EndpointOption>());
+  EXPECT_EQ("pubsub.googleapis.com", opts.get<EndpointOption>());
   EXPECT_TRUE(opts.has<UnifiedCredentialsOption>());
   EXPECT_EQ(static_cast<int>(DefaultThreadCount()),
             opts.get<GrpcNumChannelsOption>());

--- a/google/cloud/spanner/internal/defaults_test.cc
+++ b/google/cloud/spanner/internal/defaults_test.cc
@@ -62,7 +62,7 @@ TEST(Options, Defaults) {
       "GOOGLE_CLOUD_CPP_SPANNER_ROUTE_TO_LEADER", absl::nullopt);
   auto opts = spanner_internal::DefaultOptions();
 
-  EXPECT_EQ(opts.get<EndpointOption>(), "spanner.googleapis.com.");
+  EXPECT_EQ(opts.get<EndpointOption>(), "spanner.googleapis.com");
   EXPECT_EQ(opts.get<AuthorityOption>(), "spanner.googleapis.com");
   EXPECT_TRUE(opts.has<UnifiedCredentialsOption>());
   EXPECT_EQ(opts.get<GrpcNumChannelsOption>(), 4);
@@ -103,7 +103,7 @@ TEST(Options, AdminDefaults) {
       "GOOGLE_CLOUD_CPP_USER_PROJECT", absl::nullopt);
   auto opts = spanner_internal::DefaultAdminOptions();
 
-  EXPECT_EQ(opts.get<EndpointOption>(), "spanner.googleapis.com.");
+  EXPECT_EQ(opts.get<EndpointOption>(), "spanner.googleapis.com");
   EXPECT_EQ(opts.get<AuthorityOption>(), "spanner.googleapis.com");
   // In Google's testing environment `expected` can be `nullptr`, we just want
   // to verify that both are `nullptr` or neither is `nullptr`.


### PR DESCRIPTION
Part of the work for #13501 

Totally minor point: We arrange the order in some of `PopulateCommonOptions` because we expect that the `EndpointOption` is more likely to be overridden by an application than the `AuthorityOption`. (and thus we are more likely to get the micro-optimization from std::move)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13516)
<!-- Reviewable:end -->
