### PR TITLE
cleanup(GCS+gRPC): split package for GCS+gRPC

### DIFF
--- a/ci/cloudbuild/builds/cmake-install.sh
+++ b/ci/cloudbuild/builds/cmake-install.sh
@@ -154,6 +154,7 @@ expected_dirs+=(
   ./lib64/cmake/google_cloud_cpp_opentelemetry
   ./lib64/cmake/google_cloud_cpp_rest_internal
   ./lib64/cmake/google_cloud_cpp_rest_protobuf_internal
+  ./lib64/cmake/google_cloud_cpp_storage_grpc
   ./lib64/cmake/google_cloud_cpp_storage_grpc_mocks
   ./lib64/pkgconfig
 )

--- a/ci/verify_current_targets/CMakeLists.txt
+++ b/ci/verify_current_targets/CMakeLists.txt
@@ -40,7 +40,7 @@ set(ga_libraries
 # Define experimental libraries. The only difference is the name of the CMake
 # targets.
 set(experimental_libraries # cmake-format: sort
-                           bigquery_rest storage_grpc_mocks)
+                           bigquery_rest storage_grpc storage_grpc_mocks)
 
 # CMake can use pkg-config to find dependencies. We recommend using CMake
 # targets, but we want to verify our pkg-config files remain usable and

--- a/google/cloud/storage/config-grpc.cmake.in
+++ b/google/cloud/storage/config-grpc.cmake.in
@@ -13,17 +13,10 @@
 # limitations under the License.
 
 include(CMakeFindDependencyMacro)
+find_dependency(google_cloud_cpp_storage)
 find_dependency(google_cloud_cpp_googleapis)
 find_dependency(google_cloud_cpp_grpc_utils)
-find_dependency(google_cloud_cpp_rest_internal)
-find_dependency(google_cloud_cpp_common)
 find_dependency(absl)
-find_dependency(CURL)
 find_dependency(Crc32c)
-find_dependency(nlohmann_json)
-if (NOT WIN32)
-    find_dependency(OpenSSL)
-endif ()
-find_dependency(ZLIB)
 
-include("${CMAKE_CURRENT_LIST_DIR}/storage-targets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/storage_grpc-targets.cmake")

--- a/google/cloud/storage/google_cloud_cpp_storage.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage.cmake
@@ -349,13 +349,7 @@ google_cloud_cpp_add_pkgconfig(
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)
-if (GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
-    configure_file("config-grpc.cmake.in"
-                   "google_cloud_cpp_storage-config.cmake" @ONLY)
-else ()
-    configure_file("config.cmake.in" "google_cloud_cpp_storage-config.cmake"
-                   @ONLY)
-endif ()
+configure_file("config.cmake.in" "google_cloud_cpp_storage-config.cmake" @ONLY)
 write_basic_package_version_file(
     "google_cloud_cpp_storage-config-version.cmake"
     VERSION ${PROJECT_VERSION}

--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
@@ -243,8 +243,28 @@ google_cloud_cpp_add_pkgconfig(
     "openssl")
 
 install(
+    EXPORT storage_grpc-targets
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_storage_grpc"
+    COMPONENT google_cloud_cpp_development)
+
+# Create and install the CMake configuration files.
+configure_file("config-grpc.cmake.in"
+               "google_cloud_cpp_storage_grpc-config.cmake" @ONLY)
+write_basic_package_version_file(
+    "google_cloud_cpp_storage_grpc-config-version.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY ExactVersion)
+
+install(
+    FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_storage_grpc-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_storage_grpc-config-version.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_storage_grpc"
+    COMPONENT google_cloud_cpp_development)
+
+install(
     TARGETS google_cloud_cpp_storage_grpc google_cloud_cpp_storage_protos
-    EXPORT storage-targets
+    EXPORT storage_grpc-targets
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
             COMPONENT google_cloud_cpp_runtime
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/google/cloud/storage/quickstart/CMakeLists.txt
+++ b/google/cloud/storage/quickstart/CMakeLists.txt
@@ -31,6 +31,12 @@ endif ()
 add_executable(quickstart quickstart.cc)
 target_link_libraries(quickstart google-cloud-cpp::storage)
 
+find_package(google_cloud_cpp_storage_grpc CONFIG)
+if (NOT google_cloud_cpp_storage_grpc_FOUND)
+    message("GCS+gRPC plugin is disabled, skipping its quickstarts")
+    return()
+endif ()
+
 add_executable(quickstart_grpc EXCLUDE_FROM_ALL quickstart_grpc.cc)
 target_link_libraries(quickstart_grpc
                       google-cloud-cpp::experimental-storage_grpc)


### PR DESCRIPTION
Create a new `google_cloud_cpp_storage_grpc` for the GCS+gRPC plugin. With this change the contents of the `google_cloud_cpp_storage` are always the same, regardless of whether GCS+gRPC is enabled.

It is easier to reason about the packages if their contents are always consistent.

Part of the work for #13875

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13883)
<!-- Reviewable:end -->
