### PR TITLE
cleanup(GCS+gRPC): deprecate `GrpcPluginOption`

### DIFF
--- a/google/cloud/storage/benchmarks/aggregate_download_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/aggregate_download_throughput_benchmark.cc
@@ -38,7 +38,6 @@ namespace {
 using ::google::cloud::testing_util::FormatSize;
 using ::google::cloud::testing_util::Timer;
 namespace gcs = ::google::cloud::storage;
-namespace gcs_ex = ::google::cloud::storage_experimental;
 namespace gcs_bm = ::google::cloud::storage_benchmarks;
 using gcs_bm::AggregateDownloadThroughputOptions;
 using gcs_bm::FormatBandwidthGbPerSecond;
@@ -124,8 +123,7 @@ gcs::Client MakeClient(AggregateDownloadThroughputOptions const& options) {
 #if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
   namespace gcs_ex = ::google::cloud::storage_experimental;
   if (options.api == "GRPC") {
-    return gcs_ex::DefaultGrpcClient(
-        std::move(opts).set<gcs_ex::GrpcPluginOption>("media"));
+    return gcs_ex::DefaultGrpcClient(std::move(opts));
   }
 #endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
   return gcs::Client(std::move(opts));
@@ -381,8 +379,6 @@ void PrintResults(AggregateDownloadThroughputOptions const& options,
     return v;
   };
   auto const labels = clean_csv_field(options.labels);
-  auto const grpc_plugin_config =
-      clean_csv_field(options.client_options.get<gcs_ex::GrpcPluginOption>());
   auto const* client_per_thread = options.client_per_thread ? "true" : "false";
   // Print the results after each iteration. Makes it possible to interrupt
   // the benchmark in the middle and still get some data.

--- a/google/cloud/storage/benchmarks/aggregate_upload_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/aggregate_upload_throughput_benchmark.cc
@@ -116,8 +116,7 @@ gcs::Client MakeClient(AggregateUploadThroughputOptions const& options) {
 #if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
   namespace gcs_ex = ::google::cloud::storage_experimental;
   if (options.api == "GRPC") {
-    return gcs_ex::DefaultGrpcClient(
-        std::move(opts).set<gcs_ex::GrpcPluginOption>("media"));
+    return gcs_ex::DefaultGrpcClient(std::move(opts));
   }
 #endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
   return gcs::Client(std::move(opts));

--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -262,13 +262,11 @@ gcs_bm::ClientProvider BaseProvider(ThroughputOptions const& options) {
     if (t == ExperimentTransport::kDirectPath) {
       opts = google::cloud::internal::MergeOptions(options.direct_path_options,
                                                    std::move(opts));
-      opts.set<gcs_ex::GrpcPluginOption>("media");
       return gcs_ex::DefaultGrpcClient(std::move(opts));
     }
     if (t == ExperimentTransport::kGrpc) {
       opts = google::cloud::internal::MergeOptions(options.grpc_options,
                                                    std::move(opts));
-      opts.set<gcs_ex::GrpcPluginOption>("media");
       return gcs_ex::DefaultGrpcClient(std::move(opts));
     }
 #else

--- a/google/cloud/storage/doc/environment-variables.dox
+++ b/google/cloud/storage/doc/environment-variables.dox
@@ -35,14 +35,7 @@ the library. Intended for testing only.
 `GOOGLE_CLOUD_CPP_STORAGE_REST_CONFIG=...`: configuration for the REST
 protocol, but currently unused.
 
-`GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG=...`: used with
-`google::cloud::storage_experimental::DefaultGrpcClient()` to configure
-configure the gRPC protocol. Setting this to `media` enables gRPC for just
-media operations (reading and writing data), while setting this to `metadata`
-enables gRPC for all operations. Note that gRPC support is an early access
-program. Contact Google Cloud support for details.
-
-@see google::cloud::storage_experimental::GrpcPluginOption
+`GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG=...`: this is deprecated.
 
 [project-definition-link]: https://cloud.google.com/storage/docs/projects 'Project Definition in GCS'
 

--- a/google/cloud/storage/grpc_plugin.h
+++ b/google/cloud/storage/grpc_plugin.h
@@ -33,20 +33,13 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 /**
  * Configure the GCS+gRPC plugin.
  *
- * - "none": use REST, disables gRPC.
- * - "media": use gRPC for media (aka data, aka I/O) operations, and REST for
- *   all other requests. In other words, only `ReadObject()`, `WriteObject()`,
- *   and `InsertObject()` use gRPC.
- * - "metadata": use gRPC for all operations.
- *
- * @warning At present, GCS gRPC is GA with Allowlist. To access this API,
- *   kindly contact the Google Cloud Storage gRPC team at
- *   gcs-grpc-contact@google.com with a list of GCS buckets you would like to
- *   Allowlist. Please note that while the **service** is GA (with Allowlist),
- *   the client library features remain experimental and subject to change
- *   without notice.
+ * @deprecated use `google::cloud::storage::Client()` to create JSON-based
+ *     clients and `google::cloud::storage::MakeGrpcClient()` to create
+ *     gRPC-based clients. If you need to pick one dynamically a simple
+ *     `if()` statement or ternary expression can do the job.
  */
-struct GrpcPluginOption {
+struct [[deprecated(
+    "use storage::Client() or storage::MakeGrpcClient()")]] GrpcPluginOption {
   using Type = std::string;
 };
 

--- a/google/cloud/storage/grpc_plugin_test.cc
+++ b/google/cloud/storage/grpc_plugin_test.cc
@@ -21,7 +21,7 @@
 
 namespace google {
 namespace cloud {
-namespace storage_experimental {
+namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
@@ -37,6 +37,20 @@ Options TestOptions() {
       .set<EndpointOption>("localhost:1");
 }
 
+TEST(GrpcPluginTest, DefaultCreatesGrpc) {
+  // Explicitly disable logging, which may be enabled by our CI builds.
+  auto logging =
+      ScopedEnvironment("CLOUD_STORAGE_ENABLE_TRACING", absl::nullopt);
+  auto config =
+      ScopedEnvironment("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG", absl::nullopt);
+  auto client = storage_experimental::DefaultGrpcClient(TestOptions());
+  auto impl = ClientImplDetails::GetConnection(client);
+  ASSERT_THAT(impl, NotNull());
+  EXPECT_THAT(impl->InspectStackStructure(),
+              ElementsAre("GrpcStub", "StorageConnectionImpl"));
+}
+
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 TEST(GrpcPluginTest, MostConfigValuesCreatesGrpc) {
   // Explicitly disable logging, which may be enabled by our CI builds.
   auto logging =
@@ -45,8 +59,8 @@ TEST(GrpcPluginTest, MostConfigValuesCreatesGrpc) {
       ScopedEnvironment("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG", absl::nullopt);
   // Unless the config is set to "none" we want to create the gRPC stub.
   for (auto const* config : {"", "metadata", "media", "anything-but-none"}) {
-    auto client =
-        DefaultGrpcClient(TestOptions().set<GrpcPluginOption>(config));
+    auto client = storage_experimental::DefaultGrpcClient(
+        TestOptions().set<storage_experimental::GrpcPluginOption>(config));
     auto impl = ClientImplDetails::GetConnection(client);
     ASSERT_THAT(impl, NotNull());
     EXPECT_THAT(impl->InspectStackStructure(),
@@ -60,8 +74,8 @@ TEST(GrpcPluginTest, EnvironmentOverrides) {
       ScopedEnvironment("CLOUD_STORAGE_ENABLE_TRACING", absl::nullopt);
   auto config =
       ScopedEnvironment("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG", "none");
-  auto client =
-      DefaultGrpcClient(TestOptions().set<GrpcPluginOption>("metadata"));
+  auto client = storage_experimental::DefaultGrpcClient(
+      TestOptions().set<storage_experimental::GrpcPluginOption>("metadata"));
   auto impl = ClientImplDetails::GetConnection(client);
   ASSERT_THAT(impl, NotNull());
   EXPECT_THAT(impl->InspectStackStructure(),
@@ -74,7 +88,7 @@ TEST(GrpcPluginTest, UnsetConfigCreatesMetadata) {
       ScopedEnvironment("CLOUD_STORAGE_ENABLE_TRACING", absl::nullopt);
   auto config =
       ScopedEnvironment("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG", absl::nullopt);
-  auto client = DefaultGrpcClient(TestOptions());
+  auto client = storage_experimental::DefaultGrpcClient(TestOptions());
   auto impl = ClientImplDetails::GetConnection(client);
   ASSERT_THAT(impl, NotNull());
   EXPECT_THAT(impl->InspectStackStructure(),
@@ -87,29 +101,45 @@ TEST(GrpcPluginTest, NoneConfigCreatesCurl) {
       ScopedEnvironment("CLOUD_STORAGE_ENABLE_TRACING", absl::nullopt);
   auto config =
       ScopedEnvironment("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG", absl::nullopt);
-  auto client = DefaultGrpcClient(TestOptions().set<GrpcPluginOption>("none"));
+  auto client = storage_experimental::DefaultGrpcClient(
+      TestOptions().set<storage_experimental::GrpcPluginOption>("none"));
   auto impl = ClientImplDetails::GetConnection(client);
   ASSERT_THAT(impl, NotNull());
   EXPECT_THAT(impl->InspectStackStructure(),
               ElementsAre("RestStub", "StorageConnectionImpl"));
 }
 
-#include "google/cloud/internal/disable_deprecation_warnings.inc"
 TEST(GrpcPluginTest, HybridUsesGrpcBufferOptions) {
   // Explicitly disable logging, which may be enabled by our CI builds.
   auto logging =
       ScopedEnvironment("CLOUD_STORAGE_ENABLE_TRACING", absl::nullopt);
   auto config =
       ScopedEnvironment("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG", absl::nullopt);
-  auto client = DefaultGrpcClient(TestOptions().set<GrpcPluginOption>("media"));
+  auto client = storage_experimental::DefaultGrpcClient(
+      TestOptions().set<storage_experimental::GrpcPluginOption>("media"));
   EXPECT_GE(
       client.raw_client()->options().get<storage::UploadBufferSizeOption>(),
       32 * 1024 * 1024L);
+}
+
+TEST(GrpcPluginTest, BackwardsCompatibilityShims) {
+  // Explicitly disable logging, which may be enabled by our CI builds.
+  auto logging =
+      ScopedEnvironment("CLOUD_STORAGE_ENABLE_TRACING", absl::nullopt);
+  auto config =
+      ScopedEnvironment("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG", absl::nullopt);
+  namespace gcs_ex = ::google::cloud::storage_experimental;
+  auto client = gcs_ex::DefaultGrpcClient(
+      TestOptions().set<gcs_ex::GrpcPluginOption>("none"));
+  auto impl = ClientImplDetails::GetConnection(client);
+  ASSERT_THAT(impl, NotNull());
+  EXPECT_THAT(impl->InspectStackStructure(),
+              ElementsAre("RestStub", "StorageConnectionImpl"));
 }
 #include "google/cloud/internal/diagnostics_pop.inc"
 
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage_experimental
+}  // namespace storage
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/tests/smoke_test_grpc.cc
+++ b/google/cloud/storage/tests/smoke_test_grpc.cc
@@ -35,9 +35,7 @@ TEST(SmokeTest, Grpc) {
       GetEnv("GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME").value_or("");
   if (bucket_name.empty()) GTEST_SKIP();
 
-  auto client = google::cloud::storage_experimental::DefaultGrpcClient(
-      google::cloud::Options{}.set<storage_experimental::GrpcPluginOption>(
-          "metadata"));
+  auto client = google::cloud::storage_experimental::DefaultGrpcClient();
   auto gen = google::cloud::internal::MakeDefaultPRNG();
   auto object_name = google::cloud::storage::testing::MakeRandomObjectName(gen);
 


### PR DESCRIPTION
Mark it as deprecated and stop using it in our tests, benchmarks, examples, etc.  We still respect the previous behavior, but we should move the class no later than the next major version.

Part of the work for #13875

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13879)
<!-- Reviewable:end -->
