### PR TITLE
cleanup(bigtable): use more general RowKeyType

### DIFF
--- a/google/cloud/bigtable/internal/bulk_mutator_test.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator_test.cc
@@ -346,7 +346,7 @@ TEST_F(BulkMutatorTest, RetryInfoHeeded) {
       .WillOnce([this](auto context, auto const&,
                        google::bigtable::v2::MutateRowsRequest const& request) {
         metadata_fixture_.SetServerMetadata(*context, {});
-        std::vector<std::string> row_keys;
+        std::vector<RowKeyType> row_keys;
         for (auto const& entry : request.entries()) {
           row_keys.push_back(entry.row_key());
         }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13616)
<!-- Reviewable:end -->
