### PR TITLE
cleanup(GCS+gRPC): remove one public -D flag

### DIFF
--- a/google/cloud/storage/BUILD.bazel
+++ b/google/cloud/storage/BUILD.bazel
@@ -32,7 +32,7 @@ GOOGLE_CLOUD_STORAGE_WIN_DEFINES = [
 config_setting(
     name = "ctype_cord_workaround_enabled",
     flag_values = {"//:enable-ctype-cord-workaround": "true"},
-    visibility = ["//:__pkg__"],
+    visibility = [":__subpackages__"],
 )
 
 filegroup(

--- a/google/cloud/storage/BUILD.bazel
+++ b/google/cloud/storage/BUILD.bazel
@@ -32,6 +32,7 @@ GOOGLE_CLOUD_STORAGE_WIN_DEFINES = [
 config_setting(
     name = "ctype_cord_workaround_enabled",
     flag_values = {"//:enable-ctype-cord-workaround": "true"},
+    visibility = ["//:__pkg__"],
 )
 
 filegroup(
@@ -207,6 +208,13 @@ cc_library(
     linkopts = select({
         "@platforms//os:windows": [],
         "//conditions:default": ["-lpthread"],
+    }),
+    local_defines = select({
+        "@platforms//os:windows": GOOGLE_CLOUD_STORAGE_WIN_DEFINES,
+        "//conditions:default": [],
+    }) + select({
+        ":ctype_cord_workaround_enabled": ["GOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND"],
+        "//conditions:default": [],
     }),
     deps = [
         ":google_cloud_cpp_storage",

--- a/google/cloud/storage/BUILD.bazel
+++ b/google/cloud/storage/BUILD.bazel
@@ -44,12 +44,12 @@ cc_library(
     name = "google_cloud_cpp_storage_grpc",
     srcs = google_cloud_cpp_storage_grpc_srcs,
     hdrs = google_cloud_cpp_storage_grpc_hdrs,
-    defines = ["GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC"] + select({
-        ":ctype_cord_workaround_enabled": ["GOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND"],
-        "//conditions:default": [],
-    }),
+    defines = ["GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC"],
     local_defines = select({
         "@platforms//os:windows": GOOGLE_CLOUD_STORAGE_WIN_DEFINES,
+        "//conditions:default": [],
+    }) + select({
+        ":ctype_cord_workaround_enabled": ["GOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND"],
         "//conditions:default": [],
     }),
     visibility = [

--- a/google/cloud/storage/benchmarks/BUILD.bazel
+++ b/google/cloud/storage/benchmarks/BUILD.bazel
@@ -25,6 +25,10 @@ cc_library(
     testonly = True,
     srcs = storage_benchmarks_srcs,
     hdrs = storage_benchmarks_hdrs,
+    local_defines = select({
+        "//google/cloud/storage:ctype_cord_workaround_enabled": ["GOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND"],
+        "//conditions:default": [],
+    }),
     deps = [
         "//:common",
         "//:grpc_utils",

--- a/google/cloud/storage/benchmarks/CMakeLists.txt
+++ b/google/cloud/storage/benchmarks/CMakeLists.txt
@@ -45,7 +45,7 @@ target_link_libraries(
            google-cloud-cpp::storage_protos
            CURL::libcurl)
 google_cloud_cpp_add_common_options(storage_benchmarks)
-if (GOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND)
+if (Protobuf_VERSION VERSION_LESS "23.x")
     target_compile_definitions(
         storage_benchmarks
         PRIVATE GOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND)

--- a/google/cloud/storage/benchmarks/CMakeLists.txt
+++ b/google/cloud/storage/benchmarks/CMakeLists.txt
@@ -45,7 +45,7 @@ target_link_libraries(
            google-cloud-cpp::storage_protos
            CURL::libcurl)
 google_cloud_cpp_add_common_options(storage_benchmarks)
-if (Protobuf_VERSION VERSION_LESS "23.x")
+if (Protobuf_VERSION VERSION_LESS "23")
     target_compile_definitions(
         storage_benchmarks
         PRIVATE GOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND)

--- a/google/cloud/storage/benchmarks/CMakeLists.txt
+++ b/google/cloud/storage/benchmarks/CMakeLists.txt
@@ -45,6 +45,11 @@ target_link_libraries(
            google-cloud-cpp::storage_protos
            CURL::libcurl)
 google_cloud_cpp_add_common_options(storage_benchmarks)
+if (GOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND)
+    target_compile_definitions(
+        storage_benchmarks
+        PRIVATE GOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND)
+endif ()
 
 include(CreateBazelConfig)
 create_bazel_config(storage_benchmarks YEAR 2019)

--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
@@ -213,7 +213,7 @@ else ()
     if (GOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND)
         target_compile_definitions(
             google_cloud_cpp_storage_grpc
-            PUBLIC GOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND)
+            PRIVATE GOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND)
     endif ()
     set_target_properties(
         google_cloud_cpp_storage_grpc

--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
@@ -406,6 +406,10 @@ if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
 
     foreach (fname ${storage_client_grpc_unit_tests})
         google_cloud_cpp_add_executable(target "storage" "${fname}")
+        if (GOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND)
+            target_compile_definitions(
+                ${target} PRIVATE GOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND)
+        endif ()
         target_link_libraries(
             ${target}
             PRIVATE storage_client_testing


### PR DESCRIPTION
The `GOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND` pre-processor macro does not need to be part of the public flags for the library.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13885)
<!-- Reviewable:end -->
