### PR TITLE
impl(otel): add monitoring dep, exporter stub

### DIFF
--- a/cmake/GoogleCloudCppFeatures.cmake
+++ b/cmake/GoogleCloudCppFeatures.cmake
@@ -331,7 +331,7 @@ macro (google_cloud_cpp_enable_deps)
         list(INSERT GOOGLE_CLOUD_CPP_ENABLE 0 storage)
     endif ()
     if (opentelemetry IN_LIST GOOGLE_CLOUD_CPP_ENABLE)
-        list(INSERT GOOGLE_CLOUD_CPP_ENABLE 0 trace)
+        list(INSERT GOOGLE_CLOUD_CPP_ENABLE 0 monitoring trace)
     endif ()
 endmacro ()
 

--- a/google/cloud/opentelemetry/BUILD.bazel
+++ b/google/cloud/opentelemetry/BUILD.bazel
@@ -31,8 +31,10 @@ cc_library(
     hdrs = google_cloud_cpp_opentelemetry_hdrs,
     visibility = ["//:__pkg__"],
     deps = [
+        "//:monitoring",
         "//:trace",
         "//google/cloud:google_cloud_cpp_rest_internal",
+        "@io_opentelemetry_cpp//sdk/src/metrics",
         "@io_opentelemetry_cpp//sdk/src/trace",
     ],
 )
@@ -42,6 +44,7 @@ cc_library(
     srcs = [test],
     deps = [
         ":google_cloud_cpp_opentelemetry",
+        "//:monitoring_mocks",
         "//:trace_mocks",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc_private",
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",

--- a/google/cloud/opentelemetry/CMakeLists.txt
+++ b/google/cloud/opentelemetry/CMakeLists.txt
@@ -24,11 +24,13 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "otel_internal")
 set(DOXYGEN_EXAMPLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/quickstart"
                          "${CMAKE_CURRENT_SOURCE_DIR}/samples")
 set(GOOGLE_CLOUD_CPP_DOXYGEN_EXTRA_INCLUDES
+    "${PROJECT_BINARY_DIR}/google/cloud/monitoring"
     "${PROJECT_BINARY_DIR}/google/cloud/trace")
 
 include(GoogleCloudCppDoxygen)
-google_cloud_cpp_doxygen_targets("opentelemetry" DEPENDS cloud-docs
-                                 google-cloud-cpp::trace)
+google_cloud_cpp_doxygen_targets(
+    "opentelemetry" DEPENDS cloud-docs google-cloud-cpp::monitoring
+    google-cloud-cpp::trace)
 
 add_library(
     google_cloud_cpp_opentelemetry # cmake-format: sort
@@ -40,13 +42,16 @@ add_library(
     internal/recordable.h
     internal/resource_detector_impl.cc
     internal/resource_detector_impl.h
+    monitoring_exporter.cc
+    monitoring_exporter.h
     resource_detector.cc
     resource_detector.h
     trace_exporter.cc
     trace_exporter.h)
 target_link_libraries(
     google_cloud_cpp_opentelemetry
-    PUBLIC google-cloud-cpp::rest_internal google-cloud-cpp::trace
+    PUBLIC google-cloud-cpp::rest_internal google-cloud-cpp::monitoring
+           google-cloud-cpp::trace opentelemetry-cpp::metrics
            opentelemetry-cpp::trace)
 google_cloud_cpp_add_common_options(google_cloud_cpp_opentelemetry)
 target_include_directories(
@@ -89,6 +94,7 @@ google_cloud_cpp_add_pkgconfig(
     "OpenTelemetry Exporters for Google Cloud"
     "Provides exporters for sending telemetry to Google Cloud services."
     "google_cloud_cpp_rest_internal"
+    "google_cloud_cpp_monitoring"
     "google_cloud_cpp_trace"
     "opentelemetry_resources"
     "opentelemetry_trace")
@@ -116,8 +122,11 @@ add_subdirectory(integration_tests)
 
 set(opentelemetry_unit_tests
     # cmake-format: sort
-    internal/monitored_resource_test.cc internal/recordable_test.cc
-    internal/resource_detector_impl_test.cc trace_exporter_test.cc)
+    internal/monitored_resource_test.cc
+    internal/recordable_test.cc
+    internal/resource_detector_impl_test.cc
+    monitoring_exporter_test.cc
+    trace_exporter_test.cc)
 
 export_list_to_bazel("opentelemetry_unit_tests.bzl" "opentelemetry_unit_tests"
                      YEAR "2023")
@@ -134,6 +143,7 @@ foreach (fname ${opentelemetry_unit_tests})
                 google_cloud_cpp_testing_grpc
                 google_cloud_cpp_testing_rest
                 google-cloud-cpp::opentelemetry
+                google_cloud_cpp_monitoring_mocks
                 google_cloud_cpp_trace_mocks
                 GTest::gmock_main
                 GTest::gmock

--- a/google/cloud/opentelemetry/google_cloud_cpp_opentelemetry.bzl
+++ b/google/cloud/opentelemetry/google_cloud_cpp_opentelemetry.bzl
@@ -21,6 +21,7 @@ google_cloud_cpp_opentelemetry_hdrs = [
     "internal/monitored_resource.h",
     "internal/recordable.h",
     "internal/resource_detector_impl.h",
+    "monitoring_exporter.h",
     "resource_detector.h",
     "trace_exporter.h",
 ]
@@ -30,6 +31,7 @@ google_cloud_cpp_opentelemetry_srcs = [
     "internal/monitored_resource.cc",
     "internal/recordable.cc",
     "internal/resource_detector_impl.cc",
+    "monitoring_exporter.cc",
     "resource_detector.cc",
     "trace_exporter.cc",
 ]

--- a/google/cloud/opentelemetry/monitoring_exporter.cc
+++ b/google/cloud/opentelemetry/monitoring_exporter.cc
@@ -1,0 +1,39 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/opentelemetry/monitoring_exporter.h"
+#include "google/cloud/monitoring/v3/metric_client.h"
+#include "google/cloud/project.h"
+#include <memory>
+
+namespace google {
+namespace cloud {
+namespace otel_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter>
+MakeMonitoringExporter(
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    Project project,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    std::shared_ptr<monitoring_v3::MetricServiceConnection> conn) {
+  (void)project;
+  (void)conn;
+  return nullptr;
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace otel_internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/opentelemetry/monitoring_exporter.h
+++ b/google/cloud/opentelemetry/monitoring_exporter.h
@@ -1,0 +1,40 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_OPENTELEMETRY_MONITORING_EXPORTER_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_OPENTELEMETRY_MONITORING_EXPORTER_H
+
+#include "google/cloud/monitoring/v3/metric_connection.h"
+#include "google/cloud/opentelemetry/internal/recordable.h"
+#include "google/cloud/project.h"
+#include "google/cloud/version.h"
+#include <opentelemetry/sdk/metrics/push_metric_exporter.h>
+#include <memory>
+
+namespace google {
+namespace cloud {
+namespace otel_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter>
+MakeMonitoringExporter(
+    Project project,
+    std::shared_ptr<monitoring_v3::MetricServiceConnection> conn);
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace otel_internal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_OPENTELEMETRY_MONITORING_EXPORTER_H

--- a/google/cloud/opentelemetry/monitoring_exporter_test.cc
+++ b/google/cloud/opentelemetry/monitoring_exporter_test.cc
@@ -1,0 +1,37 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/opentelemetry/monitoring_exporter.h"
+#include "google/cloud/monitoring/v3/mocks/mock_metric_connection.h"
+#include "google/cloud/version.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace otel {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+TEST(MonitoringExporter, Placeholder) {
+  auto mock =
+      std::make_shared<monitoring_v3_mocks::MockMetricServiceConnection>();
+  auto exporter = otel_internal::MakeMonitoringExporter(Project("test-project"),
+                                                        std::move(mock));
+}
+
+}  // namespace
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace otel
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/opentelemetry/opentelemetry_unit_tests.bzl
+++ b/google/cloud/opentelemetry/opentelemetry_unit_tests.bzl
@@ -20,5 +20,6 @@ opentelemetry_unit_tests = [
     "internal/monitored_resource_test.cc",
     "internal/recordable_test.cc",
     "internal/resource_detector_impl_test.cc",
+    "monitoring_exporter_test.cc",
     "trace_exporter_test.cc",
 ]


### PR DESCRIPTION
Part of the work for #13869 

Ad an unimplemented stub to make a monitoring exporter. This code will at least let us test (somewhat) that the dependency on opentelemetry-cpp's metric library and our monitoring library work.

Keep this in internal. While we don't know exactly what we want in our public API, we know it will accept `Options` and not a `Connection`.

Note that we are not adding dependencies on new external repositories. We are adding new library dependencies within existing repositories (`google-cloud-cpp` or `opentelemetry-cpp`).