### PR TITLE
impl(generator): method variables for `request_id`

### DIFF
--- a/generator/generator.cc
+++ b/generator/generator.cc
@@ -19,6 +19,7 @@
 #include "generator/internal/make_generators.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/filesystem.h"
 #include "google/cloud/status_or.h"
 #include "absl/strings/str_split.h"
 #include <google/api/client.pb.h>
@@ -59,13 +60,21 @@ bool Generator::Generate(google::protobuf::FileDescriptor const* file,
     }
   }
 
+  YAML::Node service_config;
+  for (auto const& arg : *command_line_args) {
+    if (arg.first != "service_config_yaml") continue;
+    auto status = google::cloud::internal::status(arg.second);
+    if (!exists(status)) continue;
+    service_config = YAML::LoadFile(arg.second);
+  }
+
   std::vector<ServiceGenerator> services;
   services.reserve(file->service_count());
   for (int i = 0; i < file->service_count(); ++i) {
     auto const* service = file->service(i);
     if (!internal::Contains(omitted_services, service->name())) {
       services.push_back(generator_internal::MakeGenerators(
-          service, context, *command_line_args));
+          service, context, service_config, *command_line_args));
     }
   }
 

--- a/generator/generator_config.proto
+++ b/generator/generator_config.proto
@@ -171,14 +171,13 @@ message ServiceConfiguration {
   // service. This will replace the service comment from the upstream repo.
   map<string, string> service_name_to_comment = 27;
 
-  // If not empty, it overrides the location of the service config YAML file.
+  // If not empty, it overrides the name (relative to the googleapis root) of
+  // the service config YAML file.
+  //
   // Normally the directory and name for the service config YAML are fetched
-  // from the service index JSON file in the googleapis repository. When using
+  // from the service index JSON file in the googleapis repository. When
   // processing golden files we need to provide our own YAML files.
-  string override_service_config_yaml_directory = 28;
-
-  // If not empty, it overrides the name of the service config YAML file.
-  string override_service_config_yaml_name = 29;
+  string override_service_config_yaml_name = 28;
 }
 
 message DiscoveryDocumentDefinedProduct {

--- a/generator/generator_config.proto
+++ b/generator/generator_config.proto
@@ -170,6 +170,15 @@ message ServiceConfiguration {
   // overridden by an entry in service_name_mapping to a comment for the
   // service. This will replace the service comment from the upstream repo.
   map<string, string> service_name_to_comment = 27;
+
+  // If not empty, it overrides the location of the service config YAML file.
+  // Normally the directory and name for the service config YAML are fetched
+  // from the service index JSON file in the googleapis repository. When using
+  // processing golden files we need to provide our own YAML files.
+  string override_service_config_yaml_directory = 28;
+
+  // If not empty, it overrides the name of the service config YAML file.
+  string override_service_config_yaml_name = 29;
 }
 
 message DiscoveryDocumentDefinedProduct {

--- a/generator/integration_tests/golden_config.textproto
+++ b/generator/integration_tests/golden_config.textproto
@@ -73,6 +73,5 @@ service {
   gen_async_rpcs: [
     "CreateFoo"
   ]
-  override_service_config_yaml_directory: "generator/integration_tests"
-  override_service_config_yaml_name: "test_request_id.yaml"
+  override_service_config_yaml_name: "generator/integration_tests/test_request_id.yaml"
 }

--- a/generator/integration_tests/golden_config.textproto
+++ b/generator/integration_tests/golden_config.textproto
@@ -73,4 +73,6 @@ service {
   gen_async_rpcs: [
     "CreateFoo"
   ]
+  override_service_config_yaml_directory: "generator/integration_tests"
+  override_service_config_yaml_name: "test_request_id.yaml"
 }

--- a/generator/integration_tests/test_request_id.yaml
+++ b/generator/integration_tests/test_request_id.yaml
@@ -1,0 +1,16 @@
+type: google.api.Service
+config_version: 3
+name: test.googleapis.com
+title: Cloud Storage API
+
+apis:
+- name: google.test.requestid.v1.RequestIdService
+
+publishing:
+  method_settings:
+  - selector: google.test.requestid.v1.RequestIdService.CreateFoo
+    auto_populated_fields:
+    - request_id
+  - selector: google.test.requestid.v1.RequestIdService.RenameFoo
+    auto_populated_fields:
+    - request_id

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -21,6 +21,7 @@
 #include "generator/internal/http_option_utils.h"
 #include "generator/internal/longrunning.h"
 #include "generator/internal/pagination.h"
+#include "generator/internal/request_id.h"
 #include "generator/internal/resolve_method_return.h"
 #include "generator/internal/routing.h"
 #include "generator/internal/scaffold_generator.h"
@@ -899,7 +900,7 @@ std::map<std::string, std::string> ParseIdempotencyOverrides(
 
 std::map<std::string, VarsDictionary> CreateMethodVars(
     google::protobuf::ServiceDescriptor const& service,
-    VarsDictionary const& vars) {
+    YAML::Node const& service_config, VarsDictionary const& vars) {
   auto split_arg = [&vars](std::string const& arg) -> std::set<std::string> {
     auto l = vars.find(arg);
     if (l == vars.end()) return {};
@@ -931,6 +932,10 @@ std::map<std::string, VarsDictionary> CreateMethodVars(
     method_vars["response_message_type"] = method.output_type()->full_name();
     method_vars["response_type"] =
         ProtoNameToCppName(method.output_type()->full_name());
+    auto request_id_field_name = RequestIdFieldName(service_config, method);
+    if (!request_id_field_name.empty()) {
+      method_vars["request_id_field_name"] = std::move(request_id_field_name);
+    }
     SetLongrunningOperationMethodVars(method, method_vars);
     AssignPaginationMethodVars(method, method_vars);
     SetMethodSignatureMethodVars(service, method, emitted_rpcs, omitted_rpcs,

--- a/generator/internal/descriptor_utils.h
+++ b/generator/internal/descriptor_utils.h
@@ -21,6 +21,7 @@
 #include "absl/types/variant.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
+#include <yaml-cpp/yaml.h>
 #include <map>
 #include <memory>
 #include <string>
@@ -50,7 +51,7 @@ VarsDictionary CreateServiceVars(
  */
 std::map<std::string, VarsDictionary> CreateMethodVars(
     google::protobuf::ServiceDescriptor const& service,
-    VarsDictionary const& service_vars);
+    YAML::Node const& service_config, VarsDictionary const& service_vars);
 
 /**
  * Determines which `MethodPattern` to use from patterns for the given method

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -873,7 +873,6 @@ message WithRequestIdRequest {
   string field = 1 [ (google.api.field_info).format = UUID4 ];
 }
 
-
 message WithoutRequestIdRequest {
   string field = 1;
 }

--- a/generator/internal/make_generators.cc
+++ b/generator/internal/make_generators.cc
@@ -55,10 +55,11 @@ namespace generator_internal {
 std::vector<std::unique_ptr<GeneratorInterface>> MakeGenerators(
     google::protobuf::ServiceDescriptor const* service,
     google::protobuf::compiler::GeneratorContext* context,
+    YAML::Node const& service_config,
     std::vector<std::pair<std::string, std::string>> const& vars) {
   std::vector<std::unique_ptr<GeneratorInterface>> code_generators;
   VarsDictionary service_vars = CreateServiceVars(*service, vars);
-  auto method_vars = CreateMethodVars(*service, service_vars);
+  auto method_vars = CreateMethodVars(*service, service_config, service_vars);
   bool const generate_grpc_transport = [&] {
     auto iter = service_vars.find("generate_grpc_transport");
     if (iter == service_vars.end()) return true;

--- a/generator/internal/make_generators.h
+++ b/generator/internal/make_generators.h
@@ -18,6 +18,7 @@
 #include "generator/internal/generator_interface.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
+#include <yaml-cpp/yaml.h>
 #include <memory>
 #include <string>
 #include <utility>
@@ -34,6 +35,7 @@ namespace generator_internal {
 std::vector<std::unique_ptr<GeneratorInterface>> MakeGenerators(
     google::protobuf::ServiceDescriptor const* service,
     google::protobuf::compiler::GeneratorContext* context,
+    YAML::Node const& service_config,
     std::vector<std::pair<std::string, std::string>> const& vars);
 
 }  // namespace generator_internal

--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -118,7 +118,7 @@ nlohmann::json LoadApiIndex(std::string const& googleapis_path) {
 }
 
 std::map<std::string, std::string> ScaffoldVars(
-    std::string const& googleapis_path, nlohmann::json const& index,
+    std::string const& yaml_root, nlohmann::json const& index,
     google::cloud::cpp::generator::ServiceConfiguration const& service,
     bool experimental) {
   std::map<std::string, std::string> vars;
@@ -132,6 +132,12 @@ std::map<std::string, std::string> ScaffoldVars(
     vars.emplace("directory", api.value("directory", ""));
     vars.emplace("nameInServiceConfig", api.value("nameInServiceConfig", ""));
     vars.emplace("configFile", api.value("configFile", ""));
+  }
+  if (!service.override_service_config_yaml_directory().empty()) {
+    vars.emplace("directory", service.override_service_config_yaml_directory());
+  }
+  if (!service.override_service_config_yaml_name().empty()) {
+    vars.emplace("configFile", service.override_service_config_yaml_name());
   }
   auto const library = LibraryName(service.product_path());
   vars["copyright_year"] = service.initial_copyright_year();
@@ -153,18 +159,16 @@ std::map<std::string, std::string> ScaffoldVars(
                      "to change without notice.\n\nPlease,"
                    : "While this library is **GA**, please";
 
-  // Try to load the service config YAML file. On failure just return the
-  // existing vars.
-  auto const config_file = vars.find("configFile");
-  auto const directory = vars.find("directory");
-  if (config_file == vars.end() || directory == vars.end()) {
+  // Find out if the service config YAML is configured.
+  auto path = ServiceConfigYamlPath(yaml_root, vars);
+  if (path.empty()) {
     GCP_LOG(WARNING) << "Missing directory and/or YAML config file name for: "
                      << service.service_proto_path();
     return vars;
   }
 
-  auto const path =
-      googleapis_path + "/" + directory->second + "/" + config_file->second;
+  // Try to load the service config YAML file. On failure just return the
+  // existing vars.
   auto status = google::cloud::internal::status(path);
   if (!exists(status)) {
     GCP_LOG(WARNING) << "Cannot find YAML service config file (" << path
@@ -211,6 +215,14 @@ std::map<std::string, std::string> ScaffoldVars(
   }
 
   return vars;
+}
+
+std::string ServiceConfigYamlPath(
+    std::string const& root, std::map<std::string, std::string> const& vars) {
+  auto const directory = vars.find("directory");
+  auto const name = vars.find("configFile");
+  if (name == vars.end() || directory == vars.end()) return {};
+  return absl::StrCat(root, "/", directory->second, "/", name->second);
 }
 
 void MakeDirectory(std::string const& path) {

--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -130,14 +130,14 @@ std::map<std::string, std::string> ScaffoldVars(
     vars.emplace("title", api.value("title", ""));
     vars.emplace("description", api.value("description", ""));
     vars.emplace("directory", api.value("directory", ""));
+    vars.emplace("service_config_yaml_name",
+                 absl::StrCat(api.value("directory", ""), "/",
+                              api.value("configFile", "")));
     vars.emplace("nameInServiceConfig", api.value("nameInServiceConfig", ""));
-    vars.emplace("configFile", api.value("configFile", ""));
-  }
-  if (!service.override_service_config_yaml_directory().empty()) {
-    vars.emplace("directory", service.override_service_config_yaml_directory());
   }
   if (!service.override_service_config_yaml_name().empty()) {
-    vars.emplace("configFile", service.override_service_config_yaml_name());
+    vars.emplace("service_config_yaml_name",
+                 service.override_service_config_yaml_name());
   }
   auto const library = LibraryName(service.product_path());
   vars["copyright_year"] = service.initial_copyright_year();
@@ -219,10 +219,9 @@ std::map<std::string, std::string> ScaffoldVars(
 
 std::string ServiceConfigYamlPath(
     std::string const& root, std::map<std::string, std::string> const& vars) {
-  auto const directory = vars.find("directory");
-  auto const name = vars.find("configFile");
-  if (name == vars.end() || directory == vars.end()) return {};
-  return absl::StrCat(root, "/", directory->second, "/", name->second);
+  auto const name = vars.find("service_config_yaml_name");
+  if (name == vars.end()) return {};
+  return absl::StrCat(root, "/", name->second);
 }
 
 void MakeDirectory(std::string const& path) {

--- a/generator/internal/scaffold_generator.h
+++ b/generator/internal/scaffold_generator.h
@@ -83,10 +83,16 @@ nlohmann::json LoadApiIndex(std::string const& googleapis_path);
  *     engine.
  */
 std::map<std::string, std::string> ScaffoldVars(
-    std::string const& googleapis_path, nlohmann::json const& index,
+    std::string const& yaml_root, nlohmann::json const& index,
     google::cloud::cpp::generator::ServiceConfiguration const& service,
     bool experimental);
 
+/// Find out the full path for the service config YAML file from the scaffold
+/// vars.
+std::string ServiceConfigYamlPath(
+    std::string const& root, std::map<std::string, std::string> const& vars);
+
+/// Create a directory. The parent must exist.
 void MakeDirectory(std::string const& path);
 
 /**

--- a/generator/internal/service_code_generator.cc
+++ b/generator/internal/service_code_generator.cc
@@ -17,6 +17,7 @@
 #include "generator/internal/longrunning.h"
 #include "generator/internal/pagination.h"
 #include "generator/internal/printer.h"
+#include "generator/internal/request_id.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/absl_str_replace_quiet.h"
 #include "google/cloud/internal/algorithm.h"
@@ -198,6 +199,22 @@ bool ServiceCodeGenerator::HasGenerateGrpcTransport() const {
       service_vars_.find("generate_grpc_transport");
   return generate_grpc_transport != service_vars_.end() &&
          generate_grpc_transport->second == "true";
+}
+
+bool ServiceCodeGenerator::HasRequestId() const {
+  return std::any_of(service_method_vars_.begin(), service_method_vars_.end(),
+                     [](auto const& kv) {
+                       return kv.second.find("request_id_field_name") !=
+                              kv.second.end();
+                     });
+}
+
+bool ServiceCodeGenerator::HasRequestId(
+    google::protobuf::MethodDescriptor const& method) const {
+  auto mv = service_method_vars_.find(method.full_name());
+  if (mv == service_method_vars_.end()) return false;
+  auto const& method_vars = mv->second;
+  return method_vars.find("request_id_field_name") != method_vars.end();
 }
 
 std::vector<std::string>

--- a/generator/internal/service_code_generator.h
+++ b/generator/internal/service_code_generator.h
@@ -185,6 +185,13 @@ class ServiceCodeGenerator : public GeneratorInterface {
    */
   bool HasGenerateGrpcTransport() const;
 
+  /// Determine if any of the methods has an autopopulated `request_id`-like
+  /// field.
+  bool HasRequestId() const;
+
+  /// Determine if @p method has an auto-populated `request_id`-like field.
+  bool HasRequestId(google::protobuf::MethodDescriptor const& method) const;
+
   /**
    * Determines if any of the method signatures has any Protocol Buffer
    * Well-Known Types per


### PR DESCRIPTION
This sets the method variables needed to support `request_id`-like fields. As these variables need the service config YAML file, we need to make the location of these file available to the code generator. We also need to parse the file and propagate the results to the `CreateMethodVars()` function.

We use the API index file in the googleapis repository to find the location of this service config YAML file. That does not work for the golden protos used in integration tests, so we need a way to override it.

Part of the work for #13595

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13612)
<!-- Reviewable:end -->
