### PR TITLE
feat(spanner): add ExcludeTransactionFromChangeStreamsOption

### DIFF
--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -167,6 +167,10 @@ google::spanner::v1::TransactionOptions PartitionedDmlTransactionOptions() {
   google::spanner::v1::TransactionOptions options;
   *options.mutable_partitioned_dml() =
       google::spanner::v1::TransactionOptions_PartitionedDml();
+  auto const& current = internal::CurrentOptions();
+  if (current.get<spanner::ExcludeTransactionFromChangeStreamsOption>()) {
+    options.set_exclude_txn_from_change_streams(true);
+  }
   return options;
 }
 
@@ -1287,6 +1291,10 @@ spanner::BatchedCommitResultStream ConnectionImpl::BatchWriteImpl(
     for (auto& m : mutations) {
       *group->add_mutations() = std::move(m).as_proto();
     }
+  }
+  auto const& current = internal::CurrentOptions();
+  if (current.get<spanner::ExcludeTransactionFromChangeStreamsOption>()) {
+    request.set_exclude_txn_from_change_streams(true);
   }
 
   auto stub = session_pool_->GetStub(*session);

--- a/google/cloud/spanner/options.h
+++ b/google/cloud/spanner/options.h
@@ -352,6 +352,23 @@ struct TransactionTagOption {
 };
 
 /**
+ * Option for `google::cloud::Options` to control when transaction mutations
+ * will not be recorded in change streams that track columns modified by the
+ * transaction.
+ *
+ * The mutations will NOT be recorded when this option is true AND the change
+ * stream has the `allow_txn_exclusion` DDL option set.
+ *
+ * May only be specified for read-write transactions, ExecutePartitionedDml(),
+ * and the mutation-groups overload of CommitAtLeastOnce().
+ *
+ * @ingroup spanner-options
+ */
+struct ExcludeTransactionFromChangeStreamsOption {
+  using Type = bool;
+};
+
+/**
  * Option for `google::cloud::Options` to return additional statistics
  * about the committed transaction in a `spanner::CommitResult`.
  *

--- a/google/cloud/spanner/transaction.cc
+++ b/google/cloud/spanner/transaction.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/spanner/transaction.h"
 #include "google/cloud/spanner/internal/session.h"
 #include "google/cloud/spanner/internal/transaction_impl.h"
+#include "google/cloud/spanner/options.h"
 #include <google/protobuf/duration.pb.h>
 
 namespace google {
@@ -44,6 +45,10 @@ google::spanner::v1::TransactionOptions MakeOpts(
     google::spanner::v1::TransactionOptions_ReadWrite rw_opts) {
   google::spanner::v1::TransactionOptions opts;
   *opts.mutable_read_write() = std::move(rw_opts);
+  auto const& current = internal::CurrentOptions();
+  if (current.get<ExcludeTransactionFromChangeStreamsOption>()) {
+    opts.set_exclude_txn_from_change_streams(true);
+  }
   return opts;
 }
 


### PR DESCRIPTION
Mutations within an ExecutePartitionedDml(), the mutation-groups overload of a CommitAtLeastOnce(), or any read-write transaction, will not be recorded in change streams that track the modified columns if this new option is set and the change stream has the `allow_txn_exclusion` option set.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13898)
<!-- Reviewable:end -->
