### PR TITLE
test(spanner): clarify emulator startup messages and comments

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -223,8 +223,8 @@ if [[ "${LOCAL_FLAG}" = "true" ]]; then
   fi
 
   if [[ "${TRIGGER_TYPE}" != "manual" || "${VERBOSE_FLAG}" == "true" ]]; then
-    # Prints information about the machine and compiler. In manual builds this
-    # information is almost never useful.
+    # Prints information about the machine, compiler, and gcloud.
+    # In manual builds this information is almost never useful.
     io::log_h1 "Machine Info"
     printf "%10s %s\n" "host:" "$(date -u --rfc-3339=seconds)"
     printf "%10s %s\n" "google:" "$(date -ud "$(google_time)" --rfc-3339=seconds)"
@@ -236,6 +236,10 @@ if [[ "${LOCAL_FLAG}" = "true" ]]; then
     printf "%10s %s\n" "gcc:" "$(gcc --version 2>&1 | head -1)"
     printf "%10s %s\n" "clang:" "$(clang --version 2>&1 | head -1)"
     printf "%10s %s\n" "cc:" "$(cc --version 2>&1 | head -1)"
+    if type gcloud >/dev/null 2>&1; then
+      io::log_h1 "gcloud Versions"
+      gcloud --version
+    fi
   fi
 
   io::log_h1 "Starting local build: ${BUILD_FLAG}"


### PR DESCRIPTION
Cleanup the messages and comments surrounding the launch of the Spanner gRPC and HTTP emulators.

Also take this opportunity to log the Cloud SDK component versions during startup, when applicable.  This will allow us to clearly see the emulator release, for example.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13831)
<!-- Reviewable:end -->
