### PR TITLE
feat(spanner): add spanner::Value support for TypeCode::FLOAT32

### DIFF
--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -65,6 +65,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * ------------ | ------------
  * BOOL         | `bool`
  * INT64        | `std::int64_t`
+ * FLOAT32      | `float`
  * FLOAT64      | `double`
  * STRING       | `std::string`
  * BYTES        | `google::cloud::spanner::Bytes`
@@ -193,6 +194,8 @@ class Value {
   explicit Value(bool v) : Value(PrivateConstructor{}, v) {}
   /// @copydoc Value(bool)
   explicit Value(std::int64_t v) : Value(PrivateConstructor{}, v) {}
+  /// @copydoc Value(bool)
+  explicit Value(float v) : Value(PrivateConstructor{}, v) {}
   /// @copydoc Value(bool)
   explicit Value(double v) : Value(PrivateConstructor{}, v) {}
   /// @copydoc Value(bool)
@@ -378,6 +381,7 @@ class Value {
   // by the given `Type` proto.
   static bool TypeProtoIs(bool, google::spanner::v1::Type const&);
   static bool TypeProtoIs(std::int64_t, google::spanner::v1::Type const&);
+  static bool TypeProtoIs(float, google::spanner::v1::Type const&);
   static bool TypeProtoIs(double, google::spanner::v1::Type const&);
   static bool TypeProtoIs(Timestamp, google::spanner::v1::Type const&);
   static bool TypeProtoIs(CommitTimestamp, google::spanner::v1::Type const&);
@@ -443,6 +447,7 @@ class Value {
   // argument type is the tag, the argument value is ignored.
   static google::spanner::v1::Type MakeTypeProto(bool);
   static google::spanner::v1::Type MakeTypeProto(std::int64_t);
+  static google::spanner::v1::Type MakeTypeProto(float);
   static google::spanner::v1::Type MakeTypeProto(double);
   static google::spanner::v1::Type MakeTypeProto(std::string const&);
   static google::spanner::v1::Type MakeTypeProto(Bytes const&);
@@ -521,6 +526,7 @@ class Value {
   // https://github.com/googleapis/googleapis/blob/master/google/spanner/v1/type.proto
   static google::protobuf::Value MakeValueProto(bool b);
   static google::protobuf::Value MakeValueProto(std::int64_t i);
+  static google::protobuf::Value MakeValueProto(float f);
   static google::protobuf::Value MakeValueProto(double d);
   static google::protobuf::Value MakeValueProto(std::string s);
   static google::protobuf::Value MakeValueProto(Bytes b);
@@ -590,6 +596,8 @@ class Value {
   static StatusOr<std::int64_t> GetValue(std::int64_t,
                                          google::protobuf::Value const&,
                                          google::spanner::v1::Type const&);
+  static StatusOr<float> GetValue(float, google::protobuf::Value const&,
+                                  google::spanner::v1::Type const&);
   static StatusOr<double> GetValue(double, google::protobuf::Value const&,
                                    google::spanner::v1::Type const&);
   static StatusOr<std::string> GetValue(std::string const&,

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -146,6 +146,7 @@ TEST(Value, BasicSemantics) {
 
   // Note: We skip testing the NaN case here because NaN always compares not
   // equal, even with itself. So NaN is handled in a separate test.
+  static_assert(std::numeric_limits<double>::has_infinity, "");
   auto const inf = std::numeric_limits<double>::infinity();
   for (auto x : {-inf, -1.0, -0.5, 0.0, 0.5, 1.0, inf}) {
     SCOPED_TRACE("Testing: double " + std::to_string(x));
@@ -158,6 +159,7 @@ TEST(Value, BasicSemantics) {
 
   // Note: We skip testing the NaN case here because NaN always compares not
   // equal, even with itself. So NaN is handled in a separate test.
+  static_assert(std::numeric_limits<float>::has_infinity, "");
   auto const inff = std::numeric_limits<float>::infinity();
   for (auto x : {-inff, -1.0F, -0.5F, 0.0F, 0.5F, 1.0F, inff}) {
     SCOPED_TRACE("Testing: float " + std::to_string(x));


### PR DESCRIPTION
Represented as a `float` in C++, so no need for a wrapper class.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13862)
<!-- Reviewable:end -->
