### PR TITLE
fix(storage): preserve full Status in default creds

### DIFF
--- a/google/cloud/storage/oauth2/google_credentials.cc
+++ b/google/cloud/storage/oauth2/google_credentials.cc
@@ -59,14 +59,7 @@ StatusOr<std::unique_ptr<Credentials>> LoadCredsFromPath(
   if (!cred_json.is_object()) {
     // This is not a JSON file, try to load it as a P12 service account.
     auto info = ParseServiceAccountP12File(path);
-    if (!info) {
-      return Status(
-          StatusCode::kInvalidArgument,
-          "Cannot open credentials file " + path +
-              ", it does not contain a JSON object, nor can be parsed "
-              "as a PKCS#12 file. " +
-              info.status().message());
-    }
+    if (!info) return std::move(info).status();
     info->subject = std::move(service_account_subject);
     info->scopes = std::move(service_account_scopes);
     auto credentials = std::make_unique<ServiceAccountCredentials<>>(*info);

--- a/google/cloud/storage/oauth2/google_credentials_test.cc
+++ b/google/cloud/storage/oauth2/google_credentials_test.cc
@@ -460,8 +460,8 @@ TEST_F(GoogleCredentialsTest, LoadInvalidCredentials) {
     ScopedEnvironment adc_env_var(GoogleAdcEnvVar(), filename.c_str());
 
     auto creds = GoogleDefaultCredentials();
-    EXPECT_THAT(creds, StatusIs(StatusCode::kInvalidArgument,
-                                HasSubstr(filename)));
+    EXPECT_THAT(creds,
+                StatusIs(StatusCode::kInvalidArgument, HasSubstr(filename)));
   }
 }
 

--- a/google/cloud/storage/oauth2/google_credentials_test.cc
+++ b/google/cloud/storage/oauth2/google_credentials_test.cc
@@ -461,7 +461,7 @@ TEST_F(GoogleCredentialsTest, LoadInvalidCredentials) {
 
     auto creds = GoogleDefaultCredentials();
     EXPECT_THAT(creds, StatusIs(StatusCode::kInvalidArgument,
-                                HasSubstr("credentials file " + filename)));
+                                HasSubstr(filename)));
   }
 }
 


### PR DESCRIPTION
We no longer encourage using
`google::cloud::storage::oauth2::GoogleDefaultCredentials()`, but in this case the function was dropping details about an error condition that are probably useful.

Related to #13746

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13897)
<!-- Reviewable:end -->
