### PR TITLE
impl(spanner): constrain spanner::ProtoMessage<M>::operator<<()

### DIFF
--- a/google/cloud/spanner/proto_message.h
+++ b/google/cloud/spanner/proto_message.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_PROTO_MESSAGE_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_PROTO_MESSAGE_H
 
+#include "google/cloud/internal/debug_string_protobuf.h"
 #include "google/cloud/version.h"
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/message.h>
@@ -90,8 +91,7 @@ class ProtoMessage {
 
   /// Outputs string representation of the `ProtoMessage` to the stream.
   friend std::ostream& operator<<(std::ostream& os, ProtoMessage const& m) {
-    auto s = message_type(m).ShortDebugString();
-    return os << TypeName() << " { " << s << (s.empty() ? "" : " ") << "}";
+    return os << internal::DebugString(message_type(m), TracingOptions{});
   }
 
  private:

--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/spanner/value.h"
 #include "google/cloud/internal/base64_transforms.h"
+#include "google/cloud/internal/debug_string_protobuf.h"
 #include "google/cloud/internal/strerror.h"
 #include "absl/time/civil_time.h"
 #include <google/protobuf/descriptor.h>
@@ -180,9 +181,7 @@ std::ostream& StreamHelper(std::ostream& os,  // NOLINT(misc-no-recursion)
             if (auto const* pt = f->GetPrototype(d)) {
               std::unique_ptr<google::protobuf::Message> m(pt->New());
               m->ParseFromString(std::string(bytes->begin(), bytes->end()));
-              auto s = m->ShortDebugString();
-              return os << t.proto_type_fqn() << " { " << s
-                        << (s.empty() ? "" : " ") << "}";
+              return os << internal::DebugString(*m, TracingOptions{});
             }
           }
         }


### PR DESCRIPTION
Use `internal::DebugString()` to implement the output operators for `spanner::ProtoMessage<M>` and a PROTO `spanner::Value`.  This allows us to avoid the inter-release vagaries of `Message::ShortDebugString()` (by using a `google::protobuf::TextFormat::Printer` directly), and that allows us to make more-portable test expectations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13758)
<!-- Reviewable:end -->
