### PR TITLE
impl: heed `RetryInfo` in common loops

### DIFF
--- a/google/cloud/internal/async_retry_loop.h
+++ b/google/cloud/internal/async_retry_loop.h
@@ -183,6 +183,7 @@ class AsyncRetryLoopImpl
       : retry_policy_(std::move(retry_policy)),
         backoff_policy_(std::move(backoff_policy)),
         idempotency_(idempotency),
+        enable_server_retries_(options->get<EnableServerRetriesOption>()),
         cq_(std::move(cq)),
         functor_(std::forward<Functor>(functor)),
         request_(std::move(request)),
@@ -259,8 +260,9 @@ class AsyncRetryLoopImpl
     if (result.ok()) return SetDone(std::move(result));
     // Some kind of failure, first verify that it is retryable.
     last_status_ = GetResultStatus(std::move(result));
-    auto delay = Backoff(last_status_, location_, *retry_policy_,
-                         *backoff_policy_, idempotency_);
+    auto delay =
+        Backoff(last_status_, location_, *retry_policy_, *backoff_policy_,
+                idempotency_, enable_server_retries_);
     if (!delay) return SetDone(std::move(delay).status());
     StartBackoff(*delay);
   }
@@ -315,6 +317,7 @@ class AsyncRetryLoopImpl
   std::unique_ptr<RetryPolicyType> retry_policy_;
   std::unique_ptr<BackoffPolicy> backoff_policy_;
   Idempotency idempotency_ = Idempotency::kNonIdempotent;
+  bool enable_server_retries_;
   google::cloud::CompletionQueue cq_;
   std::decay_t<Functor> functor_;
   Request request_;

--- a/google/cloud/internal/async_retry_loop.h
+++ b/google/cloud/internal/async_retry_loop.h
@@ -183,7 +183,9 @@ class AsyncRetryLoopImpl
       : retry_policy_(std::move(retry_policy)),
         backoff_policy_(std::move(backoff_policy)),
         idempotency_(idempotency),
-        enable_server_retries_(options->get<EnableServerRetriesOption>()),
+        retry_info_policy_(options->get<EnableServerRetriesOption>()
+                               ? RetryInfoPolicy::kHeed
+                               : RetryInfoPolicy::kIgnore),
         cq_(std::move(cq)),
         functor_(std::forward<Functor>(functor)),
         request_(std::move(request)),
@@ -260,9 +262,8 @@ class AsyncRetryLoopImpl
     if (result.ok()) return SetDone(std::move(result));
     // Some kind of failure, first verify that it is retryable.
     last_status_ = GetResultStatus(std::move(result));
-    auto delay =
-        Backoff(last_status_, location_, *retry_policy_, *backoff_policy_,
-                idempotency_, enable_server_retries_);
+    auto delay = Backoff(last_status_, location_, *retry_policy_,
+                         *backoff_policy_, idempotency_, retry_info_policy_);
     if (!delay) return SetDone(std::move(delay).status());
     StartBackoff(*delay);
   }
@@ -317,7 +318,7 @@ class AsyncRetryLoopImpl
   std::unique_ptr<RetryPolicyType> retry_policy_;
   std::unique_ptr<BackoffPolicy> backoff_policy_;
   Idempotency idempotency_ = Idempotency::kNonIdempotent;
-  bool enable_server_retries_;
+  RetryInfoPolicy retry_info_policy_;
   google::cloud::CompletionQueue cq_;
   std::decay_t<Functor> functor_;
   Request request_;

--- a/google/cloud/internal/retry_loop.h
+++ b/google/cloud/internal/retry_loop.h
@@ -71,6 +71,8 @@ auto RetryLoopImpl(RetryPolicy& retry_policy, BackoffPolicy& backoff_policy,
                    char const* location, Sleeper sleeper)
     -> google::cloud::internal::invoke_result_t<
         Functor, grpc::ClientContext&, Options const&, Request const&> {
+  auto const enable_server_retries =
+      options.get<internal::EnableServerRetriesOption>();
   auto last_status = Status{};
   while (!retry_policy.IsExhausted()) {
     // Need to create a new context for each retry.
@@ -80,7 +82,7 @@ auto RetryLoopImpl(RetryPolicy& retry_policy, BackoffPolicy& backoff_policy,
     if (result.ok()) return result;
     last_status = GetResultStatus(std::move(result));
     auto delay = Backoff(last_status, location, retry_policy, backoff_policy,
-                         idempotency);
+                         idempotency, enable_server_retries);
     if (!delay) return std::move(delay).status();
     sleeper(*delay);
   }

--- a/google/cloud/internal/retry_loop_helpers.cc
+++ b/google/cloud/internal/retry_loop_helpers.cc
@@ -111,9 +111,9 @@ StatusOr<std::chrono::milliseconds> Backoff(Status const& status,
                                             RetryPolicy& retry,
                                             BackoffPolicy& backoff,
                                             Idempotency idempotency,
-                                            RetryInfoPolicy retry_info) {
+                                            bool enable_server_retries) {
   bool should_retry = retry.OnFailure(status);
-  if (retry_info == RetryInfoPolicy::kHeed) {
+  if (enable_server_retries) {
     auto ri = internal::GetRetryInfo(status);
     if (ri) {
       if (retry.IsExhausted()) {

--- a/google/cloud/internal/retry_loop_helpers.h
+++ b/google/cloud/internal/retry_loop_helpers.h
@@ -58,18 +58,6 @@ Status RetryLoopPolicyExhaustedError(Status const& status,
 /// cancelled.
 Status RetryLoopCancelled(Status const& status, char const* location);
 
-// Determines how the client should react if the server returns a `RetryInfo` in
-// the error details.
-enum class RetryInfoPolicy {
-  // Treat the error as transient. Use the `RetryInfo::retry_delay()` as the
-  // next backoff.
-  kHeed,
-  // Ignore the `RetryInfo`. Use the retry and idempotency policies to determine
-  // whether the request can be retried. Use the backoff policy to determine the
-  // next backoff.
-  kIgnore
-};
-
 /**
  * Returns the backoff given the status, retry policy, and backoff policy.
  *
@@ -89,7 +77,7 @@ StatusOr<std::chrono::milliseconds> Backoff(Status const& status,
                                             RetryPolicy& retry,
                                             BackoffPolicy& backoff,
                                             Idempotency idempotency,
-                                            RetryInfoPolicy retry_info);
+                                            bool enable_server_retries);
 
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/retry_loop_helpers.h
+++ b/google/cloud/internal/retry_loop_helpers.h
@@ -61,6 +61,9 @@ Status RetryLoopCancelled(Status const& status, char const* location);
 /**
  * Returns the backoff given the status, retry policy, and backoff policy.
  *
+ * Takes into account whether the server has returned a `RetryInfo` in the
+ * status's error details.
+ *
  * Returns a `Status`, representing the loop error, if no backoff should be
  * performed.
  *
@@ -71,7 +74,8 @@ StatusOr<std::chrono::milliseconds> Backoff(Status const& status,
                                             char const* location,
                                             RetryPolicy& retry,
                                             BackoffPolicy& backoff,
-                                            Idempotency idempotency);
+                                            Idempotency idempotency,
+                                            bool enable_server_retries);
 
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/retry_loop_helpers_test.cc
+++ b/google/cloud/internal/retry_loop_helpers_test.cc
@@ -166,10 +166,10 @@ TEST(Backoff, HeedsRetryInfo) {
   EXPECT_CALL(*mock_r, OnFailure(status)).WillOnce(Return(false));
   EXPECT_CALL(*mock_r, IsExhausted).WillOnce(Return(false));
   auto mock_b = std::make_unique<MockBackoffPolicy>();
-  EXPECT_CALL(*mock_b, OnCompletion).Times(0);
+  EXPECT_CALL(*mock_b, OnCompletion);
 
   auto actual = Backoff(status, "SomeFunction", *mock_r, *mock_b,
-                        Idempotency::kNonIdempotent, true);
+                        Idempotency::kNonIdempotent, RetryInfoPolicy::kHeed);
   EXPECT_THAT(actual, IsOkAndHolds(retry_delay));
 }
 
@@ -185,7 +185,7 @@ TEST(Backoff, NoRetriesIfPolicyExhausted) {
   EXPECT_CALL(*mock_b, OnCompletion).Times(0);
 
   auto actual = Backoff(status, "SomeFunction", *mock_r, *mock_b,
-                        Idempotency::kIdempotent, true);
+                        Idempotency::kIdempotent, RetryInfoPolicy::kHeed);
   EXPECT_THAT(actual, StatusIs(StatusCode::kResourceExhausted,
                                HasSubstr("policy exhausted")));
 }
@@ -201,7 +201,7 @@ TEST(Backoff, PermanentFailureWhenIgnoringRetryInfo) {
   EXPECT_CALL(*mock_b, OnCompletion).Times(0);
 
   auto actual = Backoff(status, "SomeFunction", *mock_r, *mock_b,
-                        Idempotency::kIdempotent, false);
+                        Idempotency::kIdempotent, RetryInfoPolicy::kIgnore);
   EXPECT_THAT(actual, StatusIs(StatusCode::kResourceExhausted,
                                HasSubstr("Permanent error")));
 }
@@ -218,7 +218,7 @@ TEST(Backoff, TransientFailureWhenIgnoringRetryInfo) {
       .WillOnce(Return(std::chrono::milliseconds(10)));
 
   auto actual = Backoff(status, "SomeFunction", *mock_r, *mock_b,
-                        Idempotency::kIdempotent, false);
+                        Idempotency::kIdempotent, RetryInfoPolicy::kIgnore);
   EXPECT_THAT(actual, IsOkAndHolds(std::chrono::milliseconds(10)));
 }
 
@@ -233,7 +233,7 @@ TEST(Backoff, NonIdempotentFailureWhenIgnoringRetryInfo) {
   EXPECT_CALL(*mock_b, OnCompletion).Times(0);
 
   auto actual = Backoff(status, "SomeFunction", *mock_r, *mock_b,
-                        Idempotency::kNonIdempotent, false);
+                        Idempotency::kNonIdempotent, RetryInfoPolicy::kIgnore);
   EXPECT_THAT(actual, StatusIs(StatusCode::kResourceExhausted,
                                HasSubstr("non-idempotent")));
 }

--- a/google/cloud/internal/retry_loop_helpers_test.cc
+++ b/google/cloud/internal/retry_loop_helpers_test.cc
@@ -168,8 +168,9 @@ TEST(Backoff, HeedsRetryInfo) {
   auto mock_b = std::make_unique<MockBackoffPolicy>();
   EXPECT_CALL(*mock_b, OnCompletion);
 
-  auto actual = Backoff(status, "SomeFunction", *mock_r, *mock_b,
-                        Idempotency::kNonIdempotent, RetryInfoPolicy::kHeed);
+  auto actual =
+      Backoff(status, "SomeFunction", *mock_r, *mock_b,
+              Idempotency::kNonIdempotent, /*enable_server_retries=*/true);
   EXPECT_THAT(actual, IsOkAndHolds(retry_delay));
 }
 
@@ -184,8 +185,9 @@ TEST(Backoff, NoRetriesIfPolicyExhausted) {
   auto mock_b = std::make_unique<MockBackoffPolicy>();
   EXPECT_CALL(*mock_b, OnCompletion).Times(0);
 
-  auto actual = Backoff(status, "SomeFunction", *mock_r, *mock_b,
-                        Idempotency::kIdempotent, RetryInfoPolicy::kHeed);
+  auto actual =
+      Backoff(status, "SomeFunction", *mock_r, *mock_b,
+              Idempotency::kIdempotent, /*enable_server_retries=*/true);
   EXPECT_THAT(actual, StatusIs(StatusCode::kResourceExhausted,
                                HasSubstr("policy exhausted")));
 }
@@ -200,8 +202,9 @@ TEST(Backoff, PermanentFailureWhenIgnoringRetryInfo) {
   auto mock_b = std::make_unique<MockBackoffPolicy>();
   EXPECT_CALL(*mock_b, OnCompletion).Times(0);
 
-  auto actual = Backoff(status, "SomeFunction", *mock_r, *mock_b,
-                        Idempotency::kIdempotent, RetryInfoPolicy::kIgnore);
+  auto actual =
+      Backoff(status, "SomeFunction", *mock_r, *mock_b,
+              Idempotency::kIdempotent, /*enable_server_retries=*/false);
   EXPECT_THAT(actual, StatusIs(StatusCode::kResourceExhausted,
                                HasSubstr("Permanent error")));
 }
@@ -217,8 +220,9 @@ TEST(Backoff, TransientFailureWhenIgnoringRetryInfo) {
   EXPECT_CALL(*mock_b, OnCompletion)
       .WillOnce(Return(std::chrono::milliseconds(10)));
 
-  auto actual = Backoff(status, "SomeFunction", *mock_r, *mock_b,
-                        Idempotency::kIdempotent, RetryInfoPolicy::kIgnore);
+  auto actual =
+      Backoff(status, "SomeFunction", *mock_r, *mock_b,
+              Idempotency::kIdempotent, /*enable_server_retries=*/false);
   EXPECT_THAT(actual, IsOkAndHolds(std::chrono::milliseconds(10)));
 }
 
@@ -232,8 +236,9 @@ TEST(Backoff, NonIdempotentFailureWhenIgnoringRetryInfo) {
   auto mock_b = std::make_unique<MockBackoffPolicy>();
   EXPECT_CALL(*mock_b, OnCompletion).Times(0);
 
-  auto actual = Backoff(status, "SomeFunction", *mock_r, *mock_b,
-                        Idempotency::kNonIdempotent, RetryInfoPolicy::kIgnore);
+  auto actual =
+      Backoff(status, "SomeFunction", *mock_r, *mock_b,
+              Idempotency::kNonIdempotent, /*enable_server_retries=*/false);
   EXPECT_THAT(actual, StatusIs(StatusCode::kResourceExhausted,
                                HasSubstr("non-idempotent")));
 }


### PR DESCRIPTION
Part of the work for #13514 

Retry on `RetryInfo` in the common loops. This overrides idempotency and any supplied backoff policies.

This rounds out the Bigtable client calls.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13657)
<!-- Reviewable:end -->
