### PR TITLE
impl(otel): support non-string resource attributes

### DIFF
--- a/google/cloud/opentelemetry/internal/monitored_resource.cc
+++ b/google/cloud/opentelemetry/internal/monitored_resource.cc
@@ -35,13 +35,10 @@ namespace sc = opentelemetry::sdk::resource::SemanticConventions;
 struct AsStringVisitor {
   template <typename T>
   std::string operator()(std::vector<T> const& v) const {
-    return absl::StrCat("[", absl::StrJoin(v, ", "), "]");
-  }
-  std::string operator()(std::vector<bool> const& v) const {
     return absl::StrCat("[",
                         absl::StrJoin(v, ", ",
-                                      [](std::string* out, bool v) {
-                                        out->append(v ? "true" : "false");
+                                      [this](std::string* out, T const& v) {
+                                        out->append(this->operator()(v));
                                       }),
                         "]");
   }

--- a/google/cloud/opentelemetry/internal/monitored_resource.cc
+++ b/google/cloud/opentelemetry/internal/monitored_resource.cc
@@ -13,12 +13,15 @@
 // limitations under the License.
 
 #include "google/cloud/opentelemetry/internal/monitored_resource.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
+#include "google/cloud/internal/absl_str_join_quiet.h"
 #include "google/cloud/version.h"
 #include "absl/types/optional.h"
 #include "absl/types/variant.h"
 #include <opentelemetry/common/attribute_value.h>
 #include <opentelemetry/sdk/resource/resource.h>
 #include <opentelemetry/sdk/resource/semantic_conventions.h>
+#include <numeric>
 #include <unordered_map>
 
 namespace google {
@@ -29,15 +32,25 @@ namespace {
 
 namespace sc = opentelemetry::sdk::resource::SemanticConventions;
 
-std::string AsString(
-    opentelemetry::sdk::common::OwnedAttributeValue attribute) {
-  if (absl::holds_alternative<std::string>(attribute)) {
-    return absl::get<std::string>(attribute);
+struct AsStringVisitor {
+  template <typename T>
+  std::string operator()(std::vector<T> const& v) const {
+    return absl::StrCat("[", absl::StrJoin(v, ", "), "]");
   }
-  // TODO(#11775) - convert other attribute types to strings
-  // Note that our resource detector only uses string attributes.
-  return {};
-}
+  std::string operator()(std::vector<bool> const& v) const {
+    return absl::StrCat("[",
+                        absl::StrJoin(v, ", ",
+                                      [](std::string* out, bool v) {
+                                        out->append(v ? "true" : "false");
+                                      }),
+                        "]");
+  }
+  template <typename T>
+  std::string operator()(T const& v) const {
+    return absl::StrCat(v);
+  }
+  std::string operator()(bool const& v) const { return v ? "true" : "false"; }
+};
 
 struct OTelKeyMatch {
   std::vector<std::string> otel_keys;
@@ -207,6 +220,11 @@ MonitoredResourceProvider MakeProvider(
 }
 
 }  // namespace
+
+std::string AsString(
+    opentelemetry::sdk::common::OwnedAttributeValue const& attribute) {
+  return absl::visit(AsStringVisitor{}, attribute);
+}
 
 MonitoredResource ToMonitoredResource(
     opentelemetry::sdk::resource::ResourceAttributes const& attributes) {

--- a/google/cloud/opentelemetry/internal/monitored_resource.h
+++ b/google/cloud/opentelemetry/internal/monitored_resource.h
@@ -25,6 +25,9 @@ namespace cloud {
 namespace otel_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+std::string AsString(
+    opentelemetry::sdk::common::OwnedAttributeValue const& attribute);
+
 /*
  * A struct representing a Google Cloud monitored resource.
  *

--- a/google/cloud/opentelemetry/internal/monitored_resource_test.cc
+++ b/google/cloud/opentelemetry/internal/monitored_resource_test.cc
@@ -49,6 +49,8 @@ TEST(AsString, VectorsAreJoined) {
     opentelemetry::sdk::common::OwnedAttributeValue value;
     std::string result;
   };
+
+  std::vector<std::string> const v = {"value1", "value2"};
   std::vector<TestCase> cases = {
       {std::vector<bool>{{true, false}}, "[true, false]"},
       {std::vector<int32_t>{{1, 2}}, "[1, 2]"},
@@ -57,8 +59,7 @@ TEST(AsString, VectorsAreJoined) {
       {std::vector<uint64_t>{{7, 8}}, "[7, 8]"},
       {std::vector<uint8_t>{{9, 10}}, "[9, 10]"},
       {std::vector<double>{{1.1, 2.2}}, "[1.1, 2.2]"},
-      {std::vector<std::string>{{std::string{"value1"}, std::string{"value2"}}},
-       "[value1, value2]"},
+      {v, "[value1, value2]"},
   };
 
   for (auto const& c : cases) {

--- a/google/cloud/opentelemetry/internal/monitored_resource_test.cc
+++ b/google/cloud/opentelemetry/internal/monitored_resource_test.cc
@@ -27,6 +27,45 @@ namespace sc = opentelemetry::sdk::resource::SemanticConventions;
 using ::testing::Pair;
 using ::testing::UnorderedElementsAre;
 
+TEST(AsString, Simple) {
+  struct TestCase {
+    opentelemetry::sdk::common::OwnedAttributeValue value;
+    std::string result;
+  };
+  std::vector<TestCase> cases = {
+      {true, "true"},       {false, "false"},
+      {int32_t{1}, "1"},    {uint32_t{2}, "2"},
+      {int64_t{3}, "3"},    {uint64_t{4}, "4"},
+      {double{5.6}, "5.6"}, {std::string{"value"}, "value"},
+  };
+
+  for (auto const& c : cases) {
+    EXPECT_EQ(c.result, AsString(c.value));
+  }
+}
+
+TEST(AsString, VectorsAreJoined) {
+  struct TestCase {
+    opentelemetry::sdk::common::OwnedAttributeValue value;
+    std::string result;
+  };
+  std::vector<TestCase> cases = {
+      {std::vector<bool>{{true, false}}, "[true, false]"},
+      {std::vector<int32_t>{{1, 2}}, "[1, 2]"},
+      {std::vector<uint32_t>{{3, 4}}, "[3, 4]"},
+      {std::vector<int64_t>{{5, 6}}, "[5, 6]"},
+      {std::vector<uint64_t>{{7, 8}}, "[7, 8]"},
+      {std::vector<uint8_t>{{9, 10}}, "[9, 10]"},
+      {std::vector<double>{{1.1, 2.2}}, "[1.1, 2.2]"},
+      {std::vector<std::string>{{std::string{"value1"}, std::string{"value2"}}},
+       "[value1, value2]"},
+  };
+
+  for (auto const& c : cases) {
+    EXPECT_EQ(c.result, AsString(c.value));
+  }
+}
+
 TEST(MonitoredResource, GceInstance) {
   auto attributes = opentelemetry::sdk::resource::ResourceAttributes{
       {sc::kCloudPlatform, "gcp_compute_engine"},


### PR DESCRIPTION
Related to #11775 

In our Cloud Trace and Cloud Monitoring exporters, we copy over resource attributes. Our GCP Resource Detector only uses strings for the value of these attributes. But in the off-chance that an application is using a different resource detector, handle these additional attribute types.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13902)
<!-- Reviewable:end -->
