### PR TITLE
impl(bigtable): support `RetryInfo` in `ReadRow(s)`

### DIFF
--- a/google/cloud/bigtable/internal/data_connection_impl.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl.cc
@@ -195,7 +195,9 @@ bigtable::RowReader DataConnectionImpl::ReadRowsFull(
   auto impl = std::make_shared<DefaultRowReader>(
       stub_, std::move(params.app_profile_id), std::move(params.table_name),
       std::move(params.row_set), params.rows_limit, std::move(params.filter),
-      params.reverse, retry_policy(*current), backoff_policy(*current));
+      params.reverse, retry_policy(*current), backoff_policy(*current),
+      // TODO(#13514) - use Option value.
+      false);
   return MakeRowReader(std::move(impl));
 }
 

--- a/google/cloud/bigtable/internal/default_row_reader.cc
+++ b/google/cloud/bigtable/internal/default_row_reader.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/internal/default_row_reader.h"
+#include "google/cloud/bigtable/internal/retry_info_helper.h"
 #include "google/cloud/bigtable/table.h"
 #include "google/cloud/grpc_error_delegate.h"
 
@@ -26,7 +27,8 @@ DefaultRowReader::DefaultRowReader(
     std::string table_name, bigtable::RowSet row_set, std::int64_t rows_limit,
     bigtable::Filter filter, bool reverse,
     std::unique_ptr<bigtable::DataRetryPolicy> retry_policy,
-    std::unique_ptr<BackoffPolicy> backoff_policy, Sleeper sleeper)
+    std::unique_ptr<BackoffPolicy> backoff_policy, bool use_server_retry_info,
+    Sleeper sleeper)
     : stub_(std::move(stub)),
       app_profile_id_(std::move(app_profile_id)),
       table_name_(std::move(table_name)),
@@ -36,6 +38,7 @@ DefaultRowReader::DefaultRowReader(
       reverse_(reverse),
       retry_policy_(std::move(retry_policy)),
       backoff_policy_(std::move(backoff_policy)),
+      use_server_retry_info_(use_server_retry_info),
       sleeper_(std::move(sleeper)) {}
 
 void DefaultRowReader::MakeRequest() {
@@ -125,9 +128,10 @@ absl::variant<Status, bigtable::Row> DefaultRowReader::Advance() {
     // If we receive an error, but the retryable set is empty, stop.
     if (row_set_.IsEmpty()) return Status{};
 
-    if (!retry_policy_->OnFailure(status)) return status;
-
-    sleeper_(backoff_policy_->OnCompletion());
+    auto delay = BackoffOrBreak(use_server_retry_info_, status, *retry_policy_,
+                                *backoff_policy_);
+    if (!delay) return status;
+    sleeper_(*delay);
 
     // If we reach this place, we failed and need to restart the call.
     MakeRequest();

--- a/google/cloud/bigtable/internal/default_row_reader.h
+++ b/google/cloud/bigtable/internal/default_row_reader.h
@@ -53,7 +53,7 @@ class DefaultRowReader : public RowReaderImpl {
       std::string table_name, bigtable::RowSet row_set, std::int64_t rows_limit,
       bigtable::Filter filter, bool reverse,
       std::unique_ptr<bigtable::DataRetryPolicy> retry_policy,
-      std::unique_ptr<BackoffPolicy> backoff_policy,
+      std::unique_ptr<BackoffPolicy> backoff_policy, bool use_server_retry_info,
       Sleeper sleeper = [](auto d) { std::this_thread::sleep_for(d); });
 
   ~DefaultRowReader() override;
@@ -99,6 +99,7 @@ class DefaultRowReader : public RowReaderImpl {
   bool reverse_;
   std::unique_ptr<bigtable::DataRetryPolicy> retry_policy_;
   std::unique_ptr<BackoffPolicy> backoff_policy_;
+  bool use_server_retry_info_;
   Sleeper sleeper_;
   std::shared_ptr<grpc::ClientContext> context_;
   RetryContext retry_context_;

--- a/google/cloud/bigtable/internal/default_row_reader_test.cc
+++ b/google/cloud/bigtable/internal/default_row_reader_test.cc
@@ -138,7 +138,7 @@ TEST_F(DefaultRowReaderTest, EmptyReaderHasNoRows) {
   auto impl = std::make_shared<DefaultRowReader>(
       mock, kAppProfile, kTableName, bigtable::RowSet(),
       bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
-      false, retry_.clone(), backoff_.clone());
+      false, retry_.clone(), backoff_.clone(), false);
   auto reader = bigtable_internal::MakeRowReader(std::move(impl));
   EXPECT_THAT(StatusOrRowKeys(reader), IsEmpty());
 }
@@ -161,7 +161,7 @@ TEST_F(DefaultRowReaderTest, ReadOneRow) {
   auto impl = std::make_shared<DefaultRowReader>(
       mock, kAppProfile, kTableName, bigtable::RowSet(),
       bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
-      false, retry_.clone(), backoff_.clone());
+      false, retry_.clone(), backoff_.clone(), false);
   auto reader = bigtable_internal::MakeRowReader(std::move(impl));
   EXPECT_THAT(StatusOrRowKeys(reader), ElementsAre(IsOkAndHolds("r1")));
 }
@@ -188,7 +188,7 @@ TEST_F(DefaultRowReaderTest, StreamIsDrained) {
   auto impl = std::make_shared<DefaultRowReader>(
       mock, kAppProfile, kTableName, bigtable::RowSet(),
       bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
-      false, retry_.clone(), backoff_.clone());
+      false, retry_.clone(), backoff_.clone(), false);
   auto reader = bigtable_internal::MakeRowReader(std::move(impl));
 
   auto it = reader.begin();
@@ -226,7 +226,7 @@ TEST_F(DefaultRowReaderTest, RetryThenSuccess) {
   auto impl = std::make_shared<DefaultRowReader>(
       mock, kAppProfile, kTableName, bigtable::RowSet(),
       bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
-      false, retry_.clone(), backoff_.clone());
+      false, retry_.clone(), backoff_.clone(), false);
   auto reader = bigtable_internal::MakeRowReader(std::move(impl));
   EXPECT_THAT(StatusOrRowKeys(reader), ElementsAre(IsOkAndHolds("r1")));
 }
@@ -248,7 +248,7 @@ TEST_F(DefaultRowReaderTest, NoRetryOnPermanentError) {
   auto impl = std::make_shared<DefaultRowReader>(
       mock, kAppProfile, kTableName, bigtable::RowSet(),
       bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
-      false, retry_.clone(), backoff_.clone());
+      false, retry_.clone(), backoff_.clone(), false);
   auto reader = bigtable_internal::MakeRowReader(std::move(impl));
   EXPECT_THAT(StatusOrRowKeys(reader),
               ElementsAre(StatusIs(StatusCode::kPermissionDenied)));
@@ -275,13 +275,14 @@ TEST_F(DefaultRowReaderTest, RetryPolicyExhausted) {
       .Times(kNumRetries)
       .WillRepeatedly(Return(ms(10)));
 
-  MockFunction<void(std::chrono::milliseconds)> mock_sleeper;
+  MockFunction<void(ms)> mock_sleeper;
   EXPECT_CALL(mock_sleeper, Call(ms(10))).Times(kNumRetries);
 
   auto impl = std::make_shared<DefaultRowReader>(
       mock, kAppProfile, kTableName, bigtable::RowSet(),
       bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
-      false, retry_.clone(), std::move(backoff), mock_sleeper.AsStdFunction());
+      false, retry_.clone(), std::move(backoff), false,
+      mock_sleeper.AsStdFunction());
   auto reader = bigtable_internal::MakeRowReader(std::move(impl));
   EXPECT_THAT(StatusOrRowKeys(reader),
               ElementsAre(StatusIs(StatusCode::kUnavailable)));
@@ -316,7 +317,7 @@ TEST_F(DefaultRowReaderTest, RetrySkipsAlreadyReadRows) {
   auto impl = std::make_shared<DefaultRowReader>(
       mock, kAppProfile, kTableName, bigtable::RowSet("r1", "r2"),
       bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
-      false, retry_.clone(), backoff_.clone());
+      false, retry_.clone(), backoff_.clone(), false);
   auto reader = bigtable_internal::MakeRowReader(std::move(impl));
   EXPECT_THAT(StatusOrRowKeys(reader), ElementsAre(IsOkAndHolds("r1")));
 }
@@ -359,7 +360,7 @@ TEST_F(DefaultRowReaderTest, RetrySkipsAlreadyScannedRows) {
   auto impl = std::make_shared<DefaultRowReader>(
       mock, kAppProfile, kTableName, bigtable::RowSet("r1", "r2", "r3"),
       bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
-      false, retry_.clone(), backoff_.clone());
+      false, retry_.clone(), backoff_.clone(), false);
   auto reader = bigtable_internal::MakeRowReader(std::move(impl));
   EXPECT_THAT(StatusOrRowKeys(reader), ElementsAre(IsOkAndHolds("r1")));
 }
@@ -394,7 +395,7 @@ TEST_F(DefaultRowReaderTest, FailedParseIsRetried) {
   auto impl = std::make_shared<DefaultRowReader>(
       mock, kAppProfile, kTableName, bigtable::RowSet(),
       bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
-      false, std::move(retry), backoff_.clone());
+      false, std::move(retry), backoff_.clone(), false);
   auto reader = bigtable_internal::MakeRowReader(std::move(impl));
   EXPECT_THAT(StatusOrRowKeys(reader), ElementsAre(IsOkAndHolds("r1")));
 }
@@ -433,7 +434,7 @@ TEST_F(DefaultRowReaderTest, FailedParseSkipsAlreadyReadRows) {
   auto impl = std::make_shared<DefaultRowReader>(
       mock, kAppProfile, kTableName, bigtable::RowSet("r1", "r2"),
       bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
-      false, std::move(retry), backoff_.clone());
+      false, std::move(retry), backoff_.clone(), false);
   auto reader = bigtable_internal::MakeRowReader(std::move(impl));
   EXPECT_THAT(StatusOrRowKeys(reader), ElementsAre(IsOkAndHolds("r1")));
 }
@@ -481,7 +482,7 @@ TEST_F(DefaultRowReaderTest, FailedParseSkipsAlreadyScannedRows) {
   auto impl = std::make_shared<DefaultRowReader>(
       mock, kAppProfile, kTableName, bigtable::RowSet("r1", "r2", "r3"),
       bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
-      false, std::move(retry), backoff_.clone());
+      false, std::move(retry), backoff_.clone(), false);
   auto reader = bigtable_internal::MakeRowReader(std::move(impl));
   EXPECT_THAT(StatusOrRowKeys(reader), ElementsAre(IsOkAndHolds("r1")));
 }
@@ -506,7 +507,7 @@ TEST_F(DefaultRowReaderTest, FailedParseWithPermanentError) {
   auto impl = std::make_shared<DefaultRowReader>(
       mock, kAppProfile, kTableName, bigtable::RowSet(),
       bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
-      false, retry_.clone(), backoff_.clone());
+      false, retry_.clone(), backoff_.clone(), false);
   auto reader = bigtable_internal::MakeRowReader(std::move(impl));
   EXPECT_THAT(StatusOrRowKeys(reader),
               ElementsAre(StatusIs(StatusCode::kInternal)));
@@ -532,7 +533,7 @@ TEST_F(DefaultRowReaderTest, NoRetryOnEmptyRowSet) {
   auto impl = std::make_shared<DefaultRowReader>(
       mock, kAppProfile, kTableName, bigtable::RowSet("r1", "r2"),
       bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
-      false, retry_.clone(), backoff_.clone());
+      false, retry_.clone(), backoff_.clone(), false);
   auto reader = bigtable_internal::MakeRowReader(std::move(impl));
   EXPECT_THAT(StatusOrRowKeys(reader), ElementsAre(IsOkAndHolds("r2")));
 }
@@ -554,7 +555,7 @@ TEST_F(DefaultRowReaderTest, RowLimitIsSent) {
   auto impl = std::make_shared<DefaultRowReader>(
       mock, kAppProfile, kTableName, bigtable::RowSet(), 42,
       bigtable::Filter::PassAllFilter(), false, retry_.clone(),
-      backoff_.clone());
+      backoff_.clone(), false);
   auto reader = bigtable_internal::MakeRowReader(std::move(impl));
   EXPECT_THAT(StatusOrRowKeys(reader), IsEmpty());
 }
@@ -586,7 +587,7 @@ TEST_F(DefaultRowReaderTest, RowLimitIsDecreasedOnRetry) {
   auto impl = std::make_shared<DefaultRowReader>(
       mock, kAppProfile, kTableName, bigtable::RowSet(), 42,
       bigtable::Filter::PassAllFilter(), false, retry_.clone(),
-      backoff_.clone());
+      backoff_.clone(), false);
   auto reader = bigtable_internal::MakeRowReader(std::move(impl));
   EXPECT_THAT(StatusOrRowKeys(reader), ElementsAre(IsOkAndHolds("r1")));
 }
@@ -612,7 +613,7 @@ TEST_F(DefaultRowReaderTest, NoRetryIfRowLimitReached) {
   auto impl = std::make_shared<DefaultRowReader>(
       mock, kAppProfile, kTableName, bigtable::RowSet(), 1,
       bigtable::Filter::PassAllFilter(), false, retry_.clone(),
-      backoff_.clone());
+      backoff_.clone(), false);
   auto reader = bigtable_internal::MakeRowReader(std::move(impl));
   EXPECT_THAT(StatusOrRowKeys(reader), ElementsAre(IsOkAndHolds("r1")));
 }
@@ -639,7 +640,7 @@ TEST_F(DefaultRowReaderTest, CancelDrainsStream) {
   auto impl = std::make_shared<DefaultRowReader>(
       mock, kAppProfile, kTableName, bigtable::RowSet(),
       bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
-      false, retry_.clone(), backoff_.clone());
+      false, retry_.clone(), backoff_.clone(), false);
   auto reader = bigtable_internal::MakeRowReader(std::move(impl));
 
   auto it = reader.begin();
@@ -664,7 +665,7 @@ TEST_F(DefaultRowReaderTest, CancelBeforeBegin) {
   auto impl = std::make_shared<DefaultRowReader>(
       mock, kAppProfile, kTableName, bigtable::RowSet(),
       bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
-      false, retry_.clone(), backoff_.clone());
+      false, retry_.clone(), backoff_.clone(), false);
   auto reader = bigtable_internal::MakeRowReader(std::move(impl));
 
   // Manually cancel the call before a stream was created.
@@ -689,7 +690,7 @@ TEST_F(DefaultRowReaderTest, RowReaderConstructorDoesNotCallRpc) {
   auto impl = std::make_shared<DefaultRowReader>(
       mock, kAppProfile, kTableName, bigtable::RowSet(),
       bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
-      false, retry_.clone(), backoff_.clone());
+      false, retry_.clone(), backoff_.clone(), false);
   auto reader = bigtable_internal::MakeRowReader(std::move(impl));
 }
 
@@ -718,7 +719,7 @@ TEST_F(DefaultRowReaderTest, RetryUsesNewContext) {
   auto impl = std::make_shared<DefaultRowReader>(
       mock, kAppProfile, kTableName, bigtable::RowSet(),
       bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
-      false, retry_.clone(), backoff_.clone());
+      false, retry_.clone(), backoff_.clone(), false);
   auto reader = bigtable_internal::MakeRowReader(std::move(impl));
   EXPECT_THAT(StatusOrRowKeys(reader),
               ElementsAre(StatusIs(StatusCode::kUnavailable)));
@@ -745,7 +746,7 @@ TEST_F(DefaultRowReaderTest, ReverseScanSuccess) {
   auto impl = std::make_shared<DefaultRowReader>(
       mock, kAppProfile, kTableName, bigtable::RowSet(),
       bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
-      true, retry_.clone(), backoff_.clone());
+      true, retry_.clone(), backoff_.clone(), false);
   auto reader = bigtable_internal::MakeRowReader(std::move(impl));
   EXPECT_THAT(
       StatusOrRowKeys(reader),
@@ -773,7 +774,7 @@ TEST_F(DefaultRowReaderTest, ReverseScanFailsOnIncreasingRowKeyOrder) {
   auto impl = std::make_shared<DefaultRowReader>(
       mock, kAppProfile, kTableName, bigtable::RowSet(),
       bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
-      true, retry_.clone(), backoff_.clone());
+      true, retry_.clone(), backoff_.clone(), false);
   auto reader = bigtable_internal::MakeRowReader(std::move(impl));
   EXPECT_THAT(
       StatusOrRowKeys(reader),
@@ -821,7 +822,7 @@ TEST_F(DefaultRowReaderTest, ReverseScanResumption) {
   auto impl = std::make_shared<DefaultRowReader>(
       mock, kAppProfile, kTableName, bigtable::RowSet("r1", "r2", "r3"),
       bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
-      true, retry_.clone(), backoff_.clone());
+      true, retry_.clone(), backoff_.clone(), false);
   auto reader = bigtable_internal::MakeRowReader(std::move(impl));
   EXPECT_THAT(StatusOrRowKeys(reader), ElementsAre(IsOkAndHolds("r3")));
 }
@@ -854,10 +855,78 @@ TEST_F(DefaultRowReaderTest, BigtableCookies) {
   auto impl = std::make_shared<DefaultRowReader>(
       mock, kAppProfile, kTableName, bigtable::RowSet("r1"),
       bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
-      true, retry_.clone(), backoff_.clone());
+      true, retry_.clone(), backoff_.clone(), false);
   auto reader = bigtable_internal::MakeRowReader(std::move(impl));
   EXPECT_THAT(StatusOrRowKeys(reader),
               ElementsAre(StatusIs(StatusCode::kPermissionDenied)));
+}
+
+TEST_F(DefaultRowReaderTest, RetryInfoHeeded) {
+  auto const delay = ms(std::chrono::minutes(5));
+  auto mock = std::make_shared<MockBigtableStub>();
+  EXPECT_CALL(*mock, ReadRows)
+      .WillOnce([delay](auto, auto const&,
+                        google::bigtable::v2::ReadRowsRequest const&) {
+        auto stream = std::make_unique<MockReadRowsStream>();
+        EXPECT_CALL(*stream, Read).WillOnce([delay] {
+          auto s = internal::ResourceExhaustedError("try again");
+          internal::SetRetryInfo(s, internal::RetryInfo{delay});
+          return s;
+        });
+        return stream;
+      })
+      .WillOnce([](auto, auto const&,
+                   google::bigtable::v2::ReadRowsRequest const& request) {
+        EXPECT_THAT(request, HasCorrectResourceNames());
+        auto stream = std::make_unique<MockReadRowsStream>();
+        EXPECT_CALL(*stream, Read)
+            .WillOnce(Return(MakeRow("r1")))
+            .WillOnce(Return(Status()));
+        return stream;
+      });
+
+  MockFunction<void(ms)> mock_sleeper;
+  EXPECT_CALL(mock_sleeper, Call(delay));
+
+  internal::OptionsSpan span(TestOptions(/*expected_streams=*/2));
+
+  auto impl = std::make_shared<DefaultRowReader>(
+      mock, kAppProfile, kTableName, bigtable::RowSet(),
+      bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
+      false, retry_.clone(), backoff_.clone(), true,
+      mock_sleeper.AsStdFunction());
+  auto reader = bigtable_internal::MakeRowReader(std::move(impl));
+  EXPECT_THAT(StatusOrRowKeys(reader), ElementsAre(IsOkAndHolds("r1")));
+}
+
+TEST_F(DefaultRowReaderTest, RetryInfoIgnored) {
+  auto const delay = ms(std::chrono::minutes(5));
+  auto mock = std::make_shared<MockBigtableStub>();
+  EXPECT_CALL(*mock, ReadRows)
+      .WillOnce([delay](auto, auto const&,
+                        google::bigtable::v2::ReadRowsRequest const&) {
+        auto stream = std::make_unique<MockReadRowsStream>();
+        EXPECT_CALL(*stream, Read).WillOnce([delay] {
+          auto s = internal::ResourceExhaustedError("try again");
+          internal::SetRetryInfo(s, internal::RetryInfo{delay});
+          return s;
+        });
+        return stream;
+      });
+
+  MockFunction<void(ms)> mock_sleeper;
+  EXPECT_CALL(mock_sleeper, Call).Times(0);
+
+  internal::OptionsSpan span(TestOptions(/*expected_streams=*/1));
+
+  auto impl = std::make_shared<DefaultRowReader>(
+      mock, kAppProfile, kTableName, bigtable::RowSet(),
+      bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
+      false, retry_.clone(), backoff_.clone(), false,
+      mock_sleeper.AsStdFunction());
+  auto reader = bigtable_internal::MakeRowReader(std::move(impl));
+  EXPECT_THAT(StatusOrRowKeys(reader),
+              ElementsAre(StatusIs(StatusCode::kResourceExhausted)));
 }
 
 }  // namespace


### PR DESCRIPTION
Part of the work for #13514 

We do not need to test all of the `RetryInfo` logic. That is done in `internal/retry_info_helper_test.cc`. We test enough to ensure that `bigtable_internal::BackoffOrBreak(...)` is called.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13536)
<!-- Reviewable:end -->
