### PR TITLE
refactor: helper to install mocks in cmake

### DIFF
--- a/cmake/GoogleCloudCppCommon.cmake
+++ b/cmake/GoogleCloudCppCommon.cmake
@@ -153,3 +153,45 @@ endfunction ()
 function (google_cloud_cpp_add_samples library)
     google_cloud_cpp_add_samples_relative("${library}" "")
 endfunction ()
+
+# Install headers, export target, and add a package config file for a `*_mocks`
+# library.
+#
+# Parameters:
+#
+# * library:      e.g. pubsub
+# * display_name: e.g. "Cloud Pub/Sub"
+function (google_cloud_cpp_install_mocks library display_name)
+    set(library_target "google_cloud_cpp_${library}")
+    set(mocks_target "google_cloud_cpp_${library}_mocks")
+    install(
+        EXPORT ${mocks_target}-targets
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${mocks_target}"
+        COMPONENT google_cloud_cpp_development)
+    install(
+        TARGETS ${mocks_target}
+        EXPORT ${mocks_target}-targets
+        COMPONENT google_cloud_cpp_development)
+
+    google_cloud_cpp_install_headers("${mocks_target}"
+                                     "include/google/cloud/${library}")
+
+    google_cloud_cpp_add_pkgconfig(
+        ${library}_mocks "${display_name} Mocks"
+        "Mocks for the ${display_name} C++ Client Library" "${library_target}"
+        "gmock_main")
+
+    set(GOOGLE_CLOUD_CPP_CONFIG_LIBRARY "${library_target}")
+    configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/mocks-config.cmake.in"
+                   "${mocks_target}-config.cmake" @ONLY)
+    write_basic_package_version_file(
+        "${mocks_target}-config-version.cmake"
+        VERSION ${PROJECT_VERSION}
+        COMPATIBILITY ExactVersion)
+
+    install(
+        FILES "${CMAKE_CURRENT_BINARY_DIR}/${mocks_target}-config.cmake"
+              "${CMAKE_CURRENT_BINARY_DIR}/${mocks_target}-config-version.cmake"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${mocks_target}"
+        COMPONENT google_cloud_cpp_development)
+endfunction ()

--- a/cmake/GoogleCloudCppLibrary.cmake
+++ b/cmake/GoogleCloudCppLibrary.cmake
@@ -349,36 +349,7 @@ function (google_cloud_cpp_add_gapic_library library display_name)
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${library_target}"
         COMPONENT google_cloud_cpp_development)
 
-    # Install mocks
-    install(
-        EXPORT ${mocks_target}-targets
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${mocks_target}"
-        COMPONENT google_cloud_cpp_development)
-    install(
-        TARGETS ${mocks_target}
-        EXPORT ${mocks_target}-targets
-        COMPONENT google_cloud_cpp_development)
-
-    google_cloud_cpp_install_headers("${mocks_target}"
-                                     "include/google/cloud/${library}")
-
-    google_cloud_cpp_add_pkgconfig(
-        ${library}_mocks "${display_name} Mocks"
-        "Mocks for the ${display_name} C++ Client Library" "${library_target}"
-        "gmock_main")
-
-    configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/mocks-config.cmake.in"
-                   "${mocks_target}-config.cmake" @ONLY)
-    write_basic_package_version_file(
-        "${mocks_target}-config-version.cmake"
-        VERSION ${PROJECT_VERSION}
-        COMPATIBILITY ExactVersion)
-
-    install(
-        FILES "${CMAKE_CURRENT_BINARY_DIR}/${mocks_target}-config.cmake"
-              "${CMAKE_CURRENT_BINARY_DIR}/${mocks_target}-config-version.cmake"
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${mocks_target}"
-        COMPONENT google_cloud_cpp_development)
+    google_cloud_cpp_install_mocks("${library}" "${display_name}")
 
     # ${library_alias} must be defined before we can add the samples.
     if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)

--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -510,17 +510,6 @@ install(
 
 google_cloud_cpp_install_headers("google_cloud_cpp_pubsub"
                                  "include/google/cloud/pubsub")
-# Export the CMake targets to make it easy to create configuration files.
-install(
-    EXPORT pubsub_mocks-targets
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_pubsub_mocks"
-    COMPONENT google_cloud_cpp_development)
-install(
-    TARGETS google_cloud_cpp_pubsub_mocks
-    EXPORT pubsub_mocks-targets
-    COMPONENT google_cloud_cpp_development)
-google_cloud_cpp_install_headers(google_cloud_cpp_pubsub_mocks
-                                 "include/google/cloud/pubsub")
 
 google_cloud_cpp_add_pkgconfig(
     pubsub
@@ -548,22 +537,4 @@ install(
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_pubsub"
     COMPONENT google_cloud_cpp_development)
 
-google_cloud_cpp_add_pkgconfig(
-    pubsub_mocks "Google Cloud C++ Pub/Sub Mocks"
-    "Mocks for the Google Cloud Pub/Sub C++ Client Library"
-    "google_cloud_cpp_pubsub" " gmock_main")
-
-# Create and install the CMake configuration files.
-configure_file("mocks-config.cmake.in"
-               "google_cloud_cpp_pubsub_mocks-config.cmake" @ONLY)
-write_basic_package_version_file(
-    "google_cloud_cpp_pubsub_mocks-config-version.cmake"
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY ExactVersion)
-
-install(
-    FILES
-        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_pubsub_mocks-config.cmake"
-        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_pubsub_mocks-config-version.cmake"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_pubsub_mocks"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_install_mocks(pubsub "Google Cloud Pub/Sub")


### PR DESCRIPTION
Motivated by #5782 

This helper will be convenient for when we deal with the remaining handwritten libs. They will look like `pubsub`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13545)
<!-- Reviewable:end -->
