### PR TITLE
feat(generator): add polling policy sample

### DIFF
--- a/generator/integration_tests/golden/v1/samples/golden_kitchen_sink_client_samples.cc
+++ b/generator/integration_tests/golden/v1/samples/golden_kitchen_sink_client_samples.cc
@@ -93,6 +93,37 @@ void SetRetryPolicy(std::vector<std::string> const& argv) {
   //! [set-retry-policy]
 }
 
+void SetPollingPolicy(std::vector<std::string> const& argv) {
+  if (!argv.empty()) {
+    throw google::cloud::testing_util::Usage{"set-client-policy-policy"};
+  }
+  //! [set-polling-policy]
+
+  // The polling policy controls how the client waits for long-running
+  // operations. `GenericPollingPolicy<>` combines existing policies.
+  // In this case, keep polling until the operation completes (with success
+  // or error) or 45 minutes, whichever happens first. Initially pause for
+  // 10 seconds between polling requests, increasing the pause by a factor
+  // of 4 until it becomes 2 minutes.
+  auto options = google::cloud::Options{}
+  .set<google::cloud::golden_v1::GoldenKitchenSinkPollingPolicyOption>(
+    google::cloud::golden_v1::GenericPollingPolicy<>(
+      google::cloud::golden_v1::LimitedTimeRetryPolicy(
+          /*maximum_duration=*/std::chrono::minutes(45)),
+      google::cloud::golden_v1::ExponentialBackoffPolicy(
+          /*initial_delay=*/std::chrono::seconds(10),
+          /*maximum_delay=*/std::chrono::minutes(2),
+          /*scaling=*/4.0))
+      .clone(););
+
+  auto connection = google::cloud::golden_v1::MakeGoldenKitchenSinkConnection(options);
+
+  // c1 and c2 share the same polling policies.
+  auto c1 = google::cloud::golden_v1::GoldenKitchenSinkClient(connection);
+  auto c2 = google::cloud::golden_v1::GoldenKitchenSinkClient(connection);
+  //! [set-polling-policy]
+}
+
 void WithServiceAccount(std::vector<std::string> const& argv) {
   if (argv.size() != 1 || argv[0] == "--help") {
     throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
@@ -128,6 +159,9 @@ void AutoRun(std::vector<std::string> const& argv) {
   std::cout << "\nRunning SetRetryPolicy() example" << std::endl;
   SetRetryPolicy({});
 
+  std::cout << "\nRunning SetPollingPolicy() example" << std::endl;
+  SetPollingPolicy({});
+
   std::cout << "\nRunning WithServiceAccount() example" << std::endl;
   WithServiceAccount({keyfile});
 }
@@ -138,6 +172,7 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
       {"set-retry-policy", SetRetryPolicy},
+      {"set-polling-policy", SetPollingPolicy},
       {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });

--- a/generator/integration_tests/golden/v1/samples/golden_rest_only_client_samples.cc
+++ b/generator/integration_tests/golden/v1/samples/golden_rest_only_client_samples.cc
@@ -93,6 +93,37 @@ void SetRetryPolicy(std::vector<std::string> const& argv) {
   //! [set-retry-policy]
 }
 
+void SetPollingPolicy(std::vector<std::string> const& argv) {
+  if (!argv.empty()) {
+    throw google::cloud::testing_util::Usage{"set-client-policy-policy"};
+  }
+  //! [set-polling-policy]
+
+  // The polling policy controls how the client waits for long-running
+  // operations. `GenericPollingPolicy<>` combines existing policies.
+  // In this case, keep polling until the operation completes (with success
+  // or error) or 45 minutes, whichever happens first. Initially pause for
+  // 10 seconds between polling requests, increasing the pause by a factor
+  // of 4 until it becomes 2 minutes.
+  auto options = google::cloud::Options{}
+  .set<google::cloud::golden_v1::GoldenRestOnlyPollingPolicyOption>(
+    google::cloud::golden_v1::GenericPollingPolicy<>(
+      google::cloud::golden_v1::LimitedTimeRetryPolicy(
+          /*maximum_duration=*/std::chrono::minutes(45)),
+      google::cloud::golden_v1::ExponentialBackoffPolicy(
+          /*initial_delay=*/std::chrono::seconds(10),
+          /*maximum_delay=*/std::chrono::minutes(2),
+          /*scaling=*/4.0))
+      .clone(););
+
+  auto connection = google::cloud::golden_v1::MakeGoldenRestOnlyConnectionRest(options);
+
+  // c1 and c2 share the same polling policies.
+  auto c1 = google::cloud::golden_v1::GoldenRestOnlyClient(connection);
+  auto c2 = google::cloud::golden_v1::GoldenRestOnlyClient(connection);
+  //! [set-polling-policy]
+}
+
 void WithServiceAccount(std::vector<std::string> const& argv) {
   if (argv.size() != 1 || argv[0] == "--help") {
     throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
@@ -128,6 +159,9 @@ void AutoRun(std::vector<std::string> const& argv) {
   std::cout << "\nRunning SetRetryPolicy() example" << std::endl;
   SetRetryPolicy({});
 
+  std::cout << "\nRunning SetPollingPolicy() example" << std::endl;
+  SetPollingPolicy({});
+
   std::cout << "\nRunning WithServiceAccount() example" << std::endl;
   WithServiceAccount({keyfile});
 }
@@ -138,6 +172,7 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
       {"set-retry-policy", SetRetryPolicy},
+      {"set-polling-policy", SetPollingPolicy},
       {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });

--- a/generator/integration_tests/golden/v1/samples/golden_thing_admin_client_samples.cc
+++ b/generator/integration_tests/golden/v1/samples/golden_thing_admin_client_samples.cc
@@ -93,6 +93,37 @@ void SetRetryPolicy(std::vector<std::string> const& argv) {
   //! [set-retry-policy]
 }
 
+void SetPollingPolicy(std::vector<std::string> const& argv) {
+  if (!argv.empty()) {
+    throw google::cloud::testing_util::Usage{"set-client-policy-policy"};
+  }
+  //! [set-polling-policy]
+
+  // The polling policy controls how the client waits for long-running
+  // operations. `GenericPollingPolicy<>` combines existing policies.
+  // In this case, keep polling until the operation completes (with success
+  // or error) or 45 minutes, whichever happens first. Initially pause for
+  // 10 seconds between polling requests, increasing the pause by a factor
+  // of 4 until it becomes 2 minutes.
+  auto options = google::cloud::Options{}
+  .set<google::cloud::golden_v1::GoldenThingAdminPollingPolicyOption>(
+    google::cloud::golden_v1::GenericPollingPolicy<>(
+      google::cloud::golden_v1::LimitedTimeRetryPolicy(
+          /*maximum_duration=*/std::chrono::minutes(45)),
+      google::cloud::golden_v1::ExponentialBackoffPolicy(
+          /*initial_delay=*/std::chrono::seconds(10),
+          /*maximum_delay=*/std::chrono::minutes(2),
+          /*scaling=*/4.0))
+      .clone(););
+
+  auto connection = google::cloud::golden_v1::MakeGoldenThingAdminConnection(options);
+
+  // c1 and c2 share the same polling policies.
+  auto c1 = google::cloud::golden_v1::GoldenThingAdminClient(connection);
+  auto c2 = google::cloud::golden_v1::GoldenThingAdminClient(connection);
+  //! [set-polling-policy]
+}
+
 void WithServiceAccount(std::vector<std::string> const& argv) {
   if (argv.size() != 1 || argv[0] == "--help") {
     throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
@@ -128,6 +159,9 @@ void AutoRun(std::vector<std::string> const& argv) {
   std::cout << "\nRunning SetRetryPolicy() example" << std::endl;
   SetRetryPolicy({});
 
+  std::cout << "\nRunning SetPollingPolicy() example" << std::endl;
+  SetPollingPolicy({});
+
   std::cout << "\nRunning WithServiceAccount() example" << std::endl;
   WithServiceAccount({keyfile});
 }
@@ -138,6 +172,7 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
       {"set-retry-policy", SetRetryPolicy},
+      {"set-polling-policy", SetPollingPolicy},
       {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });

--- a/generator/integration_tests/golden/v1/samples/request_id_client_samples.cc
+++ b/generator/integration_tests/golden/v1/samples/request_id_client_samples.cc
@@ -93,6 +93,37 @@ void SetRetryPolicy(std::vector<std::string> const& argv) {
   //! [set-retry-policy]
 }
 
+void SetPollingPolicy(std::vector<std::string> const& argv) {
+  if (!argv.empty()) {
+    throw google::cloud::testing_util::Usage{"set-client-policy-policy"};
+  }
+  //! [set-polling-policy]
+
+  // The polling policy controls how the client waits for long-running
+  // operations. `GenericPollingPolicy<>` combines existing policies.
+  // In this case, keep polling until the operation completes (with success
+  // or error) or 45 minutes, whichever happens first. Initially pause for
+  // 10 seconds between polling requests, increasing the pause by a factor
+  // of 4 until it becomes 2 minutes.
+  auto options = google::cloud::Options{}
+  .set<google::cloud::golden_v1::RequestIdServicePollingPolicyOption>(
+    google::cloud::golden_v1::GenericPollingPolicy<>(
+      google::cloud::golden_v1::LimitedTimeRetryPolicy(
+          /*maximum_duration=*/std::chrono::minutes(45)),
+      google::cloud::golden_v1::ExponentialBackoffPolicy(
+          /*initial_delay=*/std::chrono::seconds(10),
+          /*maximum_delay=*/std::chrono::minutes(2),
+          /*scaling=*/4.0))
+      .clone(););
+
+  auto connection = google::cloud::golden_v1::MakeRequestIdServiceConnection(options);
+
+  // c1 and c2 share the same polling policies.
+  auto c1 = google::cloud::golden_v1::RequestIdServiceClient(connection);
+  auto c2 = google::cloud::golden_v1::RequestIdServiceClient(connection);
+  //! [set-polling-policy]
+}
+
 void WithServiceAccount(std::vector<std::string> const& argv) {
   if (argv.size() != 1 || argv[0] == "--help") {
     throw google::cloud::testing_util::Usage{"with-service-account <keyfile>"};
@@ -128,6 +159,9 @@ void AutoRun(std::vector<std::string> const& argv) {
   std::cout << "\nRunning SetRetryPolicy() example" << std::endl;
   SetRetryPolicy({});
 
+  std::cout << "\nRunning SetPollingPolicy() example" << std::endl;
+  SetPollingPolicy({});
+
   std::cout << "\nRunning WithServiceAccount() example" << std::endl;
   WithServiceAccount({keyfile});
 }
@@ -138,6 +172,7 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
       {"set-retry-policy", SetRetryPolicy},
+      {"set-polling-policy", SetPollingPolicy},
       {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });

--- a/generator/internal/sample_generator.cc
+++ b/generator/internal/sample_generator.cc
@@ -176,7 +176,67 @@ void SetRetryPolicy(std::vector<std::string> const& argv) {
   //! [set-retry-policy]
 }
 )""");
+  HeaderPrint(R"""(
+void SetPollingPolicy(std::vector<std::string> const& argv) {
+  if (!argv.empty()) {
+    throw google::cloud::testing_util::Usage{"set-client-policy-policy"};
+  }
+  //! [set-polling-policy]
 
+  // The polling policy controls how the client waits for long-running
+  // operations. `GenericPollingPolicy<>` combines existing policies.
+  // In this case, keep polling until the operation completes (with success
+  // or error) or 45 minutes, whichever happens first. Initially pause for
+  // 10 seconds between polling requests, increasing the pause by a factor
+  // of 4 until it becomes 2 minutes.
+  auto options = google::cloud::Options{}
+  .set<google::cloud::$product_namespace$::$service_name$PollingPolicyOption>(
+    google::cloud::$product_namespace$::GenericPollingPolicy<>(
+      google::cloud::$product_namespace$::LimitedTimeRetryPolicy(
+          /*maximum_duration=*/std::chrono::minutes(45)),
+      google::cloud::$product_namespace$::ExponentialBackoffPolicy(
+          /*initial_delay=*/std::chrono::seconds(10),
+          /*maximum_delay=*/std::chrono::minutes(2),
+          /*scaling=*/4.0))
+      .clone(););
+  )""");
+  if (HasGenerateGrpcTransport()) {
+    HeaderPrint(R"""(
+  auto connection = google::cloud::$product_namespace$::Make$connection_class_name$()""");
+  } else {
+    HeaderPrint(R"""(
+  auto connection = google::cloud::$product_namespace$::Make$connection_class_name$Rest()""");
+  }
+  if (IsExperimental()) HeaderPrint("google::cloud::ExperimentalTag{}, ");
+  switch (endpoint_location_style) {
+    case ServiceConfiguration::LOCATION_DEPENDENT:
+      HeaderPrint(R"""("location-unused-in-this-example", )""");
+      break;
+    case ServiceConfiguration::LOCATION_DEPENDENT_COMPAT:
+    default:
+      break;
+  }
+  HeaderPrint(R"""(options);)""");
+  if (IsExperimental()) {
+    HeaderPrint(R"""(
+
+  // c1 and c2 share the same polling policies.
+  auto c1 = google::cloud::$product_namespace$::$client_class_name$(
+    google::cloud::ExperimentalTag{}, connection);
+  auto c2 = google::cloud::$product_namespace$::$client_class_name$(
+    google::cloud::ExperimentalTag{}, connection);
+  //! [set-polling-policy]
+}
+)""");
+  } else
+    HeaderPrint(R"""(
+
+  // c1 and c2 share the same polling policies.
+  auto c1 = google::cloud::$product_namespace$::$client_class_name$(connection);
+  auto c2 = google::cloud::$product_namespace$::$client_class_name$(connection);
+  //! [set-polling-policy]
+}
+)""");
   HeaderPrint(R"""(
 void WithServiceAccount(std::vector<std::string> const& argv) {
   if (argv.size() != 1 || argv[0] == "--help") {
@@ -230,6 +290,9 @@ void AutoRun(std::vector<std::string> const& argv) {
   std::cout << "\nRunning SetRetryPolicy() example" << std::endl;
   SetRetryPolicy({});
 
+  std::cout << "\nRunning SetPollingPolicy() example" << std::endl;
+  SetPollingPolicy({});
+
   std::cout << "\nRunning WithServiceAccount() example" << std::endl;
   WithServiceAccount({keyfile});
 }
@@ -240,6 +303,7 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::testing_util::Example example({
       {"set-client-endpoint", SetClientEndpoint},
       {"set-retry-policy", SetRetryPolicy},
+      {"set-polling-policy", SetPollingPolicy},
       {"with-service-account", WithServiceAccount},
       {"auto", AutoRun},
   });


### PR DESCRIPTION
Part of https://github.com/googleapis/google-cloud-cpp/issues/13455

I'm waiting to generate the rest of the files, until I get a review. I based it off the retry policy and took from the spanner sample that set a polling operation

To generate the second commit, I used: GENERATE_GOLDEN_ONLY=1 ci/cloudbuild/build.sh -t generate-libraries-pr
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13793)
<!-- Reviewable:end -->
