### PR TITLE
chore: share GCS libraries with cloud-storage-dpe team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,6 @@
 
 # The owners for all files in the repo.
 * @googleapis/cloud-cxx-owners
+
+# This code is also owned by the GCS clients team.
+/google/cloud/storage @googleapis/cloud-storage-dpe @googleapis/cloud-cxx-owners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 * @googleapis/cloud-cxx-owners
 
 # These libraries are also owned by the GCS clients team.
-/google/cloud/storage @googleapis/cloud-storage-dpe @googleapis/cloud-cxx-owners
-/google/cloud/storagecontrol @googleapis/cloud-storage-dpe @googleapis/cloud-cxx-owners
-/google/cloud/storageinsights @googleapis/cloud-storage-dpe @googleapis/cloud-cxx-owners
-/google/cloud/storagetransfer @googleapis/cloud-storage-dpe @googleapis/cloud-cxx-owners
+/google/cloud/storage/ @googleapis/cloud-storage-dpe @googleapis/cloud-cxx-owners
+/google/cloud/storagecontrol/ @googleapis/cloud-storage-dpe @googleapis/cloud-cxx-owners
+/google/cloud/storageinsights/ @googleapis/cloud-storage-dpe @googleapis/cloud-cxx-owners
+/google/cloud/storagetransfer/ @googleapis/cloud-storage-dpe @googleapis/cloud-cxx-owners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,8 @@
 # The owners for all files in the repo.
 * @googleapis/cloud-cxx-owners
 
-# This code is also owned by the GCS clients team.
+# These libraries are also owned by the GCS clients team.
 /google/cloud/storage @googleapis/cloud-storage-dpe @googleapis/cloud-cxx-owners
+/google/cloud/storagecontrol @googleapis/cloud-storage-dpe @googleapis/cloud-cxx-owners
+/google/cloud/storageinsights @googleapis/cloud-storage-dpe @googleapis/cloud-cxx-owners
+/google/cloud/storagetransfer @googleapis/cloud-storage-dpe @googleapis/cloud-cxx-owners


### PR DESCRIPTION
Syntax from: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file

```
# In this example, @doctocat owns any files in the build/logs
# directory at the root of the repository and any of its
# subdirectories.
/build/logs/ @doctocat
```

---

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13702)
<!-- Reviewable:end -->
