### PR TITLE
feat: promote `EnableServerRetriesOption`

### DIFF
--- a/google/cloud/bigtable/internal/bulk_mutator.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator.cc
@@ -218,8 +218,7 @@ Status BulkMutator::MakeOneRequest(BigtableStub& stub,
   auto context = std::make_shared<grpc::ClientContext>();
   google::cloud::internal::ConfigureContext(*context, options);
   retry_context_.PreCall(*context);
-  bool enable_server_retries =
-      options.get<internal::EnableServerRetriesOption>();
+  bool enable_server_retries = options.get<EnableServerRetriesOption>();
 
   struct UnpackVariant {
     BulkMutatorState& state;

--- a/google/cloud/bigtable/internal/bulk_mutator_test.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator_test.cc
@@ -31,7 +31,6 @@ using ::google::cloud::testing_util::chrono_literals::operator"" _ms;  // NOLINT
 using ::google::cloud::bigtable::testing::MockBigtableStub;
 using ::google::cloud::bigtable::testing::MockMutateRowsLimiter;
 using ::google::cloud::bigtable::testing::MockMutateRowsStream;
-using ::google::cloud::internal::EnableServerRetriesOption;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::AnyOf;
 using ::testing::Contains;

--- a/google/cloud/bigtable/internal/data_connection_impl.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl.cc
@@ -55,7 +55,7 @@ inline std::unique_ptr<bigtable::IdempotentMutationPolicy> idempotency_policy(
 }
 
 inline bool enable_server_retries(Options const& options) {
-  return options.get<internal::EnableServerRetriesOption>();
+  return options.get<EnableServerRetriesOption>();
 }
 
 }  // namespace

--- a/google/cloud/bigtable/internal/data_connection_impl_test.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl_test.cc
@@ -789,7 +789,7 @@ TEST_F(DataConnectionTest, BulkApplyRetryInfoHeeded) {
 
   auto conn = TestConnection(std::move(mock));
   internal::OptionsSpan span(
-      CallOptions().set<internal::EnableServerRetriesOption>(true));
+      CallOptions().set<EnableServerRetriesOption>(true));
   auto actual = conn->BulkApply(kTableName, std::move(mut));
   CheckFailedMutations(actual, {});
 }
@@ -810,7 +810,7 @@ TEST_F(DataConnectionTest, BulkApplyRetryInfoIgnored) {
 
   auto conn = TestConnection(std::move(mock));
   internal::OptionsSpan span(
-      CallOptions().set<internal::EnableServerRetriesOption>(false));
+      CallOptions().set<EnableServerRetriesOption>(false));
   auto actual = conn->BulkApply(kTableName, std::move(mut));
   CheckFailedMutations(actual, expected);
 }
@@ -955,7 +955,7 @@ TEST_F(DataConnectionTest, ReadRowsRetryInfoHeeded) {
 
   auto conn = TestConnection(std::move(mock));
   internal::OptionsSpan span(
-      CallOptions().set<internal::EnableServerRetriesOption>(true));
+      CallOptions().set<EnableServerRetriesOption>(true));
   auto reader = conn->ReadRowsFull(bigtable::ReadRowsParams{
       kTableName, kAppProfile, TestRowSet(), 42, TestFilter(), true});
   EXPECT_EQ(reader.begin(), reader.end());
@@ -975,7 +975,7 @@ TEST_F(DataConnectionTest, ReadRowsRetryInfoIgnored) {
 
   auto conn = TestConnection(std::move(mock));
   internal::OptionsSpan span(
-      CallOptions().set<internal::EnableServerRetriesOption>(false));
+      CallOptions().set<EnableServerRetriesOption>(false));
   auto reader = conn->ReadRowsFull(bigtable::ReadRowsParams{
       kTableName, kAppProfile, TestRowSet(), 42, TestFilter(), true});
   std::vector<StatusOr<bigtable::Row>> rows;
@@ -1639,7 +1639,7 @@ TEST_F(DataConnectionTest, SampleRowsRetryInfoHeeded) {
 
   auto conn = TestConnection(std::move(mock));
   internal::OptionsSpan span(
-      CallOptions().set<internal::EnableServerRetriesOption>(true));
+      CallOptions().set<EnableServerRetriesOption>(true));
   auto samples = conn->SampleRows(kTableName);
   EXPECT_STATUS_OK(samples);
 }
@@ -1657,7 +1657,7 @@ TEST_F(DataConnectionTest, SampleRowsRetryInfoIgnored) {
 
   auto conn = TestConnection(std::move(mock));
   internal::OptionsSpan span(
-      CallOptions().set<internal::EnableServerRetriesOption>(false));
+      CallOptions().set<EnableServerRetriesOption>(false));
   auto samples = conn->SampleRows(kTableName);
   EXPECT_THAT(samples, StatusIs(StatusCode::kPermissionDenied));
 }

--- a/google/cloud/bigtable/internal/defaults.cc
+++ b/google/cloud/bigtable/internal/defaults.cc
@@ -246,8 +246,8 @@ Options DefaultDataOptions(Options opts) {
     opts.set<bigtable::IdempotentMutationPolicyOption>(
         bigtable::DefaultIdempotentMutationPolicy());
   }
-  if (!opts.has<google::cloud::internal::EnableServerRetriesOption>()) {
-    opts.set<google::cloud::internal::EnableServerRetriesOption>(true);
+  if (!opts.has<EnableServerRetriesOption>()) {
+    opts.set<EnableServerRetriesOption>(true);
   }
   opts = DefaultOptions(std::move(opts));
   return opts.set<EndpointOption>(opts.get<DataEndpointOption>());

--- a/google/cloud/bigtable/internal/defaults_test.cc
+++ b/google/cloud/bigtable/internal/defaults_test.cc
@@ -15,7 +15,7 @@
 #include "google/cloud/bigtable/internal/defaults.h"
 #include "google/cloud/bigtable/internal/client_options_defaults.h"
 #include "google/cloud/bigtable/options.h"
-#include "google/cloud/connection_options.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/background_threads_impl.h"
 #include "google/cloud/status.h"
@@ -218,7 +218,6 @@ TEST(OptionsTest, DataAuthorityOption) {
 }
 
 TEST(OptionsTest, DataEnableServerRetriesOption) {
-  using ::google::cloud::internal::EnableServerRetriesOption;
   auto options = DefaultDataOptions(Options{});
   EXPECT_TRUE(options.get<EnableServerRetriesOption>());
 

--- a/google/cloud/common_options.h
+++ b/google/cloud/common_options.h
@@ -210,6 +210,24 @@ struct ProxyOption {
 };
 
 /**
+ * Let the server make retry decisions, when applicable.
+ *
+ * In some cases the server knows how to handle retry behavior better than the
+ * client. For example, if a server-side resource is exhausted and the server
+ * knows when it will come back online, it can tell the client exactly when to
+ * retry.
+ *
+ * If this option is enabled, any supplied retry, backoff, or idempotency
+ * policies may be overridden by a recommendation from the server.
+ *
+ * For example, the server may know it is safe to retry a non-idempotent
+ * request, or safe to retry a status code that is typically a permanent error.
+ */
+struct EnableServerRetriesOption {
+  using Type = bool;
+};
+
+/**
  * A list of all the common options.
  */
 using CommonOptionList =

--- a/google/cloud/grpc_options.h
+++ b/google/cloud/grpc_options.h
@@ -229,24 +229,6 @@ struct GrpcSetupPollOption {
   using Type = std::function<void(grpc::ClientContext&)>;
 };
 
-/**
- * Let the server make retry decisions, when applicable.
- *
- * In some cases the server knows how to handle retry behavior better than the
- * client. For example, if a server-side resource is exhausted and the server
- * knows when it will come back online, it can tell the client exactly when to
- * retry.
- *
- * If this option is enabled, any supplied retry, backoff, or idempotency
- * policies may be overridden by a recommendation from the server.
- *
- * For example, the server may know it is safe to retry a non-idempotent
- * request, or safe to retry a status code that is typically a permanent error.
- */
-struct EnableServerRetriesOption {
-  using Type = bool;
-};
-
 /// Configure the ClientContext using options.
 void ConfigureContext(grpc::ClientContext& context, Options const& opts);
 


### PR DESCRIPTION
Part of the work for #13514 

As discussed in the team meeting, put this thing in `common` because conceptually it is agnostic of transport.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13698)
<!-- Reviewable:end -->
