### PR TITLE
refactor(bigtable): abstract sleeper in `DefaultRowReader`

### DIFF
--- a/google/cloud/bigtable/internal/default_row_reader.h
+++ b/google/cloud/bigtable/internal/default_row_reader.h
@@ -29,8 +29,11 @@
 #include "google/cloud/bigtable/version.h"
 #include "absl/types/variant.h"
 #include <grpcpp/grpcpp.h>
+#include <chrono>
 #include <cinttypes>
+#include <functional>
 #include <string>
+#include <thread>
 
 namespace google {
 namespace cloud {
@@ -42,13 +45,16 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * `BigtableStub`.
  */
 class DefaultRowReader : public RowReaderImpl {
+  using Sleeper = std::function<void(std::chrono::milliseconds)>;
+
  public:
-  DefaultRowReader(std::shared_ptr<BigtableStub> stub,
-                   std::string app_profile_id, std::string table_name,
-                   bigtable::RowSet row_set, std::int64_t rows_limit,
-                   bigtable::Filter filter, bool reverse,
-                   std::unique_ptr<bigtable::DataRetryPolicy> retry_policy,
-                   std::unique_ptr<BackoffPolicy> backoff_policy);
+  DefaultRowReader(
+      std::shared_ptr<BigtableStub> stub, std::string app_profile_id,
+      std::string table_name, bigtable::RowSet row_set, std::int64_t rows_limit,
+      bigtable::Filter filter, bool reverse,
+      std::unique_ptr<bigtable::DataRetryPolicy> retry_policy,
+      std::unique_ptr<BackoffPolicy> backoff_policy,
+      Sleeper sleeper = [](auto d) { std::this_thread::sleep_for(d); });
 
   ~DefaultRowReader() override;
 
@@ -93,6 +99,7 @@ class DefaultRowReader : public RowReaderImpl {
   bool reverse_;
   std::unique_ptr<bigtable::DataRetryPolicy> retry_policy_;
   std::unique_ptr<BackoffPolicy> backoff_policy_;
+  Sleeper sleeper_;
   std::shared_ptr<grpc::ClientContext> context_;
   RetryContext retry_context_;
 


### PR DESCRIPTION
Motivated by #13514 

Abstract the sleeper used by the `DefaultRowReader`, so we can supply a mock in our tests.

Currently, we assume that if the backoff policy is called, we will sleep for that long. Soon the class will need to sleep an amount that is not determined by the backoff policy. Having this injection point lets us test that we are sleeping for the right amount.

Modify one test to ensure that we are actually calling the sleeper.

Note that I prefer to default parameters for internal APIs when we want the default 99% of the time. I think this makes the code cleaner.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13524)
<!-- Reviewable:end -->
