### PR TITLE
cleanup: streaming writes use explicit options

### DIFF
--- a/generator/integration_tests/benchmarks/client_benchmark.cc
+++ b/generator/integration_tests/benchmarks/client_benchmark.cc
@@ -157,7 +157,8 @@ class TestStub : public GoldenKitchenSinkStub {
       google::test::admin::database::v1::Request,
       google::test::admin::database::v1::Response>>
   AsyncStreamingWrite(google::cloud::CompletionQueue const&,
-                      std::shared_ptr<grpc::ClientContext>) override {
+                      std::shared_ptr<grpc::ClientContext>,
+                      google::cloud::internal::ImmutableOptions) override {
     return nullptr;
   }
 };

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_auth_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_auth_decorator.cc
@@ -180,13 +180,14 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
     google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>>
 GoldenKitchenSinkAuth::AsyncStreamingWrite(
     google::cloud::CompletionQueue const& cq,
-    std::shared_ptr<grpc::ClientContext> context) {
+    std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options) {
   using StreamAuth = google::cloud::internal::AsyncStreamingWriteRpcAuth<
     google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>;
 
   auto& child = child_;
-  auto call = [child, cq](std::shared_ptr<grpc::ClientContext> ctx) {
-    return child->AsyncStreamingWrite(cq, std::move(ctx));
+  auto call = [child, cq, options](std::shared_ptr<grpc::ClientContext> ctx) {
+    return child->AsyncStreamingWrite(cq, std::move(ctx), options);
   };
   return std::make_unique<StreamAuth>(
     std::move(context), auth_, StreamAuth::StreamFactory(std::move(call)));

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_auth_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_auth_decorator.cc
@@ -185,8 +185,8 @@ GoldenKitchenSinkAuth::AsyncStreamingWrite(
   using StreamAuth = google::cloud::internal::AsyncStreamingWriteRpcAuth<
     google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>;
 
-  auto& child = child_;
-  auto call = [child, cq, options](std::shared_ptr<grpc::ClientContext> ctx) {
+  auto call = [child = child_, cq, options = std::move(options)](
+                  std::shared_ptr<grpc::ClientContext> ctx) {
     return child->AsyncStreamingWrite(cq, std::move(ctx), options);
   };
   return std::make_unique<StreamAuth>(

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_auth_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_auth_decorator.h
@@ -115,7 +115,8 @@ class GoldenKitchenSinkAuth : public GoldenKitchenSinkStub {
       google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>>
   AsyncStreamingWrite(
       google::cloud::CompletionQueue const& cq,
-      std::shared_ptr<grpc::ClientContext> context) override;
+      std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options) override;
 
  private:
   std::shared_ptr<google::cloud::internal::GrpcAuthenticationStrategy> auth_;

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_logging_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_logging_decorator.cc
@@ -254,13 +254,15 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
     google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>>
 GoldenKitchenSinkLogging::AsyncStreamingWrite(
     google::cloud::CompletionQueue const& cq,
-    std::shared_ptr<grpc::ClientContext> context) {
+    std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options) {
   using LoggingStream = ::google::cloud::internal::AsyncStreamingWriteRpcLogging<
       google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>;
 
   auto request_id = google::cloud::internal::RequestIdForLogging();
   GCP_LOG(DEBUG) << __func__ << "(" << request_id << ")";
-  auto stream = child_->AsyncStreamingWrite(cq, std::move(context));
+  auto stream = child_->AsyncStreamingWrite(
+      cq, std::move(context), std::move(options));
   if (stream_logging_) {
     stream = std::make_unique<LoggingStream>(
         std::move(stream), tracing_options_, std::move(request_id));

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_logging_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_logging_decorator.h
@@ -115,7 +115,8 @@ class GoldenKitchenSinkLogging : public GoldenKitchenSinkStub {
       google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>>
   AsyncStreamingWrite(
       google::cloud::CompletionQueue const& cq,
-      std::shared_ptr<grpc::ClientContext> context) override;
+      std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options) override;
 
  private:
   std::shared_ptr<GoldenKitchenSinkStub> child_;

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.cc
@@ -230,9 +230,10 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
     google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>>
 GoldenKitchenSinkMetadata::AsyncStreamingWrite(
     google::cloud::CompletionQueue const& cq,
-    std::shared_ptr<grpc::ClientContext> context) {
-  SetMetadata(*context, internal::CurrentOptions());
-  return child_->AsyncStreamingWrite(cq, std::move(context));
+    std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options) {
+  SetMetadata(*context, *options);
+  return child_->AsyncStreamingWrite(cq, std::move(context), std::move(options));
 }
 
 void GoldenKitchenSinkMetadata::SetMetadata(grpc::ClientContext& context,

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.h
@@ -116,7 +116,8 @@ class GoldenKitchenSinkMetadata : public GoldenKitchenSinkStub {
       google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>>
   AsyncStreamingWrite(
       google::cloud::CompletionQueue const& cq,
-      std::shared_ptr<grpc::ClientContext> context) override;
+      std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options) override;
 
  private:
   void SetMetadata(grpc::ClientContext& context,

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_round_robin_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_round_robin_decorator.cc
@@ -131,8 +131,10 @@ std::unique_ptr<google::cloud::internal::AsyncStreamingWriteRpc<
     google::test::admin::database::v1::Response>>
 GoldenKitchenSinkRoundRobin::AsyncStreamingWrite(
     google::cloud::CompletionQueue const& cq,
-    std::shared_ptr<grpc::ClientContext> context) {
-  return Child()->AsyncStreamingWrite(cq, std::move(context));
+    std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options) {
+  return Child()->AsyncStreamingWrite(
+      cq, std::move(context), std::move(options));
 }
 
 std::shared_ptr<GoldenKitchenSinkStub>

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_round_robin_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_round_robin_decorator.h
@@ -113,7 +113,8 @@ class GoldenKitchenSinkRoundRobin : public GoldenKitchenSinkStub {
       google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>>
   AsyncStreamingWrite(
       google::cloud::CompletionQueue const& cq,
-      std::shared_ptr<grpc::ClientContext> context) override;
+      std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options) override;
 
  private:
   std::shared_ptr<GoldenKitchenSinkStub> Child();

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.cc
@@ -206,9 +206,10 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
     google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>>
 DefaultGoldenKitchenSinkStub::AsyncStreamingWrite(
     google::cloud::CompletionQueue const& cq,
-    std::shared_ptr<grpc::ClientContext> context) {
+    std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options) {
   return google::cloud::internal::MakeStreamingWriteRpc<google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>(
-    cq, std::move(context),
+    cq, std::move(context), std::move(options),
     [this](grpc::ClientContext* context, google::test::admin::database::v1::Response* response, grpc::CompletionQueue* cq) {
       return grpc_stub_->PrepareAsyncStreamingWrite(context, response, cq);
     });

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.h
@@ -120,7 +120,8 @@ class GoldenKitchenSinkStub {
       google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>>
   AsyncStreamingWrite(
       google::cloud::CompletionQueue const& cq,
-      std::shared_ptr<grpc::ClientContext> context) = 0;
+      std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options) = 0;
 };
 
 class DefaultGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
@@ -206,7 +207,8 @@ class DefaultGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
       google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>>
   AsyncStreamingWrite(
       google::cloud::CompletionQueue const& cq,
-      std::shared_ptr<grpc::ClientContext> context) override;
+      std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options) override;
 
  private:
   std::unique_ptr<google::test::admin::database::v1::GoldenKitchenSink::StubInterface> grpc_stub_;

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_stub.cc
@@ -196,11 +196,12 @@ std::unique_ptr<
     internal::AsyncStreamingWriteRpc<google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>>
 GoldenKitchenSinkTracingStub::AsyncStreamingWrite(
     google::cloud::CompletionQueue const& cq,
-    std::shared_ptr<grpc::ClientContext> context) {
+    std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options) {
   auto span = internal::MakeSpanGrpc("google.test.admin.database.v1.GoldenKitchenSink", "StreamingWrite");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto stream = child_->AsyncStreamingWrite(cq, context);
+  auto stream = child_->AsyncStreamingWrite(cq, context, std::move(options));
   return std::make_unique<
       internal::AsyncStreamingWriteRpcTracing<google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>>(
       std::move(context), std::move(stream), std::move(span));

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_stub.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_stub.h
@@ -114,7 +114,8 @@ class GoldenKitchenSinkTracingStub : public GoldenKitchenSinkStub {
       google::test::admin::database::v1::Request, google::test::admin::database::v1::Response>>
   AsyncStreamingWrite(
       google::cloud::CompletionQueue const& cq,
-      std::shared_ptr<grpc::ClientContext> context) override;
+      std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options) override;
 
  private:
   std::shared_ptr<GoldenKitchenSinkStub> child_;

--- a/generator/integration_tests/tests/golden_kitchen_sink_auth_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_auth_decorator_test.cc
@@ -225,14 +225,16 @@ TEST(GoldenKitchenSinkAuthDecoratorTest, AsyncStreamingWrite) {
   auto under_test = GoldenKitchenSinkAuth(MakeTypicalAsyncMockAuth(), mock);
 
   auto auth_failure = under_test.AsyncStreamingWrite(
-      cq, std::make_shared<grpc::ClientContext>());
+      cq, std::make_shared<grpc::ClientContext>(),
+      google::cloud::internal::MakeImmutableOptions({}));
   auto start = auth_failure->Start().get();
   EXPECT_FALSE(start);
   auto finish = auth_failure->Finish().get();
   EXPECT_THAT(finish, StatusIs(StatusCode::kInvalidArgument));
 
   auto auth_success = under_test.AsyncStreamingWrite(
-      cq, std::make_shared<grpc::ClientContext>());
+      cq, std::make_shared<grpc::ClientContext>(),
+      google::cloud::internal::MakeImmutableOptions({}));
   start = auth_success->Start().get();
   EXPECT_FALSE(start);
   finish = auth_success->Finish().get();

--- a/generator/integration_tests/tests/golden_kitchen_sink_logging_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_logging_decorator_test.cc
@@ -312,8 +312,9 @@ TEST_F(LoggingDecoratorTest, AsyncStreamingWrite) {
   GoldenKitchenSinkLogging stub(mock_, TracingOptions{}, {"rpc-streams"});
 
   google::cloud::CompletionQueue cq;
-  auto stream =
-      stub.AsyncStreamingWrite(cq, std::make_shared<grpc::ClientContext>());
+  auto stream = stub.AsyncStreamingWrite(
+      cq, std::make_shared<grpc::ClientContext>(),
+      google::cloud::internal::MakeImmutableOptions({}));
 
   auto start = stream->Start().get();
   EXPECT_FALSE(start);

--- a/generator/integration_tests/tests/golden_kitchen_sink_metadata_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_metadata_decorator_test.cc
@@ -307,7 +307,8 @@ TEST_F(MetadataDecoratorTest, AsyncStreamingRead) {
 
 TEST_F(MetadataDecoratorTest, AsyncStreamingWrite) {
   EXPECT_CALL(*mock_, AsyncStreamingWrite)
-      .WillOnce([this](google::cloud::CompletionQueue const&, auto context) {
+      .WillOnce([this](google::cloud::CompletionQueue const&, auto context,
+                       auto) {
         IsContextMDValid(
             *context,
             "google.test.admin.database.v1.GoldenKitchenSink.StreamingWrite",
@@ -321,8 +322,9 @@ TEST_F(MetadataDecoratorTest, AsyncStreamingWrite) {
   GoldenKitchenSinkMetadata stub(mock_, {});
 
   google::cloud::CompletionQueue cq;
-  auto stream =
-      stub.AsyncStreamingWrite(cq, std::make_shared<grpc::ClientContext>());
+  auto stream = stub.AsyncStreamingWrite(
+      cq, std::make_shared<grpc::ClientContext>(),
+      google::cloud::internal::MakeImmutableOptions({}));
 
   auto start = stream->Start().get();
   EXPECT_FALSE(start);

--- a/generator/integration_tests/tests/golden_kitchen_sink_round_robin_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_round_robin_decorator_test.cc
@@ -150,7 +150,7 @@ TEST(GoldenKitchenSinkRoundRobinDecoratorTest, AsyncStreamingWrite) {
   InSequence sequence;
   for (int i = 0; i != kRepeats; ++i) {
     for (auto& m : mocks) {
-      EXPECT_CALL(*m, AsyncStreamingWrite).WillOnce([](auto&, auto) {
+      EXPECT_CALL(*m, AsyncStreamingWrite).WillOnce([](auto&, auto, auto) {
         return std::make_unique<MockAsyncStreamingWriteRpc>();
       });
     }
@@ -159,8 +159,9 @@ TEST(GoldenKitchenSinkRoundRobinDecoratorTest, AsyncStreamingWrite) {
   CompletionQueue cq;
   GoldenKitchenSinkRoundRobin stub(AsPlainStubs(mocks));
   for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
-    auto stream =
-        stub.AsyncStreamingWrite(cq, std::make_shared<grpc::ClientContext>());
+    auto stream = stub.AsyncStreamingWrite(
+        cq, std::make_shared<grpc::ClientContext>(),
+        google::cloud::internal::MakeImmutableOptions({}));
     EXPECT_THAT(stream, NotNull());
   }
 }

--- a/generator/integration_tests/tests/golden_kitchen_sink_stub_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_stub_test.cc
@@ -687,8 +687,9 @@ TEST_F(GoldenKitchenSinkStubTest, AsyncStreamingWrite) {
 
   DefaultGoldenKitchenSinkStub stub(std::move(grpc_stub_));
 
-  auto stream =
-      stub.AsyncStreamingWrite(cq, std::make_shared<grpc::ClientContext>());
+  auto stream = stub.AsyncStreamingWrite(
+      cq, std::make_shared<grpc::ClientContext>(),
+      google::cloud::internal::MakeImmutableOptions({}));
   auto start = stream->Start();
   notify_next_op(true);
   EXPECT_TRUE(start.get());

--- a/generator/integration_tests/tests/golden_kitchen_sink_tracing_stub_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_tracing_stub_test.cc
@@ -341,7 +341,7 @@ TEST(GoldenKitchenSinkTracingStubTest, AsyncStreamingWrite) {
 
   auto mock = std::make_shared<MockGoldenKitchenSinkStub>();
   EXPECT_CALL(*mock, AsyncStreamingWrite)
-      .WillOnce([](auto const&, auto context) {
+      .WillOnce([](auto const&, auto context, auto) {
         ValidatePropagator(*context);
         EXPECT_TRUE(ThereIsAnActiveSpan());
         EXPECT_TRUE(OTelContextCaptured());
@@ -354,7 +354,8 @@ TEST(GoldenKitchenSinkTracingStubTest, AsyncStreamingWrite) {
   google::cloud::CompletionQueue cq;
   auto under_test = GoldenKitchenSinkTracingStub(mock);
   auto stream = under_test.AsyncStreamingWrite(
-      cq, std::make_shared<grpc::ClientContext>());
+      cq, std::make_shared<grpc::ClientContext>(),
+      google::cloud::internal::MakeImmutableOptions({}));
   auto start = stream->Start().get();
   EXPECT_FALSE(start);
   auto finish = stream->Finish().get();

--- a/generator/integration_tests/tests/mock_golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/tests/mock_golden_kitchen_sink_stub.h
@@ -121,7 +121,8 @@ class MockGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
            ::google::test::admin::database::v1::Response>>),
       AsyncStreamingWrite,
       (google::cloud::CompletionQueue const& cq,
-       std::shared_ptr<grpc::ClientContext> context),
+       std::shared_ptr<grpc::ClientContext> context,
+       google::cloud::internal::ImmutableOptions options),
       (override));
 };
 

--- a/generator/internal/auth_decorator_generator.cc
+++ b/generator/internal/auth_decorator_generator.cc
@@ -251,8 +251,8 @@ $auth_class_name$::Async$method_name$(
   using StreamAuth = google::cloud::internal::AsyncStreamingWriteRpcAuth<
     $request_type$, $response_type$>;
 
-  auto& child = child_;
-  auto call = [child, cq, options](std::shared_ptr<grpc::ClientContext> ctx) {
+  auto call = [child = child_, cq, options = std::move(options)](
+                  std::shared_ptr<grpc::ClientContext> ctx) {
     return child->Async$method_name$(cq, std::move(ctx), options);
   };
   return std::make_unique<StreamAuth>(

--- a/generator/internal/auth_decorator_generator.cc
+++ b/generator/internal/auth_decorator_generator.cc
@@ -246,13 +246,14 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
     $request_type$, $response_type$>>
 $auth_class_name$::Async$method_name$(
     google::cloud::CompletionQueue const& cq,
-    std::shared_ptr<grpc::ClientContext> context) {
+    std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options) {
   using StreamAuth = google::cloud::internal::AsyncStreamingWriteRpcAuth<
     $request_type$, $response_type$>;
 
   auto& child = child_;
-  auto call = [child, cq](std::shared_ptr<grpc::ClientContext> ctx) {
-    return child->Async$method_name$(cq, std::move(ctx));
+  auto call = [child, cq, options](std::shared_ptr<grpc::ClientContext> ctx) {
+    return child->Async$method_name$(cq, std::move(ctx), options);
   };
   return std::make_unique<StreamAuth>(
     std::move(context), auth_, StreamAuth::StreamFactory(std::move(call)));

--- a/generator/internal/logging_decorator_generator.cc
+++ b/generator/internal/logging_decorator_generator.cc
@@ -283,13 +283,15 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
     $request_type$, $response_type$>>
 $logging_class_name$::Async$method_name$(
     google::cloud::CompletionQueue const& cq,
-    std::shared_ptr<grpc::ClientContext> context) {
+    std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options) {
   using LoggingStream = ::google::cloud::internal::AsyncStreamingWriteRpcLogging<
       $request_type$, $response_type$>;
 
   auto request_id = google::cloud::internal::RequestIdForLogging();
   GCP_LOG(DEBUG) << __func__ << "(" << request_id << ")";
-  auto stream = child_->Async$method_name$(cq, std::move(context));
+  auto stream = child_->Async$method_name$(
+      cq, std::move(context), std::move(options));
   if (stream_logging_) {
     stream = std::make_unique<LoggingStream>(
         std::move(stream), tracing_options_, std::move(request_id));

--- a/generator/internal/metadata_decorator_generator.cc
+++ b/generator/internal/metadata_decorator_generator.cc
@@ -325,9 +325,10 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
     $request_type$, $response_type$>>
 $metadata_class_name$::Async$method_name$(
     google::cloud::CompletionQueue const& cq,
-    std::shared_ptr<grpc::ClientContext> context) {
-  SetMetadata(*context, internal::CurrentOptions());
-  return child_->Async$method_name$(cq, std::move(context));
+    std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options) {
+  SetMetadata(*context, *options);
+  return child_->Async$method_name$(cq, std::move(context), std::move(options));
 }
 )""");
       CcPrintMethod(method, __FILE__, __LINE__, definition);

--- a/generator/internal/round_robin_decorator_generator.cc
+++ b/generator/internal/round_robin_decorator_generator.cc
@@ -203,8 +203,10 @@ std::unique_ptr<google::cloud::internal::AsyncStreamingWriteRpc<
     $response_type$>>
 $round_robin_class_name$::Async$method_name$(
     google::cloud::CompletionQueue const& cq,
-    std::shared_ptr<grpc::ClientContext> context) {
-  return Child()->Async$method_name$(cq, std::move(context));
+    std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options) {
+  return Child()->Async$method_name$(
+      cq, std::move(context), std::move(options));
 }
 )""");
       continue;

--- a/generator/internal/stub_generator.cc
+++ b/generator/internal/stub_generator.cc
@@ -170,7 +170,8 @@ Status StubGenerator::GenerateHeader() {
       $request_type$, $response_type$>>
   Async$method_name$(
       google::cloud::CompletionQueue const& cq,
-      std::shared_ptr<grpc::ClientContext> context) = 0;
+      std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options) = 0;
 )""";
       HeaderPrintMethod(method, __FILE__, __LINE__, kDeclaration);
       continue;
@@ -432,9 +433,10 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
     $request_type$, $response_type$>>
 Default$stub_class_name$::Async$method_name$(
     google::cloud::CompletionQueue const& cq,
-    std::shared_ptr<grpc::ClientContext> context) {
+    std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options) {
   return google::cloud::internal::MakeStreamingWriteRpc<$request_type$, $response_type$>(
-    cq, std::move(context),
+    cq, std::move(context), std::move(options),
     [this](grpc::ClientContext* context, $response_type$* response, grpc::CompletionQueue* cq) {
       return grpc_stub_->PrepareAsync$method_name$(context, response, cq);
     });

--- a/generator/internal/stub_generator_base.cc
+++ b/generator/internal/stub_generator_base.cc
@@ -112,7 +112,8 @@ void StubGeneratorBase::HeaderPrintPublicMethods() {
       $request_type$, $response_type$>>
   Async$method_name$(
       google::cloud::CompletionQueue const& cq,
-      std::shared_ptr<grpc::ClientContext> context) override;
+      std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options) override;
 )""";
       HeaderPrintMethod(method, __FILE__, __LINE__, kDeclaration);
       continue;

--- a/generator/internal/tracing_stub_generator.cc
+++ b/generator/internal/tracing_stub_generator.cc
@@ -250,11 +250,12 @@ std::unique_ptr<
     internal::AsyncStreamingWriteRpc<$request_type$, $response_type$>>
 $tracing_stub_class_name$::Async$method_name$(
     google::cloud::CompletionQueue const& cq,
-    std::shared_ptr<grpc::ClientContext> context) {
+    std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options) {
   auto span = internal::MakeSpanGrpc("$grpc_service$", "$method_name$");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto stream = child_->Async$method_name$(cq, context);
+  auto stream = child_->Async$method_name$(cq, context, std::move(options));
   return std::make_unique<
       internal::AsyncStreamingWriteRpcTracing<$request_type$, $response_type$>>(
       std::move(context), std::move(stream), std::move(span));

--- a/google/cloud/internal/async_streaming_write_rpc_impl_test.cc
+++ b/google/cloud/internal/async_streaming_write_rpc_impl_test.cc
@@ -117,9 +117,10 @@ TEST(AsyncStreamingWriteRpcTest, Basic) {
 
   google::cloud::CompletionQueue cq(mock_cq);
 
-  OptionsSpan span(user_project("create"));
+  OptionsSpan span(user_project("unused"));
   auto stream = MakeStreamingWriteRpc<FakeRequest, FakeResponse>(
       cq, std::make_shared<grpc::ClientContext>(),
+      MakeImmutableOptions(user_project("create")),
       [&mock](grpc::ClientContext* context, FakeResponse* response,
               grpc::CompletionQueue* cq) {
         return mock.FakeRpc(context, response, cq);
@@ -228,7 +229,7 @@ TEST(AsyncStreamingWriteRpcTest, SpanActiveAcrossAsyncGrpcOperations) {
     auto span = MakeSpan("create");
     OTelScope scope(span);
     return MakeStreamingWriteRpc<FakeRequest, FakeResponse>(
-        cq, std::make_shared<grpc::ClientContext>(),
+        cq, std::make_shared<grpc::ClientContext>(), MakeImmutableOptions({}),
         [&mock, span](grpc::ClientContext* context, FakeResponse* response,
                       grpc::CompletionQueue* cq) {
           EXPECT_THAT(span, IsActive());

--- a/google/cloud/storage/internal/async/connection_impl.cc
+++ b/google/cloud/storage/internal/async/connection_impl.cc
@@ -95,12 +95,10 @@ future<StatusOr<storage::ObjectMetadata>> AsyncConnectionImpl::InsertObject(
     ApplyQueryParameters(*context, options, params.request);
     ApplyRoutingHeaders(*context, params.request);
     context->AddMetadata("x-goog-gcs-idempotency-token", id);
-    // TODO(#12359) - pass the `options` parameter
-    google::cloud::internal::OptionsSpan span(current);
-    auto rpc = stub->AsyncWriteObject(cq, std::move(context));
-    auto running =
-        InsertObject::Call(std::move(rpc), hash_function(params.request), proto,
-                           WritePayloadImpl::GetImpl(params.payload), current);
+    auto rpc = stub->AsyncWriteObject(cq, std::move(context), current);
+    auto running = InsertObject::Call(
+        std::move(rpc), hash_function(params.request), proto,
+        WritePayloadImpl::GetImpl(params.payload), std::move(current));
     return running->Start().then([running](auto f) mutable {
       running.reset();  // extend the life of the co-routine until it co-returns
       return f.get();

--- a/google/cloud/storage/internal/async/connection_impl_test.cc
+++ b/google/cloud/storage/internal/async/connection_impl_test.cc
@@ -142,9 +142,10 @@ TEST_F(AsyncConnectionImplTest, AsyncInsertObject) {
       })
       .WillOnce([&](CompletionQueue const&,
                     // NOLINTNEXTLINE(performance-unnecessary-value-param)
-                    std::shared_ptr<grpc::ClientContext> context) {
-        // TODO(#12359) - use the explicit `options` when available.
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
+                    std::shared_ptr<grpc::ClientContext> context,
+                    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+                    internal::ImmutableOptions options) {
+        EXPECT_EQ(options->get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(*context);
         EXPECT_THAT(metadata,
                     UnorderedElementsAre(

--- a/google/cloud/storage/internal/storage_auth_decorator.cc
+++ b/google/cloud/storage/internal/storage_auth_decorator.cc
@@ -380,8 +380,8 @@ StorageAuth::AsyncWriteObject(
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>;
 
-  auto& child = child_;
-  auto call = [child, cq, options](std::shared_ptr<grpc::ClientContext> ctx) {
+  auto call = [child = child_, cq, options = std::move(options)](
+                  std::shared_ptr<grpc::ClientContext> ctx) {
     return child->AsyncWriteObject(cq, std::move(ctx), options);
   };
   return std::make_unique<StreamAuth>(

--- a/google/cloud/storage/internal/storage_auth_decorator.cc
+++ b/google/cloud/storage/internal/storage_auth_decorator.cc
@@ -372,15 +372,17 @@ StorageAuth::AsyncReadObject(
 std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
     google::storage::v2::WriteObjectRequest,
     google::storage::v2::WriteObjectResponse>>
-StorageAuth::AsyncWriteObject(google::cloud::CompletionQueue const& cq,
-                              std::shared_ptr<grpc::ClientContext> context) {
+StorageAuth::AsyncWriteObject(
+    google::cloud::CompletionQueue const& cq,
+    std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options) {
   using StreamAuth = google::cloud::internal::AsyncStreamingWriteRpcAuth<
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>;
 
   auto& child = child_;
-  auto call = [child, cq](std::shared_ptr<grpc::ClientContext> ctx) {
-    return child->AsyncWriteObject(cq, std::move(ctx));
+  auto call = [child, cq, options](std::shared_ptr<grpc::ClientContext> ctx) {
+    return child->AsyncWriteObject(cq, std::move(ctx), options);
   };
   return std::make_unique<StreamAuth>(
       std::move(context), auth_, StreamAuth::StreamFactory(std::move(call)));

--- a/google/cloud/storage/internal/storage_auth_decorator.h
+++ b/google/cloud/storage/internal/storage_auth_decorator.h
@@ -202,7 +202,8 @@ class StorageAuth : public StorageStub {
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>>
   AsyncWriteObject(google::cloud::CompletionQueue const& cq,
-                   std::shared_ptr<grpc::ClientContext> context) override;
+                   std::shared_ptr<grpc::ClientContext> context,
+                   google::cloud::internal::ImmutableOptions options) override;
 
   future<StatusOr<google::storage::v2::RewriteResponse>> AsyncRewriteObject(
       google::cloud::CompletionQueue& cq,

--- a/google/cloud/storage/internal/storage_logging_decorator.cc
+++ b/google/cloud/storage/internal/storage_logging_decorator.cc
@@ -487,8 +487,10 @@ StorageLogging::AsyncReadObject(
 std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
     google::storage::v2::WriteObjectRequest,
     google::storage::v2::WriteObjectResponse>>
-StorageLogging::AsyncWriteObject(google::cloud::CompletionQueue const& cq,
-                                 std::shared_ptr<grpc::ClientContext> context) {
+StorageLogging::AsyncWriteObject(
+    google::cloud::CompletionQueue const& cq,
+    std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options) {
   using LoggingStream =
       ::google::cloud::internal::AsyncStreamingWriteRpcLogging<
           google::storage::v2::WriteObjectRequest,
@@ -496,7 +498,8 @@ StorageLogging::AsyncWriteObject(google::cloud::CompletionQueue const& cq,
 
   auto request_id = google::cloud::internal::RequestIdForLogging();
   GCP_LOG(DEBUG) << __func__ << "(" << request_id << ")";
-  auto stream = child_->AsyncWriteObject(cq, std::move(context));
+  auto stream =
+      child_->AsyncWriteObject(cq, std::move(context), std::move(options));
   if (stream_logging_) {
     stream = std::make_unique<LoggingStream>(
         std::move(stream), tracing_options_, std::move(request_id));

--- a/google/cloud/storage/internal/storage_logging_decorator.h
+++ b/google/cloud/storage/internal/storage_logging_decorator.h
@@ -202,7 +202,8 @@ class StorageLogging : public StorageStub {
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>>
   AsyncWriteObject(google::cloud::CompletionQueue const& cq,
-                   std::shared_ptr<grpc::ClientContext> context) override;
+                   std::shared_ptr<grpc::ClientContext> context,
+                   google::cloud::internal::ImmutableOptions options) override;
 
   future<StatusOr<google::storage::v2::RewriteResponse>> AsyncRewriteObject(
       google::cloud::CompletionQueue& cq,

--- a/google/cloud/storage/internal/storage_metadata_decorator.cc
+++ b/google/cloud/storage/internal/storage_metadata_decorator.cc
@@ -770,9 +770,10 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
     google::storage::v2::WriteObjectResponse>>
 StorageMetadata::AsyncWriteObject(
     google::cloud::CompletionQueue const& cq,
-    std::shared_ptr<grpc::ClientContext> context) {
-  SetMetadata(*context, internal::CurrentOptions());
-  return child_->AsyncWriteObject(cq, std::move(context));
+    std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options) {
+  SetMetadata(*context, *options);
+  return child_->AsyncWriteObject(cq, std::move(context), std::move(options));
 }
 
 future<StatusOr<google::storage::v2::RewriteResponse>>

--- a/google/cloud/storage/internal/storage_metadata_decorator.h
+++ b/google/cloud/storage/internal/storage_metadata_decorator.h
@@ -202,7 +202,8 @@ class StorageMetadata : public StorageStub {
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>>
   AsyncWriteObject(google::cloud::CompletionQueue const& cq,
-                   std::shared_ptr<grpc::ClientContext> context) override;
+                   std::shared_ptr<grpc::ClientContext> context,
+                   google::cloud::internal::ImmutableOptions options) override;
 
   future<StatusOr<google::storage::v2::RewriteResponse>> AsyncRewriteObject(
       google::cloud::CompletionQueue& cq,

--- a/google/cloud/storage/internal/storage_round_robin_decorator.cc
+++ b/google/cloud/storage/internal/storage_round_robin_decorator.cc
@@ -270,8 +270,9 @@ std::unique_ptr<google::cloud::internal::AsyncStreamingWriteRpc<
     google::storage::v2::WriteObjectResponse>>
 StorageRoundRobin::AsyncWriteObject(
     google::cloud::CompletionQueue const& cq,
-    std::shared_ptr<grpc::ClientContext> context) {
-  return Child()->AsyncWriteObject(cq, std::move(context));
+    std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options) {
+  return Child()->AsyncWriteObject(cq, std::move(context), std::move(options));
 }
 
 future<StatusOr<google::storage::v2::RewriteResponse>>

--- a/google/cloud/storage/internal/storage_round_robin_decorator.h
+++ b/google/cloud/storage/internal/storage_round_robin_decorator.h
@@ -200,7 +200,8 @@ class StorageRoundRobin : public StorageStub {
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>>
   AsyncWriteObject(google::cloud::CompletionQueue const& cq,
-                   std::shared_ptr<grpc::ClientContext> context) override;
+                   std::shared_ptr<grpc::ClientContext> context,
+                   google::cloud::internal::ImmutableOptions options) override;
 
   future<StatusOr<google::storage::v2::RewriteResponse>> AsyncRewriteObject(
       google::cloud::CompletionQueue& cq,

--- a/google/cloud/storage/internal/storage_stub.cc
+++ b/google/cloud/storage/internal/storage_stub.cc
@@ -468,11 +468,12 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
     google::storage::v2::WriteObjectResponse>>
 DefaultStorageStub::AsyncWriteObject(
     google::cloud::CompletionQueue const& cq,
-    std::shared_ptr<grpc::ClientContext> context) {
+    std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options) {
   return google::cloud::internal::MakeStreamingWriteRpc<
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>(
-      cq, std::move(context),
+      cq, std::move(context), std::move(options),
       [this](grpc::ClientContext* context,
              google::storage::v2::WriteObjectResponse* response,
              grpc::CompletionQueue* cq) {

--- a/google/cloud/storage/internal/storage_stub.h
+++ b/google/cloud/storage/internal/storage_stub.h
@@ -204,7 +204,8 @@ class StorageStub {
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>>
   AsyncWriteObject(google::cloud::CompletionQueue const& cq,
-                   std::shared_ptr<grpc::ClientContext> context) = 0;
+                   std::shared_ptr<grpc::ClientContext> context,
+                   google::cloud::internal::ImmutableOptions options) = 0;
 
   virtual future<StatusOr<google::storage::v2::RewriteResponse>>
   AsyncRewriteObject(
@@ -395,7 +396,8 @@ class DefaultStorageStub : public StorageStub {
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>>
   AsyncWriteObject(google::cloud::CompletionQueue const& cq,
-                   std::shared_ptr<grpc::ClientContext> context) override;
+                   std::shared_ptr<grpc::ClientContext> context,
+                   google::cloud::internal::ImmutableOptions options) override;
 
   future<StatusOr<google::storage::v2::RewriteResponse>> AsyncRewriteObject(
       google::cloud::CompletionQueue& cq,

--- a/google/cloud/storage/internal/storage_stub_factory_test.cc
+++ b/google/cloud/storage/internal/storage_stub_factory_test.cc
@@ -145,7 +145,7 @@ TEST_F(StorageStubFactory, WriteObject) {
         auto mock = std::make_shared<MockStorageStub>();
         EXPECT_CALL(*mock, AsyncWriteObject)
             .WillOnce([this](google::cloud::CompletionQueue const&,
-                             auto context) {
+                             auto context, auto /*options*/) {
               // Verify the Auth decorator is present
               EXPECT_THAT(context->credentials(), NotNull());
               // Verify the Metadata decorator is present
@@ -172,8 +172,9 @@ TEST_F(StorageStubFactory, WriteObject) {
   ScopedLog log;
   internal::AutomaticallyCreatedBackgroundThreads pool;
   auto stub = CreateTestStub(pool.cq(), factory.AsStdFunction(), {});
-  auto stream = stub->AsyncWriteObject(pool.cq(),
-                                       std::make_shared<grpc::ClientContext>());
+  auto stream =
+      stub->AsyncWriteObject(pool.cq(), std::make_shared<grpc::ClientContext>(),
+                             google::cloud::internal::MakeImmutableOptions({}));
   EXPECT_TRUE(stream->Start().get());
   auto close = stream->Finish().get();
   EXPECT_THAT(close, StatusIs(StatusCode::kUnavailable));

--- a/google/cloud/storage/internal/storage_tracing_stub.cc
+++ b/google/cloud/storage/internal/storage_tracing_stub.cc
@@ -463,12 +463,13 @@ std::unique_ptr<
                                      google::storage::v2::WriteObjectResponse>>
 StorageTracingStub::AsyncWriteObject(
     google::cloud::CompletionQueue const& cq,
-    std::shared_ptr<grpc::ClientContext> context) {
+    std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options) {
   auto span =
       internal::MakeSpanGrpc("google.storage.v2.Storage", "WriteObject");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto stream = child_->AsyncWriteObject(cq, context);
+  auto stream = child_->AsyncWriteObject(cq, context, std::move(options));
   return std::make_unique<internal::AsyncStreamingWriteRpcTracing<
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>>(

--- a/google/cloud/storage/internal/storage_tracing_stub.h
+++ b/google/cloud/storage/internal/storage_tracing_stub.h
@@ -201,7 +201,8 @@ class StorageTracingStub : public StorageStub {
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>>
   AsyncWriteObject(google::cloud::CompletionQueue const& cq,
-                   std::shared_ptr<grpc::ClientContext> context) override;
+                   std::shared_ptr<grpc::ClientContext> context,
+                   google::cloud::internal::ImmutableOptions options) override;
 
   future<StatusOr<google::storage::v2::RewriteResponse>> AsyncRewriteObject(
       google::cloud::CompletionQueue& cq,

--- a/google/cloud/storage/testing/mock_storage_stub.h
+++ b/google/cloud/storage/testing/mock_storage_stub.h
@@ -201,7 +201,8 @@ class MockStorageStub : public storage_internal::StorageStub {
           google::storage::v2::WriteObjectResponse>>;
   MOCK_METHOD(AsyncWriteObjectReturnType, AsyncWriteObject,
               (google::cloud::CompletionQueue const&,
-               std::shared_ptr<grpc::ClientContext>),
+               std::shared_ptr<grpc::ClientContext>,
+               google::cloud::internal::ImmutableOptions),
               (override));
   MOCK_METHOD(
       future<StatusOr<google::storage::v2::StartResumableWriteResponse>>,


### PR DESCRIPTION
Part of the work for #12359

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13655)
<!-- Reviewable:end -->
