### PR TITLE
impl(generator): add a disable parallel write flag

### DIFF
--- a/generator/internal/discovery_to_proto.cc
+++ b/generator/internal/discovery_to_proto.cc
@@ -573,7 +573,7 @@ Status GenerateProtosFromDiscoveryDoc(
     nlohmann::json const& discovery_doc, std::string const& discovery_doc_url,
     std::string const& protobuf_proto_path,
     std::string const& googleapis_proto_path, std::string const& output_path,
-    std::string const& export_output_path,
+    std::string const& export_output_path, bool disable_parallel_write,
     std::set<std::string> operation_services) {
   auto default_hostname = DefaultHostFromRootUrl(discovery_doc);
   if (!default_hostname) return std::move(default_hostname).status();
@@ -644,38 +644,50 @@ Status GenerateProtosFromDiscoveryDoc(
     (void)descriptor_pool.FindFileByName(f.relative_proto_path());
   }
 
-  std::vector<std::future<google::cloud::Status>> tasks;
-  tasks.reserve(files->first.size());
-  for (auto f : files->first) {
-    tasks.push_back(std::async(
-        std::launch::async,
-        [](DiscoveryFile const& f,
-           DiscoveryDocumentProperties const& document_properties,
-           std::map<std::string, DiscoveryTypeVertex> const& types) {
-          return f.WriteFile(document_properties, types);
-        },
-        std::move(f), document_properties, *types));
-  }
-
-  for (auto f : files->second) {
-    tasks.push_back(std::async(
-        std::launch::async,
-        [](DiscoveryProtoExportFile const& f) { return f.WriteFile(); },
-        std::move(f)));
-  }
-
-  bool file_write_error = false;
-  for (auto& t : tasks) {
-    auto result = t.get();
-    if (!result.ok()) {
-      GCP_LOG(ERROR) << result;
-      file_write_error = true;
+  if (disable_parallel_write) {
+    for (auto f : files->first) {
+      auto s = f.WriteFile(document_properties, *types);
+      if (!s.ok()) return s;
     }
-  }
 
-  if (file_write_error) {
-    return internal::InternalError(
-        "Error encountered writing file. Check log for additional details.");
+    for (auto f : files->second) {
+      auto s = f.WriteFile();
+      if (!s.ok()) return s;
+    }
+  } else {
+    std::vector<std::future<google::cloud::Status>> tasks;
+    tasks.reserve(files->first.size());
+    for (auto f : files->first) {
+      tasks.push_back(std::async(
+          std::launch::async,
+          [](DiscoveryFile const& f,
+             DiscoveryDocumentProperties const& document_properties,
+             std::map<std::string, DiscoveryTypeVertex> const& types) {
+            return f.WriteFile(document_properties, types);
+          },
+          std::move(f), document_properties, *types));
+    }
+
+    for (auto f : files->second) {
+      tasks.push_back(std::async(
+          std::launch::async,
+          [](DiscoveryProtoExportFile const& f) { return f.WriteFile(); },
+          std::move(f)));
+    }
+
+    bool file_write_error = false;
+    for (auto& t : tasks) {
+      auto result = t.get();
+      if (!result.ok()) {
+        GCP_LOG(ERROR) << result;
+        file_write_error = true;
+      }
+    }
+
+    if (file_write_error) {
+      return internal::InternalError(
+          "Error encountered writing file. Check log for additional details.");
+    }
   }
 
   return {};

--- a/generator/internal/discovery_to_proto.cc
+++ b/generator/internal/discovery_to_proto.cc
@@ -645,12 +645,12 @@ Status GenerateProtosFromDiscoveryDoc(
   }
 
   if (disable_parallel_write) {
-    for (auto f : files->first) {
+    for (auto const& f : files->first) {
       auto s = f.WriteFile(document_properties, *types);
       if (!s.ok()) return s;
     }
 
-    for (auto f : files->second) {
+    for (auto const& f : files->second) {
       auto s = f.WriteFile();
       if (!s.ok()) return s;
     }

--- a/generator/internal/discovery_to_proto.h
+++ b/generator/internal/discovery_to_proto.h
@@ -93,7 +93,7 @@ Status GenerateProtosFromDiscoveryDoc(
     nlohmann::json const& discovery_doc, std::string const& discovery_doc_url,
     std::string const& protobuf_proto_path,
     std::string const& googleapis_proto_path, std::string const& output_path,
-    std::string const& export_output_path,
+    std::string const& export_output_path, bool disable_parallel_write = true,
     std::set<std::string> operation_services = {});
 
 // Recurses through the json accumulating the values of any $ref fields

--- a/generator/internal/discovery_to_proto.h
+++ b/generator/internal/discovery_to_proto.h
@@ -93,7 +93,8 @@ Status GenerateProtosFromDiscoveryDoc(
     nlohmann::json const& discovery_doc, std::string const& discovery_doc_url,
     std::string const& protobuf_proto_path,
     std::string const& googleapis_proto_path, std::string const& output_path,
-    std::string const& export_output_path, bool disable_parallel_write = true,
+    std::string const& export_output_path,
+    bool enable_parallel_write_for_discovery_protos = false,
     std::set<std::string> operation_services = {});
 
 // Recurses through the json accumulating the values of any $ref fields

--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -59,7 +59,7 @@ ABSL_FLAG(bool, check_parameter_comment_substitutions, false,
           "Check that the built-in parameter comment substitutions applied.");
 ABSL_FLAG(bool, generate_discovery_protos, false,
           "Generate only .proto files, no C++ code.");
-ABSL_FLAG(bool, enable_parallel_write_for_discovery_protos, false,
+ABSL_FLAG(bool, enable_parallel_write_for_discovery_protos, true,
           "Enable parallelized file writing for discovery protos. This allows "
           "for readable logs.");
 namespace {

--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -59,7 +59,8 @@ ABSL_FLAG(bool, check_parameter_comment_substitutions, false,
           "Check that the built-in parameter comment substitutions applied.");
 ABSL_FLAG(bool, generate_discovery_protos, false,
           "Generate only .proto files, no C++ code.");
-
+ABSL_FLAG(bool, disable_parallel_write, false,
+          "Disable parallelized file writing. This allows for readable logs.");
 namespace {
 
 using ::google::cloud::generator_internal::GenerateMetadata;
@@ -203,6 +204,7 @@ google::cloud::Status GenerateProtosForRestProducts(
             generator_args.protobuf_proto_path,
             generator_args.googleapis_proto_path, generator_args.output_path,
             generator_args.export_output_path,
+            generator_args.disable_parallel_write,
             std::set<std::string>(p.operation_services().begin(),
                                   p.operation_services().end()));
     if (!status.ok()) return status;
@@ -435,7 +437,8 @@ int main(int argc, char** argv) {
                              absl::GetFlag(FLAGS_scaffold),
                              absl::GetFlag(FLAGS_experimental_scaffold),
                              absl::GetFlag(FLAGS_update_ci),
-                             absl::GetFlag(FLAGS_generate_discovery_protos)};
+                             absl::GetFlag(FLAGS_generate_discovery_protos),
+                             absl::GetFlag(FLAGS_disable_parallel_write)};
 
   GCP_LOG(INFO) << "proto_path = " << args.protobuf_proto_path << "\n";
   GCP_LOG(INFO) << "googleapis_path = " << args.googleapis_proto_path << "\n";

--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -85,6 +85,7 @@ struct CommandLineArgs {
   bool experimental_scaffold;
   bool update_ci;
   bool generate_discovery_protos;
+  bool disable_parallel_write;
 };
 
 google::cloud::StatusOr<google::cloud::cpp::generator::GeneratorConfiguration>

--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -59,8 +59,9 @@ ABSL_FLAG(bool, check_parameter_comment_substitutions, false,
           "Check that the built-in parameter comment substitutions applied.");
 ABSL_FLAG(bool, generate_discovery_protos, false,
           "Generate only .proto files, no C++ code.");
-ABSL_FLAG(bool, disable_parallel_write, false,
-          "Disable parallelized file writing. This allows for readable logs.");
+ABSL_FLAG(bool, enable_parallel_write_for_discovery_protos, false,
+          "Enable parallelized file writing for discovery protos. This allows "
+          "for readable logs.");
 namespace {
 
 using ::google::cloud::generator_internal::GenerateMetadata;
@@ -85,7 +86,7 @@ struct CommandLineArgs {
   bool experimental_scaffold;
   bool update_ci;
   bool generate_discovery_protos;
-  bool disable_parallel_write;
+  bool enable_parallel_write_for_discovery_protos;
 };
 
 google::cloud::StatusOr<google::cloud::cpp::generator::GeneratorConfiguration>
@@ -205,7 +206,7 @@ google::cloud::Status GenerateProtosForRestProducts(
             generator_args.protobuf_proto_path,
             generator_args.googleapis_proto_path, generator_args.output_path,
             generator_args.export_output_path,
-            generator_args.disable_parallel_write,
+            generator_args.enable_parallel_write_for_discovery_protos,
             std::set<std::string>(p.operation_services().begin(),
                                   p.operation_services().end()));
     if (!status.ok()) return status;
@@ -427,19 +428,20 @@ int main(int argc, char** argv) {
         << "; you'll need to recompile everything for that to work";
   }
 
-  CommandLineArgs const args{absl::GetFlag(FLAGS_config_file),
-                             absl::GetFlag(FLAGS_protobuf_proto_path),
-                             absl::GetFlag(FLAGS_googleapis_proto_path),
-                             absl::GetFlag(FLAGS_golden_proto_path),
-                             absl::GetFlag(FLAGS_discovery_proto_path),
-                             absl::GetFlag(FLAGS_output_path),
-                             absl::GetFlag(FLAGS_export_output_path),
-                             absl::GetFlag(FLAGS_scaffold_templates_path),
-                             absl::GetFlag(FLAGS_scaffold),
-                             absl::GetFlag(FLAGS_experimental_scaffold),
-                             absl::GetFlag(FLAGS_update_ci),
-                             absl::GetFlag(FLAGS_generate_discovery_protos),
-                             absl::GetFlag(FLAGS_disable_parallel_write)};
+  CommandLineArgs const args{
+      absl::GetFlag(FLAGS_config_file),
+      absl::GetFlag(FLAGS_protobuf_proto_path),
+      absl::GetFlag(FLAGS_googleapis_proto_path),
+      absl::GetFlag(FLAGS_golden_proto_path),
+      absl::GetFlag(FLAGS_discovery_proto_path),
+      absl::GetFlag(FLAGS_output_path),
+      absl::GetFlag(FLAGS_export_output_path),
+      absl::GetFlag(FLAGS_scaffold_templates_path),
+      absl::GetFlag(FLAGS_scaffold),
+      absl::GetFlag(FLAGS_experimental_scaffold),
+      absl::GetFlag(FLAGS_update_ci),
+      absl::GetFlag(FLAGS_generate_discovery_protos),
+      absl::GetFlag(FLAGS_enable_parallel_write_for_discovery_protos)};
 
   GCP_LOG(INFO) << "proto_path = " << args.protobuf_proto_path << "\n";
   GCP_LOG(INFO) << "googleapis_path = " << args.googleapis_proto_path << "\n";


### PR DESCRIPTION
https://github.com/googleapis/google-cloud-cpp/issues/13892

The GenerateProtosFromDiscoveryDoc is called in two places- standalone main() and unit tests. We set the default to false in the `standalone_main()` (so it is written in parallel) and the default param to true so that when it is called in the unit tests it is set and the output is not obscured.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13895)
<!-- Reviewable:end -->
