### PR TITLE
cleanup(GCS+gRPC): stop using FQDN in default endpoint

### DIFF
--- a/google/cloud/storage/internal/grpc/stub.cc
+++ b/google/cloud/storage/internal/grpc/stub.cc
@@ -232,14 +232,11 @@ Options DefaultOptionsGrpc(Options options) {
     options.set<UnifiedCredentialsOption>(MakeInsecureCredentials());
   }
 
-  auto default_ep = google::cloud::internal::UniverseDomainEndpoint(
-      "storage.googleapis.com.", options);
-  auto authority_ep = google::cloud::internal::UniverseDomainEndpoint(
+  auto const ep = google::cloud::internal::UniverseDomainEndpoint(
       "storage.googleapis.com", options);
   options = google::cloud::internal::MergeOptions(
-      std::move(options), Options{}
-                              .set<EndpointOption>(std::move(default_ep))
-                              .set<AuthorityOption>(std::move(authority_ep)));
+      std::move(options),
+      Options{}.set<EndpointOption>(ep).set<AuthorityOption>(ep));
   // We can only compute this once the endpoint is known, so take an additional
   // step.
   auto const num_channels =

--- a/google/cloud/storage/internal/grpc/stub_test.cc
+++ b/google/cloud/storage/internal/grpc/stub_test.cc
@@ -111,7 +111,7 @@ TEST(DefaultOptionsGrpc, DefaultOptionsGrpcChannelCount) {
 
 TEST(DefaultOptionsGrpc, DefaultEndpoints) {
   auto options = DefaultOptionsGrpc();
-  EXPECT_EQ(options.get<EndpointOption>(), "storage.googleapis.com.");
+  EXPECT_EQ(options.get<EndpointOption>(), "storage.googleapis.com");
   EXPECT_EQ(options.get<AuthorityOption>(), "storage.googleapis.com");
 }
 


### PR DESCRIPTION
Part of the work for #13501 