### PR TITLE
ci(speech): update quickstart to V2 demonstrating regional endpoints

### DIFF
--- a/ci/etc/integration-tests-config.sh
+++ b/ci/etc/integration-tests-config.sh
@@ -34,6 +34,8 @@ export GOOGLE_CLOUD_CPP_USER_PROJECT="${GOOGLE_CLOUD_PROJECT}"
 export GOOGLE_CLOUD_CPP_TEST_REGION="us-central1"
 # Some quickstart programs require a zone.
 export GOOGLE_CLOUD_CPP_TEST_ZONE="us-central1-a"
+# Some tests and quickstarts need to specify a location as "global".
+export GOOGLE_CLOUD_CPP_TEST_GLOBAL="global"
 # Some quickstart programs require an organization.
 export GOOGLE_CLOUD_CPP_TEST_ORGANIZATION="1006341795026"
 

--- a/ci/etc/integration-tests-config.sh
+++ b/ci/etc/integration-tests-config.sh
@@ -34,8 +34,6 @@ export GOOGLE_CLOUD_CPP_USER_PROJECT="${GOOGLE_CLOUD_PROJECT}"
 export GOOGLE_CLOUD_CPP_TEST_REGION="us-central1"
 # Some quickstart programs require a zone.
 export GOOGLE_CLOUD_CPP_TEST_ZONE="us-central1-a"
-# Some tests and quickstarts need to specify a location as "global".
-export GOOGLE_CLOUD_CPP_TEST_GLOBAL="global"
 # Some quickstart programs require an organization.
 export GOOGLE_CLOUD_CPP_TEST_ORGANIZATION="1006341795026"
 

--- a/google/cloud/speech/CMakeLists.txt
+++ b/google/cloud/speech/CMakeLists.txt
@@ -27,10 +27,8 @@ if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     google_cloud_cpp_add_common_options(speech_quickstart)
     add_test(
         NAME speech_quickstart_global
-        COMMAND
-            cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
-            $<TARGET_FILE:speech_quickstart> GOOGLE_CLOUD_PROJECT
-            GOOGLE_CLOUD_CPP_TEST_GLOBAL)
+        COMMAND cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+                $<TARGET_FILE:speech_quickstart> GOOGLE_CLOUD_PROJECT "global")
     set_tests_properties(speech_quickstart_global
                          PROPERTIES LABELS "integration-test;quickstart")
     add_test(

--- a/google/cloud/speech/CMakeLists.txt
+++ b/google/cloud/speech/CMakeLists.txt
@@ -26,12 +26,20 @@ if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     target_link_libraries(speech_quickstart PRIVATE google-cloud-cpp::speech)
     google_cloud_cpp_add_common_options(speech_quickstart)
     add_test(
-        NAME speech_quickstart
-        COMMAND cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
-                $<TARGET_FILE:speech_quickstart>)
-    set_tests_properties(
-        speech_quickstart
-        PROPERTIES
-            LABELS "integration-test;quickstart" ENVIRONMENT
-            GOOGLE_CLOUD_CPP_USER_PROJECT=$ENV{GOOGLE_CLOUD_CPP_USER_PROJECT})
+        NAME speech_quickstart_global
+        COMMAND
+            cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+            $<TARGET_FILE:speech_quickstart> GOOGLE_CLOUD_PROJECT
+            GOOGLE_CLOUD_CPP_TEST_GLOBAL)
+    set_tests_properties(speech_quickstart_global
+                         PROPERTIES LABELS "integration-test;quickstart")
+    add_test(
+        NAME speech_quickstart_regional
+        COMMAND
+            cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+            $<TARGET_FILE:speech_quickstart> GOOGLE_CLOUD_PROJECT
+            GOOGLE_CLOUD_CPP_TEST_REGION)
+    set_tests_properties(speech_quickstart_regional
+                         PROPERTIES LABELS "integration-test;quickstart")
+
 endif ()

--- a/google/cloud/speech/CMakeLists.txt
+++ b/google/cloud/speech/CMakeLists.txt
@@ -27,8 +27,10 @@ if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     google_cloud_cpp_add_common_options(speech_quickstart)
     add_test(
         NAME speech_quickstart_global
-        COMMAND cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
-                $<TARGET_FILE:speech_quickstart> GOOGLE_CLOUD_PROJECT "global")
+        COMMAND
+            cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+            $<TARGET_FILE:speech_quickstart> GOOGLE_CLOUD_PROJECT
+            GOOGLE_CLOUD_CPP_TEST_GLOBAL)
     set_tests_properties(speech_quickstart_global
                          PROPERTIES LABELS "integration-test;quickstart")
     add_test(

--- a/google/cloud/speech/README.md
+++ b/google/cloud/speech/README.md
@@ -36,7 +36,7 @@ void ConfigureRecognizer(google::cloud::speech::v2::RecognizeRequest& request) {
 
 int main(int argc, char* argv[]) try {
   auto constexpr kDefaultUri = "gs://cloud-samples-data/speech/hello.wav";
-  if (argc < 3 || argc > 4) {
+  if (argc != 3 && argc != 4) {
     std::cerr << "Usage: " << argv[0] << " project <region>|global [gcs-uri]\n"
               << "  Specify the region desired or \"global\"\n"
               << "  The gcs-uri must be in gs://... format. It defaults to "

--- a/google/cloud/speech/README.md
+++ b/google/cloud/speech/README.md
@@ -61,8 +61,7 @@ int main(int argc, char* argv[]) try {
     location = "";
   }
 
-  connection = speech::MakeSpeechConnection(location);
-  auto client = speech::SpeechClient(connection);
+  auto client = speech::SpeechClient(speech::MakeSpeechConnection(location));
   auto response = client.Recognize(request);
   if (!response) throw std::move(response).status();
   std::cout << response->DebugString() << "\n";

--- a/google/cloud/speech/README.md
+++ b/google/cloud/speech/README.md
@@ -36,7 +36,7 @@ void ConfigureRecognizer(google::cloud::speech::v2::RecognizeRequest& request) {
 
 int main(int argc, char* argv[]) try {
   auto constexpr kDefaultUri = "gs://cloud-samples-data/speech/hello.wav";
-  if (argc > 4) {
+  if (argc < 3 || argc > 4) {
     std::cerr << "Usage: " << argv[0] << " project <region>|global [gcs-uri]\n"
               << "  Specify the region desired or \"global\"\n"
               << "  The gcs-uri must be in gs://... format. It defaults to "
@@ -52,15 +52,13 @@ int main(int argc, char* argv[]) try {
   google::cloud::speech::v2::RecognizeRequest request;
   ConfigureRecognizer(request);
   request.set_uri(uri);
+  request.set_recognizer("projects/" + project + "/locations/" + location +
+                         "/recognizers/_");
 
   if (location == "global") {
     connection = speech::MakeSpeechConnection();
-    request.set_recognizer("projects/" + project +
-                           "/locations/global/recognizers/_");
   } else {
     connection = speech::MakeSpeechConnection(location);
-    request.set_recognizer("projects/" + project + "/locations/" + location +
-                           "/recognizers/_");
   }
 
   auto client = speech::SpeechClient(connection);

--- a/google/cloud/speech/README.md
+++ b/google/cloud/speech/README.md
@@ -44,7 +44,7 @@ int main(int argc, char* argv[]) try {
     return 1;
   }
   std::string const project = argv[1];
-  std::string const location = argv[2];
+  std::string location = argv[2];
   auto const uri = std::string{argc == 4 ? argv[3] : kDefaultUri};
   namespace speech = ::google::cloud::speech_v2;
 
@@ -56,11 +56,12 @@ int main(int argc, char* argv[]) try {
                          "/recognizers/_");
 
   if (location == "global") {
-    connection = speech::MakeSpeechConnection();
-  } else {
-    connection = speech::MakeSpeechConnection(location);
+    // An empty location string indicates that the global endpoint of the
+    // service should be used.
+    location = "";
   }
 
+  connection = speech::MakeSpeechConnection(location);
   auto client = speech::SpeechClient(connection);
   auto response = client.Recognize(request);
   if (!response) throw std::move(response).status();

--- a/google/cloud/speech/quickstart/quickstart.cc
+++ b/google/cloud/speech/quickstart/quickstart.cc
@@ -26,7 +26,7 @@ void ConfigureRecognizer(google::cloud::speech::v2::RecognizeRequest& request) {
 
 int main(int argc, char* argv[]) try {
   auto constexpr kDefaultUri = "gs://cloud-samples-data/speech/hello.wav";
-  if (argc > 4) {
+  if (argc < 3 || argc > 4) {
     std::cerr << "Usage: " << argv[0] << " project <region>|global [gcs-uri]\n"
               << "  Specify the region desired or \"global\"\n"
               << "  The gcs-uri must be in gs://... format. It defaults to "
@@ -42,15 +42,13 @@ int main(int argc, char* argv[]) try {
   google::cloud::speech::v2::RecognizeRequest request;
   ConfigureRecognizer(request);
   request.set_uri(uri);
+  request.set_recognizer("projects/" + project + "/locations/" + location +
+                         "/recognizers/_");
 
   if (location == "global") {
     connection = speech::MakeSpeechConnection();
-    request.set_recognizer("projects/" + project +
-                           "/locations/global/recognizers/_");
   } else {
     connection = speech::MakeSpeechConnection(location);
-    request.set_recognizer("projects/" + project + "/locations/" + location +
-                           "/recognizers/_");
   }
 
   auto client = speech::SpeechClient(connection);

--- a/google/cloud/speech/quickstart/quickstart.cc
+++ b/google/cloud/speech/quickstart/quickstart.cc
@@ -51,8 +51,7 @@ int main(int argc, char* argv[]) try {
     location = "";
   }
 
-  connection = speech::MakeSpeechConnection(location);
-  auto client = speech::SpeechClient(connection);
+  auto client = speech::SpeechClient(speech::MakeSpeechConnection(location));
   auto response = client.Recognize(request);
   if (!response) throw std::move(response).status();
   std::cout << response->DebugString() << "\n";

--- a/google/cloud/speech/quickstart/quickstart.cc
+++ b/google/cloud/speech/quickstart/quickstart.cc
@@ -13,28 +13,48 @@
 // limitations under the License.
 
 //! [all]
-#include "google/cloud/speech/v1/speech_client.h"
+#include "google/cloud/speech/v2/speech_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
 
+// Configure a simple recognizer for en-US.
+void ConfigureRecognizer(google::cloud::speech::v2::RecognizeRequest& request) {
+  *request.mutable_config()->add_language_codes() = "en-US";
+  request.mutable_config()->set_model("short");
+  *request.mutable_config()->mutable_auto_decoding_config() = {};
+}
+
 int main(int argc, char* argv[]) try {
   auto constexpr kDefaultUri = "gs://cloud-samples-data/speech/hello.wav";
-  if (argc > 2) {
-    std::cerr << "Usage: " << argv[0] << " [gcs-uri]\n"
+  if (argc > 4) {
+    std::cerr << "Usage: " << argv[0] << " project <region>|global [gcs-uri]\n"
+              << "  Specify the region desired or \"global\"\n"
               << "  The gcs-uri must be in gs://... format. It defaults to "
               << kDefaultUri << "\n";
     return 1;
   }
-  auto uri = std::string{argc == 2 ? argv[1] : kDefaultUri};
+  std::string const project = argv[1];
+  std::string const location = argv[2];
+  auto const uri = std::string{argc == 4 ? argv[3] : kDefaultUri};
+  namespace speech = ::google::cloud::speech_v2;
 
-  namespace speech = ::google::cloud::speech_v1;
-  auto client = speech::SpeechClient(speech::MakeSpeechConnection());
+  std::shared_ptr<speech::SpeechConnection> connection;
+  google::cloud::speech::v2::RecognizeRequest request;
+  ConfigureRecognizer(request);
+  request.set_uri(uri);
 
-  google::cloud::speech::v1::RecognitionConfig config;
-  config.set_language_code("en-US");
-  google::cloud::speech::v1::RecognitionAudio audio;
-  audio.set_uri(uri);
-  auto response = client.Recognize(config, audio);
+  if (location == "global") {
+    connection = speech::MakeSpeechConnection();
+    request.set_recognizer("projects/" + project +
+                           "/locations/global/recognizers/_");
+  } else {
+    connection = speech::MakeSpeechConnection(location);
+    request.set_recognizer("projects/" + project + "/locations/" + location +
+                           "/recognizers/_");
+  }
+
+  auto client = speech::SpeechClient(connection);
+  auto response = client.Recognize(request);
   if (!response) throw std::move(response).status();
   std::cout << response->DebugString() << "\n";
 

--- a/google/cloud/speech/quickstart/quickstart.cc
+++ b/google/cloud/speech/quickstart/quickstart.cc
@@ -26,7 +26,7 @@ void ConfigureRecognizer(google::cloud::speech::v2::RecognizeRequest& request) {
 
 int main(int argc, char* argv[]) try {
   auto constexpr kDefaultUri = "gs://cloud-samples-data/speech/hello.wav";
-  if (argc < 3 || argc > 4) {
+  if (argc != 3 && argc != 4) {
     std::cerr << "Usage: " << argv[0] << " project <region>|global [gcs-uri]\n"
               << "  Specify the region desired or \"global\"\n"
               << "  The gcs-uri must be in gs://... format. It defaults to "

--- a/google/cloud/speech/quickstart/quickstart.cc
+++ b/google/cloud/speech/quickstart/quickstart.cc
@@ -34,7 +34,7 @@ int main(int argc, char* argv[]) try {
     return 1;
   }
   std::string const project = argv[1];
-  std::string const location = argv[2];
+  std::string location = argv[2];
   auto const uri = std::string{argc == 4 ? argv[3] : kDefaultUri};
   namespace speech = ::google::cloud::speech_v2;
 
@@ -46,11 +46,12 @@ int main(int argc, char* argv[]) try {
                          "/recognizers/_");
 
   if (location == "global") {
-    connection = speech::MakeSpeechConnection();
-  } else {
-    connection = speech::MakeSpeechConnection(location);
+    // An empty location string indicates that the global endpoint of the
+    // service should be used.
+    location = "";
   }
 
+  connection = speech::MakeSpeechConnection(location);
   auto client = speech::SpeechClient(connection);
   auto response = client.Recognize(request);
   if (!response) throw std::move(response).status();


### PR DESCRIPTION
While we need to wait until after the next release to commit these changes, for our own CI purposes, this quickstart shows how to use the API available at HEAD to direct the speech client to use regional endpoints and reocgnizers.

part of the work for #13729

blocked on https://github.com/microsoft/vcpkg/pull/38204

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13760)
<!-- Reviewable:end -->
