### PR TITLE
impl(bigtable): heed `RetryInfo` in `ReadRows()`

### DIFF
--- a/google/cloud/bigtable/internal/data_connection_impl.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl.cc
@@ -202,8 +202,7 @@ bigtable::RowReader DataConnectionImpl::ReadRowsFull(
       stub_, std::move(params.app_profile_id), std::move(params.table_name),
       std::move(params.row_set), params.rows_limit, std::move(params.filter),
       params.reverse, retry_policy(*current), backoff_policy(*current),
-      // TODO(#13514) - use Option value.
-      false);
+      enable_server_retries(*current));
   return MakeRowReader(std::move(impl));
 }
 

--- a/google/cloud/bigtable/internal/default_row_reader.h
+++ b/google/cloud/bigtable/internal/default_row_reader.h
@@ -53,7 +53,7 @@ class DefaultRowReader : public RowReaderImpl {
       std::string table_name, bigtable::RowSet row_set, std::int64_t rows_limit,
       bigtable::Filter filter, bool reverse,
       std::unique_ptr<bigtable::DataRetryPolicy> retry_policy,
-      std::unique_ptr<BackoffPolicy> backoff_policy, bool use_server_retry_info,
+      std::unique_ptr<BackoffPolicy> backoff_policy, bool enable_server_retries,
       Sleeper sleeper = [](auto d) { std::this_thread::sleep_for(d); });
 
   ~DefaultRowReader() override;
@@ -99,7 +99,7 @@ class DefaultRowReader : public RowReaderImpl {
   bool reverse_;
   std::unique_ptr<bigtable::DataRetryPolicy> retry_policy_;
   std::unique_ptr<BackoffPolicy> backoff_policy_;
-  bool use_server_retry_info_;
+  bool enable_server_retries_;
   Sleeper sleeper_;
   std::shared_ptr<grpc::ClientContext> context_;
   RetryContext retry_context_;


### PR DESCRIPTION
Part of the work for #13514 

Heed the `EnableServerRetriesOption` in `ReadRows`. Also rename the member variable used by `DefaultRowReader` to match the option name.

It may not look like it, but there is thinking involved here! We could have added a `bool enable_server_retries_` to the `ReadRowsParams` struct.

I do not think we should do that because:
- the struct should only contain parameters specific to `ReadRows()`
- `EnableServerRetriesOption` applies to all RPCs
- it is more like an extension of the retry/backoff policy options which we do not include in the struct.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13565)
<!-- Reviewable:end -->
