### PR TITLE
impl(pubsub): add expire message functionality

### DIFF
--- a/google/cloud/pubsub/internal/batch_callback.h
+++ b/google/cloud/pubsub/internal/batch_callback.h
@@ -52,6 +52,8 @@ class BatchCallback {
 
   virtual void ModackStart(std::string const& ack_id) = 0;
   virtual void ModackEnd(std::string const& ack_id) = 0;
+
+  virtual void ExpireMessage(std::string const& ack_id) = 0;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsub/internal/batch_callback_wrapper.h
+++ b/google/cloud/pubsub/internal/batch_callback_wrapper.h
@@ -67,6 +67,10 @@ class BatchCallbackWrapper : public BatchCallback {
     child_->ModackEnd(ack_id);
   }
 
+  void ExpireMessage(std::string const& ack_id) override {
+    child_->ExpireMessage(ack_id);
+  }
+
  private:
   std::shared_ptr<BatchCallback> child_;
   Callback wrapper_;

--- a/google/cloud/pubsub/internal/default_batch_callback.h
+++ b/google/cloud/pubsub/internal/default_batch_callback.h
@@ -59,7 +59,7 @@ class DefaultBatchCallback : public BatchCallback {
   void ModackStart(std::string const&) override {}
   void ModackEnd(std::string const&) override {}
 
-  void ExpireMessage(std::string const& ack_id) override {}
+  void ExpireMessage(std::string const&) override {}
 
  private:
   CallbackFunction callback_;

--- a/google/cloud/pubsub/internal/default_batch_callback.h
+++ b/google/cloud/pubsub/internal/default_batch_callback.h
@@ -59,6 +59,8 @@ class DefaultBatchCallback : public BatchCallback {
   void ModackStart(std::string const&) override {}
   void ModackEnd(std::string const&) override {}
 
+  void ExpireMessage(std::string const& ack_id) override {}
+
  private:
   CallbackFunction callback_;
   std::shared_ptr<MessageCallback> message_callback_;

--- a/google/cloud/pubsub/internal/subscription_lease_management.cc
+++ b/google/cloud/pubsub/internal/subscription_lease_management.cc
@@ -26,10 +26,11 @@ std::chrono::seconds constexpr SubscriptionLeaseManagement::kAckDeadlineSlack;
 
 void SubscriptionLeaseManagement::Start(std::shared_ptr<BatchCallback> cb) {
   auto weak = std::weak_ptr<SubscriptionLeaseManagement>(shared_from_this());
-  child_->Start(std::make_shared<BatchCallbackWrapper>(
+  callback_ = std::make_shared<BatchCallbackWrapper>(
       std::move(cb), [weak](BatchCallback::StreamingPullResponse const& r) {
         if (auto self = weak.lock()) self->OnRead(r.response);
-      }));
+      });
+  child_->Start(callback_);
 }
 
 void SubscriptionLeaseManagement::Shutdown() {
@@ -109,7 +110,10 @@ void SubscriptionLeaseManagement::RefreshMessageLeases(
   for (auto const& kv : leases_) {
     // This message lease cannot be extended any further, and we do not want to
     // send an extension of 0 seconds because that is a nack.
-    if (kv.second.handling_deadline < now + seconds(1)) continue;
+    if (kv.second.handling_deadline < now + seconds(1)) {
+      callback_->ExpireMessage(kv.first);
+      continue;
+    }
     auto const message_extension =
         std::chrono::duration_cast<seconds>(kv.second.handling_deadline - now);
     extension = (std::min)(extension, message_extension);

--- a/google/cloud/pubsub/internal/subscription_lease_management.h
+++ b/google/cloud/pubsub/internal/subscription_lease_management.h
@@ -94,7 +94,7 @@ class SubscriptionLeaseManagement
   std::chrono::seconds const max_deadline_extension_;
 
   std::mutex mu_;
-
+  std::shared_ptr<BatchCallback> callback_;
   // A collection of message ack_ids to maintain the message leases.
   struct LeaseStatus {
     std::chrono::system_clock::time_point estimated_server_deadline;

--- a/google/cloud/pubsub/internal/subscription_lease_management.h
+++ b/google/cloud/pubsub/internal/subscription_lease_management.h
@@ -92,9 +92,9 @@ class SubscriptionLeaseManagement
   std::shared_ptr<SessionShutdownManager> const shutdown_manager_;
   std::chrono::seconds const max_deadline_time_;
   std::chrono::seconds const max_deadline_extension_;
+  std::shared_ptr<BatchCallback> callback_;
 
   std::mutex mu_;
-  std::shared_ptr<BatchCallback> callback_;
   // A collection of message ack_ids to maintain the message leases.
   struct LeaseStatus {
     std::chrono::system_clock::time_point estimated_server_deadline;

--- a/google/cloud/pubsub/internal/subscription_lease_management_test.cc
+++ b/google/cloud/pubsub/internal/subscription_lease_management_test.cc
@@ -228,6 +228,58 @@ TEST(SubscriptionLeaseManagementTest, UsesDeadlineExtension) {
   EXPECT_THAT(done.get(), IsOk());
 }
 
+TEST(SubscriptionLeaseManagementTest, ExpiredMessage) {
+  auto mock = std::make_shared<pubsub_testing::MockSubscriptionBatchSource>();
+  std::shared_ptr<BatchCallback> batch_callback;
+  EXPECT_CALL(*mock, Start).WillOnce([&](std::shared_ptr<BatchCallback> cb) {
+    batch_callback = std::move(cb);
+  });
+
+  auto mock_batch_callback =
+      std::make_shared<pubsub_testing::MockBatchCallback>();
+  EXPECT_CALL(*mock_batch_callback, callback).Times(1);
+  EXPECT_CALL(*mock_batch_callback, ExpireMessage).Times(2);
+
+  auto constexpr kTestDeadline = std::chrono::seconds(1);
+  {
+    ::testing::InSequence sequence;
+    // We expect this message to be acked.
+    EXPECT_CALL(*mock, AckMessage("ack-0-1")).WillOnce(SimpleAckNack);
+    // Then all unhandled messages are nacked on shutdown.
+    EXPECT_CALL(*mock, BulkNack(UnorderedElementsAre("ack-0-2", "ack-0-0")))
+        .WillOnce([](std::vector<std::string> const&) {
+          return make_ready_future(Status{});
+        });
+    EXPECT_CALL(*mock, Shutdown).Times(1);
+  }
+
+  auto fake_cq = std::make_shared<FakeCompletionQueueImpl>();
+  CompletionQueue cq(fake_cq);
+
+  auto shutdown_manager = std::make_shared<SessionShutdownManager>();
+  auto uut = SubscriptionLeaseManagement::Create(
+      cq, shutdown_manager, mock, kTestDeadline, std::chrono::seconds(600));
+
+  auto done = shutdown_manager->Start({});
+  uut->Start(mock_batch_callback);
+  batch_callback->callback(
+      BatchCallback::StreamingPullResponse{GenerateMessages("0-", 3)});
+  ASSERT_EQ(1U, fake_cq->size());
+
+  // Ack one of the messages and then fire the timer. The expectations set above
+  // will verify that only the remaining messages have their lease extended.
+  uut->AckMessage("ack-0-1");
+  fake_cq->SimulateCompletion(true);
+  ASSERT_EQ(1U, fake_cq->size());
+
+  shutdown_manager->MarkAsShutdown(__func__, Status{});
+  uut->Shutdown();
+
+  fake_cq->SimulateCompletion(false);
+  ASSERT_EQ(0U, fake_cq->size());
+  EXPECT_THAT(done.get(), IsOk());
+}
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace pubsub_internal

--- a/google/cloud/pubsub/internal/tracing_batch_callback.cc
+++ b/google/cloud/pubsub/internal/tracing_batch_callback.cc
@@ -154,7 +154,7 @@ class TracingBatchCallback : public BatchCallback {
       } else if (event == "gl-cpp.nack_end") {
         subscribe_span->second->SetAttribute("messaging.gcp_pubsub.result",
                                              "nack");
-      } else if ("gl-cpp.expired") {
+      } else if (event == "gl-cpp.expired") {
         subscribe_span->second->SetAttribute("messaging.gcp_pubsub.result",
                                              "expired");
       }

--- a/google/cloud/pubsub/internal/tracing_batch_callback.cc
+++ b/google/cloud/pubsub/internal/tracing_batch_callback.cc
@@ -137,7 +137,7 @@ class TracingBatchCallback : public BatchCallback {
   }
 
   void ExpireMessage(std::string const& ack_id) override {
-    AddEvent(ack_id, "gl-cpp.expired", true);
+    AddEvent(ack_id, "gl-cpp.expired");
   }
 
  private:
@@ -148,17 +148,17 @@ class TracingBatchCallback : public BatchCallback {
     auto subscribe_span = subscribe_span_by_ack_id_.find(ack_id);
     if (subscribe_span != subscribe_span_by_ack_id_.end()) {
       subscribe_span->second->AddEvent(event);
+      if (event == "gl-cpp.ack_end") {
+        subscribe_span->second->SetAttribute("messaging.gcp_pubsub.result",
+                                             "ack");
+      } else if (event == "gl-cpp.nack_end") {
+        subscribe_span->second->SetAttribute("messaging.gcp_pubsub.result",
+                                             "nack");
+      } else if ("gl-cpp.expired") {
+        subscribe_span->second->SetAttribute("messaging.gcp_pubsub.result",
+                                             "expired");
+      }
       if (end_event) {
-        if (event == "gl-cpp.ack_end") {
-          subscribe_span->second->SetAttribute("messaging.gcp_pubsub.result",
-                                               "ack");
-        } else if (event == "gl-cpp.nack_end") {
-          subscribe_span->second->SetAttribute("messaging.gcp_pubsub.result",
-                                               "nack");
-        } else {
-          subscribe_span->second->SetAttribute("messaging.gcp_pubsub.result",
-                                               "expired");
-        }
         subscribe_span->second->End();
         subscribe_span_by_ack_id_.erase(subscribe_span);
       }

--- a/google/cloud/pubsub/internal/tracing_batch_callback_test.cc
+++ b/google/cloud/pubsub/internal/tracing_batch_callback_test.cc
@@ -222,6 +222,8 @@ TEST(TracingBatchCallback, Ack) {
   EXPECT_THAT(
       spans, Contains(AllOf(SpanHasInstrumentationScope(), SpanKindIsConsumer(),
                             SpanNamed("test-sub subscribe"),
+                            SpanHasAttributes(OTelAttribute<std::string>(
+                                "messaging.gcp_pubsub.result", "ack")),
                             SpanHasEvents(EventNamed("gl-cpp.ack_start"),
                                           EventNamed("gl-cpp.ack_end")))));
 }
@@ -240,6 +242,8 @@ TEST(TracingBatchCallback, Nack) {
   EXPECT_THAT(
       spans, Contains(AllOf(SpanHasInstrumentationScope(), SpanKindIsConsumer(),
                             SpanNamed("test-sub subscribe"),
+                            SpanHasAttributes(OTelAttribute<std::string>(
+                                "messaging.gcp_pubsub.result", "nack")),
                             SpanHasEvents(EventNamed("gl-cpp.nack_start"),
                                           EventNamed("gl-cpp.nack_end")))));
 }
@@ -262,6 +266,24 @@ TEST(TracingBatchCallback, Modack) {
                             SpanHasEvents(EventNamed("gl-cpp.modack_start"),
                                           EventNamed("gl-cpp.modack_end"),
                                           EventNamed("gl-cpp.ack_end")))));
+}
+
+TEST(TracingBatchCallback, Expire) {
+  auto span_catcher = InstallSpanCatcher();
+  auto mock = std::make_shared<pubsub_testing::MockBatchCallback>();
+  EXPECT_CALL(*mock, callback).Times(1);
+  auto batch_callback = MakeTestBatchCallback(std::move(mock));
+
+  batch_callback->callback(MakeResponse(1));
+  batch_callback->ExpireMessage("ack-id-0");
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(
+      spans, Contains(AllOf(SpanHasInstrumentationScope(), SpanKindIsConsumer(),
+                            SpanNamed("test-sub subscribe"),
+                            SpanHasAttributes(OTelAttribute<std::string>(
+                                "messaging.gcp_pubsub.result", "expired")),
+                            SpanHasEvents(EventNamed("gl-cpp.expired")))));
 }
 
 }  // namespace

--- a/google/cloud/pubsub/testing/mock_batch_callback.h
+++ b/google/cloud/pubsub/testing/mock_batch_callback.h
@@ -44,6 +44,7 @@ class MockBatchCallback : public pubsub_internal::BatchCallback {
   MOCK_METHOD(void, NackEnd, (std::string const&));
   MOCK_METHOD(void, ModackStart, (std::string const&));
   MOCK_METHOD(void, ModackEnd, (std::string const&));
+  MOCK_METHOD(void, ExpireMessage, (std::string const&));
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
[13720](https://github.com/googleapis/google-cloud-cpp/issues/13720)

- Store the batch callback on the lease management layer
- Modify the EndMessage function to add an attribute in the BatchCallback interface messaging.gcp_pubsub.result 
- End the span in the lease management layer if the message expires.



<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13888)
<!-- Reviewable:end -->
