### PR TITLE
feat(bigtable): use server retry hints

### DIFF
--- a/google/cloud/bigtable/internal/bigtable_stub_factory.cc
+++ b/google/cloud/bigtable/internal/bigtable_stub_factory.cc
@@ -54,6 +54,7 @@ std::string FeaturesMetadata() {
     proto.set_mutate_rows_rate_limit(true);
     proto.set_mutate_rows_rate_limit2(true);
     proto.set_routing_cookie(true);
+    proto.set_retry_info(true);
     return internal::UrlsafeBase64Encode(proto.SerializeAsString());
   }());
   return *kFeatures;


### PR DESCRIPTION
Fixes #13514 

Flip the feature flag that tells Bigtable that our client supports `RetryInfo`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13708)
<!-- Reviewable:end -->
