### PR TITLE
fix(speech): enable location specific connections

### DIFF
--- a/generator/generator_config.textproto
+++ b/generator/generator_config.textproto
@@ -3149,6 +3149,7 @@ service {
   product_path: "google/cloud/speech/v2"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 # Sql

--- a/google/cloud/speech/doc/environment-variables.dox
+++ b/google/cloud/speech/doc/environment-variables.dox
@@ -15,10 +15,6 @@ environment variables are convenient when troubleshooting problems.
   used by `MakeAdaptationConnection()`.
 
 - `GOOGLE_CLOUD_CPP_SPEECH_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "<location>-speech.googleapis.com")
-  used by `MakeSpeechConnection()`.
-
-- `GOOGLE_CLOUD_CPP_SPEECH_ENDPOINT=...` overrides the
   `EndpointOption` (which defaults to "speech.googleapis.com")
   used by `MakeSpeechConnection()`.
 

--- a/google/cloud/speech/doc/environment-variables.dox
+++ b/google/cloud/speech/doc/environment-variables.dox
@@ -15,6 +15,10 @@ environment variables are convenient when troubleshooting problems.
   used by `MakeAdaptationConnection()`.
 
 - `GOOGLE_CLOUD_CPP_SPEECH_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "<location>-speech.googleapis.com")
+  used by `MakeSpeechConnection()`.
+
+- `GOOGLE_CLOUD_CPP_SPEECH_ENDPOINT=...` overrides the
   `EndpointOption` (which defaults to "speech.googleapis.com")
   used by `MakeSpeechConnection()`.
 

--- a/google/cloud/speech/v2/internal/speech_option_defaults.cc
+++ b/google/cloud/speech/v2/internal/speech_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/speech/v2/internal/speech_option_defaults.h"
 #include "google/cloud/speech/v2/speech_connection.h"
 #include "google/cloud/speech/v2/speech_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -33,10 +34,12 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options SpeechDefaultOptions(Options options) {
+Options SpeechDefaultOptions(std::string const& location, Options options) {
   options = internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_SPEECH_ENDPOINT", "",
-      "GOOGLE_CLOUD_CPP_SPEECH_AUTHORITY", "speech.googleapis.com");
+      "GOOGLE_CLOUD_CPP_SPEECH_AUTHORITY",
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "speech.googleapis.com"));
   options = internal::PopulateGrpcOptions(std::move(options));
   if (!options.has<speech_v2::SpeechRetryPolicyOption>()) {
     options.set<speech_v2::SpeechRetryPolicyOption>(

--- a/google/cloud/speech/v2/internal/speech_option_defaults.h
+++ b/google/cloud/speech/v2/internal/speech_option_defaults.h
@@ -21,13 +21,14 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace speech_v2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options SpeechDefaultOptions(Options options);
+Options SpeechDefaultOptions(std::string const& location, Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace speech_v2_internal

--- a/google/cloud/speech/v2/speech_connection.cc
+++ b/google/cloud/speech/v2/speech_connection.cc
@@ -209,11 +209,13 @@ SpeechConnection::UndeletePhraseSet(
       Status(StatusCode::kUnimplemented, "not implemented"));
 }
 
-std::shared_ptr<SpeechConnection> MakeSpeechConnection(Options options) {
+std::shared_ptr<SpeechConnection> MakeSpeechConnection(
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  UnifiedCredentialsOptionList,
                                  SpeechPolicyOptionList>(options, __func__);
-  options = speech_v2_internal::SpeechDefaultOptions(std::move(options));
+  options =
+      speech_v2_internal::SpeechDefaultOptions(location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto auth = internal::CreateAuthenticationStrategy(background->cq(), options);
   auto stub =
@@ -221,6 +223,10 @@ std::shared_ptr<SpeechConnection> MakeSpeechConnection(Options options) {
   return speech_v2_internal::MakeSpeechTracingConnection(
       std::make_shared<speech_v2_internal::SpeechConnectionImpl>(
           std::move(background), std::move(stub), std::move(options)));
+}
+
+std::shared_ptr<SpeechConnection> MakeSpeechConnection(Options options) {
+  return MakeSpeechConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/speech/v2/speech_connection.h
+++ b/google/cloud/speech/v2/speech_connection.h
@@ -33,6 +33,7 @@
 #include <google/cloud/speech/v2/cloud_speech.pb.h>
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -285,8 +286,19 @@ class SpeechConnection {
  * @note Unexpected options will be ignored. To log unexpected options instead,
  *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `SpeechConnection` created by
  * this function.
+ */
+std::shared_ptr<SpeechConnection> MakeSpeechConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<SpeechConnection> MakeSpeechConnection(Options options = {});
 


### PR DESCRIPTION
part of the work for #13729 

In Speech V2 locations (aka regions) can be specified for recognizers, but the connection must also be configured for that same location. While explicitly setting `Options` can achieve this result, adding a location aware `MakeSpeechConnection` overload streamlines this process. When the location is provided to `MakeSpeechConnection`, the SDK handles setting the appropriate `Options` on behalf of the user.

e.g.
```
namespace speech = ::google::cloud::speech_v2;
auto client = speech::SpeechClient(speech::MakeSpeechConnection("asia-southeast1"));
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13757)
<!-- Reviewable:end -->
