### PR TITLE
ci: Bazel builds use .cloudcxxrc

### DIFF
--- a/ci/cloudbuild/builds/asan.sh
+++ b/ci/cloudbuild/builds/asan.sh
@@ -18,12 +18,13 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/bazel.sh
+source module ci/cloudbuild/builds/lib/cloudcxxrc.sh
 source module ci/cloudbuild/builds/lib/integration.sh
 source module ci/lib/io.sh
 
 mapfile -t args < <(bazel::common_args)
 args+=("--config=asan")
-io::run bazel test "${args[@]}" --test_tag_filters=-integration-test ...
+io::run bazel test "${args[@]}" --test_tag_filters=-integration-test "${BAZEL_TARGETS[@]}"
 
 mapfile -t integration_args < <(integration::bazel_args)
 integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"

--- a/ci/cloudbuild/builds/bazel-oldest.sh
+++ b/ci/cloudbuild/builds/bazel-oldest.sh
@@ -20,9 +20,10 @@ export USE_BAZEL_VERSION=6.4.0
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/bazel.sh
+source module ci/cloudbuild/builds/lib/cloudcxxrc.sh
 
 export CC=clang
 export CXX=clang++
 
 mapfile -t args < <(bazel::common_args)
-bazel test "${args[@]}" --test_tag_filters=-integration-test ...
+bazel test "${args[@]}" --test_tag_filters=-integration-test "${BAZEL_TARGETS[@]}"

--- a/ci/cloudbuild/builds/bazel-otel-abi-2.sh
+++ b/ci/cloudbuild/builds/bazel-otel-abi-2.sh
@@ -18,7 +18,8 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/bazel.sh
+source module ci/cloudbuild/builds/lib/cloudcxxrc.sh
 
 mapfile -t args < <(bazel::common_args)
 args+=("--config=otel2")
-io::run bazel test "${args[@]}" --test_tag_filters=-integration-test ...
+io::run bazel test "${args[@]}" --test_tag_filters=-integration-test "${BAZEL_TARGETS[@]}"

--- a/ci/cloudbuild/builds/bazel-targets.sh
+++ b/ci/cloudbuild/builds/bazel-targets.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/bazel.sh
+source module ci/cloudbuild/builds/lib/cloudcxxrc.sh
 
 mapfile -t args < <(bazel::common_args)
 for repo_root in "ci/verify_current_targets" "ci/verify_deprecated_targets"; do

--- a/ci/cloudbuild/builds/conformance.sh
+++ b/ci/cloudbuild/builds/conformance.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/bazel.sh
+source module ci/cloudbuild/builds/lib/cloudcxxrc.sh
 source module ci/cloudbuild/builds/lib/conformance.sh
 source module ci/lib/io.sh
 

--- a/ci/cloudbuild/builds/coverage.sh
+++ b/ci/cloudbuild/builds/coverage.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/bazel.sh
+source module ci/cloudbuild/builds/lib/cloudcxxrc.sh
 source module ci/cloudbuild/builds/lib/integration.sh
 
 export CC=gcc
@@ -50,7 +51,7 @@ args+=("--instrument_test_targets")
 #     https://github.com/bazelbuild/bazel/issues/3236
 args+=("--sandbox_tmpfs_path=/tmp")
 io::log_h2 "Running coverage on non-integration tests."
-bazel coverage "${args[@]}" --test_tag_filters=-integration-test ...
+bazel coverage "${args[@]}" --test_tag_filters=-integration-test "${BAZEL_TARGETS[@]}"
 
 GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS="instance"
 mapfile -t integration_args < <(integration::bazel_args)

--- a/ci/cloudbuild/builds/development.sh
+++ b/ci/cloudbuild/builds/development.sh
@@ -20,24 +20,12 @@ source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
 source module ci/cloudbuild/builds/lib/features.sh
 source module ci/cloudbuild/builds/lib/integration.sh
+source module ci/cloudbuild/builds/lib/cloudcxxrc.sh
 source module ci/lib/io.sh
 
 export CC=clang
 export CXX=clang++
 export CTCACHE_DIR=~/.cache/ctcache
-
-# Load the build configuration. Start with the default, then any settings for
-# all workspaces, then the settings for the current workspace.
-#
-# Developers only need to override what changes, keep a configuration file that
-# applies to all their builds, and have some workspaces with custom settings.
-source module ci/etc/cloudcxxrc
-if [[ -r "${HOME}/.cloudcxxrc" ]]; then
-  source "${HOME}/.cloudcxxrc"
-fi
-if [[ -r "${PROJECT_ROOT}/.cloudcxxrc" ]]; then
-  source "${PROJECT_ROOT}/.cloudcxxrc"
-fi
 
 # Always remove the CMakeCache because it may be invalidated by `cloudcxxrc`
 # changes.

--- a/ci/cloudbuild/builds/grpc-at-head.sh
+++ b/ci/cloudbuild/builds/grpc-at-head.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/bazel.sh
+source module ci/cloudbuild/builds/lib/cloudcxxrc.sh
 source module ci/cloudbuild/builds/lib/integration.sh
 
 rm -fr /h/grpc && git -C /h clone -q --depth 1 https://github.com/grpc/grpc.git
@@ -30,7 +31,7 @@ args+=(
   "--override_repository=com_github_grpc_grpc=/h/grpc"
   "--override_repository=com_google_protobuf=/h/protobuf"
 )
-bazel test "${args[@]}" --test_tag_filters=-integration-test ...
+bazel test "${args[@]}" --test_tag_filters=-integration-test "${BAZEL_TARGETS[@]}"
 
 mapfile -t integration_args < <(integration::bazel_args)
 integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"

--- a/ci/cloudbuild/builds/integration-production.sh
+++ b/ci/cloudbuild/builds/integration-production.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/bazel.sh
+source module ci/cloudbuild/builds/lib/cloudcxxrc.sh
 source module ci/cloudbuild/builds/lib/git.sh
 source module ci/cloudbuild/builds/lib/integration.sh
 source module ci/lib/io.sh
@@ -26,7 +27,7 @@ export CC=clang
 export CXX=clang++
 
 mapfile -t args < <(bazel::common_args)
-bazel test "${args[@]}" --test_tag_filters=-integration-test ...
+io::run bazel test "${args[@]}" --test_tag_filters=-integration-test "${BAZEL_TARGETS[@]}"
 
 excluded_rules=(
   "-//examples:grpc_credential_types"
@@ -40,4 +41,4 @@ io::log_h2 "Running the integration tests against prod"
 mapfile -t integration_args < <(integration::bazel_args)
 io::run bazel test "${args[@]}" "${integration_args[@]}" \
   --cache_test_results="auto" --test_tag_filters="integration-test" \
-  -- ... "${excluded_rules[@]}"
+  -- "${BAZEL_TARGETS[@]}" "${excluded_rules[@]}"

--- a/ci/cloudbuild/builds/lib/cloudcxxrc.sh
+++ b/ci/cloudbuild/builds/lib/cloudcxxrc.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Make our include guard clean against set -o nounset.
+test -n "${CI_CLOUDBUILD_BUILDS_LIB_CLOUDCXXRC_SH__:-}" || declare -i CI_CLOUDBUILD_BUILDS_LIB_CLOUDCXXRC_SH__=0
+if ((CI_CLOUDBUILD_BUILDS_LIB_CLOUDCXXRC_SH__++ != 0)); then
+  return 0
+fi # include guard
+
+# Load vuild customizations. Start with the default, then any settings for
+# all workspaces, then the settings for the current workspace.
+#
+# Developers only need to override what changes, keep a configuration file that
+# applies to all their builds, and have some workspaces with custom settings.
+source module ci/etc/cloudcxxrc
+if [[ -r "${HOME}/.cloudcxxrc" ]]; then
+  source "${HOME}/.cloudcxxrc"
+fi
+if [[ -r "${PROJECT_ROOT}/.cloudcxxrc" ]]; then
+  source "${PROJECT_ROOT}/.cloudcxxrc"
+fi

--- a/ci/cloudbuild/builds/lib/cloudcxxrc.sh
+++ b/ci/cloudbuild/builds/lib/cloudcxxrc.sh
@@ -38,7 +38,7 @@ function bazel::has_no_tests() {
   shift
   query_expr="$(printf '+ %s' "${BAZEL_TARGETS[@]}")"
   query_expr="tests(${query_expr:2} intersect ${target})"
-  if ! bazel query --noshow_progress "${query_expr}" | grep -q "${target}" ; then
+  if ! bazel query --noshow_progress "${query_expr}" | grep -q "${target}"; then
     return 0
   fi
   return 1

--- a/ci/cloudbuild/builds/lib/cloudcxxrc.sh
+++ b/ci/cloudbuild/builds/lib/cloudcxxrc.sh
@@ -20,7 +20,7 @@ if ((CI_CLOUDBUILD_BUILDS_LIB_CLOUDCXXRC_SH__++ != 0)); then
   return 0
 fi # include guard
 
-# Load vuild customizations. Start with the default, then any settings for
+# Load build customizations. Start with the default, then any settings for
 # all workspaces, then the settings for the current workspace.
 #
 # Developers only need to override what changes, keep a configuration file that
@@ -32,3 +32,14 @@ fi
 if [[ -r "${PROJECT_ROOT}/.cloudcxxrc" ]]; then
   source "${PROJECT_ROOT}/.cloudcxxrc"
 fi
+
+function bazel::has_no_tests() {
+  local target=$1
+  shift
+  query_expr="$(printf '+ %s' "${BAZEL_TARGETS[@]}")"
+  query_expr="tests(${query_expr:2} intersect ${target})"
+  if ! bazel query --noshow_progress "${query_expr}" | grep -q "${target}" ; then
+    return 0
+  fi
+  return 1
+}

--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -180,11 +180,6 @@ function integration::bazel_with_emulators() {
     production_tests_tag_filters="integration-test,-no-msan"
   fi
 
-  io::log_h2 "Running integration tests that require production access"
-  bazel "${verb}" "${args[@]}" \
-    --test_tag_filters="${production_tests_tag_filters}" \
-    "${production_integration_tests[@]}"
-
   io::log_h2 "Running Pub/Sub integration tests (with emulator)"
   "google/cloud/pubsub/ci/${EMULATOR_SCRIPT}" \
     bazel "${verb}" "${args[@]}" --test_tag_filters="integration-test"
@@ -204,6 +199,16 @@ function integration::bazel_with_emulators() {
   io::log_h2 "Running REST integration tests (with emulator)"
   "google/cloud/internal/ci/${EMULATOR_SCRIPT}" \
     bazel "${verb}" "${args[@]}" --test_tag_filters="integration-test"
+
+  if [[ "${BAZEL_TARGETS[*]}" != "..." ]]; then
+    io::log_h2 "Skipping some integration tests because BAZEL_TARGETS is not the default"
+    return 0
+  fi
+
+  io::log_h2 "Running integration tests that require production access"
+  bazel "${verb}" "${args[@]}" \
+    --test_tag_filters="${production_tests_tag_filters}" \
+    "${production_integration_tests[@]}"
 
   # This test is run separately because the access token changes every time and
   # that would mess up bazel's test cache for all the other tests.

--- a/ci/cloudbuild/builds/libcxx.sh
+++ b/ci/cloudbuild/builds/libcxx.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/bazel.sh
+source module ci/cloudbuild/builds/lib/cloudcxxrc.sh
 source module ci/cloudbuild/builds/lib/integration.sh
 
 export CC=clang
@@ -25,7 +26,7 @@ export CXX=clang++
 
 mapfile -t args < <(bazel::common_args)
 args+=("--config=libcxx")
-bazel test "${args[@]}" --test_tag_filters=-integration-test ...
+bazel test "${args[@]}" --test_tag_filters=-integration-test "${BAZEL_TARGETS[@]}"
 
 mapfile -t integration_args < <(integration::bazel_args)
 integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"

--- a/ci/cloudbuild/builds/msan.sh
+++ b/ci/cloudbuild/builds/msan.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/bazel.sh
+source module ci/cloudbuild/builds/lib/cloudcxxrc.sh
 source module ci/cloudbuild/builds/lib/integration.sh
 source module ci/lib/io.sh
 
@@ -26,7 +27,7 @@ export CXX=clang++
 
 mapfile -t args < <(bazel::common_args)
 args+=("--config=msan")
-io::run bazel test "${args[@]}" --test_tag_filters=-integration-test,-no-msan ...
+io::run bazel test "${args[@]}" --test_tag_filters=-integration-test,-no-msan "${BAZEL_TARGETS[@]}"
 
 mapfile -t integration_args < <(integration::bazel_args)
 integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"

--- a/ci/cloudbuild/builds/otel-disabled-bazel.sh
+++ b/ci/cloudbuild/builds/otel-disabled-bazel.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/bazel.sh
+source module ci/cloudbuild/builds/lib/cloudcxxrc.sh
 
 export CC=clang
 export CXX=clang++
@@ -33,4 +34,4 @@ ignore=(
   # depends on google-cloud-cpp being built with OpenTelemetry.
   "-//google/cloud/opentelemetry/quickstart/..."
 )
-bazel test "${args[@]}" --test_tag_filters=-integration-test -- ... "${ignore[@]}"
+bazel test "${args[@]}" --test_tag_filters=-integration-test -- "${BAZEL_TARGETS[@]}" "${ignore[@]}"

--- a/ci/cloudbuild/builds/protobuf-at-head.sh
+++ b/ci/cloudbuild/builds/protobuf-at-head.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/bazel.sh
+source module ci/cloudbuild/builds/lib/cloudcxxrc.sh
 source module ci/cloudbuild/builds/lib/integration.sh
 
 rm -fr /h/protobuf && git -C /h clone -q --depth 1 https://github.com/protocolbuffers/protobuf.git
@@ -26,7 +27,7 @@ mapfile -t args < <(bazel::common_args)
 args+=(
   "--override_repository=com_google_protobuf=/h/protobuf"
 )
-bazel test "${args[@]}" --test_tag_filters=-integration-test ...
+bazel test "${args[@]}" --test_tag_filters=-integration-test "${BAZEL_TARGETS[@]}"
 
 mapfile -t integration_args < <(integration::bazel_args)
 integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"

--- a/ci/cloudbuild/builds/tsan.sh
+++ b/ci/cloudbuild/builds/tsan.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/bazel.sh
+source module ci/cloudbuild/builds/lib/cloudcxxrc.sh
 source module ci/cloudbuild/builds/lib/integration.sh
 source module ci/lib/io.sh
 
@@ -28,7 +29,7 @@ mapfile -t args < <(bazel::common_args)
 args+=("--config=tsan")
 # report_atomic_races=0: https://github.com/google/sanitizers/issues/953
 args+=("--test_env=TSAN_OPTIONS=suppressions=${PROJECT_ROOT}/ci/tsan_suppressions.txt:halt_on_error=1:second_deadlock_stack=1:report_atomic_races=0")
-io::run bazel test "${args[@]}" --test_tag_filters=-integration-test ...
+io::run bazel test "${args[@]}" --test_tag_filters=-integration-test "${BAZEL_TARGETS[@]}"
 
 mapfile -t integration_args < <(integration::bazel_args)
 integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"

--- a/ci/cloudbuild/builds/ubsan.sh
+++ b/ci/cloudbuild/builds/ubsan.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/bazel.sh
+source module ci/cloudbuild/builds/lib/cloudcxxrc.sh
 source module ci/cloudbuild/builds/lib/integration.sh
 source module ci/lib/io.sh
 
@@ -31,7 +32,7 @@ deleted_packages="$(find google/cloud -type d -name quickstart -o -name demo | x
 mapfile -t args < <(bazel::common_args)
 args+=("--config=ubsan")
 args+=("--deleted_packages=${deleted_packages:1}")
-io::run bazel test "${args[@]}" --test_tag_filters=-integration-test ...
+io::run bazel test "${args[@]}" --test_tag_filters=-integration-test "${BAZEL_TARGETS[@]}"
 
 mapfile -t integration_args < <(integration::bazel_args)
 integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"

--- a/ci/cloudbuild/builds/xsan.sh
+++ b/ci/cloudbuild/builds/xsan.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/bazel.sh
+source module ci/cloudbuild/builds/lib/cloudcxxrc.sh
 source module ci/cloudbuild/builds/lib/integration.sh
 source module ci/lib/io.sh
 
@@ -26,7 +27,7 @@ export CXX=clang++
 
 mapfile -t args < <(bazel::common_args)
 args+=("--config=xsan")
-io::run bazel test "${args[@]}" --test_tag_filters=-integration-test ...
+io::run bazel test "${args[@]}" --test_tag_filters=-integration-test "${BAZEL_TARGETS[@]}"
 
 mapfile -t integration_args < <(integration::bazel_args)
 integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"

--- a/ci/etc/cloudcxxrc
+++ b/ci/etc/cloudcxxrc
@@ -20,6 +20,9 @@ ALWAYS_RESET_CMAKE_CACHE=NO
 # By default compile most features.
 ENABLED_FEATURES=__ga_libraries__,__experimental_libraries__,opentelemetry,experimental-storage_grpc
 
+# By default compile all the code.
+BAZEL_TARGETS=("...")
+
 # Set to `YES` to run the unit tests.
 RUN_UNIT_TESTS=YES
 

--- a/google/cloud/bigtable/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/bigtable/ci/run_integration_tests_emulator_bazel.sh
@@ -17,6 +17,7 @@
 set -euo pipefail
 
 source "$(dirname "$0")/../../../../ci/lib/init.sh"
+source module /ci/cloudbuild/builds/lib/cloudcxxrc.sh
 
 if [[ $# -lt 1 ]]; then
   echo "Usage: $(basename "$0") <bazel-program> [bazel-test-args]"
@@ -28,6 +29,10 @@ shift
 BAZEL_VERB="$1"
 shift
 bazel_test_args=("$@")
+
+if bazel::has_no_tests "//google/cloud/bigtable/..." "${BAZEL_TARGETS[@]}"; then
+  exit 0
+fi
 
 # Configure run_emulators_utils.sh to find the instance admin emulator.
 BAZEL_BIN_DIR="$("${BAZEL_BIN}" info bazel-bin)"

--- a/google/cloud/internal/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/internal/ci/run_integration_tests_emulator_bazel.sh
@@ -17,6 +17,7 @@
 set -euo pipefail
 
 source "$(dirname "$0")/../../../../ci/lib/init.sh"
+source module /ci/cloudbuild/builds/lib/cloudcxxrc.sh
 source module /ci/lib/run_gcs_httpbin_emulator_utils.sh
 
 if [[ $# -lt 1 ]]; then
@@ -28,6 +29,10 @@ BAZEL_BIN="$1"
 shift
 BAZEL_VERB="$1"
 shift
+
+if bazel::has_no_tests "//google/cloud:all"; then
+  exit 0
+fi
 
 # Separate caller-provided excluded targets (starting with "-//..."), so that
 # we can make sure those appear on the command line after `--`.

--- a/google/cloud/pubsub/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/pubsub/ci/run_integration_tests_emulator_bazel.sh
@@ -17,6 +17,7 @@
 set -euo pipefail
 
 source "$(dirname "$0")/../../../../ci/lib/init.sh"
+source module /ci/cloudbuild/builds/lib/cloudcxxrc.sh
 source module /google/cloud/pubsub/ci/lib/pubsub_emulator.sh
 
 if [[ $# -lt 1 ]]; then
@@ -29,6 +30,10 @@ shift
 BAZEL_VERB="$1"
 shift
 bazel_test_args=("$@")
+
+if bazel::has_no_tests "//google/cloud/pubsub/..."; then
+  exit 0
+fi
 
 # These can only run against production
 production_only_targets=(

--- a/google/cloud/spanner/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/spanner/ci/run_integration_tests_emulator_bazel.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../../../ci/lib/init.sh"
 source module /ci/lib/io.sh
+source module /ci/cloudbuild/builds/lib/cloudcxxrc.sh
 source module /google/cloud/spanner/ci/lib/spanner_emulator.sh
 
 if [[ $# -lt 2 ]]; then
@@ -30,6 +31,10 @@ shift
 BAZEL_VERB="$1"
 shift
 bazel_test_args=("$@")
+
+if bazel::has_no_tests "//google/cloud/spanner/..."; then
+  exit 0
+fi
 
 # Run in $HOME because spanner_emulator::start creates unsightly *.log
 # files in the workspace otherwise.

--- a/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
@@ -17,6 +17,7 @@
 set -euo pipefail
 
 source "$(dirname "$0")/../../../../ci/lib/init.sh"
+source module /ci/cloudbuild/builds/lib/cloudcxxrc.sh
 source module /ci/lib/run_gcs_httpbin_emulator_utils.sh
 
 if [[ $# -lt 1 ]]; then
@@ -32,6 +33,10 @@ shift
 
 bazel_test_args=()
 excluded_targets=()
+
+if bazel::has_no_tests "//google/cloud/storage/..."; then
+  exit 0
+fi
 
 # Separate caller-provided excluded targets (starting with "-//..."), so that
 # we can make sure those appear on the command line after `--`.


### PR DESCRIPTION
Sometimes we want to run the build scripts on our workstations, but we are only interested in storage, or pubsub, or spanner. We can do this for CMake-builds using `.cloudcxxrc` and the `development.sh` build. With this change any Bazel-based build can be configured to compile a subset of the targets.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13824)
<!-- Reviewable:end -->
