### PR TITLE
fix(storagecontrol): override idempotency policy

### DIFF
--- a/generator/generator_config.textproto
+++ b/generator/generator_config.textproto
@@ -3240,6 +3240,11 @@ service {
   initial_copyright_year: "2024"
   retryable_status_codes: ["kUnavailable"]
   omit_repo_metadata: true
+  idempotency_overrides: [
+    {rpc_name: "StorageControl.GetFolder", idempotency: IDEMPOTENT},
+    {rpc_name: "StorageControl.ListFolders", idempotency: IDEMPOTENT},
+    {rpc_name: "StorageControl.GetStorageLayout", idempotency: IDEMPOTENT}
+  ]
 }
 
 # Storage Insights

--- a/google/cloud/storagecontrol/v2/storage_control_connection_idempotency_policy.cc
+++ b/google/cloud/storagecontrol/v2/storage_control_connection_idempotency_policy.cc
@@ -46,12 +46,12 @@ Idempotency StorageControlConnectionIdempotencyPolicy::DeleteFolder(
 
 Idempotency StorageControlConnectionIdempotencyPolicy::GetFolder(
     google::storage::control::v2::GetFolderRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency StorageControlConnectionIdempotencyPolicy::ListFolders(
     google::storage::control::v2::ListFoldersRequest) {  // NOLINT
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 Idempotency StorageControlConnectionIdempotencyPolicy::RenameFolder(
@@ -61,7 +61,7 @@ Idempotency StorageControlConnectionIdempotencyPolicy::RenameFolder(
 
 Idempotency StorageControlConnectionIdempotencyPolicy::GetStorageLayout(
     google::storage::control::v2::GetStorageLayoutRequest const&) {
-  return Idempotency::kNonIdempotent;
+  return Idempotency::kIdempotent;
 }
 
 std::unique_ptr<StorageControlConnectionIdempotencyPolicy>


### PR DESCRIPTION
The protos for this service lack the `http` annotations we normally use to determine if an operation is idempotent.  Override the few RPCs that are idempotent by virtual of being read-only operations.

Motivated by #13595 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13606)
<!-- Reviewable:end -->
