### PR TITLE
fix(common): streaming RPCs save initial options

### DIFF
--- a/google/cloud/internal/async_streaming_read_rpc_impl_test.cc
+++ b/google/cloud/internal/async_streaming_read_rpc_impl_test.cc
@@ -123,7 +123,7 @@ TEST(AsyncStreamingReadRpcTest, Basic) {
 
   OptionsSpan start_span(user_project("start"));
   auto start = stream->Start().then([](future<bool> f) {
-    EXPECT_EQ(CurrentOptions().get<UserProjectOption>(), "start");
+    EXPECT_EQ(CurrentOptions().get<UserProjectOption>(), "create");
     return f.get();
   });
   ASSERT_THAT(operations, SizeIs(1));
@@ -132,7 +132,7 @@ TEST(AsyncStreamingReadRpcTest, Basic) {
   EXPECT_TRUE(start.get());
 
   OptionsSpan read0_span(user_project("read0"));
-  auto read0 = stream->Read().then(check_read_span("read0"));
+  auto read0 = stream->Read().then(check_read_span("create"));
   ASSERT_THAT(operations, SizeIs(1));
   OptionsSpan read0_clear(Options{});
   notify_next_op();
@@ -142,7 +142,7 @@ TEST(AsyncStreamingReadRpcTest, Basic) {
   EXPECT_EQ("value0_0", response0->value);
 
   OptionsSpan read1_span(user_project("read1"));
-  auto read1 = stream->Read().then(check_read_span("read1"));
+  auto read1 = stream->Read().then(check_read_span("create"));
   ASSERT_THAT(operations, SizeIs(1));
   OptionsSpan read1_clear(Options{});
   notify_next_op(false);
@@ -151,7 +151,7 @@ TEST(AsyncStreamingReadRpcTest, Basic) {
 
   OptionsSpan finish_span(user_project("finish"));
   auto finish = stream->Finish().then([](future<Status> f) {
-    EXPECT_EQ(CurrentOptions().get<UserProjectOption>(), "finish");
+    EXPECT_EQ(CurrentOptions().get<UserProjectOption>(), "create");
     return f.get();
   });
   ASSERT_THAT(operations, SizeIs(1));

--- a/google/cloud/internal/async_streaming_write_rpc_impl_test.cc
+++ b/google/cloud/internal/async_streaming_write_rpc_impl_test.cc
@@ -127,7 +127,7 @@ TEST(AsyncStreamingWriteRpcTest, Basic) {
 
   OptionsSpan start_span(user_project("start"));
   auto start = stream->Start().then([](future<bool> f) {
-    EXPECT_EQ(CurrentOptions().get<UserProjectOption>(), "start");
+    EXPECT_EQ(CurrentOptions().get<UserProjectOption>(), "create");
     return f.get();
   });
   ASSERT_THAT(operations, SizeIs(1));
@@ -137,7 +137,7 @@ TEST(AsyncStreamingWriteRpcTest, Basic) {
 
   OptionsSpan write0_span(user_project("write0"));
   auto write0 = stream->Write(FakeRequest{}, grpc::WriteOptions())
-                    .then(check_write_span("write0"));
+                    .then(check_write_span("create"));
   ASSERT_THAT(operations, SizeIs(1));
   OptionsSpan write0_clear(Options{});
   notify_next_op();
@@ -145,14 +145,14 @@ TEST(AsyncStreamingWriteRpcTest, Basic) {
 
   OptionsSpan write1_span(user_project("write1"));
   auto write1 = stream->Write(FakeRequest{}, grpc::WriteOptions())
-                    .then(check_write_span("write1"));
+                    .then(check_write_span("create"));
   ASSERT_THAT(operations, SizeIs(1));
   OptionsSpan write1_clear(Options{});
   notify_next_op(false);
   EXPECT_FALSE(write1.get());
 
   OptionsSpan writes_done_span(user_project("writes_done"));
-  auto writes_done = stream->WritesDone().then(check_write_span("writes_done"));
+  auto writes_done = stream->WritesDone().then(check_write_span("create"));
   ASSERT_THAT(operations, SizeIs(1));
   OptionsSpan writes_done_clear(Options{});
   notify_next_op(false);
@@ -160,7 +160,7 @@ TEST(AsyncStreamingWriteRpcTest, Basic) {
 
   OptionsSpan finish_span(user_project("finish"));
   auto finish = stream->Finish().then([](future<StatusOr<FakeResponse>> f) {
-    EXPECT_EQ(CurrentOptions().get<UserProjectOption>(), "finish");
+    EXPECT_EQ(CurrentOptions().get<UserProjectOption>(), "create");
     return f.get();
   });
   ASSERT_THAT(operations, SizeIs(1));


### PR DESCRIPTION
The streaming RPC wrappers should save the `Options` in effect when the RPC is created, and then set the `OptionsSpan` to reflect the initial values.

Part of the work for #12359

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13648)
<!-- Reviewable:end -->
