### PR TITLE
impl(otel): process `SumPointData` metrics

### DIFF
--- a/google/cloud/opentelemetry/internal/time_series.cc
+++ b/google/cloud/opentelemetry/internal/time_series.cc
@@ -15,14 +15,48 @@
 #include "google/cloud/opentelemetry/internal/time_series.h"
 #include "google/cloud/opentelemetry/internal/monitored_resource.h"
 #include "google/cloud/internal/absl_str_replace_quiet.h"
+#include "google/cloud/internal/time_utils.h"
 #include "google/cloud/log.h"
 #include <opentelemetry/common/attribute_value.h>
+#include <opentelemetry/sdk/metrics/data/metric_data.h>
 #include <cctype>
 
 namespace google {
 namespace cloud {
 namespace otel_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+google::protobuf::Timestamp ToProtoTimestamp(
+    opentelemetry::common::SystemTimestamp ts) {
+  return internal::ToProtoTimestamp(
+      absl::FromUnixNanos(ts.time_since_epoch().count()));
+}
+
+google::monitoring::v3::TypedValue ToValue(
+    opentelemetry::sdk::metrics::ValueType value) {
+  google::monitoring::v3::TypedValue proto;
+  if (absl::holds_alternative<double>(value)) {
+    proto.set_double_value(absl::get<double>(value));
+  } else {
+    proto.set_int64_value(absl::get<std::int64_t>(value));
+  }
+  return proto;
+}
+
+google::api::MetricDescriptor::ValueType ToValueType(
+    opentelemetry::sdk::metrics::InstrumentValueType value_type) {
+  switch (value_type) {
+    case opentelemetry::sdk::metrics::InstrumentValueType::kInt:
+    case opentelemetry::sdk::metrics::InstrumentValueType::kLong:
+      return google::api::MetricDescriptor::INT64;
+    case opentelemetry::sdk::metrics::InstrumentValueType::kFloat:
+    case opentelemetry::sdk::metrics::InstrumentValueType::kDouble:
+      return google::api::MetricDescriptor::DOUBLE;
+  }
+}
+
+}  // namespace
 
 google::api::Metric ToMetric(
     opentelemetry::sdk::metrics::MetricData const& metric_data,
@@ -49,6 +83,36 @@ google::api::Metric ToMetric(
     labels[std::move(key)] = AsString(kv.second);
   }
   return proto;
+}
+
+google::monitoring::v3::TimeInterval ToNonEmptyTimeInterval(
+    opentelemetry::sdk::metrics::MetricData const& metric_data) {
+  // GCM requires that time intervals are non-empty. To achieve this, we
+  // override the end value to be at least 1ms after the start value.
+  // https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/babed4870546b78cee69606726961cfd20cbea42/exporter/metric/metric.go#L604-L609
+  auto end_ts_nanos = (std::max)(
+      metric_data.end_ts.time_since_epoch(),
+      metric_data.start_ts.time_since_epoch() + std::chrono::milliseconds(1));
+
+  google::monitoring::v3::TimeInterval proto;
+  *proto.mutable_start_time() = ToProtoTimestamp(metric_data.start_ts);
+  *proto.mutable_end_time() =
+      internal::ToProtoTimestamp(absl::FromUnixNanos(end_ts_nanos.count()));
+  return proto;
+}
+
+google::monitoring::v3::TimeSeries ToTimeSeries(
+    opentelemetry::sdk::metrics::MetricData const& metric_data,
+    opentelemetry::sdk::metrics::SumPointData const& sum_data) {
+  google::monitoring::v3::TimeSeries ts;
+  ts.set_unit(metric_data.instrument_descriptor.unit_);
+  ts.set_metric_kind(google::api::MetricDescriptor::CUMULATIVE);
+  ts.set_value_type(ToValueType(metric_data.instrument_descriptor.value_type_));
+
+  auto& p = *ts.add_points();
+  *p.mutable_interval() = ToNonEmptyTimeInterval(metric_data);
+  *p.mutable_value() = ToValue(sum_data.value_);
+  return ts;
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/opentelemetry/internal/time_series.cc
+++ b/google/cloud/opentelemetry/internal/time_series.cc
@@ -54,6 +54,7 @@ google::api::MetricDescriptor::ValueType ToValueType(
     case opentelemetry::sdk::metrics::InstrumentValueType::kDouble:
       return google::api::MetricDescriptor::DOUBLE;
   }
+  return google::api::MetricDescriptor::INT64;
 }
 
 }  // namespace

--- a/google/cloud/opentelemetry/internal/time_series.h
+++ b/google/cloud/opentelemetry/internal/time_series.h
@@ -16,7 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_OPENTELEMETRY_INTERNAL_TIME_SERIES_H
 
 #include "google/cloud/version.h"
-#include <google/api/metric.pb.h>
+#include <google/monitoring/v3/metric_service.pb.h>
 #include <opentelemetry/sdk/metrics/metric_reader.h>
 
 namespace google {
@@ -27,6 +27,10 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 google::api::Metric ToMetric(
     opentelemetry::sdk::metrics::MetricData const& metric_data,
     opentelemetry::sdk::metrics::PointAttributes const& attributes);
+
+google::monitoring::v3::TimeSeries ToTimeSeries(
+    opentelemetry::sdk::metrics::MetricData const& metric_data,
+    opentelemetry::sdk::metrics::SumPointData const& sum);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace otel_internal

--- a/google/cloud/opentelemetry/internal/time_series.h
+++ b/google/cloud/opentelemetry/internal/time_series.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_OPENTELEMETRY_INTERNAL_TIME_SERIES_H
 
 #include "google/cloud/version.h"
+#include <google/api/metric.pb.h>
 #include <google/monitoring/v3/metric_service.pb.h>
 #include <opentelemetry/sdk/metrics/metric_reader.h>
 

--- a/google/cloud/opentelemetry/internal/time_series_test.cc
+++ b/google/cloud/opentelemetry/internal/time_series_test.cc
@@ -29,12 +29,11 @@ using ::testing::Contains;
 using ::testing::ElementsAre;
 using ::testing::Eq;
 using ::testing::HasSubstr;
-using ::testing::Matcher;
 using ::testing::Pair;
 using ::testing::ResultOf;
 using ::testing::UnorderedElementsAre;
 
-Matcher<google::monitoring::v3::Point const&> DoubleTypedValue(double v) {
+auto DoubleTypedValue(double v) {
   return ResultOf(
       "double_value",
       [](google::monitoring::v3::Point const& p) {
@@ -43,7 +42,7 @@ Matcher<google::monitoring::v3::Point const&> DoubleTypedValue(double v) {
       Eq(v));
 }
 
-Matcher<google::monitoring::v3::Point const&> Int64TypedValue(std::int64_t v) {
+auto Int64TypedValue(std::int64_t v) {
   return ResultOf(
       "int64_value",
       [](google::monitoring::v3::Point const& p) {
@@ -52,9 +51,8 @@ Matcher<google::monitoring::v3::Point const&> Int64TypedValue(std::int64_t v) {
       Eq(v));
 }
 
-Matcher<google::monitoring::v3::Point const&> Interval(
-    std::chrono::system_clock::time_point start,
-    std::chrono::system_clock::time_point end) {
+auto Interval(std::chrono::system_clock::time_point start,
+              std::chrono::system_clock::time_point end) {
   return AllOf(
       ResultOf(
           "start_time",
@@ -68,7 +66,7 @@ Matcher<google::monitoring::v3::Point const&> Interval(
             return internal::ToChronoTimePoint(p.interval().end_time());
           },
           Eq(end)));
-};
+}
 
 TEST(ToMetric, Simple) {
   opentelemetry::sdk::metrics::MetricData md;
@@ -159,7 +157,7 @@ TEST(SumPointData, NonEmptyInterval) {
   EXPECT_LE(end - start, std::chrono::seconds::zero());
 
   // The spec says to drop the end timestamp, and use the start timestamp plus
-  // some delta as the end timestamp.
+  // 1ms as the end timestamp.
   auto const expected_end = start + std::chrono::milliseconds(1);
 
   opentelemetry::sdk::metrics::MetricData md;

--- a/google/cloud/opentelemetry/internal/time_series_test.cc
+++ b/google/cloud/opentelemetry/internal/time_series_test.cc
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/opentelemetry/internal/time_series.h"
+#include "google/cloud/internal/time_utils.h"
+#include "google/cloud/testing_util/chrono_output.h"
 #include "google/cloud/testing_util/scoped_log.h"
 #include <gmock/gmock.h>
 
@@ -22,10 +24,51 @@ namespace otel_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+using ::testing::AllOf;
 using ::testing::Contains;
+using ::testing::ElementsAre;
+using ::testing::Eq;
 using ::testing::HasSubstr;
+using ::testing::Matcher;
 using ::testing::Pair;
+using ::testing::ResultOf;
 using ::testing::UnorderedElementsAre;
+
+Matcher<google::monitoring::v3::Point const&> DoubleTypedValue(double v) {
+  return ResultOf(
+      "double_value",
+      [](google::monitoring::v3::Point const& p) {
+        return p.value().double_value();
+      },
+      Eq(v));
+}
+
+Matcher<google::monitoring::v3::Point const&> Int64TypedValue(std::int64_t v) {
+  return ResultOf(
+      "int64_value",
+      [](google::monitoring::v3::Point const& p) {
+        return p.value().int64_value();
+      },
+      Eq(v));
+}
+
+Matcher<google::monitoring::v3::Point const&> Interval(
+    std::chrono::system_clock::time_point start,
+    std::chrono::system_clock::time_point end) {
+  return AllOf(
+      ResultOf(
+          "start_time",
+          [](google::monitoring::v3::Point const& p) {
+            return internal::ToChronoTimePoint(p.interval().start_time());
+          },
+          Eq(start)),
+      ResultOf(
+          "end_time",
+          [](google::monitoring::v3::Point const& p) {
+            return internal::ToChronoTimePoint(p.interval().end_time());
+          },
+          Eq(end)));
+};
 
 TEST(ToMetric, Simple) {
   opentelemetry::sdk::metrics::MetricData md;
@@ -44,12 +87,10 @@ TEST(ToMetric, Simple) {
 TEST(ToMetric, BadLabelNames) {
   testing_util::ScopedLog log;
 
-  opentelemetry::sdk::metrics::MetricData md;
-
   opentelemetry::sdk::metrics::PointAttributes attributes = {
       {"99", "dropped"}, {"a key-with.bad/characters", "value"}};
 
-  auto metric = ToMetric(md, attributes);
+  auto metric = ToMetric({}, attributes);
 
   EXPECT_THAT(metric.labels(),
               UnorderedElementsAre(Pair("a_key_with_bad_characters", "value")));
@@ -57,6 +98,78 @@ TEST(ToMetric, BadLabelNames) {
   EXPECT_THAT(
       log.ExtractLines(),
       Contains(AllOf(HasSubstr("Dropping metric label"), HasSubstr("99"))));
+}
+
+TEST(SumPointData, Simple) {
+  auto const start = std::chrono::system_clock::now();
+  auto const end = start + std::chrono::seconds(5);
+
+  opentelemetry::sdk::metrics::MetricData md;
+  md.instrument_descriptor.unit_ = "unit";
+  md.instrument_descriptor.value_type_ =
+      opentelemetry::sdk::metrics::InstrumentValueType::kInt;
+  md.start_ts = start;
+  md.end_ts = end;
+
+  opentelemetry::sdk::metrics::SumPointData point;
+  point.value_ = 42L;
+
+  auto ts = ToTimeSeries(md, point);
+  EXPECT_EQ(ts.unit(), "unit");
+  EXPECT_EQ(ts.metric_kind(), google::api::MetricDescriptor::CUMULATIVE);
+  EXPECT_THAT(ts.points(),
+              ElementsAre(AllOf(Int64TypedValue(42), Interval(start, end))));
+}
+
+TEST(SumPointData, IntValueTypes) {
+  for (auto value_type : {
+           opentelemetry::sdk::metrics::InstrumentValueType::kInt,
+           opentelemetry::sdk::metrics::InstrumentValueType::kLong,
+       }) {
+    opentelemetry::sdk::metrics::MetricData md;
+    md.instrument_descriptor.value_type_ = value_type;
+
+    opentelemetry::sdk::metrics::SumPointData point;
+    point.value_ = 42L;
+
+    auto ts = ToTimeSeries(md, point);
+    EXPECT_THAT(ts.points(), ElementsAre(Int64TypedValue(42)));
+  }
+}
+
+TEST(SumPointData, DoubleValueTypes) {
+  for (auto value_type : {
+           opentelemetry::sdk::metrics::InstrumentValueType::kFloat,
+           opentelemetry::sdk::metrics::InstrumentValueType::kDouble,
+       }) {
+    opentelemetry::sdk::metrics::MetricData md;
+    md.instrument_descriptor.value_type_ = value_type;
+
+    opentelemetry::sdk::metrics::SumPointData point;
+    point.value_ = 42.0;
+
+    auto ts = ToTimeSeries(md, point);
+    EXPECT_THAT(ts.points(), ElementsAre(DoubleTypedValue(42)));
+  }
+}
+
+TEST(SumPointData, NonEmptyInterval) {
+  auto const start = std::chrono::system_clock::now();
+  auto const end = start - std::chrono::seconds(5);
+  EXPECT_LE(end - start, std::chrono::seconds::zero());
+
+  // The spec says to drop the end timestamp, and use the start timestamp plus
+  // some delta as the end timestamp.
+  auto const expected_end = start + std::chrono::milliseconds(1);
+
+  opentelemetry::sdk::metrics::MetricData md;
+  md.instrument_descriptor.value_type_ =
+      opentelemetry::sdk::metrics::InstrumentValueType::kInt;
+  md.start_ts = start;
+  md.end_ts = end;
+
+  auto ts = ToTimeSeries(md, opentelemetry::sdk::metrics::SumPointData{});
+  EXPECT_THAT(ts.points(), ElementsAre(Interval(start, expected_end)));
 }
 
 }  // namespace


### PR DESCRIPTION
Part of the work for #13869 

Add ability to translate `SumPointData` metrics to a `google::monitoring::v3::TimeSeries`.

New helpers like `ToValueType(...)` and `ToNonEmptyTimeInterval(...)` will get more use as we add conversions from other metric types.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13917)
<!-- Reviewable:end -->
