### PR TITLE
ci(gcb): the first kaniko attempt can fail

### DIFF
--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -86,6 +86,7 @@ steps:
 - name: 'gcr.io/${PROJECT_ID}/${_IMAGE}:${BUILD_ID}'
   id: 'download-runner-image-attempt-1'
   entrypoint: '/bin/true'
+  allowFailure: true
 
 - name: 'gcr.io/kaniko-project/executor:v1.20.1'
   id: 'kaniko-attempt-2'


### PR DESCRIPTION
I did not think about what would happen to the
`download-runner-image-attempt-1` step if `kaniko-attempt-1` fails. Obviously the download step would fail too, but we can safely ignore that failure.

Part of the work for #6438 

Tested on https://console.cloud.google.com/cloud-build/builds;region=us-east1/19677ef2-0432-406a-9487-aca8f72beb1c;tab=detail?project=cloud-cpp-testing-resources

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13652)
<!-- Reviewable:end -->
