### PR TITLE
impl: make googleapis renovate.sh (more) hermetic

### DIFF
--- a/external/googleapis/renovate.sh
+++ b/external/googleapis/renovate.sh
@@ -69,12 +69,10 @@ if git diff --quiet bazel/google_cloud_cpp_deps.bzl \
   exit 0
 fi
 
-banner "Updating the protodeps/protolists"
-external/googleapis/update_libraries.sh
-
 banner "Regenerating libraries"
 # generate-libraries fails if it creates a diff, so ignore its status.
-ci/cloudbuild/build.sh --docker --trigger=generate-libraries-pr || true
+TRIGGER_TYPE='pr' ci/cloudbuild/build.sh \
+  --docker --trigger=generate-libraries-pr || true
 
 banner "Creating commits"
 git commit -m"chore: update googleapis SHA circa $(date +%Y-%m-%d)" \


### PR DESCRIPTION
Move the `external/googleapis/update_libraries.sh` invocation from the script to within the `generate-libraries` build by marking the latter as triggered by a PR instead of manually.  This means we will no longer be depending on the locally-installed version of bazel.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13690)
<!-- Reviewable:end -->
