### PR TITLE
ci: check-api skips absl namespace

### DIFF
--- a/ci/cloudbuild/builds/check-api.sh
+++ b/ci/cloudbuild/builds/check-api.sh
@@ -123,7 +123,7 @@ function check_abi() {
       # characters in the string "internal", and it should again be followed
       # by some other number indicating the length of the symbol within the
       # "internal" namespace. See: https://en.wikipedia.org/wiki/Name_mangling
-      -skip-internal-symbols "(8internal|_internal|4grpc)\d"
+      -skip-internal-symbols "(8internal|_internal|4grpc|4absl)\d"
       # We also ignore the raw gRPC Stub class. The generated gRPC headers that
       # contain these classes are installed alongside our headers. When a new
       # RPC is added to a service, these classes gain a pure virtual method. Our


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13604)
<!-- Reviewable:end -->
