### PR TITLE
impl: add GOOGLE_CLOUD_UNIVERSE_DOMAIN

### DIFF
--- a/google/cloud/internal/populate_common_options.cc
+++ b/google/cloud/internal/populate_common_options.cc
@@ -20,6 +20,7 @@
 #include "google/cloud/internal/service_endpoint.h"
 #include "google/cloud/internal/user_agent_prefix.h"
 #include "google/cloud/opentelemetry_options.h"
+#include "google/cloud/universe_domain_options.h"
 #include "absl/strings/str_split.h"
 
 namespace google {
@@ -31,6 +32,8 @@ Options PopulateCommonOptions(Options opts, std::string const& endpoint_env_var,
                               std::string const& emulator_env_var,
                               std::string const& authority_env_var,
                               std::string default_endpoint) {
+  auto e = GetEnv("GOOGLE_CLOUD_UNIVERSE_DOMAIN");
+  if (e && !e->empty()) opts.set<UniverseDomainOption>(*std::move(e));
   default_endpoint = UniverseDomainEndpoint(std::move(default_endpoint), opts);
   if (!endpoint_env_var.empty()) {
     auto e = GetEnv(endpoint_env_var.c_str());
@@ -59,7 +62,7 @@ Options PopulateCommonOptions(Options opts, std::string const& endpoint_env_var,
     opts.set<AuthorityOption>(std::move(default_endpoint));
   }
 
-  auto e = GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+  e = GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
   if (e && !e->empty()) {
     opts.set<UserProjectOption>(*std::move(e));
   }

--- a/google/cloud/universe_domain_options.h
+++ b/google/cloud/universe_domain_options.h
@@ -30,6 +30,38 @@ namespace internal {
 /**
  * Use with `google::cloud::Options` to configure the universe domain used in
  * determining service endpoints.
+ *
+ * Consider a service with the endpoint "foo.googleapis.com" in the Google
+ * Default Universe:
+ *
+ * @code
+ * namespace gc = ::google::cloud;
+ * auto conn = MakeFooConnection();
+ * assert(conn->options().get<gc::EndpointOption>() == "foo.googleapis.com");
+ *
+ * auto options = gc::Options{}.set<gc::UniverseDomainOption>("ud.net");
+ * auto conn = MakeFooConnection(options);
+ * assert(conn->options().get<EndpointOption>() == "foo.ud.net");
+ * @endcode
+ *
+ * @note Any `EndpointOption`, `AuthorityOption`, or endpoint environment
+ * variable (`GOOGLE_CLOUD_CPP_<SERVICE>_ENDPOINT`) will take precedence over
+ * this option. That is:
+ *
+ * @code
+ * namespace gc = ::google::cloud;
+ * auto options = gc::Options{}.set<gc::EndpointOption>("foo.googleapis.com")
+ *                             .set<gc::UniverseDomainOption>("ud.net");
+ * auto conn = MakeFooConnection(options);
+ * assert(conn->options().get<gc::EndpointOption>() == "foo.googleapis.com");
+ * @endcode
+ *
+ * @par Environment variable
+ * This option is controlled by the `GOOGLE_CLOUD_UNIVERSE_DOMAIN` environment
+ * variable. The environment variable must be set to a non-empty value.
+ *
+ * `EndpointOption`, `AuthorityOption`, and endpoint environment variables all
+ * take precedence over `GOOGLE_CLOUD_UNIVERSE_DOMAIN`.
  */
 struct UniverseDomainOption {
   using Type = std::string;


### PR DESCRIPTION
Part of the work for #13122. I will need separate PRs for `bigtable`, `storage`.

Add `GOOGLE_CLOUD_UNIVERSE_DOMAIN` to control the `UniverseDomainOption`.

Any of `EndpointOption` / `AuthorityOption` / endpoint env var will take precedence over the universe domain env var. It is best to keep them separated.

Document this.

---

We ought to be setting `UniverseDomainOption` with the value we end up using when the environment variable is present.

I considered modifying `internal::UniverseDomainEndpoint` to set the `UniverseDomainOption` if the environment variable is set. It would have led to a smaller PR, but I didn't like the idea of passing it an `Options&`. The function would be doing too much in my opinion.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13781)
<!-- Reviewable:end -->
