### PR TITLE
cleanup(generator): async rpcs use explicit options

### DIFF
--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_auth_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_auth_decorator.cc
@@ -243,34 +243,38 @@ GoldenThingAdminAuth::AsyncLongRunningWithoutRouting(
       });
 }
 
-future<StatusOr<google::test::admin::database::v1::Database>> GoldenThingAdminAuth::AsyncGetDatabase(
+future<StatusOr<google::test::admin::database::v1::Database>>
+GoldenThingAdminAuth::AsyncGetDatabase(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::admin::database::v1::GetDatabaseRequest const& request) {
-  using ReturnType = StatusOr<google::test::admin::database::v1::Database>;
-  auto& child = child_;
   return auth_->AsyncConfigureContext(std::move(context)).then(
-      [cq, child, request](
+      [cq, child = child_, options = std::move(options), request](
           future<StatusOr<std::shared_ptr<grpc::ClientContext>>> f) mutable {
         auto context = f.get();
         if (!context) {
-          return make_ready_future(ReturnType(std::move(context).status()));
+          return make_ready_future(StatusOr<google::test::admin::database::v1::Database>(
+              std::move(context).status()));
         }
-        return child->AsyncGetDatabase(cq, *std::move(context), request);
+        return child->AsyncGetDatabase(
+            cq, *std::move(context), std::move(options), request);
       });
 }
 
-future<Status> GoldenThingAdminAuth::AsyncDropDatabase(
+future<Status>
+GoldenThingAdminAuth::AsyncDropDatabase(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::admin::database::v1::DropDatabaseRequest const& request) {
-  auto& child = child_;
   return auth_->AsyncConfigureContext(std::move(context)).then(
-      [cq, child, request](
+      [cq, child = child_, options = std::move(options), request](
           future<StatusOr<std::shared_ptr<grpc::ClientContext>>> f) mutable {
         auto context = f.get();
         if (!context) return make_ready_future(std::move(context).status());
-        return child->AsyncDropDatabase(cq, *std::move(context), request);
+        return child->AsyncDropDatabase(
+            cq, *std::move(context), std::move(options), request);
       });
 }
 

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_auth_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_auth_decorator.h
@@ -137,11 +137,13 @@ class GoldenThingAdminAuth : public GoldenThingAdminStub {
   future<StatusOr<google::test::admin::database::v1::Database>> AsyncGetDatabase(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::admin::database::v1::GetDatabaseRequest const& request) override;
 
   future<Status> AsyncDropDatabase(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::admin::database::v1::DropDatabaseRequest const& request) override;
 
   future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_connection_impl.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_connection_impl.cc
@@ -469,15 +469,18 @@ GoldenThingAdminConnectionImpl::AsyncGetDatabase(google::test::admin::database::
   auto request_copy = request;
   auto const idempotent =
       idempotency_policy(*current)->GetDatabase(request_copy);
+  auto retry = retry_policy(*current);
+  auto backoff = backoff_policy(*current);
   return google::cloud::internal::AsyncRetryLoop(
-      retry_policy(*current), backoff_policy(*current), idempotent,
-      background_->cq(),
+      std::move(retry), std::move(backoff), idempotent, background_->cq(),
       [stub = stub_](CompletionQueue& cq,
                      std::shared_ptr<grpc::ClientContext> context,
+                     google::cloud::internal::ImmutableOptions options,
                      google::test::admin::database::v1::GetDatabaseRequest const& request) {
-        return stub->AsyncGetDatabase(cq, std::move(context), request);
+        return stub->AsyncGetDatabase(
+            cq, std::move(context), std::move(options), request);
       },
-      std::move(request_copy), __func__);
+      std::move(current), std::move(request_copy), __func__);
 }
 
 future<Status>
@@ -486,15 +489,18 @@ GoldenThingAdminConnectionImpl::AsyncDropDatabase(google::test::admin::database:
   auto request_copy = request;
   auto const idempotent =
       idempotency_policy(*current)->DropDatabase(request_copy);
+  auto retry = retry_policy(*current);
+  auto backoff = backoff_policy(*current);
   return google::cloud::internal::AsyncRetryLoop(
-      retry_policy(*current), backoff_policy(*current), idempotent,
-      background_->cq(),
+      std::move(retry), std::move(backoff), idempotent, background_->cq(),
       [stub = stub_](CompletionQueue& cq,
                      std::shared_ptr<grpc::ClientContext> context,
+                     google::cloud::internal::ImmutableOptions options,
                      google::test::admin::database::v1::DropDatabaseRequest const& request) {
-        return stub->AsyncDropDatabase(cq, std::move(context), request);
+        return stub->AsyncDropDatabase(
+            cq, std::move(context), std::move(options), request);
       },
-      std::move(request_copy), __func__);
+      std::move(current), std::move(request_copy), __func__);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_logging_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_logging_decorator.cc
@@ -311,28 +311,34 @@ future<StatusOr<google::test::admin::database::v1::Database>>
 GoldenThingAdminLogging::AsyncGetDatabase(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::admin::database::v1::GetDatabaseRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](google::cloud::CompletionQueue& cq,
              std::shared_ptr<grpc::ClientContext> context,
+             google::cloud::internal::ImmutableOptions options,
              google::test::admin::database::v1::GetDatabaseRequest const& request) {
-        return child_->AsyncGetDatabase(cq, std::move(context), request);
+        return child_->AsyncGetDatabase(
+            cq, std::move(context), std::move(options), request);
       },
-      cq, std::move(context), request, __func__, tracing_options_);
+      cq, std::move(context), std::move(options), request, __func__, tracing_options_);
 }
 
 future<Status>
 GoldenThingAdminLogging::AsyncDropDatabase(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::admin::database::v1::DropDatabaseRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](google::cloud::CompletionQueue& cq,
              std::shared_ptr<grpc::ClientContext> context,
+             google::cloud::internal::ImmutableOptions options,
              google::test::admin::database::v1::DropDatabaseRequest const& request) {
-        return child_->AsyncDropDatabase(cq, std::move(context), request);
+        return child_->AsyncDropDatabase(
+            cq, std::move(context), std::move(options), request);
       },
-      cq, std::move(context), request, __func__, tracing_options_);
+      cq, std::move(context), std::move(options), request, __func__, tracing_options_);
 }
 
 future<StatusOr<google::longrunning::Operation>>

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_logging_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_logging_decorator.h
@@ -137,11 +137,13 @@ class GoldenThingAdminLogging : public GoldenThingAdminStub {
   future<StatusOr<google::test::admin::database::v1::Database>> AsyncGetDatabase(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::admin::database::v1::GetDatabaseRequest const& request) override;
 
   future<Status> AsyncDropDatabase(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::admin::database::v1::DropDatabaseRequest const& request) override;
 
   future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_metadata_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_metadata_decorator.cc
@@ -258,18 +258,21 @@ GoldenThingAdminMetadata::AsyncLongRunningWithoutRouting(
 
 future<StatusOr<google::test::admin::database::v1::Database>>
 GoldenThingAdminMetadata::AsyncGetDatabase(
-    google::cloud::CompletionQueue& cq,
-    std::shared_ptr<grpc::ClientContext> context,
-    google::test::admin::database::v1::GetDatabaseRequest const& request) {
-  SetMetadata(*context, internal::CurrentOptions(), absl::StrCat("name=", internal::UrlEncode(request.name())));
-  return child_->AsyncGetDatabase(cq, std::move(context), request);
+      google::cloud::CompletionQueue& cq,
+      std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
+      google::test::admin::database::v1::GetDatabaseRequest const& request) {
+  SetMetadata(*context, *options, absl::StrCat("name=", internal::UrlEncode(request.name())));
+  return child_->AsyncGetDatabase(
+      cq, std::move(context), std::move(options), request);
 }
 
 future<Status>
 GoldenThingAdminMetadata::AsyncDropDatabase(
-    google::cloud::CompletionQueue& cq,
-    std::shared_ptr<grpc::ClientContext> context,
-    google::test::admin::database::v1::DropDatabaseRequest const& request) {
+      google::cloud::CompletionQueue& cq,
+      std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
+      google::test::admin::database::v1::DropDatabaseRequest const& request) {
   std::vector<std::string> params;
   params.reserve(3);
 
@@ -307,11 +310,12 @@ GoldenThingAdminMetadata::AsyncDropDatabase(
   database_matcher->AppendParam(request, params);
 
   if (params.empty()) {
-    SetMetadata(*context, internal::CurrentOptions());
+    SetMetadata(*context, *options);
   } else {
-    SetMetadata(*context, internal::CurrentOptions(), absl::StrJoin(params, "&"));
+    SetMetadata(*context, *options, absl::StrJoin(params, "&"));
   }
-  return child_->AsyncDropDatabase(cq, std::move(context), request);
+  return child_->AsyncDropDatabase(
+      cq, std::move(context), std::move(options), request);
 }
 
 future<StatusOr<google::longrunning::Operation>>

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_metadata_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_metadata_decorator.h
@@ -138,11 +138,13 @@ class GoldenThingAdminMetadata : public GoldenThingAdminStub {
   future<StatusOr<google::test::admin::database::v1::Database>> AsyncGetDatabase(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::admin::database::v1::GetDatabaseRequest const& request) override;
 
   future<Status> AsyncDropDatabase(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::admin::database::v1::DropDatabaseRequest const& request) override;
 
   future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_connection_impl.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_connection_impl.cc
@@ -407,37 +407,37 @@ GoldenThingAdminRestConnectionImpl::ListBackupOperations(google::test::admin::da
 future<StatusOr<google::test::admin::database::v1::Database>>
 GoldenThingAdminRestConnectionImpl::AsyncGetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request) {
   auto current = google::cloud::internal::SaveCurrentOptions();
+  auto retry = retry_policy(*current);
+  auto backoff = backoff_policy(*current);
+  auto const idempotent = idempotency_policy(*current)->GetDatabase(request);
   return rest_internal::AsyncRestRetryLoop(
-      retry_policy(*current), backoff_policy(*current),
-      idempotency_policy(*current)->GetDatabase(request),
-      background_->cq(),
+      std::move(retry), std::move(backoff), idempotent, background_->cq(),
       [stub = stub_](CompletionQueue& cq,
                      std::unique_ptr<rest_internal::RestContext> context,
-                     // NOLINTNEXTLINE(performance-unnecessary-value-param)
                      google::cloud::internal::ImmutableOptions options,
                      google::test::admin::database::v1::GetDatabaseRequest const& request) {
         return stub->AsyncGetDatabase(
-            cq, std::move(context), *options, request);
+            cq, std::move(context), std::move(options), request);
       },
-      current, request, __func__);
+      std::move(current), request, __func__);
 }
 
 future<Status>
 GoldenThingAdminRestConnectionImpl::AsyncDropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request) {
   auto current = google::cloud::internal::SaveCurrentOptions();
+  auto retry = retry_policy(*current);
+  auto backoff = backoff_policy(*current);
+  auto const idempotent = idempotency_policy(*current)->DropDatabase(request);
   return rest_internal::AsyncRestRetryLoop(
-      retry_policy(*current), backoff_policy(*current),
-      idempotency_policy(*current)->DropDatabase(request),
-      background_->cq(),
+      std::move(retry), std::move(backoff), idempotent, background_->cq(),
       [stub = stub_](CompletionQueue& cq,
                      std::unique_ptr<rest_internal::RestContext> context,
-                     // NOLINTNEXTLINE(performance-unnecessary-value-param)
                      google::cloud::internal::ImmutableOptions options,
                      google::test::admin::database::v1::DropDatabaseRequest const& request) {
         return stub->AsyncDropDatabase(
-            cq, std::move(context), *options, request);
+            cq, std::move(context), std::move(options), request);
       },
-      current, request, __func__);
+      std::move(current), request, __func__);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_logging_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_logging_decorator.cc
@@ -292,31 +292,36 @@ future<StatusOr<google::test::admin::database::v1::Database>>
 GoldenThingAdminRestLogging::AsyncGetDatabase(
     google::cloud::CompletionQueue& cq,
     std::unique_ptr<rest_internal::RestContext> rest_context,
-    Options const& options,
+    google::cloud::internal::ImmutableOptions options,
     google::test::admin::database::v1::GetDatabaseRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](CompletionQueue& cq,
              std::unique_ptr<rest_internal::RestContext> rest_context,
-             Options const& options, google::test::admin::database::v1::GetDatabaseRequest const& request) {
-        return child_->AsyncGetDatabase(cq, std::move(rest_context), options, request);
+             google::cloud::internal::ImmutableOptions options,
+             google::test::admin::database::v1::GetDatabaseRequest const& request) {
+        return child_->AsyncGetDatabase(
+            cq, std::move(rest_context), std::move(options), request);
       },
-      cq, std::move(rest_context), options, request, __func__, tracing_options_);
+      cq, std::move(rest_context), std::move(options), request, __func__,
+      tracing_options_);
 }
 
 future<Status>
 GoldenThingAdminRestLogging::AsyncDropDatabase(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<rest_internal::RestContext> rest_context,
-      Options const& options,
+      google::cloud::internal::ImmutableOptions options,
       google::test::admin::database::v1::DropDatabaseRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](CompletionQueue& cq,
              std::unique_ptr<rest_internal::RestContext> rest_context,
-             Options const& options,
+             google::cloud::internal::ImmutableOptions options,
              google::test::admin::database::v1::DropDatabaseRequest const& request) {
-        return child_->AsyncDropDatabase(cq, std::move(rest_context), options, request);
+        return child_->AsyncDropDatabase(
+            cq, std::move(rest_context), std::move(options), request);
       },
-      cq, std::move(rest_context), options, request, __func__, tracing_options_);
+      cq, std::move(rest_context), std::move(options), request, __func__,
+      tracing_options_);
 }
 
 future<StatusOr<google::longrunning::Operation>>

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_logging_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_logging_decorator.h
@@ -121,12 +121,14 @@ class GoldenThingAdminRestLogging : public GoldenThingAdminRestStub {
   future<StatusOr<google::test::admin::database::v1::Database>> AsyncGetDatabase(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
-      Options const& options, google::test::admin::database::v1::GetDatabaseRequest const& request) override;
+      google::cloud::internal::ImmutableOptions options,
+      google::test::admin::database::v1::GetDatabaseRequest const& request) override;
 
   future<Status> AsyncDropDatabase(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
-      Options const& options, google::test::admin::database::v1::DropDatabaseRequest const& request) override;
+      google::cloud::internal::ImmutableOptions options,
+      google::test::admin::database::v1::DropDatabaseRequest const& request) override;
 
   future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
       google::cloud::CompletionQueue& cq,

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_metadata_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_metadata_decorator.cc
@@ -229,17 +229,20 @@ GoldenThingAdminRestMetadata::ListBackupOperations(
 future<StatusOr<google::test::admin::database::v1::Database>>
 GoldenThingAdminRestMetadata::AsyncGetDatabase(
     google::cloud::CompletionQueue& cq,
-      std::unique_ptr<rest_internal::RestContext> rest_context,
-    Options const& options, google::test::admin::database::v1::GetDatabaseRequest const& request) {
-  SetMetadata(*rest_context, options);
-  return child_->AsyncGetDatabase(cq, std::move(rest_context), options, request);
+    std::unique_ptr<rest_internal::RestContext> rest_context,
+    google::cloud::internal::ImmutableOptions options,
+    google::test::admin::database::v1::GetDatabaseRequest const& request) {
+  SetMetadata(*rest_context, *options);
+  return child_->AsyncGetDatabase(
+      cq, std::move(rest_context), std::move(options), request);
 }
 
 future<Status>
 GoldenThingAdminRestMetadata::AsyncDropDatabase(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<rest_internal::RestContext> rest_context,
-    Options const& options, google::test::admin::database::v1::DropDatabaseRequest const& request) {
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<rest_internal::RestContext> rest_context,
+    google::cloud::internal::ImmutableOptions options,
+    google::test::admin::database::v1::DropDatabaseRequest const& request) {
   std::vector<std::string> params;
   params.reserve(3);
 
@@ -276,9 +279,10 @@ GoldenThingAdminRestMetadata::AsyncDropDatabase(
   }();
   database_matcher->AppendParam(request, params);
 
-  SetMetadata(*rest_context, options, params);
+  SetMetadata(*rest_context, *options, params);
 
-  return child_->AsyncDropDatabase(cq, std::move(rest_context), options, request);
+  return child_->AsyncDropDatabase(
+      cq, std::move(rest_context), std::move(options), request);
 }
 
 future<StatusOr<google::longrunning::Operation>>

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_metadata_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_metadata_decorator.h
@@ -119,12 +119,14 @@ class GoldenThingAdminRestMetadata : public GoldenThingAdminRestStub {
   google::cloud::future<StatusOr<google::test::admin::database::v1::Database>> AsyncGetDatabase(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
-      Options const& options, google::test::admin::database::v1::GetDatabaseRequest const& request) override;
+      google::cloud::internal::ImmutableOptions options,
+      google::test::admin::database::v1::GetDatabaseRequest const& request) override;
 
   google::cloud::future<Status> AsyncDropDatabase(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
-      Options const& options, google::test::admin::database::v1::DropDatabaseRequest const& request) override;
+      google::cloud::internal::ImmutableOptions options,
+      google::test::admin::database::v1::DropDatabaseRequest const& request) override;
 
   google::cloud::future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
       google::cloud::CompletionQueue& cq,

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_stub.cc
@@ -66,13 +66,16 @@ DefaultGoldenThingAdminRestStub::AsyncCreateDatabase(
       google::test::admin::database::v1::CreateDatabaseRequest const& request) {
   promise<StatusOr<google::longrunning::Operation>> p;
   future<StatusOr<google::longrunning::Operation>> f = p.get_future();
-  std::thread t{[](auto p, auto service, auto request, auto rest_context, auto options) {
+  std::thread t{[](
+          auto p, auto service, auto request, auto rest_context, auto options) {
       p.set_value(rest_internal::Post<google::longrunning::Operation>(
           *service, *rest_context, request,
           false,
           absl::StrCat("/", rest_internal::DetermineApiVersion("v1", *options), "/", request.parent(), "/", "databases"),
       rest_internal::TrimEmptyQueryParameters({std::make_pair("create_statement", request.create_statement())})));
-  }, std::move(p), service_, request, std::move(rest_context), std::move(options)};
+    },
+    std::move(p), service_, request, std::move(rest_context),
+    std::move(options)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {
       t.join();
@@ -99,13 +102,16 @@ DefaultGoldenThingAdminRestStub::AsyncUpdateDatabaseDdl(
       google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) {
   promise<StatusOr<google::longrunning::Operation>> p;
   future<StatusOr<google::longrunning::Operation>> f = p.get_future();
-  std::thread t{[](auto p, auto service, auto request, auto rest_context, auto options) {
+  std::thread t{[](
+          auto p, auto service, auto request, auto rest_context, auto options) {
       p.set_value(rest_internal::Patch<google::longrunning::Operation>(
           *service, *rest_context, request,
           false,
           absl::StrCat("/", rest_internal::DetermineApiVersion("v1", *options), "/", request.database(), "/", "ddl"),
       rest_internal::TrimEmptyQueryParameters({std::make_pair("operation_id", request.operation_id())})));
-  }, std::move(p), service_, request, std::move(rest_context), std::move(options)};
+    },
+    std::move(p), service_, request, std::move(rest_context),
+    std::move(options)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {
       t.join();
@@ -171,13 +177,16 @@ DefaultGoldenThingAdminRestStub::AsyncCreateBackup(
       google::test::admin::database::v1::CreateBackupRequest const& request) {
   promise<StatusOr<google::longrunning::Operation>> p;
   future<StatusOr<google::longrunning::Operation>> f = p.get_future();
-  std::thread t{[](auto p, auto service, auto request, auto rest_context, auto options) {
+  std::thread t{[](
+          auto p, auto service, auto request, auto rest_context, auto options) {
       p.set_value(rest_internal::Post<google::longrunning::Operation>(
           *service, *rest_context, request.backup(),
           false,
           absl::StrCat("/", rest_internal::DetermineApiVersion("v1", *options), "/", request.parent(), "/", "backups"),
       rest_internal::TrimEmptyQueryParameters({std::make_pair("backup_id", request.backup_id())})));
-  }, std::move(p), service_, request, std::move(rest_context), std::move(options)};
+    },
+    std::move(p), service_, request, std::move(rest_context),
+    std::move(options)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {
       t.join();
@@ -236,14 +245,17 @@ DefaultGoldenThingAdminRestStub::AsyncRestoreDatabase(
       google::test::admin::database::v1::RestoreDatabaseRequest const& request) {
   promise<StatusOr<google::longrunning::Operation>> p;
   future<StatusOr<google::longrunning::Operation>> f = p.get_future();
-  std::thread t{[](auto p, auto service, auto request, auto rest_context, auto options) {
+  std::thread t{[](
+          auto p, auto service, auto request, auto rest_context, auto options) {
       p.set_value(rest_internal::Post<google::longrunning::Operation>(
           *service, *rest_context, request,
           false,
           absl::StrCat("/", rest_internal::DetermineApiVersion("v1", *options), "/", request.parent(), "/", "databases", ":restore"),
       rest_internal::TrimEmptyQueryParameters({std::make_pair("database_id", request.database_id()),
         std::make_pair("backup", request.backup())})));
-  }, std::move(p), service_, request, std::move(rest_context), std::move(options)};
+    },
+    std::move(p), service_, request, std::move(rest_context),
+    std::move(options)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {
       t.join();
@@ -282,14 +294,18 @@ future<StatusOr<google::test::admin::database::v1::Database>>
 DefaultGoldenThingAdminRestStub::AsyncGetDatabase(
     google::cloud::CompletionQueue& cq,
     std::unique_ptr<rest_internal::RestContext> rest_context,
-    Options const& options, google::test::admin::database::v1::GetDatabaseRequest const& request) {
+    google::cloud::internal::ImmutableOptions options,
+    google::test::admin::database::v1::GetDatabaseRequest const& request) {
   promise<StatusOr<google::test::admin::database::v1::Database>> p;
   future<StatusOr<google::test::admin::database::v1::Database>> f = p.get_future();
-  std::thread t{[](auto p, auto service, auto request, auto rest_context, auto options) {
+  std::thread t{[](
+          auto p, auto service, auto request, auto rest_context, auto options) {
       p.set_value(rest_internal::Get<google::test::admin::database::v1::Database>(
           *service, *rest_context, request, false,
-          absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/", request.name())));
-  }, std::move(p), service_, request, std::move(rest_context), options};
+          absl::StrCat("/", rest_internal::DetermineApiVersion("v1", *options), "/", request.name())));
+    },
+    std::move(p), service_, request, std::move(rest_context),
+    std::move(options)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {
       t.join();
@@ -302,14 +318,18 @@ future<Status>
 DefaultGoldenThingAdminRestStub::AsyncDropDatabase(
     google::cloud::CompletionQueue& cq,
     std::unique_ptr<rest_internal::RestContext> rest_context,
-    Options const& options, google::test::admin::database::v1::DropDatabaseRequest const& request) {
+    google::cloud::internal::ImmutableOptions options,
+    google::test::admin::database::v1::DropDatabaseRequest const& request) {
   promise<StatusOr<google::protobuf::Empty>> p;
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
-  std::thread t{[](auto p, auto service, auto request, auto rest_context, auto options) {
+  std::thread t{[](
+          auto p, auto service, auto request, auto rest_context, auto options) {
       p.set_value(rest_internal::Delete<google::protobuf::Empty>(
           *service, *rest_context, request, false,
-          absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/", request.database())));
-  }, std::move(p), service_, request, std::move(rest_context), options};
+          absl::StrCat("/", rest_internal::DetermineApiVersion("v1", *options), "/", request.database())));
+    },
+    std::move(p), service_, request, std::move(rest_context),
+    std::move(options)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {
       t.join();

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_stub.h
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_stub.h
@@ -117,12 +117,14 @@ class GoldenThingAdminRestStub {
   virtual future<StatusOr<google::test::admin::database::v1::Database>> AsyncGetDatabase(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
-      Options const& options, google::test::admin::database::v1::GetDatabaseRequest const& request) = 0;
+      google::cloud::internal::ImmutableOptions options,
+      google::test::admin::database::v1::GetDatabaseRequest const& request) = 0;
 
   virtual future<Status> AsyncDropDatabase(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
-      Options const& options, google::test::admin::database::v1::DropDatabaseRequest const& request) = 0;
+      google::cloud::internal::ImmutableOptions options,
+      google::test::admin::database::v1::DropDatabaseRequest const& request) = 0;
 
   virtual future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
       google::cloud::CompletionQueue& cq,
@@ -226,12 +228,14 @@ class DefaultGoldenThingAdminRestStub : public GoldenThingAdminRestStub {
   future<StatusOr<google::test::admin::database::v1::Database>> AsyncGetDatabase(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
-      Options const& options, google::test::admin::database::v1::GetDatabaseRequest const& request) override;
+      google::cloud::internal::ImmutableOptions options,
+      google::test::admin::database::v1::GetDatabaseRequest const& request) override;
 
   future<Status> AsyncDropDatabase(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
-      Options const& options, google::test::admin::database::v1::DropDatabaseRequest const& request) override;
+      google::cloud::internal::ImmutableOptions options,
+      google::test::admin::database::v1::DropDatabaseRequest const& request) override;
 
   future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
       google::cloud::CompletionQueue& cq,

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_round_robin_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_round_robin_decorator.cc
@@ -172,16 +172,20 @@ future<StatusOr<google::test::admin::database::v1::Database>>
 GoldenThingAdminRoundRobin::AsyncGetDatabase(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::test::admin::database::v1::GetDatabaseRequest const& request) {
-  return Child()->AsyncGetDatabase(cq, std::move(context), request);
+  return Child()->AsyncGetDatabase(
+      cq, std::move(context), std::move(options), request);
 }
 
 future<Status>
 GoldenThingAdminRoundRobin::AsyncDropDatabase(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::test::admin::database::v1::DropDatabaseRequest const& request) {
-  return Child()->AsyncDropDatabase(cq, std::move(context), request);
+  return Child()->AsyncDropDatabase(
+      cq, std::move(context), std::move(options), request);
 }
 
 future<StatusOr<google::longrunning::Operation>>

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_round_robin_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_round_robin_decorator.h
@@ -134,11 +134,13 @@ class GoldenThingAdminRoundRobin : public GoldenThingAdminStub {
   future<StatusOr<google::test::admin::database::v1::Database>> AsyncGetDatabase(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::admin::database::v1::GetDatabaseRequest const& request) override;
 
   future<Status> AsyncDropDatabase(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::admin::database::v1::DropDatabaseRequest const& request) override;
 
   future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_stub.cc
@@ -289,6 +289,8 @@ future<StatusOr<google::test::admin::database::v1::Database>>
 DefaultGoldenThingAdminStub::AsyncGetDatabase(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    google::cloud::internal::ImmutableOptions,
     google::test::admin::database::v1::GetDatabaseRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::test::admin::database::v1::GetDatabaseRequest,
                                     google::test::admin::database::v1::Database>(
@@ -305,6 +307,8 @@ future<Status>
 DefaultGoldenThingAdminStub::AsyncDropDatabase(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    google::cloud::internal::ImmutableOptions,
     google::test::admin::database::v1::DropDatabaseRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::test::admin::database::v1::DropDatabaseRequest,
                                     google::protobuf::Empty>(
@@ -315,15 +319,16 @@ DefaultGoldenThingAdminStub::AsyncDropDatabase(
         return grpc_stub_->AsyncDropDatabase(context, request, cq);
       },
       request, std::move(context))
-      .then([](future<StatusOr<google::protobuf::Empty>> f) {
-        return f.get().status();
-      });
+          .then([](future<StatusOr<google::protobuf::Empty>> f) {
+            return f.get().status();
+          });
 }
 
 future<StatusOr<google::longrunning::Operation>>
 DefaultGoldenThingAdminStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -340,6 +345,7 @@ DefaultGoldenThingAdminStub::AsyncGetOperation(
 future<Status> DefaultGoldenThingAdminStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_stub.h
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_stub.h
@@ -138,12 +138,14 @@ class GoldenThingAdminStub {
   AsyncGetDatabase(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::test::admin::database::v1::GetDatabaseRequest const& request) = 0;
 
   virtual future<Status>
   AsyncDropDatabase(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::test::admin::database::v1::DropDatabaseRequest const& request) = 0;
 
   virtual future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
@@ -265,11 +267,13 @@ class DefaultGoldenThingAdminStub : public GoldenThingAdminStub {
   future<StatusOr<google::test::admin::database::v1::Database>> AsyncGetDatabase(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::admin::database::v1::GetDatabaseRequest const& request) override;
 
   future<Status> AsyncDropDatabase(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::admin::database::v1::DropDatabaseRequest const& request) override;
 
   future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_tracing_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_tracing_stub.cc
@@ -239,25 +239,29 @@ GoldenThingAdminTracingStub::AsyncLongRunningWithoutRouting(
   return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 
-future<StatusOr<google::test::admin::database::v1::Database>> GoldenThingAdminTracingStub::AsyncGetDatabase(
+future<StatusOr<google::test::admin::database::v1::Database>>
+GoldenThingAdminTracingStub::AsyncGetDatabase(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::admin::database::v1::GetDatabaseRequest const& request) {
   auto span = internal::MakeSpanGrpc("google.test.admin.database.v1.GoldenThingAdmin", "GetDatabase");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto f = child_->AsyncGetDatabase(cq, context, request);
+  auto f = child_->AsyncGetDatabase(cq, context, std::move(options), request);
   return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 
-future<Status> GoldenThingAdminTracingStub::AsyncDropDatabase(
+future<Status>
+GoldenThingAdminTracingStub::AsyncDropDatabase(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::admin::database::v1::DropDatabaseRequest const& request) {
   auto span = internal::MakeSpanGrpc("google.test.admin.database.v1.GoldenThingAdmin", "DropDatabase");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto f = child_->AsyncDropDatabase(cq, context, request);
+  auto f = child_->AsyncDropDatabase(cq, context, std::move(options), request);
   return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_tracing_stub.h
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_tracing_stub.h
@@ -135,11 +135,13 @@ class GoldenThingAdminTracingStub : public GoldenThingAdminStub {
   future<StatusOr<google::test::admin::database::v1::Database>> AsyncGetDatabase(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::admin::database::v1::GetDatabaseRequest const& request) override;
 
   future<Status> AsyncDropDatabase(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::admin::database::v1::DropDatabaseRequest const& request) override;
 
   future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(

--- a/generator/integration_tests/golden/v1/internal/request_id_auth_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/request_id_auth_decorator.cc
@@ -68,20 +68,22 @@ StatusOr<google::test::requestid::v1::ListFoosResponse> RequestIdServiceAuth::Li
   return child_->ListFoos(context, options, request);
 }
 
-future<StatusOr<google::test::requestid::v1::Foo>> RequestIdServiceAuth::AsyncCreateFoo(
+future<StatusOr<google::test::requestid::v1::Foo>>
+RequestIdServiceAuth::AsyncCreateFoo(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::requestid::v1::CreateFooRequest const& request) {
-  using ReturnType = StatusOr<google::test::requestid::v1::Foo>;
-  auto& child = child_;
   return auth_->AsyncConfigureContext(std::move(context)).then(
-      [cq, child, request](
+      [cq, child = child_, options = std::move(options), request](
           future<StatusOr<std::shared_ptr<grpc::ClientContext>>> f) mutable {
         auto context = f.get();
         if (!context) {
-          return make_ready_future(ReturnType(std::move(context).status()));
+          return make_ready_future(StatusOr<google::test::requestid::v1::Foo>(
+              std::move(context).status()));
         }
-        return child->AsyncCreateFoo(cq, *std::move(context), request);
+        return child->AsyncCreateFoo(
+            cq, *std::move(context), std::move(options), request);
       });
 }
 

--- a/generator/integration_tests/golden/v1/internal/request_id_auth_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/request_id_auth_decorator.h
@@ -58,6 +58,7 @@ class RequestIdServiceAuth : public RequestIdServiceStub {
   future<StatusOr<google::test::requestid::v1::Foo>> AsyncCreateFoo(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::requestid::v1::CreateFooRequest const& request) override;
 
   future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(

--- a/generator/integration_tests/golden/v1/internal/request_id_connection_impl.cc
+++ b/generator/integration_tests/golden/v1/internal/request_id_connection_impl.cc
@@ -155,15 +155,18 @@ RequestIdServiceConnectionImpl::AsyncCreateFoo(google::test::requestid::v1::Crea
   }
   auto const idempotent =
       idempotency_policy(*current)->CreateFoo(request_copy);
+  auto retry = retry_policy(*current);
+  auto backoff = backoff_policy(*current);
   return google::cloud::internal::AsyncRetryLoop(
-      retry_policy(*current), backoff_policy(*current), idempotent,
-      background_->cq(),
+      std::move(retry), std::move(backoff), idempotent, background_->cq(),
       [stub = stub_](CompletionQueue& cq,
                      std::shared_ptr<grpc::ClientContext> context,
+                     google::cloud::internal::ImmutableOptions options,
                      google::test::requestid::v1::CreateFooRequest const& request) {
-        return stub->AsyncCreateFoo(cq, std::move(context), request);
+        return stub->AsyncCreateFoo(
+            cq, std::move(context), std::move(options), request);
       },
-      std::move(request_copy), __func__);
+      std::move(current), std::move(request_copy), __func__);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/integration_tests/golden/v1/internal/request_id_logging_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/request_id_logging_decorator.cc
@@ -85,14 +85,17 @@ future<StatusOr<google::test::requestid::v1::Foo>>
 RequestIdServiceLogging::AsyncCreateFoo(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::requestid::v1::CreateFooRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](google::cloud::CompletionQueue& cq,
              std::shared_ptr<grpc::ClientContext> context,
+             google::cloud::internal::ImmutableOptions options,
              google::test::requestid::v1::CreateFooRequest const& request) {
-        return child_->AsyncCreateFoo(cq, std::move(context), request);
+        return child_->AsyncCreateFoo(
+            cq, std::move(context), std::move(options), request);
       },
-      cq, std::move(context), request, __func__, tracing_options_);
+      cq, std::move(context), std::move(options), request, __func__, tracing_options_);
 }
 
 future<StatusOr<google::longrunning::Operation>>

--- a/generator/integration_tests/golden/v1/internal/request_id_logging_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/request_id_logging_decorator.h
@@ -58,6 +58,7 @@ class RequestIdServiceLogging : public RequestIdServiceStub {
   future<StatusOr<google::test::requestid::v1::Foo>> AsyncCreateFoo(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::requestid::v1::CreateFooRequest const& request) override;
 
   future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(

--- a/generator/integration_tests/golden/v1/internal/request_id_metadata_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/request_id_metadata_decorator.cc
@@ -115,9 +115,10 @@ RequestIdServiceMetadata::ListFoos(
 
 future<StatusOr<google::test::requestid::v1::Foo>>
 RequestIdServiceMetadata::AsyncCreateFoo(
-    google::cloud::CompletionQueue& cq,
-    std::shared_ptr<grpc::ClientContext> context,
-    google::test::requestid::v1::CreateFooRequest const& request) {
+      google::cloud::CompletionQueue& cq,
+      std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
+      google::test::requestid::v1::CreateFooRequest const& request) {
   std::vector<std::string> params;
   params.reserve(1);
 
@@ -126,11 +127,12 @@ RequestIdServiceMetadata::AsyncCreateFoo(
   }
 
   if (params.empty()) {
-    SetMetadata(*context, internal::CurrentOptions());
+    SetMetadata(*context, *options);
   } else {
-    SetMetadata(*context, internal::CurrentOptions(), absl::StrJoin(params, "&"));
+    SetMetadata(*context, *options, absl::StrJoin(params, "&"));
   }
-  return child_->AsyncCreateFoo(cq, std::move(context), request);
+  return child_->AsyncCreateFoo(
+      cq, std::move(context), std::move(options), request);
 }
 
 future<StatusOr<google::longrunning::Operation>>

--- a/generator/integration_tests/golden/v1/internal/request_id_metadata_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/request_id_metadata_decorator.h
@@ -59,6 +59,7 @@ class RequestIdServiceMetadata : public RequestIdServiceStub {
   future<StatusOr<google::test::requestid::v1::Foo>> AsyncCreateFoo(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::requestid::v1::CreateFooRequest const& request) override;
 
   future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(

--- a/generator/integration_tests/golden/v1/internal/request_id_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/request_id_stub.cc
@@ -78,6 +78,8 @@ future<StatusOr<google::test::requestid::v1::Foo>>
 DefaultRequestIdServiceStub::AsyncCreateFoo(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    google::cloud::internal::ImmutableOptions,
     google::test::requestid::v1::CreateFooRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::test::requestid::v1::CreateFooRequest,
                                     google::test::requestid::v1::Foo>(
@@ -94,6 +96,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultRequestIdServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -110,6 +113,7 @@ DefaultRequestIdServiceStub::AsyncGetOperation(
 future<Status> DefaultRequestIdServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/generator/integration_tests/golden/v1/internal/request_id_stub.h
+++ b/generator/integration_tests/golden/v1/internal/request_id_stub.h
@@ -58,6 +58,7 @@ class RequestIdServiceStub {
   AsyncCreateFoo(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::test::requestid::v1::CreateFooRequest const& request) = 0;
 
   virtual future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
@@ -100,6 +101,7 @@ class DefaultRequestIdServiceStub : public RequestIdServiceStub {
   future<StatusOr<google::test::requestid::v1::Foo>> AsyncCreateFoo(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::requestid::v1::CreateFooRequest const& request) override;
 
   future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(

--- a/generator/integration_tests/golden/v1/internal/request_id_tracing_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/request_id_tracing_stub.cc
@@ -66,14 +66,16 @@ StatusOr<google::test::requestid::v1::ListFoosResponse> RequestIdServiceTracingS
                            child_->ListFoos(context, options, request));
 }
 
-future<StatusOr<google::test::requestid::v1::Foo>> RequestIdServiceTracingStub::AsyncCreateFoo(
+future<StatusOr<google::test::requestid::v1::Foo>>
+RequestIdServiceTracingStub::AsyncCreateFoo(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::requestid::v1::CreateFooRequest const& request) {
   auto span = internal::MakeSpanGrpc("google.test.requestid.v1.RequestIdService", "CreateFoo");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto f = child_->AsyncCreateFoo(cq, context, request);
+  auto f = child_->AsyncCreateFoo(cq, context, std::move(options), request);
   return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 

--- a/generator/integration_tests/golden/v1/internal/request_id_tracing_stub.h
+++ b/generator/integration_tests/golden/v1/internal/request_id_tracing_stub.h
@@ -56,6 +56,7 @@ class RequestIdServiceTracingStub : public RequestIdServiceStub {
   future<StatusOr<google::test::requestid::v1::Foo>> AsyncCreateFoo(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::test::requestid::v1::CreateFooRequest const& request) override;
 
   future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(

--- a/generator/integration_tests/tests/golden_thing_admin_auth_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_auth_decorator_test.cc
@@ -349,12 +349,14 @@ TEST(GoldenThingAdminAuthDecoratorTest, AsyncGetDatabase) {
   auto under_test = GoldenThingAdminAuth(MakeTypicalAsyncMockAuth(), mock);
   google::test::admin::database::v1::GetDatabaseRequest request;
   CompletionQueue cq;
-  auto auth_failure = under_test.AsyncGetDatabase(
-      cq, std::make_shared<grpc::ClientContext>(), request);
+  auto auth_failure =
+      under_test.AsyncGetDatabase(cq, std::make_shared<grpc::ClientContext>(),
+                                  internal::MakeImmutableOptions({}), request);
   EXPECT_THAT(auth_failure.get(), StatusIs(StatusCode::kInvalidArgument));
 
-  auto auth_success = under_test.AsyncGetDatabase(
-      cq, std::make_shared<grpc::ClientContext>(), request);
+  auto auth_success =
+      under_test.AsyncGetDatabase(cq, std::make_shared<grpc::ClientContext>(),
+                                  internal::MakeImmutableOptions({}), request);
   EXPECT_THAT(auth_success.get(), StatusIs(StatusCode::kPermissionDenied));
 }
 
@@ -368,11 +370,13 @@ TEST(GoldenThingAdminAuthDecoratorTest, AsyncDropDatabase) {
   google::test::admin::database::v1::DropDatabaseRequest request;
   CompletionQueue cq;
   auto auth_failure = under_test.AsyncDropDatabase(
-      cq, std::make_shared<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(),
+      google::cloud::internal::MakeImmutableOptions({}), request);
   EXPECT_THAT(auth_failure.get(), StatusIs(StatusCode::kInvalidArgument));
 
   auto auth_success = under_test.AsyncDropDatabase(
-      cq, std::make_shared<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(),
+      google::cloud::internal::MakeImmutableOptions({}), request);
   EXPECT_THAT(auth_success.get(), StatusIs(StatusCode::kPermissionDenied));
 }
 

--- a/generator/integration_tests/tests/golden_thing_admin_connection_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_connection_test.cc
@@ -1274,7 +1274,7 @@ TEST(GoldenThingAdminConnectionTest, AsyncGetDatabaseSuccess) {
   auto mock = std::make_shared<MockGoldenThingAdminStub>();
   EXPECT_CALL(*mock, AsyncGetDatabase)
       .WillOnce(
-          [](CompletionQueue&, auto,
+          [](CompletionQueue&, auto, auto,
              ::google::test::admin::database::v1::GetDatabaseRequest const&) {
             google::test::admin::database::v1::Database db;
             db.set_name("test-database");
@@ -1296,7 +1296,7 @@ TEST(GoldenThingAdminConnectionTest, AsyncGetDatabaseTooManyFailures) {
   EXPECT_CALL(*mock, AsyncGetDatabase)
       .Times(AtLeast(2))
       .WillRepeatedly(
-          [](CompletionQueue&, auto,
+          [](CompletionQueue&, auto, auto,
              ::google::test::admin::database::v1::GetDatabaseRequest const&) {
             return make_ready_future<
                 StatusOr<google::test::admin::database::v1::Database>>(
@@ -1330,7 +1330,7 @@ TEST(GoldenThingAdminConnectionTest, AsyncGetDatabaseCancel) {
   auto mock = std::make_shared<MockGoldenThingAdminStub>();
   EXPECT_CALL(*mock, AsyncGetDatabase)
       .WillOnce(
-          [&p](CompletionQueue&, auto,
+          [&p](CompletionQueue&, auto, auto,
                ::google::test::admin::database::v1::GetDatabaseRequest const&) {
             return p.get_future();
           });
@@ -1357,7 +1357,7 @@ TEST(GoldenThingAdminConnectionTest, AsyncDropDatabaseSuccess) {
   EXPECT_CALL(*mock, AsyncDropDatabase)
       .WillOnce(
           [&expected_name](
-              CompletionQueue&, auto,
+              CompletionQueue&, auto, auto,
               ::google::test::admin::database::v1::DropDatabaseRequest const&
                   request) {
             EXPECT_EQ(expected_name, request.database());
@@ -1383,7 +1383,7 @@ TEST(GoldenThingAdminConnectionTest, AsyncDropDatabaseFailure) {
       .Times(AtLeast(2))
       .WillRepeatedly(
           [&expected_name](
-              CompletionQueue&, auto,
+              CompletionQueue&, auto, auto,
               ::google::test::admin::database::v1::DropDatabaseRequest const&
                   request) {
             EXPECT_EQ(expected_name, request.database());
@@ -1418,7 +1418,7 @@ TEST(GoldenThingAdminConnectionTest, AsyncDropDatabaseCancel) {
   EXPECT_CALL(*mock, AsyncDropDatabase)
       .WillOnce(
           [&p, &expected_name](
-              CompletionQueue&, auto,
+              CompletionQueue&, auto, auto,
               ::google::test::admin::database::v1::DropDatabaseRequest const&
                   request) {
             EXPECT_EQ(expected_name, request.database());

--- a/generator/integration_tests/tests/golden_thing_admin_logging_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_logging_decorator_test.cc
@@ -313,6 +313,7 @@ TEST_F(LoggingDecoratorTest, AsyncGetDatabase) {
   CompletionQueue cq;
   auto status = stub.AsyncGetDatabase(
                         cq, std::make_shared<grpc::ClientContext>(),
+                        internal::MakeImmutableOptions({}),
                         google::test::admin::database::v1::GetDatabaseRequest())
                     .get();
   EXPECT_EQ(TransientError(), status.status());
@@ -332,6 +333,7 @@ TEST_F(LoggingDecoratorTest, AsyncDropDatabase) {
   auto status =
       stub.AsyncDropDatabase(
               cq, std::make_shared<grpc::ClientContext>(),
+              internal::MakeImmutableOptions({}),
               google::test::admin::database::v1::DropDatabaseRequest())
           .get();
   EXPECT_EQ(TransientError(), status);

--- a/generator/integration_tests/tests/golden_thing_admin_metadata_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_metadata_decorator_test.cc
@@ -459,7 +459,7 @@ TEST_F(MetadataDecoratorTest, ListBackupOperations) {
 TEST_F(MetadataDecoratorTest, AsyncGetDatabase) {
   EXPECT_CALL(*mock_, AsyncGetDatabase)
       .WillOnce(
-          [this](google::cloud::CompletionQueue&, auto context,
+          [this](google::cloud::CompletionQueue&, auto context, auto,
                  google::test::admin::database::v1::GetDatabaseRequest const&
                      request) {
             IsContextMDValid(*context,
@@ -476,15 +476,16 @@ TEST_F(MetadataDecoratorTest, AsyncGetDatabase) {
   google::test::admin::database::v1::GetDatabaseRequest request;
   request.set_name(
       "projects/my_project/instances/my_instance/databases/my_database");
-  auto status = stub.AsyncGetDatabase(
-      cq, std::make_shared<grpc::ClientContext>(), request);
+  auto status =
+      stub.AsyncGetDatabase(cq, std::make_shared<grpc::ClientContext>(),
+                            internal::MakeImmutableOptions({}), request);
   EXPECT_EQ(TransientError(), status.get().status());
 }
 
 TEST_F(MetadataDecoratorTest, AsyncDropDatabase) {
   EXPECT_CALL(*mock_, AsyncDropDatabase)
       .WillOnce(
-          [this](google::cloud::CompletionQueue&, auto context,
+          [this](google::cloud::CompletionQueue&, auto context, auto,
                  google::test::admin::database::v1::DropDatabaseRequest const&
                      request) {
             IsContextMDValid(*context,
@@ -500,7 +501,8 @@ TEST_F(MetadataDecoratorTest, AsyncDropDatabase) {
   request.set_database(
       "projects/my_project/instances/my_instance/databases/my_database");
   auto status = stub.AsyncDropDatabase(
-      cq, std::make_shared<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(),
+      google::cloud::internal::MakeImmutableOptions({}), request);
   EXPECT_EQ(TransientError(), status.get());
 }
 

--- a/generator/integration_tests/tests/golden_thing_admin_rest_connection_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_rest_connection_test.cc
@@ -1317,7 +1317,7 @@ TEST(GoldenThingAdminConnectionTest, AsyncGetDatabaseSuccess) {
   EXPECT_CALL(*mock, AsyncGetDatabase)
       .WillOnce(
           [](CompletionQueue&, std::unique_ptr<rest_internal::RestContext>,
-             Options const&,
+             auto,
              ::google::test::admin::database::v1::GetDatabaseRequest const&) {
             google::test::admin::database::v1::Database db;
             db.set_name("test-database");
@@ -1340,7 +1340,7 @@ TEST(GoldenThingAdminConnectionTest, AsyncGetDatabaseTooManyFailures) {
       .Times(AtLeast(2))
       .WillRepeatedly(
           [](CompletionQueue&, std::unique_ptr<rest_internal::RestContext>,
-             Options const&,
+             auto,
              ::google::test::admin::database::v1::GetDatabaseRequest const&) {
             return make_ready_future<
                 StatusOr<google::test::admin::database::v1::Database>>(
@@ -1375,7 +1375,7 @@ TEST(GoldenThingAdminConnectionTest, AsyncGetDatabaseCancel) {
   EXPECT_CALL(*mock, AsyncGetDatabase)
       .WillOnce(
           [&p](CompletionQueue&, std::unique_ptr<rest_internal::RestContext>,
-               Options const&,
+               auto,
                ::google::test::admin::database::v1::GetDatabaseRequest const&) {
             return p.get_future();
           });
@@ -1406,7 +1406,7 @@ TEST(GoldenThingAdminConnectionTest, AsyncDropDatabaseSuccess) {
       .WillOnce(
           [&expected_name](
               CompletionQueue&, std::unique_ptr<rest_internal::RestContext>,
-              Options const&,
+              auto,
               ::google::test::admin::database::v1::DropDatabaseRequest const&
                   request) {
             EXPECT_EQ(expected_name, request.database());
@@ -1433,7 +1433,7 @@ TEST(GoldenThingAdminConnectionTest, AsyncDropDatabaseFailure) {
       .WillRepeatedly(
           [&expected_name](
               CompletionQueue&, std::unique_ptr<rest_internal::RestContext>,
-              Options const&,
+              auto,
               ::google::test::admin::database::v1::DropDatabaseRequest const&
                   request) {
             EXPECT_EQ(expected_name, request.database());
@@ -1473,7 +1473,7 @@ TEST(GoldenThingAdminConnectionTest, AsyncDropDatabaseCancel) {
       .WillOnce(
           [&p, &expected_name](
               CompletionQueue&, std::unique_ptr<rest_internal::RestContext>,
-              Options const&,
+              auto,
               ::google::test::admin::database::v1::DropDatabaseRequest const&
                   request) {
             EXPECT_EQ(expected_name, request.database());

--- a/generator/integration_tests/tests/golden_thing_admin_rest_stub_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_rest_stub_test.cc
@@ -758,9 +758,10 @@ TEST(GoldenThingAdminRestStubTest, AsyncGetDatabase) {
       });
   DefaultGoldenThingAdminRestStub stub(std::move(mock_service_client),
                                        std::move(mock_operations_client), {});
-  auto success = stub.AsyncGetDatabase(cq, std::move(rest_context), Options{},
-                                       proto_request)
-                     .get();
+  auto success =
+      stub.AsyncGetDatabase(cq, std::move(rest_context),
+                            internal::MakeImmutableOptions({}), proto_request)
+          .get();
   cq.Shutdown();
   t.join();
 
@@ -795,9 +796,11 @@ TEST(GoldenThingAdminRestStubTest, AsyncDropDatabase) {
       });
   DefaultGoldenThingAdminRestStub stub(std::move(mock_service_client),
                                        std::move(mock_operations_client), {});
-  auto success = stub.AsyncDropDatabase(cq, std::move(rest_context), Options{},
-                                        proto_request)
-                     .get();
+  auto success =
+      stub.AsyncDropDatabase(cq, std::move(rest_context),
+                             google::cloud::internal::MakeImmutableOptions({}),
+                             proto_request)
+          .get();
   cq.Shutdown();
   t.join();
 

--- a/generator/integration_tests/tests/golden_thing_admin_round_robin_decorator_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_round_robin_decorator_test.cc
@@ -106,6 +106,7 @@ TEST(GoldenThingAdminRoundRobinDecoratorTest, AsyncGetDatabase) {
     auto status =
         stub.AsyncGetDatabase(
                 cq, std::make_shared<grpc::ClientContext>(),
+                internal::MakeImmutableOptions({}),
                 google::test::admin::database::v1::GetDatabaseRequest{})
             .get();
     EXPECT_STATUS_OK(status);
@@ -128,6 +129,7 @@ TEST(GoldenThingAdminRoundRobinDecoratorTest, AsyncDropDatabase) {
     auto status =
         stub.AsyncDropDatabase(
                 cq, std::make_shared<grpc::ClientContext>(),
+                google::cloud::internal::MakeImmutableOptions({}),
                 google::test::admin::database::v1::DropDatabaseRequest{})
             .get();
     EXPECT_STATUS_OK(status);

--- a/generator/integration_tests/tests/golden_thing_admin_stub_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_stub_test.cc
@@ -877,7 +877,8 @@ TEST_F(GoldenStubTest, AsyncGetDatabase) {
                                    std::move(longrunning_stub_));
   google::test::admin::database::v1::GetDatabaseRequest request;
   auto failure = stub.AsyncGetDatabase(
-      cq, std::make_shared<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(),
+      google::cloud::internal::MakeImmutableOptions({}), request);
   EXPECT_THAT(failure.get(), StatusIs(StatusCode::kCancelled));
 }
 
@@ -898,7 +899,8 @@ TEST_F(GoldenStubTest, AsyncDropDatabase) {
                                    std::move(longrunning_stub_));
   google::test::admin::database::v1::DropDatabaseRequest request;
   auto failure = stub.AsyncDropDatabase(
-      cq, std::make_shared<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(),
+      google::cloud::internal::MakeImmutableOptions({}), request);
   EXPECT_THAT(failure.get(), StatusIs(StatusCode::kCancelled));
 }
 

--- a/generator/integration_tests/tests/golden_thing_admin_tracing_stub_test.cc
+++ b/generator/integration_tests/tests/golden_thing_admin_tracing_stub_test.cc
@@ -558,7 +558,7 @@ TEST(GoldenThingAdminTracingStubTest, AsyncGetDatabase) {
 
   auto mock = std::make_shared<MockGoldenThingAdminStub>();
   EXPECT_CALL(*mock, AsyncGetDatabase)
-      .WillOnce([](auto const&, auto context, auto const&) {
+      .WillOnce([](auto const&, auto context, auto, auto const&) {
         ValidatePropagator(*context);
         EXPECT_TRUE(ThereIsAnActiveSpan());
         EXPECT_TRUE(OTelContextCaptured());
@@ -571,7 +571,8 @@ TEST(GoldenThingAdminTracingStubTest, AsyncGetDatabase) {
   google::test::admin::database::v1::GetDatabaseRequest request;
   CompletionQueue cq;
   auto result = under_test.AsyncGetDatabase(
-      cq, std::make_shared<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(),
+      google::cloud::internal::MakeImmutableOptions({}), request);
   EXPECT_THAT(result.get(), StatusIs(StatusCode::kAborted));
 
   auto spans = span_catcher->GetSpans();
@@ -592,7 +593,7 @@ TEST(GoldenThingAdminTracingStubTest, AsyncDropDatabase) {
 
   auto mock = std::make_shared<MockGoldenThingAdminStub>();
   EXPECT_CALL(*mock, AsyncDropDatabase)
-      .WillOnce([](auto const&, auto context, auto const&) {
+      .WillOnce([](auto const&, auto context, auto, auto const&) {
         ValidatePropagator(*context);
         EXPECT_TRUE(ThereIsAnActiveSpan());
         EXPECT_TRUE(OTelContextCaptured());
@@ -603,7 +604,8 @@ TEST(GoldenThingAdminTracingStubTest, AsyncDropDatabase) {
   google::test::admin::database::v1::DropDatabaseRequest request;
   CompletionQueue cq;
   auto result = under_test.AsyncDropDatabase(
-      cq, std::make_shared<grpc::ClientContext>(), request);
+      cq, std::make_shared<grpc::ClientContext>(),
+      google::cloud::internal::MakeImmutableOptions({}), request);
   EXPECT_THAT(result.get(), StatusIs(StatusCode::kAborted));
 
   auto spans = span_catcher->GetSpans();

--- a/generator/integration_tests/tests/mock_golden_thing_admin_rest_stub.h
+++ b/generator/integration_tests/tests/mock_golden_thing_admin_rest_stub.h
@@ -130,7 +130,7 @@ class MockGoldenThingAdminRestStub
       AsyncGetDatabase,
       (google::cloud::CompletionQueue & cq,
        std::unique_ptr<google::cloud::rest_internal::RestContext>,
-       Options const&,
+       google::cloud::internal::ImmutableOptions,
        google::test::admin::database::v1::GetDatabaseRequest const& request),
       (override));
 
@@ -138,7 +138,7 @@ class MockGoldenThingAdminRestStub
       future<Status>, AsyncDropDatabase,
       (google::cloud::CompletionQueue & cq,
        std::unique_ptr<google::cloud::rest_internal::RestContext>,
-       Options const&,
+       google::cloud::internal::ImmutableOptions,
        google::test::admin::database::v1::DropDatabaseRequest const& request),
       (override));
 

--- a/generator/integration_tests/tests/mock_golden_thing_admin_stub.h
+++ b/generator/integration_tests/tests/mock_golden_thing_admin_stub.h
@@ -127,12 +127,14 @@ class MockGoldenThingAdminStub
               AsyncGetDatabase,
               (google::cloud::CompletionQueue&,
                std::shared_ptr<grpc::ClientContext>,
+               google::cloud::internal::ImmutableOptions,
                ::google::test::admin::database::v1::GetDatabaseRequest const&),
               (override));
 
   MOCK_METHOD(future<Status>, AsyncDropDatabase,
               (google::cloud::CompletionQueue&,
                std::shared_ptr<grpc::ClientContext>,
+               google::cloud::internal::ImmutableOptions,
                ::google::test::admin::database::v1::DropDatabaseRequest const&),
               (override));
 

--- a/generator/integration_tests/tests/request_id_connection_impl_test.cc
+++ b/generator/integration_tests/tests/request_id_connection_impl_test.cc
@@ -69,6 +69,7 @@ class MockRequestIdServiceStub
               AsyncCreateFoo,
               (google::cloud::CompletionQueue&,
                std::shared_ptr<grpc::ClientContext>,
+               google::cloud::internal::ImmutableOptions,
                google::test::requestid::v1::CreateFooRequest const&),
               (override));
 
@@ -163,7 +164,7 @@ TEST(RequestIdTest, AsyncUnaryRpc) {
 #endif  // GTEST_USES_POSIX_RE
   auto mock = std::make_shared<MockRequestIdServiceStub>();
   EXPECT_CALL(*mock,
-              AsyncCreateFoo(_, _, RequestIdIsUuidV4<CreateFooRequest>()))
+              AsyncCreateFoo(_, _, _, RequestIdIsUuidV4<CreateFooRequest>()))
       .WillOnce(
           Return(ByMove(make_ready_future(StatusOr<Foo>(TransientError())))))
       .WillOnce(Return(ByMove(make_ready_future(make_status_or(Foo{})))));
@@ -178,8 +179,8 @@ TEST(RequestIdTest, AsyncUnaryRpc) {
 TEST(RequestIdTest, AsyncUnaryRpcExplicit) {
   auto mock = std::make_shared<MockRequestIdServiceStub>();
   EXPECT_CALL(
-      *mock,
-      AsyncCreateFoo(_, _, WithRequestId<CreateFooRequest>("test-request-id")))
+      *mock, AsyncCreateFoo(_, _, _,
+                            WithRequestId<CreateFooRequest>("test-request-id")))
       .WillOnce(
           Return(ByMove(make_ready_future(StatusOr<Foo>(TransientError())))))
       .WillOnce(Return(ByMove(make_ready_future(make_status_or(Foo{})))));

--- a/generator/internal/connection_impl_rest_generator.cc
+++ b/generator/internal/connection_impl_rest_generator.cc
@@ -423,19 +423,19 @@ future<StatusOr<$response_type$>>)""",
                       R"""(
 $connection_impl_rest_class_name$::Async$method_name$($request_type$ const& request) {
   auto current = google::cloud::internal::SaveCurrentOptions();
+  auto retry = retry_policy(*current);
+  auto backoff = backoff_policy(*current);
+  auto const idempotent = idempotency_policy(*current)->$method_name$(request);
   return rest_internal::AsyncRestRetryLoop(
-      retry_policy(*current), backoff_policy(*current),
-      idempotency_policy(*current)->$method_name$(request),
-      background_->cq(),
+      std::move(retry), std::move(backoff), idempotent, background_->cq(),
       [stub = stub_](CompletionQueue& cq,
                      std::unique_ptr<rest_internal::RestContext> context,
-                     // NOLINTNEXTLINE(performance-unnecessary-value-param)
                      google::cloud::internal::ImmutableOptions options,
                      $request_type$ const& request) {
         return stub->Async$method_name$(
-            cq, std::move(context), *options, request);
+            cq, std::move(context), std::move(options), request);
       },
-      current, request, __func__);
+      std::move(current), request, __func__);
 }
 )""");
 }

--- a/generator/internal/http_option_utils.cc
+++ b/generator/internal/http_option_utils.cc
@@ -65,23 +65,25 @@ struct RestPathVisitor {
   void operator()(PathTemplate::Match const&) { ; }
   void operator()(PathTemplate::MatchRecursive const&) { ; }
   void operator()(std::string const& s) {
-    path.emplace_back([piece = s, api = api_version](
-                          google::protobuf::MethodDescriptor const& method) {
-      if (piece != api) return absl::StrFormat("\"%s\"", piece);
-      if (IsLongrunningOperation(method)) {
-        return absl::StrFormat(
-            "rest_internal::DetermineApiVersion(\"%s\", *options)", api);
-      }
-      return absl::StrFormat(
-          "rest_internal::DetermineApiVersion(\"%s\", options)", api);
-    });
+    path.emplace_back(
+        [piece = s, api = api_version](
+            google::protobuf::MethodDescriptor const& method, bool is_async) {
+          if (piece != api) return absl::StrFormat("\"%s\"", piece);
+          if (IsLongrunningOperation(method) || is_async) {
+            return absl::StrFormat(
+                "rest_internal::DetermineApiVersion(\"%s\", *options)", api);
+          }
+          return absl::StrFormat(
+              "rest_internal::DetermineApiVersion(\"%s\", options)", api);
+        });
   }
   void operator()(PathTemplate::Variable const& v) {
-    path.emplace_back([piece = v.field_path](
-                          google::protobuf::MethodDescriptor const& method) {
-      return absl::StrFormat("request.%s()",
-                             FormatFieldAccessorCall(method, piece));
-    });
+    path.emplace_back(
+        [piece = v.field_path](google::protobuf::MethodDescriptor const& method,
+                               bool) {
+          return absl::StrFormat("request.%s()",
+                                 FormatFieldAccessorCall(method, piece));
+        });
   }
   void operator()(PathTemplate::Segment const& s) {
     RestPathVisitorHelper(api_version, s, path);
@@ -130,16 +132,23 @@ void SetHttpDerivedMethodVars(
       method_vars["method_request_body"] = info.body;
       method_vars["method_http_verb"] = info.http_verb;
       // method_rest_path is only used for REST transport.
+      auto trailer = [&info] {
+        if (info.rest_path_verb.empty()) return std::string(")");
+        return absl::StrFormat(R"""(, ":%s"))""", info.rest_path_verb);
+      };
+      auto path_expression = [&info, method = &method](bool is_async) {
+        return absl::StrCat(
+            ", ", absl::StrJoin(info.rest_path, R"""(, "/", )""",
+                                [method, is_async](
+                                    std::string* out,
+                                    HttpExtensionInfo::RestPathPiece const& p) {
+                                  out->append(p(*method, is_async));
+                                }));
+      };
       method_vars["method_rest_path"] = absl::StrCat(
-          "absl::StrCat(\"/\", ",
-          absl::StrJoin(
-              info.rest_path, ", \"/\", ",
-              [&](std::string* out, HttpExtensionInfo::RestPathPiece const& p) {
-                out->append(p(method));
-              }),
-          info.rest_path_verb.empty()
-              ? ")"
-              : absl::StrFormat(", \":%s\")", info.rest_path_verb));
+          R"""(absl::StrCat("/")""", path_expression(false), trailer());
+      method_vars["method_rest_path_async"] = absl::StrCat(
+          R"""(absl::StrCat("/")""", path_expression(true), trailer());
     }
 
     // This visitor handles the case where no request field is specified in the
@@ -150,16 +159,21 @@ void SetHttpDerivedMethodVars(
       method_vars["method_request_params"] = method.full_name();
       if (absl::StrContains(info.url_path, info.api_version)) {
         std::string needle = absl::StrFormat("/%s/", info.api_version);
-        auto start = info.url_path.find(needle);
-        method_vars["method_rest_path"] = absl::StrCat(
-            "absl::StrCat(\"", info.url_path.substr(0, start), "/\", ",
-            absl::StrFormat(
-                R"""(rest_internal::DetermineApiVersion("%s", %s), "/)""",
-                info.api_version,
-                IsLongrunningOperation(method) ? "*options" : "options"),
-            info.url_path.substr(start + needle.length()), "\")");
+        auto url_path = absl::string_view(info.url_path);
+        auto start = url_path.find(needle);
+        auto pre_needle = url_path.substr(0, start);
+        auto pos_needle = url_path.substr(start + needle.length());
+
+        method_vars["method_rest_path"] = absl::StrFormat(
+            R"""(absl::StrCat("%s/", rest_internal::DetermineApiVersion("%s", options), "/%s"))""",
+            pre_needle, info.api_version, pos_needle);
+        method_vars["method_rest_path_async"] = absl::StrFormat(
+            R"""(absl::StrCat("%s/", rest_internal::DetermineApiVersion("%s", *options), "/%s"))""",
+            pre_needle, info.api_version, pos_needle);
       } else {
         method_vars["method_rest_path"] =
+            absl::StrCat("\"", info.url_path, "\"");
+        method_vars["method_rest_path_async"] =
             absl::StrCat("\"", info.url_path, "\"");
       }
     }
@@ -172,6 +186,7 @@ void SetHttpDerivedMethodVars(
       method_vars["method_http_verb"] = method.full_name();
       method_vars["method_request_param_value"] = method.full_name();
       method_vars["method_rest_path"] = method.full_name();
+      method_vars["method_rest_path_async"] = method.full_name();
     }
     google::protobuf::MethodDescriptor const& method;
     VarsDictionary& method_vars;

--- a/generator/internal/http_option_utils.h
+++ b/generator/internal/http_option_utils.h
@@ -33,8 +33,8 @@ struct HttpSimpleInfo {
 };
 
 struct HttpExtensionInfo {
-  using RestPathPiece =
-      std::function<std::string(google::protobuf::MethodDescriptor const&)>;
+  using RestPathPiece = std::function<std::string(
+      google::protobuf::MethodDescriptor const&, bool)>;
   std::string http_verb;
   std::string url_path;
   std::vector<std::pair<std::string, std::string>> field_substitutions;

--- a/generator/internal/http_option_utils_test.cc
+++ b/generator/internal/http_option_utils_test.cc
@@ -455,6 +455,9 @@ TEST_F(HttpOptionUtilsTest, SetHttpDerivedMethodVarsSimpleInfo) {
   EXPECT_THAT(
       vars.at("method_rest_path"),
       Eq(R"""(absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/simple"))"""));
+  EXPECT_THAT(
+      vars.at("method_rest_path_async"),
+      Eq(R"""(absl::StrCat("/", rest_internal::DetermineApiVersion("v1", *options), "/simple"))"""));
 }
 
 TEST_F(HttpOptionUtilsTest, SetHttpDerivedMethodVarsExtensionInfoSingleParam) {
@@ -471,6 +474,9 @@ TEST_F(HttpOptionUtilsTest, SetHttpDerivedMethodVarsExtensionInfoSingleParam) {
   EXPECT_THAT(
       vars.at("method_rest_path"),
       Eq(R"""(absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/", request.parent(), "/", "databases"))"""));
+  EXPECT_THAT(
+      vars.at("method_rest_path_async"),
+      Eq(R"""(absl::StrCat("/", rest_internal::DetermineApiVersion("v1", *options), "/", request.parent(), "/", "databases"))"""));
 }
 
 TEST_F(HttpOptionUtilsTest,
@@ -490,6 +496,9 @@ TEST_F(HttpOptionUtilsTest,
   EXPECT_THAT(
       vars.at("method_rest_path"),
       Eq(R"""(absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/", "projects", "/", request.project(), "/", "instances", "/", request.instance(), "/", "databases"))"""));
+  EXPECT_THAT(
+      vars.at("method_rest_path_async"),
+      Eq(R"""(absl::StrCat("/", rest_internal::DetermineApiVersion("v1", *options), "/", "projects", "/", request.project(), "/", "instances", "/", request.instance(), "/", "databases"))"""));
 }
 
 TEST_F(HttpOptionUtilsTest,
@@ -505,6 +514,9 @@ TEST_F(HttpOptionUtilsTest,
   EXPECT_THAT(
       vars.at("method_rest_path"),
       Eq(R"""(absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/", "projects", "/", request.project(), "/", "instances", "/", request.instance(), "/", "databases"))"""));
+  EXPECT_THAT(
+      vars.at("method_rest_path_async"),
+      Eq(R"""(absl::StrCat("/", rest_internal::DetermineApiVersion("v1", *options), "/", "projects", "/", request.project(), "/", "instances", "/", request.instance(), "/", "databases"))"""));
 }
 
 TEST_F(HttpOptionUtilsTest, SetHttpQueryParametersNoParams) {

--- a/generator/internal/metadata_decorator_rest_generator.cc
+++ b/generator/internal/metadata_decorator_rest_generator.cc
@@ -165,21 +165,24 @@ class $metadata_rest_class_name$ : public $stub_rest_class_name$ {
   }
 
   for (auto const& method : async_methods()) {
-    if (IsStreaming(method)) continue;
+    // No streaming RPCs for REST, and Longrunning is already taken care of.
+    if (IsStreaming(method) || IsLongrunningOperation(method)) continue;
     if (!HasHttpAnnotation(method)) continue;
     if (IsResponseTypeEmpty(method)) {
       HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
   google::cloud::future<Status> Async$method_name$(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
-      Options const& options, $request_type$ const& request) override;
+      google::cloud::internal::ImmutableOptions options,
+      $request_type$ const& request) override;
 )""");
     } else {
       HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
   google::cloud::future<StatusOr<$response_type$>> Async$method_name$(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
-      Options const& options, $request_type$ const& request) override;
+      google::cloud::internal::ImmutableOptions options,
+      $request_type$ const& request) override;
 )""");
     }
   }
@@ -305,20 +308,23 @@ $metadata_rest_class_name$::$method_name$(
   }
 
   for (auto const& method : async_methods()) {
-    if (IsStreaming(method)) continue;
+    // No streaming RPCs for REST, and Longrunning is already taken care of.
+    if (IsStreaming(method) || IsLongrunningOperation(method)) continue;
     if (!HasHttpAnnotation(method)) continue;
     if (IsResponseTypeEmpty(method)) {
       CcPrintMethod(method, __FILE__, __LINE__, R"""(
 future<Status>
 $metadata_rest_class_name$::Async$method_name$(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<rest_internal::RestContext> rest_context,
-    Options const& options, $request_type$ const& request) {
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<rest_internal::RestContext> rest_context,
+    google::cloud::internal::ImmutableOptions options,
+    $request_type$ const& request) {
 )""");
       CcPrintMethod(method, __FILE__, __LINE__,
-                    SetMetadataText(method, kPointer, "options"));
+                    SetMetadataText(method, kPointer, "*options"));
       CcPrintMethod(method, __FILE__, __LINE__, R"""(
-  return child_->Async$method_name$(cq, std::move(rest_context), options, request);
+  return child_->Async$method_name$(
+      cq, std::move(rest_context), std::move(options), request);
 }
 )""");
     } else {
@@ -326,13 +332,15 @@ $metadata_rest_class_name$::Async$method_name$(
 future<StatusOr<$response_type$>>
 $metadata_rest_class_name$::Async$method_name$(
     google::cloud::CompletionQueue& cq,
-      std::unique_ptr<rest_internal::RestContext> rest_context,
-    Options const& options, $request_type$ const& request) {
+    std::unique_ptr<rest_internal::RestContext> rest_context,
+    google::cloud::internal::ImmutableOptions options,
+    $request_type$ const& request) {
 )""");
       CcPrintMethod(method, __FILE__, __LINE__,
-                    SetMetadataText(method, kPointer, "options"));
+                    SetMetadataText(method, kPointer, "*options"));
       CcPrintMethod(method, __FILE__, __LINE__, R"""(
-  return child_->Async$method_name$(cq, std::move(rest_context), options, request);
+  return child_->Async$method_name$(
+      cq, std::move(rest_context), std::move(options), request);
 }
 )""");
     }

--- a/generator/internal/stub_rest_generator.cc
+++ b/generator/internal/stub_rest_generator.cc
@@ -98,21 +98,24 @@ class $stub_rest_class_name$ {
   }
 
   for (auto const& method : async_methods()) {
-    if (IsStreaming(method)) continue;
+    // No streaming RPCs for REST, and Longrunning is already taken care of.
+    if (IsStreaming(method) || IsLongrunningOperation(method)) continue;
     if (!HasHttpAnnotation(method)) continue;
     if (IsResponseTypeEmpty(method)) {
       HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
   virtual future<Status> Async$method_name$(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
-      Options const& options, $request_type$ const& request) = 0;
+      google::cloud::internal::ImmutableOptions options,
+      $request_type$ const& request) = 0;
 )""");
     } else {
       HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
   virtual future<StatusOr<$response_type$>> Async$method_name$(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
-      Options const& options, $request_type$ const& request) = 0;
+      google::cloud::internal::ImmutableOptions options,
+      $request_type$ const& request) = 0;
 )""");
     }
   }
@@ -201,20 +204,23 @@ class Default$stub_rest_class_name$ : public $stub_rest_class_name$ {
   }
 
   for (auto const& method : async_methods()) {
-    if (IsStreaming(method)) continue;
+    // No streaming RPCs for REST, and Longrunning is already taken care of.
+    if (IsStreaming(method) || IsLongrunningOperation(method)) continue;
     if (IsResponseTypeEmpty(method)) {
       HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
   future<Status> Async$method_name$(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
-      Options const& options, $request_type$ const& request) override;
+      google::cloud::internal::ImmutableOptions options,
+      $request_type$ const& request) override;
 )""");
     } else {
       HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
   future<StatusOr<$response_type$>> Async$method_name$(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
-      Options const& options, $request_type$ const& request) override;
+      google::cloud::internal::ImmutableOptions options,
+      $request_type$ const& request) override;
 )""");
     }
   }
@@ -333,12 +339,15 @@ Default$stub_rest_class_name$::Async$method_name$(
       $request_type$ const& request) {
   promise<StatusOr<$response_type$>> p;
   future<StatusOr<$response_type$>> f = p.get_future();
-  std::thread t{[](auto p, auto service, auto request, auto rest_context, auto options) {
+  std::thread t{[](
+          auto p, auto service, auto request, auto rest_context, auto options) {
       p.set_value(rest_internal::$method_http_verb$<$response_type$>(
           *service, *rest_context, $request_resource$,
           $preserve_proto_field_names_in_json$,
-          $method_rest_path$$method_http_query_parameters$));
-  }, std::move(p), service_, request, std::move(rest_context), std::move(options)};
+          $method_rest_path_async$$method_http_query_parameters$));
+    },
+    std::move(p), service_, request, std::move(rest_context),
+    std::move(options)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {
       t.join();
@@ -376,7 +385,8 @@ Default$stub_rest_class_name$::$method_name$(
   }
 
   for (auto const& method : async_methods()) {
-    if (IsStreaming(method)) continue;
+    // No streaming RPCs for REST, and Longrunning is already taken care of.
+    if (IsStreaming(method) || IsLongrunningOperation(method)) continue;
     if (!HasHttpAnnotation(method)) continue;
     if (IsResponseTypeEmpty(method)) {
       CcPrintMethod(method, __FILE__, __LINE__, R"""(
@@ -384,14 +394,18 @@ future<Status>
 Default$stub_rest_class_name$::Async$method_name$(
     google::cloud::CompletionQueue& cq,
     std::unique_ptr<rest_internal::RestContext> rest_context,
-    Options const& options, $request_type$ const& request) {
+    google::cloud::internal::ImmutableOptions options,
+    $request_type$ const& request) {
   promise<StatusOr<google::protobuf::Empty>> p;
   future<StatusOr<google::protobuf::Empty>> f = p.get_future();
-  std::thread t{[](auto p, auto service, auto request, auto rest_context, auto options) {
+  std::thread t{[](
+          auto p, auto service, auto request, auto rest_context, auto options) {
       p.set_value(rest_internal::$method_http_verb$<google::protobuf::Empty>(
           *service, *rest_context, $request_resource$, $preserve_proto_field_names_in_json$,
-          $method_rest_path$$method_http_query_parameters$));
-  }, std::move(p), service_, request, std::move(rest_context), options};
+          $method_rest_path_async$$method_http_query_parameters$));
+    },
+    std::move(p), service_, request, std::move(rest_context),
+    std::move(options)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {
       t.join();
@@ -406,14 +420,18 @@ future<StatusOr<$response_type$>>
 Default$stub_rest_class_name$::Async$method_name$(
     google::cloud::CompletionQueue& cq,
     std::unique_ptr<rest_internal::RestContext> rest_context,
-    Options const& options, $request_type$ const& request) {
+    google::cloud::internal::ImmutableOptions options,
+    $request_type$ const& request) {
   promise<StatusOr<$response_type$>> p;
   future<StatusOr<$response_type$>> f = p.get_future();
-  std::thread t{[](auto p, auto service, auto request, auto rest_context, auto options) {
+  std::thread t{[](
+          auto p, auto service, auto request, auto rest_context, auto options) {
       p.set_value(rest_internal::$method_http_verb$<$response_type$>(
           *service, *rest_context, $request_resource$, $preserve_proto_field_names_in_json$,
-          $method_rest_path$$method_http_query_parameters$));
-  }, std::move(p), service_, request, std::move(rest_context), options};
+          $method_rest_path_async$$method_http_query_parameters$));
+    },
+    std::move(p), service_, request, std::move(rest_context),
+    std::move(options)};
   return f.then([t = std::move(t), cq](auto f) mutable {
     cq.RunAsync([t = std::move(t)]() mutable {
       t.join();

--- a/google/cloud/accesscontextmanager/v1/internal/access_context_manager_stub.cc
+++ b/google/cloud/accesscontextmanager/v1/internal/access_context_manager_stub.cc
@@ -482,6 +482,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultAccessContextManagerStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -498,6 +499,7 @@ DefaultAccessContextManagerStub::AsyncGetOperation(
 future<Status> DefaultAccessContextManagerStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/aiplatform/v1/internal/dataset_stub.cc
+++ b/google/cloud/aiplatform/v1/internal/dataset_stub.cc
@@ -304,6 +304,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultDatasetServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -320,6 +321,7 @@ DefaultDatasetServiceStub::AsyncGetOperation(
 future<Status> DefaultDatasetServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/aiplatform/v1/internal/deployment_resource_pool_stub.cc
+++ b/google/cloud/aiplatform/v1/internal/deployment_resource_pool_stub.cc
@@ -106,6 +106,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultDeploymentResourcePoolServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -122,6 +123,7 @@ DefaultDeploymentResourcePoolServiceStub::AsyncGetOperation(
 future<Status> DefaultDeploymentResourcePoolServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/aiplatform/v1/internal/endpoint_stub.cc
+++ b/google/cloud/aiplatform/v1/internal/endpoint_stub.cc
@@ -164,6 +164,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultEndpointServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -180,6 +181,7 @@ DefaultEndpointServiceStub::AsyncGetOperation(
 future<Status> DefaultEndpointServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/aiplatform/v1/internal/feature_online_store_admin_stub.cc
+++ b/google/cloud/aiplatform/v1/internal/feature_online_store_admin_stub.cc
@@ -243,6 +243,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultFeatureOnlineStoreAdminServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -259,6 +260,7 @@ DefaultFeatureOnlineStoreAdminServiceStub::AsyncGetOperation(
 future<Status> DefaultFeatureOnlineStoreAdminServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/aiplatform/v1/internal/featurestore_stub.cc
+++ b/google/cloud/aiplatform/v1/internal/featurestore_stub.cc
@@ -370,6 +370,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultFeaturestoreServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -386,6 +387,7 @@ DefaultFeaturestoreServiceStub::AsyncGetOperation(
 future<Status> DefaultFeaturestoreServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/aiplatform/v1/internal/index_endpoint_stub.cc
+++ b/google/cloud/aiplatform/v1/internal/index_endpoint_stub.cc
@@ -164,6 +164,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultIndexEndpointServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -180,6 +181,7 @@ DefaultIndexEndpointServiceStub::AsyncGetOperation(
 future<Status> DefaultIndexEndpointServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/aiplatform/v1/internal/index_stub.cc
+++ b/google/cloud/aiplatform/v1/internal/index_stub.cc
@@ -137,6 +137,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultIndexServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -153,6 +154,7 @@ DefaultIndexServiceStub::AsyncGetOperation(
 future<Status> DefaultIndexServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/aiplatform/v1/internal/job_stub.cc
+++ b/google/cloud/aiplatform/v1/internal/job_stub.cc
@@ -538,6 +538,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultJobServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -554,6 +555,7 @@ DefaultJobServiceStub::AsyncGetOperation(
 future<Status> DefaultJobServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/aiplatform/v1/internal/metadata_stub.cc
+++ b/google/cloud/aiplatform/v1/internal/metadata_stub.cc
@@ -484,6 +484,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultMetadataServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -500,6 +501,7 @@ DefaultMetadataServiceStub::AsyncGetOperation(
 future<Status> DefaultMetadataServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/aiplatform/v1/internal/migration_stub.cc
+++ b/google/cloud/aiplatform/v1/internal/migration_stub.cc
@@ -69,6 +69,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultMigrationServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -85,6 +86,7 @@ DefaultMigrationServiceStub::AsyncGetOperation(
 future<Status> DefaultMigrationServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/aiplatform/v1/internal/model_stub.cc
+++ b/google/cloud/aiplatform/v1/internal/model_stub.cc
@@ -303,6 +303,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultModelServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -319,6 +320,7 @@ DefaultModelServiceStub::AsyncGetOperation(
 future<Status> DefaultModelServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/aiplatform/v1/internal/pipeline_stub.cc
+++ b/google/cloud/aiplatform/v1/internal/pipeline_stub.cc
@@ -173,6 +173,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultPipelineServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -189,6 +190,7 @@ DefaultPipelineServiceStub::AsyncGetOperation(
 future<Status> DefaultPipelineServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/aiplatform/v1/internal/schedule_stub.cc
+++ b/google/cloud/aiplatform/v1/internal/schedule_stub.cc
@@ -124,6 +124,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultScheduleServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -140,6 +141,7 @@ DefaultScheduleServiceStub::AsyncGetOperation(
 future<Status> DefaultScheduleServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/aiplatform/v1/internal/specialist_pool_stub.cc
+++ b/google/cloud/aiplatform/v1/internal/specialist_pool_stub.cc
@@ -116,6 +116,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultSpecialistPoolServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -132,6 +133,7 @@ DefaultSpecialistPoolServiceStub::AsyncGetOperation(
 future<Status> DefaultSpecialistPoolServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/aiplatform/v1/internal/tensorboard_stub.cc
+++ b/google/cloud/aiplatform/v1/internal/tensorboard_stub.cc
@@ -477,6 +477,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultTensorboardServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -493,6 +494,7 @@ DefaultTensorboardServiceStub::AsyncGetOperation(
 future<Status> DefaultTensorboardServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/aiplatform/v1/internal/vizier_stub.cc
+++ b/google/cloud/aiplatform/v1/internal/vizier_stub.cc
@@ -228,6 +228,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultVizierServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -244,6 +245,7 @@ DefaultVizierServiceStub::AsyncGetOperation(
 future<Status> DefaultVizierServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/alloydb/v1/internal/alloy_db_admin_stub.cc
+++ b/google/cloud/alloydb/v1/internal/alloy_db_admin_stub.cc
@@ -511,6 +511,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultAlloyDBAdminStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -527,6 +528,7 @@ DefaultAlloyDBAdminStub::AsyncGetOperation(
 future<Status> DefaultAlloyDBAdminStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/apigateway/v1/internal/api_gateway_stub.cc
+++ b/google/cloud/apigateway/v1/internal/api_gateway_stub.cc
@@ -272,6 +272,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultApiGatewayServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -288,6 +289,7 @@ DefaultApiGatewayServiceStub::AsyncGetOperation(
 future<Status> DefaultApiGatewayServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/apikeys/v2/internal/api_keys_stub.cc
+++ b/google/cloud/apikeys/v2/internal/api_keys_stub.cc
@@ -151,6 +151,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultApiKeysStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -167,6 +168,7 @@ DefaultApiKeysStub::AsyncGetOperation(
 future<Status> DefaultApiKeysStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/appengine/v1/internal/applications_stub.cc
+++ b/google/cloud/appengine/v1/internal/applications_stub.cc
@@ -101,6 +101,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultApplicationsStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -117,6 +118,7 @@ DefaultApplicationsStub::AsyncGetOperation(
 future<Status> DefaultApplicationsStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/appengine/v1/internal/domain_mappings_stub.cc
+++ b/google/cloud/appengine/v1/internal/domain_mappings_stub.cc
@@ -113,6 +113,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultDomainMappingsStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -129,6 +130,7 @@ DefaultDomainMappingsStub::AsyncGetOperation(
 future<Status> DefaultDomainMappingsStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/appengine/v1/internal/instances_stub.cc
+++ b/google/cloud/appengine/v1/internal/instances_stub.cc
@@ -93,6 +93,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultInstancesStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -109,6 +110,7 @@ DefaultInstancesStub::AsyncGetOperation(
 future<Status> DefaultInstancesStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/appengine/v1/internal/services_stub.cc
+++ b/google/cloud/appengine/v1/internal/services_stub.cc
@@ -92,6 +92,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultServicesStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -108,6 +109,7 @@ DefaultServicesStub::AsyncGetOperation(
 future<Status> DefaultServicesStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/appengine/v1/internal/versions_stub.cc
+++ b/google/cloud/appengine/v1/internal/versions_stub.cc
@@ -109,6 +109,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultVersionsStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -125,6 +126,7 @@ DefaultVersionsStub::AsyncGetOperation(
 future<Status> DefaultVersionsStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/artifactregistry/v1/internal/artifact_registry_stub.cc
+++ b/google/cloud/artifactregistry/v1/internal/artifact_registry_stub.cc
@@ -539,6 +539,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultArtifactRegistryStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -555,6 +556,7 @@ DefaultArtifactRegistryStub::AsyncGetOperation(
 future<Status> DefaultArtifactRegistryStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/asset/v1/internal/asset_stub.cc
+++ b/google/cloud/asset/v1/internal/asset_stub.cc
@@ -327,6 +327,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultAssetServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -343,6 +344,7 @@ DefaultAssetServiceStub::AsyncGetOperation(
 future<Status> DefaultAssetServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/assuredworkloads/v1/internal/assured_workloads_stub.cc
+++ b/google/cloud/assuredworkloads/v1/internal/assured_workloads_stub.cc
@@ -153,6 +153,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultAssuredWorkloadsServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -169,6 +170,7 @@ DefaultAssuredWorkloadsServiceStub::AsyncGetOperation(
 future<Status> DefaultAssuredWorkloadsServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/automl/v1/internal/auto_ml_stub.cc
+++ b/google/cloud/automl/v1/internal/auto_ml_stub.cc
@@ -301,6 +301,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultAutoMlStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -317,6 +318,7 @@ DefaultAutoMlStub::AsyncGetOperation(
 future<Status> DefaultAutoMlStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/automl/v1/internal/prediction_stub.cc
+++ b/google/cloud/automl/v1/internal/prediction_stub.cc
@@ -65,6 +65,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultPredictionServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -81,6 +82,7 @@ DefaultPredictionServiceStub::AsyncGetOperation(
 future<Status> DefaultPredictionServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/baremetalsolution/v2/internal/bare_metal_solution_stub.cc
+++ b/google/cloud/baremetalsolution/v2/internal/bare_metal_solution_stub.cc
@@ -699,6 +699,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultBareMetalSolutionStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -715,6 +716,7 @@ DefaultBareMetalSolutionStub::AsyncGetOperation(
 future<Status> DefaultBareMetalSolutionStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/batch/v1/internal/batch_stub.cc
+++ b/google/cloud/batch/v1/internal/batch_stub.cc
@@ -109,6 +109,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultBatchServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -125,6 +126,7 @@ DefaultBatchServiceStub::AsyncGetOperation(
 future<Status> DefaultBatchServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/beyondcorp/appconnections/v1/internal/app_connections_stub.cc
+++ b/google/cloud/beyondcorp/appconnections/v1/internal/app_connections_stub.cc
@@ -139,6 +139,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultAppConnectionsServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -155,6 +156,7 @@ DefaultAppConnectionsServiceStub::AsyncGetOperation(
 future<Status> DefaultAppConnectionsServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/beyondcorp/appconnectors/v1/internal/app_connectors_stub.cc
+++ b/google/cloud/beyondcorp/appconnectors/v1/internal/app_connectors_stub.cc
@@ -143,6 +143,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultAppConnectorsServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -159,6 +160,7 @@ DefaultAppConnectorsServiceStub::AsyncGetOperation(
 future<Status> DefaultAppConnectorsServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/beyondcorp/appgateways/v1/internal/app_gateways_stub.cc
+++ b/google/cloud/beyondcorp/appgateways/v1/internal/app_gateways_stub.cc
@@ -101,6 +101,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultAppGatewaysServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -117,6 +118,7 @@ DefaultAppGatewaysServiceStub::AsyncGetOperation(
 future<Status> DefaultAppGatewaysServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/bigquery/analyticshub/v1/internal/analytics_hub_stub.cc
+++ b/google/cloud/bigquery/analyticshub/v1/internal/analytics_hub_stub.cc
@@ -341,6 +341,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultAnalyticsHubServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -357,6 +358,7 @@ DefaultAnalyticsHubServiceStub::AsyncGetOperation(
 future<Status> DefaultAnalyticsHubServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/bigtable/admin/internal/bigtable_instance_admin_stub.cc
+++ b/google/cloud/bigtable/admin/internal/bigtable_instance_admin_stub.cc
@@ -322,6 +322,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultBigtableInstanceAdminStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -338,6 +339,7 @@ DefaultBigtableInstanceAdminStub::AsyncGetOperation(
 future<Status> DefaultBigtableInstanceAdminStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/bigtable/admin/internal/bigtable_table_admin_auth_decorator.cc
+++ b/google/cloud/bigtable/admin/internal/bigtable_table_admin_auth_decorator.cc
@@ -264,19 +264,20 @@ future<StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>>
 BigtableTableAdminAuth::AsyncCheckConsistency(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::admin::v2::CheckConsistencyRequest const& request) {
-  using ReturnType =
-      StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>;
-  auto& child = child_;
   return auth_->AsyncConfigureContext(std::move(context))
-      .then([cq, child,
+      .then([cq, child = child_, options = std::move(options),
              request](future<StatusOr<std::shared_ptr<grpc::ClientContext>>>
                           f) mutable {
         auto context = f.get();
         if (!context) {
-          return make_ready_future(ReturnType(std::move(context).status()));
+          return make_ready_future(
+              StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>(
+                  std::move(context).status()));
         }
-        return child->AsyncCheckConsistency(cq, *std::move(context), request);
+        return child->AsyncCheckConsistency(cq, *std::move(context),
+                                            std::move(options), request);
       });
 }
 

--- a/google/cloud/bigtable/admin/internal/bigtable_table_admin_auth_decorator.h
+++ b/google/cloud/bigtable/admin/internal/bigtable_table_admin_auth_decorator.h
@@ -138,6 +138,7 @@ class BigtableTableAdminAuth : public BigtableTableAdminStub {
   AsyncCheckConsistency(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::admin::v2::CheckConsistencyRequest const& request)
       override;
 

--- a/google/cloud/bigtable/admin/internal/bigtable_table_admin_connection_impl.cc
+++ b/google/cloud/bigtable/admin/internal/bigtable_table_admin_connection_impl.cc
@@ -522,15 +522,18 @@ BigtableTableAdminConnectionImpl::AsyncCheckConsistency(
   auto request_copy = request;
   auto const idempotent =
       idempotency_policy(*current)->CheckConsistency(request_copy);
+  auto retry = retry_policy(*current);
+  auto backoff = backoff_policy(*current);
   return google::cloud::internal::AsyncRetryLoop(
-      retry_policy(*current), backoff_policy(*current), idempotent,
-      background_->cq(),
+      std::move(retry), std::move(backoff), idempotent, background_->cq(),
       [stub = stub_](
           CompletionQueue& cq, std::shared_ptr<grpc::ClientContext> context,
+          google::cloud::internal::ImmutableOptions options,
           google::bigtable::admin::v2::CheckConsistencyRequest const& request) {
-        return stub->AsyncCheckConsistency(cq, std::move(context), request);
+        return stub->AsyncCheckConsistency(cq, std::move(context),
+                                           std::move(options), request);
       },
-      std::move(request_copy), __func__);
+      std::move(current), std::move(request_copy), __func__);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/admin/internal/bigtable_table_admin_logging_decorator.cc
+++ b/google/cloud/bigtable/admin/internal/bigtable_table_admin_logging_decorator.cc
@@ -308,15 +308,19 @@ future<StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>>
 BigtableTableAdminLogging::AsyncCheckConsistency(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::admin::v2::CheckConsistencyRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](
           google::cloud::CompletionQueue& cq,
           std::shared_ptr<grpc::ClientContext> context,
+          google::cloud::internal::ImmutableOptions options,
           google::bigtable::admin::v2::CheckConsistencyRequest const& request) {
-        return child_->AsyncCheckConsistency(cq, std::move(context), request);
+        return child_->AsyncCheckConsistency(cq, std::move(context),
+                                             std::move(options), request);
       },
-      cq, std::move(context), request, __func__, tracing_options_);
+      cq, std::move(context), std::move(options), request, __func__,
+      tracing_options_);
 }
 
 future<StatusOr<google::longrunning::Operation>>

--- a/google/cloud/bigtable/admin/internal/bigtable_table_admin_logging_decorator.h
+++ b/google/cloud/bigtable/admin/internal/bigtable_table_admin_logging_decorator.h
@@ -138,6 +138,7 @@ class BigtableTableAdminLogging : public BigtableTableAdminStub {
   AsyncCheckConsistency(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::admin::v2::CheckConsistencyRequest const& request)
       override;
 

--- a/google/cloud/bigtable/admin/internal/bigtable_table_admin_metadata_decorator.cc
+++ b/google/cloud/bigtable/admin/internal/bigtable_table_admin_metadata_decorator.cc
@@ -242,10 +242,12 @@ future<StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>>
 BigtableTableAdminMetadata::AsyncCheckConsistency(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::admin::v2::CheckConsistencyRequest const& request) {
-  SetMetadata(*context, internal::CurrentOptions(),
+  SetMetadata(*context, *options,
               absl::StrCat("name=", internal::UrlEncode(request.name())));
-  return child_->AsyncCheckConsistency(cq, std::move(context), request);
+  return child_->AsyncCheckConsistency(cq, std::move(context),
+                                       std::move(options), request);
 }
 
 future<StatusOr<google::longrunning::Operation>>

--- a/google/cloud/bigtable/admin/internal/bigtable_table_admin_metadata_decorator.h
+++ b/google/cloud/bigtable/admin/internal/bigtable_table_admin_metadata_decorator.h
@@ -139,6 +139,7 @@ class BigtableTableAdminMetadata : public BigtableTableAdminStub {
   AsyncCheckConsistency(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::admin::v2::CheckConsistencyRequest const& request)
       override;
 

--- a/google/cloud/bigtable/admin/internal/bigtable_table_admin_stub.cc
+++ b/google/cloud/bigtable/admin/internal/bigtable_table_admin_stub.cc
@@ -302,6 +302,8 @@ future<StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>>
 DefaultBigtableTableAdminStub::AsyncCheckConsistency(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    google::cloud::internal::ImmutableOptions,
     google::bigtable::admin::v2::CheckConsistencyRequest const& request) {
   return internal::MakeUnaryRpcImpl<
       google::bigtable::admin::v2::CheckConsistencyRequest,
@@ -320,6 +322,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultBigtableTableAdminStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -336,6 +339,7 @@ DefaultBigtableTableAdminStub::AsyncGetOperation(
 future<Status> DefaultBigtableTableAdminStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/bigtable/admin/internal/bigtable_table_admin_stub.h
+++ b/google/cloud/bigtable/admin/internal/bigtable_table_admin_stub.h
@@ -140,6 +140,7 @@ class BigtableTableAdminStub {
   AsyncCheckConsistency(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::admin::v2::CheckConsistencyRequest const& request) = 0;
 
   virtual future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
@@ -264,6 +265,7 @@ class DefaultBigtableTableAdminStub : public BigtableTableAdminStub {
   AsyncCheckConsistency(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::admin::v2::CheckConsistencyRequest const& request)
       override;
 

--- a/google/cloud/bigtable/admin/internal/bigtable_table_admin_tracing_stub.cc
+++ b/google/cloud/bigtable/admin/internal/bigtable_table_admin_tracing_stub.cc
@@ -283,12 +283,14 @@ future<StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>>
 BigtableTableAdminTracingStub::AsyncCheckConsistency(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::admin::v2::CheckConsistencyRequest const& request) {
   auto span = internal::MakeSpanGrpc(
       "google.bigtable.admin.v2.BigtableTableAdmin", "CheckConsistency");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto f = child_->AsyncCheckConsistency(cq, context, request);
+  auto f =
+      child_->AsyncCheckConsistency(cq, context, std::move(options), request);
   return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 

--- a/google/cloud/bigtable/admin/internal/bigtable_table_admin_tracing_stub.h
+++ b/google/cloud/bigtable/admin/internal/bigtable_table_admin_tracing_stub.h
@@ -137,6 +137,7 @@ class BigtableTableAdminTracingStub : public BigtableTableAdminStub {
   AsyncCheckConsistency(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::admin::v2::CheckConsistencyRequest const& request)
       override;
 

--- a/google/cloud/bigtable/internal/bigtable_auth_decorator.cc
+++ b/google/cloud/bigtable/internal/bigtable_auth_decorator.cc
@@ -144,18 +144,20 @@ future<StatusOr<google::bigtable::v2::MutateRowResponse>>
 BigtableAuth::AsyncMutateRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::MutateRowRequest const& request) {
-  using ReturnType = StatusOr<google::bigtable::v2::MutateRowResponse>;
-  auto& child = child_;
   return auth_->AsyncConfigureContext(std::move(context))
-      .then([cq, child,
+      .then([cq, child = child_, options = std::move(options),
              request](future<StatusOr<std::shared_ptr<grpc::ClientContext>>>
                           f) mutable {
         auto context = f.get();
         if (!context) {
-          return make_ready_future(ReturnType(std::move(context).status()));
+          return make_ready_future(
+              StatusOr<google::bigtable::v2::MutateRowResponse>(
+                  std::move(context).status()));
         }
-        return child->AsyncMutateRow(cq, *std::move(context), request);
+        return child->AsyncMutateRow(cq, *std::move(context),
+                                     std::move(options), request);
       });
 }
 
@@ -182,18 +184,20 @@ future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
 BigtableAuth::AsyncCheckAndMutateRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::CheckAndMutateRowRequest const& request) {
-  using ReturnType = StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>;
-  auto& child = child_;
   return auth_->AsyncConfigureContext(std::move(context))
-      .then([cq, child,
+      .then([cq, child = child_, options = std::move(options),
              request](future<StatusOr<std::shared_ptr<grpc::ClientContext>>>
                           f) mutable {
         auto context = f.get();
         if (!context) {
-          return make_ready_future(ReturnType(std::move(context).status()));
+          return make_ready_future(
+              StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>(
+                  std::move(context).status()));
         }
-        return child->AsyncCheckAndMutateRow(cq, *std::move(context), request);
+        return child->AsyncCheckAndMutateRow(cq, *std::move(context),
+                                             std::move(options), request);
       });
 }
 
@@ -201,18 +205,20 @@ future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>
 BigtableAuth::AsyncReadModifyWriteRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
-  using ReturnType = StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>;
-  auto& child = child_;
   return auth_->AsyncConfigureContext(std::move(context))
-      .then([cq, child,
+      .then([cq, child = child_, options = std::move(options),
              request](future<StatusOr<std::shared_ptr<grpc::ClientContext>>>
                           f) mutable {
         auto context = f.get();
         if (!context) {
-          return make_ready_future(ReturnType(std::move(context).status()));
+          return make_ready_future(
+              StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>(
+                  std::move(context).status()));
         }
-        return child->AsyncReadModifyWriteRow(cq, *std::move(context), request);
+        return child->AsyncReadModifyWriteRow(cq, *std::move(context),
+                                              std::move(options), request);
       });
 }
 

--- a/google/cloud/bigtable/internal/bigtable_auth_decorator.h
+++ b/google/cloud/bigtable/internal/bigtable_auth_decorator.h
@@ -89,6 +89,7 @@ class BigtableAuth : public BigtableStub {
   future<StatusOr<google::bigtable::v2::MutateRowResponse>> AsyncMutateRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::MutateRowRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -103,12 +104,14 @@ class BigtableAuth : public BigtableStub {
   AsyncCheckAndMutateRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::CheckAndMutateRowRequest const& request) override;
 
   future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>
   AsyncReadModifyWriteRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::ReadModifyWriteRowRequest const& request) override;
 
  private:

--- a/google/cloud/bigtable/internal/bigtable_channel_refresh.cc
+++ b/google/cloud/bigtable/internal/bigtable_channel_refresh.cc
@@ -97,8 +97,10 @@ future<StatusOr<google::bigtable::v2::MutateRowResponse>>
 BigtableChannelRefresh::AsyncMutateRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::MutateRowRequest const& request) {
-  return child_->AsyncMutateRow(cq, std::move(context), request);
+  return child_->AsyncMutateRow(cq, std::move(context), std::move(options),
+                                request);
 }
 
 std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -116,16 +118,20 @@ future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
 BigtableChannelRefresh::AsyncCheckAndMutateRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::CheckAndMutateRowRequest const& request) {
-  return child_->AsyncCheckAndMutateRow(cq, std::move(context), request);
+  return child_->AsyncCheckAndMutateRow(cq, std::move(context),
+                                        std::move(options), request);
 }
 
 future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>
 BigtableChannelRefresh::AsyncReadModifyWriteRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
-  return child_->AsyncReadModifyWriteRow(cq, std::move(context), request);
+  return child_->AsyncReadModifyWriteRow(cq, std::move(context),
+                                         std::move(options), request);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/internal/bigtable_channel_refresh.h
+++ b/google/cloud/bigtable/internal/bigtable_channel_refresh.h
@@ -95,6 +95,7 @@ class BigtableChannelRefresh : public BigtableStub {
   future<StatusOr<google::bigtable::v2::MutateRowResponse>> AsyncMutateRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions,
       google::bigtable::v2::MutateRowRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -109,12 +110,14 @@ class BigtableChannelRefresh : public BigtableStub {
   AsyncCheckAndMutateRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions,
       google::bigtable::v2::CheckAndMutateRowRequest const& request) override;
 
   future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>
   AsyncReadModifyWriteRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions,
       google::bigtable::v2::ReadModifyWriteRowRequest const& request) override;
 
  private:

--- a/google/cloud/bigtable/internal/bigtable_logging_decorator.cc
+++ b/google/cloud/bigtable/internal/bigtable_logging_decorator.cc
@@ -203,14 +203,18 @@ future<StatusOr<google::bigtable::v2::MutateRowResponse>>
 BigtableLogging::AsyncMutateRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::MutateRowRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](google::cloud::CompletionQueue& cq,
              std::shared_ptr<grpc::ClientContext> context,
+             google::cloud::internal::ImmutableOptions options,
              google::bigtable::v2::MutateRowRequest const& request) {
-        return child_->AsyncMutateRow(cq, std::move(context), request);
+        return child_->AsyncMutateRow(cq, std::move(context),
+                                      std::move(options), request);
       },
-      cq, std::move(context), request, __func__, tracing_options_);
+      cq, std::move(context), std::move(options), request, __func__,
+      tracing_options_);
 }
 
 std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -238,28 +242,36 @@ future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
 BigtableLogging::AsyncCheckAndMutateRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::CheckAndMutateRowRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](google::cloud::CompletionQueue& cq,
              std::shared_ptr<grpc::ClientContext> context,
+             google::cloud::internal::ImmutableOptions options,
              google::bigtable::v2::CheckAndMutateRowRequest const& request) {
-        return child_->AsyncCheckAndMutateRow(cq, std::move(context), request);
+        return child_->AsyncCheckAndMutateRow(cq, std::move(context),
+                                              std::move(options), request);
       },
-      cq, std::move(context), request, __func__, tracing_options_);
+      cq, std::move(context), std::move(options), request, __func__,
+      tracing_options_);
 }
 
 future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>
 BigtableLogging::AsyncReadModifyWriteRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](google::cloud::CompletionQueue& cq,
              std::shared_ptr<grpc::ClientContext> context,
+             google::cloud::internal::ImmutableOptions options,
              google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
-        return child_->AsyncReadModifyWriteRow(cq, std::move(context), request);
+        return child_->AsyncReadModifyWriteRow(cq, std::move(context),
+                                               std::move(options), request);
       },
-      cq, std::move(context), request, __func__, tracing_options_);
+      cq, std::move(context), std::move(options), request, __func__,
+      tracing_options_);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/internal/bigtable_logging_decorator.h
+++ b/google/cloud/bigtable/internal/bigtable_logging_decorator.h
@@ -89,6 +89,7 @@ class BigtableLogging : public BigtableStub {
   future<StatusOr<google::bigtable::v2::MutateRowResponse>> AsyncMutateRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::MutateRowRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -103,12 +104,14 @@ class BigtableLogging : public BigtableStub {
   AsyncCheckAndMutateRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::CheckAndMutateRowRequest const& request) override;
 
   future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>
   AsyncReadModifyWriteRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::ReadModifyWriteRowRequest const& request) override;
 
  private:

--- a/google/cloud/bigtable/internal/bigtable_metadata_decorator.cc
+++ b/google/cloud/bigtable/internal/bigtable_metadata_decorator.cc
@@ -355,6 +355,7 @@ future<StatusOr<google::bigtable::v2::MutateRowResponse>>
 BigtableMetadata::AsyncMutateRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::MutateRowRequest const& request) {
   std::vector<std::string> params;
   params.reserve(2);
@@ -378,12 +379,12 @@ BigtableMetadata::AsyncMutateRow(
   }
 
   if (params.empty()) {
-    SetMetadata(*context, internal::CurrentOptions());
+    SetMetadata(*context, *options);
   } else {
-    SetMetadata(*context, internal::CurrentOptions(),
-                absl::StrJoin(params, "&"));
+    SetMetadata(*context, *options, absl::StrJoin(params, "&"));
   }
-  return child_->AsyncMutateRow(cq, std::move(context), request);
+  return child_->AsyncMutateRow(cq, std::move(context), std::move(options),
+                                request);
 }
 
 std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -427,6 +428,7 @@ future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
 BigtableMetadata::AsyncCheckAndMutateRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::CheckAndMutateRowRequest const& request) {
   std::vector<std::string> params;
   params.reserve(2);
@@ -450,18 +452,19 @@ BigtableMetadata::AsyncCheckAndMutateRow(
   }
 
   if (params.empty()) {
-    SetMetadata(*context, internal::CurrentOptions());
+    SetMetadata(*context, *options);
   } else {
-    SetMetadata(*context, internal::CurrentOptions(),
-                absl::StrJoin(params, "&"));
+    SetMetadata(*context, *options, absl::StrJoin(params, "&"));
   }
-  return child_->AsyncCheckAndMutateRow(cq, std::move(context), request);
+  return child_->AsyncCheckAndMutateRow(cq, std::move(context),
+                                        std::move(options), request);
 }
 
 future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>
 BigtableMetadata::AsyncReadModifyWriteRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
   std::vector<std::string> params;
   params.reserve(2);
@@ -485,12 +488,12 @@ BigtableMetadata::AsyncReadModifyWriteRow(
   }
 
   if (params.empty()) {
-    SetMetadata(*context, internal::CurrentOptions());
+    SetMetadata(*context, *options);
   } else {
-    SetMetadata(*context, internal::CurrentOptions(),
-                absl::StrJoin(params, "&"));
+    SetMetadata(*context, *options, absl::StrJoin(params, "&"));
   }
-  return child_->AsyncReadModifyWriteRow(cq, std::move(context), request);
+  return child_->AsyncReadModifyWriteRow(cq, std::move(context),
+                                         std::move(options), request);
 }
 
 void BigtableMetadata::SetMetadata(grpc::ClientContext& context,

--- a/google/cloud/bigtable/internal/bigtable_metadata_decorator.h
+++ b/google/cloud/bigtable/internal/bigtable_metadata_decorator.h
@@ -89,6 +89,7 @@ class BigtableMetadata : public BigtableStub {
   future<StatusOr<google::bigtable::v2::MutateRowResponse>> AsyncMutateRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::MutateRowRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -103,12 +104,14 @@ class BigtableMetadata : public BigtableStub {
   AsyncCheckAndMutateRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::CheckAndMutateRowRequest const& request) override;
 
   future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>
   AsyncReadModifyWriteRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::ReadModifyWriteRowRequest const& request) override;
 
  private:

--- a/google/cloud/bigtable/internal/bigtable_round_robin_decorator.cc
+++ b/google/cloud/bigtable/internal/bigtable_round_robin_decorator.cc
@@ -104,8 +104,10 @@ future<StatusOr<google::bigtable::v2::MutateRowResponse>>
 BigtableRoundRobin::AsyncMutateRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::MutateRowRequest const& request) {
-  return Child()->AsyncMutateRow(cq, std::move(context), request);
+  return Child()->AsyncMutateRow(cq, std::move(context), std::move(options),
+                                 request);
 }
 
 std::unique_ptr<google::cloud::internal::AsyncStreamingReadRpc<
@@ -123,16 +125,20 @@ future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
 BigtableRoundRobin::AsyncCheckAndMutateRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::CheckAndMutateRowRequest const& request) {
-  return Child()->AsyncCheckAndMutateRow(cq, std::move(context), request);
+  return Child()->AsyncCheckAndMutateRow(cq, std::move(context),
+                                         std::move(options), request);
 }
 
 future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>
 BigtableRoundRobin::AsyncReadModifyWriteRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
-  return Child()->AsyncReadModifyWriteRow(cq, std::move(context), request);
+  return Child()->AsyncReadModifyWriteRow(cq, std::move(context),
+                                          std::move(options), request);
 }
 
 std::shared_ptr<BigtableStub> BigtableRoundRobin::Child() {

--- a/google/cloud/bigtable/internal/bigtable_round_robin_decorator.h
+++ b/google/cloud/bigtable/internal/bigtable_round_robin_decorator.h
@@ -87,6 +87,7 @@ class BigtableRoundRobin : public BigtableStub {
   future<StatusOr<google::bigtable::v2::MutateRowResponse>> AsyncMutateRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::MutateRowRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -101,12 +102,14 @@ class BigtableRoundRobin : public BigtableStub {
   AsyncCheckAndMutateRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::CheckAndMutateRowRequest const& request) override;
 
   future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>
   AsyncReadModifyWriteRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::ReadModifyWriteRowRequest const& request) override;
 
  private:

--- a/google/cloud/bigtable/internal/bigtable_stub.cc
+++ b/google/cloud/bigtable/internal/bigtable_stub.cc
@@ -152,6 +152,8 @@ future<StatusOr<google::bigtable::v2::MutateRowResponse>>
 DefaultBigtableStub::AsyncMutateRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    google::cloud::internal::ImmutableOptions,
     google::bigtable::v2::MutateRowRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::bigtable::v2::MutateRowRequest,
                                     google::bigtable::v2::MutateRowResponse>(
@@ -186,6 +188,8 @@ future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
 DefaultBigtableStub::AsyncCheckAndMutateRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    google::cloud::internal::ImmutableOptions,
     google::bigtable::v2::CheckAndMutateRowRequest const& request) {
   return internal::MakeUnaryRpcImpl<
       google::bigtable::v2::CheckAndMutateRowRequest,
@@ -203,6 +207,8 @@ future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>
 DefaultBigtableStub::AsyncReadModifyWriteRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    google::cloud::internal::ImmutableOptions,
     google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
   return internal::MakeUnaryRpcImpl<
       google::bigtable::v2::ReadModifyWriteRowRequest,

--- a/google/cloud/bigtable/internal/bigtable_stub.h
+++ b/google/cloud/bigtable/internal/bigtable_stub.h
@@ -92,6 +92,7 @@ class BigtableStub {
   virtual future<StatusOr<google::bigtable::v2::MutateRowResponse>>
   AsyncMutateRow(google::cloud::CompletionQueue& cq,
                  std::shared_ptr<grpc::ClientContext> context,
+                 google::cloud::internal::ImmutableOptions options,
                  google::bigtable::v2::MutateRowRequest const& request) = 0;
 
   virtual std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -105,12 +106,14 @@ class BigtableStub {
   AsyncCheckAndMutateRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::CheckAndMutateRowRequest const& request) = 0;
 
   virtual future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>
   AsyncReadModifyWriteRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::ReadModifyWriteRowRequest const& request) = 0;
 };
 
@@ -171,6 +174,7 @@ class DefaultBigtableStub : public BigtableStub {
   future<StatusOr<google::bigtable::v2::MutateRowResponse>> AsyncMutateRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::MutateRowRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -185,12 +189,14 @@ class DefaultBigtableStub : public BigtableStub {
   AsyncCheckAndMutateRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::CheckAndMutateRowRequest const& request) override;
 
   future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>
   AsyncReadModifyWriteRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::ReadModifyWriteRowRequest const& request) override;
 
  private:

--- a/google/cloud/bigtable/internal/bigtable_tracing_stub.cc
+++ b/google/cloud/bigtable/internal/bigtable_tracing_stub.cc
@@ -162,12 +162,13 @@ future<StatusOr<google::bigtable::v2::MutateRowResponse>>
 BigtableTracingStub::AsyncMutateRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::MutateRowRequest const& request) {
   auto span =
       internal::MakeSpanGrpc("google.bigtable.v2.Bigtable", "MutateRow");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto f = child_->AsyncMutateRow(cq, context, request);
+  auto f = child_->AsyncMutateRow(cq, context, std::move(options), request);
   return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 
@@ -193,12 +194,14 @@ future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
 BigtableTracingStub::AsyncCheckAndMutateRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::CheckAndMutateRowRequest const& request) {
   auto span = internal::MakeSpanGrpc("google.bigtable.v2.Bigtable",
                                      "CheckAndMutateRow");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto f = child_->AsyncCheckAndMutateRow(cq, context, request);
+  auto f =
+      child_->AsyncCheckAndMutateRow(cq, context, std::move(options), request);
   return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 
@@ -206,12 +209,14 @@ future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>
 BigtableTracingStub::AsyncReadModifyWriteRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
   auto span = internal::MakeSpanGrpc("google.bigtable.v2.Bigtable",
                                      "ReadModifyWriteRow");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto f = child_->AsyncReadModifyWriteRow(cq, context, request);
+  auto f =
+      child_->AsyncReadModifyWriteRow(cq, context, std::move(options), request);
   return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 

--- a/google/cloud/bigtable/internal/bigtable_tracing_stub.h
+++ b/google/cloud/bigtable/internal/bigtable_tracing_stub.h
@@ -88,6 +88,7 @@ class BigtableTracingStub : public BigtableStub {
   future<StatusOr<google::bigtable::v2::MutateRowResponse>> AsyncMutateRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::MutateRowRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -102,12 +103,14 @@ class BigtableTracingStub : public BigtableStub {
   AsyncCheckAndMutateRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::CheckAndMutateRowRequest const& request) override;
 
   future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>
   AsyncReadModifyWriteRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::bigtable::v2::ReadModifyWriteRowRequest const& request) override;
 
  private:

--- a/google/cloud/bigtable/internal/data_connection_impl_test.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl_test.cc
@@ -412,7 +412,7 @@ TEST_F(DataConnectionTest, ApplyBigtableCookie) {
 TEST_F(DataConnectionTest, AsyncApplySuccess) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRow)
-      .WillOnce([](google::cloud::CompletionQueue&, auto,
+      .WillOnce([](google::cloud::CompletionQueue&, auto, auto,
                    v2::MutateRowRequest const& request) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -429,7 +429,7 @@ TEST_F(DataConnectionTest, AsyncApplySuccess) {
 TEST_F(DataConnectionTest, AsyncApplyPermanentFailure) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRow)
-      .WillOnce([](google::cloud::CompletionQueue&, auto,
+      .WillOnce([](google::cloud::CompletionQueue&, auto, auto,
                    v2::MutateRowRequest const& request) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -448,7 +448,7 @@ TEST_F(DataConnectionTest, AsyncApplyRetryExhausted) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRow)
       .Times(kNumRetries + 1)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          v2::MutateRowRequest const& request) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -474,7 +474,7 @@ TEST_F(DataConnectionTest, AsyncApplyRetryExhausted) {
 TEST_F(DataConnectionTest, AsyncApplyRetryIdempotency) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRow)
-      .WillOnce([](google::cloud::CompletionQueue&, auto,
+      .WillOnce([](google::cloud::CompletionQueue&, auto, auto,
                    v2::MutateRowRequest const& request) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -503,7 +503,7 @@ TEST_F(DataConnectionTest, AsyncApplyBigtableCookie) {
   EXPECT_CALL(*mock, AsyncMutateRow)
       .WillOnce([this](CompletionQueue&,
                        std::shared_ptr<grpc::ClientContext> const& context,
-                       v2::MutateRowRequest const&) {
+                       auto, v2::MutateRowRequest const&) {
         // Return a bigtable cookie in the first request.
         metadata_fixture_.SetServerMetadata(
             *context, {{}, {{"x-goog-cbt-cookie-routing", "routing"}}});
@@ -512,7 +512,7 @@ TEST_F(DataConnectionTest, AsyncApplyBigtableCookie) {
       })
       .WillOnce([this](CompletionQueue&,
                        std::shared_ptr<grpc::ClientContext> const& context,
-                       v2::MutateRowRequest const&) {
+                       auto, v2::MutateRowRequest const&) {
         // Verify that the next request includes the bigtable cookie from above.
         auto headers = metadata_fixture_.GetMetadata(*context);
         EXPECT_THAT(headers,
@@ -1270,7 +1270,7 @@ TEST_F(DataConnectionTest, AsyncCheckAndMutateRowSuccess) {
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncCheckAndMutateRow)
-      .WillOnce([&](google::cloud::CompletionQueue&, auto,
+      .WillOnce([&](google::cloud::CompletionQueue&, auto, auto,
                     v2::CheckAndMutateRowRequest const& request) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -1285,7 +1285,7 @@ TEST_F(DataConnectionTest, AsyncCheckAndMutateRowSuccess) {
         resp.set_predicate_matched(true);
         return make_ready_future(make_status_or(resp));
       })
-      .WillOnce([&](google::cloud::CompletionQueue&, auto,
+      .WillOnce([&](google::cloud::CompletionQueue&, auto, auto,
                     v2::CheckAndMutateRowRequest const& request) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -1324,7 +1324,7 @@ TEST_F(DataConnectionTest, AsyncCheckAndMutateRowIdempotency) {
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncCheckAndMutateRow)
-      .WillOnce([&](google::cloud::CompletionQueue&, auto,
+      .WillOnce([&](google::cloud::CompletionQueue&, auto, auto,
                     v2::CheckAndMutateRowRequest const& request) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -1363,7 +1363,7 @@ TEST_F(DataConnectionTest, AsyncCheckAndMutateRowPermanentError) {
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncCheckAndMutateRow)
-      .WillOnce([&](google::cloud::CompletionQueue&, auto,
+      .WillOnce([&](google::cloud::CompletionQueue&, auto, auto,
                     v2::CheckAndMutateRowRequest const& request) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -1393,7 +1393,7 @@ TEST_F(DataConnectionTest, AsyncCheckAndMutateRowRetryExhausted) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncCheckAndMutateRow)
       .Times(kNumRetries + 1)
-      .WillRepeatedly([&](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([&](google::cloud::CompletionQueue&, auto, auto,
                           v2::CheckAndMutateRowRequest const& request) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -1435,7 +1435,7 @@ TEST_F(DataConnectionTest, AsyncCheckAndMutateRowBigtableCookie) {
   EXPECT_CALL(*mock, AsyncCheckAndMutateRow)
       .WillOnce([this](CompletionQueue&,
                        std::shared_ptr<grpc::ClientContext> const& context,
-                       v2::CheckAndMutateRowRequest const&) {
+                       auto, v2::CheckAndMutateRowRequest const&) {
         // Return a bigtable cookie in the first request.
         metadata_fixture_.SetServerMetadata(
             *context, {{}, {{"x-goog-cbt-cookie-routing", "routing"}}});
@@ -1444,7 +1444,7 @@ TEST_F(DataConnectionTest, AsyncCheckAndMutateRowBigtableCookie) {
       })
       .WillOnce([this](CompletionQueue&,
                        std::shared_ptr<grpc::ClientContext> const& context,
-                       v2::CheckAndMutateRowRequest const&) {
+                       auto, v2::CheckAndMutateRowRequest const&) {
         // Verify that the next request includes the bigtable cookie from above.
         auto headers = metadata_fixture_.GetMetadata(*context);
         EXPECT_THAT(headers,
@@ -1791,7 +1791,7 @@ TEST_F(DataConnectionTest, AsyncReadModifyWriteRowSuccess) {
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadModifyWriteRow)
-      .WillOnce([&response](google::cloud::CompletionQueue&, auto,
+      .WillOnce([&response](google::cloud::CompletionQueue&, auto, auto,
                             v2::ReadModifyWriteRowRequest const& request) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -1817,7 +1817,7 @@ TEST_F(DataConnectionTest, AsyncReadModifyWriteRowSuccess) {
 TEST_F(DataConnectionTest, AsyncReadModifyWriteRowPermanentError) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadModifyWriteRow)
-      .WillOnce([](google::cloud::CompletionQueue&, auto,
+      .WillOnce([](google::cloud::CompletionQueue&, auto, auto,
                    v2::ReadModifyWriteRowRequest const& request) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -1840,7 +1840,7 @@ TEST_F(DataConnectionTest, AsyncReadModifyWriteRowPermanentError) {
 TEST_F(DataConnectionTest, AsyncReadModifyWriteRowTransientErrorNotRetried) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadModifyWriteRow)
-      .WillOnce([](google::cloud::CompletionQueue&, auto,
+      .WillOnce([](google::cloud::CompletionQueue&, auto, auto,
                    v2::ReadModifyWriteRowRequest const& request) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());

--- a/google/cloud/bigtable/testing/mock_bigtable_stub.h
+++ b/google/cloud/bigtable/testing/mock_bigtable_stub.h
@@ -82,6 +82,7 @@ class MockBigtableStub : public bigtable_internal::BigtableStub {
               AsyncMutateRow,
               (google::cloud::CompletionQueue&,
                std::shared_ptr<grpc::ClientContext>,
+               google::cloud::internal::ImmutableOptions,
                google::bigtable::v2::MutateRowRequest const&),
               (override));
   MOCK_METHOD(std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -96,12 +97,14 @@ class MockBigtableStub : public bigtable_internal::BigtableStub {
               AsyncCheckAndMutateRow,
               (google::cloud::CompletionQueue&,
                std::shared_ptr<grpc::ClientContext>,
+               google::cloud::internal::ImmutableOptions,
                google::bigtable::v2::CheckAndMutateRowRequest const&),
               (override));
   MOCK_METHOD(
       future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>,
       AsyncReadModifyWriteRow,
       (google::cloud::CompletionQueue&, std::shared_ptr<grpc::ClientContext>,
+       google::cloud::internal::ImmutableOptions,
        google::bigtable::v2::ReadModifyWriteRowRequest const&),
       (override));
 };

--- a/google/cloud/certificatemanager/v1/internal/certificate_manager_stub.cc
+++ b/google/cloud/certificatemanager/v1/internal/certificate_manager_stub.cc
@@ -458,6 +458,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultCertificateManagerStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -474,6 +475,7 @@ DefaultCertificateManagerStub::AsyncGetOperation(
 future<Status> DefaultCertificateManagerStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/channel/v1/internal/cloud_channel_reports_stub.cc
+++ b/google/cloud/channel/v1/internal/cloud_channel_reports_stub.cc
@@ -77,6 +77,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultCloudChannelReportsServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -93,6 +94,7 @@ DefaultCloudChannelReportsServiceStub::AsyncGetOperation(
 future<Status> DefaultCloudChannelReportsServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/channel/v1/internal/cloud_channel_stub.cc
+++ b/google/cloud/channel/v1/internal/cloud_channel_stub.cc
@@ -731,6 +731,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultCloudChannelServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -747,6 +748,7 @@ DefaultCloudChannelServiceStub::AsyncGetOperation(
 future<Status> DefaultCloudChannelServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/cloudbuild/v1/internal/cloud_build_stub.cc
+++ b/google/cloud/cloudbuild/v1/internal/cloud_build_stub.cc
@@ -302,6 +302,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultCloudBuildStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -318,6 +319,7 @@ DefaultCloudBuildStub::AsyncGetOperation(
 future<Status> DefaultCloudBuildStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/cloudbuild/v2/internal/repository_manager_stub.cc
+++ b/google/cloud/cloudbuild/v2/internal/repository_manager_stub.cc
@@ -249,6 +249,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultRepositoryManagerStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -265,6 +266,7 @@ DefaultRepositoryManagerStub::AsyncGetOperation(
 future<Status> DefaultRepositoryManagerStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/commerce/consumer/procurement/v1/internal/consumer_procurement_stub.cc
+++ b/google/cloud/commerce/consumer/procurement/v1/internal/consumer_procurement_stub.cc
@@ -83,6 +83,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultConsumerProcurementServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -99,6 +100,7 @@ DefaultConsumerProcurementServiceStub::AsyncGetOperation(
 future<Status> DefaultConsumerProcurementServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/composer/v1/internal/environments_stub.cc
+++ b/google/cloud/composer/v1/internal/environments_stub.cc
@@ -413,6 +413,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultEnvironmentsStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -429,6 +430,7 @@ DefaultEnvironmentsStub::AsyncGetOperation(
 future<Status> DefaultEnvironmentsStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/config/v1/internal/config_stub.cc
+++ b/google/cloud/config/v1/internal/config_stub.cc
@@ -327,6 +327,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultConfigStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -343,6 +344,7 @@ DefaultConfigStub::AsyncGetOperation(
 future<Status> DefaultConfigStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/connectors/v1/internal/connectors_stub.cc
+++ b/google/cloud/connectors/v1/internal/connectors_stub.cc
@@ -276,6 +276,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultConnectorsStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -292,6 +293,7 @@ DefaultConnectorsStub::AsyncGetOperation(
 future<Status> DefaultConnectorsStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/contactcenterinsights/v1/internal/contact_center_insights_stub.cc
+++ b/google/cloud/contactcenterinsights/v1/internal/contact_center_insights_stub.cc
@@ -608,6 +608,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultContactCenterInsightsStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -624,6 +625,7 @@ DefaultContactCenterInsightsStub::AsyncGetOperation(
 future<Status> DefaultContactCenterInsightsStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/datacatalog/lineage/v1/internal/lineage_stub.cc
+++ b/google/cloud/datacatalog/lineage/v1/internal/lineage_stub.cc
@@ -270,6 +270,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultLineageStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -286,6 +287,7 @@ DefaultLineageStub::AsyncGetOperation(
 future<Status> DefaultLineageStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/datacatalog/v1/internal/data_catalog_stub.cc
+++ b/google/cloud/datacatalog/v1/internal/data_catalog_stub.cc
@@ -458,6 +458,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultDataCatalogStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -474,6 +475,7 @@ DefaultDataCatalogStub::AsyncGetOperation(
 future<Status> DefaultDataCatalogStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/datafusion/v1/internal/data_fusion_stub.cc
+++ b/google/cloud/datafusion/v1/internal/data_fusion_stub.cc
@@ -148,6 +148,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultDataFusionStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -164,6 +165,7 @@ DefaultDataFusionStub::AsyncGetOperation(
 future<Status> DefaultDataFusionStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/datamigration/v1/internal/data_migration_stub.cc
+++ b/google/cloud/datamigration/v1/internal/data_migration_stub.cc
@@ -720,6 +720,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultDataMigrationServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -736,6 +737,7 @@ DefaultDataMigrationServiceStub::AsyncGetOperation(
 future<Status> DefaultDataMigrationServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/dataplex/v1/internal/dataplex_stub.cc
+++ b/google/cloud/dataplex/v1/internal/dataplex_stub.cc
@@ -519,6 +519,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultDataplexServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -535,6 +536,7 @@ DefaultDataplexServiceStub::AsyncGetOperation(
 future<Status> DefaultDataplexServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/dataproc/v1/internal/batch_controller_stub.cc
+++ b/google/cloud/dataproc/v1/internal/batch_controller_stub.cc
@@ -88,6 +88,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultBatchControllerStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -104,6 +105,7 @@ DefaultBatchControllerStub::AsyncGetOperation(
 future<Status> DefaultBatchControllerStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/dataproc/v1/internal/cluster_controller_stub.cc
+++ b/google/cloud/dataproc/v1/internal/cluster_controller_stub.cc
@@ -167,6 +167,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultClusterControllerStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -183,6 +184,7 @@ DefaultClusterControllerStub::AsyncGetOperation(
 future<Status> DefaultClusterControllerStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/dataproc/v1/internal/job_controller_stub.cc
+++ b/google/cloud/dataproc/v1/internal/job_controller_stub.cc
@@ -120,6 +120,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultJobControllerStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -136,6 +137,7 @@ DefaultJobControllerStub::AsyncGetOperation(
 future<Status> DefaultJobControllerStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/dataproc/v1/internal/node_group_controller_stub.cc
+++ b/google/cloud/dataproc/v1/internal/node_group_controller_stub.cc
@@ -83,6 +83,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultNodeGroupControllerStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -99,6 +100,7 @@ DefaultNodeGroupControllerStub::AsyncGetOperation(
 future<Status> DefaultNodeGroupControllerStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/dataproc/v1/internal/workflow_template_stub.cc
+++ b/google/cloud/dataproc/v1/internal/workflow_template_stub.cc
@@ -140,6 +140,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultWorkflowTemplateServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -156,6 +157,7 @@ DefaultWorkflowTemplateServiceStub::AsyncGetOperation(
 future<Status> DefaultWorkflowTemplateServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/datastore/admin/v1/internal/datastore_admin_stub.cc
+++ b/google/cloud/datastore/admin/v1/internal/datastore_admin_stub.cc
@@ -131,6 +131,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultDatastoreAdminStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -147,6 +148,7 @@ DefaultDatastoreAdminStub::AsyncGetOperation(
 future<Status> DefaultDatastoreAdminStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/datastream/v1/internal/datastream_stub.cc
+++ b/google/cloud/datastream/v1/internal/datastream_stub.cc
@@ -415,6 +415,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultDatastreamStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -431,6 +432,7 @@ DefaultDatastreamStub::AsyncGetOperation(
 future<Status> DefaultDatastreamStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/deploy/v1/internal/cloud_deploy_stub.cc
+++ b/google/cloud/deploy/v1/internal/cloud_deploy_stub.cc
@@ -600,6 +600,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultCloudDeployStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -616,6 +617,7 @@ DefaultCloudDeployStub::AsyncGetOperation(
 future<Status> DefaultCloudDeployStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/dialogflow_cx/internal/agents_stub.cc
+++ b/google/cloud/dialogflow_cx/internal/agents_stub.cc
@@ -184,6 +184,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultAgentsStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -200,6 +201,7 @@ DefaultAgentsStub::AsyncGetOperation(
 future<Status> DefaultAgentsStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/dialogflow_cx/internal/entity_types_stub.cc
+++ b/google/cloud/dialogflow_cx/internal/entity_types_stub.cc
@@ -134,6 +134,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultEntityTypesStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -150,6 +151,7 @@ DefaultEntityTypesStub::AsyncGetOperation(
 future<Status> DefaultEntityTypesStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/dialogflow_cx/internal/environments_stub.cc
+++ b/google/cloud/dialogflow_cx/internal/environments_stub.cc
@@ -178,6 +178,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultEnvironmentsStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -194,6 +195,7 @@ DefaultEnvironmentsStub::AsyncGetOperation(
 future<Status> DefaultEnvironmentsStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/dialogflow_cx/internal/flows_stub.cc
+++ b/google/cloud/dialogflow_cx/internal/flows_stub.cc
@@ -173,6 +173,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultFlowsStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -189,6 +190,7 @@ DefaultFlowsStub::AsyncGetOperation(
 future<Status> DefaultFlowsStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/dialogflow_cx/internal/intents_stub.cc
+++ b/google/cloud/dialogflow_cx/internal/intents_stub.cc
@@ -132,6 +132,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultIntentsStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -148,6 +149,7 @@ DefaultIntentsStub::AsyncGetOperation(
 future<Status> DefaultIntentsStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/dialogflow_cx/internal/test_cases_stub.cc
+++ b/google/cloud/dialogflow_cx/internal/test_cases_stub.cc
@@ -211,6 +211,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultTestCasesStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -227,6 +228,7 @@ DefaultTestCasesStub::AsyncGetOperation(
 future<Status> DefaultTestCasesStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/dialogflow_cx/internal/versions_stub.cc
+++ b/google/cloud/dialogflow_cx/internal/versions_stub.cc
@@ -132,6 +132,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultVersionsStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -148,6 +149,7 @@ DefaultVersionsStub::AsyncGetOperation(
 future<Status> DefaultVersionsStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/dialogflow_es/internal/agents_stub.cc
+++ b/google/cloud/dialogflow_es/internal/agents_stub.cc
@@ -164,6 +164,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultAgentsStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -180,6 +181,7 @@ DefaultAgentsStub::AsyncGetOperation(
 future<Status> DefaultAgentsStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/dialogflow_es/internal/conversation_datasets_stub.cc
+++ b/google/cloud/dialogflow_es/internal/conversation_datasets_stub.cc
@@ -125,6 +125,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultConversationDatasetsStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -141,6 +142,7 @@ DefaultConversationDatasetsStub::AsyncGetOperation(
 future<Status> DefaultConversationDatasetsStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/dialogflow_es/internal/conversation_models_stub.cc
+++ b/google/cloud/dialogflow_es/internal/conversation_models_stub.cc
@@ -196,6 +196,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultConversationModelsStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -212,6 +213,7 @@ DefaultConversationModelsStub::AsyncGetOperation(
 future<Status> DefaultConversationModelsStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/dialogflow_es/internal/conversation_profiles_stub.cc
+++ b/google/cloud/dialogflow_es/internal/conversation_profiles_stub.cc
@@ -146,6 +146,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultConversationProfilesStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -162,6 +163,7 @@ DefaultConversationProfilesStub::AsyncGetOperation(
 future<Status> DefaultConversationProfilesStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/dialogflow_es/internal/documents_stub.cc
+++ b/google/cloud/dialogflow_es/internal/documents_stub.cc
@@ -173,6 +173,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultDocumentsStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -189,6 +190,7 @@ DefaultDocumentsStub::AsyncGetOperation(
 future<Status> DefaultDocumentsStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/dialogflow_es/internal/entity_types_stub.cc
+++ b/google/cloud/dialogflow_es/internal/entity_types_stub.cc
@@ -191,6 +191,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultEntityTypesStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -207,6 +208,7 @@ DefaultEntityTypesStub::AsyncGetOperation(
 future<Status> DefaultEntityTypesStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/dialogflow_es/internal/intents_stub.cc
+++ b/google/cloud/dialogflow_es/internal/intents_stub.cc
@@ -131,6 +131,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultIntentsStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -147,6 +148,7 @@ DefaultIntentsStub::AsyncGetOperation(
 future<Status> DefaultIntentsStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/discoveryengine/v1/internal/completion_stub.cc
+++ b/google/cloud/discoveryengine/v1/internal/completion_stub.cc
@@ -89,6 +89,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultCompletionServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -105,6 +106,7 @@ DefaultCompletionServiceStub::AsyncGetOperation(
 future<Status> DefaultCompletionServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/discoveryengine/v1/internal/document_stub.cc
+++ b/google/cloud/discoveryengine/v1/internal/document_stub.cc
@@ -132,6 +132,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultDocumentServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -148,6 +149,7 @@ DefaultDocumentServiceStub::AsyncGetOperation(
 future<Status> DefaultDocumentServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/discoveryengine/v1/internal/schema_stub.cc
+++ b/google/cloud/discoveryengine/v1/internal/schema_stub.cc
@@ -116,6 +116,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultSchemaServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -132,6 +133,7 @@ DefaultSchemaServiceStub::AsyncGetOperation(
 future<Status> DefaultSchemaServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/discoveryengine/v1/internal/user_event_stub.cc
+++ b/google/cloud/discoveryengine/v1/internal/user_event_stub.cc
@@ -79,6 +79,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultUserEventServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -95,6 +96,7 @@ DefaultUserEventServiceStub::AsyncGetOperation(
 future<Status> DefaultUserEventServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/documentai/v1/internal/document_processor_stub.cc
+++ b/google/cloud/documentai/v1/internal/document_processor_stub.cc
@@ -385,6 +385,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultDocumentProcessorServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -401,6 +402,7 @@ DefaultDocumentProcessorServiceStub::AsyncGetOperation(
 future<Status> DefaultDocumentProcessorServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/domains/v1/internal/domains_stub.cc
+++ b/google/cloud/domains/v1/internal/domains_stub.cc
@@ -280,6 +280,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultDomainsStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -296,6 +297,7 @@ DefaultDomainsStub::AsyncGetOperation(
 future<Status> DefaultDomainsStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/edgecontainer/v1/internal/edge_container_stub.cc
+++ b/google/cloud/edgecontainer/v1/internal/edge_container_stub.cc
@@ -299,6 +299,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultEdgeContainerStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -315,6 +316,7 @@ DefaultEdgeContainerStub::AsyncGetOperation(
 future<Status> DefaultEdgeContainerStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/edgenetwork/v1/internal/edge_network_stub.cc
+++ b/google/cloud/edgenetwork/v1/internal/edge_network_stub.cc
@@ -419,6 +419,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultEdgeNetworkStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -435,6 +436,7 @@ DefaultEdgeNetworkStub::AsyncGetOperation(
 future<Status> DefaultEdgeNetworkStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/eventarc/v1/internal/eventarc_stub.cc
+++ b/google/cloud/eventarc/v1/internal/eventarc_stub.cc
@@ -305,6 +305,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultEventarcStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -321,6 +322,7 @@ DefaultEventarcStub::AsyncGetOperation(
 future<Status> DefaultEventarcStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/filestore/v1/internal/cloud_filestore_manager_stub.cc
+++ b/google/cloud/filestore/v1/internal/cloud_filestore_manager_stub.cc
@@ -306,6 +306,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultCloudFilestoreManagerStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -322,6 +323,7 @@ DefaultCloudFilestoreManagerStub::AsyncGetOperation(
 future<Status> DefaultCloudFilestoreManagerStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/functions/v1/internal/cloud_functions_stub.cc
+++ b/google/cloud/functions/v1/internal/cloud_functions_stub.cc
@@ -185,6 +185,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultCloudFunctionsServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -201,6 +202,7 @@ DefaultCloudFunctionsServiceStub::AsyncGetOperation(
 future<Status> DefaultCloudFunctionsServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/functions/v2/internal/function_stub.cc
+++ b/google/cloud/functions/v2/internal/function_stub.cc
@@ -149,6 +149,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultFunctionServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -165,6 +166,7 @@ DefaultFunctionServiceStub::AsyncGetOperation(
 future<Status> DefaultFunctionServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/gkebackup/v1/internal/backup_for_gke_stub.cc
+++ b/google/cloud/gkebackup/v1/internal/backup_for_gke_stub.cc
@@ -401,6 +401,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultBackupForGKEStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -417,6 +418,7 @@ DefaultBackupForGKEStub::AsyncGetOperation(
 future<Status> DefaultBackupForGKEStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/gkehub/v1/internal/gke_hub_stub.cc
+++ b/google/cloud/gkehub/v1/internal/gke_hub_stub.cc
@@ -203,6 +203,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultGkeHubStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -219,6 +220,7 @@ DefaultGkeHubStub::AsyncGetOperation(
 future<Status> DefaultGkeHubStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/gkemulticloud/v1/internal/attached_clusters_stub.cc
+++ b/google/cloud/gkemulticloud/v1/internal/attached_clusters_stub.cc
@@ -191,6 +191,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultAttachedClustersStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -207,6 +208,7 @@ DefaultAttachedClustersStub::AsyncGetOperation(
 future<Status> DefaultAttachedClustersStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/gkemulticloud/v1/internal/aws_clusters_stub.cc
+++ b/google/cloud/gkemulticloud/v1/internal/aws_clusters_stub.cc
@@ -284,6 +284,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultAwsClustersStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -300,6 +301,7 @@ DefaultAwsClustersStub::AsyncGetOperation(
 future<Status> DefaultAwsClustersStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/gkemulticloud/v1/internal/azure_clusters_stub.cc
+++ b/google/cloud/gkemulticloud/v1/internal/azure_clusters_stub.cc
@@ -335,6 +335,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultAzureClustersStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -351,6 +352,7 @@ DefaultAzureClustersStub::AsyncGetOperation(
 future<Status> DefaultAzureClustersStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/iam/v2/internal/policies_stub.cc
+++ b/google/cloud/iam/v2/internal/policies_stub.cc
@@ -109,6 +109,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultPoliciesStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -125,6 +126,7 @@ DefaultPoliciesStub::AsyncGetOperation(
 future<Status> DefaultPoliciesStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/ids/v1/internal/ids_stub.cc
+++ b/google/cloud/ids/v1/internal/ids_stub.cc
@@ -94,6 +94,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultIDSStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -110,6 +111,7 @@ DefaultIDSStub::AsyncGetOperation(
 future<Status> DefaultIDSStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/logging/v2/internal/config_service_v2_stub.cc
+++ b/google/cloud/logging/v2/internal/config_service_v2_stub.cc
@@ -430,6 +430,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultConfigServiceV2Stub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -446,6 +447,7 @@ DefaultConfigServiceV2Stub::AsyncGetOperation(
 future<Status> DefaultConfigServiceV2Stub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/logging/v2/internal/logging_service_v2_auth_decorator.cc
+++ b/google/cloud/logging/v2/internal/logging_service_v2_auth_decorator.cc
@@ -99,18 +99,20 @@ future<StatusOr<google::logging::v2::WriteLogEntriesResponse>>
 LoggingServiceV2Auth::AsyncWriteLogEntries(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::logging::v2::WriteLogEntriesRequest const& request) {
-  using ReturnType = StatusOr<google::logging::v2::WriteLogEntriesResponse>;
-  auto& child = child_;
   return auth_->AsyncConfigureContext(std::move(context))
-      .then([cq, child,
+      .then([cq, child = child_, options = std::move(options),
              request](future<StatusOr<std::shared_ptr<grpc::ClientContext>>>
                           f) mutable {
         auto context = f.get();
         if (!context) {
-          return make_ready_future(ReturnType(std::move(context).status()));
+          return make_ready_future(
+              StatusOr<google::logging::v2::WriteLogEntriesResponse>(
+                  std::move(context).status()));
         }
-        return child->AsyncWriteLogEntries(cq, *std::move(context), request);
+        return child->AsyncWriteLogEntries(cq, *std::move(context),
+                                           std::move(options), request);
       });
 }
 

--- a/google/cloud/logging/v2/internal/logging_service_v2_auth_decorator.h
+++ b/google/cloud/logging/v2/internal/logging_service_v2_auth_decorator.h
@@ -72,6 +72,7 @@ class LoggingServiceV2Auth : public LoggingServiceV2Stub {
   AsyncWriteLogEntries(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::logging::v2::WriteLogEntriesRequest const& request) override;
 
  private:

--- a/google/cloud/logging/v2/internal/logging_service_v2_connection_impl.cc
+++ b/google/cloud/logging/v2/internal/logging_service_v2_connection_impl.cc
@@ -194,15 +194,18 @@ LoggingServiceV2ConnectionImpl::AsyncWriteLogEntries(
   auto request_copy = request;
   auto const idempotent =
       idempotency_policy(*current)->WriteLogEntries(request_copy);
+  auto retry = retry_policy(*current);
+  auto backoff = backoff_policy(*current);
   return google::cloud::internal::AsyncRetryLoop(
-      retry_policy(*current), backoff_policy(*current), idempotent,
-      background_->cq(),
+      std::move(retry), std::move(backoff), idempotent, background_->cq(),
       [stub = stub_](
           CompletionQueue& cq, std::shared_ptr<grpc::ClientContext> context,
+          google::cloud::internal::ImmutableOptions options,
           google::logging::v2::WriteLogEntriesRequest const& request) {
-        return stub->AsyncWriteLogEntries(cq, std::move(context), request);
+        return stub->AsyncWriteLogEntries(cq, std::move(context),
+                                          std::move(options), request);
       },
-      std::move(request_copy), __func__);
+      std::move(current), std::move(request_copy), __func__);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/logging/v2/internal/logging_service_v2_logging_decorator.cc
+++ b/google/cloud/logging/v2/internal/logging_service_v2_logging_decorator.cc
@@ -125,14 +125,18 @@ future<StatusOr<google::logging::v2::WriteLogEntriesResponse>>
 LoggingServiceV2Logging::AsyncWriteLogEntries(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::logging::v2::WriteLogEntriesRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](google::cloud::CompletionQueue& cq,
              std::shared_ptr<grpc::ClientContext> context,
+             google::cloud::internal::ImmutableOptions options,
              google::logging::v2::WriteLogEntriesRequest const& request) {
-        return child_->AsyncWriteLogEntries(cq, std::move(context), request);
+        return child_->AsyncWriteLogEntries(cq, std::move(context),
+                                            std::move(options), request);
       },
-      cq, std::move(context), request, __func__, tracing_options_);
+      cq, std::move(context), std::move(options), request, __func__,
+      tracing_options_);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/logging/v2/internal/logging_service_v2_logging_decorator.h
+++ b/google/cloud/logging/v2/internal/logging_service_v2_logging_decorator.h
@@ -72,6 +72,7 @@ class LoggingServiceV2Logging : public LoggingServiceV2Stub {
   AsyncWriteLogEntries(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::logging::v2::WriteLogEntriesRequest const& request) override;
 
  private:

--- a/google/cloud/logging/v2/internal/logging_service_v2_metadata_decorator.cc
+++ b/google/cloud/logging/v2/internal/logging_service_v2_metadata_decorator.cc
@@ -101,9 +101,11 @@ future<StatusOr<google::logging::v2::WriteLogEntriesResponse>>
 LoggingServiceV2Metadata::AsyncWriteLogEntries(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::logging::v2::WriteLogEntriesRequest const& request) {
-  SetMetadata(*context, internal::CurrentOptions());
-  return child_->AsyncWriteLogEntries(cq, std::move(context), request);
+  SetMetadata(*context, *options);
+  return child_->AsyncWriteLogEntries(cq, std::move(context),
+                                      std::move(options), request);
 }
 
 void LoggingServiceV2Metadata::SetMetadata(grpc::ClientContext& context,

--- a/google/cloud/logging/v2/internal/logging_service_v2_metadata_decorator.h
+++ b/google/cloud/logging/v2/internal/logging_service_v2_metadata_decorator.h
@@ -73,6 +73,7 @@ class LoggingServiceV2Metadata : public LoggingServiceV2Stub {
   AsyncWriteLogEntries(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::logging::v2::WriteLogEntriesRequest const& request) override;
 
  private:

--- a/google/cloud/logging/v2/internal/logging_service_v2_stub.cc
+++ b/google/cloud/logging/v2/internal/logging_service_v2_stub.cc
@@ -112,6 +112,8 @@ future<StatusOr<google::logging::v2::WriteLogEntriesResponse>>
 DefaultLoggingServiceV2Stub::AsyncWriteLogEntries(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    google::cloud::internal::ImmutableOptions,
     google::logging::v2::WriteLogEntriesRequest const& request) {
   return internal::MakeUnaryRpcImpl<
       google::logging::v2::WriteLogEntriesRequest,

--- a/google/cloud/logging/v2/internal/logging_service_v2_stub.h
+++ b/google/cloud/logging/v2/internal/logging_service_v2_stub.h
@@ -73,6 +73,7 @@ class LoggingServiceV2Stub {
   AsyncWriteLogEntries(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::logging::v2::WriteLogEntriesRequest const& request) = 0;
 };
 
@@ -117,6 +118,7 @@ class DefaultLoggingServiceV2Stub : public LoggingServiceV2Stub {
   AsyncWriteLogEntries(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::logging::v2::WriteLogEntriesRequest const& request) override;
 
  private:

--- a/google/cloud/logging/v2/internal/logging_service_v2_tracing_stub.cc
+++ b/google/cloud/logging/v2/internal/logging_service_v2_tracing_stub.cc
@@ -114,12 +114,14 @@ future<StatusOr<google::logging::v2::WriteLogEntriesResponse>>
 LoggingServiceV2TracingStub::AsyncWriteLogEntries(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::logging::v2::WriteLogEntriesRequest const& request) {
   auto span = internal::MakeSpanGrpc("google.logging.v2.LoggingServiceV2",
                                      "WriteLogEntries");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto f = child_->AsyncWriteLogEntries(cq, context, request);
+  auto f =
+      child_->AsyncWriteLogEntries(cq, context, std::move(options), request);
   return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 

--- a/google/cloud/logging/v2/internal/logging_service_v2_tracing_stub.h
+++ b/google/cloud/logging/v2/internal/logging_service_v2_tracing_stub.h
@@ -72,6 +72,7 @@ class LoggingServiceV2TracingStub : public LoggingServiceV2Stub {
   AsyncWriteLogEntries(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::logging::v2::WriteLogEntriesRequest const& request) override;
 
  private:

--- a/google/cloud/managedidentities/v1/internal/managed_identities_stub.cc
+++ b/google/cloud/managedidentities/v1/internal/managed_identities_stub.cc
@@ -208,6 +208,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultManagedIdentitiesServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -224,6 +225,7 @@ DefaultManagedIdentitiesServiceStub::AsyncGetOperation(
 future<Status> DefaultManagedIdentitiesServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/memcache/v1/internal/cloud_memcache_stub.cc
+++ b/google/cloud/memcache/v1/internal/cloud_memcache_stub.cc
@@ -169,6 +169,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultCloudMemcacheStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -185,6 +186,7 @@ DefaultCloudMemcacheStub::AsyncGetOperation(
 future<Status> DefaultCloudMemcacheStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/metastore/v1/internal/dataproc_metastore_federation_stub.cc
+++ b/google/cloud/metastore/v1/internal/dataproc_metastore_federation_stub.cc
@@ -116,6 +116,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultDataprocMetastoreFederationStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -132,6 +133,7 @@ DefaultDataprocMetastoreFederationStub::AsyncGetOperation(
 future<Status> DefaultDataprocMetastoreFederationStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/metastore/v1/internal/dataproc_metastore_stub.cc
+++ b/google/cloud/metastore/v1/internal/dataproc_metastore_stub.cc
@@ -329,6 +329,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultDataprocMetastoreStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -345,6 +346,7 @@ DefaultDataprocMetastoreStub::AsyncGetOperation(
 future<Status> DefaultDataprocMetastoreStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/migrationcenter/v1/internal/migration_center_stub.cc
+++ b/google/cloud/migrationcenter/v1/internal/migration_center_stub.cc
@@ -796,6 +796,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultMigrationCenterStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -812,6 +813,7 @@ DefaultMigrationCenterStub::AsyncGetOperation(
 future<Status> DefaultMigrationCenterStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/monitoring/metricsscope/v1/internal/metrics_scopes_stub.cc
+++ b/google/cloud/monitoring/metricsscope/v1/internal/metrics_scopes_stub.cc
@@ -104,6 +104,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultMetricsScopesStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -120,6 +121,7 @@ DefaultMetricsScopesStub::AsyncGetOperation(
 future<Status> DefaultMetricsScopesStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/monitoring/v3/internal/metric_auth_decorator.cc
+++ b/google/cloud/monitoring/v3/internal/metric_auth_decorator.cc
@@ -113,15 +113,16 @@ Status MetricServiceAuth::CreateServiceTimeSeries(
 future<Status> MetricServiceAuth::AsyncCreateTimeSeries(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::monitoring::v3::CreateTimeSeriesRequest const& request) {
-  auto& child = child_;
   return auth_->AsyncConfigureContext(std::move(context))
-      .then([cq, child,
+      .then([cq, child = child_, options = std::move(options),
              request](future<StatusOr<std::shared_ptr<grpc::ClientContext>>>
                           f) mutable {
         auto context = f.get();
         if (!context) return make_ready_future(std::move(context).status());
-        return child->AsyncCreateTimeSeries(cq, *std::move(context), request);
+        return child->AsyncCreateTimeSeries(cq, *std::move(context),
+                                            std::move(options), request);
       });
 }
 

--- a/google/cloud/monitoring/v3/internal/metric_auth_decorator.h
+++ b/google/cloud/monitoring/v3/internal/metric_auth_decorator.h
@@ -86,6 +86,7 @@ class MetricServiceAuth : public MetricServiceStub {
   future<Status> AsyncCreateTimeSeries(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::monitoring::v3::CreateTimeSeriesRequest const& request) override;
 
  private:

--- a/google/cloud/monitoring/v3/internal/metric_connection_impl.cc
+++ b/google/cloud/monitoring/v3/internal/metric_connection_impl.cc
@@ -260,15 +260,18 @@ future<Status> MetricServiceConnectionImpl::AsyncCreateTimeSeries(
   auto request_copy = request;
   auto const idempotent =
       idempotency_policy(*current)->CreateTimeSeries(request_copy);
+  auto retry = retry_policy(*current);
+  auto backoff = backoff_policy(*current);
   return google::cloud::internal::AsyncRetryLoop(
-      retry_policy(*current), backoff_policy(*current), idempotent,
-      background_->cq(),
+      std::move(retry), std::move(backoff), idempotent, background_->cq(),
       [stub = stub_](
           CompletionQueue& cq, std::shared_ptr<grpc::ClientContext> context,
+          google::cloud::internal::ImmutableOptions options,
           google::monitoring::v3::CreateTimeSeriesRequest const& request) {
-        return stub->AsyncCreateTimeSeries(cq, std::move(context), request);
+        return stub->AsyncCreateTimeSeries(cq, std::move(context),
+                                           std::move(options), request);
       },
-      std::move(request_copy), __func__);
+      std::move(current), std::move(request_copy), __func__);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/monitoring/v3/internal/metric_logging_decorator.cc
+++ b/google/cloud/monitoring/v3/internal/metric_logging_decorator.cc
@@ -155,14 +155,18 @@ Status MetricServiceLogging::CreateServiceTimeSeries(
 future<Status> MetricServiceLogging::AsyncCreateTimeSeries(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::monitoring::v3::CreateTimeSeriesRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](google::cloud::CompletionQueue& cq,
              std::shared_ptr<grpc::ClientContext> context,
+             google::cloud::internal::ImmutableOptions options,
              google::monitoring::v3::CreateTimeSeriesRequest const& request) {
-        return child_->AsyncCreateTimeSeries(cq, std::move(context), request);
+        return child_->AsyncCreateTimeSeries(cq, std::move(context),
+                                             std::move(options), request);
       },
-      cq, std::move(context), request, __func__, tracing_options_);
+      cq, std::move(context), std::move(options), request, __func__,
+      tracing_options_);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/monitoring/v3/internal/metric_logging_decorator.h
+++ b/google/cloud/monitoring/v3/internal/metric_logging_decorator.h
@@ -86,6 +86,7 @@ class MetricServiceLogging : public MetricServiceStub {
   future<Status> AsyncCreateTimeSeries(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::monitoring::v3::CreateTimeSeriesRequest const& request) override;
 
  private:

--- a/google/cloud/monitoring/v3/internal/metric_metadata_decorator.cc
+++ b/google/cloud/monitoring/v3/internal/metric_metadata_decorator.cc
@@ -125,10 +125,12 @@ Status MetricServiceMetadata::CreateServiceTimeSeries(
 future<Status> MetricServiceMetadata::AsyncCreateTimeSeries(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::monitoring::v3::CreateTimeSeriesRequest const& request) {
-  SetMetadata(*context, internal::CurrentOptions(),
+  SetMetadata(*context, *options,
               absl::StrCat("name=", internal::UrlEncode(request.name())));
-  return child_->AsyncCreateTimeSeries(cq, std::move(context), request);
+  return child_->AsyncCreateTimeSeries(cq, std::move(context),
+                                       std::move(options), request);
 }
 
 void MetricServiceMetadata::SetMetadata(grpc::ClientContext& context,

--- a/google/cloud/monitoring/v3/internal/metric_metadata_decorator.h
+++ b/google/cloud/monitoring/v3/internal/metric_metadata_decorator.h
@@ -86,6 +86,7 @@ class MetricServiceMetadata : public MetricServiceStub {
   future<Status> AsyncCreateTimeSeries(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::monitoring::v3::CreateTimeSeriesRequest const& request) override;
 
  private:

--- a/google/cloud/monitoring/v3/internal/metric_stub.cc
+++ b/google/cloud/monitoring/v3/internal/metric_stub.cc
@@ -145,6 +145,8 @@ Status DefaultMetricServiceStub::CreateServiceTimeSeries(
 future<Status> DefaultMetricServiceStub::AsyncCreateTimeSeries(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    google::cloud::internal::ImmutableOptions,
     google::monitoring::v3::CreateTimeSeriesRequest const& request) {
   return internal::MakeUnaryRpcImpl<
              google::monitoring::v3::CreateTimeSeriesRequest,

--- a/google/cloud/monitoring/v3/internal/metric_stub.h
+++ b/google/cloud/monitoring/v3/internal/metric_stub.h
@@ -83,6 +83,7 @@ class MetricServiceStub {
   virtual future<Status> AsyncCreateTimeSeries(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::monitoring::v3::CreateTimeSeriesRequest const& request) = 0;
 };
 
@@ -141,6 +142,7 @@ class DefaultMetricServiceStub : public MetricServiceStub {
   future<Status> AsyncCreateTimeSeries(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::monitoring::v3::CreateTimeSeriesRequest const& request) override;
 
  private:

--- a/google/cloud/monitoring/v3/internal/metric_tracing_stub.cc
+++ b/google/cloud/monitoring/v3/internal/metric_tracing_stub.cc
@@ -146,12 +146,14 @@ Status MetricServiceTracingStub::CreateServiceTimeSeries(
 future<Status> MetricServiceTracingStub::AsyncCreateTimeSeries(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::monitoring::v3::CreateTimeSeriesRequest const& request) {
   auto span = internal::MakeSpanGrpc("google.monitoring.v3.MetricService",
                                      "CreateTimeSeries");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto f = child_->AsyncCreateTimeSeries(cq, context, request);
+  auto f =
+      child_->AsyncCreateTimeSeries(cq, context, std::move(options), request);
   return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 

--- a/google/cloud/monitoring/v3/internal/metric_tracing_stub.h
+++ b/google/cloud/monitoring/v3/internal/metric_tracing_stub.h
@@ -85,6 +85,7 @@ class MetricServiceTracingStub : public MetricServiceStub {
   future<Status> AsyncCreateTimeSeries(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::monitoring::v3::CreateTimeSeriesRequest const& request) override;
 
  private:

--- a/google/cloud/netapp/v1/internal/net_app_stub.cc
+++ b/google/cloud/netapp/v1/internal/net_app_stub.cc
@@ -845,6 +845,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultNetAppStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -861,6 +862,7 @@ DefaultNetAppStub::AsyncGetOperation(
 future<Status> DefaultNetAppStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/networkconnectivity/v1/internal/hub_stub.cc
+++ b/google/cloud/networkconnectivity/v1/internal/hub_stub.cc
@@ -326,6 +326,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultHubServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -342,6 +343,7 @@ DefaultHubServiceStub::AsyncGetOperation(
 future<Status> DefaultHubServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/networkmanagement/v1/internal/reachability_stub.cc
+++ b/google/cloud/networkmanagement/v1/internal/reachability_stub.cc
@@ -141,6 +141,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultReachabilityServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -157,6 +158,7 @@ DefaultReachabilityServiceStub::AsyncGetOperation(
 future<Status> DefaultReachabilityServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/networksecurity/v1/internal/network_security_stub.cc
+++ b/google/cloud/networksecurity/v1/internal/network_security_stub.cc
@@ -296,6 +296,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultNetworkSecurityStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -312,6 +313,7 @@ DefaultNetworkSecurityStub::AsyncGetOperation(
 future<Status> DefaultNetworkSecurityStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/networkservices/v1/internal/network_services_stub.cc
+++ b/google/cloud/networkservices/v1/internal/network_services_stub.cc
@@ -678,6 +678,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultNetworkServicesStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -694,6 +695,7 @@ DefaultNetworkServicesStub::AsyncGetOperation(
 future<Status> DefaultNetworkServicesStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/notebooks/v1/internal/managed_notebook_stub.cc
+++ b/google/cloud/notebooks/v1/internal/managed_notebook_stub.cc
@@ -255,6 +255,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultManagedNotebookServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -271,6 +272,7 @@ DefaultManagedNotebookServiceStub::AsyncGetOperation(
 future<Status> DefaultManagedNotebookServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/notebooks/v1/internal/notebook_stub.cc
+++ b/google/cloud/notebooks/v1/internal/notebook_stub.cc
@@ -604,6 +604,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultNotebookServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -620,6 +621,7 @@ DefaultNotebookServiceStub::AsyncGetOperation(
 future<Status> DefaultNotebookServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/notebooks/v2/internal/notebook_stub.cc
+++ b/google/cloud/notebooks/v2/internal/notebook_stub.cc
@@ -238,6 +238,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultNotebookServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -254,6 +255,7 @@ DefaultNotebookServiceStub::AsyncGetOperation(
 future<Status> DefaultNotebookServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/optimization/v1/internal/fleet_routing_stub.cc
+++ b/google/cloud/optimization/v1/internal/fleet_routing_stub.cc
@@ -66,6 +66,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultFleetRoutingStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -82,6 +83,7 @@ DefaultFleetRoutingStub::AsyncGetOperation(
 future<Status> DefaultFleetRoutingStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/osconfig/v1/internal/os_config_zonal_stub.cc
+++ b/google/cloud/osconfig/v1/internal/os_config_zonal_stub.cc
@@ -214,6 +214,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultOsConfigZonalServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -230,6 +231,7 @@ DefaultOsConfigZonalServiceStub::AsyncGetOperation(
 future<Status> DefaultOsConfigZonalServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/policysimulator/v1/internal/simulator_stub.cc
+++ b/google/cloud/policysimulator/v1/internal/simulator_stub.cc
@@ -79,6 +79,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultSimulatorStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -95,6 +96,7 @@ DefaultSimulatorStub::AsyncGetOperation(
 future<Status> DefaultSimulatorStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/privateca/v1/internal/certificate_authority_stub.cc
+++ b/google/cloud/privateca/v1/internal/certificate_authority_stub.cc
@@ -531,6 +531,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultCertificateAuthorityServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -547,6 +548,7 @@ DefaultCertificateAuthorityServiceStub::AsyncGetOperation(
 future<Status> DefaultCertificateAuthorityServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/pubsub/internal/default_batch_sink.h
+++ b/google/cloud/pubsub/internal/default_batch_sink.h
@@ -52,7 +52,7 @@ class DefaultBatchSink : public BatchSink {
 
   std::shared_ptr<PublisherStub> stub_;
   CompletionQueue cq_;
-  Options options_;
+  google::cloud::internal::ImmutableOptions options_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsub/internal/default_pull_ack_handler.cc
+++ b/google/cloud/pubsub/internal/default_pull_ack_handler.cc
@@ -65,10 +65,12 @@ future<Status> DefaultPullAckHandler::ack() {
         std::make_unique<ExactlyOnceRetryPolicy>(ack_id_),
         ExactlyOnceBackoffPolicy(), google::cloud::Idempotency::kIdempotent,
         cq_,
-        [stub = std::move(s)](auto cq, auto context, auto const& request) {
-          return stub->AsyncAcknowledge(cq, std::move(context), request);
+        [stub = std::move(s)](auto cq, auto context, auto options,
+                              auto const& request) {
+          return stub->AsyncAcknowledge(cq, std::move(context),
+                                        std::move(options), request);
         },
-        request, __func__);
+        google::cloud::internal::MakeImmutableOptions({}), request, __func__);
   }
   return make_ready_future(
       Status(StatusCode::kFailedPrecondition, "session already shutdown"));
@@ -84,10 +86,12 @@ future<Status> DefaultPullAckHandler::nack() {
         std::make_unique<ExactlyOnceRetryPolicy>(ack_id_),
         ExactlyOnceBackoffPolicy(), google::cloud::Idempotency::kIdempotent,
         cq_,
-        [stub = std::move(s)](auto cq, auto context, auto const& request) {
-          return stub->AsyncModifyAckDeadline(cq, std::move(context), request);
+        [stub = std::move(s)](auto cq, auto context, auto options,
+                              auto const& request) {
+          return stub->AsyncModifyAckDeadline(cq, std::move(context),
+                                              std::move(options), request);
         },
-        request, __func__);
+        google::cloud::internal::MakeImmutableOptions({}), request, __func__);
   }
   return make_ready_future(
       Status(StatusCode::kFailedPrecondition, "session already shutdown"));

--- a/google/cloud/pubsub/internal/default_pull_ack_handler_test.cc
+++ b/google/cloud/pubsub/internal/default_pull_ack_handler_test.cc
@@ -82,7 +82,7 @@ TEST(PullAckHandlerTest, AckSimple) {
   auto request_matcher = AllOf(
       Property(&AcknowledgeRequest::ack_ids, ElementsAre("test-ack-id")),
       Property(&AcknowledgeRequest::subscription, subscription.FullName()));
-  EXPECT_CALL(*mock, AsyncAcknowledge(_, _, request_matcher))
+  EXPECT_CALL(*mock, AsyncAcknowledge(_, _, _, request_matcher))
       .WillOnce(Return(ByMove(make_ready_future(TransientError()))))
       .WillOnce(
           Return(ByMove(make_ready_future(TransientError("test-ack-id")))))
@@ -110,7 +110,7 @@ TEST(PullAckHandlerTest, AckPermanentError) {
   auto request_matcher = AllOf(
       Property(&AcknowledgeRequest::ack_ids, ElementsAre("test-ack-id")),
       Property(&AcknowledgeRequest::subscription, subscription.FullName()));
-  EXPECT_CALL(*mock, AsyncAcknowledge(_, _, request_matcher))
+  EXPECT_CALL(*mock, AsyncAcknowledge(_, _, _, request_matcher))
       .WillOnce(Return(ByMove(make_ready_future(PermanentError()))));
   AsyncSequencer<bool> aseq;
   auto cq = MakeMockCompletionQueue(aseq);
@@ -132,7 +132,7 @@ TEST(PullAckHandlerTest, NackSimple) {
       Property(&ModifyAckDeadlineRequest::ack_deadline_seconds, 0),
       Property(&ModifyAckDeadlineRequest::subscription,
                subscription.FullName()));
-  EXPECT_CALL(*mock, AsyncModifyAckDeadline(_, _, request_matcher))
+  EXPECT_CALL(*mock, AsyncModifyAckDeadline(_, _, _, request_matcher))
       .WillOnce(Return(ByMove(make_ready_future(TransientError()))))
       .WillOnce(
           Return(ByMove(make_ready_future(TransientError("test-ack-id")))))
@@ -162,7 +162,7 @@ TEST(PullAckHandlerTest, NackPermanentError) {
       Property(&ModifyAckDeadlineRequest::ack_deadline_seconds, 0),
       Property(&ModifyAckDeadlineRequest::subscription,
                subscription.FullName()));
-  EXPECT_CALL(*mock, AsyncModifyAckDeadline(_, _, request_matcher))
+  EXPECT_CALL(*mock, AsyncModifyAckDeadline(_, _, _, request_matcher))
       .WillOnce(Return(ByMove(make_ready_future(PermanentError()))));
   AsyncSequencer<bool> aseq;
   auto cq = MakeMockCompletionQueue(aseq);

--- a/google/cloud/pubsub/internal/default_pull_lease_manager.h
+++ b/google/cloud/pubsub/internal/default_pull_lease_manager.h
@@ -73,7 +73,7 @@ class DefaultPullLeaseManager
 
   CompletionQueue cq_;
   std::weak_ptr<SubscriberStub> stub_;
-  Options options_;
+  google::cloud::internal::ImmutableOptions options_;
   pubsub::Subscription subscription_;
   std::string ack_id_;
   std::shared_ptr<Clock> clock_;

--- a/google/cloud/pubsub/internal/extend_leases_with_retry.cc
+++ b/google/cloud/pubsub/internal/extend_leases_with_retry.cc
@@ -108,7 +108,10 @@ class ExtendLeasesWithRetryHandle
   void MakeAttempt() {
     ++attempts_;
     auto context = std::make_shared<grpc::ClientContext>();
-    stub_->AsyncModifyAckDeadline(cq_, std::move(context), request_)
+    auto options = google::cloud::internal::MakeImmutableOptions({});
+    stub_
+        ->AsyncModifyAckDeadline(cq_, std::move(context), std::move(options),
+                                 request_)
         .then(
             [self = shared_from_this()](auto f) { self->OnAttempt(f.get()); });
   }

--- a/google/cloud/pubsub/internal/extend_leases_with_retry_test.cc
+++ b/google/cloud/pubsub/internal/extend_leases_with_retry_test.cc
@@ -50,7 +50,7 @@ TEST(ExtendLeasesWithRetry, Success) {
 
   ::testing::InSequence sequence;
   EXPECT_CALL(*mock, AsyncModifyAckDeadline(
-                         _, _,
+                         _, _, _,
                          Property(&ModifyAckDeadlineRequest::ack_ids,
                                   ElementsAre("test-001", "test-002"))))
       .WillOnce(Return(ByMove(make_ready_future(MakeTransient()))));
@@ -58,7 +58,7 @@ TEST(ExtendLeasesWithRetry, Success) {
       .WillOnce(Return(ByMove(make_ready_future(
           make_status_or(std::chrono::system_clock::now())))));
   EXPECT_CALL(*mock, AsyncModifyAckDeadline(
-                         _, _,
+                         _, _, _,
                          Property(&ModifyAckDeadlineRequest::ack_ids,
                                   ElementsAre("test-001", "test-002"))))
       .WillOnce(Return(ByMove(make_ready_future(Status{}))));
@@ -76,7 +76,7 @@ TEST(ExtendLeasesWithRetry, SuccessWithPartials) {
 
   ::testing::InSequence sequence;
   EXPECT_CALL(*mock, AsyncModifyAckDeadline(
-                         _, _,
+                         _, _, _,
                          Property(&ModifyAckDeadlineRequest::ack_ids,
                                   ElementsAre("test-001", "test-002",
                                               "test-003", "test-004"))))
@@ -89,7 +89,7 @@ TEST(ExtendLeasesWithRetry, SuccessWithPartials) {
       .WillOnce(Return(ByMove(make_ready_future(
           make_status_or(std::chrono::system_clock::now())))));
   EXPECT_CALL(*mock, AsyncModifyAckDeadline(
-                         _, _,
+                         _, _, _,
                          Property(&ModifyAckDeadlineRequest::ack_ids,
                                   ElementsAre("test-001", "test-002"))))
       .WillOnce(Return(ByMove(make_ready_future(Status{}))));
@@ -108,7 +108,7 @@ TEST(ExtendLeasesWithRetry, FailurePermanentError) {
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
 
   EXPECT_CALL(*mock, AsyncModifyAckDeadline(
-                         _, _,
+                         _, _, _,
                          Property(&ModifyAckDeadlineRequest::ack_ids,
                                   ElementsAre("test-001", "test-002"))))
       .WillOnce(Return(ByMove(make_ready_future(MakeStatusWithDetails({})))));
@@ -127,7 +127,7 @@ TEST(ExtendLeasesWithRetry, FailureTooManyTransients) {
   ::testing::InSequence sequence;
   EXPECT_CALL(*mock,
               AsyncModifyAckDeadline(
-                  _, _,
+                  _, _, _,
                   Property(&ModifyAckDeadlineRequest::ack_ids,
                            ElementsAre("test-001", "test-002", "test-003"))))
       .WillOnce(Return(ByMove(make_ready_future(MakeStatusWithDetails({
@@ -140,7 +140,7 @@ TEST(ExtendLeasesWithRetry, FailureTooManyTransients) {
         .WillOnce(Return(ByMove(make_ready_future(
             make_status_or(std::chrono::system_clock::now())))));
     EXPECT_CALL(*mock, AsyncModifyAckDeadline(
-                           _, _,
+                           _, _, _,
                            Property(&ModifyAckDeadlineRequest::ack_ids,
                                     ElementsAre("test-001", "test-002"))))
         .WillOnce(Return(ByMove(make_ready_future(MakeStatusWithDetails({

--- a/google/cloud/pubsub/internal/publisher_auth_decorator.h
+++ b/google/cloud/pubsub/internal/publisher_auth_decorator.h
@@ -79,6 +79,7 @@ class PublisherAuth : public PublisherStub {
   future<StatusOr<google::pubsub::v1::PublishResponse>> AsyncPublish(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::pubsub::v1::PublishRequest const& request) override;
 
  private:

--- a/google/cloud/pubsub/internal/publisher_logging_decorator.cc
+++ b/google/cloud/pubsub/internal/publisher_logging_decorator.cc
@@ -141,14 +141,18 @@ future<StatusOr<google::pubsub::v1::PublishResponse>>
 PublisherLogging::AsyncPublish(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::pubsub::v1::PublishRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](google::cloud::CompletionQueue& cq,
              std::shared_ptr<grpc::ClientContext> context,
+             google::cloud::internal::ImmutableOptions options,
              google::pubsub::v1::PublishRequest const& request) {
-        return child_->AsyncPublish(cq, std::move(context), request);
+        return child_->AsyncPublish(cq, std::move(context), std::move(options),
+                                    request);
       },
-      cq, std::move(context), request, __func__, tracing_options_);
+      cq, std::move(context), std::move(options), request, __func__,
+      tracing_options_);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsub/internal/publisher_logging_decorator.h
+++ b/google/cloud/pubsub/internal/publisher_logging_decorator.h
@@ -79,6 +79,7 @@ class PublisherLogging : public PublisherStub {
   future<StatusOr<google::pubsub::v1::PublishResponse>> AsyncPublish(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::pubsub::v1::PublishRequest const& request) override;
 
  private:

--- a/google/cloud/pubsub/internal/publisher_metadata_decorator.cc
+++ b/google/cloud/pubsub/internal/publisher_metadata_decorator.cc
@@ -123,10 +123,12 @@ future<StatusOr<google::pubsub::v1::PublishResponse>>
 PublisherMetadata::AsyncPublish(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::pubsub::v1::PublishRequest const& request) {
-  SetMetadata(*context, internal::CurrentOptions(),
+  SetMetadata(*context, *options,
               absl::StrCat("topic=", internal::UrlEncode(request.topic())));
-  return child_->AsyncPublish(cq, std::move(context), request);
+  return child_->AsyncPublish(cq, std::move(context), std::move(options),
+                              request);
 }
 
 void PublisherMetadata::SetMetadata(grpc::ClientContext& context,

--- a/google/cloud/pubsub/internal/publisher_metadata_decorator.h
+++ b/google/cloud/pubsub/internal/publisher_metadata_decorator.h
@@ -79,6 +79,7 @@ class PublisherMetadata : public PublisherStub {
   future<StatusOr<google::pubsub::v1::PublishResponse>> AsyncPublish(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::pubsub::v1::PublishRequest const& request) override;
 
  private:

--- a/google/cloud/pubsub/internal/publisher_round_robin_decorator.cc
+++ b/google/cloud/pubsub/internal/publisher_round_robin_decorator.cc
@@ -89,8 +89,10 @@ future<StatusOr<google::pubsub::v1::PublishResponse>>
 PublisherRoundRobin::AsyncPublish(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::pubsub::v1::PublishRequest const& request) {
-  return Child()->AsyncPublish(cq, std::move(context), request);
+  return Child()->AsyncPublish(cq, std::move(context), std::move(options),
+                               request);
 }
 
 std::shared_ptr<PublisherStub> PublisherRoundRobin::Child() {

--- a/google/cloud/pubsub/internal/publisher_round_robin_decorator.h
+++ b/google/cloud/pubsub/internal/publisher_round_robin_decorator.h
@@ -77,6 +77,7 @@ class PublisherRoundRobin : public PublisherStub {
   future<StatusOr<google::pubsub::v1::PublishResponse>> AsyncPublish(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::pubsub::v1::PublishRequest const& request) override;
 
  private:

--- a/google/cloud/pubsub/internal/publisher_stub.cc
+++ b/google/cloud/pubsub/internal/publisher_stub.cc
@@ -138,6 +138,8 @@ future<StatusOr<google::pubsub::v1::PublishResponse>>
 DefaultPublisherStub::AsyncPublish(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    google::cloud::internal::ImmutableOptions,
     google::pubsub::v1::PublishRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::pubsub::v1::PublishRequest,
                                     google::pubsub::v1::PublishResponse>(

--- a/google/cloud/pubsub/internal/publisher_stub.h
+++ b/google/cloud/pubsub/internal/publisher_stub.h
@@ -79,6 +79,7 @@ class PublisherStub {
   virtual future<StatusOr<google::pubsub::v1::PublishResponse>> AsyncPublish(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::pubsub::v1::PublishRequest const& request) = 0;
 };
 
@@ -129,6 +130,7 @@ class DefaultPublisherStub : public PublisherStub {
   future<StatusOr<google::pubsub::v1::PublishResponse>> AsyncPublish(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::pubsub::v1::PublishRequest const& request) override;
 
  private:

--- a/google/cloud/pubsub/internal/publisher_stub_factory_test.cc
+++ b/google/cloud/pubsub/internal/publisher_stub_factory_test.cc
@@ -637,18 +637,21 @@ TEST_F(PublisherStubFactory, AsyncPublish) {
       .WillOnce([this](std::shared_ptr<grpc::Channel> const&) {
         auto mock = std::make_shared<MockPublisherStub>();
         EXPECT_CALL(*mock, AsyncPublish)
-            .WillOnce(
-                [this](google::cloud::CompletionQueue&, auto context,
-                       google::pubsub::v1::PublishRequest const& request) {
-                  // Verify the Auth decorator is present
-                  EXPECT_THAT(context->credentials(), NotNull());
-                  // Verify the Metadata decorator is present
-                  IsContextMDValid(
-                      *context, "google.pubsub.v1.Publisher.Publish", request);
-                  return make_ready_future(
-                      StatusOr<google::pubsub::v1::PublishResponse>(
-                          Status(StatusCode::kUnavailable, "nothing here")));
-                });
+            .WillOnce([this](
+                          google::cloud::CompletionQueue&, auto context,
+                          google::cloud::internal::ImmutableOptions const& options,
+                          google::pubsub::v1::PublishRequest const& request) {
+              // Verify the Auth decorator is present
+              EXPECT_THAT(context->credentials(), NotNull());
+              // Verify the Metadata decorator is present
+              IsContextMDValid(*context, "google.pubsub.v1.Publisher.Publish",
+                               request);
+              // Verify the options are carried forward
+              EXPECT_EQ(options->get<UserProjectOption>(), "test-user-project");
+              return make_ready_future(
+                  StatusOr<google::pubsub::v1::PublishResponse>(
+                      Status(StatusCode::kUnavailable, "nothing here")));
+            });
         return mock;
       });
   EXPECT_CALL(factory, Call)
@@ -662,8 +665,11 @@ TEST_F(PublisherStubFactory, AsyncPublish) {
   google::pubsub::v1::PublishRequest req;
   req.set_topic("projects/test-project/topics/my-topic");
   auto stub = CreateTestStub(cq, factory.AsStdFunction());
-  auto response =
-      stub->AsyncPublish(cq, std::make_shared<grpc::ClientContext>(), req);
+  auto response = stub->AsyncPublish(
+      cq, std::make_shared<grpc::ClientContext>(),
+      internal::MakeImmutableOptions(
+          Options{}.set<UserProjectOption>("test-user-project")),
+      req);
   EXPECT_THAT(response.get(), StatusIs(StatusCode::kUnavailable));
   EXPECT_THAT(log.ExtractLines(), Contains(HasSubstr("AsyncPublish")));
 }

--- a/google/cloud/pubsub/internal/publisher_stub_factory_test.cc
+++ b/google/cloud/pubsub/internal/publisher_stub_factory_test.cc
@@ -637,21 +637,22 @@ TEST_F(PublisherStubFactory, AsyncPublish) {
       .WillOnce([this](std::shared_ptr<grpc::Channel> const&) {
         auto mock = std::make_shared<MockPublisherStub>();
         EXPECT_CALL(*mock, AsyncPublish)
-            .WillOnce([this](
-                          google::cloud::CompletionQueue&, auto context,
-                          google::cloud::internal::ImmutableOptions const& options,
-                          google::pubsub::v1::PublishRequest const& request) {
-              // Verify the Auth decorator is present
-              EXPECT_THAT(context->credentials(), NotNull());
-              // Verify the Metadata decorator is present
-              IsContextMDValid(*context, "google.pubsub.v1.Publisher.Publish",
-                               request);
-              // Verify the options are carried forward
-              EXPECT_EQ(options->get<UserProjectOption>(), "test-user-project");
-              return make_ready_future(
-                  StatusOr<google::pubsub::v1::PublishResponse>(
-                      Status(StatusCode::kUnavailable, "nothing here")));
-            });
+            .WillOnce(
+                [this](google::cloud::CompletionQueue&, auto context,
+                       google::cloud::internal::ImmutableOptions const& options,
+                       google::pubsub::v1::PublishRequest const& request) {
+                  // Verify the Auth decorator is present
+                  EXPECT_THAT(context->credentials(), NotNull());
+                  // Verify the Metadata decorator is present
+                  IsContextMDValid(
+                      *context, "google.pubsub.v1.Publisher.Publish", request);
+                  // Verify the options are carried forward
+                  EXPECT_EQ(options->get<UserProjectOption>(),
+                            "test-user-project");
+                  return make_ready_future(
+                      StatusOr<google::pubsub::v1::PublishResponse>(
+                          Status(StatusCode::kUnavailable, "nothing here")));
+                });
         return mock;
       });
   EXPECT_CALL(factory, Call)

--- a/google/cloud/pubsub/internal/publisher_tracing_stub.cc
+++ b/google/cloud/pubsub/internal/publisher_tracing_stub.cc
@@ -136,11 +136,12 @@ future<StatusOr<google::pubsub::v1::PublishResponse>>
 PublisherTracingStub::AsyncPublish(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::pubsub::v1::PublishRequest const& request) {
   auto span = internal::MakeSpanGrpc("google.pubsub.v1.Publisher", "Publish");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto f = child_->AsyncPublish(cq, context, request);
+  auto f = child_->AsyncPublish(cq, context, std::move(options), request);
   return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 

--- a/google/cloud/pubsub/internal/publisher_tracing_stub.h
+++ b/google/cloud/pubsub/internal/publisher_tracing_stub.h
@@ -78,6 +78,7 @@ class PublisherTracingStub : public PublisherStub {
   future<StatusOr<google::pubsub::v1::PublishResponse>> AsyncPublish(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::pubsub::v1::PublishRequest const& request) override;
 
  private:

--- a/google/cloud/pubsub/internal/pull_ack_handler_factory_test.cc
+++ b/google/cloud/pubsub/internal/pull_ack_handler_factory_test.cc
@@ -69,10 +69,10 @@ TEST(PullAckHandlerTest, AckSimple) {
   auto request_matcher = AllOf(
       Property(&AcknowledgeRequest::ack_ids, ElementsAre("test-ack-id")),
       Property(&AcknowledgeRequest::subscription, subscription.FullName()));
-  EXPECT_CALL(*mock, AsyncAcknowledge(_, _, _)).WillRepeatedly([]() {
+  EXPECT_CALL(*mock, AsyncAcknowledge).WillRepeatedly([] {
     return make_ready_future(Status{});
   });
-  EXPECT_CALL(*mock, AsyncModifyAckDeadline(_, _, _)).WillRepeatedly([]() {
+  EXPECT_CALL(*mock, AsyncModifyAckDeadline).WillRepeatedly([] {
     return make_ready_future(Status{});
   });
   AsyncSequencer<bool> aseq;
@@ -112,11 +112,11 @@ TEST(PullAckHandlerTest, TracingEnabled) {
   auto request_matcher = AllOf(
       Property(&AcknowledgeRequest::ack_ids, ElementsAre("test-ack-id")),
       Property(&AcknowledgeRequest::subscription, subscription.FullName()));
-  EXPECT_CALL(*mock, AsyncAcknowledge(_, _, request_matcher))
+  EXPECT_CALL(*mock, AsyncAcknowledge(_, _, _, request_matcher))
       .WillOnce(Return(ByMove(make_ready_future(Status{}))));
   // Since the lease manager is started in the constructor of the ack handler,
   // we need to match the lease manager calls.
-  EXPECT_CALL(*mock, AsyncModifyAckDeadline(_, _, _)).WillRepeatedly([]() {
+  EXPECT_CALL(*mock, AsyncModifyAckDeadline).WillRepeatedly([] {
     return make_ready_future(Status{});
   });
   AsyncSequencer<bool> aseq;
@@ -150,11 +150,11 @@ TEST(PullAckHandlerTest, TracingDisabled) {
   auto request_matcher = AllOf(
       Property(&AcknowledgeRequest::ack_ids, ElementsAre("test-ack-id")),
       Property(&AcknowledgeRequest::subscription, subscription.FullName()));
-  EXPECT_CALL(*mock, AsyncAcknowledge(_, _, request_matcher))
+  EXPECT_CALL(*mock, AsyncAcknowledge(_, _, _, request_matcher))
       .WillOnce(Return(ByMove(make_ready_future(Status{}))));
   // Since the lease manager is started in the constructor of the ack handler,
   // we need to match the lease manager calls.
-  EXPECT_CALL(*mock, AsyncModifyAckDeadline(_, _, _)).WillRepeatedly([]() {
+  EXPECT_CALL(*mock, AsyncModifyAckDeadline).WillRepeatedly([]() {
     return make_ready_future(Status{});
   });
   AsyncSequencer<bool> aseq;

--- a/google/cloud/pubsub/internal/pull_lease_manager_factory_test.cc
+++ b/google/cloud/pubsub/internal/pull_lease_manager_factory_test.cc
@@ -74,7 +74,7 @@ TEST(DefaultPullLeaseManager, ExtendLeaseDeadlineSimple) {
                kLeaseExtension.count()),
       Property(&ModifyAckDeadlineRequest::subscription,
                subscription.FullName()));
-  EXPECT_CALL(*mock, AsyncModifyAckDeadline(_, _, request_matcher))
+  EXPECT_CALL(*mock, AsyncModifyAckDeadline(_, _, _, request_matcher))
       .WillOnce(Return(ByMove(make_ready_future(Status{}))));
   AsyncSequencer<bool> aseq;
   auto cq = MakeMockCompletionQueue(aseq);
@@ -115,7 +115,7 @@ TEST(DefaultPullLeaseManager, TracingEnabled) {
                kLeaseExtension.count()),
       Property(&ModifyAckDeadlineRequest::subscription,
                subscription.FullName()));
-  EXPECT_CALL(*mock, AsyncModifyAckDeadline(_, _, request_matcher))
+  EXPECT_CALL(*mock, AsyncModifyAckDeadline(_, _, _, request_matcher))
       .WillOnce(Return(ByMove(make_ready_future(Status{}))));
   AsyncSequencer<bool> aseq;
   auto cq = MakeMockCompletionQueue(aseq);
@@ -150,7 +150,7 @@ TEST(DefaultPullLeaseManager, TracingDisabled) {
                kLeaseExtension.count()),
       Property(&ModifyAckDeadlineRequest::subscription,
                subscription.FullName()));
-  EXPECT_CALL(*mock, AsyncModifyAckDeadline(_, _, request_matcher))
+  EXPECT_CALL(*mock, AsyncModifyAckDeadline(_, _, _, request_matcher))
       .WillOnce(Return(ByMove(make_ready_future(Status{}))));
   AsyncSequencer<bool> aseq;
   auto cq = MakeMockCompletionQueue(aseq);

--- a/google/cloud/pubsub/internal/subscriber_auth_decorator.cc
+++ b/google/cloud/pubsub/internal/subscriber_auth_decorator.cc
@@ -160,30 +160,32 @@ StatusOr<google::pubsub::v1::SeekResponse> SubscriberAuth::Seek(
 future<Status> SubscriberAuth::AsyncModifyAckDeadline(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::pubsub::v1::ModifyAckDeadlineRequest const& request) {
-  auto& child = child_;
   return auth_->AsyncConfigureContext(std::move(context))
-      .then([cq, child,
+      .then([cq, child = child_, options = std::move(options),
              request](future<StatusOr<std::shared_ptr<grpc::ClientContext>>>
                           f) mutable {
         auto context = f.get();
         if (!context) return make_ready_future(std::move(context).status());
-        return child->AsyncModifyAckDeadline(cq, *std::move(context), request);
+        return child->AsyncModifyAckDeadline(cq, *std::move(context),
+                                             std::move(options), request);
       });
 }
 
 future<Status> SubscriberAuth::AsyncAcknowledge(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::pubsub::v1::AcknowledgeRequest const& request) {
-  auto& child = child_;
   return auth_->AsyncConfigureContext(std::move(context))
-      .then([cq, child,
+      .then([cq, child = child_, options = std::move(options),
              request](future<StatusOr<std::shared_ptr<grpc::ClientContext>>>
                           f) mutable {
         auto context = f.get();
         if (!context) return make_ready_future(std::move(context).status());
-        return child->AsyncAcknowledge(cq, *std::move(context), request);
+        return child->AsyncAcknowledge(cq, *std::move(context),
+                                       std::move(options), request);
       });
 }
 

--- a/google/cloud/pubsub/internal/subscriber_auth_decorator.h
+++ b/google/cloud/pubsub/internal/subscriber_auth_decorator.h
@@ -101,11 +101,13 @@ class SubscriberAuth : public SubscriberStub {
   future<Status> AsyncModifyAckDeadline(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::pubsub::v1::ModifyAckDeadlineRequest const& request) override;
 
   future<Status> AsyncAcknowledge(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::pubsub::v1::AcknowledgeRequest const& request) override;
 
  private:

--- a/google/cloud/pubsub/internal/subscriber_connection_impl_test.cc
+++ b/google/cloud/pubsub/internal/subscriber_connection_impl_test.cc
@@ -147,12 +147,12 @@ TEST(SubscriberConnectionTest, Subscribe) {
   auto const subscription = Subscription("test-project", "test-subscription");
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, AsyncModifyAckDeadline)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::ModifyAckDeadlineRequest const&) {
         return make_ready_future(Status{});
       });
   EXPECT_CALL(*mock, AsyncAcknowledge)
-      .WillOnce([](google::cloud::CompletionQueue&, auto,
+      .WillOnce([](google::cloud::CompletionQueue&, auto, auto,
                    google::pubsub::v1::AcknowledgeRequest const& request) {
         EXPECT_THAT(request.ack_ids(), Contains("test-ack-id-0"));
         return make_ready_future(Status{});
@@ -190,12 +190,12 @@ TEST(SubscriberConnectionTest, SubscribeOverrideSubscription) {
   auto const s2 = Subscription("test-project", "test-override-subscription");
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, AsyncModifyAckDeadline)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::ModifyAckDeadlineRequest const&) {
         return make_ready_future(Status{});
       });
   EXPECT_CALL(*mock, AsyncAcknowledge)
-      .WillOnce([](google::cloud::CompletionQueue&, auto,
+      .WillOnce([](google::cloud::CompletionQueue&, auto, auto,
                    google::pubsub::v1::AcknowledgeRequest const& request) {
         EXPECT_THAT(request.ack_ids(), Contains("test-ack-id-0"));
         return make_ready_future(Status{});
@@ -233,12 +233,12 @@ TEST(SubscriberConnectionTest, ExactlyOnce) {
   auto const subscription = Subscription("test-project", "test-subscription");
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, AsyncModifyAckDeadline)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::ModifyAckDeadlineRequest const&) {
         return make_ready_future(Status{});
       });
   EXPECT_CALL(*mock, AsyncAcknowledge)
-      .WillOnce([](google::cloud::CompletionQueue&, auto,
+      .WillOnce([](google::cloud::CompletionQueue&, auto, auto,
                    google::pubsub::v1::AcknowledgeRequest const& request) {
         EXPECT_THAT(request.ack_ids(), Contains("test-ack-id-0"));
         return make_ready_future(
@@ -278,12 +278,12 @@ TEST(SubscriberConnectionTest, ExactlyOnceOverrideSubscription) {
   auto const s2 = Subscription("test-project", "test-override-subscription");
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, AsyncModifyAckDeadline)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::ModifyAckDeadlineRequest const&) {
         return make_ready_future(Status{});
       });
   EXPECT_CALL(*mock, AsyncAcknowledge)
-      .WillOnce([](google::cloud::CompletionQueue&, auto,
+      .WillOnce([](google::cloud::CompletionQueue&, auto, auto,
                    google::pubsub::v1::AcknowledgeRequest const& request) {
         EXPECT_THAT(request.ack_ids(), Contains("test-ack-id-0"));
         return make_ready_future(Status{});
@@ -323,12 +323,12 @@ TEST(SubscriberConnectionTest, StreamingPullFailure) {
 
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, AsyncModifyAckDeadline)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::ModifyAckDeadlineRequest const&) {
         return make_ready_future(Status{});
       });
   EXPECT_CALL(*mock, AsyncAcknowledge)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::AcknowledgeRequest const&) {
         return make_ready_future(Status{});
       });
@@ -370,12 +370,12 @@ TEST(SubscriberConnectionTest, Pull) {
   auto const subscription = Subscription("test-project", "test-subscription");
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, AsyncModifyAckDeadline)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::ModifyAckDeadlineRequest const&) {
         return make_ready_future(Status{});
       });
   EXPECT_CALL(*mock, AsyncAcknowledge)
-      .WillOnce([](google::cloud::CompletionQueue&, auto,
+      .WillOnce([](google::cloud::CompletionQueue&, auto, auto,
                    google::pubsub::v1::AcknowledgeRequest const& request) {
         EXPECT_THAT(request.ack_ids(), Contains("test-ack-id-0"));
         return make_ready_future(
@@ -417,12 +417,12 @@ TEST(SubscriberConnectionTest, PullReturnsNoMessage) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   auto constexpr kNumRetries = 4;
   EXPECT_CALL(*mock, AsyncModifyAckDeadline)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::ModifyAckDeadlineRequest const&) {
         return make_ready_future(Status{});
       });
   EXPECT_CALL(*mock, AsyncAcknowledge)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::AcknowledgeRequest const&) {
         return make_ready_future(Status{});
       });
@@ -464,12 +464,12 @@ TEST(SubscriberConnectionTest, PullOverrideSubscription) {
   auto const s2 = Subscription("test-project", "test-override-subscription");
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, AsyncModifyAckDeadline)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::ModifyAckDeadlineRequest const&) {
         return make_ready_future(Status{});
       });
   EXPECT_CALL(*mock, AsyncAcknowledge)
-      .WillOnce([](google::cloud::CompletionQueue&, auto,
+      .WillOnce([](google::cloud::CompletionQueue&, auto, auto,
                    google::pubsub::v1::AcknowledgeRequest const& request) {
         EXPECT_THAT(request.ack_ids(), Contains("test-ack-id-0"));
         return make_ready_future(

--- a/google/cloud/pubsub/internal/subscriber_logging_decorator.cc
+++ b/google/cloud/pubsub/internal/subscriber_logging_decorator.cc
@@ -209,27 +209,35 @@ StatusOr<google::pubsub::v1::SeekResponse> SubscriberLogging::Seek(
 future<Status> SubscriberLogging::AsyncModifyAckDeadline(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::pubsub::v1::ModifyAckDeadlineRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](google::cloud::CompletionQueue& cq,
              std::shared_ptr<grpc::ClientContext> context,
+             google::cloud::internal::ImmutableOptions options,
              google::pubsub::v1::ModifyAckDeadlineRequest const& request) {
-        return child_->AsyncModifyAckDeadline(cq, std::move(context), request);
+        return child_->AsyncModifyAckDeadline(cq, std::move(context),
+                                              std::move(options), request);
       },
-      cq, std::move(context), request, __func__, tracing_options_);
+      cq, std::move(context), std::move(options), request, __func__,
+      tracing_options_);
 }
 
 future<Status> SubscriberLogging::AsyncAcknowledge(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::pubsub::v1::AcknowledgeRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](google::cloud::CompletionQueue& cq,
              std::shared_ptr<grpc::ClientContext> context,
+             google::cloud::internal::ImmutableOptions options,
              google::pubsub::v1::AcknowledgeRequest const& request) {
-        return child_->AsyncAcknowledge(cq, std::move(context), request);
+        return child_->AsyncAcknowledge(cq, std::move(context),
+                                        std::move(options), request);
       },
-      cq, std::move(context), request, __func__, tracing_options_);
+      cq, std::move(context), std::move(options), request, __func__,
+      tracing_options_);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsub/internal/subscriber_logging_decorator.h
+++ b/google/cloud/pubsub/internal/subscriber_logging_decorator.h
@@ -101,11 +101,13 @@ class SubscriberLogging : public SubscriberStub {
   future<Status> AsyncModifyAckDeadline(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::pubsub::v1::ModifyAckDeadlineRequest const& request) override;
 
   future<Status> AsyncAcknowledge(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::pubsub::v1::AcknowledgeRequest const& request) override;
 
  private:

--- a/google/cloud/pubsub/internal/subscriber_metadata_decorator.cc
+++ b/google/cloud/pubsub/internal/subscriber_metadata_decorator.cc
@@ -173,21 +173,25 @@ StatusOr<google::pubsub::v1::SeekResponse> SubscriberMetadata::Seek(
 future<Status> SubscriberMetadata::AsyncModifyAckDeadline(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::pubsub::v1::ModifyAckDeadlineRequest const& request) {
-  SetMetadata(*context, internal::CurrentOptions(),
+  SetMetadata(*context, *options,
               absl::StrCat("subscription=",
                            internal::UrlEncode(request.subscription())));
-  return child_->AsyncModifyAckDeadline(cq, std::move(context), request);
+  return child_->AsyncModifyAckDeadline(cq, std::move(context),
+                                        std::move(options), request);
 }
 
 future<Status> SubscriberMetadata::AsyncAcknowledge(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::pubsub::v1::AcknowledgeRequest const& request) {
-  SetMetadata(*context, internal::CurrentOptions(),
+  SetMetadata(*context, *options,
               absl::StrCat("subscription=",
                            internal::UrlEncode(request.subscription())));
-  return child_->AsyncAcknowledge(cq, std::move(context), request);
+  return child_->AsyncAcknowledge(cq, std::move(context), std::move(options),
+                                  request);
 }
 
 void SubscriberMetadata::SetMetadata(grpc::ClientContext& context,

--- a/google/cloud/pubsub/internal/subscriber_metadata_decorator.h
+++ b/google/cloud/pubsub/internal/subscriber_metadata_decorator.h
@@ -101,11 +101,13 @@ class SubscriberMetadata : public SubscriberStub {
   future<Status> AsyncModifyAckDeadline(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::pubsub::v1::ModifyAckDeadlineRequest const& request) override;
 
   future<Status> AsyncAcknowledge(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::pubsub::v1::AcknowledgeRequest const& request) override;
 
  private:

--- a/google/cloud/pubsub/internal/subscriber_round_robin_decorator.cc
+++ b/google/cloud/pubsub/internal/subscriber_round_robin_decorator.cc
@@ -124,15 +124,19 @@ StatusOr<google::pubsub::v1::SeekResponse> SubscriberRoundRobin::Seek(
 future<Status> SubscriberRoundRobin::AsyncModifyAckDeadline(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::pubsub::v1::ModifyAckDeadlineRequest const& request) {
-  return Child()->AsyncModifyAckDeadline(cq, std::move(context), request);
+  return Child()->AsyncModifyAckDeadline(cq, std::move(context),
+                                         std::move(options), request);
 }
 
 future<Status> SubscriberRoundRobin::AsyncAcknowledge(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::pubsub::v1::AcknowledgeRequest const& request) {
-  return Child()->AsyncAcknowledge(cq, std::move(context), request);
+  return Child()->AsyncAcknowledge(cq, std::move(context), std::move(options),
+                                   request);
 }
 
 std::shared_ptr<SubscriberStub> SubscriberRoundRobin::Child() {

--- a/google/cloud/pubsub/internal/subscriber_round_robin_decorator.h
+++ b/google/cloud/pubsub/internal/subscriber_round_robin_decorator.h
@@ -99,11 +99,13 @@ class SubscriberRoundRobin : public SubscriberStub {
   future<Status> AsyncModifyAckDeadline(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::pubsub::v1::ModifyAckDeadlineRequest const& request) override;
 
   future<Status> AsyncAcknowledge(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::pubsub::v1::AcknowledgeRequest const& request) override;
 
  private:

--- a/google/cloud/pubsub/internal/subscriber_stub.cc
+++ b/google/cloud/pubsub/internal/subscriber_stub.cc
@@ -198,6 +198,8 @@ StatusOr<google::pubsub::v1::SeekResponse> DefaultSubscriberStub::Seek(
 future<Status> DefaultSubscriberStub::AsyncModifyAckDeadline(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    google::cloud::internal::ImmutableOptions,
     google::pubsub::v1::ModifyAckDeadlineRequest const& request) {
   return internal::MakeUnaryRpcImpl<
              google::pubsub::v1::ModifyAckDeadlineRequest,
@@ -217,6 +219,8 @@ future<Status> DefaultSubscriberStub::AsyncModifyAckDeadline(
 future<Status> DefaultSubscriberStub::AsyncAcknowledge(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    google::cloud::internal::ImmutableOptions,
     google::pubsub::v1::AcknowledgeRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::pubsub::v1::AcknowledgeRequest,
                                     google::protobuf::Empty>(

--- a/google/cloud/pubsub/internal/subscriber_stub.h
+++ b/google/cloud/pubsub/internal/subscriber_stub.h
@@ -101,11 +101,13 @@ class SubscriberStub {
   virtual future<Status> AsyncModifyAckDeadline(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::pubsub::v1::ModifyAckDeadlineRequest const& request) = 0;
 
   virtual future<Status> AsyncAcknowledge(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::pubsub::v1::AcknowledgeRequest const& request) = 0;
 };
 
@@ -178,11 +180,13 @@ class DefaultSubscriberStub : public SubscriberStub {
   future<Status> AsyncModifyAckDeadline(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::pubsub::v1::ModifyAckDeadlineRequest const& request) override;
 
   future<Status> AsyncAcknowledge(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::pubsub::v1::AcknowledgeRequest const& request) override;
 
  private:

--- a/google/cloud/pubsub/internal/subscriber_tracing_stub.cc
+++ b/google/cloud/pubsub/internal/subscriber_tracing_stub.cc
@@ -198,24 +198,27 @@ StatusOr<google::pubsub::v1::SeekResponse> SubscriberTracingStub::Seek(
 future<Status> SubscriberTracingStub::AsyncModifyAckDeadline(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::pubsub::v1::ModifyAckDeadlineRequest const& request) {
   auto span = internal::MakeSpanGrpc("google.pubsub.v1.Subscriber",
                                      "ModifyAckDeadline");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto f = child_->AsyncModifyAckDeadline(cq, context, request);
+  auto f =
+      child_->AsyncModifyAckDeadline(cq, context, std::move(options), request);
   return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 
 future<Status> SubscriberTracingStub::AsyncAcknowledge(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::pubsub::v1::AcknowledgeRequest const& request) {
   auto span =
       internal::MakeSpanGrpc("google.pubsub.v1.Subscriber", "Acknowledge");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto f = child_->AsyncAcknowledge(cq, context, request);
+  auto f = child_->AsyncAcknowledge(cq, context, std::move(options), request);
   return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 

--- a/google/cloud/pubsub/internal/subscriber_tracing_stub.h
+++ b/google/cloud/pubsub/internal/subscriber_tracing_stub.h
@@ -100,11 +100,13 @@ class SubscriberTracingStub : public SubscriberStub {
   future<Status> AsyncModifyAckDeadline(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::pubsub::v1::ModifyAckDeadlineRequest const& request) override;
 
   future<Status> AsyncAcknowledge(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::pubsub::v1::AcknowledgeRequest const& request) override;
 
  private:

--- a/google/cloud/pubsub/internal/subscription_session_test.cc
+++ b/google/cloud/pubsub/internal/subscription_session_test.cc
@@ -85,7 +85,7 @@ TEST(SubscriptionSessionTest, ScheduleCallbacks) {
   using us = std::chrono::microseconds;
   EXPECT_CALL(*mock, AsyncAcknowledge)
       .WillRepeatedly(
-          [&](google::cloud::CompletionQueue&, auto,
+          [&](google::cloud::CompletionQueue&, auto, auto,
               google::pubsub::v1::AcknowledgeRequest const& request) {
             for (auto const& a : request.ack_ids()) {
               std::lock_guard<std::mutex> lk(ack_id_mu);
@@ -97,7 +97,7 @@ TEST(SubscriptionSessionTest, ScheduleCallbacks) {
                 [](TimerFuture) { return Status{}; });
           });
   EXPECT_CALL(*mock, AsyncModifyAckDeadline)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::ModifyAckDeadlineRequest const&) {
         return make_ready_future(Status{});
       });
@@ -204,7 +204,7 @@ TEST(SubscriptionSessionTest, ScheduleCallbacksExactlyOnce) {
   using us = std::chrono::microseconds;
   EXPECT_CALL(*mock, AsyncAcknowledge)
       .WillRepeatedly(
-          [&](google::cloud::CompletionQueue&, auto,
+          [&](google::cloud::CompletionQueue&, auto, auto,
               google::pubsub::v1::AcknowledgeRequest const& request) {
             for (auto const& a : request.ack_ids()) {
               std::lock_guard<std::mutex> lk(ack_id_mu);
@@ -216,7 +216,7 @@ TEST(SubscriptionSessionTest, ScheduleCallbacksExactlyOnce) {
                 [](auto) { return Status{}; });
           });
   EXPECT_CALL(*mock, AsyncModifyAckDeadline)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::ModifyAckDeadlineRequest const&) {
         return make_ready_future(Status{});
       });
@@ -314,7 +314,7 @@ TEST(SubscriptionSessionTest, ExactlyOnceAckErrors) {
       .Times(AtLeast(1))
       .WillRepeatedly(FakeAsyncStreamingPull);
   EXPECT_CALL(*mock, AsyncAcknowledge)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::AcknowledgeRequest const& r) {
         if (r.ack_ids_size() == 1 && r.ack_ids(0) == "test-ack-id-0") {
           return make_ready_future(Status{StatusCode::kUnauthenticated, "0"});
@@ -322,7 +322,7 @@ TEST(SubscriptionSessionTest, ExactlyOnceAckErrors) {
         return make_ready_future(Status{});
       });
   EXPECT_CALL(*mock, AsyncModifyAckDeadline)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::ModifyAckDeadlineRequest const&
                              r) {
         if (r.ack_ids_size() == 1 && r.ack_ids(0) == "test-ack-id-1") {
@@ -379,7 +379,7 @@ TEST(SubscriptionSessionTest, DefaultAckHandlerLogsErrors) {
       .Times(AtLeast(1))
       .WillRepeatedly(FakeAsyncStreamingPull);
   EXPECT_CALL(*mock, AsyncAcknowledge)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::AcknowledgeRequest const& r) {
         if (r.ack_ids_size() == 1 && r.ack_ids(0) == "test-ack-id-0") {
           return make_ready_future(Status{StatusCode::kUnauthenticated,
@@ -389,7 +389,7 @@ TEST(SubscriptionSessionTest, DefaultAckHandlerLogsErrors) {
       });
   EXPECT_CALL(*mock, AsyncModifyAckDeadline)
       .WillRepeatedly(
-          [](google::cloud::CompletionQueue&, auto,
+          [](google::cloud::CompletionQueue&, auto, auto,
              google::pubsub::v1::ModifyAckDeadlineRequest const& r) {
             if (r.ack_ids_size() == 1 && r.ack_ids(0) == "test-ack-id-1") {
               return make_ready_future(Status{StatusCode::kPermissionDenied,
@@ -451,12 +451,12 @@ TEST(SubscriptionSessionTest, SequencedCallbacks) {
       .Times(AtLeast(1))
       .WillRepeatedly(FakeAsyncStreamingPull);
   EXPECT_CALL(*mock, AsyncAcknowledge)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::AcknowledgeRequest const&) {
         return make_ready_future(Status{});
       });
   EXPECT_CALL(*mock, AsyncModifyAckDeadline)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::ModifyAckDeadlineRequest const&) {
         return make_ready_future(Status{});
       });
@@ -499,12 +499,12 @@ TEST(SubscriptionSessionTest, ShutdownNackCallbacks) {
       .Times(AtLeast(1))
       .WillRepeatedly(FakeAsyncStreamingPull);
   EXPECT_CALL(*mock, AsyncAcknowledge)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::AcknowledgeRequest const&) {
         return make_ready_future(Status{});
       });
   EXPECT_CALL(*mock, AsyncModifyAckDeadline)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::ModifyAckDeadlineRequest const&) {
         return make_ready_future(Status{});
       });
@@ -548,12 +548,12 @@ TEST(SubscriptionSessionTest, ShutdownWaitsFutures) {
       .Times(AtLeast(1))
       .WillRepeatedly(FakeAsyncStreamingPull);
   EXPECT_CALL(*mock, AsyncAcknowledge)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::AcknowledgeRequest const&) {
         return make_ready_future(Status{});
       });
   EXPECT_CALL(*mock, AsyncModifyAckDeadline)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::ModifyAckDeadlineRequest const&) {
         return make_ready_future(Status{});
       });
@@ -608,12 +608,12 @@ TEST(SubscriptionSessionTest, ShutdownWaitsConditionVars) {
       .Times(AtLeast(1))
       .WillRepeatedly(FakeAsyncStreamingPull);
   EXPECT_CALL(*mock, AsyncAcknowledge)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::AcknowledgeRequest const&) {
         return make_ready_future(Status{});
       });
   EXPECT_CALL(*mock, AsyncModifyAckDeadline)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::ModifyAckDeadlineRequest const&) {
         return make_ready_future(Status{});
       });
@@ -676,12 +676,12 @@ TEST(SubscriptionSessionTest, ShutdownWaitsEarlyAcks) {
       .Times(AtLeast(1))
       .WillRepeatedly(FakeAsyncStreamingPull);
   EXPECT_CALL(*mock, AsyncAcknowledge)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::AcknowledgeRequest const&) {
         return make_ready_future(Status{});
       });
   EXPECT_CALL(*mock, AsyncModifyAckDeadline)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::ModifyAckDeadlineRequest const&) {
         return make_ready_future(Status{});
       });
@@ -748,12 +748,12 @@ TEST(SubscriptionSessionTest, FireAndForget) {
       .Times(AtLeast(1))
       .WillRepeatedly(FakeAsyncStreamingPull);
   EXPECT_CALL(*mock, AsyncAcknowledge)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::AcknowledgeRequest const&) {
         return make_ready_future(Status{});
       });
   EXPECT_CALL(*mock, AsyncModifyAckDeadline)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::ModifyAckDeadlineRequest const&) {
         return make_ready_future(Status{});
       });
@@ -849,12 +849,12 @@ TEST(SubscriptionSessionTest, FireAndForgetShutdown) {
   };
   EXPECT_CALL(*mock, AsyncStreamingPull).WillRepeatedly(async_pull_mock);
   EXPECT_CALL(*mock, AsyncAcknowledge)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::AcknowledgeRequest const&) {
         return make_ready_future(Status{});
       });
   EXPECT_CALL(*mock, AsyncModifyAckDeadline)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::ModifyAckDeadlineRequest const&) {
         return make_ready_future(Status{});
       });

--- a/google/cloud/pubsub/publisher_connection_test.cc
+++ b/google/cloud/pubsub/publisher_connection_test.cc
@@ -57,7 +57,7 @@ TEST(PublisherConnectionTest, Basic) {
   Topic const topic("test-project", "test-topic");
 
   EXPECT_CALL(*mock, AsyncPublish)
-      .WillOnce([&](google::cloud::CompletionQueue&, auto,
+      .WillOnce([&](google::cloud::CompletionQueue&, auto, auto,
                     google::pubsub::v1::PublishRequest const& request) {
         EXPECT_EQ(topic.FullName(), request.topic());
         EXPECT_EQ(1, request.messages_size());
@@ -81,7 +81,7 @@ TEST(PublisherConnectionTest, Metadata) {
 
   EXPECT_CALL(*mock, AsyncPublish)
       .Times(AtLeast(1))
-      .WillRepeatedly([&](google::cloud::CompletionQueue&, auto context,
+      .WillRepeatedly([&](google::cloud::CompletionQueue&, auto context, auto,
                           google::pubsub::v1::PublishRequest const& request) {
         google::cloud::testing_util::ValidateMetadataFixture fixture;
         fixture.IsContextMDValid(
@@ -109,7 +109,7 @@ TEST(PublisherConnectionTest, Logging) {
 
   EXPECT_CALL(*mock, AsyncPublish)
       .Times(AtLeast(1))
-      .WillRepeatedly([&](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([&](google::cloud::CompletionQueue&, auto, auto,
                           google::pubsub::v1::PublishRequest const& request) {
         google::pubsub::v1::PublishResponse response;
         for (auto const& m : request.messages()) {
@@ -142,7 +142,7 @@ TEST(PublisherConnectionTest, FlowControl) {
   AsyncSequencer<void> publish;
   EXPECT_CALL(*mock, AsyncPublish)
       .Times(AtLeast(1))
-      .WillRepeatedly([&](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([&](google::cloud::CompletionQueue&, auto, auto,
                           google::pubsub::v1::PublishRequest const& request) {
         {
           std::lock_guard<std::mutex> lk(mu);
@@ -193,7 +193,7 @@ TEST(PublisherConnectionTest, OrderingKey) {
   Topic const topic("test-project", "test-topic");
 
   EXPECT_CALL(*mock, AsyncPublish)
-      .WillOnce([&](google::cloud::CompletionQueue&, auto,
+      .WillOnce([&](google::cloud::CompletionQueue&, auto, auto,
                     google::pubsub::v1::PublishRequest const& request) {
         EXPECT_EQ(topic.FullName(), request.topic());
         EXPECT_EQ(1, request.messages_size());
@@ -233,7 +233,7 @@ TEST(PublisherConnectionTest, HandleInvalidResponse) {
   Topic const topic("test-project", "test-topic");
 
   EXPECT_CALL(*mock, AsyncPublish)
-      .WillOnce([&](google::cloud::CompletionQueue&, auto,
+      .WillOnce([&](google::cloud::CompletionQueue&, auto, auto,
                     google::pubsub::v1::PublishRequest const&) {
         google::pubsub::v1::PublishResponse response;
         return make_ready_future(make_status_or(response));
@@ -257,7 +257,7 @@ TEST(PublisherConnectionTest, HandleTooManyFailures) {
 
   EXPECT_CALL(*mock, AsyncPublish)
       .Times(AtLeast(2))
-      .WillRepeatedly([&](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([&](google::cloud::CompletionQueue&, auto, auto,
                           google::pubsub::v1::PublishRequest const&) {
         return make_ready_future(StatusOr<google::pubsub::v1::PublishResponse>(
             Status(StatusCode::kUnavailable, "try-again")));
@@ -276,7 +276,7 @@ TEST(PublisherConnectionTest, HandlePermanentError) {
   Topic const topic("test-project", "test-topic");
 
   EXPECT_CALL(*mock, AsyncPublish)
-      .WillOnce([&](google::cloud::CompletionQueue&, auto,
+      .WillOnce([&](google::cloud::CompletionQueue&, auto, auto,
                     google::pubsub::v1::PublishRequest const&) {
         return make_ready_future(StatusOr<google::pubsub::v1::PublishResponse>(
             Status(StatusCode::kPermissionDenied, "uh-oh")));
@@ -295,7 +295,7 @@ TEST(PublisherConnectionTest, HandleTransientDisabledRetry) {
   Topic const topic("test-project", "test-topic");
 
   EXPECT_CALL(*mock, AsyncPublish)
-      .WillOnce([&](google::cloud::CompletionQueue&, auto,
+      .WillOnce([&](google::cloud::CompletionQueue&, auto, auto,
                     google::pubsub::v1::PublishRequest const&) {
         return make_ready_future(StatusOr<google::pubsub::v1::PublishResponse>(
             Status(StatusCode::kUnavailable, "try-again")));
@@ -317,12 +317,12 @@ TEST(PublisherConnectionTest, HandleTransientEnabledRetry) {
   Topic const topic("test-project", "test-topic");
 
   EXPECT_CALL(*mock, AsyncPublish)
-      .WillOnce([&](google::cloud::CompletionQueue&, auto,
+      .WillOnce([&](google::cloud::CompletionQueue&, auto, auto,
                     google::pubsub::v1::PublishRequest const&) {
         return make_ready_future(StatusOr<google::pubsub::v1::PublishResponse>(
             Status(StatusCode::kUnavailable, "try-again")));
       })
-      .WillOnce([&](google::cloud::CompletionQueue&, auto,
+      .WillOnce([&](google::cloud::CompletionQueue&, auto, auto,
                     google::pubsub::v1::PublishRequest const& request) {
         EXPECT_EQ(topic.FullName(), request.topic());
         EXPECT_EQ(1, request.messages_size());
@@ -355,7 +355,7 @@ TEST(MakePublisherConnectionTest, TracingEnabled) {
   Topic const topic("test-project", "test-topic");
 
   EXPECT_CALL(*mock, AsyncPublish)
-      .WillOnce([&](google::cloud::CompletionQueue&, auto context,
+      .WillOnce([&](google::cloud::CompletionQueue&, auto context, auto,
                     google::pubsub::v1::PublishRequest const&) {
         ValidatePropagator(*context);
         google::pubsub::v1::PublishResponse response;
@@ -387,7 +387,7 @@ TEST(MakePublisherConnectionTest, TracingDisabled) {
   auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
   Topic const topic("test-project", "test-topic");
   EXPECT_CALL(*mock, AsyncPublish)
-      .WillOnce([&](google::cloud::CompletionQueue&, auto,
+      .WillOnce([&](google::cloud::CompletionQueue&, auto, auto,
                     google::pubsub::v1::PublishRequest const&) {
         google::pubsub::v1::PublishResponse response;
         response.add_message_ids("test-message-id-0");

--- a/google/cloud/pubsub/subscriber_connection_test.cc
+++ b/google/cloud/pubsub/subscriber_connection_test.cc
@@ -69,12 +69,12 @@ TEST(SubscriberConnectionTest, MakeSubscriberConnectionSetupsLogging) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   Subscription const subscription("test-project", "test-subscription");
   EXPECT_CALL(*mock, AsyncModifyAckDeadline)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::ModifyAckDeadlineRequest const&) {
         return make_ready_future(Status{});
       });
   EXPECT_CALL(*mock, AsyncAcknowledge)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::AcknowledgeRequest const&) {
         return make_ready_future(Status{});
       });
@@ -121,12 +121,12 @@ TEST(SubscriberConnectionTest, MakeSubscriberConnectionSetupsMetadata) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   Subscription const subscription("test-project", "test-subscription");
   EXPECT_CALL(*mock, AsyncModifyAckDeadline)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::ModifyAckDeadlineRequest const&) {
         return make_ready_future(Status{});
       });
   EXPECT_CALL(*mock, AsyncAcknowledge)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::AcknowledgeRequest const&) {
         return make_ready_future(Status{});
       });
@@ -183,13 +183,13 @@ TEST(MakeSubscriberConnectionTest, TracingEnabledForUnaryPull) {
   auto const subscription = Subscription("test-project", "test-subscription");
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, AsyncModifyAckDeadline)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto context,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto context, auto,
                          google::pubsub::v1::ModifyAckDeadlineRequest const&) {
         SetServerMetadata(*context, {});
         return make_ready_future(Status{});
       });
   EXPECT_CALL(*mock, AsyncAcknowledge)
-      .WillOnce([](google::cloud::CompletionQueue&, auto context,
+      .WillOnce([](google::cloud::CompletionQueue&, auto context, auto,
                    google::pubsub::v1::AcknowledgeRequest const& request) {
         SetServerMetadata(*context, {});
         EXPECT_THAT(request.ack_ids(), Contains("test-ack-id-0"));
@@ -233,12 +233,12 @@ TEST(MakeSubscriberConnectionTest, TracingDisabledForUnaryPull) {
   auto const subscription = Subscription("test-project", "test-subscription");
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, AsyncModifyAckDeadline)
-      .WillRepeatedly([](google::cloud::CompletionQueue&, auto,
+      .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
                          google::pubsub::v1::ModifyAckDeadlineRequest const&) {
         return make_ready_future(Status{});
       });
   EXPECT_CALL(*mock, AsyncAcknowledge)
-      .WillOnce([](google::cloud::CompletionQueue&, auto,
+      .WillOnce([](google::cloud::CompletionQueue&, auto, auto,
                    google::pubsub::v1::AcknowledgeRequest const& request) {
         EXPECT_THAT(request.ack_ids(), Contains("test-ack-id-0"));
         return make_ready_future(

--- a/google/cloud/pubsub/testing/mock_publisher_stub.h
+++ b/google/cloud/pubsub/testing/mock_publisher_stub.h
@@ -78,6 +78,7 @@ class MockPublisherStub : public pubsub_internal::PublisherStub {
               AsyncPublish,
               (google::cloud::CompletionQueue&,
                std::shared_ptr<grpc::ClientContext>,
+               google::cloud::internal::ImmutableOptions,
                google::pubsub::v1::PublishRequest const&),
               (override));
 

--- a/google/cloud/pubsub/testing/mock_subscriber_stub.h
+++ b/google/cloud/pubsub/testing/mock_subscriber_stub.h
@@ -80,12 +80,14 @@ class MockSubscriberStub : public pubsub_internal::SubscriberStub {
   MOCK_METHOD(future<Status>, AsyncAcknowledge,
               (google::cloud::CompletionQueue&,
                std::shared_ptr<grpc::ClientContext>,
+               google::cloud::internal::ImmutableOptions,
                google::pubsub::v1::AcknowledgeRequest const&),
               (override));
 
   MOCK_METHOD(future<Status>, AsyncModifyAckDeadline,
               (google::cloud::CompletionQueue&,
                std::shared_ptr<grpc::ClientContext>,
+               google::cloud::internal::ImmutableOptions,
                google::pubsub::v1::ModifyAckDeadlineRequest const&),
               (override));
 

--- a/google/cloud/pubsublite/internal/admin_auth_decorator.cc
+++ b/google/cloud/pubsublite/internal/admin_auth_decorator.cc
@@ -213,18 +213,20 @@ future<StatusOr<google::cloud::pubsublite::v1::TopicPartitions>>
 AdminServiceAuth::AsyncGetTopicPartitions(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::cloud::pubsublite::v1::GetTopicPartitionsRequest const& request) {
-  using ReturnType = StatusOr<google::cloud::pubsublite::v1::TopicPartitions>;
-  auto& child = child_;
   return auth_->AsyncConfigureContext(std::move(context))
-      .then([cq, child,
+      .then([cq, child = child_, options = std::move(options),
              request](future<StatusOr<std::shared_ptr<grpc::ClientContext>>>
                           f) mutable {
         auto context = f.get();
         if (!context) {
-          return make_ready_future(ReturnType(std::move(context).status()));
+          return make_ready_future(
+              StatusOr<google::cloud::pubsublite::v1::TopicPartitions>(
+                  std::move(context).status()));
         }
-        return child->AsyncGetTopicPartitions(cq, *std::move(context), request);
+        return child->AsyncGetTopicPartitions(cq, *std::move(context),
+                                              std::move(options), request);
       });
 }
 

--- a/google/cloud/pubsublite/internal/admin_auth_decorator.h
+++ b/google/cloud/pubsublite/internal/admin_auth_decorator.h
@@ -140,6 +140,7 @@ class AdminServiceAuth : public AdminServiceStub {
   AsyncGetTopicPartitions(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::cloud::pubsublite::v1::GetTopicPartitionsRequest const& request)
       override;
 

--- a/google/cloud/pubsublite/internal/admin_connection_impl.cc
+++ b/google/cloud/pubsublite/internal/admin_connection_impl.cc
@@ -469,16 +469,19 @@ AdminServiceConnectionImpl::AsyncGetTopicPartitions(
   auto request_copy = request;
   auto const idempotent =
       idempotency_policy(*current)->GetTopicPartitions(request_copy);
+  auto retry = retry_policy(*current);
+  auto backoff = backoff_policy(*current);
   return google::cloud::internal::AsyncRetryLoop(
-      retry_policy(*current), backoff_policy(*current), idempotent,
-      background_->cq(),
+      std::move(retry), std::move(backoff), idempotent, background_->cq(),
       [stub = stub_](
           CompletionQueue& cq, std::shared_ptr<grpc::ClientContext> context,
+          google::cloud::internal::ImmutableOptions options,
           google::cloud::pubsublite::v1::GetTopicPartitionsRequest const&
               request) {
-        return stub->AsyncGetTopicPartitions(cq, std::move(context), request);
+        return stub->AsyncGetTopicPartitions(cq, std::move(context),
+                                             std::move(options), request);
       },
-      std::move(request_copy), __func__);
+      std::move(current), std::move(request_copy), __func__);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsublite/internal/admin_logging_decorator.cc
+++ b/google/cloud/pubsublite/internal/admin_logging_decorator.cc
@@ -283,15 +283,19 @@ future<StatusOr<google::cloud::pubsublite::v1::TopicPartitions>>
 AdminServiceLogging::AsyncGetTopicPartitions(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::cloud::pubsublite::v1::GetTopicPartitionsRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](google::cloud::CompletionQueue& cq,
              std::shared_ptr<grpc::ClientContext> context,
+             google::cloud::internal::ImmutableOptions options,
              google::cloud::pubsublite::v1::GetTopicPartitionsRequest const&
                  request) {
-        return child_->AsyncGetTopicPartitions(cq, std::move(context), request);
+        return child_->AsyncGetTopicPartitions(cq, std::move(context),
+                                               std::move(options), request);
       },
-      cq, std::move(context), request, __func__, tracing_options_);
+      cq, std::move(context), std::move(options), request, __func__,
+      tracing_options_);
 }
 
 future<StatusOr<google::longrunning::Operation>>

--- a/google/cloud/pubsublite/internal/admin_logging_decorator.h
+++ b/google/cloud/pubsublite/internal/admin_logging_decorator.h
@@ -140,6 +140,7 @@ class AdminServiceLogging : public AdminServiceStub {
   AsyncGetTopicPartitions(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::cloud::pubsublite::v1::GetTopicPartitionsRequest const& request)
       override;
 

--- a/google/cloud/pubsublite/internal/admin_metadata_decorator.cc
+++ b/google/cloud/pubsublite/internal/admin_metadata_decorator.cc
@@ -221,10 +221,12 @@ future<StatusOr<google::cloud::pubsublite::v1::TopicPartitions>>
 AdminServiceMetadata::AsyncGetTopicPartitions(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::cloud::pubsublite::v1::GetTopicPartitionsRequest const& request) {
-  SetMetadata(*context, internal::CurrentOptions(),
+  SetMetadata(*context, *options,
               absl::StrCat("name=", internal::UrlEncode(request.name())));
-  return child_->AsyncGetTopicPartitions(cq, std::move(context), request);
+  return child_->AsyncGetTopicPartitions(cq, std::move(context),
+                                         std::move(options), request);
 }
 
 future<StatusOr<google::longrunning::Operation>>

--- a/google/cloud/pubsublite/internal/admin_metadata_decorator.h
+++ b/google/cloud/pubsublite/internal/admin_metadata_decorator.h
@@ -140,6 +140,7 @@ class AdminServiceMetadata : public AdminServiceStub {
   AsyncGetTopicPartitions(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::cloud::pubsublite::v1::GetTopicPartitionsRequest const& request)
       override;
 

--- a/google/cloud/pubsublite/internal/admin_stub.cc
+++ b/google/cloud/pubsublite/internal/admin_stub.cc
@@ -270,6 +270,8 @@ future<StatusOr<google::cloud::pubsublite::v1::TopicPartitions>>
 DefaultAdminServiceStub::AsyncGetTopicPartitions(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    google::cloud::internal::ImmutableOptions,
     google::cloud::pubsublite::v1::GetTopicPartitionsRequest const& request) {
   return internal::MakeUnaryRpcImpl<
       google::cloud::pubsublite::v1::GetTopicPartitionsRequest,
@@ -288,6 +290,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultAdminServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -304,6 +307,7 @@ DefaultAdminServiceStub::AsyncGetOperation(
 future<Status> DefaultAdminServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/pubsublite/internal/admin_stub.h
+++ b/google/cloud/pubsublite/internal/admin_stub.h
@@ -143,6 +143,7 @@ class AdminServiceStub {
   AsyncGetTopicPartitions(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::cloud::pubsublite::v1::GetTopicPartitionsRequest const&
           request) = 0;
 
@@ -270,6 +271,7 @@ class DefaultAdminServiceStub : public AdminServiceStub {
   AsyncGetTopicPartitions(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::cloud::pubsublite::v1::GetTopicPartitionsRequest const& request)
       override;
 

--- a/google/cloud/pubsublite/internal/admin_tracing_stub.cc
+++ b/google/cloud/pubsublite/internal/admin_tracing_stub.cc
@@ -266,12 +266,14 @@ future<StatusOr<google::cloud::pubsublite::v1::TopicPartitions>>
 AdminServiceTracingStub::AsyncGetTopicPartitions(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::cloud::pubsublite::v1::GetTopicPartitionsRequest const& request) {
   auto span = internal::MakeSpanGrpc("google.cloud.pubsublite.v1.AdminService",
                                      "GetTopicPartitions");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto f = child_->AsyncGetTopicPartitions(cq, context, request);
+  auto f =
+      child_->AsyncGetTopicPartitions(cq, context, std::move(options), request);
   return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 

--- a/google/cloud/pubsublite/internal/admin_tracing_stub.h
+++ b/google/cloud/pubsublite/internal/admin_tracing_stub.h
@@ -138,6 +138,7 @@ class AdminServiceTracingStub : public AdminServiceStub {
   AsyncGetTopicPartitions(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::cloud::pubsublite::v1::GetTopicPartitionsRequest const& request)
       override;
 

--- a/google/cloud/rapidmigrationassessment/v1/internal/rapid_migration_assessment_stub.cc
+++ b/google/cloud/rapidmigrationassessment/v1/internal/rapid_migration_assessment_stub.cc
@@ -215,6 +215,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultRapidMigrationAssessmentStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -231,6 +232,7 @@ DefaultRapidMigrationAssessmentStub::AsyncGetOperation(
 future<Status> DefaultRapidMigrationAssessmentStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/redis/cluster/v1/internal/cloud_redis_cluster_stub.cc
+++ b/google/cloud/redis/cluster/v1/internal/cloud_redis_cluster_stub.cc
@@ -116,6 +116,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultCloudRedisClusterStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -132,6 +133,7 @@ DefaultCloudRedisClusterStub::AsyncGetOperation(
 future<Status> DefaultCloudRedisClusterStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/redis/v1/internal/cloud_redis_stub.cc
+++ b/google/cloud/redis/v1/internal/cloud_redis_stub.cc
@@ -215,6 +215,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultCloudRedisStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -231,6 +232,7 @@ DefaultCloudRedisStub::AsyncGetOperation(
 future<Status> DefaultCloudRedisStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/resourcemanager/v3/internal/folders_stub.cc
+++ b/google/cloud/resourcemanager/v3/internal/folders_stub.cc
@@ -200,6 +200,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultFoldersStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -216,6 +217,7 @@ DefaultFoldersStub::AsyncGetOperation(
 future<Status> DefaultFoldersStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/resourcemanager/v3/internal/projects_stub.cc
+++ b/google/cloud/resourcemanager/v3/internal/projects_stub.cc
@@ -200,6 +200,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultProjectsStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -216,6 +217,7 @@ DefaultProjectsStub::AsyncGetOperation(
 future<Status> DefaultProjectsStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/resourcemanager/v3/internal/tag_bindings_stub.cc
+++ b/google/cloud/resourcemanager/v3/internal/tag_bindings_stub.cc
@@ -100,6 +100,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultTagBindingsStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -116,6 +117,7 @@ DefaultTagBindingsStub::AsyncGetOperation(
 future<Status> DefaultTagBindingsStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/resourcemanager/v3/internal/tag_holds_stub.cc
+++ b/google/cloud/resourcemanager/v3/internal/tag_holds_stub.cc
@@ -85,6 +85,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultTagHoldsStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -101,6 +102,7 @@ DefaultTagHoldsStub::AsyncGetOperation(
 future<Status> DefaultTagHoldsStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/resourcemanager/v3/internal/tag_keys_stub.cc
+++ b/google/cloud/resourcemanager/v3/internal/tag_keys_stub.cc
@@ -163,6 +163,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultTagKeysStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -179,6 +180,7 @@ DefaultTagKeysStub::AsyncGetOperation(
 future<Status> DefaultTagKeysStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/resourcemanager/v3/internal/tag_values_stub.cc
+++ b/google/cloud/resourcemanager/v3/internal/tag_values_stub.cc
@@ -163,6 +163,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultTagValuesStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -179,6 +180,7 @@ DefaultTagValuesStub::AsyncGetOperation(
 future<Status> DefaultTagValuesStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/retail/v2/internal/completion_stub.cc
+++ b/google/cloud/retail/v2/internal/completion_stub.cc
@@ -66,6 +66,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultCompletionServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -82,6 +83,7 @@ DefaultCompletionServiceStub::AsyncGetOperation(
 future<Status> DefaultCompletionServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/retail/v2/internal/model_stub.cc
+++ b/google/cloud/retail/v2/internal/model_stub.cc
@@ -137,6 +137,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultModelServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -153,6 +154,7 @@ DefaultModelServiceStub::AsyncGetOperation(
 future<Status> DefaultModelServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/retail/v2/internal/product_stub.cc
+++ b/google/cloud/retail/v2/internal/product_stub.cc
@@ -206,6 +206,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultProductServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -222,6 +223,7 @@ DefaultProductServiceStub::AsyncGetOperation(
 future<Status> DefaultProductServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/retail/v2/internal/user_event_stub.cc
+++ b/google/cloud/retail/v2/internal/user_event_stub.cc
@@ -112,6 +112,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultUserEventServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -128,6 +129,7 @@ DefaultUserEventServiceStub::AsyncGetOperation(
 future<Status> DefaultUserEventServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/run/v2/internal/executions_stub.cc
+++ b/google/cloud/run/v2/internal/executions_stub.cc
@@ -94,6 +94,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultExecutionsStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -110,6 +111,7 @@ DefaultExecutionsStub::AsyncGetOperation(
 future<Status> DefaultExecutionsStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/run/v2/internal/jobs_stub.cc
+++ b/google/cloud/run/v2/internal/jobs_stub.cc
@@ -158,6 +158,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultJobsStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -174,6 +175,7 @@ DefaultJobsStub::AsyncGetOperation(
 future<Status> DefaultJobsStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/run/v2/internal/revisions_stub.cc
+++ b/google/cloud/run/v2/internal/revisions_stub.cc
@@ -76,6 +76,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultRevisionsStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -92,6 +93,7 @@ DefaultRevisionsStub::AsyncGetOperation(
 future<Status> DefaultRevisionsStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/run/v2/internal/services_stub.cc
+++ b/google/cloud/run/v2/internal/services_stub.cc
@@ -146,6 +146,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultServicesStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -162,6 +163,7 @@ DefaultServicesStub::AsyncGetOperation(
 future<Status> DefaultServicesStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/securesourcemanager/v1/internal/secure_source_manager_stub.cc
+++ b/google/cloud/securesourcemanager/v1/internal/secure_source_manager_stub.cc
@@ -207,6 +207,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultSecureSourceManagerStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -223,6 +224,7 @@ DefaultSecureSourceManagerStub::AsyncGetOperation(
 future<Status> DefaultSecureSourceManagerStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/securitycenter/v1/internal/security_center_stub.cc
+++ b/google/cloud/securitycenter/v1/internal/security_center_stub.cc
@@ -637,6 +637,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultSecurityCenterStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -653,6 +654,7 @@ DefaultSecurityCenterStub::AsyncGetOperation(
 future<Status> DefaultSecurityCenterStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/servicemanagement/v1/internal/service_manager_stub.cc
+++ b/google/cloud/servicemanagement/v1/internal/service_manager_stub.cc
@@ -234,6 +234,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultServiceManagerStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -250,6 +251,7 @@ DefaultServiceManagerStub::AsyncGetOperation(
 future<Status> DefaultServiceManagerStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/serviceusage/v1/internal/service_usage_stub.cc
+++ b/google/cloud/serviceusage/v1/internal/service_usage_stub.cc
@@ -127,6 +127,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultServiceUsageStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -143,6 +144,7 @@ DefaultServiceUsageStub::AsyncGetOperation(
 future<Status> DefaultServiceUsageStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/shell/v1/internal/cloud_shell_stub.cc
+++ b/google/cloud/shell/v1/internal/cloud_shell_stub.cc
@@ -120,6 +120,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultCloudShellServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -136,6 +137,7 @@ DefaultCloudShellServiceStub::AsyncGetOperation(
 future<Status> DefaultCloudShellServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/spanner/admin/internal/database_admin_stub.cc
+++ b/google/cloud/spanner/admin/internal/database_admin_stub.cc
@@ -323,6 +323,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultDatabaseAdminStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -339,6 +340,7 @@ DefaultDatabaseAdminStub::AsyncGetOperation(
 future<Status> DefaultDatabaseAdminStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/spanner/admin/internal/instance_admin_stub.cc
+++ b/google/cloud/spanner/admin/internal/instance_admin_stub.cc
@@ -335,6 +335,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultInstanceAdminStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -351,6 +352,7 @@ DefaultInstanceAdminStub::AsyncGetOperation(
 future<Status> DefaultInstanceAdminStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/spanner/internal/session_pool.cc
+++ b/google/cloud/spanner/internal/session_pool.cc
@@ -463,11 +463,13 @@ SessionPool::AsyncBatchCreateSessions(
       retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
       Idempotency::kIdempotent, cq,
       [stub](CompletionQueue& cq, std::shared_ptr<grpc::ClientContext> context,
+             internal::ImmutableOptions options,
              google::spanner::v1::BatchCreateSessionsRequest const& request) {
         RouteToLeader(*context);  // always for BatchCreateSessions()
-        return stub->AsyncBatchCreateSessions(cq, std::move(context), request);
+        return stub->AsyncBatchCreateSessions(cq, std::move(context),
+                                              std::move(options), request);
       },
-      std::move(request), __func__);
+      internal::SaveCurrentOptions(), std::move(request), __func__);
 }
 
 future<Status> SessionPool::AsyncDeleteSession(
@@ -479,10 +481,12 @@ future<Status> SessionPool::AsyncDeleteSession(
       retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
       Idempotency::kIdempotent, cq,
       [stub](CompletionQueue& cq, std::shared_ptr<grpc::ClientContext> context,
+             google::cloud::internal::ImmutableOptions options,
              google::spanner::v1::DeleteSessionRequest const& request) {
-        return stub->AsyncDeleteSession(cq, std::move(context), request);
+        return stub->AsyncDeleteSession(cq, std::move(context),
+                                        std::move(options), request);
       },
-      std::move(request), __func__);
+      internal::SaveCurrentOptions(), std::move(request), __func__);
 }
 
 /// Refresh the session `session_name` by executing a `SELECT 1` query on it.
@@ -500,11 +504,13 @@ SessionPool::AsyncRefreshSession(CompletionQueue& cq,
       retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
       Idempotency::kIdempotent, cq,
       [stub](CompletionQueue& cq, std::shared_ptr<grpc::ClientContext> context,
+             google::cloud::internal::ImmutableOptions options,
              google::spanner::v1::ExecuteSqlRequest const& request) {
         // Read-only transaction, so no route-to-leader.
-        return stub->AsyncExecuteSql(cq, std::move(context), request);
+        return stub->AsyncExecuteSql(cq, std::move(context), std::move(options),
+                                     request);
       },
-      std::move(request), __func__);
+      internal::SaveCurrentOptions(), std::move(request), __func__);
 }
 
 Status SessionPool::HandleBatchCreateSessionsDone(

--- a/google/cloud/spanner/internal/session_pool_test.cc
+++ b/google/cloud/spanner/internal/session_pool_test.cc
@@ -510,7 +510,7 @@ TEST_F(SessionPoolTest, SessionRefresh) {
 
   EXPECT_CALL(*mock, AsyncExecuteSql)
       .WillOnce(
-          [&result](CompletionQueue&, auto,
+          [&result](CompletionQueue&, auto, auto,
                     google::spanner::v1::ExecuteSqlRequest const& request) {
             EXPECT_EQ("s2", request.session());
             return make_ready_future(make_status_or(std::move(result)));
@@ -569,7 +569,7 @@ TEST_F(SessionPoolTest, SessionRefreshNotFound) {
       .WillOnce(Return(ByMove(MakeSessionsResponse({"s3"}))));
 
   EXPECT_CALL(*mock, AsyncExecuteSql)
-      .WillOnce([](CompletionQueue&, auto,
+      .WillOnce([](CompletionQueue&, auto, auto,
                    google::spanner::v1::ExecuteSqlRequest const& request) {
         EXPECT_EQ("s2", request.session());
         // The "SELECT 1" refresh returns "Session not found".

--- a/google/cloud/spanner/internal/spanner_auth_decorator.cc
+++ b/google/cloud/spanner/internal/spanner_auth_decorator.cc
@@ -153,52 +153,55 @@ future<StatusOr<google::spanner::v1::BatchCreateSessionsResponse>>
 SpannerAuth::AsyncBatchCreateSessions(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::spanner::v1::BatchCreateSessionsRequest const& request) {
-  using ReturnType = StatusOr<google::spanner::v1::BatchCreateSessionsResponse>;
-  auto& child = child_;
   return auth_->AsyncConfigureContext(std::move(context))
-      .then([cq, child,
+      .then([cq, child = child_, options = std::move(options),
              request](future<StatusOr<std::shared_ptr<grpc::ClientContext>>>
                           f) mutable {
         auto context = f.get();
         if (!context) {
-          return make_ready_future(ReturnType(std::move(context).status()));
+          return make_ready_future(
+              StatusOr<google::spanner::v1::BatchCreateSessionsResponse>(
+                  std::move(context).status()));
         }
         return child->AsyncBatchCreateSessions(cq, *std::move(context),
-                                               request);
+                                               std::move(options), request);
       });
 }
 
 future<Status> SpannerAuth::AsyncDeleteSession(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::spanner::v1::DeleteSessionRequest const& request) {
-  auto& child = child_;
   return auth_->AsyncConfigureContext(std::move(context))
-      .then([cq, child,
+      .then([cq, child = child_, options = std::move(options),
              request](future<StatusOr<std::shared_ptr<grpc::ClientContext>>>
                           f) mutable {
         auto context = f.get();
         if (!context) return make_ready_future(std::move(context).status());
-        return child->AsyncDeleteSession(cq, *std::move(context), request);
+        return child->AsyncDeleteSession(cq, *std::move(context),
+                                         std::move(options), request);
       });
 }
 
 future<StatusOr<google::spanner::v1::ResultSet>> SpannerAuth::AsyncExecuteSql(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::spanner::v1::ExecuteSqlRequest const& request) {
-  using ReturnType = StatusOr<google::spanner::v1::ResultSet>;
-  auto& child = child_;
   return auth_->AsyncConfigureContext(std::move(context))
-      .then([cq, child,
+      .then([cq, child = child_, options = std::move(options),
              request](future<StatusOr<std::shared_ptr<grpc::ClientContext>>>
                           f) mutable {
         auto context = f.get();
         if (!context) {
-          return make_ready_future(ReturnType(std::move(context).status()));
+          return make_ready_future(StatusOr<google::spanner::v1::ResultSet>(
+              std::move(context).status()));
         }
-        return child->AsyncExecuteSql(cq, *std::move(context), request);
+        return child->AsyncExecuteSql(cq, *std::move(context),
+                                      std::move(options), request);
       });
 }
 

--- a/google/cloud/spanner/internal/spanner_auth_decorator.h
+++ b/google/cloud/spanner/internal/spanner_auth_decorator.h
@@ -100,16 +100,19 @@ class SpannerAuth : public SpannerStub {
   AsyncBatchCreateSessions(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::spanner::v1::BatchCreateSessionsRequest const& request) override;
 
   future<Status> AsyncDeleteSession(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::spanner::v1::DeleteSessionRequest const& request) override;
 
   future<StatusOr<google::spanner::v1::ResultSet>> AsyncExecuteSql(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::spanner::v1::ExecuteSqlRequest const& request) override;
 
  private:

--- a/google/cloud/spanner/internal/spanner_logging_decorator.cc
+++ b/google/cloud/spanner/internal/spanner_logging_decorator.cc
@@ -226,42 +226,53 @@ future<StatusOr<google::spanner::v1::BatchCreateSessionsResponse>>
 SpannerLogging::AsyncBatchCreateSessions(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::spanner::v1::BatchCreateSessionsRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](google::cloud::CompletionQueue& cq,
              std::shared_ptr<grpc::ClientContext> context,
+             google::cloud::internal::ImmutableOptions options,
              google::spanner::v1::BatchCreateSessionsRequest const& request) {
         return child_->AsyncBatchCreateSessions(cq, std::move(context),
-                                                request);
+                                                std::move(options), request);
       },
-      cq, std::move(context), request, __func__, tracing_options_);
+      cq, std::move(context), std::move(options), request, __func__,
+      tracing_options_);
 }
 
 future<Status> SpannerLogging::AsyncDeleteSession(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::spanner::v1::DeleteSessionRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](google::cloud::CompletionQueue& cq,
              std::shared_ptr<grpc::ClientContext> context,
+             google::cloud::internal::ImmutableOptions options,
              google::spanner::v1::DeleteSessionRequest const& request) {
-        return child_->AsyncDeleteSession(cq, std::move(context), request);
+        return child_->AsyncDeleteSession(cq, std::move(context),
+                                          std::move(options), request);
       },
-      cq, std::move(context), request, __func__, tracing_options_);
+      cq, std::move(context), std::move(options), request, __func__,
+      tracing_options_);
 }
 
 future<StatusOr<google::spanner::v1::ResultSet>>
 SpannerLogging::AsyncExecuteSql(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::spanner::v1::ExecuteSqlRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](google::cloud::CompletionQueue& cq,
              std::shared_ptr<grpc::ClientContext> context,
+             google::cloud::internal::ImmutableOptions options,
              google::spanner::v1::ExecuteSqlRequest const& request) {
-        return child_->AsyncExecuteSql(cq, std::move(context), request);
+        return child_->AsyncExecuteSql(cq, std::move(context),
+                                       std::move(options), request);
       },
-      cq, std::move(context), request, __func__, tracing_options_);
+      cq, std::move(context), std::move(options), request, __func__,
+      tracing_options_);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/spanner/internal/spanner_logging_decorator.h
+++ b/google/cloud/spanner/internal/spanner_logging_decorator.h
@@ -100,16 +100,19 @@ class SpannerLogging : public SpannerStub {
   AsyncBatchCreateSessions(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::spanner::v1::BatchCreateSessionsRequest const& request) override;
 
   future<Status> AsyncDeleteSession(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::spanner::v1::DeleteSessionRequest const& request) override;
 
   future<StatusOr<google::spanner::v1::ResultSet>> AsyncExecuteSql(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::spanner::v1::ExecuteSqlRequest const& request) override;
 
  private:

--- a/google/cloud/spanner/internal/spanner_metadata_decorator.cc
+++ b/google/cloud/spanner/internal/spanner_metadata_decorator.cc
@@ -161,30 +161,36 @@ future<StatusOr<google::spanner::v1::BatchCreateSessionsResponse>>
 SpannerMetadata::AsyncBatchCreateSessions(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::spanner::v1::BatchCreateSessionsRequest const& request) {
   SetMetadata(
-      *context, internal::CurrentOptions(),
+      *context, *options,
       absl::StrCat("database=", internal::UrlEncode(request.database())));
-  return child_->AsyncBatchCreateSessions(cq, std::move(context), request);
+  return child_->AsyncBatchCreateSessions(cq, std::move(context),
+                                          std::move(options), request);
 }
 
 future<Status> SpannerMetadata::AsyncDeleteSession(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::spanner::v1::DeleteSessionRequest const& request) {
-  SetMetadata(*context, internal::CurrentOptions(),
+  SetMetadata(*context, *options,
               absl::StrCat("name=", internal::UrlEncode(request.name())));
-  return child_->AsyncDeleteSession(cq, std::move(context), request);
+  return child_->AsyncDeleteSession(cq, std::move(context), std::move(options),
+                                    request);
 }
 
 future<StatusOr<google::spanner::v1::ResultSet>>
 SpannerMetadata::AsyncExecuteSql(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::spanner::v1::ExecuteSqlRequest const& request) {
-  SetMetadata(*context, internal::CurrentOptions(),
+  SetMetadata(*context, *options,
               absl::StrCat("session=", internal::UrlEncode(request.session())));
-  return child_->AsyncExecuteSql(cq, std::move(context), request);
+  return child_->AsyncExecuteSql(cq, std::move(context), std::move(options),
+                                 request);
 }
 
 void SpannerMetadata::SetMetadata(grpc::ClientContext& context,

--- a/google/cloud/spanner/internal/spanner_metadata_decorator.h
+++ b/google/cloud/spanner/internal/spanner_metadata_decorator.h
@@ -100,16 +100,19 @@ class SpannerMetadata : public SpannerStub {
   AsyncBatchCreateSessions(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::spanner::v1::BatchCreateSessionsRequest const& request) override;
 
   future<Status> AsyncDeleteSession(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::spanner::v1::DeleteSessionRequest const& request) override;
 
   future<StatusOr<google::spanner::v1::ResultSet>> AsyncExecuteSql(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::spanner::v1::ExecuteSqlRequest const& request) override;
 
  private:

--- a/google/cloud/spanner/internal/spanner_stub.cc
+++ b/google/cloud/spanner/internal/spanner_stub.cc
@@ -181,6 +181,8 @@ future<StatusOr<google::spanner::v1::BatchCreateSessionsResponse>>
 DefaultSpannerStub::AsyncBatchCreateSessions(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    google::cloud::internal::ImmutableOptions,
     google::spanner::v1::BatchCreateSessionsRequest const& request) {
   return internal::MakeUnaryRpcImpl<
       google::spanner::v1::BatchCreateSessionsRequest,
@@ -197,6 +199,8 @@ DefaultSpannerStub::AsyncBatchCreateSessions(
 future<Status> DefaultSpannerStub::AsyncDeleteSession(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    google::cloud::internal::ImmutableOptions,
     google::spanner::v1::DeleteSessionRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::spanner::v1::DeleteSessionRequest,
                                     google::protobuf::Empty>(
@@ -216,6 +220,8 @@ future<StatusOr<google::spanner::v1::ResultSet>>
 DefaultSpannerStub::AsyncExecuteSql(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    google::cloud::internal::ImmutableOptions,
     google::spanner::v1::ExecuteSqlRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::spanner::v1::ExecuteSqlRequest,
                                     google::spanner::v1::ResultSet>(

--- a/google/cloud/spanner/internal/spanner_stub.h
+++ b/google/cloud/spanner/internal/spanner_stub.h
@@ -102,16 +102,19 @@ class SpannerStub {
   AsyncBatchCreateSessions(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::spanner::v1::BatchCreateSessionsRequest const& request) = 0;
 
   virtual future<Status> AsyncDeleteSession(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::spanner::v1::DeleteSessionRequest const& request) = 0;
 
   virtual future<StatusOr<google::spanner::v1::ResultSet>> AsyncExecuteSql(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::spanner::v1::ExecuteSqlRequest const& request) = 0;
 };
 
@@ -183,16 +186,19 @@ class DefaultSpannerStub : public SpannerStub {
   AsyncBatchCreateSessions(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::spanner::v1::BatchCreateSessionsRequest const& request) override;
 
   future<Status> AsyncDeleteSession(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::spanner::v1::DeleteSessionRequest const& request) override;
 
   future<StatusOr<google::spanner::v1::ResultSet>> AsyncExecuteSql(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::spanner::v1::ExecuteSqlRequest const& request) override;
 
  private:

--- a/google/cloud/spanner/internal/spanner_tracing_stub.cc
+++ b/google/cloud/spanner/internal/spanner_tracing_stub.cc
@@ -190,24 +190,27 @@ future<StatusOr<google::spanner::v1::BatchCreateSessionsResponse>>
 SpannerTracingStub::AsyncBatchCreateSessions(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::spanner::v1::BatchCreateSessionsRequest const& request) {
   auto span = internal::MakeSpanGrpc("google.spanner.v1.Spanner",
                                      "BatchCreateSessions");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto f = child_->AsyncBatchCreateSessions(cq, context, request);
+  auto f = child_->AsyncBatchCreateSessions(cq, context, std::move(options),
+                                            request);
   return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 
 future<Status> SpannerTracingStub::AsyncDeleteSession(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::spanner::v1::DeleteSessionRequest const& request) {
   auto span =
       internal::MakeSpanGrpc("google.spanner.v1.Spanner", "DeleteSession");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto f = child_->AsyncDeleteSession(cq, context, request);
+  auto f = child_->AsyncDeleteSession(cq, context, std::move(options), request);
   return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 
@@ -215,11 +218,12 @@ future<StatusOr<google::spanner::v1::ResultSet>>
 SpannerTracingStub::AsyncExecuteSql(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::spanner::v1::ExecuteSqlRequest const& request) {
   auto span = internal::MakeSpanGrpc("google.spanner.v1.Spanner", "ExecuteSql");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto f = child_->AsyncExecuteSql(cq, context, request);
+  auto f = child_->AsyncExecuteSql(cq, context, std::move(options), request);
   return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 

--- a/google/cloud/spanner/internal/spanner_tracing_stub.h
+++ b/google/cloud/spanner/internal/spanner_tracing_stub.h
@@ -99,16 +99,19 @@ class SpannerTracingStub : public SpannerStub {
   AsyncBatchCreateSessions(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::spanner::v1::BatchCreateSessionsRequest const& request) override;
 
   future<Status> AsyncDeleteSession(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::spanner::v1::DeleteSessionRequest const& request) override;
 
   future<StatusOr<google::spanner::v1::ResultSet>> AsyncExecuteSql(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::spanner::v1::ExecuteSqlRequest const& request) override;
 
  private:

--- a/google/cloud/spanner/testing/mock_spanner_stub.h
+++ b/google/cloud/spanner/testing/mock_spanner_stub.h
@@ -41,8 +41,9 @@ class MockSpannerStub : public google::cloud::spanner_internal::SpannerStub {
   MOCK_METHOD(
       future<StatusOr<google::spanner::v1::BatchCreateSessionsResponse>>,
       AsyncBatchCreateSessions,
-      (CompletionQueue & cq, std::shared_ptr<grpc::ClientContext> context,
-       google::spanner::v1::BatchCreateSessionsRequest const& request),
+      (CompletionQueue&, std::shared_ptr<grpc::ClientContext>,
+       google::cloud::internal::ImmutableOptions,
+       google::spanner::v1::BatchCreateSessionsRequest const&),
       (override));
 
   MOCK_METHOD(Status, DeleteSession,
@@ -52,6 +53,7 @@ class MockSpannerStub : public google::cloud::spanner_internal::SpannerStub {
 
   MOCK_METHOD(future<Status>, AsyncDeleteSession,
               (CompletionQueue&, std::shared_ptr<grpc::ClientContext>,
+               google::cloud::internal::ImmutableOptions,
                google::spanner::v1::DeleteSessionRequest const&),
               (override));
 
@@ -62,6 +64,7 @@ class MockSpannerStub : public google::cloud::spanner_internal::SpannerStub {
 
   MOCK_METHOD(future<StatusOr<google::spanner::v1::ResultSet>>, AsyncExecuteSql,
               (CompletionQueue&, std::shared_ptr<grpc::ClientContext>,
+               google::cloud::internal::ImmutableOptions,
                google::spanner::v1::ExecuteSqlRequest const&),
               (override));
 

--- a/google/cloud/speech/v1/internal/speech_stub.cc
+++ b/google/cloud/speech/v1/internal/speech_stub.cc
@@ -83,6 +83,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultSpeechStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -99,6 +100,7 @@ DefaultSpeechStub::AsyncGetOperation(
 future<Status> DefaultSpeechStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/speech/v2/internal/speech_stub.cc
+++ b/google/cloud/speech/v2/internal/speech_stub.cc
@@ -393,6 +393,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultSpeechStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -409,6 +410,7 @@ DefaultSpeechStub::AsyncGetOperation(
 future<Status> DefaultSpeechStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/storage/internal/async/connection_impl.cc
+++ b/google/cloud/storage/internal/async/connection_impl.cc
@@ -312,8 +312,7 @@ AsyncConnectionImpl::StartResumableWrite(
   auto backoff = backoff_policy(*current);
   return google::cloud::internal::AsyncRetryLoop(
       std::move(retry), std::move(backoff), idempotency, cq_,
-      [stub = stub_,
-       request = std::move(request)](
+      [stub = stub_, request = std::move(request)](
           CompletionQueue& cq, std::shared_ptr<grpc::ClientContext> context,
           google::cloud::internal::ImmutableOptions options,
           google::storage::v2::StartResumableWriteRequest const& proto) {
@@ -354,8 +353,7 @@ AsyncConnectionImpl::QueryWriteStatus(
   auto backoff = backoff_policy(*current);
   return google::cloud::internal::AsyncRetryLoop(
       std::move(retry), std::move(backoff), idempotency, cq_,
-      [stub = stub_,
-       request = std::move(request)](
+      [stub = stub_, request = std::move(request)](
           CompletionQueue& cq, std::shared_ptr<grpc::ClientContext> context,
           google::cloud::internal::ImmutableOptions options,
           google::storage::v2::QueryWriteStatusRequest const& proto) {

--- a/google/cloud/storage/internal/async/connection_impl_test.cc
+++ b/google/cloud/storage/internal/async/connection_impl_test.cc
@@ -33,7 +33,6 @@ namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-using ::google::cloud::internal::CurrentOptions;
 using ::google::cloud::storage::testing::MockAsyncBidiWriteObjectStream;
 using ::google::cloud::storage::testing::MockAsyncInsertStream;
 using ::google::cloud::storage::testing::MockAsyncObjectMediaStream;
@@ -445,7 +444,7 @@ TEST_F(AsyncConnectionImplTest, UnbufferedUploadNewUpload) {
         });
       })
       .WillOnce(
-          [&](auto&, auto,
+          [&](auto&, auto, auto,
               google::storage::v2::StartResumableWriteRequest const& request) {
             auto const& spec = request.write_object_spec();
             EXPECT_TRUE(spec.has_if_generation_match());
@@ -580,7 +579,7 @@ TEST_F(AsyncConnectionImplTest, UnbufferedUploadResumeUpload) {
         });
       })
       .WillOnce(
-          [&](auto&, auto,
+          [&](auto&, auto, auto,
               google::storage::v2::QueryWriteStatusRequest const& request) {
             EXPECT_EQ(request.upload_id(), "test-upload-id");
 
@@ -706,7 +705,7 @@ TEST_F(AsyncConnectionImplTest, UnbufferedUploadResumeFinalizedUpload) {
         });
       })
       .WillOnce(
-          [&](auto&, auto,
+          [&](auto&, auto, auto,
               google::storage::v2::QueryWriteStatusRequest const& request) {
             EXPECT_EQ(request.upload_id(), "test-upload-id");
 
@@ -959,7 +958,7 @@ TEST_F(AsyncConnectionImplTest, BufferedUploadNewUpload) {
         });
       })
       .WillOnce(
-          [&](auto&, auto,
+          [&](auto&, auto, auto,
               google::storage::v2::StartResumableWriteRequest const& request) {
             auto const& spec = request.write_object_spec();
             EXPECT_TRUE(spec.has_if_generation_match());
@@ -1080,7 +1079,7 @@ TEST_F(AsyncConnectionImplTest, BufferedUploadNewUploadResume) {
         });
       })
       .WillOnce(
-          [&](auto&, auto,
+          [&](auto&, auto, auto,
               google::storage::v2::StartResumableWriteRequest const& request) {
             auto const& spec = request.write_object_spec();
             EXPECT_TRUE(spec.has_if_generation_match());
@@ -1105,7 +1104,7 @@ TEST_F(AsyncConnectionImplTest, BufferedUploadNewUploadResume) {
         });
       })
       .WillOnce(
-          [&](auto&, auto,
+          [&](auto&, auto, auto,
               google::storage::v2::QueryWriteStatusRequest const& request) {
             EXPECT_EQ(request.upload_id(), "test-upload-id");
 
@@ -1268,10 +1267,11 @@ TEST_F(AsyncConnectionImplTest, DeleteObject) {
         });
       })
       .WillOnce([&](CompletionQueue&, auto context,
+                    google::cloud::internal::ImmutableOptions const& options,
                     google::storage::v2::DeleteObjectRequest const& request) {
         // Verify at least one option is initialized with the correct
         // values.
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
+        EXPECT_EQ(options->get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(*context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),

--- a/google/cloud/storage/internal/async/rewriter_connection_impl_test.cc
+++ b/google/cloud/storage/internal/async/rewriter_connection_impl_test.cc
@@ -86,7 +86,8 @@ TEST_F(RewriterConnectionImplTest, Basic) {
           return TransientError();
         });
       })
-      .WillOnce([&](auto&, auto context, internal::ImmutableOptions const& options,
+      .WillOnce([&](auto&, auto context,
+                    internal::ImmutableOptions const& options,
                     auto const& request) {
         EXPECT_EQ(options->get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(*context);
@@ -113,7 +114,8 @@ TEST_F(RewriterConnectionImplTest, Basic) {
           return TransientError();
         });
       })
-      .WillOnce([&](auto&, auto context, internal::ImmutableOptions const& options,
+      .WillOnce([&](auto&, auto context,
+                    internal::ImmutableOptions const& options,
                     auto const& request) {
         EXPECT_EQ(options->get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(*context);
@@ -140,7 +142,8 @@ TEST_F(RewriterConnectionImplTest, Basic) {
           return TransientError();
         });
       })
-      .WillOnce([&](auto&, auto context, internal::ImmutableOptions const& options,
+      .WillOnce([&](auto&, auto context,
+                    internal::ImmutableOptions const& options,
                     auto const& request) {
         EXPECT_EQ(options->get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(*context);

--- a/google/cloud/storage/internal/async/rewriter_connection_impl_test.cc
+++ b/google/cloud/storage/internal/async/rewriter_connection_impl_test.cc
@@ -30,7 +30,6 @@ namespace cloud {
 namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::CurrentOptions;
 using ::google::cloud::storage::testing::MockStorageStub;
 using ::google::cloud::storage_experimental::RewriteObjectResponse;
 using ::google::cloud::testing_util::AsyncSequencer;
@@ -87,9 +86,9 @@ TEST_F(RewriterConnectionImplTest, Basic) {
           return TransientError();
         });
       })
-      .WillOnce([&](auto&, auto context, auto const& request) {
-        // TODO(#12359) - use the explicit `options` when available.
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
+      .WillOnce([&](auto&, auto context, internal::ImmutableOptions const& options,
+                    auto const& request) {
+        EXPECT_EQ(options->get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(*context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -114,9 +113,9 @@ TEST_F(RewriterConnectionImplTest, Basic) {
           return TransientError();
         });
       })
-      .WillOnce([&](auto&, auto context, auto const& request) {
-        // TODO(#12359) - use the explicit `options` when available.
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
+      .WillOnce([&](auto&, auto context, internal::ImmutableOptions const& options,
+                    auto const& request) {
+        EXPECT_EQ(options->get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(*context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -141,9 +140,9 @@ TEST_F(RewriterConnectionImplTest, Basic) {
           return TransientError();
         });
       })
-      .WillOnce([&](auto&, auto context, auto const& request) {
-        // TODO(#12359) - use the explicit `options` when available.
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
+      .WillOnce([&](auto&, auto context, internal::ImmutableOptions const& options,
+                    auto const& request) {
+        EXPECT_EQ(options->get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(*context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),

--- a/google/cloud/storage/internal/storage_auth_decorator.cc
+++ b/google/cloud/storage/internal/storage_auth_decorator.cc
@@ -321,33 +321,35 @@ StatusOr<google::storage::v2::HmacKeyMetadata> StorageAuth::UpdateHmacKey(
 future<StatusOr<google::storage::v2::Object>> StorageAuth::AsyncComposeObject(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::storage::v2::ComposeObjectRequest const& request) {
-  using ReturnType = StatusOr<google::storage::v2::Object>;
-  auto& child = child_;
   return auth_->AsyncConfigureContext(std::move(context))
-      .then([cq, child,
+      .then([cq, child = child_, options = std::move(options),
              request](future<StatusOr<std::shared_ptr<grpc::ClientContext>>>
                           f) mutable {
         auto context = f.get();
         if (!context) {
-          return make_ready_future(ReturnType(std::move(context).status()));
+          return make_ready_future(StatusOr<google::storage::v2::Object>(
+              std::move(context).status()));
         }
-        return child->AsyncComposeObject(cq, *std::move(context), request);
+        return child->AsyncComposeObject(cq, *std::move(context),
+                                         std::move(options), request);
       });
 }
 
 future<Status> StorageAuth::AsyncDeleteObject(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::storage::v2::DeleteObjectRequest const& request) {
-  auto& child = child_;
   return auth_->AsyncConfigureContext(std::move(context))
-      .then([cq, child,
+      .then([cq, child = child_, options = std::move(options),
              request](future<StatusOr<std::shared_ptr<grpc::ClientContext>>>
                           f) mutable {
         auto context = f.get();
         if (!context) return make_ready_future(std::move(context).status());
-        return child->AsyncDeleteObject(cq, *std::move(context), request);
+        return child->AsyncDeleteObject(cq, *std::move(context),
+                                        std::move(options), request);
       });
 }
 
@@ -393,18 +395,20 @@ future<StatusOr<google::storage::v2::RewriteResponse>>
 StorageAuth::AsyncRewriteObject(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::storage::v2::RewriteObjectRequest const& request) {
-  using ReturnType = StatusOr<google::storage::v2::RewriteResponse>;
-  auto& child = child_;
   return auth_->AsyncConfigureContext(std::move(context))
-      .then([cq, child,
+      .then([cq, child = child_, options = std::move(options),
              request](future<StatusOr<std::shared_ptr<grpc::ClientContext>>>
                           f) mutable {
         auto context = f.get();
         if (!context) {
-          return make_ready_future(ReturnType(std::move(context).status()));
+          return make_ready_future(
+              StatusOr<google::storage::v2::RewriteResponse>(
+                  std::move(context).status()));
         }
-        return child->AsyncRewriteObject(cq, *std::move(context), request);
+        return child->AsyncRewriteObject(cq, *std::move(context),
+                                         std::move(options), request);
       });
 }
 
@@ -412,19 +416,20 @@ future<StatusOr<google::storage::v2::StartResumableWriteResponse>>
 StorageAuth::AsyncStartResumableWrite(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::storage::v2::StartResumableWriteRequest const& request) {
-  using ReturnType = StatusOr<google::storage::v2::StartResumableWriteResponse>;
-  auto& child = child_;
   return auth_->AsyncConfigureContext(std::move(context))
-      .then([cq, child,
+      .then([cq, child = child_, options = std::move(options),
              request](future<StatusOr<std::shared_ptr<grpc::ClientContext>>>
                           f) mutable {
         auto context = f.get();
         if (!context) {
-          return make_ready_future(ReturnType(std::move(context).status()));
+          return make_ready_future(
+              StatusOr<google::storage::v2::StartResumableWriteResponse>(
+                  std::move(context).status()));
         }
         return child->AsyncStartResumableWrite(cq, *std::move(context),
-                                               request);
+                                               std::move(options), request);
       });
 }
 
@@ -432,18 +437,20 @@ future<StatusOr<google::storage::v2::QueryWriteStatusResponse>>
 StorageAuth::AsyncQueryWriteStatus(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::storage::v2::QueryWriteStatusRequest const& request) {
-  using ReturnType = StatusOr<google::storage::v2::QueryWriteStatusResponse>;
-  auto& child = child_;
   return auth_->AsyncConfigureContext(std::move(context))
-      .then([cq, child,
+      .then([cq, child = child_, options = std::move(options),
              request](future<StatusOr<std::shared_ptr<grpc::ClientContext>>>
                           f) mutable {
         auto context = f.get();
         if (!context) {
-          return make_ready_future(ReturnType(std::move(context).status()));
+          return make_ready_future(
+              StatusOr<google::storage::v2::QueryWriteStatusResponse>(
+                  std::move(context).status()));
         }
-        return child->AsyncQueryWriteStatus(cq, *std::move(context), request);
+        return child->AsyncQueryWriteStatus(cq, *std::move(context),
+                                            std::move(options), request);
       });
 }
 

--- a/google/cloud/storage/internal/storage_auth_decorator.h
+++ b/google/cloud/storage/internal/storage_auth_decorator.h
@@ -185,11 +185,13 @@ class StorageAuth : public StorageStub {
   future<StatusOr<google::storage::v2::Object>> AsyncComposeObject(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::ComposeObjectRequest const& request) override;
 
   future<Status> AsyncDeleteObject(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::DeleteObjectRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -210,18 +212,21 @@ class StorageAuth : public StorageStub {
   future<StatusOr<google::storage::v2::RewriteResponse>> AsyncRewriteObject(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::RewriteObjectRequest const& request) override;
 
   future<StatusOr<google::storage::v2::StartResumableWriteResponse>>
   AsyncStartResumableWrite(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::StartResumableWriteRequest const& request) override;
 
   future<StatusOr<google::storage::v2::QueryWriteStatusResponse>>
   AsyncQueryWriteStatus(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::QueryWriteStatusRequest const& request) override;
 
  private:

--- a/google/cloud/storage/internal/storage_logging_decorator.cc
+++ b/google/cloud/storage/internal/storage_logging_decorator.cc
@@ -442,27 +442,35 @@ future<StatusOr<google::storage::v2::Object>>
 StorageLogging::AsyncComposeObject(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::storage::v2::ComposeObjectRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](google::cloud::CompletionQueue& cq,
              std::shared_ptr<grpc::ClientContext> context,
+             google::cloud::internal::ImmutableOptions options,
              google::storage::v2::ComposeObjectRequest const& request) {
-        return child_->AsyncComposeObject(cq, std::move(context), request);
+        return child_->AsyncComposeObject(cq, std::move(context),
+                                          std::move(options), request);
       },
-      cq, std::move(context), request, __func__, tracing_options_);
+      cq, std::move(context), std::move(options), request, __func__,
+      tracing_options_);
 }
 
 future<Status> StorageLogging::AsyncDeleteObject(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::storage::v2::DeleteObjectRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](google::cloud::CompletionQueue& cq,
              std::shared_ptr<grpc::ClientContext> context,
+             google::cloud::internal::ImmutableOptions options,
              google::storage::v2::DeleteObjectRequest const& request) {
-        return child_->AsyncDeleteObject(cq, std::move(context), request);
+        return child_->AsyncDeleteObject(cq, std::move(context),
+                                         std::move(options), request);
       },
-      cq, std::move(context), request, __func__, tracing_options_);
+      cq, std::move(context), std::move(options), request, __func__,
+      tracing_options_);
 }
 
 std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -513,43 +521,54 @@ future<StatusOr<google::storage::v2::RewriteResponse>>
 StorageLogging::AsyncRewriteObject(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::storage::v2::RewriteObjectRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](google::cloud::CompletionQueue& cq,
              std::shared_ptr<grpc::ClientContext> context,
+             google::cloud::internal::ImmutableOptions options,
              google::storage::v2::RewriteObjectRequest const& request) {
-        return child_->AsyncRewriteObject(cq, std::move(context), request);
+        return child_->AsyncRewriteObject(cq, std::move(context),
+                                          std::move(options), request);
       },
-      cq, std::move(context), request, __func__, tracing_options_);
+      cq, std::move(context), std::move(options), request, __func__,
+      tracing_options_);
 }
 
 future<StatusOr<google::storage::v2::StartResumableWriteResponse>>
 StorageLogging::AsyncStartResumableWrite(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::storage::v2::StartResumableWriteRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](google::cloud::CompletionQueue& cq,
              std::shared_ptr<grpc::ClientContext> context,
+             google::cloud::internal::ImmutableOptions options,
              google::storage::v2::StartResumableWriteRequest const& request) {
         return child_->AsyncStartResumableWrite(cq, std::move(context),
-                                                request);
+                                                std::move(options), request);
       },
-      cq, std::move(context), request, __func__, tracing_options_);
+      cq, std::move(context), std::move(options), request, __func__,
+      tracing_options_);
 }
 
 future<StatusOr<google::storage::v2::QueryWriteStatusResponse>>
 StorageLogging::AsyncQueryWriteStatus(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::storage::v2::QueryWriteStatusRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](google::cloud::CompletionQueue& cq,
              std::shared_ptr<grpc::ClientContext> context,
+             google::cloud::internal::ImmutableOptions options,
              google::storage::v2::QueryWriteStatusRequest const& request) {
-        return child_->AsyncQueryWriteStatus(cq, std::move(context), request);
+        return child_->AsyncQueryWriteStatus(cq, std::move(context),
+                                             std::move(options), request);
       },
-      cq, std::move(context), request, __func__, tracing_options_);
+      cq, std::move(context), std::move(options), request, __func__,
+      tracing_options_);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/storage_logging_decorator.h
+++ b/google/cloud/storage/internal/storage_logging_decorator.h
@@ -185,11 +185,13 @@ class StorageLogging : public StorageStub {
   future<StatusOr<google::storage::v2::Object>> AsyncComposeObject(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::ComposeObjectRequest const& request) override;
 
   future<Status> AsyncDeleteObject(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::DeleteObjectRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -210,18 +212,21 @@ class StorageLogging : public StorageStub {
   future<StatusOr<google::storage::v2::RewriteResponse>> AsyncRewriteObject(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::RewriteObjectRequest const& request) override;
 
   future<StatusOr<google::storage::v2::StartResumableWriteResponse>>
   AsyncStartResumableWrite(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::StartResumableWriteRequest const& request) override;
 
   future<StatusOr<google::storage::v2::QueryWriteStatusResponse>>
   AsyncQueryWriteStatus(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::QueryWriteStatusRequest const& request) override;
 
  private:

--- a/google/cloud/storage/internal/storage_metadata_decorator.cc
+++ b/google/cloud/storage/internal/storage_metadata_decorator.cc
@@ -704,6 +704,7 @@ future<StatusOr<google::storage::v2::Object>>
 StorageMetadata::AsyncComposeObject(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::storage::v2::ComposeObjectRequest const& request) {
   std::vector<std::string> params;
   params.reserve(1);
@@ -714,17 +715,18 @@ StorageMetadata::AsyncComposeObject(
   }
 
   if (params.empty()) {
-    SetMetadata(*context, internal::CurrentOptions());
+    SetMetadata(*context, *options);
   } else {
-    SetMetadata(*context, internal::CurrentOptions(),
-                absl::StrJoin(params, "&"));
+    SetMetadata(*context, *options, absl::StrJoin(params, "&"));
   }
-  return child_->AsyncComposeObject(cq, std::move(context), request);
+  return child_->AsyncComposeObject(cq, std::move(context), std::move(options),
+                                    request);
 }
 
 future<Status> StorageMetadata::AsyncDeleteObject(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::storage::v2::DeleteObjectRequest const& request) {
   std::vector<std::string> params;
   params.reserve(1);
@@ -735,12 +737,12 @@ future<Status> StorageMetadata::AsyncDeleteObject(
   }
 
   if (params.empty()) {
-    SetMetadata(*context, internal::CurrentOptions());
+    SetMetadata(*context, *options);
   } else {
-    SetMetadata(*context, internal::CurrentOptions(),
-                absl::StrJoin(params, "&"));
+    SetMetadata(*context, *options, absl::StrJoin(params, "&"));
   }
-  return child_->AsyncDeleteObject(cq, std::move(context), request);
+  return child_->AsyncDeleteObject(cq, std::move(context), std::move(options),
+                                   request);
 }
 
 std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -782,6 +784,7 @@ future<StatusOr<google::storage::v2::RewriteResponse>>
 StorageMetadata::AsyncRewriteObject(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::storage::v2::RewriteObjectRequest const& request) {
   std::vector<std::string> params;
   params.reserve(2);
@@ -797,18 +800,19 @@ StorageMetadata::AsyncRewriteObject(
   }
 
   if (params.empty()) {
-    SetMetadata(*context, internal::CurrentOptions());
+    SetMetadata(*context, *options);
   } else {
-    SetMetadata(*context, internal::CurrentOptions(),
-                absl::StrJoin(params, "&"));
+    SetMetadata(*context, *options, absl::StrJoin(params, "&"));
   }
-  return child_->AsyncRewriteObject(cq, std::move(context), request);
+  return child_->AsyncRewriteObject(cq, std::move(context), std::move(options),
+                                    request);
 }
 
 future<StatusOr<google::storage::v2::StartResumableWriteResponse>>
 StorageMetadata::AsyncStartResumableWrite(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::storage::v2::StartResumableWriteRequest const& request) {
   std::vector<std::string> params;
   params.reserve(1);
@@ -820,18 +824,19 @@ StorageMetadata::AsyncStartResumableWrite(
   }
 
   if (params.empty()) {
-    SetMetadata(*context, internal::CurrentOptions());
+    SetMetadata(*context, *options);
   } else {
-    SetMetadata(*context, internal::CurrentOptions(),
-                absl::StrJoin(params, "&"));
+    SetMetadata(*context, *options, absl::StrJoin(params, "&"));
   }
-  return child_->AsyncStartResumableWrite(cq, std::move(context), request);
+  return child_->AsyncStartResumableWrite(cq, std::move(context),
+                                          std::move(options), request);
 }
 
 future<StatusOr<google::storage::v2::QueryWriteStatusResponse>>
 StorageMetadata::AsyncQueryWriteStatus(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::storage::v2::QueryWriteStatusRequest const& request) {
   std::vector<std::string> params;
   params.reserve(1);
@@ -850,12 +855,12 @@ StorageMetadata::AsyncQueryWriteStatus(
   bucket_matcher->AppendParam(request, params);
 
   if (params.empty()) {
-    SetMetadata(*context, internal::CurrentOptions());
+    SetMetadata(*context, *options);
   } else {
-    SetMetadata(*context, internal::CurrentOptions(),
-                absl::StrJoin(params, "&"));
+    SetMetadata(*context, *options, absl::StrJoin(params, "&"));
   }
-  return child_->AsyncQueryWriteStatus(cq, std::move(context), request);
+  return child_->AsyncQueryWriteStatus(cq, std::move(context),
+                                       std::move(options), request);
 }
 
 void StorageMetadata::SetMetadata(grpc::ClientContext& context,

--- a/google/cloud/storage/internal/storage_metadata_decorator.h
+++ b/google/cloud/storage/internal/storage_metadata_decorator.h
@@ -185,11 +185,13 @@ class StorageMetadata : public StorageStub {
   future<StatusOr<google::storage::v2::Object>> AsyncComposeObject(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::ComposeObjectRequest const& request) override;
 
   future<Status> AsyncDeleteObject(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::DeleteObjectRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -210,18 +212,21 @@ class StorageMetadata : public StorageStub {
   future<StatusOr<google::storage::v2::RewriteResponse>> AsyncRewriteObject(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::RewriteObjectRequest const& request) override;
 
   future<StatusOr<google::storage::v2::StartResumableWriteResponse>>
   AsyncStartResumableWrite(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::StartResumableWriteRequest const& request) override;
 
   future<StatusOr<google::storage::v2::QueryWriteStatusResponse>>
   AsyncQueryWriteStatus(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::QueryWriteStatusRequest const& request) override;
 
  private:

--- a/google/cloud/storage/internal/storage_round_robin_decorator.cc
+++ b/google/cloud/storage/internal/storage_round_robin_decorator.cc
@@ -245,15 +245,19 @@ future<StatusOr<google::storage::v2::Object>>
 StorageRoundRobin::AsyncComposeObject(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::storage::v2::ComposeObjectRequest const& request) {
-  return Child()->AsyncComposeObject(cq, std::move(context), request);
+  return Child()->AsyncComposeObject(cq, std::move(context), std::move(options),
+                                     request);
 }
 
 future<Status> StorageRoundRobin::AsyncDeleteObject(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::storage::v2::DeleteObjectRequest const& request) {
-  return Child()->AsyncDeleteObject(cq, std::move(context), request);
+  return Child()->AsyncDeleteObject(cq, std::move(context), std::move(options),
+                                    request);
 }
 
 std::unique_ptr<google::cloud::internal::AsyncStreamingReadRpc<
@@ -281,24 +285,30 @@ future<StatusOr<google::storage::v2::RewriteResponse>>
 StorageRoundRobin::AsyncRewriteObject(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::storage::v2::RewriteObjectRequest const& request) {
-  return Child()->AsyncRewriteObject(cq, std::move(context), request);
+  return Child()->AsyncRewriteObject(cq, std::move(context), std::move(options),
+                                     request);
 }
 
 future<StatusOr<google::storage::v2::StartResumableWriteResponse>>
 StorageRoundRobin::AsyncStartResumableWrite(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::storage::v2::StartResumableWriteRequest const& request) {
-  return Child()->AsyncStartResumableWrite(cq, std::move(context), request);
+  return Child()->AsyncStartResumableWrite(cq, std::move(context),
+                                           std::move(options), request);
 }
 
 future<StatusOr<google::storage::v2::QueryWriteStatusResponse>>
 StorageRoundRobin::AsyncQueryWriteStatus(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::storage::v2::QueryWriteStatusRequest const& request) {
-  return Child()->AsyncQueryWriteStatus(cq, std::move(context), request);
+  return Child()->AsyncQueryWriteStatus(cq, std::move(context),
+                                        std::move(options), request);
 }
 
 std::shared_ptr<StorageStub> StorageRoundRobin::Child() {

--- a/google/cloud/storage/internal/storage_round_robin_decorator.h
+++ b/google/cloud/storage/internal/storage_round_robin_decorator.h
@@ -183,11 +183,13 @@ class StorageRoundRobin : public StorageStub {
   future<StatusOr<google::storage::v2::Object>> AsyncComposeObject(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::ComposeObjectRequest const& request) override;
 
   future<Status> AsyncDeleteObject(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::DeleteObjectRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -208,18 +210,21 @@ class StorageRoundRobin : public StorageStub {
   future<StatusOr<google::storage::v2::RewriteResponse>> AsyncRewriteObject(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::RewriteObjectRequest const& request) override;
 
   future<StatusOr<google::storage::v2::StartResumableWriteResponse>>
   AsyncStartResumableWrite(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::StartResumableWriteRequest const& request) override;
 
   future<StatusOr<google::storage::v2::QueryWriteStatusResponse>>
   AsyncQueryWriteStatus(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::QueryWriteStatusRequest const& request) override;
 
  private:

--- a/google/cloud/storage/internal/storage_stub.cc
+++ b/google/cloud/storage/internal/storage_stub.cc
@@ -416,6 +416,8 @@ future<StatusOr<google::storage::v2::Object>>
 DefaultStorageStub::AsyncComposeObject(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    google::cloud::internal::ImmutableOptions,
     google::storage::v2::ComposeObjectRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::storage::v2::ComposeObjectRequest,
                                     google::storage::v2::Object>(
@@ -431,6 +433,8 @@ DefaultStorageStub::AsyncComposeObject(
 future<Status> DefaultStorageStub::AsyncDeleteObject(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    google::cloud::internal::ImmutableOptions,
     google::storage::v2::DeleteObjectRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::storage::v2::DeleteObjectRequest,
                                     google::protobuf::Empty>(
@@ -486,6 +490,8 @@ future<StatusOr<google::storage::v2::RewriteResponse>>
 DefaultStorageStub::AsyncRewriteObject(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    google::cloud::internal::ImmutableOptions,
     google::storage::v2::RewriteObjectRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::storage::v2::RewriteObjectRequest,
                                     google::storage::v2::RewriteResponse>(
@@ -502,6 +508,8 @@ future<StatusOr<google::storage::v2::StartResumableWriteResponse>>
 DefaultStorageStub::AsyncStartResumableWrite(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    google::cloud::internal::ImmutableOptions,
     google::storage::v2::StartResumableWriteRequest const& request) {
   return internal::MakeUnaryRpcImpl<
       google::storage::v2::StartResumableWriteRequest,
@@ -519,6 +527,8 @@ future<StatusOr<google::storage::v2::QueryWriteStatusResponse>>
 DefaultStorageStub::AsyncQueryWriteStatus(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    google::cloud::internal::ImmutableOptions,
     google::storage::v2::QueryWriteStatusRequest const& request) {
   return internal::MakeUnaryRpcImpl<
       google::storage::v2::QueryWriteStatusRequest,

--- a/google/cloud/storage/internal/storage_stub.h
+++ b/google/cloud/storage/internal/storage_stub.h
@@ -187,11 +187,13 @@ class StorageStub {
   virtual future<StatusOr<google::storage::v2::Object>> AsyncComposeObject(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::ComposeObjectRequest const& request) = 0;
 
   virtual future<Status> AsyncDeleteObject(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::DeleteObjectRequest const& request) = 0;
 
   virtual std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -212,18 +214,21 @@ class StorageStub {
   AsyncRewriteObject(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::RewriteObjectRequest const& request) = 0;
 
   virtual future<StatusOr<google::storage::v2::StartResumableWriteResponse>>
   AsyncStartResumableWrite(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::StartResumableWriteRequest const& request) = 0;
 
   virtual future<StatusOr<google::storage::v2::QueryWriteStatusResponse>>
   AsyncQueryWriteStatus(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::QueryWriteStatusRequest const& request) = 0;
 };
 
@@ -380,11 +385,13 @@ class DefaultStorageStub : public StorageStub {
   future<StatusOr<google::storage::v2::Object>> AsyncComposeObject(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::ComposeObjectRequest const& request) override;
 
   future<Status> AsyncDeleteObject(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::DeleteObjectRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -405,18 +412,21 @@ class DefaultStorageStub : public StorageStub {
   future<StatusOr<google::storage::v2::RewriteResponse>> AsyncRewriteObject(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::RewriteObjectRequest const& request) override;
 
   future<StatusOr<google::storage::v2::StartResumableWriteResponse>>
   AsyncStartResumableWrite(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::StartResumableWriteRequest const& request) override;
 
   future<StatusOr<google::storage::v2::QueryWriteStatusResponse>>
   AsyncQueryWriteStatus(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::QueryWriteStatusRequest const& request) override;
 
  private:

--- a/google/cloud/storage/internal/storage_tracing_stub.cc
+++ b/google/cloud/storage/internal/storage_tracing_stub.cc
@@ -421,24 +421,26 @@ future<StatusOr<google::storage::v2::Object>>
 StorageTracingStub::AsyncComposeObject(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::storage::v2::ComposeObjectRequest const& request) {
   auto span =
       internal::MakeSpanGrpc("google.storage.v2.Storage", "ComposeObject");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto f = child_->AsyncComposeObject(cq, context, request);
+  auto f = child_->AsyncComposeObject(cq, context, std::move(options), request);
   return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 
 future<Status> StorageTracingStub::AsyncDeleteObject(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::storage::v2::DeleteObjectRequest const& request) {
   auto span =
       internal::MakeSpanGrpc("google.storage.v2.Storage", "DeleteObject");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto f = child_->AsyncDeleteObject(cq, context, request);
+  auto f = child_->AsyncDeleteObject(cq, context, std::move(options), request);
   return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 
@@ -481,12 +483,13 @@ future<StatusOr<google::storage::v2::RewriteResponse>>
 StorageTracingStub::AsyncRewriteObject(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::storage::v2::RewriteObjectRequest const& request) {
   auto span =
       internal::MakeSpanGrpc("google.storage.v2.Storage", "RewriteObject");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto f = child_->AsyncRewriteObject(cq, context, request);
+  auto f = child_->AsyncRewriteObject(cq, context, std::move(options), request);
   return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 
@@ -494,12 +497,14 @@ future<StatusOr<google::storage::v2::StartResumableWriteResponse>>
 StorageTracingStub::AsyncStartResumableWrite(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::storage::v2::StartResumableWriteRequest const& request) {
   auto span = internal::MakeSpanGrpc("google.storage.v2.Storage",
                                      "StartResumableWrite");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto f = child_->AsyncStartResumableWrite(cq, context, request);
+  auto f = child_->AsyncStartResumableWrite(cq, context, std::move(options),
+                                            request);
   return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 
@@ -507,12 +512,14 @@ future<StatusOr<google::storage::v2::QueryWriteStatusResponse>>
 StorageTracingStub::AsyncQueryWriteStatus(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    google::cloud::internal::ImmutableOptions options,
     google::storage::v2::QueryWriteStatusRequest const& request) {
   auto span =
       internal::MakeSpanGrpc("google.storage.v2.Storage", "QueryWriteStatus");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto f = child_->AsyncQueryWriteStatus(cq, context, request);
+  auto f =
+      child_->AsyncQueryWriteStatus(cq, context, std::move(options), request);
   return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 

--- a/google/cloud/storage/internal/storage_tracing_stub.h
+++ b/google/cloud/storage/internal/storage_tracing_stub.h
@@ -184,11 +184,13 @@ class StorageTracingStub : public StorageStub {
   future<StatusOr<google::storage::v2::Object>> AsyncComposeObject(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::ComposeObjectRequest const& request) override;
 
   future<Status> AsyncDeleteObject(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::DeleteObjectRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -209,18 +211,21 @@ class StorageTracingStub : public StorageStub {
   future<StatusOr<google::storage::v2::RewriteResponse>> AsyncRewriteObject(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::RewriteObjectRequest const& request) override;
 
   future<StatusOr<google::storage::v2::StartResumableWriteResponse>>
   AsyncStartResumableWrite(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::StartResumableWriteRequest const& request) override;
 
   future<StatusOr<google::storage::v2::QueryWriteStatusResponse>>
   AsyncQueryWriteStatus(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
       google::storage::v2::QueryWriteStatusRequest const& request) override;
 
  private:

--- a/google/cloud/storage/testing/mock_storage_stub.h
+++ b/google/cloud/storage/testing/mock_storage_stub.h
@@ -175,11 +175,13 @@ class MockStorageStub : public storage_internal::StorageStub {
   MOCK_METHOD(future<StatusOr<google::storage::v2::Object>>, AsyncComposeObject,
               (google::cloud::CompletionQueue&,
                std::shared_ptr<grpc::ClientContext>,
+               google::cloud::internal::ImmutableOptions,
                google::storage::v2::ComposeObjectRequest const&),
               (override));
   MOCK_METHOD(future<Status>, AsyncDeleteObject,
               (google::cloud::CompletionQueue&,
                std::shared_ptr<grpc::ClientContext>,
+               google::cloud::internal::ImmutableOptions,
                google::storage::v2::DeleteObjectRequest const&),
               (override));
   MOCK_METHOD(std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -194,6 +196,7 @@ class MockStorageStub : public storage_internal::StorageStub {
               AsyncRewriteObject,
               (google::cloud::CompletionQueue&,
                std::shared_ptr<grpc::ClientContext>,
+               google::cloud::internal::ImmutableOptions,
                google::storage::v2::RewriteObjectRequest const&),
               (override));
   using AsyncWriteObjectReturnType =
@@ -209,12 +212,14 @@ class MockStorageStub : public storage_internal::StorageStub {
       future<StatusOr<google::storage::v2::StartResumableWriteResponse>>,
       AsyncStartResumableWrite,
       (google::cloud::CompletionQueue&, std::shared_ptr<grpc::ClientContext>,
+       google::cloud::internal::ImmutableOptions,
        google::storage::v2::StartResumableWriteRequest const&),
       (override));
   MOCK_METHOD(future<StatusOr<google::storage::v2::QueryWriteStatusResponse>>,
               AsyncQueryWriteStatus,
               (google::cloud::CompletionQueue&,
                std::shared_ptr<grpc::ClientContext>,
+               google::cloud::internal::ImmutableOptions,
                google::storage::v2::QueryWriteStatusRequest const&),
               (override));
 };

--- a/google/cloud/storagecontrol/v2/internal/storage_control_stub.cc
+++ b/google/cloud/storagecontrol/v2/internal/storage_control_stub.cc
@@ -112,6 +112,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultStorageControlStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -128,6 +129,7 @@ DefaultStorageControlStub::AsyncGetOperation(
 future<Status> DefaultStorageControlStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/storagetransfer/v1/internal/storage_transfer_stub.cc
+++ b/google/cloud/storagetransfer/v1/internal/storage_transfer_stub.cc
@@ -210,6 +210,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultStorageTransferServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -226,6 +227,7 @@ DefaultStorageTransferServiceStub::AsyncGetOperation(
 future<Status> DefaultStorageTransferServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/talent/v4/internal/job_stub.cc
+++ b/google/cloud/talent/v4/internal/job_stub.cc
@@ -169,6 +169,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultJobServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -185,6 +186,7 @@ DefaultJobServiceStub::AsyncGetOperation(
 future<Status> DefaultJobServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/telcoautomation/v1/internal/telco_automation_stub.cc
+++ b/google/cloud/telcoautomation/v1/internal/telco_automation_stub.cc
@@ -532,6 +532,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultTelcoAutomationStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -548,6 +549,7 @@ DefaultTelcoAutomationStub::AsyncGetOperation(
 future<Status> DefaultTelcoAutomationStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/tpu/v1/internal/tpu_stub.cc
+++ b/google/cloud/tpu/v1/internal/tpu_stub.cc
@@ -189,6 +189,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultTpuStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -205,6 +206,7 @@ DefaultTpuStub::AsyncGetOperation(
 future<Status> DefaultTpuStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/tpu/v2/internal/tpu_stub.cc
+++ b/google/cloud/tpu/v2/internal/tpu_stub.cc
@@ -213,6 +213,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultTpuStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -229,6 +230,7 @@ DefaultTpuStub::AsyncGetOperation(
 future<Status> DefaultTpuStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/translate/v3/internal/translation_stub.cc
+++ b/google/cloud/translate/v3/internal/translation_stub.cc
@@ -315,6 +315,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultTranslationServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -331,6 +332,7 @@ DefaultTranslationServiceStub::AsyncGetOperation(
 future<Status> DefaultTranslationServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/video/livestream/v1/internal/livestream_stub.cc
+++ b/google/cloud/video/livestream/v1/internal/livestream_stub.cc
@@ -375,6 +375,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultLivestreamServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -391,6 +392,7 @@ DefaultLivestreamServiceStub::AsyncGetOperation(
 future<Status> DefaultLivestreamServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/video/stitcher/v1/internal/video_stitcher_stub.cc
+++ b/google/cloud/video/stitcher/v1/internal/video_stitcher_stub.cc
@@ -389,6 +389,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultVideoStitcherServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -405,6 +406,7 @@ DefaultVideoStitcherServiceStub::AsyncGetOperation(
 future<Status> DefaultVideoStitcherServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/videointelligence/v1/internal/video_intelligence_stub.cc
+++ b/google/cloud/videointelligence/v1/internal/video_intelligence_stub.cc
@@ -54,6 +54,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultVideoIntelligenceServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -70,6 +71,7 @@ DefaultVideoIntelligenceServiceStub::AsyncGetOperation(
 future<Status> DefaultVideoIntelligenceServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/vision/v1/internal/image_annotator_stub.cc
+++ b/google/cloud/vision/v1/internal/image_annotator_stub.cc
@@ -97,6 +97,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultImageAnnotatorStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -113,6 +114,7 @@ DefaultImageAnnotatorStub::AsyncGetOperation(
 future<Status> DefaultImageAnnotatorStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/vision/v1/internal/product_search_stub.cc
+++ b/google/cloud/vision/v1/internal/product_search_stub.cc
@@ -274,6 +274,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultProductSearchStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -290,6 +291,7 @@ DefaultProductSearchStub::AsyncGetOperation(
 future<Status> DefaultProductSearchStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/vmmigration/v1/internal/vm_migration_stub.cc
+++ b/google/cloud/vmmigration/v1/internal/vm_migration_stub.cc
@@ -785,6 +785,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultVmMigrationStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -801,6 +802,7 @@ DefaultVmMigrationStub::AsyncGetOperation(
 future<Status> DefaultVmMigrationStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/vmwareengine/v1/internal/vmware_engine_stub.cc
+++ b/google/cloud/vmwareengine/v1/internal/vmware_engine_stub.cc
@@ -1273,6 +1273,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultVmwareEngineStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -1289,6 +1290,7 @@ DefaultVmwareEngineStub::AsyncGetOperation(
 future<Status> DefaultVmwareEngineStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/vpcaccess/v1/internal/vpc_access_stub.cc
+++ b/google/cloud/vpcaccess/v1/internal/vpc_access_stub.cc
@@ -97,6 +97,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultVpcAccessServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -113,6 +114,7 @@ DefaultVpcAccessServiceStub::AsyncGetOperation(
 future<Status> DefaultVpcAccessServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/webrisk/v1/internal/web_risk_stub.cc
+++ b/google/cloud/webrisk/v1/internal/web_risk_stub.cc
@@ -101,6 +101,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultWebRiskServiceStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -117,6 +118,7 @@ DefaultWebRiskServiceStub::AsyncGetOperation(
 future<Status> DefaultWebRiskServiceStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/workflows/v1/internal/workflows_stub.cc
+++ b/google/cloud/workflows/v1/internal/workflows_stub.cc
@@ -113,6 +113,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultWorkflowsStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -129,6 +130,7 @@ DefaultWorkflowsStub::AsyncGetOperation(
 future<Status> DefaultWorkflowsStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,

--- a/google/cloud/workstations/v1/internal/workstations_stub.cc
+++ b/google/cloud/workstations/v1/internal/workstations_stub.cc
@@ -373,6 +373,7 @@ future<StatusOr<google::longrunning::Operation>>
 DefaultWorkstationsStub::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::GetOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
@@ -389,6 +390,7 @@ DefaultWorkstationsStub::AsyncGetOperation(
 future<Status> DefaultWorkstationsStub::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
     google::longrunning::CancelOperationRequest const& request) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,


### PR DESCRIPTION
Part of the work for #12359

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13680)
<!-- Reviewable:end -->
