### PR TITLE
refactor: split `MockRequestIdServiceStub`

### DIFF
--- a/generator/integration_tests/CMakeLists.txt
+++ b/generator/integration_tests/CMakeLists.txt
@@ -93,7 +93,8 @@ find_package(GTest CONFIG REQUIRED)
 
 add_library(
     google_cloud_cpp_generator_golden_testing # cmake-format: sort
-    tests/mock_golden_kitchen_sink_stub.h tests/mock_golden_thing_admin_stub.h)
+    tests/mock_golden_kitchen_sink_stub.h tests/mock_golden_thing_admin_stub.h
+    tests/mock_request_id_stub.h)
 target_link_libraries(
     google_cloud_cpp_generator_golden_testing
     PUBLIC google_cloud_cpp_testing google_cloud_cpp_mocks

--- a/generator/integration_tests/tests/mock_request_id_stub.h
+++ b/generator/integration_tests/tests/mock_request_id_stub.h
@@ -1,0 +1,77 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_TESTS_MOCK_REQUEST_ID_STUB_H
+#define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_TESTS_MOCK_REQUEST_ID_STUB_H
+
+#include "generator/integration_tests/golden/v1/internal/request_id_stub.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace golden_v1_testing {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+class MockRequestIdServiceStub
+    : public google::cloud::golden_v1_internal::RequestIdServiceStub {
+ public:
+  ~MockRequestIdServiceStub() override = default;
+
+  MOCK_METHOD(StatusOr<google::test::requestid::v1::Foo>, CreateFoo,
+              (grpc::ClientContext&, Options const&,
+               google::test::requestid::v1::CreateFooRequest const&),
+              (override));
+
+  MOCK_METHOD(future<StatusOr<google::longrunning::Operation>>, AsyncRenameFoo,
+              (google::cloud::CompletionQueue&,
+               std::shared_ptr<grpc::ClientContext>,
+               google::cloud::internal::ImmutableOptions,
+               google::test::requestid::v1::RenameFooRequest const&),
+              (override));
+
+  MOCK_METHOD(StatusOr<google::test::requestid::v1::ListFoosResponse>, ListFoos,
+              (grpc::ClientContext&, Options const&,
+               google::test::requestid::v1::ListFoosRequest const&),
+              (override));
+
+  MOCK_METHOD(future<StatusOr<google::test::requestid::v1::Foo>>,
+              AsyncCreateFoo,
+              (google::cloud::CompletionQueue&,
+               std::shared_ptr<grpc::ClientContext>,
+               google::cloud::internal::ImmutableOptions,
+               google::test::requestid::v1::CreateFooRequest const&),
+              (override));
+
+  MOCK_METHOD(future<StatusOr<google::longrunning::Operation>>,
+              AsyncGetOperation,
+              (google::cloud::CompletionQueue&,
+               std::shared_ptr<grpc::ClientContext>,
+               google::cloud::internal::ImmutableOptions,
+               google::longrunning::GetOperationRequest const&),
+              (override));
+
+  MOCK_METHOD(future<Status>, AsyncCancelOperation,
+              (google::cloud::CompletionQueue&,
+               std::shared_ptr<grpc::ClientContext>,
+               google::cloud::internal::ImmutableOptions,
+               google::longrunning::CancelOperationRequest const&),
+              (override));
+};
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace golden_v1_testing
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_TESTS_MOCK_REQUEST_ID_STUB_H

--- a/generator/integration_tests/tests/request_id_connection_impl_test.cc
+++ b/generator/integration_tests/tests/request_id_connection_impl_test.cc
@@ -15,6 +15,7 @@
 #include "generator/integration_tests/golden/v1/internal/request_id_connection_impl.h"
 #include "generator/integration_tests/golden/v1/internal/request_id_option_defaults.h"
 #include "generator/integration_tests/golden/v1/internal/request_id_stub.h"
+#include "generator/integration_tests/tests/mock_request_id_stub.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/options.h"
 #include "google/cloud/testing_util/status_matchers.h"
@@ -30,6 +31,7 @@ namespace golden_v1 {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+using ::google::cloud::golden_v1_testing::MockRequestIdServiceStub;
 using ::google::cloud::testing_util::IsOkAndHolds;
 using ::google::test::requestid::v1::CreateFooRequest;
 using ::google::test::requestid::v1::Foo;
@@ -43,52 +45,6 @@ using ::testing::Eq;
 using ::testing::IsEmpty;
 using ::testing::ResultOf;
 using ::testing::Return;
-
-class MockRequestIdServiceStub
-    : public google::cloud::golden_v1_internal::RequestIdServiceStub {
- public:
-  ~MockRequestIdServiceStub() override = default;
-
-  MOCK_METHOD(StatusOr<google::test::requestid::v1::Foo>, CreateFoo,
-              (grpc::ClientContext&, Options const&,
-               google::test::requestid::v1::CreateFooRequest const&),
-              (override));
-
-  MOCK_METHOD(future<StatusOr<google::longrunning::Operation>>, AsyncRenameFoo,
-              (google::cloud::CompletionQueue&,
-               std::shared_ptr<grpc::ClientContext>,
-               google::cloud::internal::ImmutableOptions,
-               google::test::requestid::v1::RenameFooRequest const&),
-              (override));
-
-  MOCK_METHOD(StatusOr<google::test::requestid::v1::ListFoosResponse>, ListFoos,
-              (grpc::ClientContext&, Options const&,
-               google::test::requestid::v1::ListFoosRequest const&),
-              (override));
-
-  MOCK_METHOD(future<StatusOr<google::test::requestid::v1::Foo>>,
-              AsyncCreateFoo,
-              (google::cloud::CompletionQueue&,
-               std::shared_ptr<grpc::ClientContext>,
-               google::cloud::internal::ImmutableOptions,
-               google::test::requestid::v1::CreateFooRequest const&),
-              (override));
-
-  MOCK_METHOD(future<StatusOr<google::longrunning::Operation>>,
-              AsyncGetOperation,
-              (google::cloud::CompletionQueue&,
-               std::shared_ptr<grpc::ClientContext>,
-               google::cloud::internal::ImmutableOptions,
-               google::longrunning::GetOperationRequest const&),
-              (override));
-
-  MOCK_METHOD(future<Status>, AsyncCancelOperation,
-              (google::cloud::CompletionQueue&,
-               std::shared_ptr<grpc::ClientContext>,
-               google::cloud::internal::ImmutableOptions,
-               google::longrunning::CancelOperationRequest const&),
-              (override));
-};
 
 template <typename Request>
 auto WithRequestId(std::string expected) {


### PR DESCRIPTION
Part of the work for #13704

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13709)
<!-- Reviewable:end -->
