### PR TITLE
impl(bigtable): heed `RetryInfo` in `BulkApply()`

### DIFF
--- a/google/cloud/bigtable/internal/bulk_mutator.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator.cc
@@ -127,7 +127,7 @@ void BulkMutatorState::OnRead(
 void BulkMutatorState::OnFinish(Status finish_status,
                                 bool enable_server_retries) {
   last_status_ = std::move(finish_status);
-  bool retryable =
+  bool const retryable =
       enable_server_retries &&
       google::cloud::internal::GetRetryInfo(last_status_).has_value();
 

--- a/google/cloud/bigtable/internal/bulk_mutator.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator.cc
@@ -25,8 +25,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 namespace btproto = ::google::bigtable::v2;
 
-using ::google::cloud::Idempotency;
-
 BulkMutatorState::BulkMutatorState(
     std::string const& app_profile_id, std::string const& table_name,
     bigtable::IdempotentMutationPolicy& idempotent_policy,
@@ -98,6 +96,9 @@ void BulkMutatorState::OnRead(
     auto const index = static_cast<std::size_t>(entry.index());
     auto& annotation = annotations_[index];
     annotation.has_mutation_result = true;
+    // Note that we do not need to heed `RetryInfo` for the status of individual
+    // entries. The server only ever includes `RetryInfo` as the final status of
+    // the stream.
     auto status = MakeStatusFromRpcError(entry.status());
     // Successful responses are not even recorded, this class only reports
     // the failures.  The data for successful responses is discarded, because
@@ -123,8 +124,12 @@ void BulkMutatorState::OnRead(
   }
 }
 
-void BulkMutatorState::OnFinish(google::cloud::Status finish_status) {
+void BulkMutatorState::OnFinish(Status finish_status,
+                                bool enable_server_retries) {
   last_status_ = std::move(finish_status);
+  bool retryable =
+      enable_server_retries &&
+      google::cloud::internal::GetRetryInfo(last_status_).has_value();
 
   int index = 0;
   for (auto& annotation : annotations_) {
@@ -134,15 +139,15 @@ void BulkMutatorState::OnFinish(google::cloud::Status finish_status) {
     }
     // If there are any mutations with unknown state, they need to be handled.
     auto& original = *mutations_.mutable_entries(index);
-    if (annotation.idempotency == Idempotency::kIdempotent) {
+    if (retryable || annotation.idempotency == Idempotency::kIdempotent) {
       // If the mutation was retryable, move it to the pending mutations to try
       // again, along with their index.
       pending_mutations_.add_entries()->Swap(&original);
       pending_annotations_.push_back(std::move(annotation));
     } else {
       if (last_status_.ok()) {
-        google::cloud::Status status(
-            google::cloud::StatusCode::kInternal,
+        Status status(
+            StatusCode::kInternal,
             "The server never sent a confirmation for this mutation but the "
             "stream didn't fail either. This is most likely a bug, please "
             "report it at "
@@ -168,8 +173,8 @@ std::vector<bigtable::FailedMutation> BulkMutatorState::OnRetryDone() && {
     } else if (!last_status_.ok()) {
       result.emplace_back(last_status_, annotation.original_index);
     } else {
-      google::cloud::Status status(
-          google::cloud::StatusCode::kInternal,
+      Status status(
+          StatusCode::kInternal,
           "The server never sent a confirmation for this mutation but the "
           "stream didn't fail either. This is most likely a bug, please "
           "report it at "
@@ -213,17 +218,21 @@ Status BulkMutator::MakeOneRequest(BigtableStub& stub,
   auto context = std::make_shared<grpc::ClientContext>();
   google::cloud::internal::ConfigureContext(*context, options);
   retry_context_.PreCall(*context);
+  bool enable_server_retries =
+      options.get<internal::EnableServerRetriesOption>();
 
   struct UnpackVariant {
     BulkMutatorState& state;
     MutateRowsLimiter& limiter;
+    bool enable_server_retries;
+
     bool operator()(btproto::MutateRowsResponse r) {
       limiter.Update(r);
       state.OnRead(std::move(r));
       return true;
     }
     bool operator()(Status s) {
-      state.OnFinish(std::move(s));
+      state.OnFinish(std::move(s), enable_server_retries);
       return false;
     }
   };
@@ -233,7 +242,8 @@ Status BulkMutator::MakeOneRequest(BigtableStub& stub,
 
   // Read the stream of responses.
   auto stream = stub.MutateRows(context, options, mutations);
-  while (absl::visit(UnpackVariant{state_, limiter}, stream->Read())) {
+  while (absl::visit(UnpackVariant{state_, limiter, enable_server_retries},
+                     stream->Read())) {
   }
   retry_context_.PostCall(*context);
   return state_.last_status();

--- a/google/cloud/bigtable/internal/bulk_mutator.h
+++ b/google/cloud/bigtable/internal/bulk_mutator.h
@@ -50,7 +50,7 @@ class BulkMutatorState {
   void OnRead(google::bigtable::v2::MutateRowsResponse response);
 
   /// Handle the result of a `Finish()` operation on the MutateRows() RPC.
-  void OnFinish(google::cloud::Status finish_status);
+  void OnFinish(Status finish_status, bool enable_server_retries = false);
 
   /// Terminate the retry loop and return all the failures.
   std::vector<bigtable::FailedMutation> OnRetryDone() &&;
@@ -69,7 +69,7 @@ class BulkMutatorState {
    * known, the result of the RPC is applied to any mutation with an unknown
    * result.
    */
-  google::cloud::Status last_status_;
+  Status last_status_;
 
   /// Accumulate any permanent failures and the list of mutations we gave up on.
   std::vector<bigtable::FailedMutation> failures_;

--- a/google/cloud/bigtable/internal/bulk_mutator_test.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator_test.cc
@@ -31,9 +31,11 @@ using ::google::cloud::testing_util::chrono_literals::operator"" _ms;  // NOLINT
 using ::google::cloud::bigtable::testing::MockBigtableStub;
 using ::google::cloud::bigtable::testing::MockMutateRowsLimiter;
 using ::google::cloud::bigtable::testing::MockMutateRowsStream;
+using ::google::cloud::internal::EnableServerRetriesOption;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::AnyOf;
 using ::testing::Contains;
+using ::testing::ElementsAre;
 using ::testing::Eq;
 using ::testing::IsEmpty;
 using ::testing::Matcher;
@@ -319,6 +321,87 @@ TEST_F(BulkMutatorTest, RetryOnlyIdempotent) {
   ASSERT_EQ(1UL, failures.size());
   EXPECT_EQ(0, failures[0].original_index());
   EXPECT_THAT(failures[0].status(), StatusIs(StatusCode::kUnavailable));
+}
+
+TEST_F(BulkMutatorTest, RetryInfoHeeded) {
+  // Create a BulkMutation with a non-idempotent mutation.
+  BulkMutation mut(NonIdempotentMutation("row"));
+
+  auto mock = std::make_shared<MockBigtableStub>();
+  EXPECT_CALL(*mock, MutateRows)
+      .WillOnce([this](auto context, auto const&,
+                       google::bigtable::v2::MutateRowsRequest const&) {
+        metadata_fixture_.SetServerMetadata(*context, {});
+        auto status =
+            google::cloud::internal::ResourceExhaustedError("try again");
+        google::cloud::internal::SetRetryInfo(
+            status, google::cloud::internal::RetryInfo{0_ms});
+        auto stream = std::make_unique<MockMutateRowsStream>();
+        EXPECT_CALL(*stream, Read).WillOnce(Return(status));
+        return stream;
+      })
+      // By supplying a `RetryInfo` in the error details, the server is telling
+      // us that it is safe to retry the mutation, even though it is not
+      // idempotent.
+      .WillOnce([this](auto context, auto const&,
+                       google::bigtable::v2::MutateRowsRequest const& request) {
+        metadata_fixture_.SetServerMetadata(*context, {});
+        std::vector<std::string> row_keys;
+        for (auto const& entry : request.entries()) {
+          row_keys.push_back(entry.row_key());
+        }
+        EXPECT_THAT(row_keys, ElementsAre("row"));
+        auto stream = std::make_unique<MockMutateRowsStream>();
+        EXPECT_CALL(*stream, Read)
+            .WillOnce(Return(MakeResponse({{0, grpc::StatusCode::OK}})))
+            .WillOnce(Return(Status()));
+        return stream;
+      });
+
+  auto policy = DefaultIdempotentMutationPolicy();
+  bigtable_internal::BulkMutator mutator(kAppProfile, kTableName, *policy,
+                                         std::move(mut));
+
+  for (int i = 0; i != 2; ++i) {
+    EXPECT_TRUE(mutator.HasPendingMutations());
+    bigtable_internal::NoopMutateRowsLimiter limiter;
+    (void)mutator.MakeOneRequest(
+        *mock, limiter, Options{}.set<EnableServerRetriesOption>(true));
+  }
+  auto failures = std::move(mutator).OnRetryDone();
+  EXPECT_THAT(failures, IsEmpty());
+}
+
+TEST_F(BulkMutatorTest, RetryInfoIgnored) {
+  // Create a BulkMutation with a non-idempotent mutation.
+  BulkMutation mut(NonIdempotentMutation("row"));
+
+  auto mock = std::make_shared<MockBigtableStub>();
+  EXPECT_CALL(*mock, MutateRows)
+      .WillOnce([this](auto context, auto const&,
+                       google::bigtable::v2::MutateRowsRequest const&) {
+        metadata_fixture_.SetServerMetadata(*context, {});
+        auto status =
+            google::cloud::internal::ResourceExhaustedError("try again");
+        google::cloud::internal::SetRetryInfo(
+            status, google::cloud::internal::RetryInfo{0_ms});
+        auto stream = std::make_unique<MockMutateRowsStream>();
+        EXPECT_CALL(*stream, Read).WillOnce(Return(status));
+        return stream;
+      });
+
+  auto policy = DefaultIdempotentMutationPolicy();
+  bigtable_internal::BulkMutator mutator(kAppProfile, kTableName, *policy,
+                                         std::move(mut));
+
+  EXPECT_TRUE(mutator.HasPendingMutations());
+  bigtable_internal::NoopMutateRowsLimiter limiter;
+  auto status = mutator.MakeOneRequest(
+      *mock, limiter, Options{}.set<EnableServerRetriesOption>(false));
+  EXPECT_THAT(status, StatusIs(StatusCode::kResourceExhausted));
+  EXPECT_FALSE(mutator.HasPendingMutations());
+  auto failures = std::move(mutator).OnRetryDone();
+  EXPECT_THAT(failures, ElementsAre(FailedMutation(status, 0)));
 }
 
 TEST_F(BulkMutatorTest, UnconfirmedAreFailed) {


### PR DESCRIPTION
Part of the work for #13514 

Support `RetryInfo` in `BulkApply`. In the `DataConnectionImpl` this means retrying errors that might not normally be retried, and using the backoff value if present. In the `BulkMutator` this means marking any mutation as retryable, regardless of idempotency, when `RetryInfo` is present.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13581)
<!-- Reviewable:end -->
