### PR TITLE
ci: use pkgconf-2.2.x

### DIFF
--- a/ci/cloudbuild/dockerfiles/centos-7.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/centos-7.Dockerfile
@@ -44,11 +44,11 @@ ENV LD_LIBRARY_PATH /opt/rh/devtoolset-7/root/usr/lib64:/opt/rh/devtoolset-7/roo
 # [bug](https://bugs.freedesktop.org/show_bug.cgi?id=54716) that can make
 # invocations take extremely long to complete.
 
-WORKDIR /var/tmp/build/pkg-config-cpp
-RUN curl -fsSL https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz | \
+WORKDIR /var/tmp/build/pkgconf
+RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-internal-glib && \
-    make -j "$(nproc)" && \
+    ./configure --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
+    make -j ${NCPU:-4} && \
     make install && \
     ldconfig && cd /var/tmp && rm -fr build
 

--- a/ci/cloudbuild/dockerfiles/demo-alpine-stable.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-alpine-stable.Dockerfile
@@ -36,10 +36,10 @@ RUN apk update && \
 WORKDIR /var/tmp/build/pkgconf
 RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
+    ./configure --prefix=/usr && \
     make -j ${NCPU:-4} && \
     make install && \
-    ldconfig && cd /var/tmp && rm -fr build
+    cd /var/tmp && rm -fr build
 # ```
 
 # The following steps will install libraries and tools in `/usr/local`. By
@@ -47,7 +47,7 @@ RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
 # set the search path.
 
 # ```bash
-ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/lib64/pkgconfig
+ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/lib/pkgconfig
 # ```
 
 # #### Dependencies

--- a/ci/cloudbuild/dockerfiles/demo-alpine-stable.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-alpine-stable.Dockerfile
@@ -30,15 +30,23 @@ RUN apk update && \
 # Abseil, so we use the normal `pkg-config` binary, which seems to not suffer
 # from this bottleneck. For more details see
 # https://github.com/pkgconf/pkgconf/issues/229 and
-# https://github.com/googleapis/google-cloud-cpp/issues/7052.
+# https://github.com/googleapis/google-cloud-cpp/issues/7052
 
 # ```bash
-WORKDIR /var/tmp/build/pkg-config-cpp
-RUN curl -fsSL https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz | \
+WORKDIR /var/tmp/build/pkgconf
+RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-internal-glib && \
+    ./configure --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
     make -j ${NCPU:-4} && \
-    make install
+    make install && \
+    ldconfig && cd /var/tmp && rm -fr build
+# ```
+
+# The following steps will install libraries and tools in `/usr/local`. By
+# default, pkgconf does not search in these directories. We need to explicitly
+# set the search path.
+
+# ```bash
 ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/lib64/pkgconfig
 # ```
 

--- a/ci/cloudbuild/dockerfiles/demo-centos-7.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-centos-7.Dockerfile
@@ -61,13 +61,13 @@ ENV LD_LIBRARY_PATH /opt/rh/devtoolset-7/root/usr/lib64:/opt/rh/devtoolset-7/roo
 # newer. If not, `yum install pkgconfig` should work instead.
 
 # ```bash
-WORKDIR /var/tmp/build/pkg-config-cpp
-RUN curl -fsSL https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz | \
+WORKDIR /var/tmp/build/pkgconf
+RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-internal-glib && \
+    ./configure --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
     make -j ${NCPU:-4} && \
     make install && \
-    ldconfig
+    ldconfig && cd /var/tmp && rm -fr build
 # ```
 
 # The following steps will install libraries and tools in `/usr/local`. By

--- a/ci/cloudbuild/dockerfiles/demo-centos-7.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-centos-7.Dockerfile
@@ -64,7 +64,7 @@ ENV LD_LIBRARY_PATH /opt/rh/devtoolset-7/root/usr/lib64:/opt/rh/devtoolset-7/roo
 WORKDIR /var/tmp/build/pkgconf
 RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
+    ./configure --prefix=/usr --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
     make -j ${NCPU:-4} && \
     make install && \
     ldconfig && cd /var/tmp && rm -fr build

--- a/ci/cloudbuild/dockerfiles/demo-centos-7.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-centos-7.Dockerfile
@@ -67,6 +67,7 @@ RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     ./configure --prefix=/usr --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
     make -j ${NCPU:-4} && \
     make install && \
+    ln -f /usr/bin/pkgconf /usr/bin/pkg-config && \
     ldconfig && cd /var/tmp && rm -fr build
 # ```
 

--- a/ci/cloudbuild/dockerfiles/demo-debian-bookworm.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-debian-bookworm.Dockerfile
@@ -55,7 +55,7 @@ RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     make -j ${NCPU:-4} && \
     make install && \
     ldconfig && cd /var/tmp && rm -fr build
-ENV PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig/
+ENV PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/local/lib/pkgconfig
 # ```
 
 # #### crc32c

--- a/ci/cloudbuild/dockerfiles/demo-debian-bookworm.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-debian-bookworm.Dockerfile
@@ -48,13 +48,13 @@ RUN apt-get update && \
 # not, `dnf install pkgconfig` should work.
 
 # ```bash
-WORKDIR /var/tmp/build/pkg-config-cpp
-RUN curl -fsSL https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz | \
+WORKDIR /var/tmp/build/pkgconf
+RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-internal-glib && \
+    ./configure --with-system-libdir=/lib:/usr/lib --with-system-includedir=/usr/include && \
     make -j ${NCPU:-4} && \
     make install && \
-    ldconfig
+    ldconfig && cd /var/tmp && rm -fr build
 ENV PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig/
 # ```
 

--- a/ci/cloudbuild/dockerfiles/demo-debian-bookworm.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-debian-bookworm.Dockerfile
@@ -51,7 +51,7 @@ RUN apt-get update && \
 WORKDIR /var/tmp/build/pkgconf
 RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-system-libdir=/lib:/usr/lib --with-system-includedir=/usr/include && \
+    ./configure --prefix=/usr --with-system-libdir=/lib:/usr/lib --with-system-includedir=/usr/include && \
     make -j ${NCPU:-4} && \
     make install && \
     ldconfig && cd /var/tmp && rm -fr build

--- a/ci/cloudbuild/dockerfiles/demo-fedora.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-fedora.Dockerfile
@@ -48,7 +48,7 @@ RUN dnf makecache && \
 WORKDIR /var/tmp/build/pkgconf
 RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
+    ./configure --prefix=/usr --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
     make -j ${NCPU:-4} && \
     make install && \
     ldconfig && cd /var/tmp && rm -fr build

--- a/ci/cloudbuild/dockerfiles/demo-fedora.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-fedora.Dockerfile
@@ -45,13 +45,13 @@ RUN dnf makecache && \
 # not, `dnf install pkgconfig` should work.
 
 # ```bash
-WORKDIR /var/tmp/build/pkg-config-cpp
-RUN curl -fsSL https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz | \
+WORKDIR /var/tmp/build/pkgconf
+RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-internal-glib && \
+    ./configure --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
     make -j ${NCPU:-4} && \
     make install && \
-    ldconfig
+    ldconfig && cd /var/tmp && rm -fr build
 # ```
 
 # Older versions of Fedora hard-code RE2 to use C++11. It was fixed starting
@@ -63,7 +63,8 @@ RUN curl -fsSL https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.
 # ```
 
 # The following steps will install libraries and tools in `/usr/local`. By
-# default, pkg-config does not search in these directories.
+# default, pkgconf does not search in these directories. We need to explicitly
+# set the search path.
 
 # ```bash
 ENV PKG_CONFIG_PATH=/usr/local/share/pkgconfig:/usr/lib64/pkgconfig:/usr/local/lib64/pkgconfig

--- a/ci/cloudbuild/dockerfiles/demo-rockylinux-8.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-rockylinux-8.Dockerfile
@@ -36,13 +36,13 @@ RUN dnf makecache && \
 # binary. If not, `dnf install pkgconfig` should work.
 
 # ```bash
-WORKDIR /var/tmp/build/pkg-config-cpp
-RUN curl -fsSL https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz | \
+WORKDIR /var/tmp/build/pkgconf
+RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-internal-glib && \
+    ./configure --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
     make -j ${NCPU:-4} && \
     make install && \
-    ldconfig
+    ldconfig && cd /var/tmp && rm -fr build
 # ```
 
 # The following steps will install libraries and tools in `/usr/local`. By

--- a/ci/cloudbuild/dockerfiles/demo-rockylinux-8.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-rockylinux-8.Dockerfile
@@ -39,7 +39,7 @@ RUN dnf makecache && \
 WORKDIR /var/tmp/build/pkgconf
 RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
+    ./configure --prefix=/usr --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
     make -j ${NCPU:-4} && \
     make install && \
     ldconfig && cd /var/tmp && rm -fr build

--- a/ci/cloudbuild/dockerfiles/demo-rockylinux-9.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-rockylinux-9.Dockerfile
@@ -36,13 +36,13 @@ RUN dnf makecache && \
 # binary. If not, `dnf install pkgconfig` should work.
 
 # ```bash
-WORKDIR /var/tmp/build/pkg-config-cpp
-RUN curl -fsSL https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz | \
+WORKDIR /var/tmp/build/pkgconf
+RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-internal-glib && \
+    ./configure --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
     make -j ${NCPU:-4} && \
     make install && \
-    ldconfig
+    ldconfig && cd /var/tmp && rm -fr build
 # ```
 
 # The following steps will install libraries and tools in `/usr/local`. By

--- a/ci/cloudbuild/dockerfiles/demo-rockylinux-9.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-rockylinux-9.Dockerfile
@@ -39,7 +39,7 @@ RUN dnf makecache && \
 WORKDIR /var/tmp/build/pkgconf
 RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
+    ./configure --prefix=/usr --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
     make -j ${NCPU:-4} && \
     make install && \
     ldconfig && cd /var/tmp && rm -fr build

--- a/ci/cloudbuild/dockerfiles/fedora-latest-cmake.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-latest-cmake.Dockerfile
@@ -57,7 +57,7 @@ RUN echo 'root:' | chpasswd
 WORKDIR /var/tmp/build/pkgconf
 RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
+    ./configure --prefix=/usr --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
     make -j ${NCPU:-4} && \
     make install && \
     ldconfig && cd /var/tmp && rm -fr build

--- a/ci/cloudbuild/dockerfiles/fedora-latest-cmake.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-latest-cmake.Dockerfile
@@ -54,13 +54,17 @@ RUN echo 'root:' | chpasswd
 # our own `.pc` files.  We install the more traditional `pkg-config` binary.
 # For more details see
 #     https://github.com/googleapis/google-cloud-cpp/issues/7052
-WORKDIR /var/tmp/build/pkg-config-cpp
-RUN curl -fsSL https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz | \
+WORKDIR /var/tmp/build/pkgconf
+RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-internal-glib && \
+    ./configure --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
     make -j ${NCPU:-4} && \
     make install && \
-    ldconfig
+    ldconfig && cd /var/tmp && rm -fr build
+
+# The following steps will install libraries and tools in `/usr/local`. By
+# default, pkgconf does not search in these directories. We need to explicitly
+# set the search path.
 ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/lib64/pkgconfig
 
 # We disable the inline namespace because otherwise Abseil LTS updates break our

--- a/ci/cloudbuild/dockerfiles/fedora-latest-cxx14.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-latest-cxx14.Dockerfile
@@ -48,13 +48,17 @@ RUN echo 'root:' | chpasswd
 # Abseil, so we use the normal `pkg-config` binary, which seems to not suffer
 # from this bottleneck. For more details see
 # https://github.com/googleapis/google-cloud-cpp/issues/7052
-WORKDIR /var/tmp/build/pkg-config-cpp
-RUN curl -fsSL https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz | \
+WORKDIR /var/tmp/build/pkgconf
+RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-internal-glib && \
+    ./configure --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
     make -j ${NCPU:-4} && \
     make install && \
-    ldconfig
+    ldconfig && cd /var/tmp && rm -fr build
+
+# The following steps will install libraries and tools in `/usr/local`. By
+# default, pkgconf does not search in these directories. We need to explicitly
+# set the search path.
 ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/lib64/pkgconfig
 
 # Download and install direct dependencies of `google-cloud-cpp`. Including

--- a/ci/cloudbuild/dockerfiles/fedora-latest-cxx14.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-latest-cxx14.Dockerfile
@@ -51,7 +51,7 @@ RUN echo 'root:' | chpasswd
 WORKDIR /var/tmp/build/pkgconf
 RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
+    ./configure --prefix=/usr --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
     make -j ${NCPU:-4} && \
     make install && \
     ldconfig && cd /var/tmp && rm -fr build

--- a/ci/cloudbuild/dockerfiles/fedora-latest-cxx20.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-latest-cxx20.Dockerfile
@@ -50,13 +50,17 @@ RUN echo 'root:' | chpasswd
 # Abseil, so we use the normal `pkg-config` binary, which seems to not suffer
 # from this bottleneck. For more details see
 # https://github.com/googleapis/google-cloud-cpp/issues/7052
-WORKDIR /var/tmp/build/pkg-config-cpp
-RUN curl -fsSL https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz | \
+WORKDIR /var/tmp/build/pkgconf
+RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-internal-glib && \
+    ./configure --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
     make -j ${NCPU:-4} && \
     make install && \
-    ldconfig
+    ldconfig && cd /var/tmp && rm -fr build
+
+# The following steps will install libraries and tools in `/usr/local`. By
+# default, pkgconf does not search in these directories. We need to explicitly
+# set the search path.
 ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/lib64/pkgconfig
 
 # Download and install direct dependencies of `google-cloud-cpp`. Including

--- a/ci/cloudbuild/dockerfiles/fedora-latest-cxx20.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-latest-cxx20.Dockerfile
@@ -53,7 +53,7 @@ RUN echo 'root:' | chpasswd
 WORKDIR /var/tmp/build/pkgconf
 RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
+    ./configure --prefix=/usr --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
     make -j ${NCPU:-4} && \
     make install && \
     ldconfig && cd /var/tmp && rm -fr build

--- a/ci/cloudbuild/dockerfiles/fedora-m32.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-m32.Dockerfile
@@ -66,13 +66,13 @@ RUN echo 'root:' | chpasswd
 # Abseil. If you plan to use `pkg-config` with any of the installed artifacts,
 # you may want to use a recent version of the standard `pkg-config` binary. If
 # not, `dnf install pkgconfig` should work.
-WORKDIR /var/tmp/build/pkg-config-cpp
-RUN curl -fsSL https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz | \
+WORKDIR /var/tmp/build/pkgconf
+RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-internal-glib && \
+    ./configure --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
     make -j ${NCPU:-4} && \
     make install && \
-    ldconfig
+    ldconfig && cd /var/tmp && rm -fr build
 
 # The following steps will install libraries and tools in `/usr/local`. By
 # default, pkg-config does not search in these directories. Note how this build

--- a/ci/cloudbuild/dockerfiles/fedora-m32.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-m32.Dockerfile
@@ -69,7 +69,7 @@ RUN echo 'root:' | chpasswd
 WORKDIR /var/tmp/build/pkgconf
 RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
+    ./configure --prefix=/usr --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
     make -j ${NCPU:-4} && \
     make install && \
     ldconfig && cd /var/tmp && rm -fr build

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -1755,6 +1755,7 @@ curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     ./configure --prefix=/usr --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
     make -j ${NCPU:-4} && \
 sudo make install && \
+    ln -f /usr/bin/pkgconf /usr/bin/pkg-config && \
 sudo ldconfig && cd /var/tmp && rm -fr build
 ```
 

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -160,15 +160,23 @@ when handling `.pc` files with lots of `Requires:` deps, which happens with
 Abseil, so we use the normal `pkg-config` binary, which seems to not suffer from
 this bottleneck. For more details see
 https://github.com/pkgconf/pkgconf/issues/229 and
-https://github.com/googleapis/google-cloud-cpp/issues/7052.
+https://github.com/googleapis/google-cloud-cpp/issues/7052
 
 ```bash
-mkdir -p $HOME/Downloads/pkg-config-cpp && cd $HOME/Downloads/pkg-config-cpp
-curl -fsSL https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz | \
+mkdir -p $HOME/Downloads/pkgconf && cd $HOME/Downloads/pkgconf
+curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-internal-glib && \
+    ./configure --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
     make -j ${NCPU:-4} && \
-sudo make install
+sudo make install && \
+sudo ldconfig && cd /var/tmp && rm -fr build
+```
+
+The following steps will install libraries and tools in `/usr/local`. By
+default, pkgconf does not search in these directories. We need to explicitly set
+the search path.
+
+```bash
 export PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/lib64/pkgconfig
 ```
 
@@ -278,13 +286,13 @@ may want to use a recent version of the standard `pkg-config` binary. If not,
 `sudo dnf install pkgconfig` should work.
 
 ```bash
-mkdir -p $HOME/Downloads/pkg-config-cpp && cd $HOME/Downloads/pkg-config-cpp
-curl -fsSL https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz | \
+mkdir -p $HOME/Downloads/pkgconf && cd $HOME/Downloads/pkgconf
+curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-internal-glib && \
+    ./configure --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
     make -j ${NCPU:-4} && \
 sudo make install && \
-sudo ldconfig
+sudo ldconfig && cd /var/tmp && rm -fr build
 ```
 
 Older versions of Fedora hard-code RE2 to use C++11. It was fixed starting with
@@ -297,7 +305,8 @@ sed -i 's/-std=c\+\+11 //' /usr/lib64/pkgconfig/re2.pc
 ```
 
 The following steps will install libraries and tools in `/usr/local`. By
-default, pkg-config does not search in these directories.
+default, pkgconf does not search in these directories. We need to explicitly set
+the search path.
 
 ```bash
 export PKG_CONFIG_PATH=/usr/local/share/pkgconfig:/usr/lib64/pkgconfig:/usr/local/lib64/pkgconfig
@@ -841,13 +850,13 @@ may want to use a recent version of the standard `pkg-config` binary. If not,
 `sudo dnf install pkgconfig` should work.
 
 ```bash
-mkdir -p $HOME/Downloads/pkg-config-cpp && cd $HOME/Downloads/pkg-config-cpp
-curl -fsSL https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz | \
+mkdir -p $HOME/Downloads/pkgconf && cd $HOME/Downloads/pkgconf
+curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-internal-glib && \
+    ./configure --with-system-libdir=/lib:/usr/lib --with-system-includedir=/usr/include && \
     make -j ${NCPU:-4} && \
 sudo make install && \
-sudo ldconfig
+sudo ldconfig && cd /var/tmp && rm -fr build
 export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig/
 ```
 
@@ -1294,13 +1303,13 @@ may want to use a recent version of the standard `pkg-config` binary. If not,
 `sudo dnf install pkgconfig` should work.
 
 ```bash
-mkdir -p $HOME/Downloads/pkg-config-cpp && cd $HOME/Downloads/pkg-config-cpp
-curl -fsSL https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz | \
+mkdir -p $HOME/Downloads/pkgconf && cd $HOME/Downloads/pkgconf
+curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-internal-glib && \
+    ./configure --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
     make -j ${NCPU:-4} && \
 sudo make install && \
-sudo ldconfig
+sudo ldconfig && cd /var/tmp && rm -fr build
 ```
 
 The following steps will install libraries and tools in `/usr/local`. By
@@ -1508,13 +1517,13 @@ may want to use a recent version of the standard `pkg-config` binary. If not,
 `sudo dnf install pkgconfig` should work.
 
 ```bash
-mkdir -p $HOME/Downloads/pkg-config-cpp && cd $HOME/Downloads/pkg-config-cpp
-curl -fsSL https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz | \
+mkdir -p $HOME/Downloads/pkgconf && cd $HOME/Downloads/pkgconf
+curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-internal-glib && \
+    ./configure --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
     make -j ${NCPU:-4} && \
 sudo make install && \
-sudo ldconfig
+sudo ldconfig && cd /var/tmp && rm -fr build
 ```
 
 The following steps will install libraries and tools in `/usr/local`. By
@@ -1740,13 +1749,13 @@ with any of the installed artifacts, you'll want to upgrade it to something
 newer. If not, `sudo yum install pkgconfig` should work instead.
 
 ```bash
-mkdir -p $HOME/Downloads/pkg-config-cpp && cd $HOME/Downloads/pkg-config-cpp
-curl -fsSL https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz | \
+mkdir -p $HOME/Downloads/pkgconf && cd $HOME/Downloads/pkgconf
+curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-internal-glib && \
+    ./configure --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
     make -j ${NCPU:-4} && \
 sudo make install && \
-sudo ldconfig
+sudo ldconfig && cd /var/tmp && rm -fr build
 ```
 
 The following steps will install libraries and tools in `/usr/local`. By

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -166,10 +166,10 @@ https://github.com/googleapis/google-cloud-cpp/issues/7052
 mkdir -p $HOME/Downloads/pkgconf && cd $HOME/Downloads/pkgconf
 curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
+    ./configure --prefix=/usr && \
     make -j ${NCPU:-4} && \
 sudo make install && \
-sudo ldconfig && cd /var/tmp && rm -fr build
+    cd /var/tmp && rm -fr build
 ```
 
 The following steps will install libraries and tools in `/usr/local`. By
@@ -177,7 +177,7 @@ default, pkgconf does not search in these directories. We need to explicitly set
 the search path.
 
 ```bash
-export PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/lib64/pkgconfig
+export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/lib/pkgconfig
 ```
 
 #### Dependencies

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -857,7 +857,7 @@ curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     make -j ${NCPU:-4} && \
 sudo make install && \
 sudo ldconfig && cd /var/tmp && rm -fr build
-export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig/
+export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/local/lib/pkgconfig
 ```
 
 #### crc32c

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -289,7 +289,7 @@ may want to use a recent version of the standard `pkg-config` binary. If not,
 mkdir -p $HOME/Downloads/pkgconf && cd $HOME/Downloads/pkgconf
 curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
+    ./configure --prefix=/usr --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
     make -j ${NCPU:-4} && \
 sudo make install && \
 sudo ldconfig && cd /var/tmp && rm -fr build
@@ -853,7 +853,7 @@ may want to use a recent version of the standard `pkg-config` binary. If not,
 mkdir -p $HOME/Downloads/pkgconf && cd $HOME/Downloads/pkgconf
 curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-system-libdir=/lib:/usr/lib --with-system-includedir=/usr/include && \
+    ./configure --prefix=/usr --with-system-libdir=/lib:/usr/lib --with-system-includedir=/usr/include && \
     make -j ${NCPU:-4} && \
 sudo make install && \
 sudo ldconfig && cd /var/tmp && rm -fr build
@@ -1306,7 +1306,7 @@ may want to use a recent version of the standard `pkg-config` binary. If not,
 mkdir -p $HOME/Downloads/pkgconf && cd $HOME/Downloads/pkgconf
 curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
+    ./configure --prefix=/usr --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
     make -j ${NCPU:-4} && \
 sudo make install && \
 sudo ldconfig && cd /var/tmp && rm -fr build
@@ -1520,7 +1520,7 @@ may want to use a recent version of the standard `pkg-config` binary. If not,
 mkdir -p $HOME/Downloads/pkgconf && cd $HOME/Downloads/pkgconf
 curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
+    ./configure --prefix=/usr --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
     make -j ${NCPU:-4} && \
 sudo make install && \
 sudo ldconfig && cd /var/tmp && rm -fr build
@@ -1752,7 +1752,7 @@ newer. If not, `sudo yum install pkgconfig` should work instead.
 mkdir -p $HOME/Downloads/pkgconf && cd $HOME/Downloads/pkgconf
 curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./configure --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
+    ./configure --prefix=/usr --with-system-libdir=/lib64:/usr/lib64 --with-system-includedir=/usr/include && \
     make -j ${NCPU:-4} && \
 sudo make install && \
 sudo ldconfig && cd /var/tmp && rm -fr build


### PR DESCRIPTION
In some platforms the default `pkg-config` or `pkgconf` version is broken. They either take too long (minutes) to analyze the dependencies of something like `Abseil`, and/or produce dependencies in the wrong order. The 2.2.x series of `pkgconf` seems to solve these problems. It seems better to use a newer version of `pkgconf` rather than using an old version of `pkg-config`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13868)
<!-- Reviewable:end -->
