### PR TITLE
cleanup: fix buildifier lints

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("//bazel:library_names.bzl", "hdrs_filegroup_name", "library_dir_name", "mocks_filegroup_name")
+load(":libraries.bzl", "GOOGLE_CLOUD_CPP_EXPERIMENTAL_LIBRARIES", "GOOGLE_CLOUD_CPP_GA_LIBRARIES", "GOOGLE_CLOUD_CPP_TRANSITION_LIBRARIES")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
@@ -19,10 +23,6 @@ licenses(["notice"])  # Apache 2.0
 exports_files([
     "LICENSE",
 ])
-
-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
-load("//bazel:library_names.bzl", "hdrs_filegroup_name", "library_dir_name", "mocks_filegroup_name")
-load(":libraries.bzl", "GOOGLE_CLOUD_CPP_EXPERIMENTAL_LIBRARIES", "GOOGLE_CLOUD_CPP_GA_LIBRARIES", "GOOGLE_CLOUD_CPP_TRANSITION_LIBRARIES")
 
 EXPERIMENTAL_LIBRARIES = GOOGLE_CLOUD_CPP_EXPERIMENTAL_LIBRARIES
 

--- a/bazel/crc32c.BUILD
+++ b/bazel/crc32c.BUILD
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@bazel_skylib//lib:selects.bzl", "selects")
+load(":configure_template.bzl", "configure_template")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # BSD
-
-load(":configure_template.bzl", "configure_template")
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 crc32c_arm64_HDRS = [
     "src/crc32c_arm64.h",

--- a/bazel/curl.BUILD
+++ b/bazel/curl.BUILD
@@ -3,6 +3,8 @@
 # Description:
 #   curl is a tool for talking to web servers.
 
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+
 licenses(["notice"])  # MIT/X derivative license
 
 exports_files(["COPYING"])
@@ -156,6 +158,8 @@ cc_library(
     name = "curl",
     srcs = [
         "include/curl_config.h",
+        "lib/altsvc.c",
+        "lib/altsvc.h",
         "lib/amigaos.h",
         "lib/arpa_telnet.h",
         "lib/asyn.h",
@@ -179,6 +183,8 @@ cc_library(
         "lib/curl_endian.h",
         "lib/curl_fnmatch.c",
         "lib/curl_fnmatch.h",
+        "lib/curl_get_line.c",
+        "lib/curl_get_line.h",
         "lib/curl_gethostname.c",
         "lib/curl_gethostname.h",
         "lib/curl_gssapi.h",
@@ -208,6 +214,8 @@ cc_library(
         "lib/curl_threads.h",
         "lib/curlx.h",
         "lib/dict.h",
+        "lib/doh.c",
+        "lib/doh.h",
         "lib/dotdot.c",
         "lib/dotdot.h",
         "lib/easy.c",
@@ -276,16 +284,18 @@ cc_library(
         "lib/nwos.c",
         "lib/parsedate.c",
         "lib/parsedate.h",
-        "lib/pingpong.h",
         "lib/pingpong.c",
+        "lib/pingpong.h",
         "lib/pop3.h",
         "lib/progress.c",
         "lib/progress.h",
+        "lib/psl.c",
+        "lib/psl.h",
         "lib/quic.h",
         "lib/rand.c",
         "lib/rand.h",
-        "lib/rename.h",
         "lib/rename.c",
+        "lib/rename.h",
         "lib/rtsp.c",
         "lib/rtsp.h",
         "lib/security.c",
@@ -306,8 +316,8 @@ cc_library(
         "lib/smb.h",
         "lib/smtp.h",
         "lib/sockaddr.h",
-        "lib/socketpair.h",
         "lib/socketpair.c",
+        "lib/socketpair.h",
         "lib/socks.c",
         "lib/socks.h",
         "lib/speedcheck.c",
@@ -333,6 +343,8 @@ cc_library(
         "lib/transfer.h",
         "lib/url.c",
         "lib/url.h",
+        "lib/urlapi.c",
+        "lib/urlapi-int.h",
         "lib/urldata.h",
         "lib/vauth/cleartext.c",
         "lib/vauth/cram.c",
@@ -348,9 +360,12 @@ cc_library(
         "lib/vtls/gskit.h",
         "lib/vtls/gtls.h",
         "lib/vtls/mbedtls.h",
+        "lib/vtls/mesalink.c",
+        "lib/vtls/mesalink.h",
         "lib/vtls/nssg.h",
         "lib/vtls/openssl.h",
         "lib/vtls/schannel.h",
+        "lib/vtls/sectransp.h",
         "lib/vtls/vtls.c",
         "lib/vtls/vtls.h",
         "lib/vtls/wolfssl.h",
@@ -359,19 +374,6 @@ cc_library(
         "lib/wildcard.c",
         "lib/wildcard.h",
         "lib/x509asn1.h",
-        "lib/psl.h",
-        "lib/psl.c",
-        "lib/vtls/sectransp.h",
-        "lib/vtls/mesalink.h",
-        "lib/vtls/mesalink.c",
-        "lib/curl_get_line.h",
-        "lib/curl_get_line.c",
-        "lib/urlapi-int.h",
-        "lib/urlapi.c",
-        "lib/altsvc.h",
-        "lib/altsvc.c",
-        "lib/doh.h",
-        "lib/doh.c",
     ] + select({
         ":macos": [
             "lib/vtls/sectransp.c",
@@ -453,8 +455,6 @@ cc_library(
         ],
     }),
 )
-
-load("@bazel_skylib//rules:write_file.bzl", "write_file")
 
 write_file(
     name = "configure",

--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -14,10 +14,8 @@
 
 """Load dependencies needed to compile and test the google-cloud-cpp library."""
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load("//bazel:workspace0.bzl", "gl_cpp_workspace0")
 load("//bazel:development0.bzl", "gl_cpp_development0")
+load("//bazel:workspace0.bzl", "gl_cpp_workspace0")
 
 google_cloud_cpp_development_deps = gl_cpp_development0
 google_cloud_cpp_deps = gl_cpp_workspace0

--- a/bazel/workspace2.bzl
+++ b/bazel/workspace2.bzl
@@ -14,13 +14,13 @@
 
 """Load dependencies needed for google-cloud-cpp development / Phase 2."""
 
-load("@rules_cc//cc:repositories.bzl", "rules_cc_dependencies")
 load("@build_bazel_apple_support//lib:repositories.bzl", "apple_support_dependencies")
+load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 load(
     "@com_google_googleapis//:repository_rules.bzl",
     "switched_rules_by_language",
 )
-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+load("@rules_cc//cc:repositories.bzl", "rules_cc_dependencies")
 
 def gl_cpp_workspace2(name = None):
     """Loads dependencies needed to use the google-cloud-cpp libraries.

--- a/ci/cloudbuild/builds/checkers.sh
+++ b/ci/cloudbuild/builds/checkers.sh
@@ -144,7 +144,12 @@ time {
 
 # Apply buildifier to fix the BUILD and .bzl formatting rules.
 #    https://github.com/bazelbuild/buildtools/tree/master/buildifier
-printf "%-50s" "Running buildifier:" >&2
+printf "%-50s" "Running buildifier (lint):" >&2
+time {
+  git_files -z -- '*.BUILD' '*.bzl' '*.bazel' |
+    xargs -r -P "$(nproc)" -n 50 -0 buildifier --lint=fix
+}
+printf "%-50s" "Running buildifier (format):" >&2
 time {
   git_files -z -- '*.BUILD' '*.bzl' '*.bazel' |
     xargs -r -P "$(nproc)" -n 50 -0 buildifier -mode=fix

--- a/ci/cloudbuild/dockerfiles/checkers.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/checkers.Dockerfile
@@ -37,7 +37,7 @@ RUN dnf makecache && \
 
 RUN cargo install typos-cli --version 1.16.1 --root /usr/local
 
-RUN curl -L -o /usr/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/5.0.1/buildifier-linux-${ARCH} && \
+RUN curl -L -o /usr/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/v6.4.0/buildifier-linux-amd64 && \
     chmod 755 /usr/bin/buildifier
 
 RUN curl -L -o /usr/local/bin/shfmt https://github.com/mvdan/sh/releases/download/v3.4.3/shfmt_v3.4.3_linux_${ARCH} && \

--- a/ci/verify_current_targets/WORKSPACE.bazel
+++ b/ci/verify_current_targets/WORKSPACE.bazel
@@ -14,9 +14,6 @@
 
 workspace(name = "verify_current_targets")
 
-# Add the necessary Starlark functions to fetch google-cloud-cpp.
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 local_repository(
     name = "google_cloud_cpp",
     path = "../../",

--- a/ci/verify_deprecated_targets/WORKSPACE.bazel
+++ b/ci/verify_deprecated_targets/WORKSPACE.bazel
@@ -16,9 +16,6 @@
 # client library in Bazel-based projects.
 workspace(name = "verify_deprecated_targets")
 
-# Add the necessary Starlark functions to fetch google-cloud-cpp.
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 local_repository(
     name = "google_cloud_cpp",
     path = "../../",

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:private"])
-
-licenses(["notice"])  # Apache 2.0
-
 load(
     "@com_google_googleapis_imports//:imports.bzl",
     "cc_grpc_library",
     "cc_proto_library",
 )
+
+package(default_visibility = ["//visibility:private"])
+
+licenses(["notice"])  # Apache 2.0
 
 # This library defines main(). It's declared as a library so it can be part of
 # a cc_test and cc_binary target.

--- a/generator/BUILD.bazel
+++ b/generator/BUILD.bazel
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:private"])
-
-licenses(["notice"])  # Apache 2.0
-
 load(":google_cloud_cpp_generator.bzl", "google_cloud_cpp_generator_hdrs", "google_cloud_cpp_generator_srcs")
 load(":google_cloud_cpp_generator_testing.bzl", "google_cloud_cpp_generator_testing_hdrs", "google_cloud_cpp_generator_testing_srcs")
 load(":google_cloud_cpp_generator_unit_tests.bzl", "google_cloud_cpp_generator_unit_tests")
+
+package(default_visibility = ["//visibility:private"])
+
+licenses(["notice"])  # Apache 2.0
 
 cc_library(
     name = "google_cloud_cpp_generator",

--- a/generator/integration_tests/BUILD.bazel
+++ b/generator/integration_tests/BUILD.bazel
@@ -12,11 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load(
+    "@com_google_googleapis_imports//:imports.bzl",
+    "cc_grpc_library",
+    "cc_proto_library",
+)
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
-
-load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "google_cloud_cpp_generator_testing_proto",
@@ -43,12 +48,6 @@ proto_library(
         "@com_google_protobuf//:struct_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],
-)
-
-load(
-    "@com_google_googleapis_imports//:imports.bzl",
-    "cc_grpc_library",
-    "cc_proto_library",
 )
 
 cc_proto_library(

--- a/google/cloud/BUILD.bazel
+++ b/google/cloud/BUILD.bazel
@@ -12,28 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:private"])
-
-licenses(["notice"])  # Apache 2.0
-
 load(":capture_build_info.bzl", "capture_build_info")
+load(":google_cloud_cpp_common.bzl", "google_cloud_cpp_common_hdrs", "google_cloud_cpp_common_srcs")
 load(":google_cloud_cpp_common_benchmarks.bzl", "google_cloud_cpp_common_benchmarks")
 load(":google_cloud_cpp_common_unit_tests.bzl", "google_cloud_cpp_common_unit_tests")
-load(":google_cloud_cpp_common.bzl", "google_cloud_cpp_common_hdrs", "google_cloud_cpp_common_srcs")
+load(":google_cloud_cpp_grpc_utils.bzl", "google_cloud_cpp_grpc_utils_hdrs", "google_cloud_cpp_grpc_utils_srcs")
 load(":google_cloud_cpp_grpc_utils_benchmarks.bzl", "google_cloud_cpp_grpc_utils_benchmarks")
 load(":google_cloud_cpp_grpc_utils_integration_tests.bzl", "google_cloud_cpp_grpc_utils_integration_tests")
 load(":google_cloud_cpp_grpc_utils_unit_tests.bzl", "google_cloud_cpp_grpc_utils_unit_tests")
-load(":google_cloud_cpp_grpc_utils.bzl", "google_cloud_cpp_grpc_utils_hdrs", "google_cloud_cpp_grpc_utils_srcs")
 load(":google_cloud_cpp_mocks.bzl", "google_cloud_cpp_mocks_hdrs")
+load(":google_cloud_cpp_rest_internal.bzl", "google_cloud_cpp_rest_internal_hdrs", "google_cloud_cpp_rest_internal_srcs")
 load(":google_cloud_cpp_rest_internal_benchmarks.bzl", "google_cloud_cpp_rest_internal_benchmarks")
 load(":google_cloud_cpp_rest_internal_emulator_integration_tests.bzl", "google_cloud_cpp_rest_internal_emulator_integration_tests")
 load(":google_cloud_cpp_rest_internal_production_integration_tests.bzl", "google_cloud_cpp_rest_internal_production_integration_tests")
 load(":google_cloud_cpp_rest_internal_unit_tests.bzl", "google_cloud_cpp_rest_internal_unit_tests")
-load(":google_cloud_cpp_rest_internal.bzl", "google_cloud_cpp_rest_internal_hdrs", "google_cloud_cpp_rest_internal_srcs")
-load(":google_cloud_cpp_rest_protobuf_internal_unit_tests.bzl", "google_cloud_cpp_rest_protobuf_internal_unit_tests")
 load(":google_cloud_cpp_rest_protobuf_internal.bzl", "google_cloud_cpp_rest_protobuf_internal_hdrs", "google_cloud_cpp_rest_protobuf_internal_srcs")
-load(":google_cloud_cpp_universe_domain_unit_tests.bzl", "google_cloud_cpp_universe_domain_unit_tests")
+load(":google_cloud_cpp_rest_protobuf_internal_unit_tests.bzl", "google_cloud_cpp_rest_protobuf_internal_unit_tests")
 load(":google_cloud_cpp_universe_domain.bzl", "google_cloud_cpp_universe_domain_hdrs", "google_cloud_cpp_universe_domain_srcs")
+load(":google_cloud_cpp_universe_domain_unit_tests.bzl", "google_cloud_cpp_universe_domain_unit_tests")
+
+package(default_visibility = ["//visibility:private"])
+
+licenses(["notice"])  # Apache 2.0
 
 capture_build_info(
     name = "generate_build_info",

--- a/google/cloud/bigquery/BUILD.bazel
+++ b/google/cloud/bigquery/BUILD.bazel
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load(":bigquery_rest_testing.bzl", "bigquery_rest_testing_hdrs", "bigquery_rest_testing_srcs")
+load(":bigquery_rest_unit_tests.bzl", "bigquery_rest_unit_tests")
+load(":google_cloud_cpp_bigquery_rest.bzl", "google_cloud_cpp_bigquery_rest_hdrs", "google_cloud_cpp_bigquery_rest_srcs")
+load(":google_cloud_cpp_bigquery_rest_mocks.bzl", "google_cloud_cpp_bigquery_rest_mocks_hdrs", "google_cloud_cpp_bigquery_rest_mocks_srcs")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -107,8 +112,6 @@ mock_samples_glob = ["samples/mock_*.cc"]
     ],
 ) for sample in glob(mock_samples_glob)]
 
-load(":google_cloud_cpp_bigquery_rest.bzl", "google_cloud_cpp_bigquery_rest_hdrs", "google_cloud_cpp_bigquery_rest_srcs")
-
 cc_library(
     name = "google_cloud_cpp_bigquery_rest",
     srcs = google_cloud_cpp_bigquery_rest_srcs,
@@ -119,8 +122,6 @@ cc_library(
         "//google/cloud:google_cloud_cpp_rest_internal",
     ],
 )
-
-load(":google_cloud_cpp_bigquery_rest_mocks.bzl", "google_cloud_cpp_bigquery_rest_mocks_hdrs", "google_cloud_cpp_bigquery_rest_mocks_srcs")
 
 cc_library(
     name = "google_cloud_cpp_bigquery_rest_mocks",
@@ -133,8 +134,6 @@ cc_library(
         "@com_google_googletest//:gtest",
     ],
 )
-
-load(":bigquery_rest_testing.bzl", "bigquery_rest_testing_hdrs", "bigquery_rest_testing_srcs")
 
 cc_library(
     name = "bigquery_rest_testing",
@@ -150,8 +149,6 @@ cc_library(
         "@com_google_googletest//:gtest_main",
     ],
 )
-
-load(":bigquery_rest_unit_tests.bzl", "bigquery_rest_unit_tests")
 
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),

--- a/google/cloud/bigquery/v2/minimal/benchmarks/BUILD.bazel
+++ b/google/cloud/bigquery/v2/minimal/benchmarks/BUILD.bazel
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load(":experimental_bigquery_rest_client_benchmark_programs.bzl", "experimental_bigquery_rest_client_benchmark_programs")
+load(":experimental_bigquery_rest_client_benchmark_unit_tests.bzl", "experimental_bigquery_rest_client_benchmark_unit_tests")
+load(":experimental_bigquery_rest_client_benchmarks.bzl", "experimental_bigquery_rest_client_benchmarks_hdrs", "experimental_bigquery_rest_client_benchmarks_srcs")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
-
-load(":experimental_bigquery_rest_client_benchmarks.bzl", "experimental_bigquery_rest_client_benchmarks_hdrs", "experimental_bigquery_rest_client_benchmarks_srcs")
-load(":experimental_bigquery_rest_client_benchmark_unit_tests.bzl", "experimental_bigquery_rest_client_benchmark_unit_tests")
-load(":experimental_bigquery_rest_client_benchmark_programs.bzl", "experimental_bigquery_rest_client_benchmark_programs")
 
 cc_library(
     name = "experimental_bigquery_rest_client_benchmarks",

--- a/google/cloud/bigtable/BUILD.bazel
+++ b/google/cloud/bigtable/BUILD.bazel
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load(":bigtable_client_testing.bzl", "bigtable_client_testing_hdrs", "bigtable_client_testing_srcs")
+load(":bigtable_client_unit_tests.bzl", "bigtable_client_unit_tests")
+load(":google_cloud_cpp_bigtable.bzl", "google_cloud_cpp_bigtable_hdrs", "google_cloud_cpp_bigtable_srcs")
+load(":google_cloud_cpp_bigtable_mocks.bzl", "google_cloud_cpp_bigtable_mocks_hdrs")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
-
-load(":google_cloud_cpp_bigtable.bzl", "google_cloud_cpp_bigtable_hdrs", "google_cloud_cpp_bigtable_srcs")
-load(":google_cloud_cpp_bigtable_mocks.bzl", "google_cloud_cpp_bigtable_mocks_hdrs")
-load(":bigtable_client_testing.bzl", "bigtable_client_testing_hdrs", "bigtable_client_testing_srcs")
-load(":bigtable_client_unit_tests.bzl", "bigtable_client_unit_tests")
 
 filegroup(
     name = "public_hdrs",

--- a/google/cloud/bigtable/benchmarks/BUILD.bazel
+++ b/google/cloud/bigtable/benchmarks/BUILD.bazel
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load(":bigtable_benchmark_common.bzl", "bigtable_benchmark_common_hdrs", "bigtable_benchmark_common_srcs")
+load(":bigtable_benchmark_programs.bzl", "bigtable_benchmark_programs")
+load(":bigtable_benchmarks_unit_tests.bzl", "bigtable_benchmarks_unit_tests")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
-
-load(":bigtable_benchmark_common.bzl", "bigtable_benchmark_common_hdrs", "bigtable_benchmark_common_srcs")
 
 cc_library(
     name = "bigtable_benchmark_common",
@@ -30,8 +32,6 @@ cc_library(
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
     ],
 )
-
-load(":bigtable_benchmark_programs.bzl", "bigtable_benchmark_programs")
 
 [cc_binary(
     name = program.replace("/", "_").replace(".cc", ""),
@@ -47,8 +47,6 @@ load(":bigtable_benchmark_programs.bzl", "bigtable_benchmark_programs")
         "//:common",
     ],
 ) for program in bigtable_benchmark_programs]
-
-load(":bigtable_benchmarks_unit_tests.bzl", "bigtable_benchmarks_unit_tests")
 
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),

--- a/google/cloud/bigtable/examples/BUILD.bazel
+++ b/google/cloud/bigtable/examples/BUILD.bazel
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load(":bigtable_examples.bzl", "bigtable_examples")
+load(":bigtable_examples_common.bzl", "bigtable_examples_common_hdrs", "bigtable_examples_common_srcs")
+load(":bigtable_examples_unit_tests.bzl", "bigtable_examples_unit_tests")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
-
-load(":bigtable_examples_common.bzl", "bigtable_examples_common_hdrs", "bigtable_examples_common_srcs")
 
 cc_library(
     name = "bigtable_examples_common",
@@ -33,8 +35,6 @@ cc_library(
         "@com_google_googleapis//google/bigtable/v2:bigtable_cc_grpc",
     ],
 )
-
-load(":bigtable_examples_unit_tests.bzl", "bigtable_examples_unit_tests")
 
 EXCLUDED_UNIT_TESTS = ["howto_mock_data_api.cc"]
 
@@ -63,8 +63,6 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
-
-load(":bigtable_examples.bzl", "bigtable_examples")
 
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),

--- a/google/cloud/bigtable/test_proxy/BUILD.bazel
+++ b/google/cloud/bigtable/test_proxy/BUILD.bazel
@@ -12,16 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:private"])
-
-licenses(["notice"])  # Apache 2.0
-
 load(
     "@com_google_googleapis_imports//:imports.bzl",
     "cc_grpc_library",
     "cc_proto_library",
 )
 load("@rules_proto//proto:defs.bzl", "proto_library")
+
+package(default_visibility = ["//visibility:private"])
+
+licenses(["notice"])  # Apache 2.0
 
 # Defines an interface for driving Cloud Bigtable client bindings, as
 # implemented in different languages.

--- a/google/cloud/bigtable/tests/BUILD.bazel
+++ b/google/cloud/bigtable/tests/BUILD.bazel
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:private"])
-
-licenses(["notice"])  # Apache 2.0
-
 load(
     ":bigtable_client_integration_tests.bzl",
     "bigtable_client_integration_tests",
 )
+
+package(default_visibility = ["//visibility:private"])
+
+licenses(["notice"])  # Apache 2.0
 
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),

--- a/google/cloud/compute/BUILD.bazel
+++ b/google/cloud/compute/BUILD.bazel
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load(":service_dirs.bzl", "operation_service_dirs", "service_dirs")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
-
-load(":service_dirs.bzl", "operation_service_dirs", "service_dirs")
 
 # Service C++ files and mocks targets
 [[

--- a/google/cloud/compute/samples/BUILD.bazel
+++ b/google/cloud/compute/samples/BUILD.bazel
@@ -14,11 +14,11 @@
 
 """Examples for the Compute Engine C++ client library."""
 
+load(":compute_client_samples.bzl", "compute_client_samples")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
-
-load(":compute_client_samples.bzl", "compute_client_samples")
 
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),

--- a/google/cloud/logging/integration_tests/BUILD.bazel
+++ b/google/cloud/logging/integration_tests/BUILD.bazel
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load(":logging_client_integration_tests.bzl", "logging_client_integration_tests")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
-
-load(":logging_client_integration_tests.bzl", "logging_client_integration_tests")
 
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),

--- a/google/cloud/oauth2/BUILD.bazel
+++ b/google/cloud/oauth2/BUILD.bazel
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load(":google_cloud_cpp_oauth2.bzl", "google_cloud_cpp_oauth2_hdrs", "google_cloud_cpp_oauth2_srcs")
+load(":google_cloud_cpp_oauth2_unit_tests.bzl", "google_cloud_cpp_oauth2_unit_tests")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
-
-load(":google_cloud_cpp_oauth2_unit_tests.bzl", "google_cloud_cpp_oauth2_unit_tests")
-load(":google_cloud_cpp_oauth2.bzl", "google_cloud_cpp_oauth2_hdrs", "google_cloud_cpp_oauth2_srcs")
 
 filegroup(
     name = "public_hdrs",

--- a/google/cloud/opentelemetry/BUILD.bazel
+++ b/google/cloud/opentelemetry/BUILD.bazel
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load(":google_cloud_cpp_opentelemetry.bzl", "google_cloud_cpp_opentelemetry_hdrs", "google_cloud_cpp_opentelemetry_srcs")
+load(":opentelemetry_unit_tests.bzl", "opentelemetry_unit_tests")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
-
-load(":google_cloud_cpp_opentelemetry.bzl", "google_cloud_cpp_opentelemetry_hdrs", "google_cloud_cpp_opentelemetry_srcs")
-load(":opentelemetry_unit_tests.bzl", "opentelemetry_unit_tests")
 
 filegroup(
     name = "public_hdrs",

--- a/google/cloud/opentelemetry/integration_tests/BUILD.bazel
+++ b/google/cloud/opentelemetry/integration_tests/BUILD.bazel
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load(":tests.bzl", "opentelemetry_integration_tests")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
-
-load(":tests.bzl", "opentelemetry_integration_tests")
 
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),

--- a/google/cloud/pubsub/BUILD.bazel
+++ b/google/cloud/pubsub/BUILD.bazel
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load(":google_cloud_cpp_pubsub.bzl", "google_cloud_cpp_pubsub_hdrs", "google_cloud_cpp_pubsub_srcs")
+load(":google_cloud_cpp_pubsub_mocks.bzl", "google_cloud_cpp_pubsub_mocks_hdrs")
+load(":pubsub_client_testing.bzl", "pubsub_client_testing_hdrs", "pubsub_client_testing_srcs")
+load(":pubsub_client_unit_tests.bzl", "pubsub_client_unit_tests")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
-
-load(":google_cloud_cpp_pubsub.bzl", "google_cloud_cpp_pubsub_hdrs", "google_cloud_cpp_pubsub_srcs")
-load(":pubsub_client_testing.bzl", "pubsub_client_testing_hdrs", "pubsub_client_testing_srcs")
-load(":google_cloud_cpp_pubsub_mocks.bzl", "google_cloud_cpp_pubsub_mocks_hdrs")
-load(":pubsub_client_unit_tests.bzl", "pubsub_client_unit_tests")
 
 filegroup(
     name = "public_hdrs",

--- a/google/cloud/pubsub/benchmarks/BUILD.bazel
+++ b/google/cloud/pubsub/benchmarks/BUILD.bazel
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load(":pubsub_client_benchmark_programs.bzl", "pubsub_client_benchmark_programs")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
-
-load(":pubsub_client_benchmark_programs.bzl", "pubsub_client_benchmark_programs")
 
 [cc_binary(
     name = program.replace("/", "_").replace(".cc", ""),

--- a/google/cloud/pubsub/integration_tests/BUILD.bazel
+++ b/google/cloud/pubsub/integration_tests/BUILD.bazel
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load(":pubsub_client_integration_tests.bzl", "pubsub_client_integration_tests")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
-
-load(":pubsub_client_integration_tests.bzl", "pubsub_client_integration_tests")
 
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),

--- a/google/cloud/pubsub/samples/BUILD.bazel
+++ b/google/cloud/pubsub/samples/BUILD.bazel
@@ -14,11 +14,14 @@
 
 """Examples for the Cloud Pub/Sub C++ client library."""
 
+load(":pubsub_client_integration_samples.bzl", "pubsub_client_integration_samples")
+load(":pubsub_client_unit_samples.bzl", "pubsub_client_unit_samples")
+load(":pubsub_samples_common.bzl", "pubsub_samples_common_hdrs", "pubsub_samples_common_srcs")
+load(":pubsub_samples_unit_tests.bzl", "pubsub_samples_unit_tests")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
-
-load(":pubsub_samples_common.bzl", "pubsub_samples_common_hdrs", "pubsub_samples_common_srcs")
 
 cc_library(
     name = "pubsub_samples_common",
@@ -34,8 +37,6 @@ cc_library(
     ],
 )
 
-load(":pubsub_samples_unit_tests.bzl", "pubsub_samples_unit_tests")
-
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
@@ -47,8 +48,6 @@ load(":pubsub_samples_unit_tests.bzl", "pubsub_samples_unit_tests")
         "@com_google_googletest//:gtest_main",
     ],
 ) for test in pubsub_samples_unit_tests]
-
-load(":pubsub_client_integration_samples.bzl", "pubsub_client_integration_samples")
 
 proto_library(
     name = "samples_proto",
@@ -79,8 +78,6 @@ cc_proto_library(
         "//:pubsub",
     ] + (["//:iam"] if test == "iam_samples.cc" else []),
 ) for test in pubsub_client_integration_samples]
-
-load(":pubsub_client_unit_samples.bzl", "pubsub_client_unit_samples")
 
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),

--- a/google/cloud/pubsublite/BUILD.bazel
+++ b/google/cloud/pubsublite/BUILD.bazel
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:private"])
-
-licenses(["notice"])  # Apache 2.0
-
 load(":google_cloud_cpp_pubsublite.bzl", "google_cloud_cpp_pubsublite_hdrs", "google_cloud_cpp_pubsublite_srcs")
 load(":google_cloud_cpp_pubsublite_mocks.bzl", "google_cloud_cpp_pubsublite_mocks_hdrs")
 load(":pubsublite_testing.bzl", "pubsublite_testing_hdrs", "pubsublite_testing_srcs")
 load(":pubsublite_unit_tests.bzl", "pubsublite_unit_tests")
+
+package(default_visibility = ["//visibility:private"])
+
+licenses(["notice"])  # Apache 2.0
 
 filegroup(
     name = "public_hdrs",

--- a/google/cloud/pubsublite/integration_tests/BUILD.bazel
+++ b/google/cloud/pubsublite/integration_tests/BUILD.bazel
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load(":pubsublite_client_integration_tests.bzl", "pubsublite_client_integration_tests")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
-
-load(":pubsublite_client_integration_tests.bzl", "pubsublite_client_integration_tests")
 
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),

--- a/google/cloud/spanner/BUILD.bazel
+++ b/google/cloud/spanner/BUILD.bazel
@@ -12,15 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load(":google_cloud_cpp_spanner.bzl", "google_cloud_cpp_spanner_hdrs", "google_cloud_cpp_spanner_srcs")
+load(":google_cloud_cpp_spanner_mocks.bzl", "google_cloud_cpp_spanner_mocks_hdrs")
+load(":google_cloud_cpp_spanner_rest.bzl", "google_cloud_cpp_spanner_rest_hdrs", "google_cloud_cpp_spanner_rest_srcs")
+load(":spanner_client_benchmarks.bzl", "spanner_client_benchmarks")
+load(":spanner_client_testing.bzl", "spanner_client_testing_hdrs", "spanner_client_testing_srcs")
+load(":spanner_client_unit_tests.bzl", "spanner_client_unit_tests")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
-
-load(":google_cloud_cpp_spanner.bzl", "google_cloud_cpp_spanner_hdrs", "google_cloud_cpp_spanner_srcs")
-load(":google_cloud_cpp_spanner_rest.bzl", "google_cloud_cpp_spanner_rest_hdrs", "google_cloud_cpp_spanner_rest_srcs")
-load(":google_cloud_cpp_spanner_mocks.bzl", "google_cloud_cpp_spanner_mocks_hdrs")
-load(":spanner_client_unit_tests.bzl", "spanner_client_unit_tests")
-load(":spanner_client_benchmarks.bzl", "spanner_client_benchmarks")
 
 filegroup(
     name = "public_hdrs",
@@ -89,8 +90,6 @@ cc_library(
         "@com_google_googletest//:gtest_main",
     ],
 )
-
-load(":spanner_client_testing.bzl", "spanner_client_testing_hdrs", "spanner_client_testing_srcs")
 
 cc_library(
     name = "spanner_client_testing_private",

--- a/google/cloud/spanner/admin/integration_tests/BUILD.bazel
+++ b/google/cloud/spanner/admin/integration_tests/BUILD.bazel
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load(":spanner_admin_integration_tests.bzl", "spanner_admin_integration_tests")
+load(":spanner_admin_integration_tests_rest.bzl", "spanner_admin_integration_tests_rest")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
-
-load(":spanner_admin_integration_tests.bzl", "spanner_admin_integration_tests")
 
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
@@ -32,8 +33,6 @@ load(":spanner_admin_integration_tests.bzl", "spanner_admin_integration_tests")
         "@com_google_googletest//:gtest_main",
     ],
 ) for test in spanner_admin_integration_tests]
-
-load(":spanner_admin_integration_tests_rest.bzl", "spanner_admin_integration_tests_rest")
 
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),

--- a/google/cloud/spanner/benchmarks/BUILD.bazel
+++ b/google/cloud/spanner/benchmarks/BUILD.bazel
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load(":spanner_client_benchmark_programs.bzl", "spanner_client_benchmark_programs")
+load(":spanner_client_benchmarks.bzl", "spanner_client_benchmarks_hdrs", "spanner_client_benchmarks_srcs")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
-
-load(":spanner_client_benchmarks.bzl", "spanner_client_benchmarks_hdrs", "spanner_client_benchmarks_srcs")
-load(":spanner_client_benchmark_programs.bzl", "spanner_client_benchmark_programs")
 
 cc_library(
     name = "spanner_client_benchmarks",

--- a/google/cloud/spanner/integration_tests/BUILD.bazel
+++ b/google/cloud/spanner/integration_tests/BUILD.bazel
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load(":spanner_client_integration_tests.bzl", "spanner_client_integration_tests")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
-
-load(":spanner_client_integration_tests.bzl", "spanner_client_integration_tests")
 
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),

--- a/google/cloud/spanner/samples/BUILD.bazel
+++ b/google/cloud/spanner/samples/BUILD.bazel
@@ -14,11 +14,12 @@
 
 """Examples for the Cloud Spanner C++ client library."""
 
+load(":spanner_client_integration_samples.bzl", "spanner_client_integration_samples")
+load(":spanner_client_unit_samples.bzl", "spanner_client_unit_samples")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
-
-load(":spanner_client_integration_samples.bzl", "spanner_client_integration_samples")
 
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
@@ -34,8 +35,6 @@ load(":spanner_client_integration_samples.bzl", "spanner_client_integration_samp
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
     ],
 ) for test in spanner_client_integration_samples]
-
-load(":spanner_client_unit_samples.bzl", "spanner_client_unit_samples")
 
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),

--- a/google/cloud/storage/BUILD.bazel
+++ b/google/cloud/storage/BUILD.bazel
@@ -12,17 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:private"])
-
-licenses(["notice"])  # Apache 2.0
-
 load(":google_cloud_cpp_storage.bzl", "google_cloud_cpp_storage_hdrs", "google_cloud_cpp_storage_srcs")
 load(":google_cloud_cpp_storage_grpc.bzl", "google_cloud_cpp_storage_grpc_hdrs", "google_cloud_cpp_storage_grpc_srcs")
 load(":google_cloud_cpp_storage_grpc_mocks.bzl", "google_cloud_cpp_storage_grpc_mocks_hdrs")
+load(":storage_client_benchmarks.bzl", "storage_client_benchmarks")
 load(":storage_client_grpc_unit_tests.bzl", "storage_client_grpc_unit_tests")
 load(":storage_client_testing.bzl", "storage_client_testing_hdrs", "storage_client_testing_srcs")
 load(":storage_client_unit_tests.bzl", "storage_client_unit_tests")
-load(":storage_client_benchmarks.bzl", "storage_client_benchmarks")
+
+package(default_visibility = ["//visibility:private"])
+
+licenses(["notice"])  # Apache 2.0
 
 # These are needed to use the BoringSSL libraries, and should be set in any
 # downstream dependency too.

--- a/google/cloud/storage/benchmarks/BUILD.bazel
+++ b/google/cloud/storage/benchmarks/BUILD.bazel
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load(":storage_benchmark_programs.bzl", "storage_benchmark_programs")
+load(":storage_benchmarks.bzl", "storage_benchmarks_hdrs", "storage_benchmarks_srcs")
+load(":storage_benchmarks_unit_tests.bzl", "storage_benchmarks_unit_tests")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
-
-load(":storage_benchmarks.bzl", "storage_benchmarks_hdrs", "storage_benchmarks_srcs")
-load(":storage_benchmark_programs.bzl", "storage_benchmark_programs")
-load(":storage_benchmarks_unit_tests.bzl", "storage_benchmarks_unit_tests")
 
 cc_library(
     name = "storage_benchmarks",

--- a/google/cloud/storage/examples/BUILD.bazel
+++ b/google/cloud/storage/examples/BUILD.bazel
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load(":storage_examples.bzl", "storage_examples")
+load(":storage_examples_common.bzl", "storage_examples_common_hdrs", "storage_examples_common_srcs")
+load(":storage_examples_unit_tests.bzl", "storage_examples_unit_tests")
+load(":storage_grpc_examples.bzl", "storage_grpc_examples", "storage_grpc_unit_tests")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
-
-load(":storage_examples_common.bzl", "storage_examples_common_hdrs", "storage_examples_common_srcs")
-load(":storage_examples_unit_tests.bzl", "storage_examples_unit_tests")
-load(":storage_examples.bzl", "storage_examples")
-load(":storage_grpc_examples.bzl", "storage_grpc_examples", "storage_grpc_unit_tests")
 
 cc_library(
     name = "storage_examples_common",

--- a/google/cloud/storage/tests/BUILD.bazel
+++ b/google/cloud/storage/tests/BUILD.bazel
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:private"])
-
-licenses(["notice"])  # Apache 2.0
-
 load(
     ":storage_client_integration_tests.bzl",
     "storage_client_integration_tests",
 )
+
+package(default_visibility = ["//visibility:private"])
+
+licenses(["notice"])  # Apache 2.0
 
 proto_library(
     name = "storage_conformance_tests_proto",

--- a/google/cloud/testing_util/BUILD.bazel
+++ b/google/cloud/testing_util/BUILD.bazel
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load(":google_cloud_cpp_testing.bzl", "google_cloud_cpp_testing_hdrs", "google_cloud_cpp_testing_srcs")
+load(":google_cloud_cpp_testing_grpc.bzl", "google_cloud_cpp_testing_grpc_hdrs", "google_cloud_cpp_testing_grpc_srcs")
+load(":google_cloud_cpp_testing_grpc_unit_tests.bzl", "google_cloud_cpp_testing_grpc_unit_tests")
+load(":google_cloud_cpp_testing_rest.bzl", "google_cloud_cpp_testing_rest_hdrs", "google_cloud_cpp_testing_rest_srcs")
+load(":google_cloud_cpp_testing_unit_tests.bzl", "google_cloud_cpp_testing_unit_tests")
+
 # The targets in this package are intended for testing our own libraries, and
 # are not intended for public usage.
 package(default_visibility = ["//:__subpackages__"])
 
 licenses(["notice"])  # Apache 2.0
-
-load(":google_cloud_cpp_testing.bzl", "google_cloud_cpp_testing_hdrs", "google_cloud_cpp_testing_srcs")
 
 cc_library(
     name = "google_cloud_cpp_testing_private",
@@ -61,8 +65,6 @@ cc_library(
     deps = [":google_cloud_cpp_testing_private"],
 )
 
-load(":google_cloud_cpp_testing_unit_tests.bzl", "google_cloud_cpp_testing_unit_tests")
-
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
@@ -72,8 +74,6 @@ load(":google_cloud_cpp_testing_unit_tests.bzl", "google_cloud_cpp_testing_unit_
         "@com_google_googletest//:gtest_main",
     ],
 ) for test in google_cloud_cpp_testing_unit_tests]
-
-load(":google_cloud_cpp_testing_grpc.bzl", "google_cloud_cpp_testing_grpc_hdrs", "google_cloud_cpp_testing_grpc_srcs")
 
 cc_library(
     name = "google_cloud_cpp_testing_grpc_private",
@@ -104,8 +104,6 @@ cc_library(
     deps = [":google_cloud_cpp_testing_grpc_private"],
 )
 
-load(":google_cloud_cpp_testing_grpc_unit_tests.bzl", "google_cloud_cpp_testing_grpc_unit_tests")
-
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
@@ -116,8 +114,6 @@ load(":google_cloud_cpp_testing_grpc_unit_tests.bzl", "google_cloud_cpp_testing_
         "@com_google_protobuf//:protobuf",
     ],
 ) for test in google_cloud_cpp_testing_grpc_unit_tests]
-
-load(":google_cloud_cpp_testing_rest.bzl", "google_cloud_cpp_testing_rest_hdrs", "google_cloud_cpp_testing_rest_srcs")
 
 cc_library(
     name = "google_cloud_cpp_testing_rest_private",

--- a/protos/google/cloud/compute/BUILD.bazel
+++ b/protos/google/cloud/compute/BUILD.bazel
@@ -12,16 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:private"])
-
-licenses(["notice"])  # Apache 2.0
-
-load("@rules_proto//proto:defs.bzl", "proto_library")
 load(
     "@com_google_googleapis_imports//:imports.bzl",
     "cc_proto_library",
 )
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("//google/cloud/compute:service_dirs.bzl", "operation_service_dirs", "service_dirs")
+
+package(default_visibility = ["//visibility:private"])
+
+licenses(["notice"])  # Apache 2.0
 
 # Internal protos target
 filegroup(


### PR DESCRIPTION
Upgraded `buildifier(1)` to version 6.4.0, and then changed the `checkers` build to fix formatting and lints in our Bazel files. For the most part this involved moving `load()` statements to the top of the files and sorting the `load()` statements lexicographically.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13580)
<!-- Reviewable:end -->
