### PR TITLE
test(spanner): add expectations for missing emulator functionality

### DIFF
--- a/google/cloud/spanner/admin/integration_tests/backup_extra_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/backup_extra_integration_test.cc
@@ -378,7 +378,7 @@ TEST_F(BackupExtraIntegrationTest, CreateBackupWithFutureVersionTime) {
 
 /// @test Tests backup/restore with Customer Managed Encryption Key
 TEST_F(BackupExtraIntegrationTest, BackupRestoreWithCMEK) {
-  if (!RunSlowBackupTests() || Emulator()) GTEST_SKIP();
+  if (!RunSlowBackupTests()) GTEST_SKIP();
 
   auto instance_id = spanner_testing::PickRandomInstance(
       generator_, ProjectId(),
@@ -389,6 +389,10 @@ TEST_F(BackupExtraIntegrationTest, BackupRestoreWithCMEK) {
   Instance in(ProjectId(), *instance_id);
 
   auto location = spanner_testing::InstanceLocation(in);
+  if (Emulator()) {
+    EXPECT_THAT(location, StatusIs(StatusCode::kUnavailable));
+    return;
+  }
   ASSERT_STATUS_OK(location);
   KmsKeyName encryption_key(in.project_id(), *location, kKeyRing, kKeyName);
 

--- a/google/cloud/spanner/admin/integration_tests/database_admin_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/database_admin_integration_test.cc
@@ -167,8 +167,10 @@ TEST_F(DatabaseAdminClientTest, DatabaseBasicCRUD) {
   EXPECT_EQ(database->name(), list_db->name());
   EXPECT_EQ(database->database_dialect(), list_db->database_dialect());
 
-  if (!emulator_) {
-    auto current_policy = client_.GetIamPolicy(database_.FullName());
+  auto current_policy = client_.GetIamPolicy(database_.FullName());
+  if (emulator_) {
+    EXPECT_THAT(current_policy, StatusIs(StatusCode::kUnimplemented));
+  } else {
     ASSERT_STATUS_OK(current_policy);
     EXPECT_EQ(0, current_policy->bindings_size());
 
@@ -227,10 +229,8 @@ TEST_F(DatabaseAdminClientTest, DatabaseBasicCRUD) {
   EXPECT_EQ(0, get_ddl_result->statements_size());
 
   std::vector<std::string> statements;
-  if (!emulator_) {  // version_retention_period
-    statements.push_back("ALTER DATABASE `" + database_.database_id() +
-                         "` SET OPTIONS (version_retention_period='7d')");
-  }
+  statements.push_back("ALTER DATABASE `" + database_.database_id() +
+                       "` SET OPTIONS (version_retention_period='7d')");
   statements.emplace_back(R"""(
         CREATE TABLE Singers (
           SingerId      INT64 NOT NULL,
@@ -242,17 +242,22 @@ TEST_F(DatabaseAdminClientTest, DatabaseBasicCRUD) {
       )""");
   auto metadata =
       client_.UpdateDatabaseDdl(database_.FullName(), statements).get();
-  ASSERT_STATUS_OK(metadata);
-  EXPECT_THAT(metadata->database(), EndsWith(database_.database_id()));
-  EXPECT_EQ(statements.size(), metadata->statements_size());
-  EXPECT_EQ(statements.size(), metadata->commit_timestamps_size());
-  if (metadata->statements_size() >= 1) {
-    EXPECT_THAT(metadata->statements(), Contains(HasSubstr("CREATE TABLE")));
+  if (emulator_) {  // version_retention_period
+    EXPECT_THAT(metadata, StatusIs(StatusCode::kInvalidArgument));
+  } else {
+    ASSERT_STATUS_OK(metadata);
+    EXPECT_THAT(metadata->database(), EndsWith(database_.database_id()));
+    EXPECT_EQ(statements.size(), metadata->statements_size());
+    EXPECT_EQ(statements.size(), metadata->commit_timestamps_size());
+    if (metadata->statements_size() >= 1) {
+      EXPECT_THAT(metadata->statements(), Contains(HasSubstr("CREATE TABLE")));
+    }
+    if (metadata->statements_size() >= 2) {
+      EXPECT_THAT(metadata->statements(),
+                  Contains(HasSubstr("ALTER DATABASE")));
+    }
+    EXPECT_FALSE(metadata->throttled());
   }
-  if (metadata->statements_size() >= 2) {
-    EXPECT_THAT(metadata->statements(), Contains(HasSubstr("ALTER DATABASE")));
-  }
-  EXPECT_FALSE(metadata->throttled());
 
   // Verify that a new role can be created and returned.
   statements.clear();
@@ -328,11 +333,7 @@ TEST_F(DatabaseAdminClientTest, VersionRetentionPeriodCreate) {
   ASSERT_THAT(list_db, IsOk());
   EXPECT_EQ(database->name(), list_db->name());
   EXPECT_EQ(database->database_dialect(), list_db->database_dialect());
-  if (emulator_) {  // version_retention_period
-    EXPECT_EQ("", list_db->version_retention_period());
-  } else {
-    EXPECT_EQ("7d", list_db->version_retention_period());
-  }
+  EXPECT_EQ("7d", list_db->version_retention_period());
 
   auto drop = client_.DropDatabase(database_.FullName());
   EXPECT_THAT(drop, IsOk());
@@ -417,6 +418,8 @@ TEST_F(DatabaseAdminClientTest, VersionRetentionPeriodUpdate) {
   auto ddl = client_.GetDatabaseDdl(database_.FullName());
   ASSERT_THAT(ddl, IsOk());
   if (emulator_) {  // version_retention_period
+    EXPECT_THAT(ddl->statements(),
+                Not(Contains(ContainsRegex("version_retention_period *= *"))));
   } else {
     EXPECT_THAT(ddl->statements(),
                 Contains(ContainsRegex("version_retention_period *= *'7d'")));
@@ -475,7 +478,6 @@ TEST_F(DatabaseAdminClientTest, VersionRetentionPeriodUpdateFailure) {
 
 /// @test Verify we can create a database with an encryption key.
 TEST_F(DatabaseAdminClientTest, CreateWithEncryptionKey) {
-  if (emulator_) GTEST_SKIP() << "emulator does not support CMEK";
   KmsKeyName encryption_key(instance_.project_id(), location_, kKeyRing,
                             kKeyName);
   google::spanner::admin::database::v1::CreateDatabaseRequest creq;
@@ -486,35 +488,39 @@ TEST_F(DatabaseAdminClientTest, CreateWithEncryptionKey) {
   auto database = client_.CreateDatabase(creq).get();
   ASSERT_STATUS_OK(database);
   EXPECT_EQ(database->name(), database_.FullName());
-  EXPECT_TRUE(database->has_encryption_config());
-  if (database->has_encryption_config()) {
-    EXPECT_EQ(database->encryption_config().kms_key_name(),
-              encryption_key.FullName());
-  }
-
-  auto get_result = client_.GetDatabase(database_.FullName());
-  ASSERT_STATUS_OK(get_result);
-  EXPECT_EQ(database->name(), get_result->name());
-  EXPECT_TRUE(get_result->has_encryption_config());
-  if (get_result->has_encryption_config()) {
-    EXPECT_EQ(get_result->encryption_config().kms_key_name(),
-              encryption_key.FullName());
-  }
-
-  // Verify that encryption config is returned via ListDatabases().
-  auto list_db = [&] {
-    for (auto const& db :
-         client_.ListDatabases(database_.instance().FullName())) {
-      if (db && db->name() == database_.FullName()) return db;
+  if (emulator_) {
+    EXPECT_FALSE(database->has_encryption_config());
+  } else {
+    EXPECT_TRUE(database->has_encryption_config());
+    if (database->has_encryption_config()) {
+      EXPECT_EQ(database->encryption_config().kms_key_name(),
+                encryption_key.FullName());
     }
-    return StatusOr<google::spanner::admin::database::v1::Database>{
-        Status{StatusCode::kNotFound, "disappeared"}};
-  }();
-  ASSERT_THAT(list_db, IsOk());
-  EXPECT_TRUE(list_db->has_encryption_config());
-  if (list_db->has_encryption_config()) {
-    EXPECT_EQ(list_db->encryption_config().kms_key_name(),
-              encryption_key.FullName());
+
+    auto get_result = client_.GetDatabase(database_.FullName());
+    ASSERT_STATUS_OK(get_result);
+    EXPECT_EQ(database->name(), get_result->name());
+    EXPECT_TRUE(get_result->has_encryption_config());
+    if (get_result->has_encryption_config()) {
+      EXPECT_EQ(get_result->encryption_config().kms_key_name(),
+                encryption_key.FullName());
+    }
+
+    // Verify that encryption config is returned via ListDatabases().
+    auto list_db = [&] {
+      for (auto const& db :
+           client_.ListDatabases(database_.instance().FullName())) {
+        if (db && db->name() == database_.FullName()) return db;
+      }
+      return StatusOr<google::spanner::admin::database::v1::Database>{
+          Status{StatusCode::kNotFound, "disappeared"}};
+    }();
+    ASSERT_THAT(list_db, IsOk());
+    EXPECT_TRUE(list_db->has_encryption_config());
+    if (list_db->has_encryption_config()) {
+      EXPECT_EQ(list_db->encryption_config().kms_key_name(),
+                encryption_key.FullName());
+    }
   }
 
   EXPECT_STATUS_OK(client_.DropDatabase(database_.FullName()));
@@ -523,7 +529,6 @@ TEST_F(DatabaseAdminClientTest, CreateWithEncryptionKey) {
 /// @test Verify creating a database fails if a nonexistent encryption key is
 /// supplied.
 TEST_F(DatabaseAdminClientTest, CreateWithNonexistentEncryptionKey) {
-  if (emulator_) GTEST_SKIP() << "emulator does not support CMEK";
   KmsKeyName nonexistent_encryption_key(instance_.project_id(), location_,
                                         kKeyRing, "ceci-n-est-pas-une-cle");
   google::spanner::admin::database::v1::CreateDatabaseRequest creq;
@@ -533,8 +538,14 @@ TEST_F(DatabaseAdminClientTest, CreateWithNonexistentEncryptionKey) {
   creq.mutable_encryption_config()->set_kms_key_name(
       nonexistent_encryption_key.FullName());
   auto database = client_.CreateDatabase(creq).get();
-  EXPECT_THAT(database, StatusIs(StatusCode::kFailedPrecondition,
-                                 HasSubstr("KMS Key provided is not usable")));
+  if (emulator_) {
+    ASSERT_STATUS_OK(database);
+    EXPECT_STATUS_OK(client_.DropDatabase(database->name()));
+  } else {
+    EXPECT_THAT(database,
+                StatusIs(StatusCode::kFailedPrecondition,
+                         HasSubstr("KMS Key provided is not usable")));
+  }
 }
 
 /// @test Verify basic operations for PostgreSQL-type databases.
@@ -549,14 +560,14 @@ TEST_F(DatabaseAdminClientTest, DatabasePostgreSQLBasics) {
   ASSERT_STATUS_OK(database);
   EXPECT_THAT(database->name(), EndsWith(database_.database_id()));
   if (emulator_) {
-    // This will let us know when the emulator starts supporting PostgreSql.
     EXPECT_EQ(database->database_dialect(),
               google::spanner::admin::database::v1::DatabaseDialect::
                   DATABASE_DIALECT_UNSPECIFIED);
-    GTEST_SKIP() << "emulator does not support PostgreSQL";
+  } else {
+    EXPECT_EQ(
+        database->database_dialect(),
+        google::spanner::admin::database::v1::DatabaseDialect::POSTGRESQL);
   }
-  EXPECT_EQ(database->database_dialect(),
-            google::spanner::admin::database::v1::DatabaseDialect::POSTGRESQL);
 
   // Verify that GetDatabase() returns the correct dialect.
   auto get = client_.GetDatabase(database->name());

--- a/google/cloud/spanner/admin/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/instance_admin_integration_test.cc
@@ -199,7 +199,9 @@ TEST_F(InstanceAdminClientTest, InstanceCRUDOperations) {
                                      .SetNodeCount(2)
                                      .Build())
                  .get();
-  if (!Emulator() || instance) {
+  if (Emulator()) {
+    EXPECT_THAT(instance, StatusIs(StatusCode::kUnimplemented));
+  } else {
     EXPECT_STATUS_OK(instance);
     if (instance) {
       EXPECT_EQ(instance->display_name(), "New display name");
@@ -350,8 +352,8 @@ TEST_F(InstanceAdminClientTest, InstanceIam) {
   ASSERT_FALSE(in.instance_id().empty());
 
   auto actual_policy = client_.GetIamPolicy(in.FullName());
-  if (Emulator() &&
-      actual_policy.status().code() == StatusCode::kUnimplemented) {
+  if (Emulator()) {
+    EXPECT_THAT(actual_policy, StatusIs(StatusCode::kUnimplemented));
     GTEST_SKIP() << "emulator does not support IAM policies";
   }
   ASSERT_STATUS_OK(actual_policy);

--- a/google/cloud/spanner/admin/integration_tests/instance_admin_rest_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/instance_admin_rest_integration_test.cc
@@ -242,7 +242,9 @@ TEST_F(InstanceAdminClientRestTest, InstanceCRUDOperations) {
                                      .SetNodeCount(2)
                                      .Build())
                  .get();
-  if (!Emulator() || instance) {
+  if (Emulator()) {
+    EXPECT_THAT(instance, StatusIs(StatusCode::kInternal));
+  } else {
     EXPECT_STATUS_OK(instance);
     if (instance) {
       EXPECT_EQ(instance->display_name(), "New display name");

--- a/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
@@ -144,7 +144,7 @@ TEST_F(InstanceAdminClientTest, InstanceReadOperations) {
 
 /// @test Verify the basic CRUD operations for instances work.
 TEST_F(InstanceAdminClientTest, InstanceCRUDOperations) {
-  if (!Emulator() && !RunSlowInstanceTests()) {
+  if (!RunSlowInstanceTests()) {
     GTEST_SKIP() << "skipping slow instance tests; set "
                  << "GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS=instance"
                  << " to override";
@@ -186,7 +186,9 @@ TEST_F(InstanceAdminClientTest, InstanceCRUDOperations) {
                                      .SetNodeCount(2)
                                      .Build())
                  .get();
-  if (!Emulator() || instance) {
+  if (Emulator()) {
+    EXPECT_THAT(instance, StatusIs(StatusCode::kUnimplemented));
+  } else {
     EXPECT_STATUS_OK(instance);
     if (instance) {
       EXPECT_EQ(instance->display_name(), "New display name");
@@ -228,8 +230,8 @@ TEST_F(InstanceAdminClientTest, InstanceIam) {
   ASSERT_FALSE(in.instance_id().empty());
 
   auto actual_policy = client_.GetIamPolicy(in);
-  if (Emulator() &&
-      actual_policy.status().code() == StatusCode::kUnimplemented) {
+  if (Emulator()) {
+    EXPECT_THAT(actual_policy, StatusIs(StatusCode::kUnimplemented));
     GTEST_SKIP() << "emulator does not support IAM policies";
   }
   ASSERT_STATUS_OK(actual_policy);


### PR DESCRIPTION
Rather than sometimes simply skipping tests of features supposedly unsupported by the emulator, add expectations that the emulator actually fails in some way.

Some tests were already written with failure expectations, and that allowed us to actively discover what tests could be enabled after the recent SDK version update.  Extend that tactic here.

Indeed, this very process exposed some new cases where we no longer need to make allowance for emulator shortfalls.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13799)
<!-- Reviewable:end -->
