### PR TITLE
feat: cmake option to skip building mock libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,6 +239,10 @@ cmake_dependent_option(
     ON "GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS;BUILD_TESTING" OFF)
 mark_as_advanced(GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
 
+option(GOOGLE_CLOUD_CPP_WITH_MOCKS
+       "Install the google-cloud-cpp mocking libraries." ON)
+mark_as_advanced(GOOGLE_CLOUD_CPP_WITH_MOCKS)
+
 # Add any subdirectories configured in the application.
 
 # `docfx/` must be included before any library directories. The tool is used to

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,28 @@ This option is required to support package maintainers that split
     OFF)
 mark_as_advanced(GOOGLE_CLOUD_CPP_USE_INSTALLED_COMMON)
 
+include(CMakeDependentOption)
+cmake_dependent_option(
+    GOOGLE_CLOUD_CPP_WITH_MOCKS
+    [==[Build the google-cloud-cpp mocking libraries.
+
+google-cloud-cpp offers mocking libraries with mock classes, to facilitate unit
+testing of Cloud C++ clients. Consumers of this library that do not use the
+provided mocks to test code involving the Cloud C++ clients may wish to turn
+this flag off.]==]
+    ON
+    "NOT BUILD_TESTING"
+    ON)
+mark_as_advanced(GOOGLE_CLOUD_CPP_WITH_MOCKS)
+
+# The examples use exception handling to simplify the code. Therefore they
+# cannot be compiled when exceptions are disabled, and applications cannot force
+# the flag.
+cmake_dependent_option(
+    GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES "Compile the google-cloud-cpp examples."
+    ON "GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS;BUILD_TESTING" OFF)
+mark_as_advanced(GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
+
 include(GoogleCloudCppFeatures)
 
 # Controls the list of features compiled by `google-cloud-cpp`.
@@ -230,18 +252,6 @@ if (BUILD_TESTING)
     # Discover and add targets for the GTest::gtest and GTest::gmock libraries.
     include(FindGMockWithTargets)
 endif ()
-
-# The examples use exception handling to simplify the code. Therefore they
-# cannot be compiled when exceptions are disabled, and applications cannot force
-# the flag.
-cmake_dependent_option(
-    GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES "Compile the google-cloud-cpp examples."
-    ON "GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS;BUILD_TESTING" OFF)
-mark_as_advanced(GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
-
-option(GOOGLE_CLOUD_CPP_WITH_MOCKS
-       "Install the google-cloud-cpp mocking libraries." ON)
-mark_as_advanced(GOOGLE_CLOUD_CPP_WITH_MOCKS)
 
 # Add any subdirectories configured in the application.
 

--- a/cmake/GoogleCloudCppCommon.cmake
+++ b/cmake/GoogleCloudCppCommon.cmake
@@ -165,16 +165,6 @@ function (google_cloud_cpp_install_mocks library display_name)
     set(library_target "google_cloud_cpp_${library}")
     set(mocks_target "google_cloud_cpp_${library}_mocks")
 
-    # Always install the mock headers. These are harmless, in the sense that
-    # they will not cause build failures in environments without GoogleTest. The
-    # same is not true about the mocking libraries which link GoogleTest.
-    google_cloud_cpp_install_headers("${mocks_target}"
-                                     "include/google/cloud/${library}")
-
-    if (NOT GOOGLE_CLOUD_CPP_WITH_MOCKS)
-        # Only install modules for the mock libraries if they are requested.
-        return()
-    endif ()
     install(
         EXPORT ${mocks_target}-targets
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${mocks_target}"
@@ -183,6 +173,9 @@ function (google_cloud_cpp_install_mocks library display_name)
         TARGETS ${mocks_target}
         EXPORT ${mocks_target}-targets
         COMPONENT google_cloud_cpp_development)
+
+    google_cloud_cpp_install_headers("${mocks_target}"
+                                     "include/google/cloud/${library}")
 
     google_cloud_cpp_add_pkgconfig(
         ${library}_mocks "${display_name} Mocks"

--- a/cmake/GoogleCloudCppCommon.cmake
+++ b/cmake/GoogleCloudCppCommon.cmake
@@ -164,6 +164,17 @@ endfunction ()
 function (google_cloud_cpp_install_mocks library display_name)
     set(library_target "google_cloud_cpp_${library}")
     set(mocks_target "google_cloud_cpp_${library}_mocks")
+
+    # Always install the mock headers. These are harmless, in the sense that
+    # they will not cause build failures in environments without GoogleTest. The
+    # same is not true about the mocking libraries which link GoogleTest.
+    google_cloud_cpp_install_headers("${mocks_target}"
+                                     "include/google/cloud/${library}")
+
+    if (NOT GOOGLE_CLOUD_CPP_WITH_MOCKS)
+        # Only install modules for the mock libraries if they are requested.
+        return()
+    endif ()
     install(
         EXPORT ${mocks_target}-targets
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${mocks_target}"
@@ -172,9 +183,6 @@ function (google_cloud_cpp_install_mocks library display_name)
         TARGETS ${mocks_target}
         EXPORT ${mocks_target}-targets
         COMPONENT google_cloud_cpp_development)
-
-    google_cloud_cpp_install_headers("${mocks_target}"
-                                     "include/google/cloud/${library}")
 
     google_cloud_cpp_add_pkgconfig(
         ${library}_mocks "${display_name} Mocks"

--- a/cmake/GoogleCloudCppCommon.cmake
+++ b/cmake/GoogleCloudCppCommon.cmake
@@ -164,7 +164,6 @@ endfunction ()
 function (google_cloud_cpp_install_mocks library display_name)
     set(library_target "google_cloud_cpp_${library}")
     set(mocks_target "google_cloud_cpp_${library}_mocks")
-
     install(
         EXPORT ${mocks_target}-targets
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${mocks_target}"

--- a/google/cloud/bigquery/bigquery_rest.cmake
+++ b/google/cloud/bigquery/bigquery_rest.cmake
@@ -162,37 +162,90 @@ target_compile_options(google_cloud_cpp_bigquery_rest
 add_library(google-cloud-cpp::experimental-bigquery_rest ALIAS
             google_cloud_cpp_bigquery_rest)
 
-# Create a header-only library for the mocks.
-add_library(google_cloud_cpp_bigquery_rest_mocks INTERFACE)
-target_sources(
-    google_cloud_cpp_bigquery_rest_mocks
-    INTERFACE
-        ${CMAKE_CURRENT_SOURCE_DIR}/v2/minimal/mocks/mock_dataset_connection.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/v2/minimal/mocks/mock_job_connection.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/v2/minimal/mocks/mock_project_connection.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/v2/minimal/mocks/mock_table_connection.h)
-target_link_libraries(
-    google_cloud_cpp_bigquery_rest_mocks
-    INTERFACE google-cloud-cpp::experimental-bigquery_rest GTest::gmock_main
-              GTest::gmock GTest::gtest)
-set_target_properties(
-    google_cloud_cpp_bigquery_rest_mocks
-    PROPERTIES EXPORT_NAME google-cloud-cpp::experimental-bigquery_rest_mocks)
-target_include_directories(
-    google_cloud_cpp_bigquery_rest_mocks
-    INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-              $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
-              $<INSTALL_INTERFACE:include>)
-target_compile_options(google_cloud_cpp_bigquery_rest_mocks
-                       INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
-add_library(google-cloud-cpp::experimental-bigquery_rest_mocks ALIAS
-            google_cloud_cpp_bigquery_rest_mocks)
+# Get the destination directories based on the GNU recommendations.
+include(GNUInstallDirs)
+
+# Export the CMake targets to make it easy to create configuration files.
+install(
+    EXPORT google_cloud_cpp_bigquery_rest-targets
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_bigquery_rest"
+    COMPONENT google_cloud_cpp_development)
+
+# Install the libraries and headers in the locations determined by
+# GNUInstallDirs
+install(
+    TARGETS google_cloud_cpp_bigquery_rest
+    EXPORT google_cloud_cpp_bigquery_rest-targets
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+            COMPONENT google_cloud_cpp_runtime
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            COMPONENT google_cloud_cpp_runtime
+            NAMELINK_COMPONENT google_cloud_cpp_development
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            COMPONENT google_cloud_cpp_development)
+
+google_cloud_cpp_install_headers("google_cloud_cpp_bigquery_rest"
+                                 "include/google/cloud/bigquery")
+
+google_cloud_cpp_add_pkgconfig(
+    bigquery_rest "Experimental BigQuery REST client library"
+    "An experimental BigQuery C++ client library using REST for transport."
+    "google_cloud_cpp_rest_internal")
+
+# Create and install the CMake configuration files.
+include(CMakePackageConfigHelpers)
+configure_file("config-rest.cmake.in"
+               "google_cloud_cpp_bigquery_rest-config.cmake" @ONLY)
+write_basic_package_version_file(
+    "google_cloud_cpp_bigquery_rest-config-version.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY ExactVersion)
+
+install(
+    FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_bigquery_rest-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_bigquery_rest-config-version.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_bigquery_rest"
+    COMPONENT google_cloud_cpp_development)
+
+if (GOOGLE_CLOUD_CPP_WITH_MOCKS)
+    # Create a header-only library for the mocks.
+    add_library(google_cloud_cpp_bigquery_rest_mocks INTERFACE)
+    target_sources(
+        google_cloud_cpp_bigquery_rest_mocks
+        INTERFACE
+            ${CMAKE_CURRENT_SOURCE_DIR}/v2/minimal/mocks/mock_dataset_connection.h
+            ${CMAKE_CURRENT_SOURCE_DIR}/v2/minimal/mocks/mock_job_connection.h
+            ${CMAKE_CURRENT_SOURCE_DIR}/v2/minimal/mocks/mock_project_connection.h
+            ${CMAKE_CURRENT_SOURCE_DIR}/v2/minimal/mocks/mock_table_connection.h
+    )
+    target_link_libraries(
+        google_cloud_cpp_bigquery_rest_mocks
+        INTERFACE google-cloud-cpp::experimental-bigquery_rest
+                  GTest::gmock_main GTest::gmock GTest::gtest)
+    set_target_properties(
+        google_cloud_cpp_bigquery_rest_mocks
+        PROPERTIES EXPORT_NAME
+                   google-cloud-cpp::experimental-bigquery_rest_mocks)
+    target_include_directories(
+        google_cloud_cpp_bigquery_rest_mocks
+        INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+                  $<INSTALL_INTERFACE:include>)
+    target_compile_options(google_cloud_cpp_bigquery_rest_mocks
+                           INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
+    add_library(google-cloud-cpp::experimental-bigquery_rest_mocks ALIAS
+                google_cloud_cpp_bigquery_rest_mocks)
+    create_bazel_config(google_cloud_cpp_bigquery_rest_mocks YEAR "2023")
+
+    google_cloud_cpp_install_headers("google_cloud_cpp_bigquery_rest_mocks"
+                                     "include/google/cloud/bigquery")
+endif ()
 
 # To avoid maintaining the list of files for the library, export them to a .bzl
 # file.
 include(CreateBazelConfig)
 create_bazel_config(google_cloud_cpp_bigquery_rest YEAR "2023")
-create_bazel_config(google_cloud_cpp_bigquery_rest_mocks YEAR "2023")
 
 # Define the tests in a function so we have a new scope for variable names.
 function (bigquery_rest_define_tests)
@@ -315,54 +368,6 @@ function (bigquery_rest_define_tests)
         add_dependencies(bigquery_rest-tests ${target})
     endforeach ()
 endfunction ()
-
-# Get the destination directories based on the GNU recommendations.
-include(GNUInstallDirs)
-
-# Export the CMake targets to make it easy to create configuration files.
-install(
-    EXPORT google_cloud_cpp_bigquery_rest-targets
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_bigquery_rest"
-    COMPONENT google_cloud_cpp_development)
-
-# Install the libraries and headers in the locations determined by
-# GNUInstallDirs
-install(
-    TARGETS google_cloud_cpp_bigquery_rest
-    EXPORT google_cloud_cpp_bigquery_rest-targets
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-            COMPONENT google_cloud_cpp_runtime
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            COMPONENT google_cloud_cpp_runtime
-            NAMELINK_COMPONENT google_cloud_cpp_development
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            COMPONENT google_cloud_cpp_development)
-
-google_cloud_cpp_install_headers("google_cloud_cpp_bigquery_rest"
-                                 "include/google/cloud/bigquery")
-google_cloud_cpp_install_headers("google_cloud_cpp_bigquery_rest_mocks"
-                                 "include/google/cloud/bigquery")
-
-google_cloud_cpp_add_pkgconfig(
-    bigquery_rest "Experimental BigQuery REST client library"
-    "An experimental BigQuery C++ client library using REST for transport."
-    "google_cloud_cpp_rest_internal")
-
-# Create and install the CMake configuration files.
-include(CMakePackageConfigHelpers)
-configure_file("config-rest.cmake.in"
-               "google_cloud_cpp_bigquery_rest-config.cmake" @ONLY)
-write_basic_package_version_file(
-    "google_cloud_cpp_bigquery_rest-config-version.cmake"
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY ExactVersion)
-
-install(
-    FILES
-        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_bigquery_rest-config.cmake"
-        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_bigquery_rest-config-version.cmake"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_bigquery_rest"
-    COMPONENT google_cloud_cpp_development)
 
 if (BUILD_TESTING)
     bigquery_rest_define_tests()

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -279,37 +279,85 @@ add_library(google-cloud-cpp::bigtable ALIAS google_cloud_cpp_bigtable)
 include(CreateBazelConfig)
 create_bazel_config(google_cloud_cpp_bigtable)
 
-add_library(google_cloud_cpp_bigtable_mocks INTERFACE)
-set(google_cloud_cpp_bigtable_mocks_hdrs
-    # cmake-format: sort
-    admin/mocks/mock_bigtable_instance_admin_connection.h
-    admin/mocks/mock_bigtable_table_admin_connection.h
-    mocks/mock_data_connection.h
-    mocks/mock_row_reader.h)
-export_list_to_bazel("google_cloud_cpp_bigtable_mocks.bzl"
-                     google_cloud_cpp_bigtable_mocks_hdrs YEAR "2021")
-foreach (file IN LISTS google_cloud_cpp_bigtable_mocks_hdrs)
-    # We use a generator expression per the recommendation in:
-    # https://stackoverflow.com/a/62465051
-    list(APPEND mock_files
-         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${file}>")
-endforeach ()
-target_sources(google_cloud_cpp_bigtable_mocks INTERFACE ${mock_files})
-target_link_libraries(
-    google_cloud_cpp_bigtable_mocks
-    INTERFACE google-cloud-cpp::bigtable GTest::gmock_main GTest::gmock
-              GTest::gtest)
-set_target_properties(google_cloud_cpp_bigtable_mocks
-                      PROPERTIES EXPORT_NAME google-cloud-cpp::bigtable_mocks)
-target_include_directories(
-    google_cloud_cpp_bigtable_mocks
-    INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-              $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
-              $<INSTALL_INTERFACE:include>)
-target_compile_options(google_cloud_cpp_bigtable_mocks
-                       INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
-add_library(google-cloud-cpp::bigtable_mocks ALIAS
-            google_cloud_cpp_bigtable_mocks)
+# Export the CMake targets to make it easy to create configuration files.
+install(
+    EXPORT google_cloud_cpp_bigtable-targets
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_bigtable"
+    COMPONENT google_cloud_cpp_development)
+
+install(
+    TARGETS google_cloud_cpp_bigtable google_cloud_cpp_bigtable_protos
+    EXPORT google_cloud_cpp_bigtable-targets
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+            COMPONENT google_cloud_cpp_runtime
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            COMPONENT google_cloud_cpp_runtime
+            NAMELINK_COMPONENT google_cloud_cpp_development
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            COMPONENT google_cloud_cpp_development)
+
+google_cloud_cpp_install_headers("google_cloud_cpp_bigtable"
+                                 "include/google/cloud/bigtable")
+
+google_cloud_cpp_add_pkgconfig(
+    bigtable
+    "The Google Cloud Bigtable C++ Client Library"
+    "Provides C++ APIs to access Google Cloud Bigtable."
+    "google_cloud_cpp_grpc_utils"
+    "google_cloud_cpp_common"
+    "google_cloud_cpp_bigtable_protos")
+
+# Create and install the CMake configuration files.
+include(CMakePackageConfigHelpers)
+configure_file("config.cmake.in" "google_cloud_cpp_bigtable-config.cmake" @ONLY)
+write_basic_package_version_file(
+    "google_cloud_cpp_bigtable-config-version.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY ExactVersion)
+
+install(
+    FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_bigtable-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_bigtable-config-version.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_bigtable"
+    COMPONENT google_cloud_cpp_development)
+
+if (GOOGLE_CLOUD_CPP_WITH_MOCKS)
+    add_library(google_cloud_cpp_bigtable_mocks INTERFACE)
+    set(google_cloud_cpp_bigtable_mocks_hdrs
+        # cmake-format: sort
+        admin/mocks/mock_bigtable_instance_admin_connection.h
+        admin/mocks/mock_bigtable_table_admin_connection.h
+        mocks/mock_data_connection.h
+        mocks/mock_row_reader.h)
+    export_list_to_bazel("google_cloud_cpp_bigtable_mocks.bzl"
+                         google_cloud_cpp_bigtable_mocks_hdrs YEAR "2021")
+    foreach (file IN LISTS google_cloud_cpp_bigtable_mocks_hdrs)
+        # We use a generator expression per the recommendation in:
+        # https://stackoverflow.com/a/62465051
+        list(APPEND mock_files
+             "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${file}>")
+    endforeach ()
+    target_sources(google_cloud_cpp_bigtable_mocks INTERFACE ${mock_files})
+    target_link_libraries(
+        google_cloud_cpp_bigtable_mocks
+        INTERFACE google-cloud-cpp::bigtable GTest::gmock_main GTest::gmock
+                  GTest::gtest)
+    set_target_properties(
+        google_cloud_cpp_bigtable_mocks
+        PROPERTIES EXPORT_NAME google-cloud-cpp::bigtable_mocks)
+    target_include_directories(
+        google_cloud_cpp_bigtable_mocks
+        INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+                  $<INSTALL_INTERFACE:include>)
+    target_compile_options(google_cloud_cpp_bigtable_mocks
+                           INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
+    add_library(google-cloud-cpp::bigtable_mocks ALIAS
+                google_cloud_cpp_bigtable_mocks)
+
+    google_cloud_cpp_install_mocks(bigtable "Google Cloud Bigtable")
+endif ()
 
 if (BUILD_TESTING)
     add_library(
@@ -492,48 +540,3 @@ if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
     set_tests_properties(bigtable_quickstart
                          PROPERTIES LABELS "integration-test;quickstart")
 endif ()
-
-# Export the CMake targets to make it easy to create configuration files.
-install(
-    EXPORT google_cloud_cpp_bigtable-targets
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_bigtable"
-    COMPONENT google_cloud_cpp_development)
-
-install(
-    TARGETS google_cloud_cpp_bigtable google_cloud_cpp_bigtable_protos
-    EXPORT google_cloud_cpp_bigtable-targets
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-            COMPONENT google_cloud_cpp_runtime
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            COMPONENT google_cloud_cpp_runtime
-            NAMELINK_COMPONENT google_cloud_cpp_development
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            COMPONENT google_cloud_cpp_development)
-
-google_cloud_cpp_install_headers("google_cloud_cpp_bigtable"
-                                 "include/google/cloud/bigtable")
-
-google_cloud_cpp_add_pkgconfig(
-    bigtable
-    "The Google Cloud Bigtable C++ Client Library"
-    "Provides C++ APIs to access Google Cloud Bigtable."
-    "google_cloud_cpp_grpc_utils"
-    "google_cloud_cpp_common"
-    "google_cloud_cpp_bigtable_protos")
-
-# Create and install the CMake configuration files.
-include(CMakePackageConfigHelpers)
-configure_file("config.cmake.in" "google_cloud_cpp_bigtable-config.cmake" @ONLY)
-write_basic_package_version_file(
-    "google_cloud_cpp_bigtable-config-version.cmake"
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY ExactVersion)
-
-install(
-    FILES
-        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_bigtable-config.cmake"
-        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_bigtable-config-version.cmake"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_bigtable"
-    COMPONENT google_cloud_cpp_development)
-
-google_cloud_cpp_install_mocks(bigtable "Google Cloud Bigtable")

--- a/google/cloud/compute/CMakeLists.txt
+++ b/google/cloud/compute/CMakeLists.txt
@@ -110,42 +110,44 @@ set_target_properties(google_cloud_cpp_compute
                       PROPERTIES EXPORT_NAME "google-cloud-cpp::compute")
 add_library(google-cloud-cpp::compute ALIAS google_cloud_cpp_compute)
 
-# Create a header-only library for the mocks. We use a CMake `INTERFACE` library
-# for these, a regular library would not work on macOS (where the library needs
-# at least one .o file). Unfortunately INTERFACE libraries are a bit weird in
-# that they need absolute paths for their sources.
-foreach (dir IN LISTS service_dirs operation_service_dirs)
-    string(REPLACE "/v1/" "" short_dir "${dir}")
-    file(
-        GLOB ${short_dir}_relative_mock_files
-        LIST_DIRECTORIES false
-        RELATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}" "${dir}mocks/*.h")
-    list(SORT ${short_dir}_relative_mock_files)
-    set(mock_files)
-    foreach (file IN LISTS ${short_dir}_relative_mock_files)
-        list(APPEND mock_files "${file}")
+if (GOOGLE_CLOUD_CPP_WITH_MOCKS)
+    # Create a header-only library for the mocks. We use a CMake `INTERFACE`
+    # library for these, a regular library would not work on macOS (where the
+    # library needs at least one .o file). Unfortunately INTERFACE libraries are
+    # a bit weird in that they need absolute paths for their sources.
+    foreach (dir IN LISTS service_dirs operation_service_dirs)
+        string(REPLACE "/v1/" "" short_dir "${dir}")
+        file(
+            GLOB ${short_dir}_relative_mock_files
+            LIST_DIRECTORIES false
+            RELATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}" "${dir}mocks/*.h")
+        list(SORT ${short_dir}_relative_mock_files)
+        set(mock_files)
+        foreach (file IN LISTS ${short_dir}_relative_mock_files)
+            list(APPEND mock_files "${file}")
+        endforeach ()
+        add_library(google_cloud_cpp_compute_${short_dir}_mocks INTERFACE)
+        target_sources(google_cloud_cpp_compute_${short_dir}_mocks
+                       INTERFACE ${mock_files})
+        target_link_libraries(
+            google_cloud_cpp_compute_${short_dir}_mocks
+            INTERFACE google-cloud-cpp::compute-${short_dir} GTest::gmock_main
+                      GTest::gmock GTest::gtest)
+        set_target_properties(
+            google_cloud_cpp_compute_${short_dir}_mocks
+            PROPERTIES EXPORT_NAME google-cloud-cpp::compute-${short_dir}_mocks)
+        target_include_directories(
+            google_cloud_cpp_compute_${short_dir}_mocks
+            INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                      $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+                      $<INSTALL_INTERFACE:include>)
+        target_compile_options(google_cloud_cpp_compute_${short_dir}_mocks
+                               INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
+        google_cloud_cpp_install_headers(
+            "google_cloud_cpp_compute_${short_dir}_mocks"
+            "include/google/cloud/compute")
     endforeach ()
-    add_library(google_cloud_cpp_compute_${short_dir}_mocks INTERFACE)
-    target_sources(google_cloud_cpp_compute_${short_dir}_mocks
-                   INTERFACE ${mock_files})
-    target_link_libraries(
-        google_cloud_cpp_compute_${short_dir}_mocks
-        INTERFACE google-cloud-cpp::compute-${short_dir} GTest::gmock_main
-                  GTest::gmock GTest::gtest)
-    set_target_properties(
-        google_cloud_cpp_compute_${short_dir}_mocks
-        PROPERTIES EXPORT_NAME google-cloud-cpp::compute-${short_dir}_mocks)
-    target_include_directories(
-        google_cloud_cpp_compute_${short_dir}_mocks
-        INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-                  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
-                  $<INSTALL_INTERFACE:include>)
-    target_compile_options(google_cloud_cpp_compute_${short_dir}_mocks
-                           INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
-    google_cloud_cpp_install_headers(
-        "google_cloud_cpp_compute_${short_dir}_mocks"
-        "include/google/cloud/compute")
-endforeach ()
+endif ()
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(compute_quickstart "quickstart/quickstart.cc")

--- a/google/cloud/google_cloud_cpp_common.cmake
+++ b/google/cloud/google_cloud_cpp_common.cmake
@@ -290,40 +290,43 @@ target_compile_options(google_cloud_cpp_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 add_library(google-cloud-cpp::mocks ALIAS google_cloud_cpp_mocks)
 
-# Export the CMake targets to make it easy to create configuration files.
-install(
-    EXPORT google_cloud_cpp_mocks-targets
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_mocks"
-    COMPONENT google_cloud_cpp_development)
-
-install(
-    TARGETS google_cloud_cpp_mocks
-    EXPORT google_cloud_cpp_mocks-targets
-    COMPONENT google_cloud_cpp_development)
 install(
     FILES ${google_cloud_cpp_mocks_hdrs}
     DESTINATION "include/google/cloud/mocks"
     COMPONENT google_cloud_cpp_development)
 
-google_cloud_cpp_add_pkgconfig(
-    "mocks" "Google Cloud C++ Testing Library"
-    "Helpers for testing the Google Cloud C++ Client Libraries"
-    "google_cloud_cpp_common" "gmock_main")
+if (GOOGLE_CLOUD_CPP_WITH_MOCKS)
+    # Export the CMake targets to make it easy to create configuration files.
+    install(
+        EXPORT google_cloud_cpp_mocks-targets
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_mocks"
+        COMPONENT google_cloud_cpp_development)
 
-# Create and install the CMake configuration files.
-configure_file("mocks-config.cmake.in" "google_cloud_cpp_mocks-config.cmake"
-               @ONLY)
-write_basic_package_version_file(
-    "google_cloud_cpp_mocks-config-version.cmake"
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY ExactVersion)
+    install(
+        TARGETS google_cloud_cpp_mocks
+        EXPORT google_cloud_cpp_mocks-targets
+        COMPONENT google_cloud_cpp_development)
 
-install(
-    FILES
-        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_mocks-config.cmake"
-        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_mocks-config-version.cmake"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_mocks"
-    COMPONENT google_cloud_cpp_development)
+    google_cloud_cpp_add_pkgconfig(
+        "mocks" "Google Cloud C++ Testing Library"
+        "Helpers for testing the Google Cloud C++ Client Libraries"
+        "google_cloud_cpp_common" "gmock_main")
+
+    # Create and install the CMake configuration files.
+    configure_file("mocks-config.cmake.in"
+                   "google_cloud_cpp_mocks-config.cmake" @ONLY)
+    write_basic_package_version_file(
+        "google_cloud_cpp_mocks-config-version.cmake"
+        VERSION ${PROJECT_VERSION}
+        COMPATIBILITY ExactVersion)
+
+    install(
+        FILES
+            "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_mocks-config.cmake"
+            "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_mocks-config-version.cmake"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_mocks"
+        COMPONENT google_cloud_cpp_development)
+endif ()
 
 if (BUILD_TESTING)
     include(FindBenchmarkWithWorkarounds)

--- a/google/cloud/google_cloud_cpp_common.cmake
+++ b/google/cloud/google_cloud_cpp_common.cmake
@@ -266,36 +266,37 @@ install(
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_common"
     COMPONENT google_cloud_cpp_development)
 
-# Create a header-only library for the mocks. We use a CMake `INTERFACE` library
-# for these, a regular library would not work on macOS (where the library needs
-# at least one .o file).
-add_library(google_cloud_cpp_mocks INTERFACE)
-set(google_cloud_cpp_mocks_hdrs
-    # cmake-format: sort
-    mocks/current_options.h mocks/mock_async_streaming_read_write_rpc.h
-    mocks/mock_stream_range.h)
-export_list_to_bazel("google_cloud_cpp_mocks.bzl" "google_cloud_cpp_mocks_hdrs"
-                     YEAR "2022")
-target_link_libraries(
-    google_cloud_cpp_mocks INTERFACE google-cloud-cpp::common GTest::gmock_main
-                                     GTest::gmock GTest::gtest)
-set_target_properties(google_cloud_cpp_mocks PROPERTIES EXPORT_NAME
-                                                        google-cloud-cpp::mocks)
-target_include_directories(
-    google_cloud_cpp_mocks
-    INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-              $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
-              $<INSTALL_INTERFACE:include>)
-target_compile_options(google_cloud_cpp_mocks
-                       INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
-add_library(google-cloud-cpp::mocks ALIAS google_cloud_cpp_mocks)
-
-install(
-    FILES ${google_cloud_cpp_mocks_hdrs}
-    DESTINATION "include/google/cloud/mocks"
-    COMPONENT google_cloud_cpp_development)
-
 if (GOOGLE_CLOUD_CPP_WITH_MOCKS)
+    # Create a header-only library for the mocks. We use a CMake `INTERFACE`
+    # library for these, a regular library would not work on macOS (where the
+    # library needs at least one .o file).
+    add_library(google_cloud_cpp_mocks INTERFACE)
+    set(google_cloud_cpp_mocks_hdrs
+        # cmake-format: sort
+        mocks/current_options.h mocks/mock_async_streaming_read_write_rpc.h
+        mocks/mock_stream_range.h)
+    export_list_to_bazel("google_cloud_cpp_mocks.bzl"
+                         "google_cloud_cpp_mocks_hdrs" YEAR "2022")
+    target_link_libraries(
+        google_cloud_cpp_mocks
+        INTERFACE google-cloud-cpp::common GTest::gmock_main GTest::gmock
+                  GTest::gtest)
+    set_target_properties(google_cloud_cpp_mocks
+                          PROPERTIES EXPORT_NAME google-cloud-cpp::mocks)
+    target_include_directories(
+        google_cloud_cpp_mocks
+        INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+                  $<INSTALL_INTERFACE:include>)
+    target_compile_options(google_cloud_cpp_mocks
+                           INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
+    add_library(google-cloud-cpp::mocks ALIAS google_cloud_cpp_mocks)
+
+    install(
+        FILES ${google_cloud_cpp_mocks_hdrs}
+        DESTINATION "include/google/cloud/mocks"
+        COMPONENT google_cloud_cpp_development)
+
     # Export the CMake targets to make it easy to create configuration files.
     install(
         EXPORT google_cloud_cpp_mocks-targets

--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -298,50 +298,107 @@ add_library(google-cloud-cpp::pubsub ALIAS google_cloud_cpp_pubsub)
 include(CreateBazelConfig)
 create_bazel_config(google_cloud_cpp_pubsub YEAR "2020")
 
-# Create a header-only library for the mocks. We use a CMake `INTERFACE` library
-# for these, a regular library would not work on macOS (where the library needs
-# at least one .o file). Unfortunately INTERFACE libraries are a bit weird in
-# that they need absolute paths for their sources.
-add_library(google_cloud_cpp_pubsub_mocks INTERFACE)
-set(google_cloud_cpp_pubsub_mocks_hdrs
-    # cmake-format: sort
-    admin/mocks/mock_subscription_admin_connection.h
-    admin/mocks/mock_topic_admin_connection.h
-    mocks/mock_ack_handler.h
-    mocks/mock_blocking_publisher_connection.h
-    mocks/mock_exactly_once_ack_handler.h
-    mocks/mock_publisher_connection.h
-    mocks/mock_pull_ack_handler.h
-    mocks/mock_schema_connection.h
-    mocks/mock_subscriber_connection.h
-    mocks/mock_subscription_admin_connection.h
-    mocks/mock_topic_admin_connection.h)
-export_list_to_bazel("google_cloud_cpp_pubsub_mocks.bzl"
-                     "google_cloud_cpp_pubsub_mocks_hdrs" YEAR "2020")
-# Add the prefix to each file name for cmake
-set(cmake_google_cloud_cpp_pubsub_mocks_hdrs)
-foreach (fname ${google_cloud_cpp_pubsub_mocks_hdrs})
-    list(APPEND cmake_google_cloud_cpp_pubsub_mocks_hdrs
-         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${fname}>")
-endforeach ()
-target_sources(google_cloud_cpp_pubsub_mocks
-               INTERFACE ${cmake_google_cloud_cpp_pubsub_mocks_hdrs})
-target_link_libraries(
-    google_cloud_cpp_pubsub_mocks
-    INTERFACE google-cloud-cpp::pubsub GTest::gmock_main GTest::gmock
-              GTest::gtest)
-set_target_properties(google_cloud_cpp_pubsub_mocks
-                      PROPERTIES EXPORT_NAME google-cloud-cpp::pubsub_mocks)
-target_include_directories(
-    google_cloud_cpp_pubsub_mocks
-    INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-              $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
-              $<INSTALL_INTERFACE:include>)
-set_target_properties(google_cloud_cpp_pubsub_mocks
-                      PROPERTIES EXPORT_NAME "google-cloud-cpp::pubsub_mocks")
-target_compile_options(google_cloud_cpp_pubsub_mocks
-                       INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
-add_library(google-cloud-cpp::pubsub_mocks ALIAS google_cloud_cpp_pubsub_mocks)
+# Get the destination directories based on the GNU recommendations.
+include(GNUInstallDirs)
+
+# Export the CMake targets to make it easy to create configuration files.
+install(
+    EXPORT pubsub-targets
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_pubsub"
+    COMPONENT google_cloud_cpp_development)
+
+# Install the libraries and headers in the locations determined by
+# GNUInstallDirs
+install(
+    TARGETS google_cloud_cpp_pubsub google_cloud_cpp_pubsub_protos
+    EXPORT pubsub-targets
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+            COMPONENT google_cloud_cpp_runtime
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            COMPONENT google_cloud_cpp_runtime
+            NAMELINK_COMPONENT google_cloud_cpp_development
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            COMPONENT google_cloud_cpp_development)
+
+google_cloud_cpp_install_headers("google_cloud_cpp_pubsub"
+                                 "include/google/cloud/pubsub")
+
+google_cloud_cpp_add_pkgconfig(
+    pubsub
+    "The Google Cloud Pub/Sub C++ Client Library"
+    "Provides C++ APIs to access Google Cloud Pub/Sub."
+    "google_cloud_cpp_grpc_utils"
+    "google_cloud_cpp_common"
+    "google_cloud_cpp_pubsub_protos"
+    "absl_str_format")
+
+# Create and install the CMake configuration files.
+include(CMakePackageConfigHelpers)
+set(GOOGLE_CLOUD_CPP_CONFIG_LIBRARY "pubsub")
+configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.cmake.in"
+               "google_cloud_cpp_pubsub-config.cmake" @ONLY)
+write_basic_package_version_file(
+    "google_cloud_cpp_pubsub-config-version.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY ExactVersion)
+
+install(
+    FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_pubsub-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_pubsub-config-version.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_pubsub"
+    COMPONENT google_cloud_cpp_development)
+
+if (GOOGLE_CLOUD_CPP_WITH_MOCKS)
+    # Create a header-only library for the mocks. We use a CMake `INTERFACE`
+    # library for these, a regular library would not work on macOS (where the
+    # library needs at least one .o file). Unfortunately INTERFACE libraries are
+    # a bit weird in that they need absolute paths for their sources.
+    add_library(google_cloud_cpp_pubsub_mocks INTERFACE)
+    set(google_cloud_cpp_pubsub_mocks_hdrs
+        # cmake-format: sort
+        admin/mocks/mock_subscription_admin_connection.h
+        admin/mocks/mock_topic_admin_connection.h
+        mocks/mock_ack_handler.h
+        mocks/mock_blocking_publisher_connection.h
+        mocks/mock_exactly_once_ack_handler.h
+        mocks/mock_publisher_connection.h
+        mocks/mock_pull_ack_handler.h
+        mocks/mock_schema_connection.h
+        mocks/mock_subscriber_connection.h
+        mocks/mock_subscription_admin_connection.h
+        mocks/mock_topic_admin_connection.h)
+    export_list_to_bazel("google_cloud_cpp_pubsub_mocks.bzl"
+                         "google_cloud_cpp_pubsub_mocks_hdrs" YEAR "2020")
+    # Add the prefix to each file name for cmake
+    set(cmake_google_cloud_cpp_pubsub_mocks_hdrs)
+    foreach (fname ${google_cloud_cpp_pubsub_mocks_hdrs})
+        list(APPEND cmake_google_cloud_cpp_pubsub_mocks_hdrs
+             "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${fname}>")
+    endforeach ()
+    target_sources(google_cloud_cpp_pubsub_mocks
+                   INTERFACE ${cmake_google_cloud_cpp_pubsub_mocks_hdrs})
+    target_link_libraries(
+        google_cloud_cpp_pubsub_mocks
+        INTERFACE google-cloud-cpp::pubsub GTest::gmock_main GTest::gmock
+                  GTest::gtest)
+    set_target_properties(google_cloud_cpp_pubsub_mocks
+                          PROPERTIES EXPORT_NAME google-cloud-cpp::pubsub_mocks)
+    target_include_directories(
+        google_cloud_cpp_pubsub_mocks
+        INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+                  $<INSTALL_INTERFACE:include>)
+    set_target_properties(
+        google_cloud_cpp_pubsub_mocks
+        PROPERTIES EXPORT_NAME "google-cloud-cpp::pubsub_mocks")
+    target_compile_options(google_cloud_cpp_pubsub_mocks
+                           INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
+    add_library(google-cloud-cpp::pubsub_mocks ALIAS
+                google_cloud_cpp_pubsub_mocks)
+
+    google_cloud_cpp_install_mocks(pubsub "Google Cloud Pub/Sub")
+endif ()
 
 # Define the tests in a function so we have a new scope for variable names.
 function (google_cloud_cpp_pubsub_client_define_tests)
@@ -485,56 +542,3 @@ if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
     set_tests_properties(pubsub_quickstart
                          PROPERTIES LABELS "integration-test;quickstart")
 endif ()
-
-# Get the destination directories based on the GNU recommendations.
-include(GNUInstallDirs)
-
-# Export the CMake targets to make it easy to create configuration files.
-install(
-    EXPORT pubsub-targets
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_pubsub"
-    COMPONENT google_cloud_cpp_development)
-
-# Install the libraries and headers in the locations determined by
-# GNUInstallDirs
-install(
-    TARGETS google_cloud_cpp_pubsub google_cloud_cpp_pubsub_protos
-    EXPORT pubsub-targets
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-            COMPONENT google_cloud_cpp_runtime
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            COMPONENT google_cloud_cpp_runtime
-            NAMELINK_COMPONENT google_cloud_cpp_development
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            COMPONENT google_cloud_cpp_development)
-
-google_cloud_cpp_install_headers("google_cloud_cpp_pubsub"
-                                 "include/google/cloud/pubsub")
-
-google_cloud_cpp_add_pkgconfig(
-    pubsub
-    "The Google Cloud Pub/Sub C++ Client Library"
-    "Provides C++ APIs to access Google Cloud Pub/Sub."
-    "google_cloud_cpp_grpc_utils"
-    "google_cloud_cpp_common"
-    "google_cloud_cpp_pubsub_protos"
-    "absl_str_format")
-
-# Create and install the CMake configuration files.
-include(CMakePackageConfigHelpers)
-set(GOOGLE_CLOUD_CPP_CONFIG_LIBRARY "pubsub")
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.cmake.in"
-               "google_cloud_cpp_pubsub-config.cmake" @ONLY)
-write_basic_package_version_file(
-    "google_cloud_cpp_pubsub-config-version.cmake"
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY ExactVersion)
-
-install(
-    FILES
-        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_pubsub-config.cmake"
-        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_pubsub-config-version.cmake"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_pubsub"
-    COMPONENT google_cloud_cpp_development)
-
-google_cloud_cpp_install_mocks(pubsub "Google Cloud Pub/Sub")

--- a/google/cloud/pubsublite/CMakeLists.txt
+++ b/google/cloud/pubsublite/CMakeLists.txt
@@ -198,37 +198,90 @@ add_library(google-cloud-cpp::experimental-pubsublite ALIAS
 include(CreateBazelConfig)
 create_bazel_config(google_cloud_cpp_pubsublite YEAR "2021")
 
-# Create a header-only library for the mocks. We use a CMake `INTERFACE` library
-# for these, a regular library would not work on macOS (where the library needs
-# at least one .o file). Unfortunately INTERFACE libraries are a bit weird in
-# that they need absolute paths for their sources.
-add_library(google_cloud_cpp_pubsublite_mocks INTERFACE)
-set(google_cloud_cpp_pubsublite_mocks_hdrs
-    # cmake-format: sort
-    mocks/mock_admin_connection.h mocks/mock_topic_stats_connection.h)
-export_list_to_bazel("google_cloud_cpp_pubsublite_mocks.bzl"
-                     google_cloud_cpp_pubsublite_mocks_hdrs YEAR "2021")
-foreach (file IN LISTS google_cloud_cpp_pubsublite_mocks_hdrs)
-    # We use a generator expression per the recommendation in:
-    # https://stackoverflow.com/a/62465051
-    list(APPEND mock_files
-         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${file}>")
-endforeach ()
-target_sources(google_cloud_cpp_pubsublite_mocks INTERFACE ${mock_files})
-target_link_libraries(
-    google_cloud_cpp_pubsublite_mocks
-    INTERFACE google-cloud-cpp::experimental-pubsublite GTest::gmock_main
-              GTest::gmock GTest::gtest)
-set_target_properties(
-    google_cloud_cpp_pubsublite_mocks
-    PROPERTIES EXPORT_NAME google-cloud-cpp::experimental-pubsublite_mocks)
-target_include_directories(
-    google_cloud_cpp_pubsublite_mocks
-    INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-              $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
-              $<INSTALL_INTERFACE:include>)
-target_compile_options(google_cloud_cpp_pubsublite_mocks
-                       INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
+# Get the destination directories based on the GNU recommendations.
+include(GNUInstallDirs)
+
+# Export the CMake targets to make it easy to create configuration files.
+install(
+    EXPORT google_cloud_cpp_pubsublite-targets
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_pubsublite"
+    COMPONENT google_cloud_cpp_development)
+
+# Install the libraries and headers in the locations determined by
+# GNUInstallDirs
+install(
+    TARGETS google_cloud_cpp_pubsublite google_cloud_cpp_pubsublite_protos
+    EXPORT google_cloud_cpp_pubsublite-targets
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+            COMPONENT google_cloud_cpp_runtime
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            COMPONENT google_cloud_cpp_runtime
+            NAMELINK_COMPONENT google_cloud_cpp_development
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            COMPONENT google_cloud_cpp_development)
+
+google_cloud_cpp_install_headers("google_cloud_cpp_pubsublite"
+                                 "include/google/cloud/pubsublite")
+
+google_cloud_cpp_add_pkgconfig(
+    pubsublite
+    "The Pub/Sub Lite API C++ Client Library"
+    "Provides C++ APIs to access Pub/Sub Lite API."
+    "google_cloud_cpp_grpc_utils"
+    "google_cloud_cpp_common"
+    "google_cloud_cpp_pubsublite_protos")
+
+# Create and install the CMake configuration files.
+include(CMakePackageConfigHelpers)
+configure_file("config.cmake.in" "google_cloud_cpp_pubsublite-config.cmake"
+               @ONLY)
+write_basic_package_version_file(
+    "google_cloud_cpp_pubsublite-config-version.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY ExactVersion)
+
+install(
+    FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_pubsublite-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_pubsublite-config-version.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_pubsublite"
+    COMPONENT google_cloud_cpp_development)
+
+if (GOOGLE_CLOUD_CPP_WITH_MOCKS)
+    # Create a header-only library for the mocks. We use a CMake `INTERFACE`
+    # library for these, a regular library would not work on macOS (where the
+    # library needs at least one .o file). Unfortunately INTERFACE libraries are
+    # a bit weird in that they need absolute paths for their sources.
+    add_library(google_cloud_cpp_pubsublite_mocks INTERFACE)
+    set(google_cloud_cpp_pubsublite_mocks_hdrs
+        # cmake-format: sort
+        mocks/mock_admin_connection.h mocks/mock_topic_stats_connection.h)
+    export_list_to_bazel("google_cloud_cpp_pubsublite_mocks.bzl"
+                         google_cloud_cpp_pubsublite_mocks_hdrs YEAR "2021")
+    foreach (file IN LISTS google_cloud_cpp_pubsublite_mocks_hdrs)
+        # We use a generator expression per the recommendation in:
+        # https://stackoverflow.com/a/62465051
+        list(APPEND mock_files
+             "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${file}>")
+    endforeach ()
+    target_sources(google_cloud_cpp_pubsublite_mocks INTERFACE ${mock_files})
+    target_link_libraries(
+        google_cloud_cpp_pubsublite_mocks
+        INTERFACE google-cloud-cpp::experimental-pubsublite GTest::gmock_main
+                  GTest::gmock GTest::gtest)
+    set_target_properties(
+        google_cloud_cpp_pubsublite_mocks
+        PROPERTIES EXPORT_NAME google-cloud-cpp::experimental-pubsublite_mocks)
+    target_include_directories(
+        google_cloud_cpp_pubsublite_mocks
+        INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+                  $<INSTALL_INTERFACE:include>)
+    target_compile_options(google_cloud_cpp_pubsublite_mocks
+                           INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
+
+    google_cloud_cpp_install_mocks(pubsublite "Pub/Sub Lite API")
+endif ()
 
 # Define the tests in a function so we have a new scope for variable names.
 function (google_cloud_cpp_pubsublite_client_define_tests)
@@ -322,54 +375,3 @@ if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     set_tests_properties(pubsublite_quickstart
                          PROPERTIES LABELS "integration-test;quickstart")
 endif ()
-
-# Get the destination directories based on the GNU recommendations.
-include(GNUInstallDirs)
-
-# Export the CMake targets to make it easy to create configuration files.
-install(
-    EXPORT google_cloud_cpp_pubsublite-targets
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_pubsublite"
-    COMPONENT google_cloud_cpp_development)
-
-# Install the libraries and headers in the locations determined by
-# GNUInstallDirs
-install(
-    TARGETS google_cloud_cpp_pubsublite google_cloud_cpp_pubsublite_protos
-    EXPORT google_cloud_cpp_pubsublite-targets
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-            COMPONENT google_cloud_cpp_runtime
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            COMPONENT google_cloud_cpp_runtime
-            NAMELINK_COMPONENT google_cloud_cpp_development
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            COMPONENT google_cloud_cpp_development)
-
-google_cloud_cpp_install_headers("google_cloud_cpp_pubsublite"
-                                 "include/google/cloud/pubsublite")
-
-google_cloud_cpp_add_pkgconfig(
-    pubsublite
-    "The Pub/Sub Lite API C++ Client Library"
-    "Provides C++ APIs to access Pub/Sub Lite API."
-    "google_cloud_cpp_grpc_utils"
-    "google_cloud_cpp_common"
-    "google_cloud_cpp_pubsublite_protos")
-
-# Create and install the CMake configuration files.
-include(CMakePackageConfigHelpers)
-configure_file("config.cmake.in" "google_cloud_cpp_pubsublite-config.cmake"
-               @ONLY)
-write_basic_package_version_file(
-    "google_cloud_cpp_pubsublite-config-version.cmake"
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY ExactVersion)
-
-install(
-    FILES
-        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_pubsublite-config.cmake"
-        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_pubsublite-config-version.cmake"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_pubsublite"
-    COMPONENT google_cloud_cpp_development)
-
-google_cloud_cpp_install_mocks(pubsublite "Pub/Sub Lite API")

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -294,43 +294,98 @@ if ("experimental-http-transcoding" IN_LIST GOOGLE_CLOUD_CPP_ENABLE)
     create_bazel_config(google_cloud_cpp_spanner_rest YEAR "2023")
 endif ()
 
-# Create a header-only library for the mocks. We use a CMake `INTERFACE` library
-# for these, a regular library would not work on macOS (where the library needs
-# at least one .o file). Unfortunately INTERFACE libraries are a bit weird in
-# that they need absolute paths for their sources.
-add_library(google_cloud_cpp_spanner_mocks INTERFACE)
-set(google_cloud_cpp_spanner_mocks_hdrs
-    # cmake-format: sort
-    admin/mocks/mock_database_admin_connection.h
-    admin/mocks/mock_instance_admin_connection.h
-    mocks/mock_database_admin_connection.h
-    mocks/mock_instance_admin_connection.h
-    mocks/mock_spanner_connection.h
-    mocks/row.h)
-export_list_to_bazel("google_cloud_cpp_spanner_mocks.bzl"
-                     google_cloud_cpp_spanner_mocks_hdrs YEAR "2019")
-foreach (file IN LISTS google_cloud_cpp_spanner_mocks_hdrs)
-    # We use a generator expression per the recommendation in:
-    # https://stackoverflow.com/a/62465051
-    list(APPEND mock_files
-         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${file}>")
-endforeach ()
-target_sources(google_cloud_cpp_spanner_mocks INTERFACE ${mock_files})
-target_link_libraries(
-    google_cloud_cpp_spanner_mocks
-    INTERFACE google-cloud-cpp::spanner GTest::gmock_main GTest::gmock
-              GTest::gtest)
-set_target_properties(google_cloud_cpp_spanner_mocks
-                      PROPERTIES EXPORT_NAME google-cloud-cpp::spanner_mocks)
-target_include_directories(
-    google_cloud_cpp_spanner_mocks
-    INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-              $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
-              $<INSTALL_INTERFACE:include>)
-target_compile_options(google_cloud_cpp_spanner_mocks
-                       INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
-add_library(google-cloud-cpp::spanner_mocks ALIAS
-            google_cloud_cpp_spanner_mocks)
+# Export the CMake targets to make it easy to create configuration files.
+install(
+    EXPORT spanner-targets
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_spanner"
+    COMPONENT google_cloud_cpp_development)
+
+# Install the libraries and headers in the locations determined by
+# GNUInstallDirs
+install(
+    TARGETS google_cloud_cpp_spanner google_cloud_cpp_spanner_protos
+    EXPORT spanner-targets
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+            COMPONENT google_cloud_cpp_runtime
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            COMPONENT google_cloud_cpp_runtime
+            NAMELINK_COMPONENT google_cloud_cpp_development
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            COMPONENT google_cloud_cpp_development)
+
+google_cloud_cpp_install_headers("google_cloud_cpp_spanner"
+                                 "include/google/cloud/spanner")
+
+google_cloud_cpp_add_pkgconfig(
+    spanner
+    "The Google Cloud Spanner C++ Client Library"
+    "Provides C++ APIs to access Google Cloud Spanner."
+    "google_cloud_cpp_grpc_utils"
+    "google_cloud_cpp_common"
+    "google_cloud_cpp_spanner_protos"
+    "absl_numeric"
+    "absl_strings"
+    "absl_time")
+
+# Create and install the CMake configuration files.
+include(CMakePackageConfigHelpers)
+set(GOOGLE_CLOUD_CPP_CONFIG_LIBRARY "spanner")
+configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.cmake.in"
+               "google_cloud_cpp_spanner-config.cmake" @ONLY)
+write_basic_package_version_file(
+    "google_cloud_cpp_spanner-config-version.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY ExactVersion)
+
+install(
+    FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_spanner-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_spanner-config-version.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_spanner"
+    COMPONENT google_cloud_cpp_development)
+
+if (GOOGLE_CLOUD_CPP_WITH_MOCKS)
+    # Create a header-only library for the mocks. We use a CMake `INTERFACE`
+    # library for these, a regular library would not work on macOS (where the
+    # library needs at least one .o file). Unfortunately INTERFACE libraries are
+    # a bit weird in that they need absolute paths for their sources.
+    add_library(google_cloud_cpp_spanner_mocks INTERFACE)
+    set(google_cloud_cpp_spanner_mocks_hdrs
+        # cmake-format: sort
+        admin/mocks/mock_database_admin_connection.h
+        admin/mocks/mock_instance_admin_connection.h
+        mocks/mock_database_admin_connection.h
+        mocks/mock_instance_admin_connection.h
+        mocks/mock_spanner_connection.h
+        mocks/row.h)
+    export_list_to_bazel("google_cloud_cpp_spanner_mocks.bzl"
+                         google_cloud_cpp_spanner_mocks_hdrs YEAR "2019")
+    foreach (file IN LISTS google_cloud_cpp_spanner_mocks_hdrs)
+        # We use a generator expression per the recommendation in:
+        # https://stackoverflow.com/a/62465051
+        list(APPEND mock_files
+             "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${file}>")
+    endforeach ()
+    target_sources(google_cloud_cpp_spanner_mocks INTERFACE ${mock_files})
+    target_link_libraries(
+        google_cloud_cpp_spanner_mocks
+        INTERFACE google-cloud-cpp::spanner GTest::gmock_main GTest::gmock
+                  GTest::gtest)
+    set_target_properties(
+        google_cloud_cpp_spanner_mocks
+        PROPERTIES EXPORT_NAME google-cloud-cpp::spanner_mocks)
+    target_include_directories(
+        google_cloud_cpp_spanner_mocks
+        INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+                  $<INSTALL_INTERFACE:include>)
+    target_compile_options(google_cloud_cpp_spanner_mocks
+                           INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
+    add_library(google-cloud-cpp::spanner_mocks ALIAS
+                google_cloud_cpp_spanner_mocks)
+
+    google_cloud_cpp_install_mocks(spanner "Google Cloud Spanner")
+endif ()
 
 # Define the tests in a function so we have a new scope for variable names.
 function (spanner_client_define_tests)
@@ -525,55 +580,3 @@ if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
     set_tests_properties(spanner_quickstart
                          PROPERTIES LABELS "integration-test;quickstart")
 endif ()
-
-# Export the CMake targets to make it easy to create configuration files.
-install(
-    EXPORT spanner-targets
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_spanner"
-    COMPONENT google_cloud_cpp_development)
-
-# Install the libraries and headers in the locations determined by
-# GNUInstallDirs
-install(
-    TARGETS google_cloud_cpp_spanner google_cloud_cpp_spanner_protos
-    EXPORT spanner-targets
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-            COMPONENT google_cloud_cpp_runtime
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            COMPONENT google_cloud_cpp_runtime
-            NAMELINK_COMPONENT google_cloud_cpp_development
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            COMPONENT google_cloud_cpp_development)
-
-google_cloud_cpp_install_headers("google_cloud_cpp_spanner"
-                                 "include/google/cloud/spanner")
-
-google_cloud_cpp_add_pkgconfig(
-    spanner
-    "The Google Cloud Spanner C++ Client Library"
-    "Provides C++ APIs to access Google Cloud Spanner."
-    "google_cloud_cpp_grpc_utils"
-    "google_cloud_cpp_common"
-    "google_cloud_cpp_spanner_protos"
-    "absl_numeric"
-    "absl_strings"
-    "absl_time")
-
-# Create and install the CMake configuration files.
-include(CMakePackageConfigHelpers)
-set(GOOGLE_CLOUD_CPP_CONFIG_LIBRARY "spanner")
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.cmake.in"
-               "google_cloud_cpp_spanner-config.cmake" @ONLY)
-write_basic_package_version_file(
-    "google_cloud_cpp_spanner-config-version.cmake"
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY ExactVersion)
-
-install(
-    FILES
-        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_spanner-config.cmake"
-        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_spanner-config-version.cmake"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_spanner"
-    COMPONENT google_cloud_cpp_development)
-
-google_cloud_cpp_install_mocks(spanner "Google Cloud Spanner")

--- a/google/cloud/sql/CMakeLists.txt
+++ b/google/cloud/sql/CMakeLists.txt
@@ -81,50 +81,6 @@ target_compile_options(google_cloud_cpp_sql
 
 add_library(google-cloud-cpp::sql ALIAS google_cloud_cpp_sql)
 
-# Create a header-only library for the mocks. We use a CMake `INTERFACE` library
-# for these, a regular library would not work on macOS (where the library needs
-# at least one .o file). Unfortunately INTERFACE libraries are a bit weird in
-# that they need absolute paths for their sources.
-file(
-    GLOB relative_mock_files
-    RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
-    ${mocks_globs})
-list(SORT relative_mock_files)
-set(mock_files)
-foreach (file IN LISTS relative_mock_files)
-    # We use a generator expression per the recommendation in:
-    # https://stackoverflow.com/a/62465051
-    list(APPEND mock_files
-         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${file}>")
-endforeach ()
-add_library(google_cloud_cpp_sql_mocks INTERFACE)
-target_sources(google_cloud_cpp_sql_mocks INTERFACE ${mock_files})
-target_link_libraries(
-    google_cloud_cpp_sql_mocks
-    INTERFACE google-cloud-cpp::sql GTest::gmock_main GTest::gmock GTest::gtest)
-set_target_properties(google_cloud_cpp_sql_mocks
-                      PROPERTIES EXPORT_NAME google-cloud-cpp::sql_mocks)
-target_include_directories(
-    google_cloud_cpp_sql_mocks
-    INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-              $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
-              $<INSTALL_INTERFACE:include>)
-target_compile_options(google_cloud_cpp_sql_mocks
-                       INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
-
-if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
-    add_executable(sql_quickstart "quickstart/quickstart.cc")
-    target_link_libraries(sql_quickstart PRIVATE google-cloud-cpp::sql)
-    google_cloud_cpp_add_common_options(sql_quickstart)
-    add_test(
-        NAME sql_quickstart
-        COMMAND cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
-                $<TARGET_FILE:sql_quickstart> GOOGLE_CLOUD_PROJECT)
-    set_tests_properties(sql_quickstart
-                         PROPERTIES LABELS "integration-test;quickstart")
-    add_subdirectory(integration_tests)
-endif ()
-
 # Get the destination directories based on the GNU recommendations.
 include(GNUInstallDirs)
 
@@ -180,7 +136,54 @@ install(
 
 external_googleapis_install_pc("google_cloud_cpp_sql_protos")
 
-google_cloud_cpp_install_mocks(sql "Cloud SQL Admin API")
+if (GOOGLE_CLOUD_CPP_WITH_MOCKS)
+    # Create a header-only library for the mocks. We use a CMake `INTERFACE`
+    # library for these, a regular library would not work on macOS (where the
+    # library needs at least one .o file). Unfortunately INTERFACE libraries are
+    # a bit weird in that they need absolute paths for their sources.
+    file(
+        GLOB relative_mock_files
+        RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
+        ${mocks_globs})
+    list(SORT relative_mock_files)
+    set(mock_files)
+    foreach (file IN LISTS relative_mock_files)
+        # We use a generator expression per the recommendation in:
+        # https://stackoverflow.com/a/62465051
+        list(APPEND mock_files
+             "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${file}>")
+    endforeach ()
+    add_library(google_cloud_cpp_sql_mocks INTERFACE)
+    target_sources(google_cloud_cpp_sql_mocks INTERFACE ${mock_files})
+    target_link_libraries(
+        google_cloud_cpp_sql_mocks
+        INTERFACE google-cloud-cpp::sql GTest::gmock_main GTest::gmock
+                  GTest::gtest)
+    set_target_properties(google_cloud_cpp_sql_mocks
+                          PROPERTIES EXPORT_NAME google-cloud-cpp::sql_mocks)
+    target_include_directories(
+        google_cloud_cpp_sql_mocks
+        INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+                  $<INSTALL_INTERFACE:include>)
+    target_compile_options(google_cloud_cpp_sql_mocks
+                           INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
+
+    google_cloud_cpp_install_mocks(sql "Cloud SQL Admin API")
+endif ()
+
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
+    add_executable(sql_quickstart "quickstart/quickstart.cc")
+    target_link_libraries(sql_quickstart PRIVATE google-cloud-cpp::sql)
+    google_cloud_cpp_add_common_options(sql_quickstart)
+    add_test(
+        NAME sql_quickstart
+        COMMAND cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+                $<TARGET_FILE:sql_quickstart> GOOGLE_CLOUD_PROJECT)
+    set_tests_properties(sql_quickstart
+                         PROPERTIES LABELS "integration-test;quickstart")
+    add_subdirectory(integration_tests)
+endif ()
 
 # google-cloud-cpp::sql must be defined before we can add the samples.
 foreach (dir IN LISTS service_dirs)

--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
@@ -247,41 +247,43 @@ add_library(google-cloud-cpp::experimental-storage_grpc_mocks ALIAS
             google_cloud_cpp_storage_grpc_mocks)
 
 install(
-    EXPORT storage_grpc_mocks-targets
-    DESTINATION
-        "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_storage_grpc_mocks"
-    COMPONENT google_cloud_cpp_development)
-
-install(
-    TARGETS google_cloud_cpp_storage_grpc_mocks
-    EXPORT storage_grpc_mocks-targets
-    COMPONENT google_cloud_cpp_development)
-
-install(
     FILES ${google_cloud_cpp_storage_grpc_mocks_hdrs}
     DESTINATION "include/google/cloud/storage/mocks"
     COMPONENT google_cloud_cpp_development)
 
-google_cloud_cpp_add_pkgconfig(
-    storage_grpc_mocks "Google Cloud Storage (gRPC) Mocks"
-    "Mocks for the Google Cloud Storage (gRPC) C++ Client Library"
-    "google_cloud_cpp_storage" " gmock_main")
+if (GOOGLE_CLOUD_CPP_WITH_MOCKS)
+    install(
+        EXPORT storage_grpc_mocks-targets
+        DESTINATION
+            "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_storage_grpc_mocks"
+        COMPONENT google_cloud_cpp_development)
 
-# Create and install the CMake configuration files.
-configure_file("mocks-config.cmake.in"
-               "google_cloud_cpp_storage_grpc_mocks-config.cmake" @ONLY)
-write_basic_package_version_file(
-    "google_cloud_cpp_storage_grpc_mocks-config-version.cmake"
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY ExactVersion)
+    install(
+        TARGETS google_cloud_cpp_storage_grpc_mocks
+        EXPORT storage_grpc_mocks-targets
+        COMPONENT google_cloud_cpp_development)
 
-install(
-    FILES
-        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_storage_grpc_mocks-config.cmake"
-        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_storage_grpc_mocks-config-version.cmake"
-    DESTINATION
-        "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_storage_grpc_mocks"
-    COMPONENT google_cloud_cpp_development)
+    google_cloud_cpp_add_pkgconfig(
+        storage_grpc_mocks "Google Cloud Storage (gRPC) Mocks"
+        "Mocks for the Google Cloud Storage (gRPC) C++ Client Library"
+        "google_cloud_cpp_storage" " gmock_main")
+
+    # Create and install the CMake configuration files.
+    configure_file("mocks-config.cmake.in"
+                   "google_cloud_cpp_storage_grpc_mocks-config.cmake" @ONLY)
+    write_basic_package_version_file(
+        "google_cloud_cpp_storage_grpc_mocks-config-version.cmake"
+        VERSION ${PROJECT_VERSION}
+        COMPATIBILITY ExactVersion)
+
+    install(
+        FILES
+            "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_storage_grpc_mocks-config.cmake"
+            "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_storage_grpc_mocks-config-version.cmake"
+        DESTINATION
+            "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_storage_grpc_mocks"
+        COMPONENT google_cloud_cpp_development)
+endif ()
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
     # This is a bit weird, we add an additional link library to

--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
@@ -219,39 +219,42 @@ install(
 google_cloud_cpp_install_headers(google_cloud_cpp_storage_grpc
                                  include/google/cloud/storage)
 
-# Create a header-only library for the mocks. We use a CMake `INTERFACE` library
-# for these, a regular library would not work on macOS (where the library needs
-# at least one .o file). Unfortunately INTERFACE libraries are a bit weird in
-# that they need absolute paths for their sources.
-add_library(google_cloud_cpp_storage_grpc_mocks INTERFACE)
-set(google_cloud_cpp_storage_grpc_mocks_hdrs
-    # cmake-format: sort
-    mocks/mock_async_connection.h mocks/mock_async_reader_connection.h
-    mocks/mock_async_rewriter_connection.h mocks/mock_async_writer_connection.h)
-export_list_to_bazel("google_cloud_cpp_storage_grpc_mocks.bzl"
-                     "google_cloud_cpp_storage_grpc_mocks_hdrs" YEAR "2023")
-target_link_libraries(
-    google_cloud_cpp_storage_grpc_mocks
-    INTERFACE google-cloud-cpp::experimental-storage_grpc GTest::gmock)
-set_target_properties(
-    google_cloud_cpp_storage_grpc_mocks
-    PROPERTIES EXPORT_NAME "google-cloud-cpp::experimental-storage_grpc_mocks")
-target_include_directories(
-    google_cloud_cpp_storage_grpc_mocks
-    INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-              $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
-              $<INSTALL_INTERFACE:include>)
-target_compile_options(google_cloud_cpp_storage_grpc_mocks
-                       INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
-add_library(google-cloud-cpp::experimental-storage_grpc_mocks ALIAS
-            google_cloud_cpp_storage_grpc_mocks)
-
-install(
-    FILES ${google_cloud_cpp_storage_grpc_mocks_hdrs}
-    DESTINATION "include/google/cloud/storage/mocks"
-    COMPONENT google_cloud_cpp_development)
-
 if (GOOGLE_CLOUD_CPP_WITH_MOCKS)
+    # Create a header-only library for the mocks. We use a CMake `INTERFACE`
+    # library for these, a regular library would not work on macOS (where the
+    # library needs at least one .o file). Unfortunately INTERFACE libraries are
+    # a bit weird in that they need absolute paths for their sources.
+    add_library(google_cloud_cpp_storage_grpc_mocks INTERFACE)
+    set(google_cloud_cpp_storage_grpc_mocks_hdrs
+        # cmake-format: sort
+        mocks/mock_async_connection.h
+        mocks/mock_async_reader_connection.h
+        mocks/mock_async_rewriter_connection.h
+        mocks/mock_async_writer_connection.h)
+    export_list_to_bazel("google_cloud_cpp_storage_grpc_mocks.bzl"
+                         "google_cloud_cpp_storage_grpc_mocks_hdrs" YEAR "2023")
+    target_link_libraries(
+        google_cloud_cpp_storage_grpc_mocks
+        INTERFACE google-cloud-cpp::experimental-storage_grpc GTest::gmock)
+    set_target_properties(
+        google_cloud_cpp_storage_grpc_mocks
+        PROPERTIES EXPORT_NAME
+                   "google-cloud-cpp::experimental-storage_grpc_mocks")
+    target_include_directories(
+        google_cloud_cpp_storage_grpc_mocks
+        INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+                  $<INSTALL_INTERFACE:include>)
+    target_compile_options(google_cloud_cpp_storage_grpc_mocks
+                           INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
+    add_library(google-cloud-cpp::experimental-storage_grpc_mocks ALIAS
+                google_cloud_cpp_storage_grpc_mocks)
+
+    install(
+        FILES ${google_cloud_cpp_storage_grpc_mocks_hdrs}
+        DESTINATION "include/google/cloud/storage/mocks"
+        COMPONENT google_cloud_cpp_development)
+
     install(
         EXPORT storage_grpc_mocks-targets
         DESTINATION


### PR DESCRIPTION
Motivated by #13621 

Consumers of `google-cloud-cpp` who want to test their code can use this flag to install mocks, without needing to build all of our unit tests, internal testing infrastructure.

# Background

We create mocking libraries (which are all header only) and install them by default (even when `BUILD_TESTING=OFF`). For many months, we only did this in Pub/Sub and GCS+gRPC, but in the latest release, we started installing mocks for all GAPICs. (And in this release, for all libraries except compute).

These libraries link to GoogleTest, which can be hard to find. This can break some (atypical?) builds. (See the linked issue, which uses `FetchContent()`.

# Things to Scrutinize

- The option controls whether or not we install the mock libraries. It could control whether or not we define mock targets at all. Or whether we install headers.
  - naming follow up: it could be called `GOOGLE_CLOUD_CPP_INSTALL_MOCKS`.
- We are not exercising the option set to OFF in our CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13673)
<!-- Reviewable:end -->
