### PR TITLE
impl(bigtable): heed `RetryInfo` in `AsyncReadRows`

### DIFF
--- a/google/cloud/bigtable/internal/async_row_reader.cc
+++ b/google/cloud/bigtable/internal/async_row_reader.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/internal/async_row_reader.h"
+#include "google/cloud/bigtable/internal/retry_info_helper.h"
 #include "google/cloud/bigtable/version.h"
 #include "google/cloud/internal/grpc_opentelemetry.h"
 #include "google/cloud/log.h"
@@ -44,7 +45,7 @@ void AsyncRowReader::MakeRequest() {
 
   internal::ScopedCallContext scope(call_context_);
   context_ = std::make_shared<grpc::ClientContext>();
-  internal::ConfigureContext(*context_, internal::CurrentOptions());
+  internal::ConfigureContext(*context_, *call_context_.options);
   retry_context_->PreCall(*context_);
 
   auto self = this->shared_from_this();
@@ -208,7 +209,9 @@ void AsyncRowReader::OnStreamFinished(Status status) {
     return;
   }
 
-  if (!retry_policy_->OnFailure(status_)) {
+  auto delay = BackoffOrBreak(enable_server_retries_, status_, *retry_policy_,
+                              *backoff_policy_);
+  if (!delay) {
     // Can't retry.
     whole_op_finished_ = true;
     TryGiveRowToUser();
@@ -217,8 +220,8 @@ void AsyncRowReader::OnStreamFinished(Status status) {
   retry_context_->PostCall(*context_);
   context_.reset();
   auto self = this->shared_from_this();
-  internal::TracedAsyncBackoff(cq_, internal::CurrentOptions(),
-                               backoff_policy_->OnCompletion(), "Async Backoff")
+  internal::TracedAsyncBackoff(cq_, *call_context_.options, *delay,
+                               "Async Backoff")
       .then([self](auto result) {
         if (auto tp = result.get()) {
           self->MakeRequest();

--- a/google/cloud/bigtable/internal/async_row_reader.h
+++ b/google/cloud/bigtable/internal/async_row_reader.h
@@ -60,12 +60,14 @@ class AsyncRowReader : public std::enable_shared_from_this<AsyncRowReader> {
                      bigtable::RowSet row_set, std::int64_t rows_limit,
                      bigtable::Filter filter, bool reverse,
                      std::unique_ptr<bigtable::DataRetryPolicy> retry_policy,
-                     std::unique_ptr<BackoffPolicy> backoff_policy) {
+                     std::unique_ptr<BackoffPolicy> backoff_policy,
+                     bool enable_server_retries) {
     auto reader = std::shared_ptr<AsyncRowReader>(new AsyncRowReader(
         std::move(cq), std::move(stub), std::move(app_profile_id),
         std::move(table_name), std::move(on_row), std::move(on_finish),
         std::move(row_set), rows_limit, std::move(filter), reverse,
-        std::move(retry_policy), std::move(backoff_policy)));
+        std::move(retry_policy), std::move(backoff_policy),
+        enable_server_retries));
     reader->MakeRequest();
   }
 
@@ -76,7 +78,8 @@ class AsyncRowReader : public std::enable_shared_from_this<AsyncRowReader> {
                  bigtable::RowSet row_set, std::int64_t rows_limit,
                  bigtable::Filter filter, bool reverse,
                  std::unique_ptr<bigtable::DataRetryPolicy> retry_policy,
-                 std::unique_ptr<BackoffPolicy> backoff_policy)
+                 std::unique_ptr<BackoffPolicy> backoff_policy,
+                 bool enable_server_retries)
       : cq_(std::move(cq)),
         stub_(std::move(stub)),
         app_profile_id_(std::move(app_profile_id)),
@@ -88,7 +91,8 @@ class AsyncRowReader : public std::enable_shared_from_this<AsyncRowReader> {
         filter_(std::move(filter)),
         reverse_(std::move(reverse)),
         retry_policy_(std::move(retry_policy)),
-        backoff_policy_(std::move(backoff_policy)) {}
+        backoff_policy_(std::move(backoff_policy)),
+        enable_server_retries_(enable_server_retries) {}
 
   void MakeRequest();
 
@@ -134,6 +138,7 @@ class AsyncRowReader : public std::enable_shared_from_this<AsyncRowReader> {
   bool reverse_;
   std::unique_ptr<bigtable::DataRetryPolicy> retry_policy_;
   std::unique_ptr<BackoffPolicy> backoff_policy_;
+  bool enable_server_retries_;
   std::unique_ptr<bigtable::internal::ReadRowsParser> parser_;
   /// Number of rows read so far, used to set row_limit in retries.
   std::int64_t rows_count_ = 0;

--- a/google/cloud/bigtable/internal/data_connection_impl.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl.cc
@@ -430,7 +430,7 @@ void DataConnectionImpl::AsyncReadRows(
       background_->cq(), stub_, app_profile_id(*current), table_name,
       std::move(on_row), std::move(on_finish), std::move(row_set), rows_limit,
       std::move(filter), reverse, retry_policy(*current),
-      backoff_policy(*current));
+      backoff_policy(*current), enable_server_retries(*current));
 }
 
 future<StatusOr<std::pair<bool, bigtable::Row>>>


### PR DESCRIPTION
Part of the work for #13514

and basically the same as #13568

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13609)
<!-- Reviewable:end -->
