### PR TITLE
fix(compute): shorten paths for Bazel+MSVC

### DIFF
--- a/google/cloud/compute/BUILD.bazel
+++ b/google/cloud/compute/BUILD.bazel
@@ -86,7 +86,9 @@ licenses(["notice"])  # Apache 2.0
 ) for service in service_dirs]
 
 [cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
+    # Sample names include the name of the client, which is unique. Removing
+    # the directory saves enough characters to stay within the MSVC limitations.
+    name = sample[sample.rfind("/") + 1:].replace(".cc", ""),
     srcs = [sample],
     tags = ["integration-test"],
     deps = [

--- a/google/cloud/compute/BUILD.bazel
+++ b/google/cloud/compute/BUILD.bazel
@@ -56,12 +56,12 @@ licenses(["notice"])  # Apache 2.0
     hdrs = [":" + service.replace("/v1/", "_hdrs")],
     visibility = ["//:__pkg__"],
     deps = [
-        "//protos/google/cloud/compute:" + service.replace("/v1/", "") + "_cc_proto",
         "//:common",
         "//:grpc_utils",
         "//google/cloud:google_cloud_cpp_rest_internal",
         "//google/cloud:google_cloud_cpp_rest_protobuf_internal",
         "//protos:system_includes",
+        "//protos/google/cloud/compute:cc_proto",
     ],
 ) for service in operation_service_dirs]
 
@@ -76,12 +76,12 @@ licenses(["notice"])  # Apache 2.0
         ":google_cloud_cpp_compute_global_organization_operations",
         ":google_cloud_cpp_compute_region_operations",
         ":google_cloud_cpp_compute_zone_operations",
-        "//protos/google/cloud/compute:" + service.replace("/v1/", "") + "_cc_proto",
         "//:common",
         "//:grpc_utils",
         "//google/cloud:google_cloud_cpp_rest_internal",
         "//google/cloud:google_cloud_cpp_rest_protobuf_internal",
         "//protos:system_includes",
+        "//protos/google/cloud/compute:cc_proto",
     ],
 ) for service in service_dirs]
 

--- a/google/cloud/compute/CMakeLists.txt
+++ b/google/cloud/compute/CMakeLists.txt
@@ -68,22 +68,17 @@ list(APPEND DOXYGEN_EXAMPLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/samples"
      "${CMAKE_CURRENT_SOURCE_DIR}/quickstart")
 include(GoogleCloudCppDoxygen)
 
-foreach (dir IN LISTS service_dirs operation_service_dirs)
-    string(REPLACE "/v1/" "" short_dir "${dir}")
-    list(APPEND compute_proto_lib_targets "compute_${short_dir}_protos")
-endforeach ()
-
 set(GOOGLE_CLOUD_CPP_DOXYGEN_EXTRA_INCLUDES
     "${PROJECT_BINARY_DIR}/protos/google/cloud/compute")
 google_cloud_cpp_doxygen_targets("compute" THREADED DEPENDS cloud-docs
-                                 ${compute_proto_lib_targets})
+                                 "compute_protos")
 
 foreach (dir IN LISTS operation_service_dirs)
     string(REPLACE "/v1/" "" short_dir "${dir}")
     compute_service_library(
         ${dir} compute_${short_dir} DEPS
         google-cloud-cpp::rest_protobuf_internal
-        google-cloud-cpp::compute_${short_dir}_protos)
+        google-cloud-cpp::compute_protos)
     list(APPEND compute_operation_lib_targets "compute_${short_dir}")
 endforeach ()
 
@@ -93,7 +88,7 @@ foreach (dir IN LISTS service_dirs)
         ${dir}
         compute_${short_dir}
         DEPS
-        google-cloud-cpp::compute_${short_dir}_protos
+        google-cloud-cpp::compute_protos
         google-cloud-cpp::compute_global_operations
         google-cloud-cpp::compute_global_organization_operations
         google-cloud-cpp::compute_region_operations
@@ -214,7 +209,7 @@ foreach (dir IN LISTS operation_service_dirs)
         "google_cloud_cpp_rest_protobuf_internal"
         "google_cloud_cpp_grpc_utils"
         "google_cloud_cpp_common"
-        "google_cloud_cpp_compute_${short_dir}_protos")
+        "google_cloud_cpp_compute_protos")
 endforeach ()
 
 foreach (dir IN LISTS service_dirs)
@@ -228,7 +223,7 @@ foreach (dir IN LISTS service_dirs)
         "google_cloud_cpp_compute_global_organization_operations"
         "google_cloud_cpp_compute_region_operations"
         "google_cloud_cpp_compute_zone_operations"
-        "google_cloud_cpp_compute_${short_dir}_protos")
+        "google_cloud_cpp_compute_protos")
 endforeach ()
 
 set(compute_pc_modules ${compute_lib_targets})

--- a/protos/google/cloud/compute/BUILD.bazel
+++ b/protos/google/cloud/compute/BUILD.bazel
@@ -29,61 +29,40 @@ filegroup(
     srcs = glob(["v1/internal/*.proto"]),
 )
 
+# Service proto files
+[[
+    filegroup(
+        name = service.replace("/v1/", "_proto_srcs"),
+        srcs = glob([service + "*.proto"]),
+    ),
+] for service in service_dirs + operation_service_dirs]
+
 proto_library(
-    name = "internal_proto",
-    srcs = [":internal_protos"],
+    name = "proto",
+    srcs = [":internal_protos"] + [":" + service.replace("/v1/", "_proto_srcs") for service in service_dirs + operation_service_dirs],
     strip_import_prefix = "/protos",
     visibility = [
         "//:__pkg__",
         "//google/cloud/compute:__pkg__",
     ],
     deps = [
+        "@com_google_googleapis//google/api:annotations_proto",
+        "@com_google_googleapis//google/api:client_proto",
+        "@com_google_googleapis//google/api:field_behavior_proto",
+        "@com_google_googleapis//google/api:http_proto",
+        "@com_google_googleapis//google/api:resource_proto",
+        "@com_google_googleapis//google/api:routing_proto",
         "@com_google_googleapis//google/cloud:extended_operations_proto",
         "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:empty_proto",
     ],
 )
 
 cc_proto_library(
-    name = "internal_cc_proto",
+    name = "cc_proto",
     visibility = [
         "//:__pkg__",
         "//google/cloud/compute:__pkg__",
     ],
-    deps = [":internal_proto"],
+    deps = [":proto"],
 )
-
-# Service proto targets
-[[
-    filegroup(
-        name = service.replace("/v1/", "_proto_srcs"),
-        srcs = glob([service + "*.proto"]),
-    ),
-    proto_library(
-        name = service.replace("/v1/", "_proto"),
-        srcs = [":" + service.replace("/v1/", "_proto_srcs")],
-        strip_import_prefix = "/protos",
-        visibility = [
-            "//:__pkg__",
-            "//google/cloud/compute:__pkg__",
-        ],
-        deps = [
-            ":internal_proto",
-            "@com_google_googleapis//google/api:annotations_proto",
-            "@com_google_googleapis//google/api:client_proto",
-            "@com_google_googleapis//google/api:field_behavior_proto",
-            "@com_google_googleapis//google/api:http_proto",
-            "@com_google_googleapis//google/api:resource_proto",
-            "@com_google_googleapis//google/api:routing_proto",
-            "@com_google_googleapis//google/cloud:extended_operations_proto",
-            "@com_google_protobuf//:empty_proto",
-        ],
-    ),
-    cc_proto_library(
-        name = service.replace("/v1/", "_cc_proto"),
-        visibility = [
-            "//:__pkg__",
-            "//google/cloud/compute:__pkg__",
-        ],
-        deps = [":" + service.replace("/v1/", "_proto")],
-    ),
-] for service in service_dirs + operation_service_dirs]

--- a/protos/google/cloud/compute/CMakeLists.txt
+++ b/protos/google/cloud/compute/CMakeLists.txt
@@ -15,40 +15,6 @@
 # ~~~
 
 # Defines a compute proto library and installs the .proto and .pb.h files.
-function (compute_proto_library dir library)
-    cmake_parse_arguments(_opt "" "" "DEPS" ${ARGN})
-    file(
-        GLOB proto_files
-        LIST_DIRECTORIES false
-        RELATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}" "${dir}*.proto")
-    list(SORT proto_files)
-    google_cloud_cpp_proto_library(
-        "${library}" "${proto_files}" PROTO_PATH_DIRECTORIES
-        "${EXTERNAL_GOOGLEAPIS_SOURCE}" "${PROTO_INCLUDE_DIR}"
-        "${PROJECT_SOURCE_DIR}/protos")
-    set_target_properties(${library} PROPERTIES OUTPUT_NAME
-                                                "google_cloud_cpp_${library}")
-    add_library(google-cloud-cpp::${library} ALIAS ${library})
-    set_target_properties(
-        ${library}
-        PROPERTIES EXPORT_NAME google-cloud-cpp::${library}
-                   VERSION "${PROJECT_VERSION}"
-                   SOVERSION "${PROJECT_VERSION_MAJOR}")
-    target_link_libraries(${library} PUBLIC ${_opt_DEPS})
-    # Some files are too big for the MSVC defaults.
-    if (MSVC)
-        target_compile_options("${library}" PRIVATE "/bigobj")
-    endif ()
-    google_cloud_cpp_install_proto_library_protos(
-        "${library}" "${PROJECT_SOURCE_DIR}/protos")
-    google_cloud_cpp_install_proto_library_headers("${library}")
-
-    # In some configs we need to only generate the protocol definitions from
-    # `*.proto` files. We achieve this by having this target depend on all proto
-    # libraries. It has to be defined at the top level of the project.
-    add_dependencies(google-cloud-cpp-protos ${library})
-    add_dependencies("${library}" googleapis_download)
-endfunction ()
 
 include(${PROJECT_SOURCE_DIR}/google/cloud/compute/service_dirs.cmake)
 
@@ -58,15 +24,39 @@ google_cloud_cpp_find_proto_include_dir(PROTO_INCLUDE_DIR)
 google_cloud_cpp_load_protodeps(
     deps "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/compute.deps")
 
-compute_proto_library("v1/internal/" "compute_internal_protos" DEPS "${deps}")
+set(proto_globs "v1/internal/" "${service_dirs}" "${operation_service_dirs}")
+list(TRANSFORM proto_globs APPEND "*.proto")
+file(
+    GLOB proto_files
+    LIST_DIRECTORIES false
+    RELATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}" ${proto_globs})
+list(SORT proto_files)
+google_cloud_cpp_proto_library(
+    compute_protos "${proto_files}" PROTO_PATH_DIRECTORIES
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}" "${PROTO_INCLUDE_DIR}"
+    "${PROJECT_SOURCE_DIR}/protos")
+set_target_properties(compute_protos
+                      PROPERTIES OUTPUT_NAME "google_cloud_cpp_compute_protos")
+add_library(google-cloud-cpp::compute_protos ALIAS compute_protos)
+set_target_properties(
+    compute_protos
+    PROPERTIES EXPORT_NAME google-cloud-cpp::compute_protos
+               VERSION "${PROJECT_VERSION}"
+               SOVERSION "${PROJECT_VERSION_MAJOR}")
+target_link_libraries(compute_protos PUBLIC ${deps})
+# Some files are too big for the MSVC defaults.
+if (MSVC)
+    target_compile_options(compute_protos PRIVATE "/bigobj")
+endif ()
+google_cloud_cpp_install_proto_library_protos(compute_protos
+                                              "${PROJECT_SOURCE_DIR}/protos")
+google_cloud_cpp_install_proto_library_headers(compute_protos)
 
-foreach (dir IN LISTS service_dirs operation_service_dirs)
-    string(REPLACE "/v1/" "" short_dir "${dir}")
-    compute_proto_library(
-        ${dir} "compute_${short_dir}_protos" PROTO_FILES
-        "${${short_dir}_proto_files}" DEPS compute_internal_protos)
-    list(APPEND compute_proto_lib_targets "compute_${short_dir}_protos")
-endforeach ()
+# In some configs we need to only generate the protocol definitions from
+# `*.proto` files. We achieve this by having this target depend on all proto
+# libraries. It has to be defined at the top level of the project.
+add_dependencies(google-cloud-cpp-protos compute_protos)
+add_dependencies(compute_protos googleapis_download)
 
 # Get the destination directories based on the GNU recommendations.
 include(GNUInstallDirs)
@@ -80,7 +70,7 @@ install(
 # Install the libraries and headers in the locations determined by
 # GNUInstallDirs
 install(
-    TARGETS ${compute_proto_lib_targets} compute_internal_protos
+    TARGETS compute_protos
     EXPORT google_cloud_cpp_compute_protos-targets
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
             COMPONENT google_cloud_cpp_runtime
@@ -107,19 +97,11 @@ install(
     COMPONENT google_cloud_cpp_development)
 
 google_cloud_cpp_add_pkgconfig(
-    "compute_internal_protos" "The Cloud Compute API C++ Client Library"
-    "Provides C++ APIs to use the Cloud Compute API." WITH_SHORT_TARGET
-    "google_cloud_cpp_cloud_extended_operations_protos")
-
-foreach (dir IN LISTS service_dirs operation_service_dirs)
-    string(REPLACE "/v1/" "" short_dir "${dir}")
-    google_cloud_cpp_add_pkgconfig(
-        "compute_${short_dir}_protos"
-        "The Cloud Compute API C++ Client Library"
-        "Provides C++ APIs to use the Cloud Compute API."
-        WITH_SHORT_TARGET
-        "google_cloud_cpp_compute_internal_protos"
-        "google_cloud_cpp_api_annotations_protos"
-        "google_cloud_cpp_api_client_protos"
-        "google_cloud_cpp_api_field_behavior_protos")
-endforeach ()
+    "compute_protos"
+    "The Cloud Compute API C++ Client Library"
+    "Provides C++ APIs to use the Cloud Compute API."
+    WITH_SHORT_TARGET
+    "google_cloud_cpp_cloud_extended_operations_protos"
+    "google_cloud_cpp_api_annotations_protos"
+    "google_cloud_cpp_api_client_protos"
+    "google_cloud_cpp_api_field_behavior_protos")


### PR DESCRIPTION
MSVC cannot handle paths over 254 characters. Bazel creates protobuf generated files in (relatively) deep directories that include the name of the proto library, and the path to the proto file (twice in our case).

Using a single proto library for all the protos creates shorter paths. We still have a duplicate `google/cloud/compute/${service}`, but at least the target name is short.

Fixes #13835

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13836)
<!-- Reviewable:end -->
