### PR TITLE
cleanup: add date to latest release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ breaking changes in the upcoming 3.x release. This release is scheduled for
 
 ## v2.22.0 - TBD
 
-## v2.21.0
+## v2.21.0 - 2024-02
 
 ### New Libraries
 


### PR DESCRIPTION
As @scotthart points out, I forgot to include the YYYY-MM for the v2.21.0 changes.

https://github.com/googleapis/google-cloud-cpp/pull/13540#pullrequestreview-1857481598

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13543)
<!-- Reviewable:end -->
