### PR TITLE
test(spanner): enable more samples on the emulator

### DIFF
--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -5414,16 +5414,14 @@ void RunAll(bool emulator) {
   SampleBanner("make-replace-mutation");
   MakeReplaceMutation(client);
 
-  if (!emulator) {
-    SampleBanner("spanner_update_dml_returning");
-    UpdateUsingDmlReturning(client);
+  SampleBanner("spanner_update_dml_returning");
+  UpdateUsingDmlReturning(client);
 
-    SampleBanner("spanner_insert_dml_returning");
-    InsertUsingDmlReturning(client);
+  SampleBanner("spanner_insert_dml_returning");
+  InsertUsingDmlReturning(client);
 
-    SampleBanner("spanner_delete_dml_returning");
-    DeleteUsingDmlReturning(client);
-  }
+  SampleBanner("spanner_delete_dml_returning");
+  DeleteUsingDmlReturning(client);
 
   SampleBanner("delete-mutation-builder");
   DeleteMutationBuilder(client);
@@ -5447,10 +5445,8 @@ void RunAll(bool emulator) {
               "Customers");
   }
 
-  if (!emulator) {
-    SampleBanner("spanner_query_information_schema_database_options");
-    QueryInformationSchemaDatabaseOptions(client);
-  }
+  SampleBanner("spanner_query_information_schema_database_options");
+  QueryInformationSchemaDatabaseOptions(client);
 
   if (!emulator) {
     SampleBanner("spanner_create_table_with_foreign_key_delete_cascade");


### PR DESCRIPTION
While it is inconvenient to actively notice new emulator support in the samples (unlike the integration tests in #13799), we can still do manual testing to remove obsolete exclusions after an SDK update.

Here we enable some of the Google SQL samples, and almost all of the PostgreSql samples, that were previously skipped on the emulator.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13803)
<!-- Reviewable:end -->
