### PR TITLE
cleanup(pubsub): stop using FQDN in default endpoint

### DIFF
--- a/google/cloud/pubsub/options.cc
+++ b/google/cloud/pubsub/options.cc
@@ -22,10 +22,11 @@ namespace pubsub {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 Options IAMPolicyOptions(Options opts) {
-  auto ep = internal::UniverseDomainEndpoint("pubsub.googleapis.com", opts);
+  auto const ep =
+      internal::UniverseDomainEndpoint("pubsub.googleapis.com", opts);
   return internal::MergeOptions(
       std::move(opts),
-      Options{}.set<EndpointOption>(ep).set<AuthorityOption>(std::move(ep)));
+      Options{}.set<EndpointOption>(ep).set<AuthorityOption>(ep));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsub/options.cc
+++ b/google/cloud/pubsub/options.cc
@@ -22,14 +22,10 @@ namespace pubsub {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 Options IAMPolicyOptions(Options opts) {
-  auto default_ep =
-      internal::UniverseDomainEndpoint("pubsub.googleapis.com.", opts);
-  auto authority_ep =
-      internal::UniverseDomainEndpoint("pubsub.googleapis.com", opts);
+  auto ep = internal::UniverseDomainEndpoint("pubsub.googleapis.com", opts);
   return internal::MergeOptions(
-      std::move(opts), Options{}
-                           .set<EndpointOption>(std::move(default_ep))
-                           .set<AuthorityOption>(std::move(authority_ep)));
+      std::move(opts),
+      Options{}.set<EndpointOption>(ep).set<AuthorityOption>(std::move(ep)));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsub/options_test.cc
+++ b/google/cloud/pubsub/options_test.cc
@@ -25,7 +25,7 @@ namespace {
 
 TEST(IAMPolicyOptions, Default) {
   auto const actual = IAMPolicyOptions();
-  EXPECT_EQ(actual.get<EndpointOption>(), "pubsub.googleapis.com.");
+  EXPECT_EQ(actual.get<EndpointOption>(), "pubsub.googleapis.com");
   EXPECT_EQ(actual.get<AuthorityOption>(), "pubsub.googleapis.com");
 }
 
@@ -55,7 +55,7 @@ TEST(IAMPolicyOptions, OverrideAuthority) {
       IAMPolicyOptions(Options{}
                            .set<AuthorityOption>("test-only-authority")
                            .set<UserProjectOption>("test-only-user-project"));
-  EXPECT_EQ(actual.get<EndpointOption>(), "pubsub.googleapis.com.");
+  EXPECT_EQ(actual.get<EndpointOption>(), "pubsub.googleapis.com");
   EXPECT_EQ(actual.get<AuthorityOption>(), "test-only-authority");
   EXPECT_EQ(actual.get<UserProjectOption>(), "test-only-user-project");
 }


### PR DESCRIPTION
Part of the work for #13501

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13517)
<!-- Reviewable:end -->
