### PR TITLE
refactor(bigtable): no `CurrentOptions` in `BulkMutator`

### DIFF
--- a/google/cloud/bigtable/internal/bulk_mutator.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator.cc
@@ -204,12 +204,12 @@ grpc::Status BulkMutator::MakeOneRequest(bigtable::DataClient& client,
 }
 
 Status BulkMutator::MakeOneRequest(BigtableStub& stub,
-                                   MutateRowsLimiter& limiter) {
+                                   MutateRowsLimiter& limiter,
+                                   Options const& options) {
   // Send the request to the server.
   auto const& mutations = state_.BeforeStart();
 
   // Configure the context
-  auto const& options = google::cloud::internal::CurrentOptions();
   auto context = std::make_shared<grpc::ClientContext>();
   google::cloud::internal::ConfigureContext(*context, options);
   retry_context_.PreCall(*context);

--- a/google/cloud/bigtable/internal/bulk_mutator.h
+++ b/google/cloud/bigtable/internal/bulk_mutator.h
@@ -127,7 +127,8 @@ class BulkMutator {
                               grpc::ClientContext& client_context);
 
   /// Synchronously send one batch request to the given stub.
-  Status MakeOneRequest(BigtableStub& stub, MutateRowsLimiter& limiter);
+  Status MakeOneRequest(BigtableStub& stub, MutateRowsLimiter& limiter,
+                        Options const& options);
 
   /// Give up on any pending mutations, move them to the failures array.
   std::vector<bigtable::FailedMutation> OnRetryDone() &&;

--- a/google/cloud/bigtable/internal/data_connection_impl.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl.cc
@@ -174,7 +174,7 @@ std::vector<bigtable::FailedMutation> DataConnectionImpl::BulkApply(
   std::unique_ptr<bigtable::DataRetryPolicy> retry;
   std::unique_ptr<BackoffPolicy> backoff;
   while (true) {
-    auto status = mutator.MakeOneRequest(*stub_, *limiter_);
+    auto status = mutator.MakeOneRequest(*stub_, *limiter_, *current);
     if (!mutator.HasPendingMutations()) break;
     if (!retry) retry = retry_policy(*current);
     if (!retry->OnFailure(status)) break;


### PR DESCRIPTION
Related to #12359

Prefer to pass `Options` explicitly vs. accessing the `CurrentOptions()` in `BulkMutator`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13566)
<!-- Reviewable:end -->
