### PR TITLE
feat(docfx): supported nested paragraphs

### DIFF
--- a/docfx/doxygen2markdown.cc
+++ b/docfx/doxygen2markdown.cc
@@ -428,6 +428,7 @@ bool AppendIfLinebreak(std::ostream& os, MarkdownContext const& /*ctx*/,
 //     <xsd:element name="nonbreakablespace" type="docEmptyType" />
 //     <xsd:element name="iexcl" type="docEmptyType" />
 // ... other "symbols", such as currency, math formulas, accents, etc. ...
+//     <xsd:element name="para" type="docEmptyType" />
 // ... upper case greek letters ...
 // ... lower case greek letters ...
 //   </xsd:choice>
@@ -453,6 +454,7 @@ bool AppendIfDocTitleCmdGroup(std::ostream& os, MarkdownContext const& ctx,
   // Unexpected: nonbreakablespace
   // Unexpected: many many symbols
   if (AppendIfNDash(os, ctx, node)) return true;
+  if (AppendIfParagraph(os, ctx, node)) return true;
   return false;
 }
 

--- a/docfx/doxygen2markdown_test.cc
+++ b/docfx/doxygen2markdown_test.cc
@@ -906,6 +906,34 @@ Required. Parent resource name. The format of this value varies depending on the
   EXPECT_EQ(kExpected, os.str());
 }
 
+TEST(Doxygen2Markdown, ParagraphWithParagraph) {
+  auto constexpr kXml = R"xml(<?xml version="1.0" standalone="yes"?>
+    <doxygen version="1.9.1" xml:lang="en-US">
+    <para id='tested-node'>
+      <para>
+        <simplesect kind="warning">
+        <para>Something clever about the warning.</para>
+      </para>
+    </para>
+    </doxygen>)xml";
+  auto constexpr kExpected = R"md(
+
+
+
+
+
+<aside class="warning"><b>Warning:</b>
+Something clever about the warning.
+</aside>)md";
+  pugi::xml_document doc;
+  doc.load_string(kXml);
+  auto selected = doc.select_node("//*[@id='tested-node']");
+  ASSERT_TRUE(selected);
+  std::ostringstream os;
+  ASSERT_TRUE(AppendIfParagraph(os, {}, selected.node()));
+  EXPECT_EQ(kExpected, os.str());
+}
+
 TEST(Doxygen2Markdown, ItemizedListSimple) {
   pugi::xml_document doc;
   doc.load_string(R"xml(<?xml version="1.0" standalone="yes"?>


### PR DESCRIPTION
I missed that a `<para>` element may have nested `<para>` elements. There are about 300 element in a `<para>`, most of them symbols.

An example of the trouble highlighted in #13911

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13912)
<!-- Reviewable:end -->
