### PR TITLE
cleanup(storage): quash an aggregate_upload_throughput benchmark warning

### DIFF
--- a/google/cloud/storage/benchmarks/aggregate_upload_throughput_options.cc
+++ b/google/cloud/storage/benchmarks/aggregate_upload_throughput_options.cc
@@ -124,7 +124,7 @@ ParseAggregateUploadThroughputOptions(std::vector<std::string> const& argv,
        "use a different storage::Client object in each thread",
        [&options](std::string const& val) {
          options.client_per_thread =
-             testing_util::ParseBoolean(val).value_or("true");
+             testing_util::ParseBoolean(val).value_or(true);
        }},
       {"--grpc-channel-count", "controls the number of gRPC channels",
        [&options](std::string const& val) {


### PR DESCRIPTION
Use a more conventional `true` value.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13625)
<!-- Reviewable:end -->
