### PR TITLE
impl(common): improve `InvocationIdGenerator` seed

### DIFF
--- a/google/cloud/internal/invocation_id_generator.cc
+++ b/google/cloud/internal/invocation_id_generator.cc
@@ -24,7 +24,7 @@ namespace internal {
 
 // Initialize the random bit source with some minimal entropy.
 InvocationIdGenerator::InvocationIdGenerator()
-    : generator_(std::random_device{}()) {}
+    : generator_(MakeDefaultPRNG()) {}
 
 std::string InvocationIdGenerator::MakeInvocationId() {
   // A retry id is supposed to be a UUID V4 string. We assume you have read the


### PR DESCRIPTION
Use `MakeDefaultPRNG()` to initialize the PRNG (pseudo-random number generator) in `InvocationIdGenerator`.  This function consumes the same amount of entropy from the OS as the previous call, but uses `std::seed_seq` to fill the initial state of the PRNG. AFAIK, `std::seed_seq` produces better distributed seeds from the same entropy.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13711)
<!-- Reviewable:end -->
