### PR TITLE
impl(bigtable): heed `RetryInfo` in `AsyncBulkApply`

### DIFF
--- a/google/cloud/bigtable/internal/async_bulk_apply.cc
+++ b/google/cloud/bigtable/internal/async_bulk_apply.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/bigtable/internal/async_bulk_apply.h"
 #include "google/cloud/bigtable/internal/async_streaming_read.h"
+#include "google/cloud/bigtable/internal/retry_info_helper.h"
 #include "google/cloud/internal/grpc_opentelemetry.h"
 
 namespace google {
@@ -25,7 +26,7 @@ future<std::vector<bigtable::FailedMutation>> AsyncBulkApplier::Create(
     CompletionQueue cq, std::shared_ptr<BigtableStub> stub,
     std::shared_ptr<MutateRowsLimiter> limiter,
     std::unique_ptr<bigtable::DataRetryPolicy> retry_policy,
-    std::unique_ptr<BackoffPolicy> backoff_policy,
+    std::unique_ptr<BackoffPolicy> backoff_policy, bool enable_server_retries,
     bigtable::IdempotentMutationPolicy& idempotent_policy,
     std::string const& app_profile_id, std::string const& table_name,
     bigtable::BulkMutation mut) {
@@ -35,8 +36,8 @@ future<std::vector<bigtable::FailedMutation>> AsyncBulkApplier::Create(
 
   std::shared_ptr<AsyncBulkApplier> bulk_apply(new AsyncBulkApplier(
       std::move(cq), std::move(stub), std::move(limiter),
-      std::move(retry_policy), std::move(backoff_policy), idempotent_policy,
-      app_profile_id, table_name, std::move(mut)));
+      std::move(retry_policy), std::move(backoff_policy), enable_server_retries,
+      idempotent_policy, app_profile_id, table_name, std::move(mut)));
   bulk_apply->StartIteration();
   return bulk_apply->promise_.get_future();
 }
@@ -45,7 +46,7 @@ AsyncBulkApplier::AsyncBulkApplier(
     CompletionQueue cq, std::shared_ptr<BigtableStub> stub,
     std::shared_ptr<MutateRowsLimiter> limiter,
     std::unique_ptr<bigtable::DataRetryPolicy> retry_policy,
-    std::unique_ptr<BackoffPolicy> backoff_policy,
+    std::unique_ptr<BackoffPolicy> backoff_policy, bool enable_server_retries,
     bigtable::IdempotentMutationPolicy& idempotent_policy,
     std::string const& app_profile_id, std::string const& table_name,
     bigtable::BulkMutation mut)
@@ -54,6 +55,7 @@ AsyncBulkApplier::AsyncBulkApplier(
       limiter_(std::move(limiter)),
       retry_policy_(std::move(retry_policy)),
       backoff_policy_(std::move(backoff_policy)),
+      enable_server_retries_(enable_server_retries),
       state_(app_profile_id, table_name, idempotent_policy, std::move(mut)),
       promise_([this] { keep_reading_ = false; }) {}
 
@@ -68,7 +70,7 @@ void AsyncBulkApplier::StartIteration() {
 void AsyncBulkApplier::MakeRequest() {
   internal::ScopedCallContext scope(call_context_);
   context_ = std::make_shared<grpc::ClientContext>();
-  internal::ConfigureContext(*context_, internal::CurrentOptions());
+  internal::ConfigureContext(*context_, *call_context_.options);
   retry_context_->PreCall(*context_);
 
   auto self = this->shared_from_this();
@@ -89,7 +91,13 @@ void AsyncBulkApplier::OnRead(
 
 void AsyncBulkApplier::OnFinish(Status const& status) {
   state_.OnFinish(status);
-  if (!state_.HasPendingMutations() || !retry_policy_->OnFailure(status)) {
+  if (!state_.HasPendingMutations()) {
+    SetPromise();
+    return;
+  }
+  auto delay = BackoffOrBreak(enable_server_retries_, status, *retry_policy_,
+                              *backoff_policy_);
+  if (!delay) {
     SetPromise();
     return;
   }
@@ -97,8 +105,8 @@ void AsyncBulkApplier::OnFinish(Status const& status) {
   retry_context_->PostCall(*context_);
   context_.reset();
   auto self = this->shared_from_this();
-  internal::TracedAsyncBackoff(cq_, internal::CurrentOptions(),
-                               backoff_policy_->OnCompletion(), "Async Backoff")
+  internal::TracedAsyncBackoff(cq_, *call_context_.options, *delay,
+                               "Async Backoff")
       .then([self](auto result) {
         if (result.get()) {
           self->StartIteration();

--- a/google/cloud/bigtable/internal/async_bulk_apply.h
+++ b/google/cloud/bigtable/internal/async_bulk_apply.h
@@ -45,7 +45,7 @@ class AsyncBulkApplier : public std::enable_shared_from_this<AsyncBulkApplier> {
       CompletionQueue cq, std::shared_ptr<BigtableStub> stub,
       std::shared_ptr<MutateRowsLimiter> limiter,
       std::unique_ptr<bigtable::DataRetryPolicy> retry_policy,
-      std::unique_ptr<BackoffPolicy> backoff_policy,
+      std::unique_ptr<BackoffPolicy> backoff_policy, bool enable_server_retries,
       bigtable::IdempotentMutationPolicy& idempotent_policy,
       std::string const& app_profile_id, std::string const& table_name,
       bigtable::BulkMutation mut);
@@ -55,6 +55,7 @@ class AsyncBulkApplier : public std::enable_shared_from_this<AsyncBulkApplier> {
                    std::shared_ptr<MutateRowsLimiter> limiter,
                    std::unique_ptr<bigtable::DataRetryPolicy> retry_policy,
                    std::unique_ptr<BackoffPolicy> backoff_policy,
+                   bool enable_server_retries,
                    bigtable::IdempotentMutationPolicy& idempotent_policy,
                    std::string const& app_profile_id,
                    std::string const& table_name, bigtable::BulkMutation mut);
@@ -70,6 +71,7 @@ class AsyncBulkApplier : public std::enable_shared_from_this<AsyncBulkApplier> {
   std::shared_ptr<MutateRowsLimiter> limiter_;
   std::unique_ptr<bigtable::DataRetryPolicy> retry_policy_;
   std::unique_ptr<BackoffPolicy> backoff_policy_;
+  bool enable_server_retries_;
   BulkMutatorState state_;
   std::atomic<bool> keep_reading_{true};
   promise<std::vector<bigtable::FailedMutation>> promise_;

--- a/google/cloud/bigtable/internal/async_bulk_apply_test.cc
+++ b/google/cloud/bigtable/internal/async_bulk_apply_test.cc
@@ -41,12 +41,14 @@ using ::google::cloud::bigtable::testing::MockBigtableStub;
 using ::google::cloud::bigtable::testing::MockMutateRowsLimiter;
 using ::google::cloud::testing_util::MockBackoffPolicy;
 using ::google::cloud::testing_util::MockCompletionQueueImpl;
+using ::testing::ByMove;
 using ::testing::Contains;
 using ::testing::ElementsAreArray;
 using ::testing::Matcher;
 using ::testing::MockFunction;
 using ::testing::Pair;
 using ::testing::Property;
+using ::testing::Return;
 
 auto constexpr kNumRetries = 2;
 auto const* const kTableName =
@@ -126,7 +128,7 @@ TEST_F(AsyncBulkApplyTest, NoMutations) {
 
   auto actual = AsyncBulkApplier::Create(
       cq, mock, std::make_shared<NoopMutateRowsLimiter>(), std::move(retry),
-      std::move(mock_b), *idempotency, kAppProfile, kTableName,
+      std::move(mock_b), false, *idempotency, kAppProfile, kTableName,
       bigtable::BulkMutation());
 
   CheckFailedMutations(actual.get(), {});
@@ -182,7 +184,8 @@ TEST_F(AsyncBulkApplyTest, Success) {
 
   auto actual = AsyncBulkApplier::Create(
       cq, mock, std::make_shared<NoopMutateRowsLimiter>(), std::move(retry),
-      std::move(mock_b), *idempotency, kAppProfile, kTableName, std::move(mut));
+      std::move(mock_b), false, *idempotency, kAppProfile, kTableName,
+      std::move(mut));
 
   CheckFailedMutations(actual.get(), {});
 }
@@ -261,7 +264,8 @@ TEST_F(AsyncBulkApplyTest, PartialStreamIsRetried) {
 
   auto actual = AsyncBulkApplier::Create(
       cq, mock, std::make_shared<NoopMutateRowsLimiter>(), std::move(retry),
-      std::move(mock_b), *idempotency, kAppProfile, kTableName, std::move(mut));
+      std::move(mock_b), false, *idempotency, kAppProfile, kTableName,
+      std::move(mut));
 
   CheckFailedMutations(actual.get(), {});
 }
@@ -346,7 +350,8 @@ TEST_F(AsyncBulkApplyTest, IdempotentMutationPolicy) {
 
   auto actual = AsyncBulkApplier::Create(
       cq, mock, std::make_shared<NoopMutateRowsLimiter>(), std::move(retry),
-      std::move(mock_b), *idempotency, kAppProfile, kTableName, std::move(mut));
+      std::move(mock_b), false, *idempotency, kAppProfile, kTableName,
+      std::move(mut));
 
   CheckFailedMutations(actual.get(), expected);
 }
@@ -395,7 +400,99 @@ TEST_F(AsyncBulkApplyTest, TooManyStreamFailures) {
 
   auto actual = AsyncBulkApplier::Create(
       cq, mock, std::make_shared<NoopMutateRowsLimiter>(), std::move(retry),
-      std::move(mock_b), *idempotency, kAppProfile, kTableName, std::move(mut));
+      std::move(mock_b), false, *idempotency, kAppProfile, kTableName,
+      std::move(mut));
+
+  CheckFailedMutations(actual.get(), expected);
+}
+
+TEST_F(AsyncBulkApplyTest, RetryInfoHeeded) {
+  bigtable::BulkMutation mut(IdempotentMutation("r0"));
+
+  auto mock = std::make_shared<MockBigtableStub>();
+  EXPECT_CALL(*mock, AsyncMutateRows)
+      .WillOnce([this](CompletionQueue const&, auto context,
+                       v2::MutateRowsRequest const&) {
+        metadata_fixture_.SetServerMetadata(*context, {});
+        auto stream = std::make_unique<MockAsyncMutateRowsStream>();
+        EXPECT_CALL(*stream, Start).WillOnce([] {
+          return make_ready_future(false);
+        });
+        EXPECT_CALL(*stream, Finish).WillOnce([] {
+          auto status = PermanentError();
+          internal::SetRetryInfo(status, internal::RetryInfo{ms(0)});
+          return make_ready_future(status);
+        });
+        return stream;
+      })
+      .WillOnce([this](CompletionQueue const&, auto context,
+                       v2::MutateRowsRequest const&) {
+        metadata_fixture_.SetServerMetadata(*context, {});
+        auto stream = std::make_unique<MockAsyncMutateRowsStream>();
+        EXPECT_CALL(*stream, Start).WillOnce([] {
+          return make_ready_future(true);
+        });
+        EXPECT_CALL(*stream, Read)
+            .WillOnce(Return(ByMove(
+                make_ready_future(MakeResponse({{0, grpc::StatusCode::OK}})))))
+            .WillOnce(Return(ByMove(
+                make_ready_future(absl::optional<v2::MutateRowsResponse>()))));
+        EXPECT_CALL(*stream, Finish)
+            .WillOnce(Return(make_ready_future(Status())));
+        return stream;
+      });
+
+  auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
+  EXPECT_CALL(*mock_cq, MakeRelativeTimer)
+      .WillOnce(Return(ByMove(make_ready_future(
+          make_status_or(std::chrono::system_clock::now())))));
+  CompletionQueue cq(mock_cq);
+
+  auto retry = DataLimitedErrorCountRetryPolicy(kNumRetries).clone();
+  auto mock_b = std::make_unique<MockBackoffPolicy>();
+  auto idempotency = bigtable::DefaultIdempotentMutationPolicy();
+
+  auto actual = AsyncBulkApplier::Create(
+      cq, mock, std::make_shared<NoopMutateRowsLimiter>(), std::move(retry),
+      std::move(mock_b), true, *idempotency, kAppProfile, kTableName,
+      std::move(mut));
+
+  CheckFailedMutations(actual.get(), {});
+}
+
+TEST_F(AsyncBulkApplyTest, RetryInfoIgnored) {
+  std::vector<bigtable::FailedMutation> expected = {{PermanentError(), 0}};
+  bigtable::BulkMutation mut(IdempotentMutation("r0"));
+
+  auto mock = std::make_shared<MockBigtableStub>();
+  EXPECT_CALL(*mock, AsyncMutateRows)
+      .WillOnce([this](CompletionQueue const&, auto context,
+                       v2::MutateRowsRequest const&) {
+        metadata_fixture_.SetServerMetadata(*context, {});
+        auto stream = std::make_unique<MockAsyncMutateRowsStream>();
+        EXPECT_CALL(*stream, Start).WillOnce([] {
+          return make_ready_future(false);
+        });
+        EXPECT_CALL(*stream, Finish).WillOnce([] {
+          auto status = PermanentError();
+          internal::SetRetryInfo(status, internal::RetryInfo{ms(0)});
+          return make_ready_future(status);
+        });
+        return stream;
+      });
+
+  auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
+  EXPECT_CALL(*mock_cq, MakeRelativeTimer).Times(0);
+  CompletionQueue cq(mock_cq);
+
+  auto retry = DataLimitedErrorCountRetryPolicy(kNumRetries).clone();
+  auto mock_b = std::make_unique<MockBackoffPolicy>();
+  auto idempotency = bigtable::DefaultIdempotentMutationPolicy();
+
+  auto actual = AsyncBulkApplier::Create(
+      cq, mock, std::make_shared<NoopMutateRowsLimiter>(), std::move(retry),
+      std::move(mock_b), false, *idempotency, kAppProfile, kTableName,
+      std::move(mut));
 
   CheckFailedMutations(actual.get(), expected);
 }
@@ -441,7 +538,8 @@ TEST_F(AsyncBulkApplyTest, TimerError) {
 
   auto actual = AsyncBulkApplier::Create(
       cq, mock, std::make_shared<NoopMutateRowsLimiter>(), std::move(retry),
-      std::move(mock_b), *idempotency, kAppProfile, kTableName, std::move(mut));
+      std::move(mock_b), false, *idempotency, kAppProfile, kTableName,
+      std::move(mut));
 
   CheckFailedMutations(actual.get(), expected);
 }
@@ -489,7 +587,8 @@ TEST_F(AsyncBulkApplyTest, CancelAfterSuccess) {
 
   auto actual = AsyncBulkApplier::Create(
       cq, mock, std::make_shared<NoopMutateRowsLimiter>(), std::move(retry),
-      std::move(mock_b), *idempotency, kAppProfile, kTableName, std::move(mut));
+      std::move(mock_b), false, *idempotency, kAppProfile, kTableName,
+      std::move(mut));
 
   // Cancel the call after performing the one and only read of this test stream.
   actual.cancel();
@@ -552,7 +651,8 @@ TEST_F(AsyncBulkApplyTest, CancelMidStream) {
 
   auto actual = AsyncBulkApplier::Create(
       cq, mock, std::make_shared<NoopMutateRowsLimiter>(), std::move(retry),
-      std::move(mock_b), *idempotency, kAppProfile, kTableName, std::move(mut));
+      std::move(mock_b), false, *idempotency, kAppProfile, kTableName,
+      std::move(mut));
 
   // Cancel the call after performing one read of this test stream.
   actual.cancel();
@@ -610,7 +710,8 @@ TEST_F(AsyncBulkApplyTest, CurrentOptionsContinuedOnRetries) {
           .set<TestOption>(5));
   auto fut = AsyncBulkApplier::Create(
       cq, mock, std::make_shared<NoopMutateRowsLimiter>(), std::move(retry),
-      std::move(mock_b), *idempotency, kAppProfile, kTableName, std::move(mut));
+      std::move(mock_b), false, *idempotency, kAppProfile, kTableName,
+      std::move(mut));
 
   // Simulate the timer being satisfied in a thread with different prevailing
   // options than the calling thread.
@@ -674,7 +775,8 @@ TEST_F(AsyncBulkApplyTest, RetriesOkStreamWithFailedMutations) {
 
   auto actual = AsyncBulkApplier::Create(
       cq, mock, std::make_shared<NoopMutateRowsLimiter>(), std::move(retry),
-      std::move(mock_b), *idempotency, kAppProfile, kTableName, std::move(mut));
+      std::move(mock_b), false, *idempotency, kAppProfile, kTableName,
+      std::move(mut));
 
   CheckFailedMutations(actual.get(), expected);
 }
@@ -720,8 +822,8 @@ TEST_F(AsyncBulkApplyTest, Throttling) {
       });
 
   auto actual = AsyncBulkApplier::Create(
-      cq, mock, limiter, std::move(retry), std::move(mock_b), *idempotency,
-      kAppProfile, kTableName, std::move(mut));
+      cq, mock, limiter, std::move(retry), std::move(mock_b), false,
+      *idempotency, kAppProfile, kTableName, std::move(mut));
 
   CheckFailedMutations(actual.get(), expected);
 }
@@ -775,8 +877,8 @@ TEST_F(AsyncBulkApplyTest, ThrottlingBeforeEachRetry) {
   auto idempotency = bigtable::DefaultIdempotentMutationPolicy();
 
   auto actual = AsyncBulkApplier::Create(
-      cq, mock, limiter, std::move(retry), std::move(mock_b), *idempotency,
-      kAppProfile, kTableName, std::move(mut));
+      cq, mock, limiter, std::move(retry), std::move(mock_b), false,
+      *idempotency, kAppProfile, kTableName, std::move(mut));
 
   CheckFailedMutations(actual.get(), expected);
 }
@@ -830,7 +932,8 @@ TEST_F(AsyncBulkApplyTest, BigtableCookie) {
 
   auto actual = AsyncBulkApplier::Create(
       cq, mock, std::make_shared<NoopMutateRowsLimiter>(), std::move(retry),
-      std::move(mock_b), *idempotency, kAppProfile, kTableName, std::move(mut));
+      std::move(mock_b), false, *idempotency, kAppProfile, kTableName,
+      std::move(mut));
 
   CheckFailedMutations(actual.get(), expected);
 }
@@ -867,7 +970,7 @@ TEST_F(AsyncBulkApplyTest, TracedBackoff) {
   internal::OptionsSpan o(EnableTracing(Options{}));
   (void)AsyncBulkApplier::Create(
       background.cq(), mock, std::make_shared<NoopMutateRowsLimiter>(),
-      std::move(retry), std::move(mock_b), *idempotency, kAppProfile,
+      std::move(retry), std::move(mock_b), false, *idempotency, kAppProfile,
       kTableName, std::move(mut))
       .get();
 
@@ -901,7 +1004,7 @@ TEST_F(AsyncBulkApplyTest, CallSpanActiveThroughout) {
   internal::OptionsSpan o(EnableTracing(Options{}));
   auto f = AsyncBulkApplier::Create(
       background.cq(), mock, std::make_shared<NoopMutateRowsLimiter>(),
-      std::move(retry), std::move(mock_b), *idempotency, kAppProfile,
+      std::move(retry), std::move(mock_b), false, *idempotency, kAppProfile,
       kTableName, std::move(mut));
 
   auto overlay = opentelemetry::trace::Scope(internal::MakeSpan("overlay"));

--- a/google/cloud/bigtable/internal/data_connection_impl.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl.cc
@@ -191,8 +191,9 @@ DataConnectionImpl::AsyncBulkApply(std::string const& table_name,
   auto current = google::cloud::internal::SaveCurrentOptions();
   return AsyncBulkApplier::Create(
       background_->cq(), stub_, limiter_, retry_policy(*current),
-      backoff_policy(*current), *idempotency_policy(*current),
-      app_profile_id(*current), table_name, std::move(mut));
+      backoff_policy(*current), enable_server_retries(*current),
+      *idempotency_policy(*current), app_profile_id(*current), table_name,
+      std::move(mut));
 }
 
 bigtable::RowReader DataConnectionImpl::ReadRowsFull(


### PR DESCRIPTION
Part of the work for #13514 

and basically the same as #13568

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13602)
<!-- Reviewable:end -->
