### PR TITLE
fix(bigtable): respect `GOOGLE_CLOUD_CPP_OPENTELEMETRY_TRACING`

### DIFF
--- a/google/cloud/bigtable/internal/defaults.cc
+++ b/google/cloud/bigtable/internal/defaults.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/service_endpoint.h"
 #include "google/cloud/internal/user_agent_prefix.h"
+#include "google/cloud/opentelemetry_options.h"
 #include "google/cloud/options.h"
 #include "absl/algorithm/container.h"
 #include "absl/strings/str_split.h"
@@ -224,6 +225,10 @@ Options DefaultDataOptions(Options opts) {
   auto user_project = GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
   if (user_project && !user_project->empty()) {
     opts.set<UserProjectOption>(*std::move(user_project));
+  }
+  auto tracing = GetEnv("GOOGLE_CLOUD_CPP_OPENTELEMETRY_TRACING");
+  if (tracing && !tracing->empty()) {
+    opts.set<OpenTelemetryTracingOption>(true);
   }
   if (!opts.has<AuthorityOption>()) {
     auto ep = google::cloud::internal::UniverseDomainEndpoint(

--- a/google/cloud/bigtable/internal/defaults_test.cc
+++ b/google/cloud/bigtable/internal/defaults_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/background_threads_impl.h"
+#include "google/cloud/opentelemetry_options.h"
 #include "google/cloud/status.h"
 #include "google/cloud/testing_util/chrono_output.h"
 #include "google/cloud/testing_util/scoped_environment.h"
@@ -45,6 +46,8 @@ using mins = std::chrono::minutes;
 TEST(OptionsTest, Defaults) {
   ScopedEnvironment user_project("GOOGLE_CLOUD_CPP_USER_PROJECT",
                                  absl::nullopt);
+  ScopedEnvironment tracing("GOOGLE_CLOUD_CPP_OPENTELEMETRY_TRACING",
+                            absl::nullopt);
   ScopedEnvironment emulator_host("BIGTABLE_EMULATOR_HOST", absl::nullopt);
   ScopedEnvironment instance_emulator_host(
       "BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST", absl::nullopt);
@@ -57,6 +60,7 @@ TEST(OptionsTest, Defaults) {
   EXPECT_EQ(typeid(grpc::GoogleDefaultCredentials()),
             typeid(opts.get<GrpcCredentialOption>()));
   EXPECT_FALSE(opts.has<UserProjectOption>());
+  EXPECT_FALSE(opts.has<OpenTelemetryTracingOption>());
 
   auto args = google::cloud::internal::MakeChannelArguments(opts);
   // Check that the pool domain is not set by default
@@ -206,6 +210,12 @@ TEST(OptionsTest, DataUserProjectOption) {
   options =
       DefaultDataOptions(Options{}.set<UserProjectOption>("test-project"));
   EXPECT_EQ(options.get<UserProjectOption>(), "env-project");
+}
+
+TEST(OptionsTest, DataOpenTelemetryOption) {
+  auto env = ScopedEnvironment("GOOGLE_CLOUD_CPP_OPENTELEMETRY_TRACING", "on");
+  auto options = DefaultDataOptions(Options{});
+  EXPECT_TRUE(options.get<OpenTelemetryTracingOption>());
 }
 
 TEST(OptionsTest, DataAuthorityOption) {


### PR DESCRIPTION
Bigtable data plane does not use `PopulateCommonOptions(...)` so we copy the handling of `GOOGLE_CLOUD_CPP_OPENTELEMETRY_TRACING`:

https://github.com/googleapis/google-cloud-cpp/blob/c7c14df54c3d79c9d8f5c33b19f8f11d474fa281/google/cloud/internal/populate_common_options.cc#L67-L70

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13748)
<!-- Reviewable:end -->
