### PR TITLE
impl(otel): convert `LastValuePointData` to protos

### DIFF
--- a/google/cloud/opentelemetry/internal/time_series.cc
+++ b/google/cloud/opentelemetry/internal/time_series.cc
@@ -118,6 +118,21 @@ google::monitoring::v3::TimeSeries ToTimeSeries(
   return ts;
 }
 
+google::monitoring::v3::TimeSeries ToTimeSeries(
+    opentelemetry::sdk::metrics::MetricData const& metric_data,
+    opentelemetry::sdk::metrics::LastValuePointData const& gauge_data) {
+  google::monitoring::v3::TimeSeries ts;
+  ts.set_unit(metric_data.instrument_descriptor.unit_);
+  ts.set_metric_kind(google::api::MetricDescriptor::GAUGE);
+  ts.set_value_type(ToValueType(metric_data.instrument_descriptor.value_type_));
+
+  auto& p = *ts.add_points();
+  // Note that the start timestamp is omitted for gauge metrics.
+  *p.mutable_interval()->mutable_end_time() = ToProtoTimestamp(metric_data.end_ts);
+  *p.mutable_value() = ToValue(gauge_data.value_);
+  return ts;
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace otel_internal
 }  // namespace cloud

--- a/google/cloud/opentelemetry/internal/time_series.cc
+++ b/google/cloud/opentelemetry/internal/time_series.cc
@@ -128,7 +128,8 @@ google::monitoring::v3::TimeSeries ToTimeSeries(
 
   auto& p = *ts.add_points();
   // Note that the start timestamp is omitted for gauge metrics.
-  *p.mutable_interval()->mutable_end_time() = ToProtoTimestamp(metric_data.end_ts);
+  *p.mutable_interval()->mutable_end_time() =
+      ToProtoTimestamp(metric_data.end_ts);
   *p.mutable_value() = ToValue(gauge_data.value_);
   return ts;
 }

--- a/google/cloud/opentelemetry/internal/time_series.h
+++ b/google/cloud/opentelemetry/internal/time_series.h
@@ -31,7 +31,11 @@ google::api::Metric ToMetric(
 
 google::monitoring::v3::TimeSeries ToTimeSeries(
     opentelemetry::sdk::metrics::MetricData const& metric_data,
-    opentelemetry::sdk::metrics::SumPointData const& sum);
+    opentelemetry::sdk::metrics::SumPointData const& sum_data);
+
+google::monitoring::v3::TimeSeries ToTimeSeries(
+    opentelemetry::sdk::metrics::MetricData const& metric_data,
+    opentelemetry::sdk::metrics::LastValuePointData const& gauge_data);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace otel_internal

--- a/google/cloud/opentelemetry/internal/time_series_test.cc
+++ b/google/cloud/opentelemetry/internal/time_series_test.cc
@@ -33,6 +33,21 @@ using ::testing::Pair;
 using ::testing::ResultOf;
 using ::testing::UnorderedElementsAre;
 
+std::string ToString(opentelemetry::sdk::metrics::InstrumentValueType type) {
+  switch (type) {
+    case opentelemetry::sdk::metrics::InstrumentValueType::kInt:
+      return "kInt";
+    case opentelemetry::sdk::metrics::InstrumentValueType::kLong:
+      return "kLong";
+    case opentelemetry::sdk::metrics::InstrumentValueType::kFloat:
+      return "kFloat";
+    case opentelemetry::sdk::metrics::InstrumentValueType::kDouble:
+      return "kDouble";
+    default:
+      return "unreachable";
+  }
+}
+
 auto DoubleTypedValue(double v) {
   return ResultOf(
       "double_value",
@@ -120,15 +135,17 @@ TEST(SumPointData, Simple) {
 }
 
 TEST(SumPointData, IntValueTypes) {
+  opentelemetry::sdk::metrics::SumPointData point;
+  point.value_ = 42L;
+
   for (auto value_type : {
            opentelemetry::sdk::metrics::InstrumentValueType::kInt,
            opentelemetry::sdk::metrics::InstrumentValueType::kLong,
        }) {
+    SCOPED_TRACE("value_type: " + ToString(value_type));
+
     opentelemetry::sdk::metrics::MetricData md;
     md.instrument_descriptor.value_type_ = value_type;
-
-    opentelemetry::sdk::metrics::SumPointData point;
-    point.value_ = 42L;
 
     auto ts = ToTimeSeries(md, point);
     EXPECT_THAT(ts.points(), ElementsAre(Int64TypedValue(42)));
@@ -136,15 +153,17 @@ TEST(SumPointData, IntValueTypes) {
 }
 
 TEST(SumPointData, DoubleValueTypes) {
+  opentelemetry::sdk::metrics::SumPointData point;
+  point.value_ = 42.0;
+
   for (auto value_type : {
            opentelemetry::sdk::metrics::InstrumentValueType::kFloat,
            opentelemetry::sdk::metrics::InstrumentValueType::kDouble,
        }) {
+    SCOPED_TRACE("value_type: " + ToString(value_type));
+
     opentelemetry::sdk::metrics::MetricData md;
     md.instrument_descriptor.value_type_ = value_type;
-
-    opentelemetry::sdk::metrics::SumPointData point;
-    point.value_ = 42.0;
 
     auto ts = ToTimeSeries(md, point);
     EXPECT_THAT(ts.points(), ElementsAre(DoubleTypedValue(42)));
@@ -207,15 +226,17 @@ TEST(LastValuePointData, Simple) {
 }
 
 TEST(LastValuePointData, IntValueTypes) {
+  opentelemetry::sdk::metrics::LastValuePointData point;
+  point.value_ = 42L;
+
   for (auto value_type : {
            opentelemetry::sdk::metrics::InstrumentValueType::kInt,
            opentelemetry::sdk::metrics::InstrumentValueType::kLong,
        }) {
+    SCOPED_TRACE("value_type: " + ToString(value_type));
+
     opentelemetry::sdk::metrics::MetricData md;
     md.instrument_descriptor.value_type_ = value_type;
-
-    opentelemetry::sdk::metrics::LastValuePointData point;
-    point.value_ = 42L;
 
     auto ts = ToTimeSeries(md, point);
     EXPECT_THAT(ts.points(), ElementsAre(Int64TypedValue(42)));
@@ -223,15 +244,17 @@ TEST(LastValuePointData, IntValueTypes) {
 }
 
 TEST(LastValuePointData, DoubleValueTypes) {
+  opentelemetry::sdk::metrics::LastValuePointData point;
+  point.value_ = 42.0;
+
   for (auto value_type : {
            opentelemetry::sdk::metrics::InstrumentValueType::kFloat,
            opentelemetry::sdk::metrics::InstrumentValueType::kDouble,
        }) {
+    SCOPED_TRACE("value_type: " + ToString(value_type));
+
     opentelemetry::sdk::metrics::MetricData md;
     md.instrument_descriptor.value_type_ = value_type;
-
-    opentelemetry::sdk::metrics::LastValuePointData point;
-    point.value_ = 42.0;
 
     auto ts = ToTimeSeries(md, point);
     EXPECT_THAT(ts.points(), ElementsAre(DoubleTypedValue(42)));

--- a/google/cloud/opentelemetry/internal/time_series_test.cc
+++ b/google/cloud/opentelemetry/internal/time_series_test.cc
@@ -170,6 +170,74 @@ TEST(SumPointData, NonEmptyInterval) {
   EXPECT_THAT(ts.points(), ElementsAre(Interval(start, expected_end)));
 }
 
+TEST(LastValuePointData, Simple) {
+  auto const now = std::chrono::system_clock::now();
+
+  opentelemetry::sdk::metrics::MetricData md;
+  md.instrument_descriptor.unit_ = "unit";
+  md.instrument_descriptor.value_type_ =
+      opentelemetry::sdk::metrics::InstrumentValueType::kInt;
+  md.start_ts = now;
+  md.end_ts = now;
+
+  opentelemetry::sdk::metrics::LastValuePointData point;
+  point.value_ = 42L;
+
+  auto interval = [](std::chrono::system_clock::time_point end) {
+    return AllOf(
+        ResultOf(
+            "has_start_time",
+            [](google::monitoring::v3::Point const& p) {
+              return p.interval().has_start_time();
+            },
+            Eq(false)),
+        ResultOf(
+            "end_time",
+            [](google::monitoring::v3::Point const& p) {
+              return internal::ToChronoTimePoint(p.interval().end_time());
+            },
+            Eq(end)));
+  };
+
+  auto ts = ToTimeSeries(md, point);
+  EXPECT_EQ(ts.unit(), "unit");
+  EXPECT_EQ(ts.metric_kind(), google::api::MetricDescriptor::GAUGE);
+  EXPECT_THAT(ts.points(),
+              ElementsAre(AllOf(Int64TypedValue(42), interval(now))));
+}
+
+TEST(LastValuePointData, IntValueTypes) {
+  for (auto value_type : {
+           opentelemetry::sdk::metrics::InstrumentValueType::kInt,
+           opentelemetry::sdk::metrics::InstrumentValueType::kLong,
+       }) {
+    opentelemetry::sdk::metrics::MetricData md;
+    md.instrument_descriptor.value_type_ = value_type;
+
+    opentelemetry::sdk::metrics::LastValuePointData point;
+    point.value_ = 42L;
+
+    auto ts = ToTimeSeries(md, point);
+    EXPECT_THAT(ts.points(), ElementsAre(Int64TypedValue(42)));
+  }
+}
+
+TEST(LastValuePointData, DoubleValueTypes) {
+  for (auto value_type : {
+           opentelemetry::sdk::metrics::InstrumentValueType::kFloat,
+           opentelemetry::sdk::metrics::InstrumentValueType::kDouble,
+       }) {
+    opentelemetry::sdk::metrics::MetricData md;
+    md.instrument_descriptor.value_type_ = value_type;
+
+    opentelemetry::sdk::metrics::LastValuePointData point;
+    point.value_ = 42.0;
+
+    auto ts = ToTimeSeries(md, point);
+    EXPECT_THAT(ts.points(), ElementsAre(DoubleTypedValue(42)));
+  }
+}
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace otel_internal


### PR DESCRIPTION
Part of the work for #13869 

Gauge metrics are treated almost the same as Sum metrics. The differences are:
- The metric kind is `GAUGE`
- They represent a point in time, so we only set the end timestamp.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13919)
<!-- Reviewable:end -->
