### PR TITLE
feat(GCS+gRPC): resume asynchronous downloads

### DIFF
--- a/google/cloud/storage/internal/async/connection_impl.cc
+++ b/google/cloud/storage/internal/async/connection_impl.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/storage/internal/async/insert_object.h"
 #include "google/cloud/storage/internal/async/read_payload_impl.h"
 #include "google/cloud/storage/internal/async/reader_connection_impl.h"
+#include "google/cloud/storage/internal/async/reader_connection_resume.h"
 #include "google/cloud/storage/internal/async/rewriter_connection_impl.h"
 #include "google/cloud/storage/internal/async/write_payload_impl.h"
 #include "google/cloud/storage/internal/async/writer_connection_buffered.h"
@@ -115,14 +116,18 @@ future<StatusOr<std::unique_ptr<storage_experimental::AsyncReaderConnection>>>
 AsyncConnectionImpl::ReadObject(ReadObjectParams p) {
   using ReturnType =
       StatusOr<std::unique_ptr<storage_experimental::AsyncReaderConnection>>;
-
   auto current = internal::MakeImmutableOptions(std::move(p.options));
   auto proto = ToProto(p.request.impl_);
   if (!proto) return make_ready_future(ReturnType(std::move(proto).status()));
 
-  auto factory = MakeReaderConnectionFactory(
-      std::move(current), std::move(p.request), *std::move(proto));
-  return factory(storage::Generation(), 0);
+  auto const& resume_policy =
+      current->get<storage_experimental::ResumePolicyOption>();
+  auto connection = std::make_unique<AsyncReaderConnectionResume>(
+      resume_policy(),
+      MakeReaderConnectionFactory(std::move(current), std::move(p.request),
+                                  *std::move(proto)));
+
+  return make_ready_future(ReturnType(std::move(connection)));
 }
 
 future<StatusOr<storage_experimental::ReadPayload>>

--- a/google/cloud/storage/internal/async/connection_impl.cc
+++ b/google/cloud/storage/internal/async/connection_impl.cc
@@ -120,10 +120,11 @@ AsyncConnectionImpl::ReadObject(ReadObjectParams p) {
   auto proto = ToProto(p.request.impl_);
   if (!proto) return make_ready_future(ReturnType(std::move(proto).status()));
 
-  auto const& resume_policy =
-      current->get<storage_experimental::ResumePolicyOption>();
+  // Get the policy factory and immediately create a policy.
+  auto resume_policy =
+      current->get<storage_experimental::ResumePolicyOption>()();
   auto connection = std::make_unique<AsyncReaderConnectionResume>(
-      resume_policy(),
+      std::move(resume_policy),
       MakeReaderConnectionFactory(std::move(current), std::move(p.request),
                                   *std::move(proto)));
 


### PR DESCRIPTION
Sometimes an asynchronous download may get interrupted. We need to resume the download from the last received byte.

Part of the work for #12116

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13784)
<!-- Reviewable:end -->
