### PR TITLE
impl(otel): use explicit options in retry loop

### DIFF
--- a/google/cloud/opentelemetry/internal/resource_detector_impl.cc
+++ b/google/cloud/opentelemetry/internal/resource_detector_impl.cc
@@ -203,7 +203,7 @@ class GcpResourceDetector
  private:
   StatusOr<nlohmann::json> QueryMetadataServer() {
     auto stub_call = [client = client_factory_(options_)](
-                         rest_internal::RestContext& context,
+                         rest_internal::RestContext& context, Options const&,
                          rest_internal::RestRequest const& request)
         -> StatusOr<nlohmann::json> {
       auto response = client->Get(context, request);
@@ -229,7 +229,7 @@ class GcpResourceDetector
 
     return rest_internal::RestRetryLoop(retry_->clone(), backoff_->clone(),
                                         Idempotency::kIdempotent, stub_call,
-                                        request_, __func__);
+                                        options_, request_, __func__);
   }
 
   rest_internal::RestRequest request_;


### PR DESCRIPTION
Part of the work for #12359.  I am trying to remove the retry loops with implicit options, at this point they are mostly unused.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13691)
<!-- Reviewable:end -->
