### PR TITLE
cleanup(pubsub): delete old subs

### DIFF
--- a/google/cloud/pubsub/samples/subscription_admin_samples.cc
+++ b/google/cloud/pubsub/samples/subscription_admin_samples.cc
@@ -54,9 +54,9 @@ CreateSubscriptionAdminCommand(std::string const& name,
                                                            std::move(adapter)};
 }
 
-// Delete all subscriptions created with that include "cloud-cpp-samples". Ignore any
-// failures. If multiple tests are cleaning up subscriptions in parallel, then the
-// delete call might fail.
+// Delete all subscriptions created with that include "cloud-cpp-samples".
+// Ignore any failures. If multiple tests are cleaning up subscriptions in
+// parallel, then the delete call might fail.
 void CleanupSubscriptions(
     google::cloud::pubsub_admin::SubscriptionAdminClient& client,
     std::string const& project_id) {

--- a/google/cloud/pubsub/samples/subscription_admin_samples.cc
+++ b/google/cloud/pubsub/samples/subscription_admin_samples.cc
@@ -63,13 +63,12 @@ void CleanupSubscriptions(
   for (auto const& subscription : client.ListSubscriptions(
            google::cloud::Project(project_id).FullName())) {
     if (!subscription) continue;
-    std::string const keyword = "cloud-cpp-samples";
-    if (!absl::StrContains(subscription->name(), keyword)) continue;
+    std::string const keyword = "cloud-cpp-samples-";
+    auto iter = subscription->name().find(keyword);
+    if (iter == std::string::npos) continue;
     // Extract the date from the resource name which is in the format
     // `*-cloud-cpp-samples-YYYY-MM-DD-`.
-    auto date = subscription->name().substr(
-        subscription->name().find(keyword) + keyword.size() + 1, 10);
-
+    auto date = subscription->name().substr(iter + keyword.size(), 10);
     absl::CivilDay day;
     if (absl::ParseCivilTime(date, &day) &&
         absl::FromCivil(day, absl::UTCTimeZone()) <
@@ -438,7 +437,7 @@ void AutoRun(std::vector<std::string> const& argv) {
         }
       };
 
-  // Delete subscriptions over 3 days old.
+  // Delete subscriptions over 36 hours old.
   CleanupSubscriptions(subscription_admin_client, project_id,
                        absl::FromChrono(std::chrono::system_clock::now()));
 

--- a/google/cloud/pubsub/testing/random_names.cc
+++ b/google/cloud/pubsub/testing/random_names.cc
@@ -42,11 +42,13 @@ std::string RandomSubscriptionId(
   // our tests 32 characters is long enough.
   //    https://cloud.google.com/pubsub/docs/admin#resource_names
   auto constexpr kMaxRandomSubscriptionSuffixLength = 32;
+  auto now = std::chrono::system_clock::now();
+  std::string date = google::cloud::internal::FormatUtcDate(now);
   auto suffix = google::cloud::internal::Sample(
       generator, kMaxRandomSubscriptionSuffixLength,
       "abcdefghijklmnopqrstuvwxyz");
   auto p = prefix.empty() ? "cloud-cpp" : prefix;
-  return p + "-" + suffix;
+  return p + "-" + date + "-" + suffix;
 }
 
 std::string RandomSnapshotId(google::cloud::internal::DefaultPRNG& generator,


### PR DESCRIPTION
Went from 240 subs -> 14.

I think this is good since Pub/Sub is also charging for outstanding message storage. Now if our builds fail, the next one will delete the resource

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13557)
<!-- Reviewable:end -->
