### PR TITLE
cleanup(bigtable): stop using FQDN in default endpoint

### DIFF
--- a/google/cloud/bigtable/client_options.cc
+++ b/google/cloud/bigtable/client_options.cc
@@ -50,9 +50,9 @@ ClientOptions::ClientOptions(std::shared_ptr<grpc::ChannelCredentials> creds) {
 
   // This constructor ignores the emulator environment variables, which might be
   // set by `internal::DefaultOptions()`.
-  opts_.set<DataEndpointOption>("bigtable.googleapis.com.");
-  opts_.set<AdminEndpointOption>("bigtableadmin.googleapis.com.");
-  opts_.set<InstanceAdminEndpointOption>("bigtableadmin.googleapis.com.");
+  opts_.set<DataEndpointOption>("bigtable.googleapis.com");
+  opts_.set<AdminEndpointOption>("bigtableadmin.googleapis.com");
+  opts_.set<InstanceAdminEndpointOption>("bigtableadmin.googleapis.com");
 }
 
 // NOLINTNEXTLINE(readability-identifier-naming)

--- a/google/cloud/bigtable/client_options_test.cc
+++ b/google/cloud/bigtable/client_options_test.cc
@@ -44,8 +44,8 @@ using ::testing::HasSubstr;
 
 TEST(ClientOptionsTest, ClientOptionsDefaultSettings) {
   ClientOptions client_options;
-  EXPECT_EQ("bigtable.googleapis.com.", client_options.data_endpoint());
-  EXPECT_EQ("bigtableadmin.googleapis.com.", client_options.admin_endpoint());
+  EXPECT_EQ("bigtable.googleapis.com", client_options.data_endpoint());
+  EXPECT_EQ("bigtableadmin.googleapis.com", client_options.admin_endpoint());
   EXPECT_EQ(typeid(grpc::GoogleDefaultCredentials()),
             typeid(client_options.credentials()));
 
@@ -173,8 +173,8 @@ TEST_F(ClientOptionsDefaultEndpointTest, Default) {
 TEST_F(ClientOptionsDefaultEndpointTest, WithCredentials) {
   auto credentials = grpc::GoogleDefaultCredentials();
   ClientOptions tested(credentials);
-  EXPECT_EQ("bigtable.googleapis.com.", tested.data_endpoint());
-  EXPECT_EQ("bigtableadmin.googleapis.com.", tested.admin_endpoint());
+  EXPECT_EQ("bigtable.googleapis.com", tested.data_endpoint());
+  EXPECT_EQ("bigtableadmin.googleapis.com", tested.admin_endpoint());
   EXPECT_EQ(credentials.get(), tested.credentials().get());
 }
 
@@ -183,9 +183,9 @@ TEST_F(ClientOptionsDefaultEndpointTest, DefaultNoEmulator) {
 
   auto credentials = grpc::GoogleDefaultCredentials();
   ClientOptions tested(credentials);
-  EXPECT_EQ("bigtable.googleapis.com.", tested.data_endpoint());
-  EXPECT_EQ("bigtableadmin.googleapis.com.", tested.admin_endpoint());
-  EXPECT_EQ("bigtableadmin.googleapis.com.", GetInstanceAdminEndpoint(tested));
+  EXPECT_EQ("bigtable.googleapis.com", tested.data_endpoint());
+  EXPECT_EQ("bigtableadmin.googleapis.com", tested.admin_endpoint());
+  EXPECT_EQ("bigtableadmin.googleapis.com", GetInstanceAdminEndpoint(tested));
 }
 
 TEST_F(ClientOptionsDefaultEndpointTest, SeparateEmulators) {
@@ -201,12 +201,12 @@ TEST_F(ClientOptionsDefaultEndpointTest, SeparateEmulators) {
 
 TEST_F(ClientOptionsDefaultEndpointTest, DataNoEnv) {
   ScopedEnvironment bigtable_emulator_host("BIGTABLE_EMULATOR_HOST", {});
-  EXPECT_EQ("bigtable.googleapis.com.", ClientOptions{}.data_endpoint());
+  EXPECT_EQ("bigtable.googleapis.com", ClientOptions{}.data_endpoint());
 }
 
 TEST_F(ClientOptionsDefaultEndpointTest, AdminNoEnv) {
   ScopedEnvironment bigtable_emulator_host("BIGTABLE_EMULATOR_HOST", {});
-  EXPECT_EQ("bigtableadmin.googleapis.com.", ClientOptions{}.admin_endpoint());
+  EXPECT_EQ("bigtableadmin.googleapis.com", ClientOptions{}.admin_endpoint());
 }
 
 TEST_F(ClientOptionsDefaultEndpointTest, AdminEmulatorOverrides) {
@@ -219,12 +219,12 @@ TEST_F(ClientOptionsDefaultEndpointTest, AdminInstanceAdminNoEffect) {
   ScopedEnvironment bigtable_emulator_host("BIGTABLE_EMULATOR_HOST", {});
   ScopedEnvironment bigtable_instance_admin_emulator_host(
       "BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST", "127.0.0.1:1234");
-  EXPECT_EQ("bigtableadmin.googleapis.com.", ClientOptions{}.admin_endpoint());
+  EXPECT_EQ("bigtableadmin.googleapis.com", ClientOptions{}.admin_endpoint());
 }
 
 TEST_F(ClientOptionsDefaultEndpointTest, InstanceAdminNoEnv) {
   ScopedEnvironment bigtable_emulator_host("BIGTABLE_EMULATOR_HOST", {});
-  EXPECT_EQ("bigtableadmin.googleapis.com.",
+  EXPECT_EQ("bigtableadmin.googleapis.com",
             GetInstanceAdminEndpoint(ClientOptions()));
 }
 

--- a/google/cloud/bigtable/internal/defaults.cc
+++ b/google/cloud/bigtable/internal/defaults.cc
@@ -126,17 +126,17 @@ int DefaultConnectionPoolSize() {
 Options HandleUniverseDomain(Options opts) {
   if (!opts.has<DataEndpointOption>()) {
     auto ep = google::cloud::internal::UniverseDomainEndpoint(
-        "bigtable.googleapis.com.", opts);
+        "bigtable.googleapis.com", opts);
     opts.set<DataEndpointOption>(std::move(ep));
   }
   if (!opts.has<AdminEndpointOption>()) {
     auto ep = google::cloud::internal::UniverseDomainEndpoint(
-        "bigtableadmin.googleapis.com.", opts);
+        "bigtableadmin.googleapis.com", opts);
     opts.set<AdminEndpointOption>(std::move(ep));
   }
   if (!opts.has<InstanceAdminEndpointOption>()) {
     auto ep = google::cloud::internal::UniverseDomainEndpoint(
-        "bigtableadmin.googleapis.com.", opts);
+        "bigtableadmin.googleapis.com", opts);
     opts.set<InstanceAdminEndpointOption>(std::move(ep));
   }
   return opts;

--- a/google/cloud/bigtable/internal/defaults_test.cc
+++ b/google/cloud/bigtable/internal/defaults_test.cc
@@ -50,9 +50,9 @@ TEST(OptionsTest, Defaults) {
       "BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST", absl::nullopt);
 
   auto opts = DefaultOptions();
-  EXPECT_EQ("bigtable.googleapis.com.", opts.get<DataEndpointOption>());
-  EXPECT_EQ("bigtableadmin.googleapis.com.", opts.get<AdminEndpointOption>());
-  EXPECT_EQ("bigtableadmin.googleapis.com.",
+  EXPECT_EQ("bigtable.googleapis.com", opts.get<DataEndpointOption>());
+  EXPECT_EQ("bigtableadmin.googleapis.com", opts.get<AdminEndpointOption>());
+  EXPECT_EQ("bigtableadmin.googleapis.com",
             opts.get<InstanceAdminEndpointOption>());
   EXPECT_EQ(typeid(grpc::GoogleDefaultCredentials()),
             typeid(opts.get<GrpcCredentialOption>()));
@@ -293,8 +293,8 @@ TEST(EndpointEnvTest, InstanceEmulatorEnvOnly) {
                                       "instance-emulator-host:9000");
 
   auto opts = DefaultOptions();
-  EXPECT_EQ("bigtable.googleapis.com.", opts.get<DataEndpointOption>());
-  EXPECT_EQ("bigtableadmin.googleapis.com.", opts.get<AdminEndpointOption>());
+  EXPECT_EQ("bigtable.googleapis.com", opts.get<DataEndpointOption>());
+  EXPECT_EQ("bigtableadmin.googleapis.com", opts.get<AdminEndpointOption>());
   EXPECT_EQ("instance-emulator-host:9000",
             opts.get<InstanceAdminEndpointOption>());
 }
@@ -367,8 +367,8 @@ TEST(EndpointEnvTest, DirectPathEnabled) {
             opts.get<DataEndpointOption>());
   EXPECT_EQ("directpath-bigtable.googleapis.com", opts.get<AuthorityOption>());
   // Admin endpoints are not affected.
-  EXPECT_EQ("bigtableadmin.googleapis.com.", opts.get<AdminEndpointOption>());
-  EXPECT_EQ("bigtableadmin.googleapis.com.",
+  EXPECT_EQ("bigtableadmin.googleapis.com", opts.get<AdminEndpointOption>());
+  EXPECT_EQ("bigtableadmin.googleapis.com",
             opts.get<InstanceAdminEndpointOption>());
   EXPECT_EQ(1, opts.get<GrpcNumChannelsOption>());
 }
@@ -379,7 +379,7 @@ TEST(EndpointEnvTest, DirectPathNoMatch) {
                                 "bigtable-not,almost-bigtable");
 
   auto opts = DefaultDataOptions(Options{});
-  EXPECT_EQ("bigtable.googleapis.com.", opts.get<EndpointOption>());
+  EXPECT_EQ("bigtable.googleapis.com", opts.get<EndpointOption>());
   EXPECT_EQ("bigtable.googleapis.com", opts.get<AuthorityOption>());
 }
 


### PR DESCRIPTION
Part of the work for #13501, reverts #13305

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13518)
<!-- Reviewable:end -->
