### PR TITLE
cleanup: enable examples in `clang-tidy*` builds

### DIFF
--- a/ci/cloudbuild/builds/clang-tidy.sh
+++ b/ci/cloudbuild/builds/clang-tidy.sh
@@ -47,6 +47,7 @@ fi
 io::run cmake "${cmake_args[@]}" \
   -DCMAKE_CXX_CLANG_TIDY=/usr/local/bin/clang-tidy-wrapper \
   -DCMAKE_CXX_STANDARD=14 \
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=ON \
   -DGOOGLE_CLOUD_CPP_ENABLE="${ENABLED_FEATURES}" \
   -DGOOGLE_CLOUD_CPP_INTERNAL_DOCFX="${enable_docfx}"
 io::run cmake --build cmake-out

--- a/google/cloud/storage/quickstart/quickstart_async.cc
+++ b/google/cloud/storage/quickstart/quickstart_async.cc
@@ -23,9 +23,6 @@ int main(int argc, char* argv[]) {
   }
   std::string const bucket_name = argv[1];
 
-  // Create aliases to make the code easier to read.
-  namespace gcs = ::google::cloud::storage;
-
   // Create a client to communicate with Google Cloud Storage. This client
   // uses the default configuration for authentication and project id.
   auto client = google::cloud::storage_experimental::AsyncClient();

--- a/google/cloud/storage/quickstart/quickstart_grpc.cc
+++ b/google/cloud/storage/quickstart/quickstart_grpc.cc
@@ -24,9 +24,6 @@ int main(int argc, char* argv[]) {
   }
   std::string const bucket_name = argv[1];
 
-  // Create aliases to make the code easier to read.
-  namespace gcs = ::google::cloud::storage;
-
   // Create a client to communicate with Google Cloud Storage. This client
   // uses the default configuration for authentication and project id.
   auto client = google::cloud::storage_experimental::DefaultGrpcClient();


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13818)
<!-- Reviewable:end -->
