### PR TITLE
ci(securitycenter): re-enable on macOS

### DIFF
--- a/google/cloud/securitycenter/BUILD.bazel
+++ b/google/cloud/securitycenter/BUILD.bazel
@@ -49,10 +49,9 @@ cc_library(
     name = "google_cloud_cpp_securitycenter",
     srcs = [":srcs"],
     hdrs = [":hdrs"],
-    # Cannot compile on macOS or Windows - the protos have enum values that
+    # Cannot compile on Windows - the protos have enum values that
     # conflict with some system macros.
     target_compatible_with = select({
-        "@platforms//os:macos": ["@platforms//:incompatible"],
         "@platforms//os:windows": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
@@ -67,10 +66,9 @@ cc_library(
 cc_library(
     name = "google_cloud_cpp_securitycenter_mocks",
     hdrs = [":mocks"],
-    # Cannot compile on macOS or Windows - the protos have enum values that
+    # Cannot compile on Windows - the protos have enum values that
     # conflict with some system macros.
     target_compatible_with = select({
-        "@platforms//os:macos": ["@platforms//:incompatible"],
         "@platforms//os:windows": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),

--- a/google/cloud/securitycenter/CMakeLists.txt
+++ b/google/cloud/securitycenter/CMakeLists.txt
@@ -14,9 +14,9 @@
 # limitations under the License.
 # ~~~
 
-if (APPLE OR WIN32)
+if (WIN32)
     message(
-        WARNING "Cannot build google/cloud/securitycenter on macOS or Windows"
+        WARNING "Cannot build google/cloud/securitycenter on Windows"
                 " - the protos have enum names that conflict with some system"
                 " macros.")
     return()


### PR DESCRIPTION
All indications are that there were actually no macro/enum name conflicts on macOS, so limit the exclusions to Windows (where "SERVICE_STOP" is the current culprit).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13674)
<!-- Reviewable:end -->
