### PR TITLE
cleanup: `"true"` is `true` but we can do better

### DIFF
--- a/google/cloud/bigtable/benchmarks/benchmark_options.cc
+++ b/google/cloud/bigtable/benchmarks/benchmark_options.cc
@@ -88,7 +88,7 @@ google::cloud::StatusOr<BenchmarkOptions> ParseBenchmarkOptions(
        }},
       {"--use-embedded-server", "whether to use the embedded Bigtable server",
        [&options](std::string const& val) {
-         options.use_embedded_server = ParseBoolean(val).value_or("true");
+         options.use_embedded_server = ParseBoolean(val).value_or(true);
        }},
   };
 

--- a/google/cloud/storage/benchmarks/aggregate_download_throughput_options.cc
+++ b/google/cloud/storage/benchmarks/aggregate_download_throughput_options.cc
@@ -112,7 +112,7 @@ ParseAggregateDownloadThroughputOptions(std::vector<std::string> const& argv,
        "use a different storage::Client object in each thread",
        [&options](std::string const& val) {
          options.client_per_thread =
-             testing_util::ParseBoolean(val).value_or("true");
+             testing_util::ParseBoolean(val).value_or(true);
        }},
       {"--grpc-channel-count", "controls the number of gRPC channels",
        [&options](std::string const& val) {


### PR DESCRIPTION
If we really wanted to obfuscate the code we should have used `"false"`. What a wasted opportunity.

FWIW, I found these as warnings in (`-Wnonnull-compare`) in one of the asan builds.  I am not sure why these warnings are not turned on in our `-Wall -Werror` builds.  Maybe a different compiler?

```
Step #5:                  from google/cloud/bigtable/benchmarks/benchmark_options.cc:15:
Step #5: external/com_google_absl/absl/types/optional.h: In member function 'T absl::lts_20240116::optional<T>::value_or(U&&) && [with U = const char (&)[5]; T = bool]':
Step #5: external/com_google_absl/absl/types/optional.h:524:37: warning: 'nonnull' argument 'v' compared to NULL [-Wnonnull-compare]
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13772)
<!-- Reviewable:end -->
