### PR TITLE
test(GCS+gRPC): testbench supports bidi writes

### DIFF
--- a/google/cloud/storage/tests/async_client_integration_test.cc
+++ b/google/cloud/storage/tests/async_client_integration_test.cc
@@ -189,7 +189,6 @@ TEST_F(AsyncClientIntegrationTest, StreamingRead) {
 }
 
 TEST_F(AsyncClientIntegrationTest, StartUnbufferedUploadEmpty) {
-  if (UsingEmulator()) GTEST_SKIP();
   auto object_name = MakeRandomObjectName();
 
   auto client = AsyncClient();
@@ -212,7 +211,6 @@ TEST_F(AsyncClientIntegrationTest, StartUnbufferedUploadEmpty) {
 }
 
 TEST_F(AsyncClientIntegrationTest, StartUnbufferedUploadMultiple) {
-  if (UsingEmulator()) GTEST_SKIP();
   auto object_name = MakeRandomObjectName();
   // Create a small block to send over and over.
   auto constexpr kBlockSize = 256 * 1024;
@@ -244,7 +242,6 @@ TEST_F(AsyncClientIntegrationTest, StartUnbufferedUploadMultiple) {
 }
 
 TEST_F(AsyncClientIntegrationTest, StartUnbufferedUploadResume) {
-  if (UsingEmulator()) GTEST_SKIP();
   auto object_name = MakeRandomObjectName();
   // Create a small block to send over and over.
   auto constexpr kBlockSize = 256 * 1024;
@@ -312,7 +309,6 @@ TEST_F(AsyncClientIntegrationTest, StartUnbufferedUploadResume) {
 }
 
 TEST_F(AsyncClientIntegrationTest, StartUnbufferedUploadResumeFinalized) {
-  if (UsingEmulator()) GTEST_SKIP();
   auto object_name = MakeRandomObjectName();
   // Create a small block to send over and over.
   auto constexpr kBlockSize = static_cast<std::int64_t>(256 * 1024);
@@ -351,7 +347,6 @@ TEST_F(AsyncClientIntegrationTest, StartUnbufferedUploadResumeFinalized) {
 }
 
 TEST_F(AsyncClientIntegrationTest, StartBufferedUploadEmpty) {
-  if (UsingEmulator()) GTEST_SKIP();
   auto object_name = MakeRandomObjectName();
 
   auto client = AsyncClient();
@@ -374,7 +369,6 @@ TEST_F(AsyncClientIntegrationTest, StartBufferedUploadEmpty) {
 }
 
 TEST_F(AsyncClientIntegrationTest, StartBufferedUploadMultiple) {
-  if (UsingEmulator()) GTEST_SKIP();
   auto object_name = MakeRandomObjectName();
   // Create a small block to send over and over.
   auto constexpr kBlockSize = 256 * 1024;


### PR DESCRIPTION
Now that the testbench supports bidi writes we can enable the tests that depend on them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13656)
<!-- Reviewable:end -->
