### PR TITLE
impl(storagecontrol): retry on more error codes 

### DIFF
--- a/generator/generator_config.textproto
+++ b/generator/generator_config.textproto
@@ -3238,7 +3238,13 @@ service {
   service_proto_path: "google/storage/control/v2/storage_control.proto"
   product_path: "google/cloud/storagecontrol/v2"
   initial_copyright_year: "2024"
-  retryable_status_codes: ["kUnavailable"]
+  retryable_status_codes: [
+    "kResourceExhausted",
+    "kUnavailable",
+    "kDeadlineExceeded",
+    "kInternal",
+    "kUnknown"
+  ]
   omit_repo_metadata: true
   idempotency_overrides: [
     {rpc_name: "StorageControl.GetFolder", idempotency: IDEMPOTENT},

--- a/google/cloud/storagecontrol/v2/internal/storage_control_retry_traits.h
+++ b/google/cloud/storagecontrol/v2/internal/storage_control_retry_traits.h
@@ -31,7 +31,11 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct StorageControlRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kUnavailable;
+           status.code() != StatusCode::kDeadlineExceeded &&
+           status.code() != StatusCode::kInternal &&
+           status.code() != StatusCode::kResourceExhausted &&
+           status.code() != StatusCode::kUnavailable &&
+           status.code() != StatusCode::kUnknown;
   }
 };
 

--- a/google/cloud/storagecontrol/v2/storage_control_connection.h
+++ b/google/cloud/storagecontrol/v2/storage_control_connection.h
@@ -53,7 +53,11 @@ class StorageControlRetryPolicy : public ::google::cloud::RetryPolicy {
  * - More than a prescribed number of transient failures is detected.
  *
  * In this class the following status codes are treated as transient errors:
+ * - [`kDeadlineExceeded`](@ref google::cloud::StatusCode)
+ * - [`kInternal`](@ref google::cloud::StatusCode)
+ * - [`kResourceExhausted`](@ref google::cloud::StatusCode)
  * - [`kUnavailable`](@ref google::cloud::StatusCode)
+ * - [`kUnknown`](@ref google::cloud::StatusCode)
  */
 class StorageControlLimitedErrorCountRetryPolicy
     : public StorageControlRetryPolicy {
@@ -106,7 +110,11 @@ class StorageControlLimitedErrorCountRetryPolicy
  * - The elapsed time in the retry loop exceeds a prescribed duration.
  *
  * In this class the following status codes are treated as transient errors:
+ * - [`kDeadlineExceeded`](@ref google::cloud::StatusCode)
+ * - [`kInternal`](@ref google::cloud::StatusCode)
+ * - [`kResourceExhausted`](@ref google::cloud::StatusCode)
  * - [`kUnavailable`](@ref google::cloud::StatusCode)
+ * - [`kUnknown`](@ref google::cloud::StatusCode)
  */
 class StorageControlLimitedTimeRetryPolicy : public StorageControlRetryPolicy {
  public:


### PR DESCRIPTION
The `StorageControl` service uses:

- `kResourceExhausted` for request rate control, this is unusual, but
  allowed by the AIPs and should be retryable.
- `kInternal`, `kUnknown` and `kDeadlineExceeded` are not allowed by the
  AIPs, but are (unfortunately) raised by the service when it should use
  something like `kUnavailable`. Fortunately, the service also supports
  idempotency via `request_id()` fields, so it is safe to retry these
  codes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13696)
<!-- Reviewable:end -->
