### PR TITLE
cleanup(pubsub): delete topics older than 3 days

### DIFF
--- a/google/cloud/pubsub/samples/topic_admin_samples.cc
+++ b/google/cloud/pubsub/samples/topic_admin_samples.cc
@@ -35,15 +35,28 @@ using TopicAdminCommand =
 // delete call might fail.
 void CleanupTopics(
     google::cloud::pubsub_admin::TopicAdminClient& topic_admin_client,
-    std::string const& project_id) {
+    std::string const& project_id, absl::Time time_now) {
+  std::cout << "Cleaning up old topics...\n";
   auto const parent = google::cloud::Project(project_id).FullName();
   for (auto& topic : topic_admin_client.ListTopics(parent)) {
     if (!topic) continue;
-    if (!absl::StrContains(topic->name(), "cloud-cpp-samples")) continue;
+    auto topic_name = topic->name();
+    std::string keyword = "cloud-cpp-samples";
+    if (!absl::StrContains(topic->name(), keyword)) continue;
+    // Extract the date from the resource name which is in the format
+    // `*-cloud-cpp-samples-YYYY-MM-DD-`.
+    auto date =
+        topic_name.substr(topic_name.find(keyword) + keyword.size() + 1, 10);
 
-    google::pubsub::v1::DeleteTopicRequest request;
-    request.set_topic(topic->name());
-    (void)topic_admin_client.DeleteTopic(request);
+    absl::TimeZone nyc;
+    if (!absl::LoadTimeZone("America/New_York", &nyc)) continue;
+    absl::CivilDay day;
+    if (absl::ParseCivilTime(date, &day) &&
+        absl::FromCivil(day, nyc) < time_now - absl::Hours(36)) {
+      google::pubsub::v1::DeleteTopicRequest request;
+      request.set_topic(topic->name());
+      (void)topic_admin_client.DeleteTopic(request);
+    }
   }
 }
 
@@ -269,8 +282,9 @@ void AutoRun(std::vector<std::string> const& argv) {
       subscription_admin_client(
           google::cloud::pubsub_admin::MakeSubscriptionAdminConnection());
 
-  // Delete old resources.
-  CleanupTopics(topic_admin_client, project_id);
+  // Delete resources over 3 days old.
+  CleanupTopics(topic_admin_client, project_id,
+                absl::FromChrono(std::chrono::system_clock::now()));
 
   std::cout << "\nRunning CreateTopic() sample [1]" << std::endl;
   CreateTopic(topic_admin_client, {project_id, topic_id});

--- a/google/cloud/pubsub/samples/topic_admin_samples.cc
+++ b/google/cloud/pubsub/samples/topic_admin_samples.cc
@@ -30,7 +30,7 @@ using TopicAdminCommand =
     std::function<void(::google::cloud::pubsub_admin::TopicAdminClient,
                        std::vector<std::string> const&)>;
 
-// Delete all topics created with that inclue "cloud-cpp-samples". Ignore any
+// Delete all topics created with that include "cloud-cpp-samples". Ignore any
 // failures. If multiple tests are cleaning up topics in parallel, then the
 // delete call might fail.
 void CleanupTopics(
@@ -237,7 +237,7 @@ void AutoRun(std::vector<std::string> const& argv) {
   using ::google::cloud::pubsub::examples::RandomSubscriptionId;
   using ::google::cloud::pubsub::examples::RandomTopicId;
   using ::google::cloud::pubsub::examples::UsingEmulator;
- 
+
   if (!argv.empty()) throw examples::Usage{"auto"};
   examples::CheckEnvironmentVariablesAreSet({"GOOGLE_CLOUD_PROJECT"});
   auto project_id =
@@ -271,7 +271,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 
   // Delete old resources.
   CleanupTopics(topic_admin_client, project_id);
-  
+
   std::cout << "\nRunning CreateTopic() sample [1]" << std::endl;
   CreateTopic(topic_admin_client, {project_id, topic_id});
   std::cout << "\nCreate topic (" << topic_id << ")" << std::endl;


### PR DESCRIPTION
Ran once, went from 180 topics -> 40. 

I think we might be able to delete some more (cloud-cpp) too, but I will check with someone before adding that

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13556)
<!-- Reviewable:end -->
