### PR TITLE
test(storage): tolerate PKCS#12 errors on WIN32

### DIFF
--- a/google/cloud/storage/oauth2/google_credentials_test.cc
+++ b/google/cloud/storage/oauth2/google_credentials_test.cc
@@ -533,7 +533,7 @@ TEST_F(GoogleCredentialsTest, LoadP12Credentials) {
   if (creds.status().code() == StatusCode::kInvalidArgument) {
     if (absl::StrContains(creds.status().message(), "error:0308010C")) {
       // With OpenSSL 3.0 the PKCS#12 files may not be supported by default.
-      GTEST_SKIP();
+      GTEST_SKIP() << "PKCS#12 support unavailable, skipping test";
     }
 #if _WIN32
     // On Windows, the OS may not have the necessary providers to support
@@ -542,7 +542,7 @@ TEST_F(GoogleCredentialsTest, LoadP12Credentials) {
     auto const& metadata = creds.status().error_info().metadata();
     auto const l = metadata.find("gcloud-cpp.source.function");
     if (l != metadata.end() && l->second == "GetCertificatePrivateKey") {
-      GTEST_SKIP();
+      GTEST_SKIP() << "PKCS#12 support unavailable, skipping test";
     }
 #endif  // _WIN32
   }

--- a/google/cloud/storage/oauth2/google_credentials_test.cc
+++ b/google/cloud/storage/oauth2/google_credentials_test.cc
@@ -528,18 +528,29 @@ TEST_F(GoogleCredentialsTest, LoadP12Credentials) {
   ScopedEnvironment adc_env_var(GoogleAdcEnvVar(), filename.c_str());
 
   auto creds = GoogleDefaultCredentials();
-  if (creds.status().code() == StatusCode::kInvalidArgument &&
-      absl::StrContains(creds.status().message(), "error:0308010C")) {
-    // With OpenSSL 3.0 the PKCS#12 files may not be supported by default.
-    (void)std::remove(filename.c_str());
-    GTEST_SKIP();
+  EXPECT_EQ(0, std::remove(filename.c_str()));
+
+  if (creds.status().code() == StatusCode::kInvalidArgument) {
+    if (absl::StrContains(creds.status().message(), "error:0308010C")) {
+      // With OpenSSL 3.0 the PKCS#12 files may not be supported by default.
+      GTEST_SKIP();
+    }
+#if _WIN32
+    // On Windows, the OS may not have the necessary providers to support
+    // PKCS#12. Unfortunately the error message is not as unambiguous, so we use
+    // the function that fails instead.
+    auto const& metadata = creds.status().error_info().metadata();
+    auto const l = metadata.find("gcloud-cpp.source.function");
+    if (l != metadata.end() && l->second == "GetCertificatePrivateKey") {
+      GTEST_SKIP();
+    }
+#endif  // _WIN32
   }
   ASSERT_STATUS_OK(creds);
   auto* ptr = creds->get();
   EXPECT_EQ(typeid(*ptr), typeid(ServiceAccountCredentials<>));
   EXPECT_EQ(kP12ServiceAccountId, ptr->AccountEmail());
   EXPECT_FALSE(ptr->KeyId().empty());
-  EXPECT_EQ(0, std::remove(filename.c_str()));
 }
 
 }  // namespace

--- a/google/cloud/storage/oauth2/service_account_credentials_test.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials_test.cc
@@ -509,7 +509,7 @@ TEST_F(ServiceAccountCredentialsTest, ParseSimpleP12) {
   if (info.status().code() == StatusCode::kInvalidArgument) {
     if (absl::StrContains(info.status().message(), "error:0308010C")) {
       // With OpenSSL 3.0 the PKCS#12 files may not be supported by default.
-      GTEST_SKIP();
+      GTEST_SKIP() << "PKCS#12 support unavailable, skipping test";
     }
 #if _WIN32
     // On Windows, the OS may not have the necessary providers to support
@@ -518,7 +518,7 @@ TEST_F(ServiceAccountCredentialsTest, ParseSimpleP12) {
     auto const& metadata = info.status().error_info().metadata();
     auto const l = metadata.find("gcloud-cpp.source.function");
     if (l != metadata.end() && l->second == "GetCertificatePrivateKey") {
-      GTEST_SKIP();
+      GTEST_SKIP() << "PKCS#12 support unavailable, skipping test";
     }
 #endif  // _WIN32
   }
@@ -576,7 +576,7 @@ TEST_F(ServiceAccountCredentialsTest, CreateFromP12ValidFile) {
   if (actual.status().code() == StatusCode::kInvalidArgument) {
     if (absl::StrContains(actual.status().message(), "error:0308010C")) {
       // With OpenSSL 3.0 the PKCS#12 files may not be supported by default.
-      GTEST_SKIP();
+      GTEST_SKIP() << "PKCS#12 support unavailable, skipping test";
     }
 #if _WIN32
     // On Windows, the OS may not have the necessary providers to support
@@ -585,7 +585,7 @@ TEST_F(ServiceAccountCredentialsTest, CreateFromP12ValidFile) {
     auto const& metadata = actual.status().error_info().metadata();
     auto const l = metadata.find("gcloud-cpp.source.function");
     if (l != metadata.end() && l->second == "GetCertificatePrivateKey") {
-      GTEST_SKIP();
+      GTEST_SKIP() << "PKCS#12 support unavailable, skipping test";
     }
 #endif  // _WIN32
   }

--- a/google/cloud/storage/oauth2/service_account_credentials_test.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials_test.cc
@@ -504,16 +504,28 @@ TEST_F(ServiceAccountCredentialsTest, ParseSimpleP12) {
   WriteBase64AsBinary(filename, kP12KeyFileContents);
 
   auto info = ParseServiceAccountP12File(filename);
-  if (info.status().code() == StatusCode::kInvalidArgument &&
-      absl::StrContains(info.status().message(), "error:0308010C")) {
-    // With OpenSSL 3.0 the PKCS#12 files may not be supported by default.
-    GTEST_SKIP();
+  EXPECT_EQ(0, std::remove(filename.c_str()));
+
+  if (info.status().code() == StatusCode::kInvalidArgument) {
+    if (absl::StrContains(info.status().message(), "error:0308010C")) {
+      // With OpenSSL 3.0 the PKCS#12 files may not be supported by default.
+      GTEST_SKIP();
+    }
+#if _WIN32
+    // On Windows, the OS may not have the necessary providers to support
+    // PKCS#12. Unfortunately the error message is not as unambiguous, so we use
+    // the function that fails instead.
+    auto const& metadata = info.status().error_info().metadata();
+    auto const l = metadata.find("gcloud-cpp.source.function");
+    if (l != metadata.end() && l->second == "GetCertificatePrivateKey") {
+      GTEST_SKIP();
+    }
+#endif  // _WIN32
   }
   ASSERT_STATUS_OK(info);
 
   EXPECT_EQ(kP12ServiceAccountId, info->client_email);
   EXPECT_FALSE(info->private_key.empty());
-  EXPECT_EQ(0, std::remove(filename.c_str()));
 
   ServiceAccountCredentials<> credentials(*info);
 
@@ -559,14 +571,25 @@ TEST_F(ServiceAccountCredentialsTest, CreateFromP12ValidFile) {
   WriteBase64AsBinary(filename, kP12KeyFileContents);
 
   auto actual = CreateServiceAccountCredentialsFromP12FilePath(filename);
-  if (actual.status().code() == StatusCode::kInvalidArgument &&
-      absl::StrContains(actual.status().message(), "error:0308010C")) {
-    // With OpenSSL 3.0 the PKCS#12 files may not be supported by default.
-    GTEST_SKIP();
+  EXPECT_EQ(0, std::remove(filename.c_str()));
+
+  if (actual.status().code() == StatusCode::kInvalidArgument) {
+    if (absl::StrContains(actual.status().message(), "error:0308010C")) {
+      // With OpenSSL 3.0 the PKCS#12 files may not be supported by default.
+      GTEST_SKIP();
+    }
+#if _WIN32
+    // On Windows, the OS may not have the necessary providers to support
+    // PKCS#12. Unfortunately the error message is not as unambiguous, so we use
+    // the function that fails instead.
+    auto const& metadata = actual.status().error_info().metadata();
+    auto const l = metadata.find("gcloud-cpp.source.function");
+    if (l != metadata.end() && l->second == "GetCertificatePrivateKey") {
+      GTEST_SKIP();
+    }
+#endif  // _WIN32
   }
   EXPECT_STATUS_OK(actual);
-
-  EXPECT_EQ(0, std::remove(filename.c_str()));
 }
 
 /// @test Verify we can obtain JWT assertion components given the info parsed


### PR DESCRIPTION
Just like OpenSSL may not work if PKCS#12 is disabled, Windows may lack a provider for the PKCS#12 keyfiles too. I tried to use a fairly narrow way to detect that this is indeed the problem.

Related to #13746

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13893)
<!-- Reviewable:end -->
