### PR TITLE
ci(securitycenter): disable on macOS and Windows

### DIFF
--- a/google/cloud/securitycenter/BUILD.bazel
+++ b/google/cloud/securitycenter/BUILD.bazel
@@ -50,6 +50,13 @@ cc_library(
     srcs = [":srcs"],
     hdrs = [":hdrs"],
     visibility = ["//:__pkg__"],
+    # Cannot compile on macOS or Windows - the protos have enum values that
+    # conflict with some system macros.
+    target_compatible_with = select({
+        "@platforms//os:macos": ["@platforms//:incompatible"],
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     deps = [
         "//:common",
         "//:grpc_utils",
@@ -61,6 +68,13 @@ cc_library(
     name = "google_cloud_cpp_securitycenter_mocks",
     hdrs = [":mocks"],
     visibility = ["//:__pkg__"],
+    # Cannot compile on macOS or Windows - the protos have enum values that
+    # conflict with some system macros.
+    target_compatible_with = select({
+        "@platforms//os:macos": ["@platforms//:incompatible"],
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     deps = [
         ":google_cloud_cpp_securitycenter",
         "@com_google_googletest//:gtest",

--- a/google/cloud/securitycenter/CMakeLists.txt
+++ b/google/cloud/securitycenter/CMakeLists.txt
@@ -14,6 +14,14 @@
 # limitations under the License.
 # ~~~
 
+if (APPLE OR WIN32)
+    message(
+        WARNING "Cannot build google/cloud/securitycenter on macOS or Windows"
+                " - the protos have enum names that conflict with some system"
+                " macros.")
+    return()
+endif ()
+
 include(GoogleCloudCppLibrary)
 
 google_cloud_cpp_add_gapic_library(securitycenter "Security Command Center API"


### PR DESCRIPTION
Recent versions of the protos include enum values that conflict with system macros on macOS and Windows. To build on these platforms we would need to fix Protobuf and then we can build only with the newer version.