### PR TITLE
feat(cmake): automatically set `ctype=CORD` workarounds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,16 +114,6 @@ option(
     OFF)
 mark_as_advanced(GOOGLE_CLOUD_CPP_INTERNAL_DOCFX)
 
-option(
-    GOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND
-    [==[Enable the workarounds for [ctype = CORD] when using Protobuf < v23.
-More details at
-
-https://github.com/googleapis/google-cloud-cpp/blob/main/doc/ctype-cord-workarounds.md
-]==]
-    OFF)
-mark_as_advanced(GOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND)
-
 set(GOOGLE_CLOUD_CPP_OVERRIDE_GOOGLEAPIS_URL
     ""
     CACHE

--- a/ci/cloudbuild/builds/cmake-oldest-deps.sh
+++ b/ci/cloudbuild/builds/cmake-oldest-deps.sh
@@ -38,8 +38,7 @@ cmake -GNinja -S . -B cmake-out/build \
   "-DCMAKE_TOOLCHAIN_FILE=${vcpkg_root}/scripts/buildsystems/vcpkg.cmake" \
   "-DVCPKG_MANIFEST_DIR=ci/etc/oldest-deps" \
   "-DVCPKG_FEATURE_FLAGS=versions,manifest" \
-  "-DGOOGLE_CLOUD_CPP_ENABLE=${ENABLED_FEATURES}" \
-  "-DGOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND=ON"
+  "-DGOOGLE_CLOUD_CPP_ENABLE=${ENABLED_FEATURES}"
 
 io::log_h2 "Building"
 cmake --build cmake-out/build

--- a/ci/cloudbuild/builds/m32.sh
+++ b/ci/cloudbuild/builds/m32.sh
@@ -35,8 +35,7 @@ readonly ENABLED_FEATURES
 # This is the build to test with -m32, which requires a toolchain file.
 io::run cmake "${cmake_args[@]}" \
   "--toolchain" "${PROJECT_ROOT}/ci/etc/m32-toolchain.cmake" \
-  -DGOOGLE_CLOUD_CPP_ENABLE="${ENABLED_FEATURES}" \
-  -DGOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND=ON
+  -DGOOGLE_CLOUD_CPP_ENABLE="${ENABLED_FEATURES}"
 io::run cmake --build cmake-out
 mapfile -t ctest_args < <(ctest::common_args)
 io::run env -C cmake-out ctest "${ctest_args[@]}" -LE "integration-test"

--- a/ci/gha/builds/lib/cmake.sh
+++ b/ci/gha/builds/lib/cmake.sh
@@ -65,9 +65,6 @@ function cmake::vcpkg_args() {
   local args
   args=(
     -DCMAKE_TOOLCHAIN_FILE="${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
-    # The version of vcpkg we are using ships with Protobuf v21.x, the
-    # workarounds are required until v23.x.
-    -DGOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND=ON
   )
   printf "%s\n" "${args[@]}"
 }


### PR DESCRIPTION
With Protobuf < v23.x (aka 4.23.x) we need to enable some ugly workarounds to use `ctype=CORD` fields in the storage library. With this change CMake automatically sets the workaround option if needed. Bazel assumes the version of Protobuf is >= v23 and disables the workarounds by default. That is reasonable because Bazel users update more often (or at least we believe that).

Part of the work for #13875

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13877)
<!-- Reviewable:end -->
