### PR TITLE
impl(bigtable): heed `RetryInfo` in `AsyncSampleRows`

### DIFF
--- a/google/cloud/bigtable/internal/async_row_sampler.h
+++ b/google/cloud/bigtable/internal/async_row_sampler.h
@@ -41,14 +41,14 @@ class AsyncRowSampler : public std::enable_shared_from_this<AsyncRowSampler> {
   static future<StatusOr<std::vector<bigtable::RowKeySample>>> Create(
       CompletionQueue cq, std::shared_ptr<BigtableStub> stub,
       std::unique_ptr<bigtable::DataRetryPolicy> retry_policy,
-      std::unique_ptr<BackoffPolicy> backoff_policy,
+      std::unique_ptr<BackoffPolicy> backoff_policy, bool enable_server_retries,
       std::string const& app_profile_id, std::string const& table_name);
 
  private:
   AsyncRowSampler(CompletionQueue cq, std::shared_ptr<BigtableStub> stub,
                   std::unique_ptr<bigtable::DataRetryPolicy> retry_policy,
                   std::unique_ptr<BackoffPolicy> backoff_policy,
-                  std::string const& app_profile_id,
+                  bool enable_server_retries, std::string const& app_profile_id,
                   std::string const& table_name);
 
   void StartIteration();
@@ -59,6 +59,7 @@ class AsyncRowSampler : public std::enable_shared_from_this<AsyncRowSampler> {
   std::shared_ptr<BigtableStub> stub_;
   std::unique_ptr<bigtable::DataRetryPolicy> retry_policy_;
   std::unique_ptr<BackoffPolicy> backoff_policy_;
+  bool enable_server_retries_;
   std::string app_profile_id_;
   std::string table_name_;
 

--- a/google/cloud/bigtable/internal/data_connection_impl.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl.cc
@@ -376,7 +376,8 @@ DataConnectionImpl::AsyncSampleRows(std::string const& table_name) {
   auto current = google::cloud::internal::SaveCurrentOptions();
   return AsyncRowSampler::Create(
       background_->cq(), stub_, retry_policy(*current),
-      backoff_policy(*current), app_profile_id(*current), table_name);
+      backoff_policy(*current), enable_server_retries(*current),
+      app_profile_id(*current), table_name);
 }
 
 StatusOr<bigtable::Row> DataConnectionImpl::ReadModifyWriteRow(


### PR DESCRIPTION
Part of the work for #13514 

I decided I don't feel like testing `enable_server_retries(*current)` in the `DataConnectionImpl`, in the same way we don't bother testing `retry_policy(*current)`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13568)
<!-- Reviewable:end -->
