### PR TITLE
docs: fix dependency details

### DIFF
--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -2106,7 +2106,7 @@ cmake --build cmake-out --target install
 
 [^5]: The Google Cloud Storage client does not require Protobuf.
 
-[^6]: In some platforms, some libraries may need a newer version of Protobuf to
+[^6]: On some platforms, some libraries may need a newer version of Protobuf to
     workaround conflicts between system pre-processor macros and symbols used in
     the Protobuf-generated code.
 

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -113,15 +113,15 @@ quickstart guides also cover this use-case.
 
 `google-cloud-cpp` directly depends on the following libraries:
 
-| Library                           |   Minimum version | Description                                                                                   |
-| --------------------------------- | ----------------: | --------------------------------------------------------------------------------------------- |
-| [Abseil][abseil-gh]               | 20200923, Patch 3 | Abseil C++ common library (Requires >= `20210324.2` for `pkg-config` files to work correctly) |
-| [gRPC][grpc-gh]                   |            1.35.x | An RPC library and framework (not needed for Google Cloud Storage client)                     |
-| [libcurl][libcurl-gh]             |            7.47.0 | HTTP client library for the Google Cloud Storage client                                       |
-| [crc32c][crc32c-gh]               |             1.0.6 | Hardware-accelerated CRC32C implementation                                                    |
-| [OpenSSL][openssl-gh]             |             1.0.2 | Crypto functions for Google Cloud Storage authentication                                      |
-| [nlohmann/json][nlohmann-json-gh] |             3.4.0 | JSON for Modern C++                                                                           |
-| [protobuf][protobuf-gh]           |             v21.1 | C++ Micro-generator support                                                                   |
+| Library                           |   Minimum version | Description                                                |
+| --------------------------------- | ----------------: | ---------------------------------------------------------- |
+| [Abseil][abseil-gh]               | 20200923, Patch 3 | Abseil C++ common library [^1]                             |
+| [gRPC][grpc-gh]                   |            1.35.x | An RPC library and framework [^2]                          |
+| [libcurl][libcurl-gh]             |            7.47.0 | HTTP client library [^3]                                   |
+| [crc32c][crc32c-gh]               |             1.0.6 | Hardware-accelerated CRC32C implementation [^4]            |
+| [OpenSSL][openssl-gh]             |             1.0.2 | Crypto functions for [^3]                                  |
+| [nlohmann/json][nlohmann-json-gh] |             3.4.0 | JSON for Modern C++ [^3]                                   |
+| [protobuf][protobuf-gh]           |            3.15.8 | Protobuf is needed for any library based on gRPC [^5] [^6] |
 
 `google-cloud-cpp` also has an **optional** dependency on the following
 libraries:
@@ -2093,6 +2093,22 @@ cmake --build cmake-out --target install
 ```
 
 </details>
+
+[^1]: Requires >= `20210324.2` for `pkg-config` files to work correctly.
+
+[^2]: Some libraries, including the Google Cloud Storage client, can be compiled
+    without gRPC support.
+
+[^3]: Only some libraries (Compute, SQL Admin, and Google Cloud Storage) require
+    this dependency.
+
+[^4]: Only the Google Cloud Storage client library requires this dependency.
+
+[^5]: The Google Cloud Storage client does not require Protobuf.
+
+[^6]: In some platforms, some libraries may need a newer version of Protobuf to
+    workaround conflicts between system pre-processor macros and symbols used in
+    the Protobuf-generated code.
 
 [abseil-gh]: https://github.com/abseil/abseil-cpp
 [abseil/abseil-cpp#696]: https://github.com/abseil/abseil-cpp/issues/696


### PR DESCRIPTION
What libraries need `libcurl` and friends has changed over time.

We do not need Protobuf v21.x for most libraries, and that is the version we should highlight here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13631)
<!-- Reviewable:end -->
