### PR TITLE
test(common): add an IsProtoApproximatelyEqual matcher

### DIFF
--- a/google/cloud/testing_util/is_proto_equal.cc
+++ b/google/cloud/testing_util/is_proto_equal.cc
@@ -27,7 +27,7 @@ absl::optional<std::string> CompareProtos(
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
   auto const result = differencer.Compare(arg, value);
-  if (result) return {};
+  if (result) return absl::nullopt;
   return delta;
 }
 
@@ -43,7 +43,7 @@ absl::optional<std::string> CompareProtosApproximately(
   differencer.set_field_comparator(&comparator);
   differencer.ReportDifferencesToString(&delta);
   auto const result = differencer.Compare(arg, value);
-  if (result) return {};
+  if (result) return absl::nullopt;
   return delta;
 }
 
@@ -59,7 +59,7 @@ absl::optional<std::string> CompareProtosApproximately(
   differencer.set_field_comparator(&comparator);
   differencer.ReportDifferencesToString(&delta);
   auto const result = differencer.Compare(arg, value);
-  if (result) return {};
+  if (result) return absl::nullopt;
   return delta;
 }
 

--- a/google/cloud/testing_util/is_proto_equal.cc
+++ b/google/cloud/testing_util/is_proto_equal.cc
@@ -37,7 +37,7 @@ absl::optional<std::string> CompareProtosApproximately(
   std::string delta;
   google::protobuf::util::DefaultFieldComparator comparator;
   comparator.set_float_comparison(
-      google::protobuf::util::SimpleFieldComparator::APPROXIMATE);
+      google::protobuf::util::DefaultFieldComparator::APPROXIMATE);
   // Keep the comparator's default fraction and margin.
   google::protobuf::util::MessageDifferencer differencer;
   differencer.set_field_comparator(&comparator);
@@ -53,7 +53,7 @@ absl::optional<std::string> CompareProtosApproximately(
   std::string delta;
   google::protobuf::util::DefaultFieldComparator comparator;
   comparator.set_float_comparison(
-      google::protobuf::util::SimpleFieldComparator::APPROXIMATE);
+      google::protobuf::util::DefaultFieldComparator::APPROXIMATE);
   comparator.SetDefaultFractionAndMargin(fraction, margin);
   google::protobuf::util::MessageDifferencer differencer;
   differencer.set_field_comparator(&comparator);

--- a/google/cloud/testing_util/is_proto_equal.cc
+++ b/google/cloud/testing_util/is_proto_equal.cc
@@ -31,6 +31,38 @@ absl::optional<std::string> CompareProtos(
   return delta;
 }
 
+absl::optional<std::string> CompareProtosApproximately(
+    google::protobuf::Message const& arg,
+    google::protobuf::Message const& value) {
+  std::string delta;
+  google::protobuf::util::DefaultFieldComparator comparator;
+  comparator.set_float_comparison(
+      google::protobuf::util::SimpleFieldComparator::APPROXIMATE);
+  // Keep the comparator's default fraction and margin.
+  google::protobuf::util::MessageDifferencer differencer;
+  differencer.set_field_comparator(&comparator);
+  differencer.ReportDifferencesToString(&delta);
+  auto const result = differencer.Compare(arg, value);
+  if (result) return {};
+  return delta;
+}
+
+absl::optional<std::string> CompareProtosApproximately(
+    google::protobuf::Message const& arg,
+    google::protobuf::Message const& value, double fraction, double margin) {
+  std::string delta;
+  google::protobuf::util::DefaultFieldComparator comparator;
+  comparator.set_float_comparison(
+      google::protobuf::util::SimpleFieldComparator::APPROXIMATE);
+  comparator.SetDefaultFractionAndMargin(fraction, margin);
+  google::protobuf::util::MessageDifferencer differencer;
+  differencer.set_field_comparator(&comparator);
+  differencer.ReportDifferencesToString(&delta);
+  auto const result = differencer.Compare(arg, value);
+  if (result) return {};
+  return delta;
+}
+
 }  // namespace testing_util
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud

--- a/google/cloud/testing_util/is_proto_equal.h
+++ b/google/cloud/testing_util/is_proto_equal.h
@@ -38,6 +38,37 @@ MATCHER_P(IsProtoEqual, value, "Checks whether protos are equal") {
   return !delta.has_value();
 }
 
+// Compares float and double fields approximately, using the default
+// google::protobuf::MessageDifferencer tolerances.
+absl::optional<std::string> CompareProtosApproximately(
+    google::protobuf::Message const& arg,
+    google::protobuf::Message const& value);
+
+MATCHER_P(IsProtoApproximatelyEqual, value,
+          "Checks whether protos are approximately equal") {
+  absl::optional<std::string> delta = CompareProtosApproximately(arg, value);
+  if (delta.has_value()) {
+    *result_listener << "\n" << *delta;
+  }
+  return !delta.has_value();
+}
+
+// Compares float and double fields approximately, using the given
+// @p fraction and @p margin.
+absl::optional<std::string> CompareProtosApproximately(
+    google::protobuf::Message const& arg,
+    google::protobuf::Message const& value, double fraction, double margin);
+
+MATCHER_P3(IsProtoApproximatelyEqual, value, fraction, margin,
+           "Checks whether protos are approximately equal") {
+  absl::optional<std::string> delta =
+      CompareProtosApproximately(arg, value, fraction, margin);
+  if (delta.has_value()) {
+    *result_listener << "\n" << *delta;
+  }
+  return !delta.has_value();
+}
+
 }  // namespace testing_util
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud


### PR DESCRIPTION
Add a proto-message matcher that supports approximate equality checks on floating-point fields.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13873)
<!-- Reviewable:end -->
