### PR TITLE
fix(storage): respect `GOOGLE_CLOUD_CPP_OPENTELEMETRY_TRACING`

### DIFF
--- a/google/cloud/storage/client_options.cc
+++ b/google/cloud/storage/client_options.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/internal/rest_response.h"
 #include "google/cloud/internal/service_endpoint.h"
 #include "google/cloud/log.h"
+#include "google/cloud/opentelemetry_options.h"
 #include "absl/strings/str_split.h"
 #include <cstdlib>
 #include <set>
@@ -223,12 +224,17 @@ Options DefaultOptions(std::shared_ptr<oauth2::Credentials> credentials,
                                                                 "/iamapi");
   }
 
-  auto tracing = GetEnv("CLOUD_STORAGE_ENABLE_TRACING");
-  if (tracing.has_value()) {
-    for (auto c : absl::StrSplit(*tracing, ',')) {
+  auto logging = GetEnv("CLOUD_STORAGE_ENABLE_TRACING");
+  if (logging) {
+    for (auto c : absl::StrSplit(*logging, ',')) {
       GCP_LOG(INFO) << "Enabling logging for " << c;
       o.lookup<TracingComponentsOption>().insert(std::string(c));
     }
+  }
+
+  auto tracing = GetEnv("GOOGLE_CLOUD_CPP_OPENTELEMETRY_TRACING");
+  if (tracing && !tracing->empty()) {
+    o.set<OpenTelemetryTracingOption>(true);
   }
 
   auto project_id = GetEnv("GOOGLE_CLOUD_PROJECT");


### PR DESCRIPTION
Fixes #13765

Same story as #13748. `storage` and `bigtable` do not call `PopulateCommonOptions()`, so we need to manually handle `GOOGLE_CLOUD_CPP_OPENTELEMETRY_TRACING`. They are the only two such libraries that need this manual works.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13766)
<!-- Reviewable:end -->
