### PR TITLE
fix: `mocks` feature does not require gRPC

### DIFF
--- a/cmake/GoogleCloudCppFeatures.cmake
+++ b/cmake/GoogleCloudCppFeatures.cmake
@@ -27,8 +27,9 @@ set(GOOGLE_CLOUD_CPP_LEGACY_FEATURES
 # Protobuf messages. We do not bother to have an internal library that depends
 # on Protobuf but not gRPC. So these libraries must depend on
 # `google_cloud_cpp_grpc_utils`.
-set(GOOGLE_CLOUD_CPP_REST_ONLY_FEATURES
-    "oauth2;storage;experimental-bigquery_rest")
+set(GOOGLE_CLOUD_CPP_NO_GRPC_FEATURES
+    # cmake-format: sort
+    "experimental-bigquery_rest" "mocks" "oauth2" "storage")
 
 set(GOOGLE_CLOUD_CPP_EXPERIMENTAL_LIBRARIES
     # cmake-format: sort
@@ -352,7 +353,7 @@ macro (google_cloud_cpp_enable_cleanup)
     list(REMOVE_DUPLICATES GOOGLE_CLOUD_CPP_ENABLE)
 
     set(grpc_features ${GOOGLE_CLOUD_CPP_ENABLE})
-    list(REMOVE_ITEM grpc_features ${GOOGLE_CLOUD_CPP_REST_ONLY_FEATURES})
+    list(REMOVE_ITEM grpc_features ${GOOGLE_CLOUD_CPP_NO_GRPC_FEATURES})
     if (grpc_features)
         set(GOOGLE_CLOUD_CPP_ENABLE_GRPC ON)
     endif ()


### PR DESCRIPTION
It is possible someone was using `-DGOOGLE_CLOUD_CPP_ENABLE=mocks` to build `googleapis` for example, but I doubt it. I think it is a bug that trying to build `mocks` (which depends on `common`) requires gRPC. So let's make the fix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13643)
<!-- Reviewable:end -->
