### PR TITLE
ci: add clang-cxx20 build

### DIFF
--- a/ci/cloudbuild/builds/clang-cxx20.sh
+++ b/ci/cloudbuild/builds/clang-cxx20.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+source "$(dirname "$0")/../../lib/init.sh"
+source module ci/cloudbuild/builds/lib/cmake.sh
+source module ci/cloudbuild/builds/lib/ctest.sh
+source module ci/cloudbuild/builds/lib/features.sh
+source module ci/cloudbuild/builds/lib/integration.sh
+source module ci/lib/io.sh
+
+export CC=clang
+export CXX=clang++
+
+mapfile -t cmake_args < <(cmake::common_args)
+read -r ENABLED_FEATURES < <(features::always_build_cmake)
+# We should test all the GA libraries
+ENABLED_FEATURES="${ENABLED_FEATURES},__ga_libraries__"
+readonly ENABLED_FEATURES
+
+io::run cmake "${cmake_args[@]}" \
+  -DCMAKE_CXX_STANDARD=20 \
+  -DGOOGLE_CLOUD_CPP_ENABLE="${ENABLED_FEATURES}"
+io::run cmake --build cmake-out
+mapfile -t ctest_args < <(ctest::common_args)
+io::run env -C cmake-out ctest "${ctest_args[@]}" -LE "integration-test"
+
+integration::ctest_with_emulators "cmake-out"

--- a/ci/cloudbuild/triggers/clang-cxx20-ci.yaml
+++ b/ci/cloudbuild/triggers/clang-cxx20-ci.yaml
@@ -1,0 +1,14 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  push:
+    branch: ^main$
+includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
+name: clang-cxx20-ci
+substitutions:
+  _BUILD_NAME: clang-cxx20
+  _DISTRO: fedora-latest-cxx20
+  _TRIGGER_TYPE: ci
+tags:
+- ci

--- a/ci/cloudbuild/triggers/clang-cxx20-pr.yaml
+++ b/ci/cloudbuild/triggers/clang-cxx20-pr.yaml
@@ -1,0 +1,15 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  pullRequest:
+    branch: ^main$
+    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
+includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
+name: clang-cxx20-pr
+substitutions:
+  _BUILD_NAME: clang-cxx20
+  _DISTRO: fedora-latest-cxx20
+  _TRIGGER_TYPE: pr
+tags:
+- pr


### PR DESCRIPTION
Clang and GCC detect different errors, this is particularly true with new features, such as coroutines.

For an example see #13577 

Alternatively, we could switch the cxx20 build to only use Clang, your call.  I launched the build to warm up the cache and make sure there are no pre-existing errors:

https://console.cloud.google.com/cloud-build/builds;region=us-east1/a129adc5-8b40-4a8f-937d-b0a5acad1810?project=936212892354

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13626)
<!-- Reviewable:end -->
