### PR TITLE
cleanup(generator): explicit options in streaming reads

### DIFF
--- a/generator/integration_tests/benchmarks/client_benchmark.cc
+++ b/generator/integration_tests/benchmarks/client_benchmark.cc
@@ -148,6 +148,7 @@ class TestStub : public GoldenKitchenSinkStub {
   AsyncStreamingRead(
       google::cloud::CompletionQueue const&,
       std::shared_ptr<grpc::ClientContext>,
+      google::cloud::internal::ImmutableOptions,
       google::test::admin::database::v1::Request const&) override {
     return nullptr;
   }

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_auth_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_auth_decorator.cc
@@ -163,13 +163,14 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
 GoldenKitchenSinkAuth::AsyncStreamingRead(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::test::admin::database::v1::Request const& request) {
   using StreamAuth = google::cloud::internal::AsyncStreamingReadRpcAuth<
     google::test::admin::database::v1::Response>;
 
   auto& child = child_;
-  auto call = [child, cq, request](std::shared_ptr<grpc::ClientContext> ctx) {
-    return child->AsyncStreamingRead(cq, std::move(ctx), request);
+  auto call = [child, cq, opts = std::move(options), request](std::shared_ptr<grpc::ClientContext> ctx) {
+    return child->AsyncStreamingRead(cq, std::move(ctx), opts, request);
   };
   return std::make_unique<StreamAuth>(
     std::move(context), auth_, StreamAuth::StreamFactory(std::move(call)));

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_auth_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_auth_decorator.h
@@ -108,6 +108,7 @@ class GoldenKitchenSinkAuth : public GoldenKitchenSinkStub {
   AsyncStreamingRead(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::admin::database::v1::Request const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_logging_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_logging_decorator.cc
@@ -234,13 +234,15 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
 GoldenKitchenSinkLogging::AsyncStreamingRead(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::test::admin::database::v1::Request const& request) {
   using LoggingStream =
      ::google::cloud::internal::AsyncStreamingReadRpcLogging<google::test::admin::database::v1::Response>;
 
   auto request_id = google::cloud::internal::RequestIdForLogging();
   GCP_LOG(DEBUG) << __func__ << "(" << request_id << ")";
-  auto stream = child_->AsyncStreamingRead(cq, std::move(context), request);
+  auto stream = child_->AsyncStreamingRead(
+      cq, std::move(context), std::move(options), request);
   if (stream_logging_) {
     stream = std::make_unique<LoggingStream>(
         std::move(stream), tracing_options_, std::move(request_id));

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_logging_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_logging_decorator.h
@@ -108,6 +108,7 @@ class GoldenKitchenSinkLogging : public GoldenKitchenSinkStub {
   AsyncStreamingRead(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::admin::database::v1::Request const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.cc
@@ -219,9 +219,11 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
 GoldenKitchenSinkMetadata::AsyncStreamingRead(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::test::admin::database::v1::Request const& request) {
-  SetMetadata(*context, internal::CurrentOptions());
-  return child_->AsyncStreamingRead(cq, std::move(context), request);
+  SetMetadata(*context, *options);
+  return child_->AsyncStreamingRead(
+      cq, std::move(context), std::move(options), request);
 }
 
 std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.h
@@ -109,6 +109,7 @@ class GoldenKitchenSinkMetadata : public GoldenKitchenSinkStub {
   AsyncStreamingRead(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::admin::database::v1::Request const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_round_robin_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_round_robin_decorator.cc
@@ -120,8 +120,10 @@ std::unique_ptr<google::cloud::internal::AsyncStreamingReadRpc<
 GoldenKitchenSinkRoundRobin::AsyncStreamingRead(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::test::admin::database::v1::Request const& request) {
-  return Child()->AsyncStreamingRead(cq, std::move(context), request);
+  return Child()->AsyncStreamingRead(
+      cq, std::move(context), std::move(options), request);
 }
 
 std::unique_ptr<google::cloud::internal::AsyncStreamingWriteRpc<

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_round_robin_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_round_robin_decorator.h
@@ -106,6 +106,7 @@ class GoldenKitchenSinkRoundRobin : public GoldenKitchenSinkStub {
   AsyncStreamingRead(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::admin::database::v1::Request const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.cc
@@ -193,9 +193,10 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
 DefaultGoldenKitchenSinkStub::AsyncStreamingRead(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::test::admin::database::v1::Request const& request) {
   return google::cloud::internal::MakeStreamingReadRpc<google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>(
-    cq, std::move(context), request,
+    cq, std::move(context), std::move(options), request,
     [this](grpc::ClientContext* context, google::test::admin::database::v1::Request const& request, grpc::CompletionQueue* cq) {
       return grpc_stub_->PrepareAsyncStreamingRead(context, request, cq);
     });

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.h
@@ -113,6 +113,7 @@ class GoldenKitchenSinkStub {
   AsyncStreamingRead(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::admin::database::v1::Request const& request) = 0;
 
   virtual std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
@@ -198,6 +199,7 @@ class DefaultGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
   AsyncStreamingRead(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::admin::database::v1::Request const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_stub.cc
@@ -180,11 +180,13 @@ std::unique_ptr<internal::AsyncStreamingReadRpc<google::test::admin::database::v
 GoldenKitchenSinkTracingStub::AsyncStreamingRead(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::test::admin::database::v1::Request const& request) {
   auto span = internal::MakeSpanGrpc("google.test.admin.database.v1.GoldenKitchenSink", "StreamingRead");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto stream = child_->AsyncStreamingRead(cq, context, request);
+  auto stream = child_->AsyncStreamingRead(
+      cq, context, std::move(options), request);
   return std::make_unique<
       internal::AsyncStreamingReadRpcTracing<google::test::admin::database::v1::Response>>(
       std::move(context), std::move(stream), std::move(span));

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_stub.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_stub.h
@@ -107,6 +107,7 @@ class GoldenKitchenSinkTracingStub : public GoldenKitchenSinkStub {
   AsyncStreamingRead(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::admin::database::v1::Request const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<

--- a/generator/integration_tests/tests/golden_kitchen_sink_auth_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_auth_decorator_test.cc
@@ -197,14 +197,16 @@ TEST(GoldenKitchenSinkAuthDecoratorTest, AsyncStreamingRead) {
   ::google::test::admin::database::v1::Request request;
 
   auto auth_failure = under_test.AsyncStreamingRead(
-      cq, std::make_shared<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(),
+      google::cloud::internal::MakeImmutableOptions({}), request);
   auto start = auth_failure->Start().get();
   EXPECT_FALSE(start);
   auto finish = auth_failure->Finish().get();
   EXPECT_THAT(finish, StatusIs(StatusCode::kInvalidArgument));
 
   auto auth_success = under_test.AsyncStreamingRead(
-      cq, std::make_shared<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(),
+      google::cloud::internal::MakeImmutableOptions({}), request);
   start = auth_success->Start().get();
   EXPECT_FALSE(start);
   finish = auth_success->Finish().get();

--- a/generator/integration_tests/tests/golden_kitchen_sink_logging_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_logging_decorator_test.cc
@@ -288,7 +288,8 @@ TEST_F(LoggingDecoratorTest, AsyncStreamingRead) {
 
   google::cloud::CompletionQueue cq;
   auto stream = stub.AsyncStreamingRead(
-      cq, std::make_shared<grpc::ClientContext>(), Request{});
+      cq, std::make_shared<grpc::ClientContext>(),
+      google::cloud::internal::MakeImmutableOptions({}), Request{});
 
   auto start = stream->Start().get();
   EXPECT_FALSE(start);

--- a/generator/integration_tests/tests/golden_kitchen_sink_metadata_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_metadata_decorator_test.cc
@@ -282,7 +282,7 @@ TEST_F(MetadataDecoratorTest, StreamingWrite) {
 TEST_F(MetadataDecoratorTest, AsyncStreamingRead) {
   EXPECT_CALL(*mock_, AsyncStreamingRead)
       .WillOnce([this](google::cloud::CompletionQueue const&, auto context,
-                       Request const& request) {
+                       auto, Request const& request) {
         IsContextMDValid(
             *context,
             "google.test.admin.database.v1.GoldenKitchenSink.StreamingRead",
@@ -296,7 +296,8 @@ TEST_F(MetadataDecoratorTest, AsyncStreamingRead) {
 
   google::cloud::CompletionQueue cq;
   auto stream = stub.AsyncStreamingRead(
-      cq, std::make_shared<grpc::ClientContext>(), Request{});
+      cq, std::make_shared<grpc::ClientContext>(),
+      google::cloud::internal::MakeImmutableOptions({}), Request{});
 
   auto start = stream->Start().get();
   EXPECT_FALSE(start);

--- a/generator/integration_tests/tests/golden_kitchen_sink_round_robin_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_round_robin_decorator_test.cc
@@ -129,7 +129,7 @@ TEST(GoldenKitchenSinkRoundRobinDecoratorTest, AsyncStreamingRead) {
   InSequence sequence;
   for (int i = 0; i != kRepeats; ++i) {
     for (auto& m : mocks) {
-      EXPECT_CALL(*m, AsyncStreamingRead).WillOnce([](auto&, auto, auto) {
+      EXPECT_CALL(*m, AsyncStreamingRead).WillOnce([](auto&, auto, auto, auto) {
         return std::make_unique<MockAsyncStreamingReadRpc>();
       });
     }
@@ -139,7 +139,8 @@ TEST(GoldenKitchenSinkRoundRobinDecoratorTest, AsyncStreamingRead) {
   GoldenKitchenSinkRoundRobin stub(AsPlainStubs(mocks));
   for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
     auto stream = stub.AsyncStreamingRead(
-        cq, std::make_shared<grpc::ClientContext>(), Request{});
+        cq, std::make_shared<grpc::ClientContext>(),
+        google::cloud::internal::MakeImmutableOptions({}), Request{});
     EXPECT_THAT(stream, NotNull());
   }
 }

--- a/generator/integration_tests/tests/golden_kitchen_sink_stub_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_stub_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.h"
+#include "google/cloud/options.h"
 #include "google/cloud/testing_util/mock_completion_queue_impl.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
@@ -616,7 +617,8 @@ TEST_F(GoldenKitchenSinkStubTest, AsyncStreamingRead) {
 
   Request request;
   auto stream = stub.AsyncStreamingRead(
-      cq, std::make_shared<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(),
+      google::cloud::internal::MakeImmutableOptions({}), request);
   auto start = stream->Start();
   notify_next_op(true);
   EXPECT_TRUE(start.get());

--- a/generator/integration_tests/tests/golden_kitchen_sink_tracing_stub_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_tracing_stub_test.cc
@@ -304,7 +304,7 @@ TEST(GoldenKitchenSinkTracingStubTest, AsyncStreamingRead) {
 
   auto mock = std::make_shared<MockGoldenKitchenSinkStub>();
   EXPECT_CALL(*mock, AsyncStreamingRead)
-      .WillOnce([](auto const&, auto context, auto const&) {
+      .WillOnce([](auto const&, auto context, auto, auto const&) {
         ValidatePropagator(*context);
         EXPECT_TRUE(ThereIsAnActiveSpan());
         EXPECT_TRUE(OTelContextCaptured());
@@ -316,7 +316,8 @@ TEST(GoldenKitchenSinkTracingStubTest, AsyncStreamingRead) {
   google::cloud::CompletionQueue cq;
   auto under_test = GoldenKitchenSinkTracingStub(mock);
   auto stream = under_test.AsyncStreamingRead(
-      cq, std::make_shared<grpc::ClientContext>(), Request{});
+      cq, std::make_shared<grpc::ClientContext>(),
+      google::cloud::internal::MakeImmutableOptions({}), Request{});
   auto start = stream->Start().get();
   EXPECT_FALSE(start);
   auto finish = stream->Finish().get();

--- a/generator/integration_tests/tests/mock_golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/tests/mock_golden_kitchen_sink_stub.h
@@ -111,6 +111,7 @@ class MockGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
               AsyncStreamingRead,
               (google::cloud::CompletionQueue const&,
                std::shared_ptr<grpc::ClientContext>,
+               google::cloud::internal::ImmutableOptions,
                google::test::admin::database::v1::Request const&),
               (override));
 

--- a/generator/internal/auth_decorator_generator.cc
+++ b/generator/internal/auth_decorator_generator.cc
@@ -224,13 +224,14 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
 $auth_class_name$::Async$method_name$(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     $request_type$ const& request) {
   using StreamAuth = google::cloud::internal::AsyncStreamingReadRpcAuth<
     $response_type$>;
 
   auto& child = child_;
-  auto call = [child, cq, request](std::shared_ptr<grpc::ClientContext> ctx) {
-    return child->Async$method_name$(cq, std::move(ctx), request);
+  auto call = [child, cq, opts = std::move(options), request](std::shared_ptr<grpc::ClientContext> ctx) {
+    return child->Async$method_name$(cq, std::move(ctx), opts, request);
   };
   return std::make_unique<StreamAuth>(
     std::move(context), auth_, StreamAuth::StreamFactory(std::move(call)));

--- a/generator/internal/logging_decorator_generator.cc
+++ b/generator/internal/logging_decorator_generator.cc
@@ -258,13 +258,15 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
 $logging_class_name$::Async$method_name$(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     $request_type$ const& request) {
   using LoggingStream =
      ::google::cloud::internal::AsyncStreamingReadRpcLogging<$response_type$>;
 
   auto request_id = google::cloud::internal::RequestIdForLogging();
   GCP_LOG(DEBUG) << __func__ << "(" << request_id << ")";
-  auto stream = child_->Async$method_name$(cq, std::move(context), request);
+  auto stream = child_->Async$method_name$(
+      cq, std::move(context), std::move(options), request);
   if (stream_logging_) {
     stream = std::make_unique<LoggingStream>(
         std::move(stream), tracing_options_, std::move(request_id));

--- a/generator/internal/metadata_decorator_generator.cc
+++ b/generator/internal/metadata_decorator_generator.cc
@@ -302,11 +302,13 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
 $metadata_class_name$::Async$method_name$(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     $request_type$ const& request) {
 )""",
-          SetMetadataText(method, kPointer, "internal::CurrentOptions()"),
+          SetMetadataText(method, kPointer, "*options"),
           R"""(
-  return child_->Async$method_name$(cq, std::move(context), request);
+  return child_->Async$method_name$(
+      cq, std::move(context), std::move(options), request);
 }
 )""");
       CcPrintMethod(method, __FILE__, __LINE__, definition);

--- a/generator/internal/round_robin_decorator_generator.cc
+++ b/generator/internal/round_robin_decorator_generator.cc
@@ -188,8 +188,10 @@ std::unique_ptr<google::cloud::internal::AsyncStreamingReadRpc<
 $round_robin_class_name$::Async$method_name$(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     $request_type$ const& request) {
-  return Child()->Async$method_name$(cq, std::move(context), request);
+  return Child()->Async$method_name$(
+      cq, std::move(context), std::move(options), request);
 }
 )""");
       continue;

--- a/generator/internal/stub_generator.cc
+++ b/generator/internal/stub_generator.cc
@@ -158,6 +158,7 @@ Status StubGenerator::GenerateHeader() {
   Async$method_name$(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       $request_type$ const& request) = 0;
 )""";
       HeaderPrintMethod(method, __FILE__, __LINE__, kDeclaration);
@@ -413,9 +414,10 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
 Default$stub_class_name$::Async$method_name$(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     $request_type$ const& request) {
   return google::cloud::internal::MakeStreamingReadRpc<$request_type$, $response_type$>(
-    cq, std::move(context), request,
+    cq, std::move(context), std::move(options), request,
     [this](grpc::ClientContext* context, $request_type$ const& request, grpc::CompletionQueue* cq) {
       return grpc_stub_->PrepareAsync$method_name$(context, request, cq);
     });

--- a/generator/internal/stub_generator_base.cc
+++ b/generator/internal/stub_generator_base.cc
@@ -100,6 +100,7 @@ void StubGeneratorBase::HeaderPrintPublicMethods() {
   Async$method_name$(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       $request_type$ const& request) override;
 )""";
       HeaderPrintMethod(method, __FILE__, __LINE__, kDeclaration);

--- a/generator/internal/tracing_stub_generator.cc
+++ b/generator/internal/tracing_stub_generator.cc
@@ -229,11 +229,13 @@ std::unique_ptr<internal::AsyncStreamingReadRpc<$response_type$>>
 $tracing_stub_class_name$::Async$method_name$(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     $request_type$ const& request) {
   auto span = internal::MakeSpanGrpc("$grpc_service$", "$method_name$");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto stream = child_->Async$method_name$(cq, context, request);
+  auto stream = child_->Async$method_name$(
+      cq, context, std::move(options), request);
   return std::make_unique<
       internal::AsyncStreamingReadRpcTracing<$response_type$>>(
       std::move(context), std::move(stream), std::move(span));

--- a/google/cloud/bigtable/internal/async_bulk_apply.h
+++ b/google/cloud/bigtable/internal/async_bulk_apply.h
@@ -75,6 +75,7 @@ class AsyncBulkApplier : public std::enable_shared_from_this<AsyncBulkApplier> {
   BulkMutatorState state_;
   std::atomic<bool> keep_reading_{true};
   promise<std::vector<bigtable::FailedMutation>> promise_;
+  internal::ImmutableOptions options_;
   internal::CallContext call_context_;
   std::shared_ptr<grpc::ClientContext> context_;
   std::shared_ptr<RetryContext> retry_context_ =

--- a/google/cloud/bigtable/internal/async_bulk_apply_test.cc
+++ b/google/cloud/bigtable/internal/async_bulk_apply_test.cc
@@ -140,7 +140,7 @@ TEST_F(AsyncBulkApplyTest, Success) {
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRows)
-      .WillOnce([](CompletionQueue const&, auto,
+      .WillOnce([](CompletionQueue const&, auto, auto,
                    v2::MutateRowsRequest const& request) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -196,7 +196,7 @@ TEST_F(AsyncBulkApplyTest, PartialStreamIsRetried) {
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRows)
-      .WillOnce([this](CompletionQueue const&, auto context,
+      .WillOnce([this](CompletionQueue const&, auto context, auto,
                        v2::MutateRowsRequest const& request) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
@@ -222,7 +222,7 @@ TEST_F(AsyncBulkApplyTest, PartialStreamIsRetried) {
         });
         return stream;
       })
-      .WillOnce([](CompletionQueue const&, auto,
+      .WillOnce([](CompletionQueue const&, auto, auto,
                    v2::MutateRowsRequest const& request) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -281,7 +281,7 @@ TEST_F(AsyncBulkApplyTest, IdempotentMutationPolicy) {
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRows)
-      .WillOnce([this](CompletionQueue const&, auto context,
+      .WillOnce([this](CompletionQueue const&, auto context, auto,
                        v2::MutateRowsRequest const& request) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
@@ -307,7 +307,7 @@ TEST_F(AsyncBulkApplyTest, IdempotentMutationPolicy) {
         });
         return stream;
       })
-      .WillOnce([](CompletionQueue const&, auto,
+      .WillOnce([](CompletionQueue const&, auto, auto,
                    v2::MutateRowsRequest const& request) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -363,7 +363,7 @@ TEST_F(AsyncBulkApplyTest, TooManyStreamFailures) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRows)
       .Times(kNumRetries + 1)
-      .WillRepeatedly([this](CompletionQueue const&, auto context,
+      .WillRepeatedly([this](CompletionQueue const&, auto context, auto,
                              v2::MutateRowsRequest const& request) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
@@ -411,7 +411,7 @@ TEST_F(AsyncBulkApplyTest, RetryInfoHeeded) {
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRows)
-      .WillOnce([this](CompletionQueue const&, auto context,
+      .WillOnce([this](CompletionQueue const&, auto context, auto,
                        v2::MutateRowsRequest const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         auto stream = std::make_unique<MockAsyncMutateRowsStream>();
@@ -425,7 +425,7 @@ TEST_F(AsyncBulkApplyTest, RetryInfoHeeded) {
         });
         return stream;
       })
-      .WillOnce([this](CompletionQueue const&, auto context,
+      .WillOnce([this](CompletionQueue const&, auto context, auto,
                        v2::MutateRowsRequest const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         auto stream = std::make_unique<MockAsyncMutateRowsStream>();
@@ -466,7 +466,7 @@ TEST_F(AsyncBulkApplyTest, RetryInfoIgnored) {
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRows)
-      .WillOnce([this](CompletionQueue const&, auto context,
+      .WillOnce([this](CompletionQueue const&, auto context, auto,
                        v2::MutateRowsRequest const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         auto stream = std::make_unique<MockAsyncMutateRowsStream>();
@@ -503,7 +503,7 @@ TEST_F(AsyncBulkApplyTest, TimerError) {
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRows)
-      .WillOnce([this](CompletionQueue const&, auto context,
+      .WillOnce([this](CompletionQueue const&, auto context, auto,
                        v2::MutateRowsRequest const& request) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
@@ -550,7 +550,7 @@ TEST_F(AsyncBulkApplyTest, CancelAfterSuccess) {
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRows)
-      .WillOnce([&p](CompletionQueue const&, auto,
+      .WillOnce([&p](CompletionQueue const&, auto, auto,
                      v2::MutateRowsRequest const& request) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -607,7 +607,7 @@ TEST_F(AsyncBulkApplyTest, CancelMidStream) {
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRows)
-      .WillOnce([&p](CompletionQueue const&, auto,
+      .WillOnce([&p](CompletionQueue const&, auto, auto,
                      v2::MutateRowsRequest const& request) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -674,7 +674,7 @@ TEST_F(AsyncBulkApplyTest, CurrentOptionsContinuedOnRetries) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRows)
       .Times(2)
-      .WillRepeatedly([this](CompletionQueue const&, auto context,
+      .WillRepeatedly([this](CompletionQueue const&, auto context, auto,
                              v2::MutateRowsRequest const&) {
         EXPECT_EQ(5, internal::CurrentOptions().get<TestOption>());
         metadata_fixture_.SetServerMetadata(*context, {});
@@ -727,7 +727,7 @@ TEST_F(AsyncBulkApplyTest, RetriesOkStreamWithFailedMutations) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRows)
       .Times(kNumRetries + 1)
-      .WillRepeatedly([this](CompletionQueue const&, auto context,
+      .WillRepeatedly([this](CompletionQueue const&, auto context, auto,
                              v2::MutateRowsRequest const& request) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
@@ -800,7 +800,7 @@ TEST_F(AsyncBulkApplyTest, Throttling) {
     return make_ready_future();
   });
   EXPECT_CALL(*mock, AsyncMutateRows)
-      .WillOnce([&limiter](CompletionQueue const&, auto,
+      .WillOnce([&limiter](CompletionQueue const&, auto, auto,
                            v2::MutateRowsRequest const&) {
         ::testing::InSequence seq2;
         auto stream = std::make_unique<MockAsyncMutateRowsStream>();
@@ -835,7 +835,7 @@ TEST_F(AsyncBulkApplyTest, ThrottlingBeforeEachRetry) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRows)
       .Times(kNumRetries + 1)
-      .WillRepeatedly([this](CompletionQueue const&, auto context,
+      .WillRepeatedly([this](CompletionQueue const&, auto context, auto,
                              v2::MutateRowsRequest const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         auto stream = std::make_unique<MockAsyncMutateRowsStream>();
@@ -889,7 +889,7 @@ TEST_F(AsyncBulkApplyTest, BigtableCookie) {
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRows)
-      .WillOnce([this](CompletionQueue const&, auto context,
+      .WillOnce([this](CompletionQueue const&, auto context, auto,
                        v2::MutateRowsRequest const&) {
         // Return a bigtable cookie in the first request.
         metadata_fixture_.SetServerMetadata(
@@ -903,7 +903,7 @@ TEST_F(AsyncBulkApplyTest, BigtableCookie) {
         });
         return stream;
       })
-      .WillOnce([this](CompletionQueue const&, auto context,
+      .WillOnce([this](CompletionQueue const&, auto context, auto,
                        v2::MutateRowsRequest const&) {
         // Verify that the next request includes the bigtable cookie from above.
         auto headers = metadata_fixture_.GetMetadata(*context);
@@ -954,7 +954,7 @@ TEST_F(AsyncBulkApplyTest, TracedBackoff) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRows)
       .Times(kNumRetries + 1)
-      .WillRepeatedly([this](auto&, auto context, auto const&) {
+      .WillRepeatedly([this](auto&, auto context, auto, auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         return std::make_unique<ErrorStream>(TransientError());
       });
@@ -986,7 +986,7 @@ TEST_F(AsyncBulkApplyTest, CallSpanActiveThroughout) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRows)
       .Times(kNumRetries + 1)
-      .WillRepeatedly([this, span](auto&, auto context, auto const&) {
+      .WillRepeatedly([this, span](auto&, auto context, auto, auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_THAT(span, IsActive());
         return std::make_unique<ErrorStream>(TransientError());

--- a/google/cloud/bigtable/internal/async_row_reader.cc
+++ b/google/cloud/bigtable/internal/async_row_reader.cc
@@ -50,7 +50,7 @@ void AsyncRowReader::MakeRequest() {
 
   auto self = this->shared_from_this();
   PerformAsyncStreamingRead(
-      stub_->AsyncReadRows(cq_, context_, request),
+      stub_->AsyncReadRows(cq_, context_, options_, request),
       [self](v2::ReadRowsResponse r) {
         return self->OnDataReceived(std::move(r));
       },

--- a/google/cloud/bigtable/internal/async_row_reader.h
+++ b/google/cloud/bigtable/internal/async_row_reader.h
@@ -28,11 +28,14 @@
 #include "google/cloud/future.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/call_context.h"
+#include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
 #include "absl/types/optional.h"
 #include <chrono>
+#include <memory>
 #include <queue>
 #include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {
@@ -92,7 +95,9 @@ class AsyncRowReader : public std::enable_shared_from_this<AsyncRowReader> {
         reverse_(std::move(reverse)),
         retry_policy_(std::move(retry_policy)),
         backoff_policy_(std::move(backoff_policy)),
-        enable_server_retries_(enable_server_retries) {}
+        enable_server_retries_(enable_server_retries),
+        options_(internal::SaveCurrentOptions()),
+        call_context_(options_) {}
 
   void MakeRequest();
 
@@ -168,6 +173,7 @@ class AsyncRowReader : public std::enable_shared_from_this<AsyncRowReader> {
   Status status_;
   /// Tracks the level of recursion of TryGiveRowToUser
   int recursion_level_ = 0;
+  internal::ImmutableOptions options_;
   internal::CallContext call_context_;
   std::shared_ptr<grpc::ClientContext> context_;
   std::shared_ptr<RetryContext> retry_context_ =

--- a/google/cloud/bigtable/internal/async_row_sampler.cc
+++ b/google/cloud/bigtable/internal/async_row_sampler.cc
@@ -51,7 +51,9 @@ AsyncRowSampler::AsyncRowSampler(
       enable_server_retries_(enable_server_retries),
       app_profile_id_(std::move(app_profile_id)),
       table_name_(std::move(table_name)),
-      promise_([this] { keep_reading_ = false; }) {}
+      promise_([this] { keep_reading_ = false; }),
+      options_(internal::SaveCurrentOptions()),
+      call_context_(options_) {}
 
 void AsyncRowSampler::StartIteration() {
   v2::SampleRowKeysRequest request;
@@ -65,7 +67,7 @@ void AsyncRowSampler::StartIteration() {
 
   auto self = this->shared_from_this();
   PerformAsyncStreamingRead<v2::SampleRowKeysResponse>(
-      stub_->AsyncSampleRowKeys(cq_, context_, request),
+      stub_->AsyncSampleRowKeys(cq_, context_, options_, request),
       [self](v2::SampleRowKeysResponse response) {
         return self->OnRead(std::move(response));
       },

--- a/google/cloud/bigtable/internal/async_row_sampler.h
+++ b/google/cloud/bigtable/internal/async_row_sampler.h
@@ -22,6 +22,7 @@
 #include "google/cloud/bigtable/row_key_sample.h"
 #include "google/cloud/bigtable/version.h"
 #include "google/cloud/internal/call_context.h"
+#include "google/cloud/options.h"
 #include <atomic>
 #include <memory>
 #include <string>
@@ -66,6 +67,7 @@ class AsyncRowSampler : public std::enable_shared_from_this<AsyncRowSampler> {
   std::atomic<bool> keep_reading_{true};
   std::vector<bigtable::RowKeySample> samples_;
   promise<StatusOr<std::vector<bigtable::RowKeySample>>> promise_;
+  internal::ImmutableOptions options_;
   internal::CallContext call_context_;
   std::shared_ptr<grpc::ClientContext> context_;
   std::shared_ptr<RetryContext> retry_context_ =

--- a/google/cloud/bigtable/internal/async_row_sampler_test.cc
+++ b/google/cloud/bigtable/internal/async_row_sampler_test.cc
@@ -84,7 +84,7 @@ class AsyncSampleRowKeysTest : public ::testing::Test {
 TEST_F(AsyncSampleRowKeysTest, Simple) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
-      .WillOnce([](CompletionQueue const&, auto,
+      .WillOnce([](CompletionQueue const&, auto, auto,
                    v2::SampleRowKeysRequest const& request) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -133,7 +133,7 @@ TEST_F(AsyncSampleRowKeysTest, Simple) {
 TEST_F(AsyncSampleRowKeysTest, RetryResetsSamples) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
-      .WillOnce([this](CompletionQueue const&, auto context,
+      .WillOnce([this](CompletionQueue const&, auto context, auto,
                        v2::SampleRowKeysRequest const& request) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
@@ -155,7 +155,7 @@ TEST_F(AsyncSampleRowKeysTest, RetryResetsSamples) {
         });
         return stream;
       })
-      .WillOnce([](CompletionQueue const&, auto,
+      .WillOnce([](CompletionQueue const&, auto, auto,
                    v2::SampleRowKeysRequest const& request) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -206,7 +206,7 @@ TEST_F(AsyncSampleRowKeysTest, TooManyFailures) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
       .Times(kNumRetries + 1)
-      .WillRepeatedly([this](CompletionQueue const&, auto context,
+      .WillRepeatedly([this](CompletionQueue const&, auto context, auto,
                              v2::SampleRowKeysRequest const& request) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
@@ -251,7 +251,7 @@ TEST_F(AsyncSampleRowKeysTest, TooManyFailures) {
 TEST_F(AsyncSampleRowKeysTest, RetryInfoHeeded) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
-      .WillOnce([this](CompletionQueue const&, auto context,
+      .WillOnce([this](CompletionQueue const&, auto context, auto,
                        v2::SampleRowKeysRequest const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         auto stream = std::make_unique<MockAsyncSampleRowKeysStream>();
@@ -265,7 +265,7 @@ TEST_F(AsyncSampleRowKeysTest, RetryInfoHeeded) {
         });
         return stream;
       })
-      .WillOnce([this](CompletionQueue const&, auto context,
+      .WillOnce([this](CompletionQueue const&, auto context, auto,
                        v2::SampleRowKeysRequest const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         auto stream = std::make_unique<MockAsyncSampleRowKeysStream>();
@@ -305,7 +305,7 @@ TEST_F(AsyncSampleRowKeysTest, RetryInfoHeeded) {
 TEST_F(AsyncSampleRowKeysTest, RetryInfoIgnored) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
-      .WillOnce([this](CompletionQueue const&, auto context,
+      .WillOnce([this](CompletionQueue const&, auto context, auto,
                        v2::SampleRowKeysRequest const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         auto stream = std::make_unique<MockAsyncSampleRowKeysStream>();
@@ -338,7 +338,7 @@ TEST_F(AsyncSampleRowKeysTest, RetryInfoIgnored) {
 TEST_F(AsyncSampleRowKeysTest, TimerError) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
-      .WillOnce([this](CompletionQueue const&, auto context,
+      .WillOnce([this](CompletionQueue const&, auto context, auto,
                        v2::SampleRowKeysRequest const& request) {
         metadata_fixture_.SetServerMetadata(*context);
         EXPECT_EQ(kAppProfile, request.app_profile_id());
@@ -386,7 +386,7 @@ TEST_F(AsyncSampleRowKeysTest, CancelAfterSuccess) {
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
-      .WillOnce([&p](CompletionQueue const&, auto,
+      .WillOnce([&p](CompletionQueue const&, auto, auto,
                      v2::SampleRowKeysRequest const& request) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -438,7 +438,7 @@ TEST_F(AsyncSampleRowKeysTest, CancelMidStream) {
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
-      .WillOnce([&p](CompletionQueue const&, auto,
+      .WillOnce([&p](CompletionQueue const&, auto, auto,
                      v2::SampleRowKeysRequest const& request) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -503,7 +503,7 @@ TEST_F(AsyncSampleRowKeysTest, CurrentOptionsContinuedOnRetries) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
       .Times(2)
-      .WillRepeatedly([this](CompletionQueue const&, auto context,
+      .WillRepeatedly([this](CompletionQueue const&, auto context, auto,
                              v2::SampleRowKeysRequest const&) {
         EXPECT_EQ(5, internal::CurrentOptions().get<TestOption>());
         metadata_fixture_.SetServerMetadata(*context);
@@ -549,7 +549,7 @@ TEST_F(AsyncSampleRowKeysTest, CurrentOptionsContinuedOnRetries) {
 TEST_F(AsyncSampleRowKeysTest, BigtableCookie) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
-      .WillOnce([this](CompletionQueue const&, auto context,
+      .WillOnce([this](CompletionQueue const&, auto context, auto,
                        v2::SampleRowKeysRequest const&) {
         // Return a bigtable cookie in the first request.
         metadata_fixture_.SetServerMetadata(
@@ -563,7 +563,7 @@ TEST_F(AsyncSampleRowKeysTest, BigtableCookie) {
         });
         return stream;
       })
-      .WillOnce([this](CompletionQueue const&, auto context,
+      .WillOnce([this](CompletionQueue const&, auto context, auto,
                        v2::SampleRowKeysRequest const&) {
         // Verify that the next request includes the bigtable cookie from above.
         auto headers = metadata_fixture_.GetMetadata(*context);
@@ -613,7 +613,7 @@ TEST_F(AsyncSampleRowKeysTest, TracedBackoff) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
       .Times(kNumRetries + 1)
-      .WillRepeatedly([this](auto&, auto context, auto const&) {
+      .WillRepeatedly([this](auto&, auto context, auto, auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         return std::make_unique<ErrorStream>(
             internal::UnavailableError("try again"));
@@ -642,7 +642,7 @@ TEST_F(AsyncSampleRowKeysTest, CallSpanActiveThroughout) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
       .Times(kNumRetries + 1)
-      .WillRepeatedly([this, span](auto&, auto context, auto const&) {
+      .WillRepeatedly([this, span](auto&, auto context, auto, auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_THAT(span, IsActive());
         return std::make_unique<ErrorStream>(

--- a/google/cloud/bigtable/internal/bigtable_auth_decorator.cc
+++ b/google/cloud/bigtable/internal/bigtable_auth_decorator.cc
@@ -107,13 +107,15 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
 BigtableAuth::AsyncReadRows(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::ReadRowsRequest const& request) {
   using StreamAuth = google::cloud::internal::AsyncStreamingReadRpcAuth<
       google::bigtable::v2::ReadRowsResponse>;
 
   auto& child = child_;
-  auto call = [child, cq, request](std::shared_ptr<grpc::ClientContext> ctx) {
-    return child->AsyncReadRows(cq, std::move(ctx), request);
+  auto call = [child, cq, opts = std::move(options),
+               request](std::shared_ptr<grpc::ClientContext> ctx) {
+    return child->AsyncReadRows(cq, std::move(ctx), opts, request);
   };
   return std::make_unique<StreamAuth>(
       std::move(context), auth_, StreamAuth::StreamFactory(std::move(call)));
@@ -124,13 +126,15 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
 BigtableAuth::AsyncSampleRowKeys(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::SampleRowKeysRequest const& request) {
   using StreamAuth = google::cloud::internal::AsyncStreamingReadRpcAuth<
       google::bigtable::v2::SampleRowKeysResponse>;
 
   auto& child = child_;
-  auto call = [child, cq, request](std::shared_ptr<grpc::ClientContext> ctx) {
-    return child->AsyncSampleRowKeys(cq, std::move(ctx), request);
+  auto call = [child, cq, opts = std::move(options),
+               request](std::shared_ptr<grpc::ClientContext> ctx) {
+    return child->AsyncSampleRowKeys(cq, std::move(ctx), opts, request);
   };
   return std::make_unique<StreamAuth>(
       std::move(context), auth_, StreamAuth::StreamFactory(std::move(call)));
@@ -160,13 +164,15 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
 BigtableAuth::AsyncMutateRows(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::MutateRowsRequest const& request) {
   using StreamAuth = google::cloud::internal::AsyncStreamingReadRpcAuth<
       google::bigtable::v2::MutateRowsResponse>;
 
   auto& child = child_;
-  auto call = [child, cq, request](std::shared_ptr<grpc::ClientContext> ctx) {
-    return child->AsyncMutateRows(cq, std::move(ctx), request);
+  auto call = [child, cq, opts = std::move(options),
+               request](std::shared_ptr<grpc::ClientContext> ctx) {
+    return child->AsyncMutateRows(cq, std::move(ctx), opts, request);
   };
   return std::make_unique<StreamAuth>(
       std::move(context), auth_, StreamAuth::StreamFactory(std::move(call)));

--- a/google/cloud/bigtable/internal/bigtable_auth_decorator.h
+++ b/google/cloud/bigtable/internal/bigtable_auth_decorator.h
@@ -75,6 +75,7 @@ class BigtableAuth : public BigtableStub {
       google::bigtable::v2::ReadRowsResponse>>
   AsyncReadRows(google::cloud::CompletionQueue const& cq,
                 std::shared_ptr<grpc::ClientContext> context,
+                google::cloud::internal::ImmutableOptions options,
                 google::bigtable::v2::ReadRowsRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -82,6 +83,7 @@ class BigtableAuth : public BigtableStub {
   AsyncSampleRowKeys(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::SampleRowKeysRequest const& request) override;
 
   future<StatusOr<google::bigtable::v2::MutateRowResponse>> AsyncMutateRow(
@@ -94,6 +96,7 @@ class BigtableAuth : public BigtableStub {
   AsyncMutateRows(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::MutateRowsRequest const& request) override;
 
   future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>

--- a/google/cloud/bigtable/internal/bigtable_channel_refresh.cc
+++ b/google/cloud/bigtable/internal/bigtable_channel_refresh.cc
@@ -76,8 +76,10 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
 BigtableChannelRefresh::AsyncReadRows(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::ReadRowsRequest const& request) {
-  return child_->AsyncReadRows(cq, std::move(context), request);
+  return child_->AsyncReadRows(cq, std::move(context), std::move(options),
+                               request);
 }
 
 std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -85,8 +87,10 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
 BigtableChannelRefresh::AsyncSampleRowKeys(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::SampleRowKeysRequest const& request) {
-  return child_->AsyncSampleRowKeys(cq, std::move(context), request);
+  return child_->AsyncSampleRowKeys(cq, std::move(context), std::move(options),
+                                    request);
 }
 
 future<StatusOr<google::bigtable::v2::MutateRowResponse>>
@@ -102,8 +106,10 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
 BigtableChannelRefresh::AsyncMutateRows(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::MutateRowsRequest const& request) {
-  return child_->AsyncMutateRows(cq, std::move(context), request);
+  return child_->AsyncMutateRows(cq, std::move(context), std::move(options),
+                                 request);
 }
 
 future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>

--- a/google/cloud/bigtable/internal/bigtable_channel_refresh.h
+++ b/google/cloud/bigtable/internal/bigtable_channel_refresh.h
@@ -81,6 +81,7 @@ class BigtableChannelRefresh : public BigtableStub {
       google::bigtable::v2::ReadRowsResponse>>
   AsyncReadRows(google::cloud::CompletionQueue const& cq,
                 std::shared_ptr<grpc::ClientContext> context,
+                google::cloud::internal::ImmutableOptions options,
                 google::bigtable::v2::ReadRowsRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -88,6 +89,7 @@ class BigtableChannelRefresh : public BigtableStub {
   AsyncSampleRowKeys(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::SampleRowKeysRequest const& request) override;
 
   future<StatusOr<google::bigtable::v2::MutateRowResponse>> AsyncMutateRow(
@@ -100,6 +102,7 @@ class BigtableChannelRefresh : public BigtableStub {
   AsyncMutateRows(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::MutateRowsRequest const& request) override;
 
   future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>

--- a/google/cloud/bigtable/internal/bigtable_logging_decorator.cc
+++ b/google/cloud/bigtable/internal/bigtable_logging_decorator.cc
@@ -162,13 +162,15 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
 BigtableLogging::AsyncReadRows(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::ReadRowsRequest const& request) {
   using LoggingStream = ::google::cloud::internal::AsyncStreamingReadRpcLogging<
       google::bigtable::v2::ReadRowsResponse>;
 
   auto request_id = google::cloud::internal::RequestIdForLogging();
   GCP_LOG(DEBUG) << __func__ << "(" << request_id << ")";
-  auto stream = child_->AsyncReadRows(cq, std::move(context), request);
+  auto stream = child_->AsyncReadRows(cq, std::move(context),
+                                      std::move(options), request);
   if (stream_logging_) {
     stream = std::make_unique<LoggingStream>(
         std::move(stream), tracing_options_, std::move(request_id));
@@ -181,13 +183,15 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
 BigtableLogging::AsyncSampleRowKeys(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::SampleRowKeysRequest const& request) {
   using LoggingStream = ::google::cloud::internal::AsyncStreamingReadRpcLogging<
       google::bigtable::v2::SampleRowKeysResponse>;
 
   auto request_id = google::cloud::internal::RequestIdForLogging();
   GCP_LOG(DEBUG) << __func__ << "(" << request_id << ")";
-  auto stream = child_->AsyncSampleRowKeys(cq, std::move(context), request);
+  auto stream = child_->AsyncSampleRowKeys(cq, std::move(context),
+                                           std::move(options), request);
   if (stream_logging_) {
     stream = std::make_unique<LoggingStream>(
         std::move(stream), tracing_options_, std::move(request_id));
@@ -214,13 +218,15 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
 BigtableLogging::AsyncMutateRows(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::MutateRowsRequest const& request) {
   using LoggingStream = ::google::cloud::internal::AsyncStreamingReadRpcLogging<
       google::bigtable::v2::MutateRowsResponse>;
 
   auto request_id = google::cloud::internal::RequestIdForLogging();
   GCP_LOG(DEBUG) << __func__ << "(" << request_id << ")";
-  auto stream = child_->AsyncMutateRows(cq, std::move(context), request);
+  auto stream = child_->AsyncMutateRows(cq, std::move(context),
+                                        std::move(options), request);
   if (stream_logging_) {
     stream = std::make_unique<LoggingStream>(
         std::move(stream), tracing_options_, std::move(request_id));

--- a/google/cloud/bigtable/internal/bigtable_logging_decorator.h
+++ b/google/cloud/bigtable/internal/bigtable_logging_decorator.h
@@ -75,6 +75,7 @@ class BigtableLogging : public BigtableStub {
       google::bigtable::v2::ReadRowsResponse>>
   AsyncReadRows(google::cloud::CompletionQueue const& cq,
                 std::shared_ptr<grpc::ClientContext> context,
+                google::cloud::internal::ImmutableOptions options,
                 google::bigtable::v2::ReadRowsRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -82,6 +83,7 @@ class BigtableLogging : public BigtableStub {
   AsyncSampleRowKeys(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::SampleRowKeysRequest const& request) override;
 
   future<StatusOr<google::bigtable::v2::MutateRowResponse>> AsyncMutateRow(
@@ -94,6 +96,7 @@ class BigtableLogging : public BigtableStub {
   AsyncMutateRows(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::MutateRowsRequest const& request) override;
 
   future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>

--- a/google/cloud/bigtable/internal/bigtable_metadata_decorator.cc
+++ b/google/cloud/bigtable/internal/bigtable_metadata_decorator.cc
@@ -282,6 +282,7 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
 BigtableMetadata::AsyncReadRows(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::ReadRowsRequest const& request) {
   std::vector<std::string> params;
   params.reserve(2);
@@ -305,12 +306,12 @@ BigtableMetadata::AsyncReadRows(
   }
 
   if (params.empty()) {
-    SetMetadata(*context, internal::CurrentOptions());
+    SetMetadata(*context, *options);
   } else {
-    SetMetadata(*context, internal::CurrentOptions(),
-                absl::StrJoin(params, "&"));
+    SetMetadata(*context, *options, absl::StrJoin(params, "&"));
   }
-  return child_->AsyncReadRows(cq, std::move(context), request);
+  return child_->AsyncReadRows(cq, std::move(context), std::move(options),
+                               request);
 }
 
 std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -318,6 +319,7 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
 BigtableMetadata::AsyncSampleRowKeys(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::SampleRowKeysRequest const& request) {
   std::vector<std::string> params;
   params.reserve(2);
@@ -341,12 +343,12 @@ BigtableMetadata::AsyncSampleRowKeys(
   }
 
   if (params.empty()) {
-    SetMetadata(*context, internal::CurrentOptions());
+    SetMetadata(*context, *options);
   } else {
-    SetMetadata(*context, internal::CurrentOptions(),
-                absl::StrJoin(params, "&"));
+    SetMetadata(*context, *options, absl::StrJoin(params, "&"));
   }
-  return child_->AsyncSampleRowKeys(cq, std::move(context), request);
+  return child_->AsyncSampleRowKeys(cq, std::move(context), std::move(options),
+                                    request);
 }
 
 future<StatusOr<google::bigtable::v2::MutateRowResponse>>
@@ -389,6 +391,7 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
 BigtableMetadata::AsyncMutateRows(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::MutateRowsRequest const& request) {
   std::vector<std::string> params;
   params.reserve(2);
@@ -412,12 +415,12 @@ BigtableMetadata::AsyncMutateRows(
   }
 
   if (params.empty()) {
-    SetMetadata(*context, internal::CurrentOptions());
+    SetMetadata(*context, *options);
   } else {
-    SetMetadata(*context, internal::CurrentOptions(),
-                absl::StrJoin(params, "&"));
+    SetMetadata(*context, *options, absl::StrJoin(params, "&"));
   }
-  return child_->AsyncMutateRows(cq, std::move(context), request);
+  return child_->AsyncMutateRows(cq, std::move(context), std::move(options),
+                                 request);
 }
 
 future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>

--- a/google/cloud/bigtable/internal/bigtable_metadata_decorator.h
+++ b/google/cloud/bigtable/internal/bigtable_metadata_decorator.h
@@ -75,6 +75,7 @@ class BigtableMetadata : public BigtableStub {
       google::bigtable::v2::ReadRowsResponse>>
   AsyncReadRows(google::cloud::CompletionQueue const& cq,
                 std::shared_ptr<grpc::ClientContext> context,
+                google::cloud::internal::ImmutableOptions options,
                 google::bigtable::v2::ReadRowsRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -82,6 +83,7 @@ class BigtableMetadata : public BigtableStub {
   AsyncSampleRowKeys(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::SampleRowKeysRequest const& request) override;
 
   future<StatusOr<google::bigtable::v2::MutateRowResponse>> AsyncMutateRow(
@@ -94,6 +96,7 @@ class BigtableMetadata : public BigtableStub {
   AsyncMutateRows(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::MutateRowsRequest const& request) override;
 
   future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>

--- a/google/cloud/bigtable/internal/bigtable_round_robin_decorator.cc
+++ b/google/cloud/bigtable/internal/bigtable_round_robin_decorator.cc
@@ -83,8 +83,10 @@ std::unique_ptr<google::cloud::internal::AsyncStreamingReadRpc<
 BigtableRoundRobin::AsyncReadRows(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::ReadRowsRequest const& request) {
-  return Child()->AsyncReadRows(cq, std::move(context), request);
+  return Child()->AsyncReadRows(cq, std::move(context), std::move(options),
+                                request);
 }
 
 std::unique_ptr<google::cloud::internal::AsyncStreamingReadRpc<
@@ -92,8 +94,10 @@ std::unique_ptr<google::cloud::internal::AsyncStreamingReadRpc<
 BigtableRoundRobin::AsyncSampleRowKeys(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::SampleRowKeysRequest const& request) {
-  return Child()->AsyncSampleRowKeys(cq, std::move(context), request);
+  return Child()->AsyncSampleRowKeys(cq, std::move(context), std::move(options),
+                                     request);
 }
 
 future<StatusOr<google::bigtable::v2::MutateRowResponse>>
@@ -109,8 +113,10 @@ std::unique_ptr<google::cloud::internal::AsyncStreamingReadRpc<
 BigtableRoundRobin::AsyncMutateRows(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::MutateRowsRequest const& request) {
-  return Child()->AsyncMutateRows(cq, std::move(context), request);
+  return Child()->AsyncMutateRows(cq, std::move(context), std::move(options),
+                                  request);
 }
 
 future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>

--- a/google/cloud/bigtable/internal/bigtable_round_robin_decorator.h
+++ b/google/cloud/bigtable/internal/bigtable_round_robin_decorator.h
@@ -73,6 +73,7 @@ class BigtableRoundRobin : public BigtableStub {
       google::bigtable::v2::ReadRowsResponse>>
   AsyncReadRows(google::cloud::CompletionQueue const& cq,
                 std::shared_ptr<grpc::ClientContext> context,
+                google::cloud::internal::ImmutableOptions options,
                 google::bigtable::v2::ReadRowsRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -80,6 +81,7 @@ class BigtableRoundRobin : public BigtableStub {
   AsyncSampleRowKeys(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::SampleRowKeysRequest const& request) override;
 
   future<StatusOr<google::bigtable::v2::MutateRowResponse>> AsyncMutateRow(
@@ -92,6 +94,7 @@ class BigtableRoundRobin : public BigtableStub {
   AsyncMutateRows(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::MutateRowsRequest const& request) override;
 
   future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>

--- a/google/cloud/bigtable/internal/bigtable_stub.cc
+++ b/google/cloud/bigtable/internal/bigtable_stub.cc
@@ -117,11 +117,12 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
 DefaultBigtableStub::AsyncReadRows(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::ReadRowsRequest const& request) {
   return google::cloud::internal::MakeStreamingReadRpc<
       google::bigtable::v2::ReadRowsRequest,
       google::bigtable::v2::ReadRowsResponse>(
-      cq, std::move(context), request,
+      cq, std::move(context), std::move(options), request,
       [this](grpc::ClientContext* context,
              google::bigtable::v2::ReadRowsRequest const& request,
              grpc::CompletionQueue* cq) {
@@ -134,11 +135,12 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
 DefaultBigtableStub::AsyncSampleRowKeys(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::SampleRowKeysRequest const& request) {
   return google::cloud::internal::MakeStreamingReadRpc<
       google::bigtable::v2::SampleRowKeysRequest,
       google::bigtable::v2::SampleRowKeysResponse>(
-      cq, std::move(context), request,
+      cq, std::move(context), std::move(options), request,
       [this](grpc::ClientContext* context,
              google::bigtable::v2::SampleRowKeysRequest const& request,
              grpc::CompletionQueue* cq) {
@@ -167,11 +169,12 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
 DefaultBigtableStub::AsyncMutateRows(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::MutateRowsRequest const& request) {
   return google::cloud::internal::MakeStreamingReadRpc<
       google::bigtable::v2::MutateRowsRequest,
       google::bigtable::v2::MutateRowsResponse>(
-      cq, std::move(context), request,
+      cq, std::move(context), std::move(options), request,
       [this](grpc::ClientContext* context,
              google::bigtable::v2::MutateRowsRequest const& request,
              grpc::CompletionQueue* cq) {

--- a/google/cloud/bigtable/internal/bigtable_stub.h
+++ b/google/cloud/bigtable/internal/bigtable_stub.h
@@ -78,6 +78,7 @@ class BigtableStub {
       google::bigtable::v2::ReadRowsResponse>>
   AsyncReadRows(google::cloud::CompletionQueue const& cq,
                 std::shared_ptr<grpc::ClientContext> context,
+                google::cloud::internal::ImmutableOptions options,
                 google::bigtable::v2::ReadRowsRequest const& request) = 0;
 
   virtual std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -85,6 +86,7 @@ class BigtableStub {
   AsyncSampleRowKeys(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::SampleRowKeysRequest const& request) = 0;
 
   virtual future<StatusOr<google::bigtable::v2::MutateRowResponse>>
@@ -96,6 +98,7 @@ class BigtableStub {
       google::bigtable::v2::MutateRowsResponse>>
   AsyncMutateRows(google::cloud::CompletionQueue const& cq,
                   std::shared_ptr<grpc::ClientContext> context,
+                  google::cloud::internal::ImmutableOptions options,
                   google::bigtable::v2::MutateRowsRequest const& request) = 0;
 
   virtual future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
@@ -154,6 +157,7 @@ class DefaultBigtableStub : public BigtableStub {
       google::bigtable::v2::ReadRowsResponse>>
   AsyncReadRows(google::cloud::CompletionQueue const& cq,
                 std::shared_ptr<grpc::ClientContext> context,
+                google::cloud::internal::ImmutableOptions options,
                 google::bigtable::v2::ReadRowsRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -161,6 +165,7 @@ class DefaultBigtableStub : public BigtableStub {
   AsyncSampleRowKeys(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::SampleRowKeysRequest const& request) override;
 
   future<StatusOr<google::bigtable::v2::MutateRowResponse>> AsyncMutateRow(
@@ -173,6 +178,7 @@ class DefaultBigtableStub : public BigtableStub {
   AsyncMutateRows(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::MutateRowsRequest const& request) override;
 
   future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>

--- a/google/cloud/bigtable/internal/bigtable_tracing_stub.cc
+++ b/google/cloud/bigtable/internal/bigtable_tracing_stub.cc
@@ -129,11 +129,12 @@ std::unique_ptr<
 BigtableTracingStub::AsyncReadRows(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::ReadRowsRequest const& request) {
   auto span = internal::MakeSpanGrpc("google.bigtable.v2.Bigtable", "ReadRows");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto stream = child_->AsyncReadRows(cq, context, request);
+  auto stream = child_->AsyncReadRows(cq, context, std::move(options), request);
   return std::make_unique<internal::AsyncStreamingReadRpcTracing<
       google::bigtable::v2::ReadRowsResponse>>(
       std::move(context), std::move(stream), std::move(span));
@@ -144,12 +145,14 @@ std::unique_ptr<internal::AsyncStreamingReadRpc<
 BigtableTracingStub::AsyncSampleRowKeys(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::SampleRowKeysRequest const& request) {
   auto span =
       internal::MakeSpanGrpc("google.bigtable.v2.Bigtable", "SampleRowKeys");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto stream = child_->AsyncSampleRowKeys(cq, context, request);
+  auto stream =
+      child_->AsyncSampleRowKeys(cq, context, std::move(options), request);
   return std::make_unique<internal::AsyncStreamingReadRpcTracing<
       google::bigtable::v2::SampleRowKeysResponse>>(
       std::move(context), std::move(stream), std::move(span));
@@ -173,12 +176,14 @@ std::unique_ptr<
 BigtableTracingStub::AsyncMutateRows(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::MutateRowsRequest const& request) {
   auto span =
       internal::MakeSpanGrpc("google.bigtable.v2.Bigtable", "MutateRows");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto stream = child_->AsyncMutateRows(cq, context, request);
+  auto stream =
+      child_->AsyncMutateRows(cq, context, std::move(options), request);
   return std::make_unique<internal::AsyncStreamingReadRpcTracing<
       google::bigtable::v2::MutateRowsResponse>>(
       std::move(context), std::move(stream), std::move(span));

--- a/google/cloud/bigtable/internal/bigtable_tracing_stub.h
+++ b/google/cloud/bigtable/internal/bigtable_tracing_stub.h
@@ -74,6 +74,7 @@ class BigtableTracingStub : public BigtableStub {
       google::bigtable::v2::ReadRowsResponse>>
   AsyncReadRows(google::cloud::CompletionQueue const& cq,
                 std::shared_ptr<grpc::ClientContext> context,
+                google::cloud::internal::ImmutableOptions options,
                 google::bigtable::v2::ReadRowsRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -81,6 +82,7 @@ class BigtableTracingStub : public BigtableStub {
   AsyncSampleRowKeys(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::SampleRowKeysRequest const& request) override;
 
   future<StatusOr<google::bigtable::v2::MutateRowResponse>> AsyncMutateRow(
@@ -93,6 +95,7 @@ class BigtableTracingStub : public BigtableStub {
   AsyncMutateRows(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::MutateRowsRequest const& request) override;
 
   future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>

--- a/google/cloud/bigtable/testing/mock_bigtable_stub.h
+++ b/google/cloud/bigtable/testing/mock_bigtable_stub.h
@@ -67,6 +67,7 @@ class MockBigtableStub : public bigtable_internal::BigtableStub {
               AsyncReadRows,
               (google::cloud::CompletionQueue const&,
                std::shared_ptr<grpc::ClientContext>,
+               google::cloud::internal::ImmutableOptions,
                google::bigtable::v2::ReadRowsRequest const&),
               (override));
   MOCK_METHOD(std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -74,6 +75,7 @@ class MockBigtableStub : public bigtable_internal::BigtableStub {
               AsyncSampleRowKeys,
               (google::cloud::CompletionQueue const&,
                std::shared_ptr<grpc::ClientContext>,
+               google::cloud::internal::ImmutableOptions,
                google::bigtable::v2::SampleRowKeysRequest const&),
               (override));
   MOCK_METHOD(future<StatusOr<google::bigtable::v2::MutateRowResponse>>,
@@ -87,6 +89,7 @@ class MockBigtableStub : public bigtable_internal::BigtableStub {
               AsyncMutateRows,
               (google::cloud::CompletionQueue const&,
                std::shared_ptr<grpc::ClientContext>,
+               google::cloud::internal::ImmutableOptions,
                google::bigtable::v2::MutateRowsRequest const&),
               (override));
   MOCK_METHOD(future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>,

--- a/google/cloud/internal/async_streaming_read_rpc_impl_test.cc
+++ b/google/cloud/internal/async_streaming_read_rpc_impl_test.cc
@@ -113,9 +113,10 @@ TEST(AsyncStreamingReadRpcTest, Basic) {
 
   google::cloud::CompletionQueue cq(mock_cq);
 
-  OptionsSpan span(user_project("create"));
+  OptionsSpan span(user_project("unused"));
   auto stream = MakeStreamingReadRpc<FakeRequest, FakeResponse>(
-      cq, std::make_shared<grpc::ClientContext>(), FakeRequest{},
+      cq, std::make_shared<grpc::ClientContext>(),
+      MakeImmutableOptions(user_project("create")), FakeRequest{},
       [&mock](grpc::ClientContext* context, FakeRequest const& request,
               grpc::CompletionQueue* cq) {
         return mock.FakeRpc(context, request, cq);
@@ -215,7 +216,8 @@ TEST(AsyncStreamingReadRpcTest, SpanActiveAcrossAsyncGrpcOperations) {
     auto span = MakeSpan("create");
     OTelScope scope(span);
     return MakeStreamingReadRpc<FakeRequest, FakeResponse>(
-        cq, std::make_shared<grpc::ClientContext>(), FakeRequest{},
+        cq, std::make_shared<grpc::ClientContext>(), MakeImmutableOptions({}),
+        FakeRequest{},
         [&mock, span](grpc::ClientContext* context, FakeRequest const& request,
                       grpc::CompletionQueue* cq) {
           EXPECT_THAT(span, IsActive());

--- a/google/cloud/storage/internal/async/accumulate_read_object.h
+++ b/google/cloud/storage/internal/async/accumulate_read_object.h
@@ -108,9 +108,9 @@ future<AsyncAccumulateReadObjectResult> AsyncAccumulateReadObjectPartial(
  *     std::function<std::shared_ptr<grpc::ClientContext>()> context_factory,
  *     google::storage::v2::ReadObjectRequest request,
  *     std::chrono::milliseconds timeout,
- *     Options const& options) {
- *   auto retry = options.get<storage::RetryPolicyOption>()->clone();
- *   auto backoff = options.get<storage::BackoffPolicyOption>()->clone();
+ *     google::cloud::internal::ImmutableOptions options) {
+ *   auto retry = options->get<storage::RetryPolicyOption>()->clone();
+ *   auto backoff = options->get<storage::BackoffPolicyOption>()->clone();
  *   // We will use a variable of the coroutine to accumulate the (partial)
  *   // reads.
  *   AsyncAccumulateReadObjectResult result;
@@ -169,7 +169,8 @@ future<AsyncAccumulateReadObjectResult> AsyncAccumulateReadObjectPartial(
 future<AsyncAccumulateReadObjectResult> AsyncAccumulateReadObjectFull(
     CompletionQueue cq, std::shared_ptr<StorageStub> stub,
     std::function<std::shared_ptr<grpc::ClientContext>()> context_factory,
-    google::storage::v2::ReadObjectRequest request, Options const& options);
+    google::storage::v2::ReadObjectRequest request,
+    google::cloud::internal::ImmutableOptions options);
 
 /// Convert the proto into a representation more familiar to our customers.
 StatusOr<storage_experimental::ReadPayload> ToResponse(

--- a/google/cloud/storage/internal/async/connection_impl.cc
+++ b/google/cloud/storage/internal/async/connection_impl.cc
@@ -130,10 +130,7 @@ AsyncConnectionImpl::ReadObject(ReadObjectParams p) {
                   google::storage::v2::ReadObjectRequest const& proto)
       -> future<StatusOr<std::unique_ptr<StreamingRpc>>> {
     ApplyQueryParameters(*context, *current, request);
-    // TODO(#12359) - pass the `options` parameter
-    google::cloud::internal::OptionsSpan span(current);
-
-    auto rpc = stub->AsyncReadObject(cq, std::move(context), proto);
+    auto rpc = stub->AsyncReadObject(cq, std::move(context), current, proto);
     auto start = rpc->Start();
     return start.then([rpc = std::move(rpc)](auto f) mutable {
       if (f.get()) return make_ready_future(make_status_or(std::move(rpc)));
@@ -177,8 +174,7 @@ AsyncConnectionImpl::ReadObjectRange(ReadObjectParams p) {
     return context;
   };
   return storage_internal::AsyncAccumulateReadObjectFull(
-             cq_, stub_, std::move(context_factory), *std::move(proto),
-             *current)
+             cq_, stub_, std::move(context_factory), *std::move(proto), current)
       .then([current](
                 future<storage_internal::AsyncAccumulateReadObjectResult> f) {
         return ToResponse(f.get(), *current);

--- a/google/cloud/storage/internal/async/connection_impl_test.cc
+++ b/google/cloud/storage/internal/async/connection_impl_test.cc
@@ -313,10 +313,12 @@ TEST_F(AsyncConnectionImplTest, AsyncReadObject) {
       .WillOnce([&](CompletionQueue const&,
                     // NOLINTNEXTLINE(performance-unnecessary-value-param)
                     std::shared_ptr<grpc::ClientContext> context,
+                    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+                    google::cloud::internal::ImmutableOptions options,
                     google::storage::v2::ReadObjectRequest const& request) {
         // Verify at least one option is initialized with the correct
         // values.
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
+        EXPECT_EQ(options->get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(*context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),

--- a/google/cloud/storage/internal/storage_auth_decorator.cc
+++ b/google/cloud/storage/internal/storage_auth_decorator.cc
@@ -355,13 +355,15 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
 StorageAuth::AsyncReadObject(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::storage::v2::ReadObjectRequest const& request) {
   using StreamAuth = google::cloud::internal::AsyncStreamingReadRpcAuth<
       google::storage::v2::ReadObjectResponse>;
 
   auto& child = child_;
-  auto call = [child, cq, request](std::shared_ptr<grpc::ClientContext> ctx) {
-    return child->AsyncReadObject(cq, std::move(ctx), request);
+  auto call = [child, cq, opts = std::move(options),
+               request](std::shared_ptr<grpc::ClientContext> ctx) {
+    return child->AsyncReadObject(cq, std::move(ctx), opts, request);
   };
   return std::make_unique<StreamAuth>(
       std::move(context), auth_, StreamAuth::StreamFactory(std::move(call)));

--- a/google/cloud/storage/internal/storage_auth_decorator.h
+++ b/google/cloud/storage/internal/storage_auth_decorator.h
@@ -195,6 +195,7 @@ class StorageAuth : public StorageStub {
   AsyncReadObject(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::ReadObjectRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<

--- a/google/cloud/storage/internal/storage_logging_decorator.cc
+++ b/google/cloud/storage/internal/storage_logging_decorator.cc
@@ -468,13 +468,15 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
 StorageLogging::AsyncReadObject(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::storage::v2::ReadObjectRequest const& request) {
   using LoggingStream = ::google::cloud::internal::AsyncStreamingReadRpcLogging<
       google::storage::v2::ReadObjectResponse>;
 
   auto request_id = google::cloud::internal::RequestIdForLogging();
   GCP_LOG(DEBUG) << __func__ << "(" << request_id << ")";
-  auto stream = child_->AsyncReadObject(cq, std::move(context), request);
+  auto stream = child_->AsyncReadObject(cq, std::move(context),
+                                        std::move(options), request);
   if (stream_logging_) {
     stream = std::make_unique<LoggingStream>(
         std::move(stream), tracing_options_, std::move(request_id));

--- a/google/cloud/storage/internal/storage_logging_decorator.h
+++ b/google/cloud/storage/internal/storage_logging_decorator.h
@@ -195,6 +195,7 @@ class StorageLogging : public StorageStub {
   AsyncReadObject(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::ReadObjectRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<

--- a/google/cloud/storage/internal/storage_metadata_decorator.cc
+++ b/google/cloud/storage/internal/storage_metadata_decorator.cc
@@ -746,6 +746,7 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
 StorageMetadata::AsyncReadObject(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::storage::v2::ReadObjectRequest const& request) {
   std::vector<std::string> params;
   params.reserve(1);
@@ -756,12 +757,12 @@ StorageMetadata::AsyncReadObject(
   }
 
   if (params.empty()) {
-    SetMetadata(*context, internal::CurrentOptions());
+    SetMetadata(*context, *options);
   } else {
-    SetMetadata(*context, internal::CurrentOptions(),
-                absl::StrJoin(params, "&"));
+    SetMetadata(*context, *options, absl::StrJoin(params, "&"));
   }
-  return child_->AsyncReadObject(cq, std::move(context), request);
+  return child_->AsyncReadObject(cq, std::move(context), std::move(options),
+                                 request);
 }
 
 std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<

--- a/google/cloud/storage/internal/storage_metadata_decorator.h
+++ b/google/cloud/storage/internal/storage_metadata_decorator.h
@@ -195,6 +195,7 @@ class StorageMetadata : public StorageStub {
   AsyncReadObject(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::ReadObjectRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<

--- a/google/cloud/storage/internal/storage_round_robin_decorator.cc
+++ b/google/cloud/storage/internal/storage_round_robin_decorator.cc
@@ -259,8 +259,10 @@ std::unique_ptr<google::cloud::internal::AsyncStreamingReadRpc<
 StorageRoundRobin::AsyncReadObject(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::storage::v2::ReadObjectRequest const& request) {
-  return Child()->AsyncReadObject(cq, std::move(context), request);
+  return Child()->AsyncReadObject(cq, std::move(context), std::move(options),
+                                  request);
 }
 
 std::unique_ptr<google::cloud::internal::AsyncStreamingWriteRpc<

--- a/google/cloud/storage/internal/storage_round_robin_decorator.h
+++ b/google/cloud/storage/internal/storage_round_robin_decorator.h
@@ -193,6 +193,7 @@ class StorageRoundRobin : public StorageStub {
   AsyncReadObject(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::ReadObjectRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<

--- a/google/cloud/storage/internal/storage_stub.cc
+++ b/google/cloud/storage/internal/storage_stub.cc
@@ -450,11 +450,12 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
 DefaultStorageStub::AsyncReadObject(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::storage::v2::ReadObjectRequest const& request) {
   return google::cloud::internal::MakeStreamingReadRpc<
       google::storage::v2::ReadObjectRequest,
       google::storage::v2::ReadObjectResponse>(
-      cq, std::move(context), request,
+      cq, std::move(context), std::move(options), request,
       [this](grpc::ClientContext* context,
              google::storage::v2::ReadObjectRequest const& request,
              grpc::CompletionQueue* cq) {

--- a/google/cloud/storage/internal/storage_stub.h
+++ b/google/cloud/storage/internal/storage_stub.h
@@ -197,6 +197,7 @@ class StorageStub {
       google::storage::v2::ReadObjectResponse>>
   AsyncReadObject(google::cloud::CompletionQueue const& cq,
                   std::shared_ptr<grpc::ClientContext> context,
+                  google::cloud::internal::ImmutableOptions options,
                   google::storage::v2::ReadObjectRequest const& request) = 0;
 
   virtual std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
@@ -387,6 +388,7 @@ class DefaultStorageStub : public StorageStub {
   AsyncReadObject(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::ReadObjectRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<

--- a/google/cloud/storage/internal/storage_tracing_stub.cc
+++ b/google/cloud/storage/internal/storage_tracing_stub.cc
@@ -446,11 +446,13 @@ std::unique_ptr<
 StorageTracingStub::AsyncReadObject(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::storage::v2::ReadObjectRequest const& request) {
   auto span = internal::MakeSpanGrpc("google.storage.v2.Storage", "ReadObject");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto stream = child_->AsyncReadObject(cq, context, request);
+  auto stream =
+      child_->AsyncReadObject(cq, context, std::move(options), request);
   return std::make_unique<internal::AsyncStreamingReadRpcTracing<
       google::storage::v2::ReadObjectResponse>>(
       std::move(context), std::move(stream), std::move(span));

--- a/google/cloud/storage/internal/storage_tracing_stub.h
+++ b/google/cloud/storage/internal/storage_tracing_stub.h
@@ -194,6 +194,7 @@ class StorageTracingStub : public StorageStub {
   AsyncReadObject(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::ReadObjectRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<

--- a/google/cloud/storage/testing/mock_storage_stub.h
+++ b/google/cloud/storage/testing/mock_storage_stub.h
@@ -186,6 +186,7 @@ class MockStorageStub : public storage_internal::StorageStub {
               AsyncReadObject,
               (google::cloud::CompletionQueue const&,
                std::shared_ptr<grpc::ClientContext>,
+               google::cloud::internal::ImmutableOptions,
                google::storage::v2::ReadObjectRequest const&),
               (override));
   MOCK_METHOD(future<StatusOr<google::storage::v2::RewriteResponse>>,


### PR DESCRIPTION
Part of the work for #12359

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13650)
<!-- Reviewable:end -->
