### PR TITLE
impl(GCS+gRPC): default options for `AsyncClient`

### DIFF
--- a/google/cloud/storage/internal/async/connection_impl.cc
+++ b/google/cloud/storage/internal/async/connection_impl.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/storage/internal/async/connection_impl.h"
 #include "google/cloud/storage/async/reader_connection.h"
 #include "google/cloud/storage/internal/async/accumulate_read_object.h"
+#include "google/cloud/storage/internal/async/default_options.h"
 #include "google/cloud/storage/internal/async/insert_object.h"
 #include "google/cloud/storage/internal/async/read_payload_impl.h"
 #include "google/cloud/storage/internal/async/reader_connection_impl.h"
@@ -29,7 +30,6 @@
 #include "google/cloud/storage/internal/grpc/ctype_cord_workaround.h"
 #include "google/cloud/storage/internal/grpc/object_metadata_parser.h"
 #include "google/cloud/storage/internal/grpc/object_request_parser.h"
-#include "google/cloud/storage/internal/grpc/stub.h"
 #include "google/cloud/storage/internal/storage_stub.h"
 #include "google/cloud/storage/internal/storage_stub_factory.h"
 #include "google/cloud/storage/options.h"
@@ -489,7 +489,7 @@ AsyncConnectionImpl::UnbufferedUploadImpl(
 
 std::shared_ptr<storage_experimental::AsyncConnection> MakeAsyncConnection(
     CompletionQueue cq, Options options) {
-  options = storage_internal::DefaultOptionsGrpc(std::move(options));
+  options = DefaultOptionsAsync(std::move(options));
   auto p = CreateStorageStub(cq, options);
   return std::make_shared<AsyncConnectionImpl>(
       std::move(cq), std::move(p.first), std::move(p.second),

--- a/google/cloud/storage/internal/async/connection_impl_test.cc
+++ b/google/cloud/storage/internal/async/connection_impl_test.cc
@@ -14,8 +14,8 @@
 
 #include "google/cloud/storage/internal/async/connection_impl.h"
 #include "google/cloud/storage/async/writer_connection.h"
+#include "google/cloud/storage/internal/async/default_options.h"
 #include "google/cloud/storage/internal/async/write_payload_impl.h"
-#include "google/cloud/storage/internal/grpc/stub.h"
 #include "google/cloud/storage/options.h"
 #include "google/cloud/storage/retry_policy.h"
 #include "google/cloud/storage/testing/canonical_errors.h"
@@ -89,7 +89,7 @@ std::shared_ptr<storage_experimental::AsyncConnection> MakeTestConnection(
           .set<storage::BackoffPolicyOption>(
               storage::ExponentialBackoffPolicy(ms(1), ms(2), 2.0).clone()));
   return MakeAsyncConnection(std::move(cq), std::move(mock),
-                             DefaultOptionsGrpc(std::move(options)));
+                             DefaultOptionsAsync(std::move(options)));
 }
 
 std::unique_ptr<AsyncWriteObjectStream> MakeErrorInsertStream(

--- a/google/cloud/storage/internal/async/default_options.cc
+++ b/google/cloud/storage/internal/async/default_options.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/async/default_options.h"
+#include "google/cloud/storage/async/resume_policy.h"
 #include "google/cloud/storage/async/writer_connection.h"
 #include "google/cloud/storage/internal/grpc/stub.h"
 #include <limits>
@@ -58,6 +59,10 @@ auto Adjust(Options opts) {
 }  // namespace
 
 Options DefaultOptionsAsync(Options opts) {
+  opts = internal::MergeOptions(
+      std::move(opts),
+      Options{}.set<storage_experimental::ResumePolicyOption>(
+          storage_experimental::UnlimitedErrorCountResumePolicy()));
   return Adjust(DefaultOptionsGrpc(std::move(opts)));
 }
 

--- a/google/cloud/storage/internal/async/default_options_test.cc
+++ b/google/cloud/storage/internal/async/default_options_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/async/default_options.h"
+#include "google/cloud/storage/async/resume_policy.h"
 #include "google/cloud/storage/async/writer_connection.h"
 #include "google/cloud/common_options.h"
 #include <gmock/gmock.h>
@@ -25,6 +26,7 @@ namespace {
 
 using ::testing::IsEmpty;
 using ::testing::Not;
+using ::testing::NotNull;
 
 TEST(DefaultOptionsAsync, Basic) {
   auto const options = DefaultOptionsAsync({});
@@ -35,6 +37,12 @@ TEST(DefaultOptionsAsync, Basic) {
   // We use EndpointOption as a canary to test that most options are set.
   EXPECT_TRUE(options.has<EndpointOption>());
   EXPECT_THAT(options.get<EndpointOption>(), Not(IsEmpty()));
+  // Verify the ResumePolicyOption is set and it creates valid policies.
+  EXPECT_TRUE(options.has<storage_experimental::ResumePolicyOption>());
+  auto factory = options.get<storage_experimental::ResumePolicyOption>();
+  EXPECT_TRUE(static_cast<bool>(factory));
+  auto policy = factory();
+  EXPECT_THAT(policy, NotNull());
 }
 
 TEST(DefaultOptionsAsync, Adjust) {

--- a/google/cloud/storage/internal/async/rewriter_connection_impl_test.cc
+++ b/google/cloud/storage/internal/async/rewriter_connection_impl_test.cc
@@ -14,7 +14,7 @@
 
 #include "google/cloud/storage/internal/async/rewriter_connection_impl.h"
 #include "google/cloud/storage/async/object_requests.h"
-#include "google/cloud/storage/internal/grpc/stub.h"
+#include "google/cloud/storage/internal/async/default_options.h"
 #include "google/cloud/storage/options.h"
 #include "google/cloud/storage/retry_policy.h"
 #include "google/cloud/storage/testing/canonical_errors.h"
@@ -62,7 +62,8 @@ internal::ImmutableOptions TestOptions(Options options = {}) {
               storage::LimitedErrorCountRetryPolicy(2).clone())
           .set<storage::BackoffPolicyOption>(
               storage::ExponentialBackoffPolicy(ms(1), ms(2), 2.0).clone()));
-  return internal::MakeImmutableOptions(DefaultOptionsGrpc(std::move(options)));
+  return internal::MakeImmutableOptions(
+      DefaultOptionsAsync(std::move(options)));
 }
 
 auto TransientError() {


### PR DESCRIPTION
Fixed a couple of places that did not use `DefaultOptionsAsync()` to initialize the options for an `AsyncClient` or `*Connection`. Also initialize the `ResumePolicyOption` in these defaults.

Part of the work for #12116

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13776)
<!-- Reviewable:end -->
