### PR TITLE
impl: add `EnableServerRetriesOption`

### DIFF
--- a/google/cloud/bigtable/internal/defaults.cc
+++ b/google/cloud/bigtable/internal/defaults.cc
@@ -246,6 +246,9 @@ Options DefaultDataOptions(Options opts) {
     opts.set<bigtable::IdempotentMutationPolicyOption>(
         bigtable::DefaultIdempotentMutationPolicy());
   }
+  if (!opts.has<google::cloud::internal::EnableServerRetriesOption>()) {
+    opts.set<google::cloud::internal::EnableServerRetriesOption>(true);
+  }
   opts = DefaultOptions(std::move(opts));
   return opts.set<EndpointOption>(opts.get<DataEndpointOption>());
 }

--- a/google/cloud/bigtable/internal/defaults_test.cc
+++ b/google/cloud/bigtable/internal/defaults_test.cc
@@ -217,6 +217,15 @@ TEST(OptionsTest, DataAuthorityOption) {
   EXPECT_EQ(options.get<AuthorityOption>(), "custom-endpoint.googleapis.com");
 }
 
+TEST(OptionsTest, DataEnableServerRetriesOption) {
+  using ::google::cloud::internal::EnableServerRetriesOption;
+  auto options = DefaultDataOptions(Options{});
+  EXPECT_TRUE(options.get<EnableServerRetriesOption>());
+
+  options = DefaultDataOptions(Options{}.set<EnableServerRetriesOption>(false));
+  EXPECT_FALSE(options.get<EnableServerRetriesOption>());
+}
+
 TEST(OptionsTest, UniverseDomain) {
   auto options =
       Options{}.set<google::cloud::internal::UniverseDomainOption>("ud.net");

--- a/google/cloud/grpc_options.h
+++ b/google/cloud/grpc_options.h
@@ -229,6 +229,24 @@ struct GrpcSetupPollOption {
   using Type = std::function<void(grpc::ClientContext&)>;
 };
 
+/**
+ * Let the server make retry decisions, when applicable.
+ *
+ * In some cases the server knows how to handle retry behavior better than the
+ * client. For example, if a server-side resource is exhausted and the server
+ * knows when it will come back online, it can tell the client exactly when to
+ * retry.
+ *
+ * If this option is enabled, any supplied retry, backoff, or idempotency
+ * policies may be overridden by a recommendation from the server.
+ *
+ * For example, the server may know it is safe to retry a non-idempotent
+ * request, or safe to retry a status code that is typically a permanent error.
+ */
+struct EnableServerRetriesOption {
+  using Type = bool;
+};
+
 /// Configure the ClientContext using options.
 void ConfigureContext(grpc::ClientContext& context, Options const& opts);
 


### PR DESCRIPTION
Part of the work for #13514 

Add `EnableServerRetriesOption`, an option that tells the client to use the server's recommendation if the server returns a `RetryInfo` in the error details.

Add the option now in `grpc_utils` (where I expect it will belong), but in an internal namespace. This unblocks other work that needs to happen regardless of where the option ends up.

Default this option to true in bigtable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13547)
<!-- Reviewable:end -->
