### PR TITLE
feat(spanner): add representations for the Spanner PROTO/ENUM types

### DIFF
--- a/google/cloud/spanner/BUILD.bazel
+++ b/google/cloud/spanner/BUILD.bazel
@@ -91,6 +91,20 @@ cc_library(
     ],
 )
 
+proto_library(
+    name = "singer_proto",
+    srcs = [
+        "testing/singer.proto",
+    ],
+    visibility = ["//:__pkg__"],
+)
+
+cc_proto_library(
+    name = "singer_cc_proto",
+    visibility = ["//:__pkg__"],
+    deps = [":singer_proto"],
+)
+
 cc_library(
     name = "spanner_client_testing_private",
     testonly = True,
@@ -102,6 +116,7 @@ cc_library(
     deps = [
         ":google_cloud_cpp_spanner",
         ":google_cloud_cpp_spanner_mocks",
+        ":singer_cc_proto",
         "//:common",
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
         "@com_google_googletest//:gtest_main",
@@ -127,7 +142,7 @@ cc_library(
     deps = [
         ":google_cloud_cpp_spanner",
         ":google_cloud_cpp_spanner_mocks",
-        ":spanner_client_testing",
+        ":spanner_client_testing_private",
         "//:common",
         "//google/cloud:google_cloud_cpp_mocks",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc_private",

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -184,6 +184,8 @@ add_library(
     partition_options.h
     partitioned_dml_result.h
     polling_policy.h
+    proto_enum.h
+    proto_message.h
     query_options.cc
     query_options.h
     query_partition.cc
@@ -395,6 +397,10 @@ function (spanner_client_define_tests)
     # the GTest::gmock target, and the target names are also weird.
     find_package(GTest CONFIG REQUIRED)
 
+    google_cloud_cpp_proto_library(
+        spanner_client_testing_protos testing/singer.proto
+        PROTO_PATH_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR})
+
     add_library(
         spanner_client_testing # cmake-format: sort
         testing/cleanup_stale_databases.cc
@@ -426,8 +432,12 @@ function (spanner_client_define_tests)
         testing/status_utils.h)
     target_link_libraries(
         spanner_client_testing
-        PUBLIC google_cloud_cpp_testing google-cloud-cpp::spanner_mocks
-               google-cloud-cpp::spanner GTest::gmock_main GTest::gmock
+        PUBLIC google_cloud_cpp_testing
+               spanner_client_testing_protos
+               google-cloud-cpp::spanner_mocks
+               google-cloud-cpp::spanner
+               GTest::gmock_main
+               GTest::gmock
                GTest::gtest)
     create_bazel_config(spanner_client_testing YEAR "2019")
     google_cloud_cpp_add_common_options(spanner_client_testing)
@@ -476,6 +486,8 @@ function (spanner_client_define_tests)
         mutations_test.cc
         numeric_test.cc
         partition_options_test.cc
+        proto_enum_test.cc
+        proto_message_test.cc
         query_options_test.cc
         query_partition_test.cc
         read_options_test.cc

--- a/google/cloud/spanner/google_cloud_cpp_spanner.bzl
+++ b/google/cloud/spanner/google_cloud_cpp_spanner.bzl
@@ -102,6 +102,8 @@ google_cloud_cpp_spanner_hdrs = [
     "partition_options.h",
     "partitioned_dml_result.h",
     "polling_policy.h",
+    "proto_enum.h",
+    "proto_message.h",
     "query_options.h",
     "query_partition.h",
     "read_options.h",

--- a/google/cloud/spanner/proto_enum.h
+++ b/google/cloud/spanner/proto_enum.h
@@ -1,0 +1,96 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_PROTO_ENUM_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_PROTO_ENUM_H
+
+#include "google/cloud/version.h"
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/generated_enum_reflection.h>
+#include <ostream>
+#include <string>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+/**
+ * A representation of the Spanner ENUM type: a protobuf enumeration.
+ *
+ * A `ProtoEnum<E>` can be implicitly constructed from, and explicitly
+ * converted to an `E`.  Values can be copied, assigned, compared for
+ * equality, and streamed.
+ *
+ * @par Example
+ * Given a proto definition `enum Color { RED = 0; BLUE = 1; GREEN = 2; }`:
+ * @code
+ * auto e = spanner::ProtoEnum<Color>(BLUE);
+ * assert(Color(e) == BLUE);
+ * @endcode
+ */
+template <typename E>
+class ProtoEnum {
+ public:
+  using enum_type = E;
+
+  /// The default value is the first listed in the enum's definition.
+  ProtoEnum()
+      : ProtoEnum(static_cast<enum_type>(Descriptor()->value(0)->number())) {}
+
+  /// Implicit construction from the enum type.
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  ProtoEnum(enum_type v) : v_(v) {}
+
+  /// Explicit conversion to the enum type.
+  explicit operator enum_type() const { return v_; }
+
+  /// The fully-qualified name of the enum type, scope delimited by periods.
+  static std::string const& TypeName() { return Descriptor()->full_name(); }
+
+  /// @name Relational operators
+  ///@{
+  friend bool operator==(ProtoEnum const& a, ProtoEnum const& b) {
+    return a.v_ == b.v_;
+  }
+  friend bool operator!=(ProtoEnum const& a, ProtoEnum const& b) {
+    return !(a == b);
+  }
+  ///@}
+
+  /// Outputs string representation of the `ProtoEnum` to the stream.
+  friend std::ostream& operator<<(std::ostream& os, ProtoEnum const& v) {
+    auto const* ed = Descriptor();
+    if (static_cast<int>(v.v_) == v.v_) {
+      if (auto const* vd = ed->FindValueByNumber(static_cast<int>(v.v_))) {
+        return os << vd->full_name();
+      }
+    }
+    return os << ed->full_name() << ".{" << v.v_ << "}";
+  }
+
+ private:
+  static google::protobuf::EnumDescriptor const* Descriptor() {
+    return google::protobuf::GetEnumDescriptor<enum_type>();
+  }
+
+  enum_type v_;
+};
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_PROTO_ENUM_H

--- a/google/cloud/spanner/proto_enum_test.cc
+++ b/google/cloud/spanner/proto_enum_test.cc
@@ -1,0 +1,110 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/proto_enum.h"
+#include "google/cloud/spanner/testing/singer.pb.h"
+#include <gmock/gmock.h>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+TEST(ProtoEnum, TypeName) {
+  EXPECT_EQ(ProtoEnum<testing::Genre>::TypeName(),
+            "google.cloud.spanner.testing.Genre");
+}
+
+TEST(ProtoEnum, DefaultValue) {
+  ProtoEnum<testing::Genre> genre;
+  EXPECT_EQ(genre, testing::POP);
+}
+
+TEST(ProtoEnum, ValueSemantics) {
+  auto genre = ProtoEnum<testing::Genre>(testing::FOLK);
+
+  auto copy = genre;
+  EXPECT_EQ(copy, genre);
+
+  copy = genre;
+  EXPECT_EQ(copy, genre);
+
+  auto move = std::move(genre);
+  EXPECT_EQ(move, copy);
+
+  genre = copy;
+  move = std::move(genre);
+  EXPECT_EQ(move, copy);
+}
+
+TEST(ProtoEnum, RoundTrip) {
+  for (auto genre :
+       {testing::POP, testing::JAZZ, testing::FOLK, testing::ROCK}) {
+    EXPECT_EQ(ProtoEnum<testing::Genre>(genre), genre);
+  }
+}
+
+TEST(ProtoEnum, Conversions) {
+  testing::Genre g1(testing::Genre::POP);
+  EXPECT_EQ(g1, testing::Genre::POP);
+  ProtoEnum<testing::Genre> p1(testing::Genre::POP);
+  EXPECT_EQ(p1, testing::Genre::POP);
+
+  g1 = testing::Genre::JAZZ;
+  EXPECT_EQ(g1, testing::Genre::JAZZ);
+  p1 = testing::Genre::JAZZ;
+  EXPECT_EQ(p1, testing::Genre::JAZZ);
+
+  g1 = testing::Genre::FOLK;
+  EXPECT_EQ(g1, testing::Genre::FOLK);
+  p1 = g1;
+  EXPECT_EQ(p1, testing::Genre::FOLK);
+
+  g1 = testing::Genre::ROCK;
+  EXPECT_EQ(g1, testing::Genre::ROCK);
+  ProtoEnum<testing::Genre> p2(g1);
+  EXPECT_EQ(p2, testing::Genre::ROCK);
+}
+
+TEST(ProtoEnum, OutputStream) {
+  struct TestCase {
+    testing::Genre genre;
+    std::string expected;
+  };
+
+  std::vector<TestCase> test_cases = {
+      {testing::POP, "google.cloud.spanner.testing.POP"},
+      {testing::JAZZ, "google.cloud.spanner.testing.JAZZ"},
+      {testing::FOLK, "google.cloud.spanner.testing.FOLK"},
+      {testing::ROCK, "google.cloud.spanner.testing.ROCK"},
+      {static_cast<testing::Genre>(42),
+       "google.cloud.spanner.testing.Genre.{42}"},
+  };
+
+  for (auto const& tc : test_cases) {
+    std::ostringstream ss;
+    ss << ProtoEnum<testing::Genre>(tc.genre);
+    EXPECT_EQ(ss.str(), tc.expected);
+  }
+}
+
+}  // namespace
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/proto_message.h
+++ b/google/cloud/spanner/proto_message.h
@@ -1,0 +1,106 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_PROTO_MESSAGE_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_PROTO_MESSAGE_H
+
+#include "google/cloud/version.h"
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/message.h>
+#include <google/protobuf/util/message_differencer.h>
+#include <ostream>
+#include <string>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+/**
+ * A representation of the Spanner PROTO type: a protobuf message.
+ *
+ * A `ProtoMessage<M>` can be implicitly constructed from and explicitly
+ * converted to an `M`.  Values can be copied, assigned, and streamed.
+ *
+ * A `ProtoMessage<M>` can also be explicitly constructed from and converted
+ * to the `M` wire format, although this is intended for internal use only.
+ *
+ * @par Example
+ * Given a proto definition `message Mesg { string field = 1; }`:
+ * @code
+ * Mesg m;
+ * m.set_field("value");
+ * auto pm = spanner::ProtoMessage<Mesg>(m);
+ * assert(Mesg(pm).field() == "value");
+ * @endcode
+ */
+template <typename M>
+class ProtoMessage {
+ public:
+  using message_type = M;
+
+  /// The default value.
+  ProtoMessage() : ProtoMessage(message_type::default_instance()) {}
+
+  /// Implicit construction from the message type.
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  ProtoMessage(M const& m) { m.SerializeToString(&serialized_message_); }
+
+  /// Explicit construction from wire format.
+  explicit ProtoMessage(std::string serialized_message)
+      : serialized_message_(std::move(serialized_message)) {}
+
+  /// Explicit conversion to the message type.
+  explicit operator message_type() const {
+    message_type m;
+    m.ParseFromString(serialized_message_);
+    return m;
+  }
+
+  /// Explicit conversion to wire format.
+  explicit operator std::string() const { return serialized_message_; }
+
+  /// The fully-qualified name of the message type, scope delimited by periods.
+  static std::string const& TypeName() {
+    return message_type::GetDescriptor()->full_name();
+  }
+
+  /// @name Relational operators
+  ///@{
+  friend bool operator==(ProtoMessage const& a, ProtoMessage const& b) {
+    if (a.serialized_message_ == b.serialized_message_) return true;
+    return google::protobuf::util::MessageDifferencer::Equivalent(
+        message_type(a), message_type(b));
+  }
+  friend bool operator!=(ProtoMessage const& a, ProtoMessage const& b) {
+    return !(a == b);
+  }
+  ///@}
+
+  /// Outputs string representation of the `ProtoMessage` to the stream.
+  friend std::ostream& operator<<(std::ostream& os, ProtoMessage const& m) {
+    auto s = message_type(m).ShortDebugString();
+    return os << TypeName() << " { " << s << (s.empty() ? "" : " ") << "}";
+  }
+
+ private:
+  std::string serialized_message_;
+};
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_PROTO_MESSAGE_H

--- a/google/cloud/spanner/proto_message_test.cc
+++ b/google/cloud/spanner/proto_message_test.cc
@@ -1,0 +1,71 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/proto_message.h"
+#include "google/cloud/spanner/testing/singer.pb.h"
+#include "google/cloud/testing_util/is_proto_equal.h"
+#include <gmock/gmock.h>
+#include <sstream>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+using ::google::cloud::testing_util::IsProtoEqual;
+using ::testing::HasSubstr;
+
+testing::SingerInfo TestSinger() {
+  testing::SingerInfo singer;
+  singer.set_singer_id(1);
+  singer.set_birth_date("1817-05-25");
+  singer.set_nationality("French");
+  singer.set_genre(testing::Genre::FOLK);
+  return singer;
+}
+
+TEST(ProtoMessage, TypeName) {
+  EXPECT_EQ(ProtoMessage<testing::SingerInfo>::TypeName(),
+            "google.cloud.spanner.testing.SingerInfo");
+}
+
+TEST(ProtoMessage, DefaultValue) {
+  ProtoMessage<testing::SingerInfo> msg;
+  EXPECT_THAT(testing::SingerInfo(msg),
+              IsProtoEqual(testing::SingerInfo::default_instance()));
+}
+
+TEST(ProtoMessage, RoundTrip) {
+  auto const singer = TestSinger();
+  ProtoMessage<testing::SingerInfo> msg(singer);
+  EXPECT_THAT(testing::SingerInfo(msg), IsProtoEqual(singer));
+}
+
+TEST(ProtoMessage, OutputStream) {
+  std::ostringstream ss;
+  ss << ProtoMessage<testing::SingerInfo>(TestSinger());
+  auto s = ss.str();
+  EXPECT_THAT(s, HasSubstr("google.cloud.spanner.testing.SingerInfo"));
+  EXPECT_THAT(s, HasSubstr("singer_id: 1"));
+  EXPECT_THAT(s, HasSubstr(R"(birth_date: "1817-05-25")"));
+  EXPECT_THAT(s, HasSubstr(R"(nationality: "French")"));
+  EXPECT_THAT(s, HasSubstr("genre: FOLK"));
+}
+
+}  // namespace
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/spanner_client_unit_tests.bzl
+++ b/google/cloud/spanner/spanner_client_unit_tests.bzl
@@ -51,6 +51,8 @@ spanner_client_unit_tests = [
     "mutations_test.cc",
     "numeric_test.cc",
     "partition_options_test.cc",
+    "proto_enum_test.cc",
+    "proto_message_test.cc",
     "query_options_test.cc",
     "query_partition_test.cc",
     "read_options_test.cc",

--- a/google/cloud/spanner/testing/singer.proto
+++ b/google/cloud/spanner/testing/singer.proto
@@ -1,0 +1,17 @@
+syntax = "proto2";
+
+package google.cloud.spanner.testing;
+
+message SingerInfo {
+  optional int64 singer_id = 1;
+  optional string birth_date = 2;
+  optional string nationality = 3;
+  optional Genre genre = 4;
+}
+
+enum Genre {
+  POP = 0;
+  JAZZ = 1;
+  FOLK = 2;
+  ROCK = 3;
+}


### PR DESCRIPTION
`spanner::ProtoMessage<M>` represents a protobuf message, `M`, and `spanner::ProtoEnum<E>` a protobuf enumeration, `E`.

Also add a proto message and enum, `SingerInfo` and `Genre`, for testing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13743)
<!-- Reviewable:end -->
