### PR TITLE
fix(pubsub): install admin mocks

### DIFF
--- a/cmake/GoogleCloudCppCommon.cmake
+++ b/cmake/GoogleCloudCppCommon.cmake
@@ -47,6 +47,11 @@ function (google_cloud_cpp_install_headers target destination)
         get_target_property(target_sources ${target} SOURCES)
     endif ()
     foreach (header ${target_sources})
+        # Sometimes we use generator expressions for the headers.
+        string(REPLACE "$<BUILD_INTERFACE:" "" header "${header}")
+        string(REPLACE ">" "" header "${header}")
+
+        # Only install headers.
         if (NOT "${header}" MATCHES "\\.h$" AND NOT "${header}" MATCHES
                                                 "\\.inc$")
             continue()

--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -519,14 +519,8 @@ install(
     TARGETS google_cloud_cpp_pubsub_mocks
     EXPORT pubsub_mocks-targets
     COMPONENT google_cloud_cpp_development)
-install(
-    FILES ${google_cloud_cpp_pubsub_mocks_hdrs}
-    DESTINATION "include/google/cloud/pubsub/mocks"
-    COMPONENT google_cloud_cpp_development)
-install(
-    FILES ${google_cloud_cpp_pubsub_mocks_hdrs}
-    DESTINATION "include/google/cloud/pubsub/admin/mocks"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_install_headers(google_cloud_cpp_pubsub_mocks
+                                 "include/google/cloud/pubsub")
 
 google_cloud_cpp_add_pkgconfig(
     pubsub


### PR DESCRIPTION
Part of the work for #5782 

We were copying all of the mock files into both `include/google/cloud/pubsub/mocks` and `include/google/cloud/pubsub/admin/mocks`, without preserving the relative directory structure.

The handwritten and generated admin mock files have the same name, so I think we would first install the generated admin mocks (because they were first in the list), then we would overwrite them with the handwritten admin mocks.

Before:

```
docker:fedora-latest-cmake$ ls /h/google-cloud-cpp-installed/include/google/cloud/pubsub/mocks
mock_ack_handler.h		      mock_publisher_connection.h  mock_subscriber_connection.h
mock_blocking_publisher_connection.h  mock_pull_ack_handler.h	   mock_subscription_admin_connection.h
mock_exactly_once_ack_handler.h       mock_schema_connection.h	   mock_topic_admin_connection.h
docker:fedora-latest-cmake$ head -1 /h/google-cloud-cpp-installed/include/google/cloud/pubsub/mocks/mock_topic_admin_connection.h 
// Copyright 2020 Google LLC

docker:fedora-latest-cmake$ ls /h/google-cloud-cpp-installed/include/google/cloud/pubsub/admin/mocks
mock_ack_handler.h		      mock_publisher_connection.h  mock_subscriber_connection.h
mock_blocking_publisher_connection.h  mock_pull_ack_handler.h	   mock_subscription_admin_connection.h
mock_exactly_once_ack_handler.h       mock_schema_connection.h	   mock_topic_admin_connection.h
docker:fedora-latest-cmake$ head -1 /h/google-cloud-cpp-installed/include/google/cloud/pubsub/admin/mocks/mock_topic_admin_connection.h 
// Copyright 2020 Google LLC
```

After:

```
docker:fedora-latest-cmake$ ls /h/google-cloud-cpp-installed/include/google/cloud/pubsub/mocks
mock_ack_handler.h		      mock_publisher_connection.h  mock_subscriber_connection.h
mock_blocking_publisher_connection.h  mock_pull_ack_handler.h	   mock_subscription_admin_connection.h
mock_exactly_once_ack_handler.h       mock_schema_connection.h	   mock_topic_admin_connection.h
docker:fedora-latest-cmake$ head -1 /h/google-cloud-cpp-installed/include/google/cloud/pubsub/mocks/mock_topic_admin_connection.h 
// Copyright 2020 Google LLC

docker:fedora-latest-cmake$ ls /h/google-cloud-cpp-installed/include/google/cloud/pubsub/admin/mocks
mock_subscription_admin_connection.h  mock_topic_admin_connection.h
docker:fedora-latest-cmake$ head -1 /h/google-cloud-cpp-installed/include/google/cloud/pubsub/admin/mocks/mock_topic_admin_connection.h 
// Copyright 2023 Google LLC
```

---

Note that we are going to need to use the `$<BUILD_INTERFACE:...>` generator expression in order to install our other mocks too.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13537)
<!-- Reviewable:end -->
