### PR TITLE
impl(pubsub): add server.address attribute

### DIFF
--- a/google/cloud/pubsub/internal/tracing_batch_sink.cc
+++ b/google/cloud/pubsub/internal/tracing_batch_sink.cc
@@ -59,7 +59,7 @@ auto MakeLinks(Spans::const_iterator begin, Spans::const_iterator end) {
 }
 
 auto MakeParent(Links const& links, Spans const& message_spans,
-                pubsub::Topic const& topic, std::string const endpoint) {
+                pubsub::Topic const& topic, std::string const& endpoint) {
   namespace sc = ::opentelemetry::trace::SemanticConventions;
   auto options = RootStartSpanOptions();
   options.kind = opentelemetry::trace::SpanKind::kClient;

--- a/google/cloud/pubsub/internal/tracing_batch_sink.cc
+++ b/google/cloud/pubsub/internal/tracing_batch_sink.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/pubsub/internal/publisher_stub.h"
 #include "google/cloud/pubsub/internal/tracing_helpers.h"
 #include "google/cloud/pubsub/options.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/future.h"
 #include "google/cloud/internal/opentelemetry.h"
 #include "opentelemetry/context/runtime_context.h"
@@ -25,7 +26,6 @@
 #include "opentelemetry/trace/span.h"
 #include <algorithm>
 #include <string>
-#include "google/cloud/common_options.h"
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 
 namespace google {
@@ -108,7 +108,7 @@ auto MakeChild(
 Spans MakeBatchSinkSpans(Spans const& message_spans, pubsub::Topic const& topic,
                          Options const& options) {
   auto const max_otel_links = options.get<pubsub::MaxOtelLinkCountOption>();
-  auto const endpoint = options.get<EndpointOption>();
+  auto const& endpoint = options.get<EndpointOption>();
   Spans batch_sink_spans;
   // If the batch size is less than the max size, add the links to a single
   // span. If the batch size is greater than the max size, create a parent

--- a/google/cloud/pubsub/internal/tracing_batch_sink_test.cc
+++ b/google/cloud/pubsub/internal/tracing_batch_sink_test.cc
@@ -19,13 +19,13 @@
 #include "google/cloud/pubsub/options.h"
 #include "google/cloud/pubsub/testing/mock_batch_sink.h"
 #include "google/cloud/pubsub/topic.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
 #include "google/cloud/testing_util/opentelemetry_matchers.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <opentelemetry/trace/semantic_conventions.h>
-#include "google/cloud/common_options.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/internal/tracing_batch_sink_test.cc
+++ b/google/cloud/pubsub/internal/tracing_batch_sink_test.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <opentelemetry/trace/semantic_conventions.h>
+#include "google/cloud/common_options.h"
 
 namespace google {
 namespace cloud {
@@ -55,6 +56,7 @@ using ::testing::Contains;
 namespace {
 
 auto constexpr kDefaultMaxLinks = 128;
+auto constexpr kDefaultEndpoint = "endpoint";
 
 void EndSpans(std::vector<opentelemetry::nostd::shared_ptr<
                   opentelemetry::trace::Span>> const& spans) {
@@ -94,6 +96,7 @@ void AddMessages(
 auto MakeTestOptions(size_t max_otel_link_count = kDefaultMaxLinks) {
   Options options;
   options.set<pubsub::MaxOtelLinkCountOption>(max_otel_link_count);
+  options.set<EndpointOption>(kDefaultEndpoint);
   return options;
 }
 
@@ -214,6 +217,10 @@ TEST(TracingBatchSink, PublishSpanHasAttributes) {
       spans, Contains(AllOf(SpanNamed("test-topic publish"),
                             SpanHasAttributes(OTelAttribute<std::string>(
                                 "gcp.project_id", TestTopic().project_id())))));
+  EXPECT_THAT(spans,
+              Contains(AllOf(SpanNamed("test-topic publish"),
+                             SpanHasAttributes(OTelAttribute<std::string>(
+                                 "server.address", kDefaultEndpoint)))));
   EXPECT_THAT(
       spans, Contains(AllOf(
                  SpanNamed("test-topic publish"),


### PR DESCRIPTION
Note server.address is the "Server domain name if available without reverse DNS lookup."

https://opentelemetry.io/docs/specs/semconv/general/attributes/#server-attributes 

using the network attributes would be what we are setting the grpc peer values with (https://opentelemetry.io/docs/specs/semconv/attributes-registry/network/)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13617)
<!-- Reviewable:end -->
