### PR TITLE
impl(GCS+gRPC): checksum full object downloads

### DIFF
--- a/google/cloud/storage/async/object_responses.h
+++ b/google/cloud/storage/async/object_responses.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/storage/headers_map.h"
 #include "google/cloud/storage/internal/async/read_payload_fwd.h"
+#include "google/cloud/storage/internal/hash_values.h"
 #include "google/cloud/storage/object_metadata.h"
 #include "google/cloud/storage/version.h"
 #include "absl/strings/cord.h"
@@ -122,6 +123,8 @@ class ReadPayload {
   std::int64_t offset_ = 0;
   absl::optional<storage::ObjectMetadata> metadata_;
   storage::HeadersMap headers_;
+  // The full object checksums (aka hash values), if known.
+  absl::optional<storage::internal::HashValues> object_hash_values_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/google_cloud_cpp_storage.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage.cmake
@@ -385,6 +385,7 @@ if (BUILD_TESTING)
         testing/mock_client.h
         testing/mock_generic_stub.h
         testing/mock_hash_function.h
+        testing/mock_hash_validator.h
         testing/mock_http_request.cc
         testing/mock_http_request.h
         testing/mock_resume_policy.h

--- a/google/cloud/storage/internal/async/connection_impl.h
+++ b/google/cloud/storage/internal/async/connection_impl.h
@@ -84,7 +84,8 @@ class AsyncConnectionImpl
   AsyncReaderConnectionFactory MakeReaderConnectionFactory(
       google::cloud::internal::ImmutableOptions current,
       google::cloud::storage_experimental::ReadObjectRequest request,
-      google::storage::v2::ReadObjectRequest proto_request);
+      google::storage::v2::ReadObjectRequest proto_request,
+      std::shared_ptr<storage::internal::HashFunction> hash_function);
 
  private:
   std::weak_ptr<AsyncConnectionImpl> WeakFromThis() {

--- a/google/cloud/storage/internal/async/read_payload_impl.h
+++ b/google/cloud/storage/internal/async/read_payload_impl.h
@@ -17,8 +17,10 @@
 
 #include "google/cloud/storage/async/object_responses.h"
 #include "google/cloud/storage/internal/async/read_payload_fwd.h"
+#include "google/cloud/storage/internal/hash_values.h"
 #include "google/cloud/version.h"
 #include "absl/strings/cord.h"
+#include "absl/types/optional.h"
 
 namespace google {
 namespace cloud {
@@ -45,6 +47,18 @@ struct ReadPayloadImpl {
    */
   static storage_experimental::ReadPayload Make(std::string contents) {
     return storage_experimental::ReadPayload(std::move(contents));
+  }
+
+  /// Get the object hashes (by move) from the payload.
+  static absl::optional<storage::internal::HashValues> GetObjectHashes(
+      storage_experimental::ReadPayload& payload) {
+    return std::move(payload.object_hash_values_);
+  }
+
+  /// Set the object hashes in the payload.
+  static void SetObjectHashes(storage_experimental::ReadPayload& payload,
+                              storage::internal::HashValues hashes) {
+    payload.object_hash_values_ = std::move(hashes);
   }
 };
 

--- a/google/cloud/storage/internal/async/reader_connection_impl.h
+++ b/google/cloud/storage/internal/async/reader_connection_impl.h
@@ -56,6 +56,7 @@ class AsyncReaderConnectionImpl
   future<ReadResponse> DoFinish();
 
   google::cloud::internal::ImmutableOptions options_;
+  std::shared_ptr<storage::internal::HashFunction> hash_;
   std::unique_ptr<StreamingRpc> impl_;
   std::shared_ptr<storage::internal::HashFunction> hash_function_;
   std::int64_t offset_ = 0;

--- a/google/cloud/storage/internal/async/reader_connection_impl_test.cc
+++ b/google/cloud/storage/internal/async/reader_connection_impl_test.cc
@@ -13,19 +13,23 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/async/reader_connection_impl.h"
+#include "google/cloud/storage/internal/async/read_payload_impl.h"
 #include "google/cloud/storage/internal/grpc/ctype_cord_workaround.h"
+#include "google/cloud/storage/internal/grpc/object_metadata_parser.h"
 #include "google/cloud/storage/options.h"
 #include "google/cloud/storage/testing/canonical_errors.h"
 #include "google/cloud/storage/testing/mock_hash_function.h"
 #include "google/cloud/testing_util/mock_async_streaming_read_rpc.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <type_traits>
 
 namespace google {
 namespace cloud {
 namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+using ::google::cloud::storage::internal::HashValues;
 using ::google::cloud::storage::testing::MockHashFunction;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
 using ::google::cloud::storage_experimental::ReadPayload;
@@ -35,6 +39,9 @@ using ::testing::_;
 using ::testing::AllOf;
 using ::testing::An;
 using ::testing::ElementsAre;
+using ::testing::Eq;
+using ::testing::Field;
+using ::testing::Optional;
 using ::testing::Pair;
 using ::testing::ResultOf;
 using ::testing::Return;
@@ -180,6 +187,73 @@ TEST(ReaderConnectionImpl, HashingError) {
                                    std::move(hash_function));
   EXPECT_THAT(tested.Read().get(),
               VariantWith<Status>(StatusIs(StatusCode::kInvalidArgument)));
+}
+
+TEST(ReaderConnectionImpl, FullHashes) {
+  // /bin/echo -n 'The quick brown fox jumps over the lazy dog' > foo.txt
+  // gsutil hash foo.txt
+  auto constexpr kQuickFoxCrc32cChecksum = "ImIEBA==";
+  auto constexpr kQuickFoxMD5Hash = "nhB9nTcrtoJr2B01QqQZ1g==";
+  auto const crc32c = Crc32cToProto(kQuickFoxCrc32cChecksum).value();
+  auto const md5 = MD5ToProto(kQuickFoxMD5Hash).value();
+
+  auto mock = std::make_unique<MockStream>();
+  EXPECT_CALL(*mock, Read)
+      .WillOnce([] {
+        google::storage::v2::ReadObjectResponse response;
+        return make_ready_future(absl::make_optional(response));
+      })
+      .WillOnce([crc32c] {
+        google::storage::v2::ReadObjectResponse response;
+        response.mutable_object_checksums()->set_crc32c(crc32c);
+        return make_ready_future(absl::make_optional(response));
+      })
+      .WillOnce([md5] {
+        google::storage::v2::ReadObjectResponse response;
+        response.mutable_object_checksums()->set_md5_hash(md5);
+        return make_ready_future(absl::make_optional(response));
+      })
+      .WillOnce([crc32c, md5] {
+        google::storage::v2::ReadObjectResponse response;
+        response.mutable_object_checksums()->set_crc32c(crc32c);
+        response.mutable_object_checksums()->set_md5_hash(md5);
+        return make_ready_future(absl::make_optional(response));
+      });
+
+  auto hash_function = std::make_shared<MockHashFunction>();
+  EXPECT_CALL(*hash_function, Update(_, An<HashUpdateType>(), _))
+      .Times(4)
+      .WillRepeatedly(Return(Status{}));
+
+  AsyncReaderConnectionImpl tested(TestOptions(), std::move(mock),
+                                   std::move(hash_function));
+
+  EXPECT_THAT(tested.Read().get(),
+              VariantWith<ReadPayload>(ResultOf(
+                  "read payload without hash values",
+                  [](storage_experimental::ReadPayload p) {
+                    return ReadPayloadImpl::GetObjectHashes(p);
+                  },
+                  Eq(absl::nullopt))));
+
+  auto has_hash_values = [](HashValues const& expected) {
+    return ResultOf(
+        "read response has hash values",
+        [](storage_experimental::ReadPayload p) {
+          return ReadPayloadImpl::GetObjectHashes(p);
+        },
+        AllOf(Optional(Field("crc32c", &HashValues::crc32c, expected.crc32c)),
+              Optional(Field("md5", &HashValues::md5, expected.md5))));
+  };
+
+  EXPECT_THAT(tested.Read().get(),
+              VariantWith<ReadPayload>(
+                  has_hash_values(HashValues{kQuickFoxCrc32cChecksum, {}})));
+  EXPECT_THAT(tested.Read().get(), VariantWith<ReadPayload>(has_hash_values(
+                                       HashValues{{}, kQuickFoxMD5Hash})));
+  EXPECT_THAT(tested.Read().get(),
+              VariantWith<ReadPayload>(has_hash_values(
+                  HashValues{kQuickFoxCrc32cChecksum, kQuickFoxMD5Hash})));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/async/reader_connection_resume.h
+++ b/google/cloud/storage/internal/async/reader_connection_resume.h
@@ -18,6 +18,8 @@
 #include "google/cloud/storage/async/reader_connection.h"
 #include "google/cloud/storage/async/resume_policy.h"
 #include "google/cloud/storage/internal/async/reader_connection_factory.h"
+#include "google/cloud/storage/internal/hash_function.h"
+#include "google/cloud/storage/internal/hash_validator.h"
 #include "google/cloud/future.h"
 #include "google/cloud/internal/async_streaming_read_rpc.h"
 #include "google/cloud/status_or.h"
@@ -38,8 +40,12 @@ class AsyncReaderConnectionResume
  public:
   explicit AsyncReaderConnectionResume(
       std::unique_ptr<storage_experimental::ResumePolicy> resume_policy,
+      std::shared_ptr<storage::internal::HashFunction> hash,
+      std::unique_ptr<storage::internal::HashValidator> validator,
       AsyncReaderConnectionFactory reader_factory)
       : resume_policy_(std::move(resume_policy)),
+        hash_function_(std::move(hash)),
+        hash_validator_(std::move(validator)),
         reader_factory_(std::move(reader_factory)) {}
 
   void Cancel() override;
@@ -59,6 +65,8 @@ class AsyncReaderConnectionResume
   std::shared_ptr<storage_experimental::AsyncReaderConnection> CurrentImpl();
 
   std::unique_ptr<storage_experimental::ResumePolicy> resume_policy_;
+  std::shared_ptr<storage::internal::HashFunction> hash_function_;
+  std::unique_ptr<storage::internal::HashValidator> hash_validator_;
   AsyncReaderConnectionFactory reader_factory_;
   storage::Generation generation_;
   std::int64_t received_bytes_ = 0;

--- a/google/cloud/storage/internal/async/reader_connection_resume_test.cc
+++ b/google/cloud/storage/internal/async/reader_connection_resume_test.cc
@@ -14,12 +14,15 @@
 
 #include "google/cloud/storage/internal/async/reader_connection_resume.h"
 #include "google/cloud/storage/async/resume_policy.h"
+#include "google/cloud/storage/internal/async/read_payload_impl.h"
 #include "google/cloud/storage/internal/async/reader_connection_impl.h"
 #include "google/cloud/storage/internal/grpc/ctype_cord_workaround.h"
 #include "google/cloud/storage/mocks/mock_async_reader_connection.h"
 #include "google/cloud/storage/options.h"
 #include "google/cloud/storage/retry_policy.h"
 #include "google/cloud/storage/testing/canonical_errors.h"
+#include "google/cloud/storage/testing/mock_hash_function.h"
+#include "google/cloud/storage/testing/mock_hash_validator.h"
 #include "google/cloud/storage/testing/mock_resume_policy.h"
 #include "google/cloud/testing_util/mock_async_streaming_read_rpc.h"
 #include "google/cloud/testing_util/status_matchers.h"
@@ -32,11 +35,14 @@ namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+using ::google::cloud::storage::testing::MockHashFunction;
+using ::google::cloud::storage::testing::MockHashValidator;
 using ::google::cloud::storage::testing::MockResumePolicy;
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ::google::cloud::storage_experimental::ReadPayload;
 using ::google::cloud::storage_experimental::ResumePolicy;
 using ::google::cloud::testing_util::IsOk;
+using ::google::cloud::testing_util::StatusIs;
 using ::testing::_;
 using ::testing::AllOf;
 using ::testing::AtMost;
@@ -191,8 +197,10 @@ TEST(AsyncReaderConnectionResume, Resume) {
   EXPECT_CALL(*resume_policy, OnFinish)
       .WillRepeatedly(Return(ResumePolicy::kContinue));
 
-  AsyncReaderConnectionResume tested(std::move(resume_policy),
-                                     mock_factory.AsStdFunction());
+  AsyncReaderConnectionResume tested(
+      std::move(resume_policy), storage::internal::CreateNullHashFunction(),
+      storage::internal::CreateNullHashValidator(),
+      mock_factory.AsStdFunction());
   EXPECT_THAT(tested.Read().get(), IsInitialRead());
   EXPECT_THAT(tested.Read().get(),
               VariantWith<ReadPayload>(ContentsMatch(kReadSize, '2')));
@@ -210,6 +218,125 @@ TEST(AsyncReaderConnectionResume, Resume) {
               UnorderedElementsAre(Pair("hk0", "v0"), Pair("hk1", "v1")));
   EXPECT_THAT(metadata.trailers,
               UnorderedElementsAre(Pair("tk0", "v0"), Pair("tk1", "v1")));
+}
+
+TEST(AsyncReaderConnectionResume, HashValidation) {
+  auto hash_function = std::make_shared<MockHashFunction>();
+  // Normally the `AsyncReaderConnectionImpl` would call
+  // `hash_function->Update()`. Here we are mocking the `*ConnectionImpl`, so
+  // only `ProcessHashValues()` and `Finish()` get called.
+  EXPECT_CALL(*hash_function, Finish)
+      .WillOnce(Return(storage::internal::HashValues{"crc32c", "md5"}));
+
+  auto hash_validator = std::make_unique<MockHashValidator>();
+  EXPECT_CALL(*hash_validator, ProcessHashValues)
+      .WillOnce([](storage::internal::HashValues const& hv) {
+        EXPECT_EQ(hv.crc32c, "crc32c");
+        EXPECT_EQ(hv.md5, "md5");
+      })
+      .WillOnce([](storage::internal::HashValues const& hv) {
+        EXPECT_THAT(hv.crc32c, IsEmpty());
+        EXPECT_THAT(hv.md5, IsEmpty());
+      });
+  EXPECT_CALL(std::move(*hash_validator), Finish)
+      .WillOnce([](storage::internal::HashValues const&) {
+        return storage::internal::HashValidator::Result{
+            /*.received=*/{}, /*.computed=*/{}, /*.is_mismatch=*/false};
+      });
+
+  MockAsyncReaderConnectionFactory mock_factory;
+  EXPECT_CALL(mock_factory, Call(WithGeneration(0), 0)).WillOnce([] {
+    auto mock = std::make_unique<MockReader>();
+    EXPECT_CALL(*mock, Read)
+        .WillOnce([] {
+          auto payload = ReadPayload(std::string(kReadSize, '1'));
+          ReadPayloadImpl::SetObjectHashes(
+              payload, storage::internal::HashValues{"crc32c", "md5"});
+          return make_ready_future(ReadResponse(std::move(payload)));
+        })
+        .WillOnce([] {
+          auto payload = ReadPayload(std::string(kReadSize, '2'));
+          return make_ready_future(ReadResponse(std::move(payload)));
+        })
+        .WillOnce([] { return make_ready_future(ReadResponse(Status{})); });
+    return make_ready_future(make_status_or(
+        std::unique_ptr<storage_experimental::AsyncReaderConnection>(
+            std::move(mock))));
+  });
+
+  auto resume_policy = std::make_unique<MockResumePolicy>();
+  EXPECT_CALL(*resume_policy, OnStartSuccess).Times(1);
+  EXPECT_CALL(*resume_policy, OnFinish).Times(0);
+
+  AsyncReaderConnectionResume tested(
+      std::move(resume_policy), std::move(hash_function),
+      std::move(hash_validator), mock_factory.AsStdFunction());
+  EXPECT_THAT(tested.Read().get(),
+              VariantWith<ReadPayload>(ContentsMatch(kReadSize, '1')));
+  EXPECT_THAT(tested.Read().get(),
+              VariantWith<ReadPayload>(ContentsMatch(kReadSize, '2')));
+  EXPECT_THAT(tested.Read().get(), VariantWith<Status>(IsOk()));
+}
+
+TEST(AsyncReaderConnectionResume, HashValidationWithError) {
+  auto hash_function = std::make_shared<MockHashFunction>();
+  // Normally the `AsyncReaderConnectionImpl` would call
+  // `hash_function->Update()`. Here we are mocking the `*ConnectionImpl`, so
+  // only `ProcessHashValues()` and `Finish()` get called.
+  EXPECT_CALL(*hash_function, Finish)
+      .WillOnce(Return(storage::internal::HashValues{"crc32c", "md5"}));
+
+  auto hash_validator = std::make_unique<MockHashValidator>();
+  EXPECT_CALL(*hash_validator, ProcessHashValues)
+      .WillOnce([](storage::internal::HashValues const& hv) {
+        EXPECT_EQ(hv.crc32c, "crc32c");
+        EXPECT_EQ(hv.md5, "md5");
+      })
+      .WillOnce([](storage::internal::HashValues const& hv) {
+        EXPECT_THAT(hv.crc32c, IsEmpty());
+        EXPECT_THAT(hv.md5, IsEmpty());
+      });
+  EXPECT_CALL(std::move(*hash_validator), Finish)
+      .WillOnce([](storage::internal::HashValues const&) {
+        return storage::internal::HashValidator::Result{
+            /*.received=*/{"crc32c", "md5"},
+            /*.computed=*/{"crc32c-computed", "md5-computed"},
+            /*.is_mismatch=*/true};
+      });
+
+  MockAsyncReaderConnectionFactory mock_factory;
+  EXPECT_CALL(mock_factory, Call(WithGeneration(0), 0)).WillOnce([] {
+    auto mock = std::make_unique<MockReader>();
+    EXPECT_CALL(*mock, Read)
+        .WillOnce([] {
+          auto payload = ReadPayload(std::string(kReadSize, '1'));
+          ReadPayloadImpl::SetObjectHashes(
+              payload, storage::internal::HashValues{"crc32c", "md5"});
+          return make_ready_future(ReadResponse(std::move(payload)));
+        })
+        .WillOnce([] {
+          auto payload = ReadPayload(std::string(kReadSize, '2'));
+          return make_ready_future(ReadResponse(std::move(payload)));
+        })
+        .WillOnce([] { return make_ready_future(ReadResponse(Status{})); });
+    return make_ready_future(make_status_or(
+        std::unique_ptr<storage_experimental::AsyncReaderConnection>(
+            std::move(mock))));
+  });
+
+  auto resume_policy = std::make_unique<MockResumePolicy>();
+  EXPECT_CALL(*resume_policy, OnStartSuccess).Times(1);
+  EXPECT_CALL(*resume_policy, OnFinish).Times(0);
+
+  AsyncReaderConnectionResume tested(
+      std::move(resume_policy), std::move(hash_function),
+      std::move(hash_validator), mock_factory.AsStdFunction());
+  EXPECT_THAT(tested.Read().get(),
+              VariantWith<ReadPayload>(ContentsMatch(kReadSize, '1')));
+  EXPECT_THAT(tested.Read().get(),
+              VariantWith<ReadPayload>(ContentsMatch(kReadSize, '2')));
+  EXPECT_THAT(tested.Read().get(),
+              VariantWith<Status>(StatusIs(StatusCode::kInvalidArgument)));
 }
 
 TEST(AsyncReaderConnectionResume, Cancel) {
@@ -230,8 +357,10 @@ TEST(AsyncReaderConnectionResume, Cancel) {
   EXPECT_CALL(*resume_policy, OnFinish)
       .WillRepeatedly(Return(ResumePolicy::kStop));
 
-  AsyncReaderConnectionResume tested(std::move(resume_policy),
-                                     mock_factory.AsStdFunction());
+  AsyncReaderConnectionResume tested(
+      std::move(resume_policy), storage::internal::CreateNullHashFunction(),
+      storage::internal::CreateNullHashValidator(),
+      mock_factory.AsStdFunction());
   EXPECT_NO_FATAL_FAILURE(tested.Cancel());
   EXPECT_THAT(tested.Read().get(), VariantWith<Status>(TransientError()));
   EXPECT_NO_FATAL_FAILURE(tested.Cancel());
@@ -257,8 +386,10 @@ TEST(AsyncReaderConnectionResume, GetRequestMetadata) {
   EXPECT_CALL(*resume_policy, OnFinish)
       .WillRepeatedly(Return(ResumePolicy::kStop));
 
-  AsyncReaderConnectionResume tested(std::move(resume_policy),
-                                     mock_factory.AsStdFunction());
+  AsyncReaderConnectionResume tested(
+      std::move(resume_policy), storage::internal::CreateNullHashFunction(),
+      storage::internal::CreateNullHashValidator(),
+      mock_factory.AsStdFunction());
   auto const m0 = tested.GetRequestMetadata();
   EXPECT_THAT(m0.headers, IsEmpty());
   EXPECT_THAT(m0.trailers, IsEmpty());
@@ -297,8 +428,10 @@ TEST(AsyncReaderConnectionResume, ResumeUpdatesOffset) {
   EXPECT_CALL(*resume_policy, OnFinish)
       .WillRepeatedly(Return(ResumePolicy::kContinue));
 
-  AsyncReaderConnectionResume tested(std::move(resume_policy),
-                                     mock_factory.AsStdFunction());
+  AsyncReaderConnectionResume tested(
+      std::move(resume_policy), storage::internal::CreateNullHashFunction(),
+      storage::internal::CreateNullHashValidator(),
+      mock_factory.AsStdFunction());
   EXPECT_THAT(tested.Read().get(),
               VariantWith<ReadPayload>(ContentsMatch(kReadSize, '1')));
   EXPECT_THAT(tested.Read().get(),
@@ -328,8 +461,10 @@ TEST(AsyncReaderConnectionResume, StopOnReconnectError) {
   EXPECT_CALL(*resume_policy, OnFinish)
       .WillRepeatedly(Return(ResumePolicy::kContinue));
 
-  AsyncReaderConnectionResume tested(std::move(resume_policy),
-                                     mock_factory.AsStdFunction());
+  AsyncReaderConnectionResume tested(
+      std::move(resume_policy), storage::internal::CreateNullHashFunction(),
+      storage::internal::CreateNullHashValidator(),
+      mock_factory.AsStdFunction());
   EXPECT_THAT(tested.Read().get(), IsInitialRead());
   EXPECT_THAT(tested.Read().get(),
               VariantWith<ReadPayload>(ContentsMatch(kReadSize, '2')));
@@ -362,8 +497,10 @@ TEST(AsyncReaderConnectionResume, StopAfterTooManyReconnects) {
       .WillOnce(Return(ResumePolicy::kContinue))
       .WillOnce(Return(ResumePolicy::kStop));
 
-  AsyncReaderConnectionResume tested(std::move(resume_policy),
-                                     mock_factory.AsStdFunction());
+  AsyncReaderConnectionResume tested(
+      std::move(resume_policy), storage::internal::CreateNullHashFunction(),
+      storage::internal::CreateNullHashValidator(),
+      mock_factory.AsStdFunction());
   EXPECT_THAT(tested.Read().get(), IsInitialRead());
   EXPECT_THAT(tested.Read().get(),
               VariantWith<ReadPayload>(ContentsMatch(kReadSize, '2')));

--- a/google/cloud/storage/storage_client_testing.bzl
+++ b/google/cloud/storage/storage_client_testing.bzl
@@ -23,6 +23,7 @@ storage_client_testing_hdrs = [
     "testing/mock_client.h",
     "testing/mock_generic_stub.h",
     "testing/mock_hash_function.h",
+    "testing/mock_hash_validator.h",
     "testing/mock_http_request.h",
     "testing/mock_resume_policy.h",
     "testing/mock_storage_stub.h",

--- a/google/cloud/storage/testing/mock_hash_validator.h
+++ b/google/cloud/storage/testing/mock_hash_validator.h
@@ -1,0 +1,41 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_TESTING_MOCK_HASH_VALIDATOR_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_TESTING_MOCK_HASH_VALIDATOR_H
+
+#include "google/cloud/storage/internal/hash_validator.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+namespace testing {
+
+class MockHashValidator : public storage::internal::HashValidator {
+ public:
+  MOCK_METHOD(std::string, Name, (), (const, override));
+  MOCK_METHOD(void, ProcessMetadata, (ObjectMetadata const&), (override));
+  MOCK_METHOD(void, ProcessHashValues, (storage::internal::HashValues const&),
+              (override));
+  MOCK_METHOD(HashValidator::Result, Finish, (storage::internal::HashValues),
+              (ref(&&), override));
+};
+
+}  // namespace testing
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_TESTING_MOCK_HASH_VALIDATOR_H


### PR DESCRIPTION
Full object downloads include the full object checksums, which can be used to validate the download. Note that per-message checksums cannot detect if some messages are missing, duplicated, or reordered.

Fixes #12116

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13795)
<!-- Reviewable:end -->
