### PR TITLE
refactor: prepare to support `RetryInfo` in retry loops

### DIFF
--- a/google/cloud/internal/async_retry_loop.h
+++ b/google/cloud/internal/async_retry_loop.h
@@ -243,16 +243,15 @@ class AsyncRetryLoopImpl
             .then([self](future<T> f) { self->OnAttempt(f.get()); }));
   }
 
-  void StartBackoff() {
+  void StartBackoff(std::chrono::milliseconds delay) {
     auto self = this->shared_from_this();
     auto state = StartOperation();
     if (state.cancelled) return;
-    SetPending(
-        state.operation,
-        TracedAsyncBackoff(cq_, *call_context_.options,
-                           backoff_policy_->OnCompletion(), "Async Backoff")
-            .then(
-                [self](future<TimerArgType> f) { self->OnBackoff(f.get()); }));
+    SetPending(state.operation, TracedAsyncBackoff(cq_, *call_context_.options,
+                                                   delay, "Async Backoff")
+                                    .then([self](future<TimerArgType> f) {
+                                      self->OnBackoff(f.get());
+                                    }));
   }
 
   void OnAttempt(T result) {
@@ -260,17 +259,10 @@ class AsyncRetryLoopImpl
     if (result.ok()) return SetDone(std::move(result));
     // Some kind of failure, first verify that it is retryable.
     last_status_ = GetResultStatus(std::move(result));
-    if (idempotency_ == Idempotency::kNonIdempotent) {
-      return SetDone(
-          RetryLoopNonIdempotentError(std::move(last_status_), location_));
-    }
-    if (!retry_policy_->OnFailure(last_status_)) {
-      if (retry_policy_->IsPermanentFailure(last_status_)) {
-        return SetDone(RetryLoopPermanentError(last_status_, location_));
-      }
-      return SetDone(RetryLoopPolicyExhaustedError(last_status_, location_));
-    }
-    StartBackoff();
+    auto delay = BackoffOrBreak(last_status_, location_, *retry_policy_,
+                                *backoff_policy_, idempotency_);
+    if (!delay) return SetDone(std::move(delay).status());
+    StartBackoff(*delay);
   }
 
   void OnBackoff(TimerArgType tp) {

--- a/google/cloud/internal/async_retry_loop.h
+++ b/google/cloud/internal/async_retry_loop.h
@@ -259,8 +259,8 @@ class AsyncRetryLoopImpl
     if (result.ok()) return SetDone(std::move(result));
     // Some kind of failure, first verify that it is retryable.
     last_status_ = GetResultStatus(std::move(result));
-    auto delay = BackoffOrBreak(last_status_, location_, *retry_policy_,
-                                *backoff_policy_, idempotency_);
+    auto delay = Backoff(last_status_, location_, *retry_policy_,
+                         *backoff_policy_, idempotency_);
     if (!delay) return SetDone(std::move(delay).status());
     StartBackoff(*delay);
   }

--- a/google/cloud/internal/async_retry_loop_test.cc
+++ b/google/cloud/internal/async_retry_loop_test.cc
@@ -200,13 +200,10 @@ TEST(AsyncRetryLoopTest, ReturnJustStatus) {
   ASSERT_THAT(actual, IsOk());
 }
 
-class RetryPolicyWithSetup {
+class RetryPolicyWithSetup : public RetryPolicy {
  public:
-  virtual ~RetryPolicyWithSetup() = default;
-  virtual bool OnFailure(Status const&) = 0;
+  ~RetryPolicyWithSetup() override = default;
   virtual void Setup(grpc::ClientContext&) const = 0;
-  virtual bool IsExhausted() const = 0;
-  virtual bool IsPermanentFailure(Status const&) const = 0;
 };
 
 class MockRetryPolicy : public RetryPolicyWithSetup {

--- a/google/cloud/internal/retry_loop.h
+++ b/google/cloud/internal/retry_loop.h
@@ -78,15 +78,11 @@ auto RetryLoopImpl(RetryPolicy& retry_policy, BackoffPolicy& backoff_policy,
     ConfigureContext(context, options);
     auto result = functor(context, options, request);
     if (result.ok()) return result;
-
     last_status = GetResultStatus(std::move(result));
-    if (idempotency == Idempotency::kNonIdempotent) {
-      return RetryLoopNonIdempotentError(std::move(last_status), location);
-    }
-    // The retry policy is exhausted or the error is not retryable. Either
-    // way, exit the loop.
-    if (!retry_policy.OnFailure(last_status)) break;
-    sleeper(backoff_policy.OnCompletion());
+    auto delay = BackoffOrBreak(last_status, location, retry_policy,
+                                backoff_policy, idempotency);
+    if (!delay) return std::move(delay).status();
+    sleeper(*delay);
   }
   return internal::RetryLoopError(last_status, location,
                                   retry_policy.IsExhausted());

--- a/google/cloud/internal/retry_loop.h
+++ b/google/cloud/internal/retry_loop.h
@@ -79,8 +79,8 @@ auto RetryLoopImpl(RetryPolicy& retry_policy, BackoffPolicy& backoff_policy,
     auto result = functor(context, options, request);
     if (result.ok()) return result;
     last_status = GetResultStatus(std::move(result));
-    auto delay = BackoffOrBreak(last_status, location, retry_policy,
-                                backoff_policy, idempotency);
+    auto delay = Backoff(last_status, location, retry_policy, backoff_policy,
+                         idempotency);
     if (!delay) return std::move(delay).status();
     sleeper(*delay);
   }

--- a/google/cloud/internal/retry_loop_helpers.cc
+++ b/google/cloud/internal/retry_loop_helpers.cc
@@ -106,11 +106,11 @@ Status RetryLoopCancelled(Status const& status, char const* location) {
   return Status(status.code(), std::move(message), std::move(ei));
 }
 
-StatusOr<std::chrono::milliseconds> BackoffOrBreak(Status const& status,
-                                                   char const* location,
-                                                   RetryPolicy& retry,
-                                                   BackoffPolicy& backoff,
-                                                   Idempotency idempotency) {
+StatusOr<std::chrono::milliseconds> Backoff(Status const& status,
+                                            char const* location,
+                                            RetryPolicy& retry,
+                                            BackoffPolicy& backoff,
+                                            Idempotency idempotency) {
   if (idempotency == Idempotency::kNonIdempotent) {
     return RetryLoopNonIdempotentError(status, location);
   }

--- a/google/cloud/internal/retry_loop_helpers.cc
+++ b/google/cloud/internal/retry_loop_helpers.cc
@@ -106,6 +106,18 @@ Status RetryLoopCancelled(Status const& status, char const* location) {
   return Status(status.code(), std::move(message), std::move(ei));
 }
 
+StatusOr<std::chrono::milliseconds> BackoffOrBreak(Status const& status,
+                                                   char const* location,
+                                                   RetryPolicy& retry,
+                                                   BackoffPolicy& backoff,
+                                                   Idempotency idempotency) {
+  if (idempotency == Idempotency::kNonIdempotent) {
+    return RetryLoopNonIdempotentError(status, location);
+  }
+  if (retry.OnFailure(status)) return backoff.OnCompletion();
+  return RetryLoopError(status, location, retry.IsExhausted());
+}
+
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud

--- a/google/cloud/internal/retry_loop_helpers.h
+++ b/google/cloud/internal/retry_loop_helpers.h
@@ -61,14 +61,17 @@ Status RetryLoopCancelled(Status const& status, char const* location);
 /**
  * Returns the backoff given the status, retry policy, and backoff policy.
  *
+ * Returns a `Status`, representing the loop error, if no backoff should be
+ * performed.
+ *
  * This function is responsible for calling `retry.OnFailure()`, which might,
  * for example, increment an error based retry policy.
  */
-StatusOr<std::chrono::milliseconds> BackoffOrBreak(Status const& status,
-                                                   char const* location,
-                                                   RetryPolicy& retry,
-                                                   BackoffPolicy& backoff,
-                                                   Idempotency idempotency);
+StatusOr<std::chrono::milliseconds> Backoff(Status const& status,
+                                            char const* location,
+                                            RetryPolicy& retry,
+                                            BackoffPolicy& backoff,
+                                            Idempotency idempotency);
 
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/retry_loop_helpers.h
+++ b/google/cloud/internal/retry_loop_helpers.h
@@ -15,8 +15,12 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_RETRY_LOOP_HELPERS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_RETRY_LOOP_HELPERS_H
 
+#include "google/cloud/backoff_policy.h"
+#include "google/cloud/idempotency.h"
+#include "google/cloud/retry_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
+#include <chrono>
 
 namespace google {
 namespace cloud {
@@ -53,6 +57,18 @@ Status RetryLoopPolicyExhaustedError(Status const& status,
 /// This is only applicable for asynchronous RPCs, as unary RPCs cannot be
 /// cancelled.
 Status RetryLoopCancelled(Status const& status, char const* location);
+
+/**
+ * Returns the backoff given the status, retry policy, and backoff policy.
+ *
+ * This function is responsible for calling `retry.OnFailure()`, which might,
+ * for example, increment an error based retry policy.
+ */
+StatusOr<std::chrono::milliseconds> BackoffOrBreak(Status const& status,
+                                                   char const* location,
+                                                   RetryPolicy& retry,
+                                                   BackoffPolicy& backoff,
+                                                   Idempotency idempotency);
 
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/retry_loop_helpers_test.cc
+++ b/google/cloud/internal/retry_loop_helpers_test.cc
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/internal/retry_loop_helpers.h"
+#include "google/cloud/internal/make_status.h"
+#include "google/cloud/testing_util/mock_backoff_policy.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 
@@ -22,11 +24,14 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 namespace {
 
+using ::google::cloud::testing_util::IsOkAndHolds;
+using ::google::cloud::testing_util::MockBackoffPolicy;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::Contains;
 using ::testing::HasSubstr;
 using ::testing::IsSupersetOf;
 using ::testing::Pair;
+using ::testing::Return;
 
 ErrorInfo TestErrorInfo() {
   return ErrorInfo("conditionNotMet", "global",
@@ -143,6 +148,78 @@ TEST(RetryLoopHelpers, RetryLoopErrorCancelledButOkay) {
               Contains(Pair("gcloud-cpp.retry.function", "SomeFunction")));
   EXPECT_THAT(actual.error_info().metadata(),
               Contains(Pair("gcloud-cpp.retry.reason", "cancelled")));
+}
+
+class MockRetryPolicy : public RetryPolicy {
+ public:
+  MOCK_METHOD(bool, OnFailure, (Status const&), (override));
+  MOCK_METHOD(bool, IsExhausted, (), (const, override));
+  MOCK_METHOD(bool, IsPermanentFailure, (Status const&), (const, override));
+};
+
+TEST(BackoffOrBreak, NoRetriesIfPolicyExhausted) {
+  auto const retry_delay = std::chrono::minutes(5);
+  auto status = internal::ResourceExhaustedError("try again");
+  internal::SetRetryInfo(status, internal::RetryInfo{retry_delay});
+
+  auto mock_r = std::make_unique<MockRetryPolicy>();
+  EXPECT_CALL(*mock_r, OnFailure(status)).WillOnce(Return(false));
+  EXPECT_CALL(*mock_r, IsExhausted).WillOnce(Return(true));
+  auto mock_b = std::make_unique<MockBackoffPolicy>();
+  EXPECT_CALL(*mock_b, OnCompletion).Times(0);
+
+  auto actual = BackoffOrBreak(status, "SomeFunction", *mock_r, *mock_b,
+                               Idempotency::kIdempotent);
+  EXPECT_THAT(actual, StatusIs(StatusCode::kResourceExhausted,
+                               HasSubstr("policy exhausted")));
+}
+
+TEST(BackoffOrBreak, PermanentFailureWhenIgnoringRetryInfo) {
+  auto const retry_delay = std::chrono::minutes(5);
+  auto status = internal::ResourceExhaustedError("try again");
+  internal::SetRetryInfo(status, internal::RetryInfo{retry_delay});
+
+  auto mock_r = std::make_unique<MockRetryPolicy>();
+  EXPECT_CALL(*mock_r, OnFailure).WillOnce(Return(false));
+  auto mock_b = std::make_unique<MockBackoffPolicy>();
+  EXPECT_CALL(*mock_b, OnCompletion).Times(0);
+
+  auto actual = BackoffOrBreak(status, "SomeFunction", *mock_r, *mock_b,
+                               Idempotency::kIdempotent);
+  EXPECT_THAT(actual, StatusIs(StatusCode::kResourceExhausted,
+                               HasSubstr("Permanent error")));
+}
+
+TEST(BackoffOrBreak, TransientFailureWhenIgnoringRetryInfo) {
+  auto const retry_delay = std::chrono::minutes(5);
+  auto status = internal::UnavailableError("try again");
+  internal::SetRetryInfo(status, internal::RetryInfo{retry_delay});
+
+  auto mock_r = std::make_unique<MockRetryPolicy>();
+  EXPECT_CALL(*mock_r, OnFailure).WillOnce(Return(true));
+  auto mock_b = std::make_unique<MockBackoffPolicy>();
+  EXPECT_CALL(*mock_b, OnCompletion)
+      .WillOnce(Return(std::chrono::milliseconds(10)));
+
+  auto actual = BackoffOrBreak(status, "SomeFunction", *mock_r, *mock_b,
+                               Idempotency::kIdempotent);
+  EXPECT_THAT(actual, IsOkAndHolds(std::chrono::milliseconds(10)));
+}
+
+TEST(BackoffOrBreak, NonIdempotentFailureWhenIgnoringRetryInfo) {
+  auto const retry_delay = std::chrono::minutes(5);
+  auto status = internal::ResourceExhaustedError("try again");
+  internal::SetRetryInfo(status, internal::RetryInfo{retry_delay});
+
+  auto mock_r = std::make_unique<MockRetryPolicy>();
+  ON_CALL(*mock_r, OnFailure).WillByDefault(Return(true));
+  auto mock_b = std::make_unique<MockBackoffPolicy>();
+  EXPECT_CALL(*mock_b, OnCompletion).Times(0);
+
+  auto actual = BackoffOrBreak(status, "SomeFunction", *mock_r, *mock_b,
+                               Idempotency::kNonIdempotent);
+  EXPECT_THAT(actual, StatusIs(StatusCode::kResourceExhausted,
+                               HasSubstr("non-idempotent")));
 }
 
 }  // namespace

--- a/google/cloud/internal/retry_loop_helpers_test.cc
+++ b/google/cloud/internal/retry_loop_helpers_test.cc
@@ -157,7 +157,7 @@ class MockRetryPolicy : public RetryPolicy {
   MOCK_METHOD(bool, IsPermanentFailure, (Status const&), (const, override));
 };
 
-TEST(BackoffOrBreak, NoRetriesIfPolicyExhausted) {
+TEST(Backoff, NoRetriesIfPolicyExhausted) {
   auto const retry_delay = std::chrono::minutes(5);
   auto status = internal::ResourceExhaustedError("try again");
   internal::SetRetryInfo(status, internal::RetryInfo{retry_delay});
@@ -168,13 +168,13 @@ TEST(BackoffOrBreak, NoRetriesIfPolicyExhausted) {
   auto mock_b = std::make_unique<MockBackoffPolicy>();
   EXPECT_CALL(*mock_b, OnCompletion).Times(0);
 
-  auto actual = BackoffOrBreak(status, "SomeFunction", *mock_r, *mock_b,
-                               Idempotency::kIdempotent);
+  auto actual = Backoff(status, "SomeFunction", *mock_r, *mock_b,
+                        Idempotency::kIdempotent);
   EXPECT_THAT(actual, StatusIs(StatusCode::kResourceExhausted,
                                HasSubstr("policy exhausted")));
 }
 
-TEST(BackoffOrBreak, PermanentFailureWhenIgnoringRetryInfo) {
+TEST(Backoff, PermanentFailureWhenIgnoringRetryInfo) {
   auto const retry_delay = std::chrono::minutes(5);
   auto status = internal::ResourceExhaustedError("try again");
   internal::SetRetryInfo(status, internal::RetryInfo{retry_delay});
@@ -184,13 +184,13 @@ TEST(BackoffOrBreak, PermanentFailureWhenIgnoringRetryInfo) {
   auto mock_b = std::make_unique<MockBackoffPolicy>();
   EXPECT_CALL(*mock_b, OnCompletion).Times(0);
 
-  auto actual = BackoffOrBreak(status, "SomeFunction", *mock_r, *mock_b,
-                               Idempotency::kIdempotent);
+  auto actual = Backoff(status, "SomeFunction", *mock_r, *mock_b,
+                        Idempotency::kIdempotent);
   EXPECT_THAT(actual, StatusIs(StatusCode::kResourceExhausted,
                                HasSubstr("Permanent error")));
 }
 
-TEST(BackoffOrBreak, TransientFailureWhenIgnoringRetryInfo) {
+TEST(Backoff, TransientFailureWhenIgnoringRetryInfo) {
   auto const retry_delay = std::chrono::minutes(5);
   auto status = internal::UnavailableError("try again");
   internal::SetRetryInfo(status, internal::RetryInfo{retry_delay});
@@ -201,12 +201,12 @@ TEST(BackoffOrBreak, TransientFailureWhenIgnoringRetryInfo) {
   EXPECT_CALL(*mock_b, OnCompletion)
       .WillOnce(Return(std::chrono::milliseconds(10)));
 
-  auto actual = BackoffOrBreak(status, "SomeFunction", *mock_r, *mock_b,
-                               Idempotency::kIdempotent);
+  auto actual = Backoff(status, "SomeFunction", *mock_r, *mock_b,
+                        Idempotency::kIdempotent);
   EXPECT_THAT(actual, IsOkAndHolds(std::chrono::milliseconds(10)));
 }
 
-TEST(BackoffOrBreak, NonIdempotentFailureWhenIgnoringRetryInfo) {
+TEST(Backoff, NonIdempotentFailureWhenIgnoringRetryInfo) {
   auto const retry_delay = std::chrono::minutes(5);
   auto status = internal::ResourceExhaustedError("try again");
   internal::SetRetryInfo(status, internal::RetryInfo{retry_delay});
@@ -216,8 +216,8 @@ TEST(BackoffOrBreak, NonIdempotentFailureWhenIgnoringRetryInfo) {
   auto mock_b = std::make_unique<MockBackoffPolicy>();
   EXPECT_CALL(*mock_b, OnCompletion).Times(0);
 
-  auto actual = BackoffOrBreak(status, "SomeFunction", *mock_r, *mock_b,
-                               Idempotency::kNonIdempotent);
+  auto actual = Backoff(status, "SomeFunction", *mock_r, *mock_b,
+                        Idempotency::kNonIdempotent);
   EXPECT_THAT(actual, StatusIs(StatusCode::kResourceExhausted,
                                HasSubstr("non-idempotent")));
 }


### PR DESCRIPTION
Part of the work for #13514 

Why are we doing this? Because it will make it easier to add common handling for `RetryInfo`. For context, here is the full change: https://github.com/googleapis/google-cloud-cpp/commit/3f4c403e6d09bed216ad79d95c2c8eba66d234c0

The tests come from here, with some modifications:
https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/bigtable/internal/retry_info_helper_test.cc

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13632)
<!-- Reviewable:end -->
