### PR TITLE
feat(generator): support `request_id`-like fields

### DIFF
--- a/generator/integration_tests/golden/v1/internal/request_id_connection_impl.cc
+++ b/generator/integration_tests/golden/v1/internal/request_id_connection_impl.cc
@@ -66,20 +66,27 @@ RequestIdServiceConnectionImpl::RequestIdServiceConnectionImpl(
 StatusOr<google::test::requestid::v1::Foo>
 RequestIdServiceConnectionImpl::CreateFoo(google::test::requestid::v1::CreateFooRequest const& request) {
   auto current = google::cloud::internal::SaveCurrentOptions();
+  auto request_copy = request;
+  if (request_copy.request_id().empty()) {
+    request_copy.set_request_id(invocation_id_generator_->MakeInvocationId());
+  }
   return google::cloud::internal::RetryLoop(
       retry_policy(*current), backoff_policy(*current),
-      idempotency_policy(*current)->CreateFoo(request),
+      idempotency_policy(*current)->CreateFoo(request_copy),
       [this](grpc::ClientContext& context,
              google::test::requestid::v1::CreateFooRequest const& request) {
         return stub_->CreateFoo(context, request);
       },
-      request, __func__);
+      request_copy, __func__);
 }
 
 future<StatusOr<google::test::requestid::v1::Foo>>
 RequestIdServiceConnectionImpl::RenameFoo(google::test::requestid::v1::RenameFooRequest const& request) {
   auto current = google::cloud::internal::SaveCurrentOptions();
   auto request_copy = request;
+  if (request_copy.request_id().empty()) {
+    request_copy.set_request_id(invocation_id_generator_->MakeInvocationId());
+  }
   auto const idempotent =
       idempotency_policy(*current)->RenameFoo(request_copy);
   return google::cloud::internal::AsyncLongRunningOperation<google::test::requestid::v1::Foo>(
@@ -138,6 +145,9 @@ future<StatusOr<google::test::requestid::v1::Foo>>
 RequestIdServiceConnectionImpl::AsyncCreateFoo(google::test::requestid::v1::CreateFooRequest const& request) {
   auto current = google::cloud::internal::SaveCurrentOptions();
   auto request_copy = request;
+  if (request_copy.request_id().empty()) {
+    request_copy.set_request_id(invocation_id_generator_->MakeInvocationId());
+  }
   auto const idempotent =
       idempotency_policy(*current)->CreateFoo(request_copy);
   return google::cloud::internal::AsyncRetryLoop(

--- a/generator/integration_tests/golden/v1/internal/request_id_connection_impl.h
+++ b/generator/integration_tests/golden/v1/internal/request_id_connection_impl.h
@@ -27,6 +27,7 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/backoff_policy.h"
 #include "google/cloud/future.h"
+#include "google/cloud/internal/invocation_id_generator.h"
 #include "google/cloud/options.h"
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
@@ -68,6 +69,9 @@ class RequestIdServiceConnectionImpl
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<golden_v1_internal::RequestIdServiceStub> stub_;
   Options options_;
+  std::shared_ptr<google::cloud::internal::InvocationIdGenerator>
+      invocation_id_generator_ =
+          std::make_shared<google::cloud::internal::InvocationIdGenerator>();
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/integration_tests/golden/v1/request_id_client.h
+++ b/generator/integration_tests/golden/v1/request_id_client.h
@@ -101,8 +101,8 @@ class RequestIdServiceClient {
   /// [`future`]: @ref google::cloud::future
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
-  /// [google.test.requestid.v1.CreateFooRequest]: @googleapis_reference_link{generator/integration_tests/test_request_id.proto#L80}
-  /// [google.test.requestid.v1.Foo]: @googleapis_reference_link{generator/integration_tests/test_request_id.proto#L66}
+  /// [google.test.requestid.v1.CreateFooRequest]: @googleapis_reference_link{generator/integration_tests/test_request_id.proto#L79}
+  /// [google.test.requestid.v1.Foo]: @googleapis_reference_link{generator/integration_tests/test_request_id.proto#L65}
   ///
   // clang-format on
   StatusOr<google::test::requestid::v1::Foo>
@@ -131,8 +131,8 @@ class RequestIdServiceClient {
   /// [`future`]: @ref google::cloud::future
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
-  /// [google.test.requestid.v1.CreateFooRequest]: @googleapis_reference_link{generator/integration_tests/test_request_id.proto#L80}
-  /// [google.test.requestid.v1.Foo]: @googleapis_reference_link{generator/integration_tests/test_request_id.proto#L66}
+  /// [google.test.requestid.v1.CreateFooRequest]: @googleapis_reference_link{generator/integration_tests/test_request_id.proto#L79}
+  /// [google.test.requestid.v1.Foo]: @googleapis_reference_link{generator/integration_tests/test_request_id.proto#L65}
   ///
   // clang-format on
   StatusOr<google::test::requestid::v1::Foo>
@@ -165,8 +165,8 @@ class RequestIdServiceClient {
   /// [`future`]: @ref google::cloud::future
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
-  /// [google.test.requestid.v1.Foo]: @googleapis_reference_link{generator/integration_tests/test_request_id.proto#L66}
-  /// [google.test.requestid.v1.RenameFooRequest]: @googleapis_reference_link{generator/integration_tests/test_request_id.proto#L100}
+  /// [google.test.requestid.v1.Foo]: @googleapis_reference_link{generator/integration_tests/test_request_id.proto#L65}
+  /// [google.test.requestid.v1.RenameFooRequest]: @googleapis_reference_link{generator/integration_tests/test_request_id.proto#L99}
   ///
   // clang-format on
   future<StatusOr<google::test::requestid::v1::Foo>>
@@ -202,8 +202,8 @@ class RequestIdServiceClient {
   /// [`future`]: @ref google::cloud::future
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
-  /// [google.test.requestid.v1.Foo]: @googleapis_reference_link{generator/integration_tests/test_request_id.proto#L66}
-  /// [google.test.requestid.v1.RenameFooRequest]: @googleapis_reference_link{generator/integration_tests/test_request_id.proto#L100}
+  /// [google.test.requestid.v1.Foo]: @googleapis_reference_link{generator/integration_tests/test_request_id.proto#L65}
+  /// [google.test.requestid.v1.RenameFooRequest]: @googleapis_reference_link{generator/integration_tests/test_request_id.proto#L99}
   ///
   // clang-format on
   future<StatusOr<google::test::requestid::v1::Foo>>
@@ -236,8 +236,8 @@ class RequestIdServiceClient {
   /// [`future`]: @ref google::cloud::future
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
-  /// [google.test.requestid.v1.Foo]: @googleapis_reference_link{generator/integration_tests/test_request_id.proto#L66}
-  /// [google.test.requestid.v1.ListFoosRequest]: @googleapis_reference_link{generator/integration_tests/test_request_id.proto#L135}
+  /// [google.test.requestid.v1.Foo]: @googleapis_reference_link{generator/integration_tests/test_request_id.proto#L65}
+  /// [google.test.requestid.v1.ListFoosRequest]: @googleapis_reference_link{generator/integration_tests/test_request_id.proto#L134}
   ///
   // clang-format on
   StreamRange<google::test::requestid::v1::Foo>
@@ -275,8 +275,8 @@ class RequestIdServiceClient {
   /// [`future`]: @ref google::cloud::future
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
-  /// [google.test.requestid.v1.Foo]: @googleapis_reference_link{generator/integration_tests/test_request_id.proto#L66}
-  /// [google.test.requestid.v1.ListFoosRequest]: @googleapis_reference_link{generator/integration_tests/test_request_id.proto#L135}
+  /// [google.test.requestid.v1.Foo]: @googleapis_reference_link{generator/integration_tests/test_request_id.proto#L65}
+  /// [google.test.requestid.v1.ListFoosRequest]: @googleapis_reference_link{generator/integration_tests/test_request_id.proto#L134}
   ///
   // clang-format on
   StreamRange<google::test::requestid::v1::Foo>
@@ -301,8 +301,8 @@ class RequestIdServiceClient {
   /// [`future`]: @ref google::cloud::future
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
-  /// [google.test.requestid.v1.CreateFooRequest]: @googleapis_reference_link{generator/integration_tests/test_request_id.proto#L80}
-  /// [google.test.requestid.v1.Foo]: @googleapis_reference_link{generator/integration_tests/test_request_id.proto#L66}
+  /// [google.test.requestid.v1.CreateFooRequest]: @googleapis_reference_link{generator/integration_tests/test_request_id.proto#L79}
+  /// [google.test.requestid.v1.Foo]: @googleapis_reference_link{generator/integration_tests/test_request_id.proto#L65}
   ///
   // clang-format on
   future<StatusOr<google::test::requestid::v1::Foo>>
@@ -331,8 +331,8 @@ class RequestIdServiceClient {
   /// [`future`]: @ref google::cloud::future
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
-  /// [google.test.requestid.v1.CreateFooRequest]: @googleapis_reference_link{generator/integration_tests/test_request_id.proto#L80}
-  /// [google.test.requestid.v1.Foo]: @googleapis_reference_link{generator/integration_tests/test_request_id.proto#L66}
+  /// [google.test.requestid.v1.CreateFooRequest]: @googleapis_reference_link{generator/integration_tests/test_request_id.proto#L79}
+  /// [google.test.requestid.v1.Foo]: @googleapis_reference_link{generator/integration_tests/test_request_id.proto#L65}
   ///
   // clang-format on
   future<StatusOr<google::test::requestid::v1::Foo>>

--- a/generator/integration_tests/golden/v1/request_id_connection_idempotency_policy.cc
+++ b/generator/integration_tests/golden/v1/request_id_connection_idempotency_policy.cc
@@ -33,11 +33,13 @@ RequestIdServiceConnectionIdempotencyPolicy::clone() const {
   return std::make_unique<RequestIdServiceConnectionIdempotencyPolicy>(*this);
 }
 
-Idempotency RequestIdServiceConnectionIdempotencyPolicy::CreateFoo(google::test::requestid::v1::CreateFooRequest const&) {
+Idempotency RequestIdServiceConnectionIdempotencyPolicy::CreateFoo(google::test::requestid::v1::CreateFooRequest const& request) {
+  if (!request.request_id().empty()) return Idempotency::kIdempotent;
   return Idempotency::kNonIdempotent;
 }
 
-Idempotency RequestIdServiceConnectionIdempotencyPolicy::RenameFoo(google::test::requestid::v1::RenameFooRequest const&) {
+Idempotency RequestIdServiceConnectionIdempotencyPolicy::RenameFoo(google::test::requestid::v1::RenameFooRequest const& request) {
+  if (!request.request_id().empty()) return Idempotency::kIdempotent;
   return Idempotency::kNonIdempotent;
 }
 

--- a/generator/integration_tests/test_request_id.proto
+++ b/generator/integration_tests/test_request_id.proto
@@ -16,7 +16,6 @@ syntax = "proto3";
 
 package google.test.requestid.v1;
 
-import "google/api/annotations.proto";
 import "google/api/client.proto";
 import "google/api/field_behavior.proto";
 import "google/api/field_info.proto";

--- a/generator/integration_tests/tests/request_id_idempotency_test.cc
+++ b/generator/integration_tests/tests/request_id_idempotency_test.cc
@@ -30,11 +30,15 @@ TEST(RequestIdIdempotency, CreateFoo) {
   auto policy = MakeDefaultRequestIdServiceConnectionIdempotencyPolicy();
   CreateFooRequest request;
   EXPECT_EQ(policy->CreateFoo(request), Idempotency::kNonIdempotent);
+  request.set_request_id("test-request-id");
+  EXPECT_EQ(policy->CreateFoo(request), Idempotency::kIdempotent);
 }
 
 TEST(RequestIdIdempotency, ListFoos) {
   auto policy = MakeDefaultRequestIdServiceConnectionIdempotencyPolicy();
   ListFoosRequest request;
+  EXPECT_EQ(policy->ListFoos(request), Idempotency::kNonIdempotent);
+  request.set_request_id("test-request-id");
   EXPECT_EQ(policy->ListFoos(request), Idempotency::kNonIdempotent);
 }
 
@@ -42,6 +46,8 @@ TEST(RequestIdIdempotency, RenameFoo) {
   auto policy = MakeDefaultRequestIdServiceConnectionIdempotencyPolicy();
   RenameFooRequest request;
   EXPECT_EQ(policy->RenameFoo(request), Idempotency::kNonIdempotent);
+  request.set_request_id("test-request-id");
+  EXPECT_EQ(policy->RenameFoo(request), Idempotency::kIdempotent);
 }
 
 }  // namespace

--- a/generator/internal/connection_impl_generator.h
+++ b/generator/internal/connection_impl_generator.h
@@ -50,9 +50,9 @@ class ConnectionImplGenerator : public ServiceCodeGenerator {
       google::protobuf::MethodDescriptor const& method);
   static std::string AsyncMethodDeclaration(
       google::protobuf::MethodDescriptor const& method);
-  static std::string MethodDefinition(
+  std::string MethodDefinition(
       google::protobuf::MethodDescriptor const& method);
-  static std::string AsyncMethodDefinition(
+  std::string AsyncMethodDefinition(
       google::protobuf::MethodDescriptor const& method);
 };
 

--- a/google/cloud/storagecontrol/v2/internal/storage_control_connection_impl.cc
+++ b/google/cloud/storagecontrol/v2/internal/storage_control_connection_impl.cc
@@ -70,41 +70,53 @@ StatusOr<google::storage::control::v2::Folder>
 StorageControlConnectionImpl::CreateFolder(
     google::storage::control::v2::CreateFolderRequest const& request) {
   auto current = google::cloud::internal::SaveCurrentOptions();
+  auto request_copy = request;
+  if (request_copy.request_id().empty()) {
+    request_copy.set_request_id(invocation_id_generator_->MakeInvocationId());
+  }
   return google::cloud::internal::RetryLoop(
       retry_policy(*current), backoff_policy(*current),
-      idempotency_policy(*current)->CreateFolder(request),
+      idempotency_policy(*current)->CreateFolder(request_copy),
       [this](grpc::ClientContext& context,
              google::storage::control::v2::CreateFolderRequest const& request) {
         return stub_->CreateFolder(context, request);
       },
-      request, __func__);
+      request_copy, __func__);
 }
 
 Status StorageControlConnectionImpl::DeleteFolder(
     google::storage::control::v2::DeleteFolderRequest const& request) {
   auto current = google::cloud::internal::SaveCurrentOptions();
+  auto request_copy = request;
+  if (request_copy.request_id().empty()) {
+    request_copy.set_request_id(invocation_id_generator_->MakeInvocationId());
+  }
   return google::cloud::internal::RetryLoop(
       retry_policy(*current), backoff_policy(*current),
-      idempotency_policy(*current)->DeleteFolder(request),
+      idempotency_policy(*current)->DeleteFolder(request_copy),
       [this](grpc::ClientContext& context,
              google::storage::control::v2::DeleteFolderRequest const& request) {
         return stub_->DeleteFolder(context, request);
       },
-      request, __func__);
+      request_copy, __func__);
 }
 
 StatusOr<google::storage::control::v2::Folder>
 StorageControlConnectionImpl::GetFolder(
     google::storage::control::v2::GetFolderRequest const& request) {
   auto current = google::cloud::internal::SaveCurrentOptions();
+  auto request_copy = request;
+  if (request_copy.request_id().empty()) {
+    request_copy.set_request_id(invocation_id_generator_->MakeInvocationId());
+  }
   return google::cloud::internal::RetryLoop(
       retry_policy(*current), backoff_policy(*current),
-      idempotency_policy(*current)->GetFolder(request),
+      idempotency_policy(*current)->GetFolder(request_copy),
       [this](grpc::ClientContext& context,
              google::storage::control::v2::GetFolderRequest const& request) {
         return stub_->GetFolder(context, request);
       },
-      request, __func__);
+      request_copy, __func__);
 }
 
 StreamRange<google::storage::control::v2::Folder>
@@ -143,6 +155,9 @@ StorageControlConnectionImpl::RenameFolder(
     google::storage::control::v2::RenameFolderRequest const& request) {
   auto current = google::cloud::internal::SaveCurrentOptions();
   auto request_copy = request;
+  if (request_copy.request_id().empty()) {
+    request_copy.set_request_id(invocation_id_generator_->MakeInvocationId());
+  }
   auto const idempotent =
       idempotency_policy(*current)->RenameFolder(request_copy);
   return google::cloud::internal::AsyncLongRunningOperation<
@@ -179,13 +194,17 @@ StatusOr<google::storage::control::v2::StorageLayout>
 StorageControlConnectionImpl::GetStorageLayout(
     google::storage::control::v2::GetStorageLayoutRequest const& request) {
   auto current = google::cloud::internal::SaveCurrentOptions();
+  auto request_copy = request;
+  if (request_copy.request_id().empty()) {
+    request_copy.set_request_id(invocation_id_generator_->MakeInvocationId());
+  }
   return google::cloud::internal::RetryLoop(
       retry_policy(*current), backoff_policy(*current),
-      idempotency_policy(*current)->GetStorageLayout(request),
+      idempotency_policy(*current)->GetStorageLayout(request_copy),
       [this](grpc::ClientContext& context,
              google::storage::control::v2::GetStorageLayoutRequest const&
                  request) { return stub_->GetStorageLayout(context, request); },
-      request, __func__);
+      request_copy, __func__);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storagecontrol/v2/internal/storage_control_connection_impl.h
+++ b/google/cloud/storagecontrol/v2/internal/storage_control_connection_impl.h
@@ -27,6 +27,7 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/backoff_policy.h"
 #include "google/cloud/future.h"
+#include "google/cloud/internal/invocation_id_generator.h"
 #include "google/cloud/options.h"
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
@@ -77,6 +78,9 @@ class StorageControlConnectionImpl
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<storagecontrol_v2_internal::StorageControlStub> stub_;
   Options options_;
+  std::shared_ptr<google::cloud::internal::InvocationIdGenerator>
+      invocation_id_generator_ =
+          std::make_shared<google::cloud::internal::InvocationIdGenerator>();
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storagecontrol/v2/storage_control_connection_idempotency_policy.cc
+++ b/google/cloud/storagecontrol/v2/storage_control_connection_idempotency_policy.cc
@@ -35,17 +35,20 @@ StorageControlConnectionIdempotencyPolicy::clone() const {
 }
 
 Idempotency StorageControlConnectionIdempotencyPolicy::CreateFolder(
-    google::storage::control::v2::CreateFolderRequest const&) {
+    google::storage::control::v2::CreateFolderRequest const& request) {
+  if (!request.request_id().empty()) return Idempotency::kIdempotent;
   return Idempotency::kNonIdempotent;
 }
 
 Idempotency StorageControlConnectionIdempotencyPolicy::DeleteFolder(
-    google::storage::control::v2::DeleteFolderRequest const&) {
+    google::storage::control::v2::DeleteFolderRequest const& request) {
+  if (!request.request_id().empty()) return Idempotency::kIdempotent;
   return Idempotency::kNonIdempotent;
 }
 
 Idempotency StorageControlConnectionIdempotencyPolicy::GetFolder(
-    google::storage::control::v2::GetFolderRequest const&) {
+    google::storage::control::v2::GetFolderRequest const& request) {
+  if (!request.request_id().empty()) return Idempotency::kIdempotent;
   return Idempotency::kIdempotent;
 }
 
@@ -55,12 +58,14 @@ Idempotency StorageControlConnectionIdempotencyPolicy::ListFolders(
 }
 
 Idempotency StorageControlConnectionIdempotencyPolicy::RenameFolder(
-    google::storage::control::v2::RenameFolderRequest const&) {
+    google::storage::control::v2::RenameFolderRequest const& request) {
+  if (!request.request_id().empty()) return Idempotency::kIdempotent;
   return Idempotency::kNonIdempotent;
 }
 
 Idempotency StorageControlConnectionIdempotencyPolicy::GetStorageLayout(
-    google::storage::control::v2::GetStorageLayoutRequest const&) {
+    google::storage::control::v2::GetStorageLayoutRequest const& request) {
+  if (!request.request_id().empty()) return Idempotency::kIdempotent;
   return Idempotency::kIdempotent;
 }
 


### PR DESCRIPTION
With this change the generator populates the `request_id`-like fields
and also uses the field to determine if a request is idempotent.

Fixes #13595

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13615)
<!-- Reviewable:end -->
