### PR TITLE
ci: modify ctest invocation in ctest::has_no_tests()

### DIFF
--- a/ci/cloudbuild/builds/lib/ctest.sh
+++ b/ci/cloudbuild/builds/lib/ctest.sh
@@ -40,5 +40,5 @@ function ctest::has_no_tests() {
   local prefix="$2"
   shift 2
   local ctest_args=("$@")
-  ctest --test-dir "${dir}" --show-only -R "${prefix}" "${ctest_args[@]}" 2>&1 | grep -q 'Total Tests: 0'
+  env -C "${dir}" ctest --show-only -R "${prefix}" "${ctest_args[@]}" 2>&1 | grep -q 'Total Tests: 0'
 }


### PR DESCRIPTION
Move to `env -C "${dir}" ctest"` instead of `ctest --test-dir "${dir}"`.

Not only does it hide the `Testing/Temporary/LastTest.log` file away in the build directory, but it also seems to produce the "Total Tests" output we're looking for, which means the cmake-oldest-deps build will now actually run tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13881)
<!-- Reviewable:end -->
