### PR TITLE
impl(generator): add parens around return types in case of commas

### DIFF
--- a/generator/integration_tests/golden/v1/mocks/mock_golden_kitchen_sink_connection.h
+++ b/generator/integration_tests/golden/v1/mocks/mock_golden_kitchen_sink_connection.h
@@ -46,15 +46,15 @@ class MockGoldenKitchenSinkConnection : public golden_v1::GoldenKitchenSinkConne
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>,
+  MOCK_METHOD((StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>),
   GenerateAccessToken,
   (google::test::admin::database::v1::GenerateAccessTokenRequest const& request), (override));
 
-  MOCK_METHOD(StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>,
+  MOCK_METHOD((StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>),
   GenerateIdToken,
   (google::test::admin::database::v1::GenerateIdTokenRequest const& request), (override));
 
-  MOCK_METHOD(StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>,
+  MOCK_METHOD((StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>),
   WriteLogEntries,
   (google::test::admin::database::v1::WriteLogEntriesRequest const& request), (override));
 
@@ -62,7 +62,7 @@ class MockGoldenKitchenSinkConnection : public golden_v1::GoldenKitchenSinkConne
   ListLogs,
   (google::test::admin::database::v1::ListLogsRequest request), (override));
 
-  MOCK_METHOD(StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>,
+  MOCK_METHOD((StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>),
   ListServiceAccountKeys,
   (google::test::admin::database::v1::ListServiceAccountKeysRequest const& request), (override));
 
@@ -74,7 +74,7 @@ class MockGoldenKitchenSinkConnection : public golden_v1::GoldenKitchenSinkConne
   Deprecated2,
   (google::test::admin::database::v1::GenerateAccessTokenRequest const& request), (override));
 
-  MOCK_METHOD(StreamRange<google::test::admin::database::v1::Response>,
+  MOCK_METHOD((StreamRange<google::test::admin::database::v1::Response>),
   StreamingRead,
   (google::test::admin::database::v1::Request const& request), (override));
 

--- a/generator/integration_tests/golden/v1/mocks/mock_golden_thing_admin_connection.h
+++ b/generator/integration_tests/golden/v1/mocks/mock_golden_thing_admin_connection.h
@@ -50,15 +50,15 @@ class MockGoldenThingAdminConnection : public golden_v1::GoldenThingAdminConnect
   ListDatabases,
   (google::test::admin::database::v1::ListDatabasesRequest request), (override));
 
-  MOCK_METHOD(future<StatusOr<google::test::admin::database::v1::Database>>,
+  MOCK_METHOD((future<StatusOr<google::test::admin::database::v1::Database>>),
   CreateDatabase,
   (google::test::admin::database::v1::CreateDatabaseRequest const& request), (override));
 
-  MOCK_METHOD(StatusOr<google::test::admin::database::v1::Database>,
+  MOCK_METHOD((StatusOr<google::test::admin::database::v1::Database>),
   GetDatabase,
   (google::test::admin::database::v1::GetDatabaseRequest const& request), (override));
 
-  MOCK_METHOD(future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>,
+  MOCK_METHOD((future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>),
   UpdateDatabaseDdl,
   (google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request), (override));
 
@@ -66,31 +66,31 @@ class MockGoldenThingAdminConnection : public golden_v1::GoldenThingAdminConnect
   DropDatabase,
   (google::test::admin::database::v1::DropDatabaseRequest const& request), (override));
 
-  MOCK_METHOD(StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>,
+  MOCK_METHOD((StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>),
   GetDatabaseDdl,
   (google::test::admin::database::v1::GetDatabaseDdlRequest const& request), (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>),
   SetIamPolicy,
   (google::iam::v1::SetIamPolicyRequest const& request), (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>),
   GetIamPolicy,
   (google::iam::v1::GetIamPolicyRequest const& request), (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD((StatusOr<google::iam::v1::TestIamPermissionsResponse>),
   TestIamPermissions,
   (google::iam::v1::TestIamPermissionsRequest const& request), (override));
 
-  MOCK_METHOD(future<StatusOr<google::test::admin::database::v1::Backup>>,
+  MOCK_METHOD((future<StatusOr<google::test::admin::database::v1::Backup>>),
   CreateBackup,
   (google::test::admin::database::v1::CreateBackupRequest const& request), (override));
 
-  MOCK_METHOD(StatusOr<google::test::admin::database::v1::Backup>,
+  MOCK_METHOD((StatusOr<google::test::admin::database::v1::Backup>),
   GetBackup,
   (google::test::admin::database::v1::GetBackupRequest const& request), (override));
 
-  MOCK_METHOD(StatusOr<google::test::admin::database::v1::Backup>,
+  MOCK_METHOD((StatusOr<google::test::admin::database::v1::Backup>),
   UpdateBackup,
   (google::test::admin::database::v1::UpdateBackupRequest const& request), (override));
 
@@ -102,7 +102,7 @@ class MockGoldenThingAdminConnection : public golden_v1::GoldenThingAdminConnect
   ListBackups,
   (google::test::admin::database::v1::ListBackupsRequest request), (override));
 
-  MOCK_METHOD(future<StatusOr<google::test::admin::database::v1::Database>>,
+  MOCK_METHOD((future<StatusOr<google::test::admin::database::v1::Database>>),
   RestoreDatabase,
   (google::test::admin::database::v1::RestoreDatabaseRequest const& request), (override));
 
@@ -114,11 +114,11 @@ class MockGoldenThingAdminConnection : public golden_v1::GoldenThingAdminConnect
   ListBackupOperations,
   (google::test::admin::database::v1::ListBackupOperationsRequest request), (override));
 
-  MOCK_METHOD(future<StatusOr<google::test::admin::database::v1::Database>>,
+  MOCK_METHOD((future<StatusOr<google::test::admin::database::v1::Database>>),
   LongRunningWithoutRouting,
   (google::test::admin::database::v1::RestoreDatabaseRequest const& request), (override));
 
-  MOCK_METHOD(future<StatusOr<google::test::admin::database::v1::Database>>,
+  MOCK_METHOD((future<StatusOr<google::test::admin::database::v1::Database>>),
   AsyncGetDatabase,
   (google::test::admin::database::v1::GetDatabaseRequest const& request), (override));
 

--- a/generator/integration_tests/golden/v1/mocks/mock_request_id_connection.h
+++ b/generator/integration_tests/golden/v1/mocks/mock_request_id_connection.h
@@ -46,11 +46,11 @@ class MockRequestIdServiceConnection : public golden_v1::RequestIdServiceConnect
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::test::requestid::v1::Foo>,
+  MOCK_METHOD((StatusOr<google::test::requestid::v1::Foo>),
   CreateFoo,
   (google::test::requestid::v1::CreateFooRequest const& request), (override));
 
-  MOCK_METHOD(future<StatusOr<google::test::requestid::v1::Foo>>,
+  MOCK_METHOD((future<StatusOr<google::test::requestid::v1::Foo>>),
   RenameFoo,
   (google::test::requestid::v1::RenameFooRequest const& request), (override));
 
@@ -58,7 +58,7 @@ class MockRequestIdServiceConnection : public golden_v1::RequestIdServiceConnect
   ListFoos,
   (google::test::requestid::v1::ListFoosRequest request), (override));
 
-  MOCK_METHOD(future<StatusOr<google::test::requestid::v1::Foo>>,
+  MOCK_METHOD((future<StatusOr<google::test::requestid::v1::Foo>>),
   AsyncCreateFoo,
   (google::test::requestid::v1::CreateFooRequest const& request), (override));
 };

--- a/generator/internal/mock_connection_generator.cc
+++ b/generator/internal/mock_connection_generator.cc
@@ -94,7 +94,7 @@ class $mock_connection_class_name$ : public $product_namespace$::$connection_cla
                  {IsResponseTypeEmpty,
                   // clang-format off
     "\n  MOCK_METHOD(Status,\n",
-    "\n  MOCK_METHOD(StatusOr<$response_type$>,\n"},
+    "\n  MOCK_METHOD((StatusOr<$response_type$>),\n"},
    {"  $method_name$,\n"
     "  ($request_type$ const& request), (override));\n",}
                  // clang-format on
@@ -106,7 +106,7 @@ class $mock_connection_class_name$ : public $product_namespace$::$connection_cla
                  {IsResponseTypeEmpty,
                   // clang-format off
     "\n  MOCK_METHOD(future<Status>,\n",
-    "\n  MOCK_METHOD(future<StatusOr<$longrunning_deduced_response_type$>>,\n"},
+    "\n  MOCK_METHOD((future<StatusOr<$longrunning_deduced_response_type$>>),\n"},
    {"  $method_name$,\n"
     "  ($request_type$ const& request), (override));\n",}
                  // clang-format on
@@ -124,7 +124,7 @@ class $mock_connection_class_name$ : public $product_namespace$::$connection_cla
          MethodPattern(
              {
                  // clang-format off
-   {"\n  MOCK_METHOD(StreamRange<$response_type$>,\n"
+   {"\n  MOCK_METHOD((StreamRange<$response_type$>),\n"
     "  $method_name$,\n"
     "  ($request_type$ const& request), (override));\n"},
                  // clang-format on
@@ -141,7 +141,7 @@ class $mock_connection_class_name$ : public $product_namespace$::$connection_cla
                 {IsResponseTypeEmpty,
                  // clang-format off
     "\n  MOCK_METHOD(future<Status>,\n",
-    "\n  MOCK_METHOD(future<StatusOr<$response_type$>>,\n"},
+    "\n  MOCK_METHOD((future<StatusOr<$response_type$>>),\n"},
    {"  Async$method_name$,\n"
     "  ($request_type$ const& request), (override));\n",}
                 // clang-format on

--- a/google/cloud/accessapproval/v1/mocks/mock_access_approval_connection.h
+++ b/google/cloud/accessapproval/v1/mocks/mock_access_approval_connection.h
@@ -54,41 +54,41 @@ class MockAccessApprovalConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::accessapproval::v1::ApprovalRequest>,
+      (StatusOr<google::cloud::accessapproval::v1::ApprovalRequest>),
       GetApprovalRequest,
       (google::cloud::accessapproval::v1::GetApprovalRequestMessage const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::accessapproval::v1::ApprovalRequest>,
+      (StatusOr<google::cloud::accessapproval::v1::ApprovalRequest>),
       ApproveApprovalRequest,
       (google::cloud::accessapproval::v1::ApproveApprovalRequestMessage const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::accessapproval::v1::ApprovalRequest>,
+      (StatusOr<google::cloud::accessapproval::v1::ApprovalRequest>),
       DismissApprovalRequest,
       (google::cloud::accessapproval::v1::DismissApprovalRequestMessage const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::accessapproval::v1::ApprovalRequest>,
+  MOCK_METHOD((StatusOr<google::cloud::accessapproval::v1::ApprovalRequest>),
               InvalidateApprovalRequest,
               (google::cloud::accessapproval::v1::
                    InvalidateApprovalRequestMessage const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::accessapproval::v1::AccessApprovalSettings>,
+      (StatusOr<google::cloud::accessapproval::v1::AccessApprovalSettings>),
       GetAccessApprovalSettings,
       (google::cloud::accessapproval::v1::
            GetAccessApprovalSettingsMessage const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::accessapproval::v1::AccessApprovalSettings>,
+      (StatusOr<google::cloud::accessapproval::v1::AccessApprovalSettings>),
       UpdateAccessApprovalSettings,
       (google::cloud::accessapproval::v1::
            UpdateAccessApprovalSettingsMessage const& request),
@@ -100,7 +100,8 @@ class MockAccessApprovalConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::accessapproval::v1::AccessApprovalServiceAccount>,
+      (StatusOr<
+          google::cloud::accessapproval::v1::AccessApprovalServiceAccount>),
       GetAccessApprovalServiceAccount,
       (google::cloud::accessapproval::v1::
            GetAccessApprovalServiceAccountMessage const& request),

--- a/google/cloud/accesscontextmanager/v1/mocks/mock_access_context_manager_connection.h
+++ b/google/cloud/accesscontextmanager/v1/mocks/mock_access_context_manager_connection.h
@@ -55,29 +55,29 @@ class MockAccessContextManagerConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::identity::accesscontextmanager::v1::AccessPolicy>,
+      (StatusOr<google::identity::accesscontextmanager::v1::AccessPolicy>),
       GetAccessPolicy,
       (google::identity::accesscontextmanager::v1::GetAccessPolicyRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::identity::accesscontextmanager::v1::AccessPolicy>>,
+      (future<
+          StatusOr<google::identity::accesscontextmanager::v1::AccessPolicy>>),
       CreateAccessPolicy,
       (google::identity::accesscontextmanager::v1::AccessPolicy const& request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::identity::accesscontextmanager::v1::AccessPolicy>>,
+      (future<
+          StatusOr<google::identity::accesscontextmanager::v1::AccessPolicy>>),
       UpdateAccessPolicy,
       (google::identity::accesscontextmanager::v1::
            UpdateAccessPolicyRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::identity::accesscontextmanager::v1::
-                                  AccessContextManagerOperationMetadata>>,
+  MOCK_METHOD((future<StatusOr<google::identity::accesscontextmanager::v1::
+                                   AccessContextManagerOperationMetadata>>),
               DeleteAccessPolicy,
               (google::identity::accesscontextmanager::v1::
                    DeleteAccessPolicyRequest const& request),
@@ -91,35 +91,37 @@ class MockAccessContextManagerConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::identity::accesscontextmanager::v1::AccessLevel>,
+      (StatusOr<google::identity::accesscontextmanager::v1::AccessLevel>),
       GetAccessLevel,
       (google::identity::accesscontextmanager::v1::GetAccessLevelRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::identity::accesscontextmanager::v1::AccessLevel>>,
+      (future<
+          StatusOr<google::identity::accesscontextmanager::v1::AccessLevel>>),
       CreateAccessLevel,
       (google::identity::accesscontextmanager::v1::
            CreateAccessLevelRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::identity::accesscontextmanager::v1::AccessLevel>>,
+      (future<
+          StatusOr<google::identity::accesscontextmanager::v1::AccessLevel>>),
       UpdateAccessLevel,
       (google::identity::accesscontextmanager::v1::
            UpdateAccessLevelRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::identity::accesscontextmanager::v1::
-                                  AccessContextManagerOperationMetadata>>,
+  MOCK_METHOD((future<StatusOr<google::identity::accesscontextmanager::v1::
+                                   AccessContextManagerOperationMetadata>>),
               DeleteAccessLevel,
               (google::identity::accesscontextmanager::v1::
                    DeleteAccessLevelRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::identity::accesscontextmanager::v1::
-                                  ReplaceAccessLevelsResponse>>,
+  MOCK_METHOD((future<StatusOr<google::identity::accesscontextmanager::v1::
+                                   ReplaceAccessLevelsResponse>>),
               ReplaceAccessLevels,
               (google::identity::accesscontextmanager::v1::
                    ReplaceAccessLevelsRequest const& request),
@@ -134,44 +136,44 @@ class MockAccessContextManagerConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::identity::accesscontextmanager::v1::ServicePerimeter>,
+      (StatusOr<google::identity::accesscontextmanager::v1::ServicePerimeter>),
       GetServicePerimeter,
       (google::identity::accesscontextmanager::v1::
            GetServicePerimeterRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::identity::accesscontextmanager::v1::ServicePerimeter>>,
+      (future<StatusOr<
+           google::identity::accesscontextmanager::v1::ServicePerimeter>>),
       CreateServicePerimeter,
       (google::identity::accesscontextmanager::v1::
            CreateServicePerimeterRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::identity::accesscontextmanager::v1::ServicePerimeter>>,
+      (future<StatusOr<
+           google::identity::accesscontextmanager::v1::ServicePerimeter>>),
       UpdateServicePerimeter,
       (google::identity::accesscontextmanager::v1::
            UpdateServicePerimeterRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::identity::accesscontextmanager::v1::
-                                  AccessContextManagerOperationMetadata>>,
+  MOCK_METHOD((future<StatusOr<google::identity::accesscontextmanager::v1::
+                                   AccessContextManagerOperationMetadata>>),
               DeleteServicePerimeter,
               (google::identity::accesscontextmanager::v1::
                    DeleteServicePerimeterRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::identity::accesscontextmanager::v1::
-                                  ReplaceServicePerimetersResponse>>,
+  MOCK_METHOD((future<StatusOr<google::identity::accesscontextmanager::v1::
+                                   ReplaceServicePerimetersResponse>>),
               ReplaceServicePerimeters,
               (google::identity::accesscontextmanager::v1::
                    ReplaceServicePerimetersRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::identity::accesscontextmanager::v1::
-                                  CommitServicePerimetersResponse>>,
+  MOCK_METHOD((future<StatusOr<google::identity::accesscontextmanager::v1::
+                                   CommitServicePerimetersResponse>>),
               CommitServicePerimeters,
               (google::identity::accesscontextmanager::v1::
                    CommitServicePerimetersRequest const& request),
@@ -186,45 +188,45 @@ class MockAccessContextManagerConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::identity::accesscontextmanager::v1::GcpUserAccessBinding>,
+      (StatusOr<
+          google::identity::accesscontextmanager::v1::GcpUserAccessBinding>),
       GetGcpUserAccessBinding,
       (google::identity::accesscontextmanager::v1::
            GetGcpUserAccessBindingRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::identity::accesscontextmanager::v1::GcpUserAccessBinding>>,
+      (future<StatusOr<
+           google::identity::accesscontextmanager::v1::GcpUserAccessBinding>>),
       CreateGcpUserAccessBinding,
       (google::identity::accesscontextmanager::v1::
            CreateGcpUserAccessBindingRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::identity::accesscontextmanager::v1::GcpUserAccessBinding>>,
+      (future<StatusOr<
+           google::identity::accesscontextmanager::v1::GcpUserAccessBinding>>),
       UpdateGcpUserAccessBinding,
       (google::identity::accesscontextmanager::v1::
            UpdateGcpUserAccessBindingRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::identity::accesscontextmanager::v1::
-                                  GcpUserAccessBindingOperationMetadata>>,
+  MOCK_METHOD((future<StatusOr<google::identity::accesscontextmanager::v1::
+                                   GcpUserAccessBindingOperationMetadata>>),
               DeleteGcpUserAccessBinding,
               (google::identity::accesscontextmanager::v1::
                    DeleteGcpUserAccessBindingRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), SetIamPolicy,
               (google::iam::v1::SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), GetIamPolicy,
               (google::iam::v1::GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD((StatusOr<google::iam::v1::TestIamPermissionsResponse>),
               TestIamPermissions,
               (google::iam::v1::TestIamPermissionsRequest const& request),
               (override));

--- a/google/cloud/advisorynotifications/v1/mocks/mock_advisory_notifications_connection.h
+++ b/google/cloud/advisorynotifications/v1/mocks/mock_advisory_notifications_connection.h
@@ -55,20 +55,21 @@ class MockAdvisoryNotificationsServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::advisorynotifications::v1::Notification>,
+      (StatusOr<google::cloud::advisorynotifications::v1::Notification>),
       GetNotification,
       (google::cloud::advisorynotifications::v1::GetNotificationRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::advisorynotifications::v1::Settings>, GetSettings,
+      (StatusOr<google::cloud::advisorynotifications::v1::Settings>),
+      GetSettings,
       (google::cloud::advisorynotifications::v1::GetSettingsRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::advisorynotifications::v1::Settings>,
+      (StatusOr<google::cloud::advisorynotifications::v1::Settings>),
       UpdateSettings,
       (google::cloud::advisorynotifications::v1::UpdateSettingsRequest const&
            request),

--- a/google/cloud/aiplatform/v1/mocks/mock_dataset_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_dataset_connection.h
@@ -48,16 +48,16 @@ class MockDatasetServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::Dataset>>, CreateDataset,
+      (future<StatusOr<google::cloud::aiplatform::v1::Dataset>>), CreateDataset,
       (google::cloud::aiplatform::v1::CreateDatasetRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::aiplatform::v1::Dataset>, GetDataset,
+  MOCK_METHOD((StatusOr<google::cloud::aiplatform::v1::Dataset>), GetDataset,
               (google::cloud::aiplatform::v1::GetDatasetRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::Dataset>, UpdateDataset,
+      (StatusOr<google::cloud::aiplatform::v1::Dataset>), UpdateDataset,
       (google::cloud::aiplatform::v1::UpdateDatasetRequest const& request),
       (override));
 
@@ -67,38 +67,40 @@ class MockDatasetServiceConnection
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeleteDataset,
       (google::cloud::aiplatform::v1::DeleteDatasetRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::ImportDataResponse>>,
+      (future<StatusOr<google::cloud::aiplatform::v1::ImportDataResponse>>),
       ImportData,
       (google::cloud::aiplatform::v1::ImportDataRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::ExportDataResponse>>,
+      (future<StatusOr<google::cloud::aiplatform::v1::ExportDataResponse>>),
       ExportData,
       (google::cloud::aiplatform::v1::ExportDataRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::aiplatform::v1::DatasetVersion>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::aiplatform::v1::DatasetVersion>>),
               CreateDatasetVersion,
               (google::cloud::aiplatform::v1::CreateDatasetVersionRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeleteDatasetVersion,
       (google::cloud::aiplatform::v1::DeleteDatasetVersionRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::DatasetVersion>,
+      (StatusOr<google::cloud::aiplatform::v1::DatasetVersion>),
       GetDatasetVersion,
       (google::cloud::aiplatform::v1::GetDatasetVersionRequest const& request),
       (override));
@@ -110,7 +112,7 @@ class MockDatasetServiceConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DatasetVersion>>,
+      (future<StatusOr<google::cloud::aiplatform::v1::DatasetVersion>>),
       RestoreDatasetVersion,
       (google::cloud::aiplatform::v1::RestoreDatasetVersionRequest const&
            request),
@@ -132,13 +134,14 @@ class MockDatasetServiceConnection
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeleteSavedQuery,
       (google::cloud::aiplatform::v1::DeleteSavedQueryRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::AnnotationSpec>,
+      (StatusOr<google::cloud::aiplatform::v1::AnnotationSpec>),
       GetAnnotationSpec,
       (google::cloud::aiplatform::v1::GetAnnotationSpecRequest const& request),
       (override));

--- a/google/cloud/aiplatform/v1/mocks/mock_deployment_resource_pool_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_deployment_resource_pool_connection.h
@@ -48,14 +48,14 @@ class MockDeploymentResourcePoolServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeploymentResourcePool>>,
+      (future<StatusOr<google::cloud::aiplatform::v1::DeploymentResourcePool>>),
       CreateDeploymentResourcePool,
       (google::cloud::aiplatform::v1::CreateDeploymentResourcePoolRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::DeploymentResourcePool>,
+      (StatusOr<google::cloud::aiplatform::v1::DeploymentResourcePool>),
       GetDeploymentResourcePool,
       (google::cloud::aiplatform::v1::GetDeploymentResourcePoolRequest const&
            request),
@@ -69,7 +69,8 @@ class MockDeploymentResourcePoolServiceConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeleteDeploymentResourcePool,
       (google::cloud::aiplatform::v1::DeleteDeploymentResourcePoolRequest const&
            request),

--- a/google/cloud/aiplatform/v1/mocks/mock_endpoint_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_endpoint_connection.h
@@ -48,12 +48,13 @@ class MockEndpointServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::Endpoint>>, CreateEndpoint,
+      (future<StatusOr<google::cloud::aiplatform::v1::Endpoint>>),
+      CreateEndpoint,
       (google::cloud::aiplatform::v1::CreateEndpointRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::Endpoint>, GetEndpoint,
+      (StatusOr<google::cloud::aiplatform::v1::Endpoint>), GetEndpoint,
       (google::cloud::aiplatform::v1::GetEndpointRequest const& request),
       (override));
 
@@ -63,31 +64,32 @@ class MockEndpointServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::Endpoint>, UpdateEndpoint,
+      (StatusOr<google::cloud::aiplatform::v1::Endpoint>), UpdateEndpoint,
       (google::cloud::aiplatform::v1::UpdateEndpointRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeleteEndpoint,
       (google::cloud::aiplatform::v1::DeleteEndpointRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeployModelResponse>>,
+      (future<StatusOr<google::cloud::aiplatform::v1::DeployModelResponse>>),
       DeployModel,
       (google::cloud::aiplatform::v1::DeployModelRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::UndeployModelResponse>>,
+      (future<StatusOr<google::cloud::aiplatform::v1::UndeployModelResponse>>),
       UndeployModel,
       (google::cloud::aiplatform::v1::UndeployModelRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::aiplatform::v1::MutateDeployedModelResponse>>,
+      (future<StatusOr<
+           google::cloud::aiplatform::v1::MutateDeployedModelResponse>>),
       MutateDeployedModel,
       (google::cloud::aiplatform::v1::MutateDeployedModelRequest const&
            request),

--- a/google/cloud/aiplatform/v1/mocks/mock_feature_online_store_admin_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_feature_online_store_admin_connection.h
@@ -48,14 +48,14 @@ class MockFeatureOnlineStoreAdminServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::FeatureOnlineStore>>,
+      (future<StatusOr<google::cloud::aiplatform::v1::FeatureOnlineStore>>),
       CreateFeatureOnlineStore,
       (google::cloud::aiplatform::v1::CreateFeatureOnlineStoreRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::FeatureOnlineStore>,
+      (StatusOr<google::cloud::aiplatform::v1::FeatureOnlineStore>),
       GetFeatureOnlineStore,
       (google::cloud::aiplatform::v1::GetFeatureOnlineStoreRequest const&
            request),
@@ -68,27 +68,28 @@ class MockFeatureOnlineStoreAdminServiceConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::FeatureOnlineStore>>,
+      (future<StatusOr<google::cloud::aiplatform::v1::FeatureOnlineStore>>),
       UpdateFeatureOnlineStore,
       (google::cloud::aiplatform::v1::UpdateFeatureOnlineStoreRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeleteFeatureOnlineStore,
       (google::cloud::aiplatform::v1::DeleteFeatureOnlineStoreRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::FeatureView>>,
+      (future<StatusOr<google::cloud::aiplatform::v1::FeatureView>>),
       CreateFeatureView,
       (google::cloud::aiplatform::v1::CreateFeatureViewRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::FeatureView>, GetFeatureView,
+      (StatusOr<google::cloud::aiplatform::v1::FeatureView>), GetFeatureView,
       (google::cloud::aiplatform::v1::GetFeatureViewRequest const& request),
       (override));
 
@@ -98,25 +99,26 @@ class MockFeatureOnlineStoreAdminServiceConnection
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::FeatureView>>,
+      (future<StatusOr<google::cloud::aiplatform::v1::FeatureView>>),
       UpdateFeatureView,
       (google::cloud::aiplatform::v1::UpdateFeatureViewRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeleteFeatureView,
       (google::cloud::aiplatform::v1::DeleteFeatureViewRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::SyncFeatureViewResponse>,
+      (StatusOr<google::cloud::aiplatform::v1::SyncFeatureViewResponse>),
       SyncFeatureView,
       (google::cloud::aiplatform::v1::SyncFeatureViewRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::FeatureViewSync>,
+      (StatusOr<google::cloud::aiplatform::v1::FeatureViewSync>),
       GetFeatureViewSync,
       (google::cloud::aiplatform::v1::GetFeatureViewSyncRequest const& request),
       (override));

--- a/google/cloud/aiplatform/v1/mocks/mock_feature_online_store_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_feature_online_store_connection.h
@@ -48,13 +48,13 @@ class MockFeatureOnlineStoreServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::FetchFeatureValuesResponse>,
+      (StatusOr<google::cloud::aiplatform::v1::FetchFeatureValuesResponse>),
       FetchFeatureValues,
       (google::cloud::aiplatform::v1::FetchFeatureValuesRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::SearchNearestEntitiesResponse>,
+      (StatusOr<google::cloud::aiplatform::v1::SearchNearestEntitiesResponse>),
       SearchNearestEntities,
       (google::cloud::aiplatform::v1::SearchNearestEntitiesRequest const&
            request),

--- a/google/cloud/aiplatform/v1/mocks/mock_featurestore_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_featurestore_connection.h
@@ -48,13 +48,13 @@ class MockFeaturestoreServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::Featurestore>>,
+      (future<StatusOr<google::cloud::aiplatform::v1::Featurestore>>),
       CreateFeaturestore,
       (google::cloud::aiplatform::v1::CreateFeaturestoreRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::Featurestore>, GetFeaturestore,
+      (StatusOr<google::cloud::aiplatform::v1::Featurestore>), GetFeaturestore,
       (google::cloud::aiplatform::v1::GetFeaturestoreRequest const& request),
       (override));
 
@@ -64,25 +64,26 @@ class MockFeaturestoreServiceConnection
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::Featurestore>>,
+      (future<StatusOr<google::cloud::aiplatform::v1::Featurestore>>),
       UpdateFeaturestore,
       (google::cloud::aiplatform::v1::UpdateFeaturestoreRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeleteFeaturestore,
       (google::cloud::aiplatform::v1::DeleteFeaturestoreRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::EntityType>>,
+      (future<StatusOr<google::cloud::aiplatform::v1::EntityType>>),
       CreateEntityType,
       (google::cloud::aiplatform::v1::CreateEntityTypeRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::EntityType>, GetEntityType,
+      (StatusOr<google::cloud::aiplatform::v1::EntityType>), GetEntityType,
       (google::cloud::aiplatform::v1::GetEntityTypeRequest const& request),
       (override));
 
@@ -92,30 +93,31 @@ class MockFeaturestoreServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::EntityType>, UpdateEntityType,
+      (StatusOr<google::cloud::aiplatform::v1::EntityType>), UpdateEntityType,
       (google::cloud::aiplatform::v1::UpdateEntityTypeRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeleteEntityType,
       (google::cloud::aiplatform::v1::DeleteEntityTypeRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::Feature>>, CreateFeature,
+      (future<StatusOr<google::cloud::aiplatform::v1::Feature>>), CreateFeature,
       (google::cloud::aiplatform::v1::CreateFeatureRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::aiplatform::v1::BatchCreateFeaturesResponse>>,
+      (future<StatusOr<
+           google::cloud::aiplatform::v1::BatchCreateFeaturesResponse>>),
       BatchCreateFeatures,
       (google::cloud::aiplatform::v1::BatchCreateFeaturesRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::aiplatform::v1::Feature>, GetFeature,
+  MOCK_METHOD((StatusOr<google::cloud::aiplatform::v1::Feature>), GetFeature,
               (google::cloud::aiplatform::v1::GetFeatureRequest const& request),
               (override));
 
@@ -125,43 +127,44 @@ class MockFeaturestoreServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::Feature>, UpdateFeature,
+      (StatusOr<google::cloud::aiplatform::v1::Feature>), UpdateFeature,
       (google::cloud::aiplatform::v1::UpdateFeatureRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeleteFeature,
       (google::cloud::aiplatform::v1::DeleteFeatureRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::aiplatform::v1::ImportFeatureValuesResponse>>,
+      (future<StatusOr<
+           google::cloud::aiplatform::v1::ImportFeatureValuesResponse>>),
       ImportFeatureValues,
       (google::cloud::aiplatform::v1::ImportFeatureValuesRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::aiplatform::v1::BatchReadFeatureValuesResponse>>,
+      (future<StatusOr<
+           google::cloud::aiplatform::v1::BatchReadFeatureValuesResponse>>),
       BatchReadFeatureValues,
       (google::cloud::aiplatform::v1::BatchReadFeatureValuesRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::aiplatform::v1::ExportFeatureValuesResponse>>,
+      (future<StatusOr<
+           google::cloud::aiplatform::v1::ExportFeatureValuesResponse>>),
       ExportFeatureValues,
       (google::cloud::aiplatform::v1::ExportFeatureValuesRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::aiplatform::v1::DeleteFeatureValuesResponse>>,
+      (future<StatusOr<
+           google::cloud::aiplatform::v1::DeleteFeatureValuesResponse>>),
       DeleteFeatureValues,
       (google::cloud::aiplatform::v1::DeleteFeatureValuesRequest const&
            request),

--- a/google/cloud/aiplatform/v1/mocks/mock_featurestore_online_serving_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_featurestore_online_serving_connection.h
@@ -49,20 +49,20 @@ class MockFeaturestoreOnlineServingServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::ReadFeatureValuesResponse>,
+      (StatusOr<google::cloud::aiplatform::v1::ReadFeatureValuesResponse>),
       ReadFeatureValues,
       (google::cloud::aiplatform::v1::ReadFeatureValuesRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StreamRange<google::cloud::aiplatform::v1::ReadFeatureValuesResponse>,
+      (StreamRange<google::cloud::aiplatform::v1::ReadFeatureValuesResponse>),
       StreamingReadFeatureValues,
       (google::cloud::aiplatform::v1::StreamingReadFeatureValuesRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::WriteFeatureValuesResponse>,
+      (StatusOr<google::cloud::aiplatform::v1::WriteFeatureValuesResponse>),
       WriteFeatureValues,
       (google::cloud::aiplatform::v1::WriteFeatureValuesRequest const& request),
       (override));

--- a/google/cloud/aiplatform/v1/mocks/mock_index_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_index_connection.h
@@ -48,11 +48,11 @@ class MockIndexServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::Index>>, CreateIndex,
+      (future<StatusOr<google::cloud::aiplatform::v1::Index>>), CreateIndex,
       (google::cloud::aiplatform::v1::CreateIndexRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::aiplatform::v1::Index>, GetIndex,
+  MOCK_METHOD((StatusOr<google::cloud::aiplatform::v1::Index>), GetIndex,
               (google::cloud::aiplatform::v1::GetIndexRequest const& request),
               (override));
 
@@ -61,24 +61,25 @@ class MockIndexServiceConnection
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::Index>>, UpdateIndex,
+      (future<StatusOr<google::cloud::aiplatform::v1::Index>>), UpdateIndex,
       (google::cloud::aiplatform::v1::UpdateIndexRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeleteIndex,
       (google::cloud::aiplatform::v1::DeleteIndexRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::UpsertDatapointsResponse>,
+      (StatusOr<google::cloud::aiplatform::v1::UpsertDatapointsResponse>),
       UpsertDatapoints,
       (google::cloud::aiplatform::v1::UpsertDatapointsRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::RemoveDatapointsResponse>,
+      (StatusOr<google::cloud::aiplatform::v1::RemoveDatapointsResponse>),
       RemoveDatapoints,
       (google::cloud::aiplatform::v1::RemoveDatapointsRequest const& request),
       (override));

--- a/google/cloud/aiplatform/v1/mocks/mock_index_endpoint_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_index_endpoint_connection.h
@@ -47,14 +47,15 @@ class MockIndexEndpointServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::aiplatform::v1::IndexEndpoint>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::aiplatform::v1::IndexEndpoint>>),
               CreateIndexEndpoint,
               (google::cloud::aiplatform::v1::CreateIndexEndpointRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::IndexEndpoint>, GetIndexEndpoint,
+      (StatusOr<google::cloud::aiplatform::v1::IndexEndpoint>),
+      GetIndexEndpoint,
       (google::cloud::aiplatform::v1::GetIndexEndpointRequest const& request),
       (override));
 
@@ -64,34 +65,35 @@ class MockIndexEndpointServiceConnection
       (google::cloud::aiplatform::v1::ListIndexEndpointsRequest request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::aiplatform::v1::IndexEndpoint>,
+  MOCK_METHOD((StatusOr<google::cloud::aiplatform::v1::IndexEndpoint>),
               UpdateIndexEndpoint,
               (google::cloud::aiplatform::v1::UpdateIndexEndpointRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeleteIndexEndpoint,
       (google::cloud::aiplatform::v1::DeleteIndexEndpointRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeployIndexResponse>>,
+      (future<StatusOr<google::cloud::aiplatform::v1::DeployIndexResponse>>),
       DeployIndex,
       (google::cloud::aiplatform::v1::DeployIndexRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::UndeployIndexResponse>>,
+      (future<StatusOr<google::cloud::aiplatform::v1::UndeployIndexResponse>>),
       UndeployIndex,
       (google::cloud::aiplatform::v1::UndeployIndexRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::aiplatform::v1::MutateDeployedIndexResponse>>,
+      (future<StatusOr<
+           google::cloud::aiplatform::v1::MutateDeployedIndexResponse>>),
       MutateDeployedIndex,
       (google::cloud::aiplatform::v1::MutateDeployedIndexRequest const&
            request),

--- a/google/cloud/aiplatform/v1/mocks/mock_job_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_job_connection.h
@@ -47,12 +47,12 @@ class MockJobServiceConnection : public aiplatform_v1::JobServiceConnection {
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::CustomJob>, CreateCustomJob,
+      (StatusOr<google::cloud::aiplatform::v1::CustomJob>), CreateCustomJob,
       (google::cloud::aiplatform::v1::CreateCustomJobRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::CustomJob>, GetCustomJob,
+      (StatusOr<google::cloud::aiplatform::v1::CustomJob>), GetCustomJob,
       (google::cloud::aiplatform::v1::GetCustomJobRequest const& request),
       (override));
 
@@ -62,7 +62,8 @@ class MockJobServiceConnection : public aiplatform_v1::JobServiceConnection {
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeleteCustomJob,
       (google::cloud::aiplatform::v1::DeleteCustomJobRequest const& request),
       (override));
@@ -73,14 +74,14 @@ class MockJobServiceConnection : public aiplatform_v1::JobServiceConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::DataLabelingJob>,
+      (StatusOr<google::cloud::aiplatform::v1::DataLabelingJob>),
       CreateDataLabelingJob,
       (google::cloud::aiplatform::v1::CreateDataLabelingJobRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::DataLabelingJob>,
+      (StatusOr<google::cloud::aiplatform::v1::DataLabelingJob>),
       GetDataLabelingJob,
       (google::cloud::aiplatform::v1::GetDataLabelingJobRequest const& request),
       (override));
@@ -92,7 +93,8 @@ class MockJobServiceConnection : public aiplatform_v1::JobServiceConnection {
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeleteDataLabelingJob,
       (google::cloud::aiplatform::v1::DeleteDataLabelingJobRequest const&
            request),
@@ -104,14 +106,15 @@ class MockJobServiceConnection : public aiplatform_v1::JobServiceConnection {
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::aiplatform::v1::HyperparameterTuningJob>,
-              CreateHyperparameterTuningJob,
-              (google::cloud::aiplatform::v1::
-                   CreateHyperparameterTuningJobRequest const& request),
-              (override));
+  MOCK_METHOD(
+      (StatusOr<google::cloud::aiplatform::v1::HyperparameterTuningJob>),
+      CreateHyperparameterTuningJob,
+      (google::cloud::aiplatform::v1::
+           CreateHyperparameterTuningJobRequest const& request),
+      (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::HyperparameterTuningJob>,
+      (StatusOr<google::cloud::aiplatform::v1::HyperparameterTuningJob>),
       GetHyperparameterTuningJob,
       (google::cloud::aiplatform::v1::GetHyperparameterTuningJobRequest const&
            request),
@@ -125,7 +128,8 @@ class MockJobServiceConnection : public aiplatform_v1::JobServiceConnection {
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeleteHyperparameterTuningJob,
       (google::cloud::aiplatform::v1::
            DeleteHyperparameterTuningJobRequest const& request),
@@ -137,11 +141,11 @@ class MockJobServiceConnection : public aiplatform_v1::JobServiceConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::NasJob>, CreateNasJob,
+      (StatusOr<google::cloud::aiplatform::v1::NasJob>), CreateNasJob,
       (google::cloud::aiplatform::v1::CreateNasJobRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::aiplatform::v1::NasJob>, GetNasJob,
+  MOCK_METHOD((StatusOr<google::cloud::aiplatform::v1::NasJob>), GetNasJob,
               (google::cloud::aiplatform::v1::GetNasJobRequest const& request),
               (override));
 
@@ -150,7 +154,8 @@ class MockJobServiceConnection : public aiplatform_v1::JobServiceConnection {
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeleteNasJob,
       (google::cloud::aiplatform::v1::DeleteNasJobRequest const& request),
       (override));
@@ -161,7 +166,7 @@ class MockJobServiceConnection : public aiplatform_v1::JobServiceConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::NasTrialDetail>,
+      (StatusOr<google::cloud::aiplatform::v1::NasTrialDetail>),
       GetNasTrialDetail,
       (google::cloud::aiplatform::v1::GetNasTrialDetailRequest const& request),
       (override));
@@ -173,14 +178,14 @@ class MockJobServiceConnection : public aiplatform_v1::JobServiceConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::BatchPredictionJob>,
+      (StatusOr<google::cloud::aiplatform::v1::BatchPredictionJob>),
       CreateBatchPredictionJob,
       (google::cloud::aiplatform::v1::CreateBatchPredictionJobRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::BatchPredictionJob>,
+      (StatusOr<google::cloud::aiplatform::v1::BatchPredictionJob>),
       GetBatchPredictionJob,
       (google::cloud::aiplatform::v1::GetBatchPredictionJobRequest const&
            request),
@@ -193,7 +198,8 @@ class MockJobServiceConnection : public aiplatform_v1::JobServiceConnection {
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeleteBatchPredictionJob,
       (google::cloud::aiplatform::v1::DeleteBatchPredictionJobRequest const&
            request),
@@ -206,7 +212,7 @@ class MockJobServiceConnection : public aiplatform_v1::JobServiceConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::ModelDeploymentMonitoringJob>,
+      (StatusOr<google::cloud::aiplatform::v1::ModelDeploymentMonitoringJob>),
       CreateModelDeploymentMonitoringJob,
       (google::cloud::aiplatform::v1::
            CreateModelDeploymentMonitoringJobRequest const& request),
@@ -221,7 +227,7 @@ class MockJobServiceConnection : public aiplatform_v1::JobServiceConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::ModelDeploymentMonitoringJob>,
+      (StatusOr<google::cloud::aiplatform::v1::ModelDeploymentMonitoringJob>),
       GetModelDeploymentMonitoringJob,
       (google::cloud::aiplatform::v1::
            GetModelDeploymentMonitoringJobRequest const& request),
@@ -235,15 +241,17 @@ class MockJobServiceConnection : public aiplatform_v1::JobServiceConnection {
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<
-                  google::cloud::aiplatform::v1::ModelDeploymentMonitoringJob>>,
-              UpdateModelDeploymentMonitoringJob,
-              (google::cloud::aiplatform::v1::
-                   UpdateModelDeploymentMonitoringJobRequest const& request),
-              (override));
+  MOCK_METHOD(
+      (future<StatusOr<
+           google::cloud::aiplatform::v1::ModelDeploymentMonitoringJob>>),
+      UpdateModelDeploymentMonitoringJob,
+      (google::cloud::aiplatform::v1::
+           UpdateModelDeploymentMonitoringJobRequest const& request),
+      (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeleteModelDeploymentMonitoringJob,
       (google::cloud::aiplatform::v1::
            DeleteModelDeploymentMonitoringJobRequest const& request),

--- a/google/cloud/aiplatform/v1/mocks/mock_llm_utility_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_llm_utility_connection.h
@@ -48,12 +48,13 @@ class MockLlmUtilityServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::CountTokensResponse>, CountTokens,
+      (StatusOr<google::cloud::aiplatform::v1::CountTokensResponse>),
+      CountTokens,
       (google::cloud::aiplatform::v1::CountTokensRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::ComputeTokensResponse>,
+      (StatusOr<google::cloud::aiplatform::v1::ComputeTokensResponse>),
       ComputeTokens,
       (google::cloud::aiplatform::v1::ComputeTokensRequest const& request),
       (override));

--- a/google/cloud/aiplatform/v1/mocks/mock_match_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_match_connection.h
@@ -48,13 +48,13 @@ class MockMatchServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::FindNeighborsResponse>,
+      (StatusOr<google::cloud::aiplatform::v1::FindNeighborsResponse>),
       FindNeighbors,
       (google::cloud::aiplatform::v1::FindNeighborsRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::ReadIndexDatapointsResponse>,
+      (StatusOr<google::cloud::aiplatform::v1::ReadIndexDatapointsResponse>),
       ReadIndexDatapoints,
       (google::cloud::aiplatform::v1::ReadIndexDatapointsRequest const&
            request),

--- a/google/cloud/aiplatform/v1/mocks/mock_metadata_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_metadata_connection.h
@@ -47,14 +47,15 @@ class MockMetadataServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::aiplatform::v1::MetadataStore>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::aiplatform::v1::MetadataStore>>),
               CreateMetadataStore,
               (google::cloud::aiplatform::v1::CreateMetadataStoreRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::MetadataStore>, GetMetadataStore,
+      (StatusOr<google::cloud::aiplatform::v1::MetadataStore>),
+      GetMetadataStore,
       (google::cloud::aiplatform::v1::GetMetadataStoreRequest const& request),
       (override));
 
@@ -64,21 +65,20 @@ class MockMetadataServiceConnection
       (google::cloud::aiplatform::v1::ListMetadataStoresRequest request),
       (override));
 
-  MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::aiplatform::v1::DeleteMetadataStoreOperationMetadata>>,
-      DeleteMetadataStore,
-      (google::cloud::aiplatform::v1::DeleteMetadataStoreRequest const&
-           request),
-      (override));
+  MOCK_METHOD((future<StatusOr<google::cloud::aiplatform::v1::
+                                   DeleteMetadataStoreOperationMetadata>>),
+              DeleteMetadataStore,
+              (google::cloud::aiplatform::v1::DeleteMetadataStoreRequest const&
+                   request),
+              (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::Artifact>, CreateArtifact,
+      (StatusOr<google::cloud::aiplatform::v1::Artifact>), CreateArtifact,
       (google::cloud::aiplatform::v1::CreateArtifactRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::Artifact>, GetArtifact,
+      (StatusOr<google::cloud::aiplatform::v1::Artifact>), GetArtifact,
       (google::cloud::aiplatform::v1::GetArtifactRequest const& request),
       (override));
 
@@ -88,28 +88,29 @@ class MockMetadataServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::Artifact>, UpdateArtifact,
+      (StatusOr<google::cloud::aiplatform::v1::Artifact>), UpdateArtifact,
       (google::cloud::aiplatform::v1::UpdateArtifactRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeleteArtifact,
       (google::cloud::aiplatform::v1::DeleteArtifactRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::PurgeArtifactsResponse>>,
+      (future<StatusOr<google::cloud::aiplatform::v1::PurgeArtifactsResponse>>),
       PurgeArtifacts,
       (google::cloud::aiplatform::v1::PurgeArtifactsRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::Context>, CreateContext,
+      (StatusOr<google::cloud::aiplatform::v1::Context>), CreateContext,
       (google::cloud::aiplatform::v1::CreateContextRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::aiplatform::v1::Context>, GetContext,
+  MOCK_METHOD((StatusOr<google::cloud::aiplatform::v1::Context>), GetContext,
               (google::cloud::aiplatform::v1::GetContextRequest const& request),
               (override));
 
@@ -119,56 +120,57 @@ class MockMetadataServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::Context>, UpdateContext,
+      (StatusOr<google::cloud::aiplatform::v1::Context>), UpdateContext,
       (google::cloud::aiplatform::v1::UpdateContextRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeleteContext,
       (google::cloud::aiplatform::v1::DeleteContextRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::PurgeContextsResponse>>,
+      (future<StatusOr<google::cloud::aiplatform::v1::PurgeContextsResponse>>),
       PurgeContexts,
       (google::cloud::aiplatform::v1::PurgeContextsRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::aiplatform::v1::
-                           AddContextArtifactsAndExecutionsResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::aiplatform::v1::
+                            AddContextArtifactsAndExecutionsResponse>),
               AddContextArtifactsAndExecutions,
               (google::cloud::aiplatform::v1::
                    AddContextArtifactsAndExecutionsRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::AddContextChildrenResponse>,
+      (StatusOr<google::cloud::aiplatform::v1::AddContextChildrenResponse>),
       AddContextChildren,
       (google::cloud::aiplatform::v1::AddContextChildrenRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::RemoveContextChildrenResponse>,
+      (StatusOr<google::cloud::aiplatform::v1::RemoveContextChildrenResponse>),
       RemoveContextChildren,
       (google::cloud::aiplatform::v1::RemoveContextChildrenRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::LineageSubgraph>,
+      (StatusOr<google::cloud::aiplatform::v1::LineageSubgraph>),
       QueryContextLineageSubgraph,
       (google::cloud::aiplatform::v1::QueryContextLineageSubgraphRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::Execution>, CreateExecution,
+      (StatusOr<google::cloud::aiplatform::v1::Execution>), CreateExecution,
       (google::cloud::aiplatform::v1::CreateExecutionRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::Execution>, GetExecution,
+      (StatusOr<google::cloud::aiplatform::v1::Execution>), GetExecution,
       (google::cloud::aiplatform::v1::GetExecutionRequest const& request),
       (override));
 
@@ -178,42 +180,44 @@ class MockMetadataServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::Execution>, UpdateExecution,
+      (StatusOr<google::cloud::aiplatform::v1::Execution>), UpdateExecution,
       (google::cloud::aiplatform::v1::UpdateExecutionRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeleteExecution,
       (google::cloud::aiplatform::v1::DeleteExecutionRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::PurgeExecutionsResponse>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::PurgeExecutionsResponse>>),
       PurgeExecutions,
       (google::cloud::aiplatform::v1::PurgeExecutionsRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::AddExecutionEventsResponse>,
+      (StatusOr<google::cloud::aiplatform::v1::AddExecutionEventsResponse>),
       AddExecutionEvents,
       (google::cloud::aiplatform::v1::AddExecutionEventsRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::aiplatform::v1::LineageSubgraph>,
+  MOCK_METHOD((StatusOr<google::cloud::aiplatform::v1::LineageSubgraph>),
               QueryExecutionInputsAndOutputs,
               (google::cloud::aiplatform::v1::
                    QueryExecutionInputsAndOutputsRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::aiplatform::v1::MetadataSchema>,
+  MOCK_METHOD((StatusOr<google::cloud::aiplatform::v1::MetadataSchema>),
               CreateMetadataSchema,
               (google::cloud::aiplatform::v1::CreateMetadataSchemaRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::MetadataSchema>,
+      (StatusOr<google::cloud::aiplatform::v1::MetadataSchema>),
       GetMetadataSchema,
       (google::cloud::aiplatform::v1::GetMetadataSchemaRequest const& request),
       (override));
@@ -225,7 +229,7 @@ class MockMetadataServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::LineageSubgraph>,
+      (StatusOr<google::cloud::aiplatform::v1::LineageSubgraph>),
       QueryArtifactLineageSubgraph,
       (google::cloud::aiplatform::v1::QueryArtifactLineageSubgraphRequest const&
            request),

--- a/google/cloud/aiplatform/v1/mocks/mock_migration_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_migration_connection.h
@@ -54,8 +54,8 @@ class MockMigrationServiceConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::aiplatform::v1::BatchMigrateResourcesResponse>>,
+      (future<StatusOr<
+           google::cloud::aiplatform::v1::BatchMigrateResourcesResponse>>),
       BatchMigrateResources,
       (google::cloud::aiplatform::v1::BatchMigrateResourcesRequest const&
            request),

--- a/google/cloud/aiplatform/v1/mocks/mock_model_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_model_connection.h
@@ -48,12 +48,12 @@ class MockModelServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::UploadModelResponse>>,
+      (future<StatusOr<google::cloud::aiplatform::v1::UploadModelResponse>>),
       UploadModel,
       (google::cloud::aiplatform::v1::UploadModelRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::aiplatform::v1::Model>, GetModel,
+  MOCK_METHOD((StatusOr<google::cloud::aiplatform::v1::Model>), GetModel,
               (google::cloud::aiplatform::v1::GetModelRequest const& request),
               (override));
 
@@ -67,71 +67,73 @@ class MockModelServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::Model>, UpdateModel,
+      (StatusOr<google::cloud::aiplatform::v1::Model>), UpdateModel,
       (google::cloud::aiplatform::v1::UpdateModelRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::aiplatform::v1::UpdateExplanationDatasetResponse>>,
+      (future<StatusOr<
+           google::cloud::aiplatform::v1::UpdateExplanationDatasetResponse>>),
       UpdateExplanationDataset,
       (google::cloud::aiplatform::v1::UpdateExplanationDatasetRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeleteModel,
       (google::cloud::aiplatform::v1::DeleteModelRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeleteModelVersion,
       (google::cloud::aiplatform::v1::DeleteModelVersionRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::aiplatform::v1::Model>,
+  MOCK_METHOD((StatusOr<google::cloud::aiplatform::v1::Model>),
               MergeVersionAliases,
               (google::cloud::aiplatform::v1::MergeVersionAliasesRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::ExportModelResponse>>,
+      (future<StatusOr<google::cloud::aiplatform::v1::ExportModelResponse>>),
       ExportModel,
       (google::cloud::aiplatform::v1::ExportModelRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::CopyModelResponse>>,
+      (future<StatusOr<google::cloud::aiplatform::v1::CopyModelResponse>>),
       CopyModel,
       (google::cloud::aiplatform::v1::CopyModelRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::ModelEvaluation>,
+      (StatusOr<google::cloud::aiplatform::v1::ModelEvaluation>),
       ImportModelEvaluation,
       (google::cloud::aiplatform::v1::ImportModelEvaluationRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::aiplatform::v1::
-                           BatchImportModelEvaluationSlicesResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::aiplatform::v1::
+                            BatchImportModelEvaluationSlicesResponse>),
               BatchImportModelEvaluationSlices,
               (google::cloud::aiplatform::v1::
                    BatchImportModelEvaluationSlicesRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::aiplatform::v1::
-                           BatchImportEvaluatedAnnotationsResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::aiplatform::v1::
+                            BatchImportEvaluatedAnnotationsResponse>),
               BatchImportEvaluatedAnnotations,
               (google::cloud::aiplatform::v1::
                    BatchImportEvaluatedAnnotationsRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::ModelEvaluation>,
+      (StatusOr<google::cloud::aiplatform::v1::ModelEvaluation>),
       GetModelEvaluation,
       (google::cloud::aiplatform::v1::GetModelEvaluationRequest const& request),
       (override));
@@ -143,7 +145,7 @@ class MockModelServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::ModelEvaluationSlice>,
+      (StatusOr<google::cloud::aiplatform::v1::ModelEvaluationSlice>),
       GetModelEvaluationSlice,
       (google::cloud::aiplatform::v1::GetModelEvaluationSliceRequest const&
            request),

--- a/google/cloud/aiplatform/v1/mocks/mock_model_garden_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_model_garden_connection.h
@@ -48,7 +48,7 @@ class MockModelGardenServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::PublisherModel>,
+      (StatusOr<google::cloud::aiplatform::v1::PublisherModel>),
       GetPublisherModel,
       (google::cloud::aiplatform::v1::GetPublisherModelRequest const& request),
       (override));

--- a/google/cloud/aiplatform/v1/mocks/mock_notebook_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_notebook_connection.h
@@ -48,14 +48,15 @@ class MockNotebookServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::NotebookRuntimeTemplate>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::NotebookRuntimeTemplate>>),
       CreateNotebookRuntimeTemplate,
       (google::cloud::aiplatform::v1::
            CreateNotebookRuntimeTemplateRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::NotebookRuntimeTemplate>,
+      (StatusOr<google::cloud::aiplatform::v1::NotebookRuntimeTemplate>),
       GetNotebookRuntimeTemplate,
       (google::cloud::aiplatform::v1::GetNotebookRuntimeTemplateRequest const&
            request),
@@ -69,21 +70,22 @@ class MockNotebookServiceConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeleteNotebookRuntimeTemplate,
       (google::cloud::aiplatform::v1::
            DeleteNotebookRuntimeTemplateRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::NotebookRuntime>>,
+      (future<StatusOr<google::cloud::aiplatform::v1::NotebookRuntime>>),
       AssignNotebookRuntime,
       (google::cloud::aiplatform::v1::AssignNotebookRuntimeRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::NotebookRuntime>,
+      (StatusOr<google::cloud::aiplatform::v1::NotebookRuntime>),
       GetNotebookRuntime,
       (google::cloud::aiplatform::v1::GetNotebookRuntimeRequest const& request),
       (override));
@@ -95,26 +97,28 @@ class MockNotebookServiceConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeleteNotebookRuntime,
       (google::cloud::aiplatform::v1::DeleteNotebookRuntimeRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::aiplatform::v1::UpgradeNotebookRuntimeResponse>>,
+      (future<StatusOr<
+           google::cloud::aiplatform::v1::UpgradeNotebookRuntimeResponse>>),
       UpgradeNotebookRuntime,
       (google::cloud::aiplatform::v1::UpgradeNotebookRuntimeRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<
-                  google::cloud::aiplatform::v1::StartNotebookRuntimeResponse>>,
-              StartNotebookRuntime,
-              (google::cloud::aiplatform::v1::StartNotebookRuntimeRequest const&
-                   request),
-              (override));
+  MOCK_METHOD(
+      (future<StatusOr<
+           google::cloud::aiplatform::v1::StartNotebookRuntimeResponse>>),
+      StartNotebookRuntime,
+      (google::cloud::aiplatform::v1::StartNotebookRuntimeRequest const&
+           request),
+      (override));
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/aiplatform/v1/mocks/mock_persistent_resource_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_persistent_resource_connection.h
@@ -48,14 +48,14 @@ class MockPersistentResourceServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::PersistentResource>>,
+      (future<StatusOr<google::cloud::aiplatform::v1::PersistentResource>>),
       CreatePersistentResource,
       (google::cloud::aiplatform::v1::CreatePersistentResourceRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::PersistentResource>,
+      (StatusOr<google::cloud::aiplatform::v1::PersistentResource>),
       GetPersistentResource,
       (google::cloud::aiplatform::v1::GetPersistentResourceRequest const&
            request),
@@ -68,21 +68,22 @@ class MockPersistentResourceServiceConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeletePersistentResource,
       (google::cloud::aiplatform::v1::DeletePersistentResourceRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::PersistentResource>>,
+      (future<StatusOr<google::cloud::aiplatform::v1::PersistentResource>>),
       UpdatePersistentResource,
       (google::cloud::aiplatform::v1::UpdatePersistentResourceRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::PersistentResource>>,
+      (future<StatusOr<google::cloud::aiplatform::v1::PersistentResource>>),
       RebootPersistentResource,
       (google::cloud::aiplatform::v1::RebootPersistentResourceRequest const&
            request),

--- a/google/cloud/aiplatform/v1/mocks/mock_pipeline_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_pipeline_connection.h
@@ -48,13 +48,13 @@ class MockPipelineServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::TrainingPipeline>,
+      (StatusOr<google::cloud::aiplatform::v1::TrainingPipeline>),
       CreateTrainingPipeline,
       (google::cloud::aiplatform::v1::CreateTrainingPipelineRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::aiplatform::v1::TrainingPipeline>,
+  MOCK_METHOD((StatusOr<google::cloud::aiplatform::v1::TrainingPipeline>),
               GetTrainingPipeline,
               (google::cloud::aiplatform::v1::GetTrainingPipelineRequest const&
                    request),
@@ -67,7 +67,8 @@ class MockPipelineServiceConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeleteTrainingPipeline,
       (google::cloud::aiplatform::v1::DeleteTrainingPipelineRequest const&
            request),
@@ -80,12 +81,12 @@ class MockPipelineServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::PipelineJob>, CreatePipelineJob,
+      (StatusOr<google::cloud::aiplatform::v1::PipelineJob>), CreatePipelineJob,
       (google::cloud::aiplatform::v1::CreatePipelineJobRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::PipelineJob>, GetPipelineJob,
+      (StatusOr<google::cloud::aiplatform::v1::PipelineJob>), GetPipelineJob,
       (google::cloud::aiplatform::v1::GetPipelineJobRequest const& request),
       (override));
 
@@ -95,14 +96,15 @@ class MockPipelineServiceConnection
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeletePipelineJob,
       (google::cloud::aiplatform::v1::DeletePipelineJobRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::aiplatform::v1::BatchDeletePipelineJobsResponse>>,
+      (future<StatusOr<
+           google::cloud::aiplatform::v1::BatchDeletePipelineJobsResponse>>),
       BatchDeletePipelineJobs,
       (google::cloud::aiplatform::v1::BatchDeletePipelineJobsRequest const&
            request),
@@ -114,8 +116,8 @@ class MockPipelineServiceConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::aiplatform::v1::BatchCancelPipelineJobsResponse>>,
+      (future<StatusOr<
+           google::cloud::aiplatform::v1::BatchCancelPipelineJobsResponse>>),
       BatchCancelPipelineJobs,
       (google::cloud::aiplatform::v1::BatchCancelPipelineJobsRequest const&
            request),

--- a/google/cloud/aiplatform/v1/mocks/mock_prediction_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_prediction_connection.h
@@ -47,27 +47,28 @@ class MockPredictionServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::aiplatform::v1::PredictResponse>, Predict,
+  MOCK_METHOD((StatusOr<google::cloud::aiplatform::v1::PredictResponse>),
+              Predict,
               (google::cloud::aiplatform::v1::PredictRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::api::HttpBody>, RawPredict,
+  MOCK_METHOD((StatusOr<google::api::HttpBody>), RawPredict,
               (google::cloud::aiplatform::v1::RawPredictRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StreamRange<google::api::HttpBody>, StreamRawPredict,
+      (StreamRange<google::api::HttpBody>), StreamRawPredict,
       (google::cloud::aiplatform::v1::StreamRawPredictRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::DirectPredictResponse>,
+      (StatusOr<google::cloud::aiplatform::v1::DirectPredictResponse>),
       DirectPredict,
       (google::cloud::aiplatform::v1::DirectPredictRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::DirectRawPredictResponse>,
+      (StatusOr<google::cloud::aiplatform::v1::DirectRawPredictResponse>),
       DirectRawPredict,
       (google::cloud::aiplatform::v1::DirectRawPredictRequest const& request),
       (override));
@@ -90,7 +91,7 @@ class MockPredictionServiceConnection
               AsyncStreamingPredict, (), (override));
 
   MOCK_METHOD(
-      StreamRange<google::cloud::aiplatform::v1::StreamingPredictResponse>,
+      (StreamRange<google::cloud::aiplatform::v1::StreamingPredictResponse>),
       ServerStreamingPredict,
       (google::cloud::aiplatform::v1::StreamingPredictRequest const& request),
       (override));
@@ -101,18 +102,19 @@ class MockPredictionServiceConnection
            google::cloud::aiplatform::v1::StreamingRawPredictResponse>>),
       AsyncStreamingRawPredict, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::aiplatform::v1::ExplainResponse>, Explain,
+  MOCK_METHOD((StatusOr<google::cloud::aiplatform::v1::ExplainResponse>),
+              Explain,
               (google::cloud::aiplatform::v1::ExplainRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::GenerateContentResponse>,
+      (StatusOr<google::cloud::aiplatform::v1::GenerateContentResponse>),
       GenerateContent,
       (google::cloud::aiplatform::v1::GenerateContentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StreamRange<google::cloud::aiplatform::v1::GenerateContentResponse>,
+      (StreamRange<google::cloud::aiplatform::v1::GenerateContentResponse>),
       StreamGenerateContent,
       (google::cloud::aiplatform::v1::GenerateContentRequest const& request),
       (override));

--- a/google/cloud/aiplatform/v1/mocks/mock_schedule_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_schedule_connection.h
@@ -48,18 +48,19 @@ class MockScheduleServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::Schedule>, CreateSchedule,
+      (StatusOr<google::cloud::aiplatform::v1::Schedule>), CreateSchedule,
       (google::cloud::aiplatform::v1::CreateScheduleRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeleteSchedule,
       (google::cloud::aiplatform::v1::DeleteScheduleRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::Schedule>, GetSchedule,
+      (StatusOr<google::cloud::aiplatform::v1::Schedule>), GetSchedule,
       (google::cloud::aiplatform::v1::GetScheduleRequest const& request),
       (override));
 
@@ -79,7 +80,7 @@ class MockScheduleServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::Schedule>, UpdateSchedule,
+      (StatusOr<google::cloud::aiplatform::v1::Schedule>), UpdateSchedule,
       (google::cloud::aiplatform::v1::UpdateScheduleRequest const& request),
       (override));
 };

--- a/google/cloud/aiplatform/v1/mocks/mock_specialist_pool_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_specialist_pool_connection.h
@@ -47,14 +47,14 @@ class MockSpecialistPoolServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::aiplatform::v1::SpecialistPool>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::aiplatform::v1::SpecialistPool>>),
               CreateSpecialistPool,
               (google::cloud::aiplatform::v1::CreateSpecialistPoolRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::SpecialistPool>,
+      (StatusOr<google::cloud::aiplatform::v1::SpecialistPool>),
       GetSpecialistPool,
       (google::cloud::aiplatform::v1::GetSpecialistPoolRequest const& request),
       (override));
@@ -66,13 +66,14 @@ class MockSpecialistPoolServiceConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeleteSpecialistPool,
       (google::cloud::aiplatform::v1::DeleteSpecialistPoolRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::aiplatform::v1::SpecialistPool>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::aiplatform::v1::SpecialistPool>>),
               UpdateSpecialistPool,
               (google::cloud::aiplatform::v1::UpdateSpecialistPoolRequest const&
                    request),

--- a/google/cloud/aiplatform/v1/mocks/mock_tensorboard_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_tensorboard_connection.h
@@ -48,18 +48,18 @@ class MockTensorboardServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::Tensorboard>>,
+      (future<StatusOr<google::cloud::aiplatform::v1::Tensorboard>>),
       CreateTensorboard,
       (google::cloud::aiplatform::v1::CreateTensorboardRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::Tensorboard>, GetTensorboard,
+      (StatusOr<google::cloud::aiplatform::v1::Tensorboard>), GetTensorboard,
       (google::cloud::aiplatform::v1::GetTensorboardRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::Tensorboard>>,
+      (future<StatusOr<google::cloud::aiplatform::v1::Tensorboard>>),
       UpdateTensorboard,
       (google::cloud::aiplatform::v1::UpdateTensorboardRequest const& request),
       (override));
@@ -70,41 +70,42 @@ class MockTensorboardServiceConnection
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeleteTensorboard,
       (google::cloud::aiplatform::v1::DeleteTensorboardRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::ReadTensorboardUsageResponse>,
+      (StatusOr<google::cloud::aiplatform::v1::ReadTensorboardUsageResponse>),
       ReadTensorboardUsage,
       (google::cloud::aiplatform::v1::ReadTensorboardUsageRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::ReadTensorboardSizeResponse>,
+      (StatusOr<google::cloud::aiplatform::v1::ReadTensorboardSizeResponse>),
       ReadTensorboardSize,
       (google::cloud::aiplatform::v1::ReadTensorboardSizeRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::TensorboardExperiment>,
+      (StatusOr<google::cloud::aiplatform::v1::TensorboardExperiment>),
       CreateTensorboardExperiment,
       (google::cloud::aiplatform::v1::CreateTensorboardExperimentRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::TensorboardExperiment>,
+      (StatusOr<google::cloud::aiplatform::v1::TensorboardExperiment>),
       GetTensorboardExperiment,
       (google::cloud::aiplatform::v1::GetTensorboardExperimentRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::TensorboardExperiment>,
+      (StatusOr<google::cloud::aiplatform::v1::TensorboardExperiment>),
       UpdateTensorboardExperiment,
       (google::cloud::aiplatform::v1::UpdateTensorboardExperimentRequest const&
            request),
@@ -118,33 +119,34 @@ class MockTensorboardServiceConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeleteTensorboardExperiment,
       (google::cloud::aiplatform::v1::DeleteTensorboardExperimentRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::aiplatform::v1::TensorboardRun>,
+  MOCK_METHOD((StatusOr<google::cloud::aiplatform::v1::TensorboardRun>),
               CreateTensorboardRun,
               (google::cloud::aiplatform::v1::CreateTensorboardRunRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::aiplatform::v1::BatchCreateTensorboardRunsResponse>,
+      (StatusOr<
+          google::cloud::aiplatform::v1::BatchCreateTensorboardRunsResponse>),
       BatchCreateTensorboardRuns,
       (google::cloud::aiplatform::v1::BatchCreateTensorboardRunsRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::TensorboardRun>,
+      (StatusOr<google::cloud::aiplatform::v1::TensorboardRun>),
       GetTensorboardRun,
       (google::cloud::aiplatform::v1::GetTensorboardRunRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::aiplatform::v1::TensorboardRun>,
+  MOCK_METHOD((StatusOr<google::cloud::aiplatform::v1::TensorboardRun>),
               UpdateTensorboardRun,
               (google::cloud::aiplatform::v1::UpdateTensorboardRunRequest const&
                    request),
@@ -157,35 +159,36 @@ class MockTensorboardServiceConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeleteTensorboardRun,
       (google::cloud::aiplatform::v1::DeleteTensorboardRunRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::aiplatform::v1::
-                           BatchCreateTensorboardTimeSeriesResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::aiplatform::v1::
+                            BatchCreateTensorboardTimeSeriesResponse>),
               BatchCreateTensorboardTimeSeries,
               (google::cloud::aiplatform::v1::
                    BatchCreateTensorboardTimeSeriesRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::TensorboardTimeSeries>,
+      (StatusOr<google::cloud::aiplatform::v1::TensorboardTimeSeries>),
       CreateTensorboardTimeSeries,
       (google::cloud::aiplatform::v1::CreateTensorboardTimeSeriesRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::TensorboardTimeSeries>,
+      (StatusOr<google::cloud::aiplatform::v1::TensorboardTimeSeries>),
       GetTensorboardTimeSeries,
       (google::cloud::aiplatform::v1::GetTensorboardTimeSeriesRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::TensorboardTimeSeries>,
+      (StatusOr<google::cloud::aiplatform::v1::TensorboardTimeSeries>),
       UpdateTensorboardTimeSeries,
       (google::cloud::aiplatform::v1::UpdateTensorboardTimeSeriesRequest const&
            request),
@@ -198,44 +201,45 @@ class MockTensorboardServiceConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::aiplatform::v1::DeleteOperationMetadata>>),
       DeleteTensorboardTimeSeries,
       (google::cloud::aiplatform::v1::DeleteTensorboardTimeSeriesRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::aiplatform::v1::
-                           BatchReadTensorboardTimeSeriesDataResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::aiplatform::v1::
+                            BatchReadTensorboardTimeSeriesDataResponse>),
               BatchReadTensorboardTimeSeriesData,
               (google::cloud::aiplatform::v1::
                    BatchReadTensorboardTimeSeriesDataRequest const& request),
               (override));
 
-  MOCK_METHOD(
-      StatusOr<
-          google::cloud::aiplatform::v1::ReadTensorboardTimeSeriesDataResponse>,
-      ReadTensorboardTimeSeriesData,
-      (google::cloud::aiplatform::v1::
-           ReadTensorboardTimeSeriesDataRequest const& request),
-      (override));
+  MOCK_METHOD((StatusOr<google::cloud::aiplatform::v1::
+                            ReadTensorboardTimeSeriesDataResponse>),
+              ReadTensorboardTimeSeriesData,
+              (google::cloud::aiplatform::v1::
+                   ReadTensorboardTimeSeriesDataRequest const& request),
+              (override));
 
   MOCK_METHOD(
-      StreamRange<
-          google::cloud::aiplatform::v1::ReadTensorboardBlobDataResponse>,
+      (StreamRange<
+          google::cloud::aiplatform::v1::ReadTensorboardBlobDataResponse>),
       ReadTensorboardBlobData,
       (google::cloud::aiplatform::v1::ReadTensorboardBlobDataRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::aiplatform::v1::
-                           WriteTensorboardExperimentDataResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::aiplatform::v1::
+                            WriteTensorboardExperimentDataResponse>),
               WriteTensorboardExperimentData,
               (google::cloud::aiplatform::v1::
                    WriteTensorboardExperimentDataRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::WriteTensorboardRunDataResponse>,
+      (StatusOr<
+          google::cloud::aiplatform::v1::WriteTensorboardRunDataResponse>),
       WriteTensorboardRunData,
       (google::cloud::aiplatform::v1::WriteTensorboardRunDataRequest const&
            request),

--- a/google/cloud/aiplatform/v1/mocks/mock_vizier_connection.h
+++ b/google/cloud/aiplatform/v1/mocks/mock_vizier_connection.h
@@ -48,11 +48,11 @@ class MockVizierServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::Study>, CreateStudy,
+      (StatusOr<google::cloud::aiplatform::v1::Study>), CreateStudy,
       (google::cloud::aiplatform::v1::CreateStudyRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::aiplatform::v1::Study>, GetStudy,
+  MOCK_METHOD((StatusOr<google::cloud::aiplatform::v1::Study>), GetStudy,
               (google::cloud::aiplatform::v1::GetStudyRequest const& request),
               (override));
 
@@ -66,22 +66,22 @@ class MockVizierServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::Study>, LookupStudy,
+      (StatusOr<google::cloud::aiplatform::v1::Study>), LookupStudy,
       (google::cloud::aiplatform::v1::LookupStudyRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::aiplatform::v1::SuggestTrialsResponse>>,
+      (future<StatusOr<google::cloud::aiplatform::v1::SuggestTrialsResponse>>),
       SuggestTrials,
       (google::cloud::aiplatform::v1::SuggestTrialsRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::Trial>, CreateTrial,
+      (StatusOr<google::cloud::aiplatform::v1::Trial>), CreateTrial,
       (google::cloud::aiplatform::v1::CreateTrialRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::aiplatform::v1::Trial>, GetTrial,
+  MOCK_METHOD((StatusOr<google::cloud::aiplatform::v1::Trial>), GetTrial,
               (google::cloud::aiplatform::v1::GetTrialRequest const& request),
               (override));
 
@@ -89,14 +89,14 @@ class MockVizierServiceConnection
               (google::cloud::aiplatform::v1::ListTrialsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::aiplatform::v1::Trial>,
+  MOCK_METHOD((StatusOr<google::cloud::aiplatform::v1::Trial>),
               AddTrialMeasurement,
               (google::cloud::aiplatform::v1::AddTrialMeasurementRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::Trial>, CompleteTrial,
+      (StatusOr<google::cloud::aiplatform::v1::Trial>), CompleteTrial,
       (google::cloud::aiplatform::v1::CompleteTrialRequest const& request),
       (override));
 
@@ -106,19 +106,19 @@ class MockVizierServiceConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::aiplatform::v1::CheckTrialEarlyStoppingStateResponse>>,
+      (future<StatusOr<google::cloud::aiplatform::v1::
+                           CheckTrialEarlyStoppingStateResponse>>),
       CheckTrialEarlyStoppingState,
       (google::cloud::aiplatform::v1::CheckTrialEarlyStoppingStateRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::aiplatform::v1::Trial>, StopTrial,
+  MOCK_METHOD((StatusOr<google::cloud::aiplatform::v1::Trial>), StopTrial,
               (google::cloud::aiplatform::v1::StopTrialRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::aiplatform::v1::ListOptimalTrialsResponse>,
+      (StatusOr<google::cloud::aiplatform::v1::ListOptimalTrialsResponse>),
       ListOptimalTrials,
       (google::cloud::aiplatform::v1::ListOptimalTrialsRequest const& request),
       (override));

--- a/google/cloud/alloydb/v1/mocks/mock_alloy_db_admin_connection.h
+++ b/google/cloud/alloydb/v1/mocks/mock_alloy_db_admin_connection.h
@@ -50,36 +50,36 @@ class MockAlloyDBAdminConnection : public alloydb_v1::AlloyDBAdminConnection {
               (google::cloud::alloydb::v1::ListClustersRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::alloydb::v1::Cluster>, GetCluster,
+  MOCK_METHOD((StatusOr<google::cloud::alloydb::v1::Cluster>), GetCluster,
               (google::cloud::alloydb::v1::GetClusterRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::alloydb::v1::Cluster>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::alloydb::v1::Cluster>>),
               CreateCluster,
               (google::cloud::alloydb::v1::CreateClusterRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::alloydb::v1::Cluster>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::alloydb::v1::Cluster>>),
               UpdateCluster,
               (google::cloud::alloydb::v1::UpdateClusterRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::alloydb::v1::OperationMetadata>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::alloydb::v1::OperationMetadata>>),
               DeleteCluster,
               (google::cloud::alloydb::v1::DeleteClusterRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::alloydb::v1::Cluster>>, PromoteCluster,
+      (future<StatusOr<google::cloud::alloydb::v1::Cluster>>), PromoteCluster,
       (google::cloud::alloydb::v1::PromoteClusterRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::alloydb::v1::Cluster>>, RestoreCluster,
+      (future<StatusOr<google::cloud::alloydb::v1::Cluster>>), RestoreCluster,
       (google::cloud::alloydb::v1::RestoreClusterRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::alloydb::v1::Cluster>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::alloydb::v1::Cluster>>),
               CreateSecondaryCluster,
               (google::cloud::alloydb::v1::CreateSecondaryClusterRequest const&
                    request),
@@ -90,51 +90,52 @@ class MockAlloyDBAdminConnection : public alloydb_v1::AlloyDBAdminConnection {
               (google::cloud::alloydb::v1::ListInstancesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::alloydb::v1::Instance>, GetInstance,
+  MOCK_METHOD((StatusOr<google::cloud::alloydb::v1::Instance>), GetInstance,
               (google::cloud::alloydb::v1::GetInstanceRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::alloydb::v1::Instance>>, CreateInstance,
+      (future<StatusOr<google::cloud::alloydb::v1::Instance>>), CreateInstance,
       (google::cloud::alloydb::v1::CreateInstanceRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::alloydb::v1::Instance>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::alloydb::v1::Instance>>),
               CreateSecondaryInstance,
               (google::cloud::alloydb::v1::CreateSecondaryInstanceRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::alloydb::v1::BatchCreateInstancesResponse>>,
+      (future<
+          StatusOr<google::cloud::alloydb::v1::BatchCreateInstancesResponse>>),
       BatchCreateInstances,
       (google::cloud::alloydb::v1::BatchCreateInstancesRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::alloydb::v1::Instance>>, UpdateInstance,
+      (future<StatusOr<google::cloud::alloydb::v1::Instance>>), UpdateInstance,
       (google::cloud::alloydb::v1::UpdateInstanceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::alloydb::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::alloydb::v1::OperationMetadata>>),
       DeleteInstance,
       (google::cloud::alloydb::v1::DeleteInstanceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::alloydb::v1::Instance>>, FailoverInstance,
+      (future<StatusOr<google::cloud::alloydb::v1::Instance>>),
+      FailoverInstance,
       (google::cloud::alloydb::v1::FailoverInstanceRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::alloydb::v1::Instance>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::alloydb::v1::Instance>>),
               InjectFault,
               (google::cloud::alloydb::v1::InjectFaultRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::alloydb::v1::Instance>>, RestartInstance,
+      (future<StatusOr<google::cloud::alloydb::v1::Instance>>), RestartInstance,
       (google::cloud::alloydb::v1::RestartInstanceRequest const& request),
       (override));
 
@@ -142,21 +143,21 @@ class MockAlloyDBAdminConnection : public alloydb_v1::AlloyDBAdminConnection {
               (google::cloud::alloydb::v1::ListBackupsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::alloydb::v1::Backup>, GetBackup,
+  MOCK_METHOD((StatusOr<google::cloud::alloydb::v1::Backup>), GetBackup,
               (google::cloud::alloydb::v1::GetBackupRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::alloydb::v1::Backup>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::alloydb::v1::Backup>>),
               CreateBackup,
               (google::cloud::alloydb::v1::CreateBackupRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::alloydb::v1::Backup>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::alloydb::v1::Backup>>),
               UpdateBackup,
               (google::cloud::alloydb::v1::UpdateBackupRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::alloydb::v1::OperationMetadata>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::alloydb::v1::OperationMetadata>>),
               DeleteBackup,
               (google::cloud::alloydb::v1::DeleteBackupRequest const& request),
               (override));
@@ -168,14 +169,14 @@ class MockAlloyDBAdminConnection : public alloydb_v1::AlloyDBAdminConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::alloydb::v1::GenerateClientCertificateResponse>,
+      (StatusOr<google::cloud::alloydb::v1::GenerateClientCertificateResponse>),
       GenerateClientCertificate,
       (google::cloud::alloydb::v1::GenerateClientCertificateRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::alloydb::v1::ConnectionInfo>, GetConnectionInfo,
+      (StatusOr<google::cloud::alloydb::v1::ConnectionInfo>), GetConnectionInfo,
       (google::cloud::alloydb::v1::GetConnectionInfoRequest const& request),
       (override));
 
@@ -183,15 +184,15 @@ class MockAlloyDBAdminConnection : public alloydb_v1::AlloyDBAdminConnection {
               (google::cloud::alloydb::v1::ListUsersRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::alloydb::v1::User>, GetUser,
+  MOCK_METHOD((StatusOr<google::cloud::alloydb::v1::User>), GetUser,
               (google::cloud::alloydb::v1::GetUserRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::alloydb::v1::User>, CreateUser,
+  MOCK_METHOD((StatusOr<google::cloud::alloydb::v1::User>), CreateUser,
               (google::cloud::alloydb::v1::CreateUserRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::alloydb::v1::User>, UpdateUser,
+  MOCK_METHOD((StatusOr<google::cloud::alloydb::v1::User>), UpdateUser,
               (google::cloud::alloydb::v1::UpdateUserRequest const& request),
               (override));
 

--- a/google/cloud/apigateway/v1/mocks/mock_api_gateway_connection.h
+++ b/google/cloud/apigateway/v1/mocks/mock_api_gateway_connection.h
@@ -52,22 +52,22 @@ class MockApiGatewayServiceConnection
               (google::cloud::apigateway::v1::ListGatewaysRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::apigateway::v1::Gateway>, GetGateway,
+  MOCK_METHOD((StatusOr<google::cloud::apigateway::v1::Gateway>), GetGateway,
               (google::cloud::apigateway::v1::GetGatewayRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::apigateway::v1::Gateway>>, CreateGateway,
+      (future<StatusOr<google::cloud::apigateway::v1::Gateway>>), CreateGateway,
       (google::cloud::apigateway::v1::CreateGatewayRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::apigateway::v1::Gateway>>, UpdateGateway,
+      (future<StatusOr<google::cloud::apigateway::v1::Gateway>>), UpdateGateway,
       (google::cloud::apigateway::v1::UpdateGatewayRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::apigateway::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::apigateway::v1::OperationMetadata>>),
       DeleteGateway,
       (google::cloud::apigateway::v1::DeleteGatewayRequest const& request),
       (override));
@@ -76,20 +76,20 @@ class MockApiGatewayServiceConnection
               (google::cloud::apigateway::v1::ListApisRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::apigateway::v1::Api>, GetApi,
+  MOCK_METHOD((StatusOr<google::cloud::apigateway::v1::Api>), GetApi,
               (google::cloud::apigateway::v1::GetApiRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::apigateway::v1::Api>>, CreateApi,
+  MOCK_METHOD((future<StatusOr<google::cloud::apigateway::v1::Api>>), CreateApi,
               (google::cloud::apigateway::v1::CreateApiRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::apigateway::v1::Api>>, UpdateApi,
+  MOCK_METHOD((future<StatusOr<google::cloud::apigateway::v1::Api>>), UpdateApi,
               (google::cloud::apigateway::v1::UpdateApiRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::apigateway::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::apigateway::v1::OperationMetadata>>),
       DeleteApi,
       (google::cloud::apigateway::v1::DeleteApiRequest const& request),
       (override));
@@ -100,24 +100,24 @@ class MockApiGatewayServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::apigateway::v1::ApiConfig>, GetApiConfig,
+      (StatusOr<google::cloud::apigateway::v1::ApiConfig>), GetApiConfig,
       (google::cloud::apigateway::v1::GetApiConfigRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::apigateway::v1::ApiConfig>>,
+      (future<StatusOr<google::cloud::apigateway::v1::ApiConfig>>),
       CreateApiConfig,
       (google::cloud::apigateway::v1::CreateApiConfigRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::apigateway::v1::ApiConfig>>,
+      (future<StatusOr<google::cloud::apigateway::v1::ApiConfig>>),
       UpdateApiConfig,
       (google::cloud::apigateway::v1::UpdateApiConfigRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::apigateway::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::apigateway::v1::OperationMetadata>>),
       DeleteApiConfig,
       (google::cloud::apigateway::v1::DeleteApiConfigRequest const& request),
       (override));

--- a/google/cloud/apikeys/v2/mocks/mock_api_keys_connection.h
+++ b/google/cloud/apikeys/v2/mocks/mock_api_keys_connection.h
@@ -46,35 +46,36 @@ class MockApiKeysConnection : public apikeys_v2::ApiKeysConnection {
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::api::apikeys::v2::Key>>, CreateKey,
+  MOCK_METHOD((future<StatusOr<google::api::apikeys::v2::Key>>), CreateKey,
               (google::api::apikeys::v2::CreateKeyRequest const& request),
               (override));
 
   MOCK_METHOD((StreamRange<google::api::apikeys::v2::Key>), ListKeys,
               (google::api::apikeys::v2::ListKeysRequest request), (override));
 
-  MOCK_METHOD(StatusOr<google::api::apikeys::v2::Key>, GetKey,
+  MOCK_METHOD((StatusOr<google::api::apikeys::v2::Key>), GetKey,
               (google::api::apikeys::v2::GetKeyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::api::apikeys::v2::GetKeyStringResponse>,
+  MOCK_METHOD((StatusOr<google::api::apikeys::v2::GetKeyStringResponse>),
               GetKeyString,
               (google::api::apikeys::v2::GetKeyStringRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::api::apikeys::v2::Key>>, UpdateKey,
+  MOCK_METHOD((future<StatusOr<google::api::apikeys::v2::Key>>), UpdateKey,
               (google::api::apikeys::v2::UpdateKeyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::api::apikeys::v2::Key>>, DeleteKey,
+  MOCK_METHOD((future<StatusOr<google::api::apikeys::v2::Key>>), DeleteKey,
               (google::api::apikeys::v2::DeleteKeyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::api::apikeys::v2::Key>>, UndeleteKey,
+  MOCK_METHOD((future<StatusOr<google::api::apikeys::v2::Key>>), UndeleteKey,
               (google::api::apikeys::v2::UndeleteKeyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::api::apikeys::v2::LookupKeyResponse>, LookupKey,
+  MOCK_METHOD((StatusOr<google::api::apikeys::v2::LookupKeyResponse>),
+              LookupKey,
               (google::api::apikeys::v2::LookupKeyRequest const& request),
               (override));
 };

--- a/google/cloud/appengine/v1/mocks/mock_applications_connection.h
+++ b/google/cloud/appengine/v1/mocks/mock_applications_connection.h
@@ -46,21 +46,21 @@ class MockApplicationsConnection : public appengine_v1::ApplicationsConnection {
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::appengine::v1::Application>, GetApplication,
+  MOCK_METHOD((StatusOr<google::appengine::v1::Application>), GetApplication,
               (google::appengine::v1::GetApplicationRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::appengine::v1::Application>>,
+  MOCK_METHOD((future<StatusOr<google::appengine::v1::Application>>),
               CreateApplication,
               (google::appengine::v1::CreateApplicationRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::appengine::v1::Application>>,
+  MOCK_METHOD((future<StatusOr<google::appengine::v1::Application>>),
               UpdateApplication,
               (google::appengine::v1::UpdateApplicationRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::appengine::v1::Application>>,
+  MOCK_METHOD((future<StatusOr<google::appengine::v1::Application>>),
               RepairApplication,
               (google::appengine::v1::RepairApplicationRequest const& request),
               (override));

--- a/google/cloud/appengine/v1/mocks/mock_authorized_certificates_connection.h
+++ b/google/cloud/appengine/v1/mocks/mock_authorized_certificates_connection.h
@@ -54,18 +54,18 @@ class MockAuthorizedCertificatesConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::appengine::v1::AuthorizedCertificate>,
+      (StatusOr<google::appengine::v1::AuthorizedCertificate>),
       GetAuthorizedCertificate,
       (google::appengine::v1::GetAuthorizedCertificateRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::appengine::v1::AuthorizedCertificate>,
+  MOCK_METHOD((StatusOr<google::appengine::v1::AuthorizedCertificate>),
               CreateAuthorizedCertificate,
               (google::appengine::v1::CreateAuthorizedCertificateRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::appengine::v1::AuthorizedCertificate>,
+  MOCK_METHOD((StatusOr<google::appengine::v1::AuthorizedCertificate>),
               UpdateAuthorizedCertificate,
               (google::appengine::v1::UpdateAuthorizedCertificateRequest const&
                    request),

--- a/google/cloud/appengine/v1/mocks/mock_domain_mappings_connection.h
+++ b/google/cloud/appengine/v1/mocks/mock_domain_mappings_connection.h
@@ -52,24 +52,25 @@ class MockDomainMappingsConnection
               (google::appengine::v1::ListDomainMappingsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::appengine::v1::DomainMapping>, GetDomainMapping,
+  MOCK_METHOD((StatusOr<google::appengine::v1::DomainMapping>),
+              GetDomainMapping,
               (google::appengine::v1::GetDomainMappingRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::appengine::v1::DomainMapping>>,
+      (future<StatusOr<google::appengine::v1::DomainMapping>>),
       CreateDomainMapping,
       (google::appengine::v1::CreateDomainMappingRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::appengine::v1::DomainMapping>>,
+      (future<StatusOr<google::appengine::v1::DomainMapping>>),
       UpdateDomainMapping,
       (google::appengine::v1::UpdateDomainMappingRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::appengine::v1::OperationMetadataV1>>,
+      (future<StatusOr<google::appengine::v1::OperationMetadataV1>>),
       DeleteDomainMapping,
       (google::appengine::v1::DeleteDomainMappingRequest const& request),
       (override));

--- a/google/cloud/appengine/v1/mocks/mock_firewall_connection.h
+++ b/google/cloud/appengine/v1/mocks/mock_firewall_connection.h
@@ -52,20 +52,22 @@ class MockFirewallConnection : public appengine_v1::FirewallConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::appengine::v1::BatchUpdateIngressRulesResponse>,
+      (StatusOr<google::appengine::v1::BatchUpdateIngressRulesResponse>),
       BatchUpdateIngressRules,
       (google::appengine::v1::BatchUpdateIngressRulesRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::appengine::v1::FirewallRule>, CreateIngressRule,
+  MOCK_METHOD((StatusOr<google::appengine::v1::FirewallRule>),
+              CreateIngressRule,
               (google::appengine::v1::CreateIngressRuleRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::appengine::v1::FirewallRule>, GetIngressRule,
+  MOCK_METHOD((StatusOr<google::appengine::v1::FirewallRule>), GetIngressRule,
               (google::appengine::v1::GetIngressRuleRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::appengine::v1::FirewallRule>, UpdateIngressRule,
+  MOCK_METHOD((StatusOr<google::appengine::v1::FirewallRule>),
+              UpdateIngressRule,
               (google::appengine::v1::UpdateIngressRuleRequest const& request),
               (override));
 

--- a/google/cloud/appengine/v1/mocks/mock_instances_connection.h
+++ b/google/cloud/appengine/v1/mocks/mock_instances_connection.h
@@ -50,16 +50,17 @@ class MockInstancesConnection : public appengine_v1::InstancesConnection {
               (google::appengine::v1::ListInstancesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::appengine::v1::Instance>, GetInstance,
+  MOCK_METHOD((StatusOr<google::appengine::v1::Instance>), GetInstance,
               (google::appengine::v1::GetInstanceRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::appengine::v1::OperationMetadataV1>>,
+  MOCK_METHOD((future<StatusOr<google::appengine::v1::OperationMetadataV1>>),
               DeleteInstance,
               (google::appengine::v1::DeleteInstanceRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::appengine::v1::Instance>>, DebugInstance,
+  MOCK_METHOD((future<StatusOr<google::appengine::v1::Instance>>),
+              DebugInstance,
               (google::appengine::v1::DebugInstanceRequest const& request),
               (override));
 };

--- a/google/cloud/appengine/v1/mocks/mock_services_connection.h
+++ b/google/cloud/appengine/v1/mocks/mock_services_connection.h
@@ -49,15 +49,15 @@ class MockServicesConnection : public appengine_v1::ServicesConnection {
   MOCK_METHOD((StreamRange<google::appengine::v1::Service>), ListServices,
               (google::appengine::v1::ListServicesRequest request), (override));
 
-  MOCK_METHOD(StatusOr<google::appengine::v1::Service>, GetService,
+  MOCK_METHOD((StatusOr<google::appengine::v1::Service>), GetService,
               (google::appengine::v1::GetServiceRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::appengine::v1::Service>>, UpdateService,
+  MOCK_METHOD((future<StatusOr<google::appengine::v1::Service>>), UpdateService,
               (google::appengine::v1::UpdateServiceRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::appengine::v1::OperationMetadataV1>>,
+  MOCK_METHOD((future<StatusOr<google::appengine::v1::OperationMetadataV1>>),
               DeleteService,
               (google::appengine::v1::DeleteServiceRequest const& request),
               (override));

--- a/google/cloud/appengine/v1/mocks/mock_versions_connection.h
+++ b/google/cloud/appengine/v1/mocks/mock_versions_connection.h
@@ -49,19 +49,19 @@ class MockVersionsConnection : public appengine_v1::VersionsConnection {
   MOCK_METHOD((StreamRange<google::appengine::v1::Version>), ListVersions,
               (google::appengine::v1::ListVersionsRequest request), (override));
 
-  MOCK_METHOD(StatusOr<google::appengine::v1::Version>, GetVersion,
+  MOCK_METHOD((StatusOr<google::appengine::v1::Version>), GetVersion,
               (google::appengine::v1::GetVersionRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::appengine::v1::Version>>, CreateVersion,
+  MOCK_METHOD((future<StatusOr<google::appengine::v1::Version>>), CreateVersion,
               (google::appengine::v1::CreateVersionRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::appengine::v1::Version>>, UpdateVersion,
+  MOCK_METHOD((future<StatusOr<google::appengine::v1::Version>>), UpdateVersion,
               (google::appengine::v1::UpdateVersionRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::appengine::v1::OperationMetadataV1>>,
+  MOCK_METHOD((future<StatusOr<google::appengine::v1::OperationMetadataV1>>),
               DeleteVersion,
               (google::appengine::v1::DeleteVersionRequest const& request),
               (override));

--- a/google/cloud/apphub/v1/mocks/mock_app_hub_connection.h
+++ b/google/cloud/apphub/v1/mocks/mock_app_hub_connection.h
@@ -47,8 +47,8 @@ class MockAppHubConnection : public apphub_v1::AppHubConnection {
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::apphub::v1::LookupServiceProjectAttachmentResponse>,
+      (StatusOr<
+          google::cloud::apphub::v1::LookupServiceProjectAttachmentResponse>),
       LookupServiceProjectAttachment,
       (google::cloud::apphub::v1::LookupServiceProjectAttachmentRequest const&
            request),
@@ -61,29 +61,29 @@ class MockAppHubConnection : public apphub_v1::AppHubConnection {
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::apphub::v1::ServiceProjectAttachment>>,
+      (future<StatusOr<google::cloud::apphub::v1::ServiceProjectAttachment>>),
       CreateServiceProjectAttachment,
       (google::cloud::apphub::v1::CreateServiceProjectAttachmentRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::apphub::v1::ServiceProjectAttachment>,
+      (StatusOr<google::cloud::apphub::v1::ServiceProjectAttachment>),
       GetServiceProjectAttachment,
       (google::cloud::apphub::v1::GetServiceProjectAttachmentRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::apphub::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::apphub::v1::OperationMetadata>>),
       DeleteServiceProjectAttachment,
       (google::cloud::apphub::v1::DeleteServiceProjectAttachmentRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::apphub::v1::DetachServiceProjectAttachmentResponse>,
+      (StatusOr<
+          google::cloud::apphub::v1::DetachServiceProjectAttachmentResponse>),
       DetachServiceProjectAttachment,
       (google::cloud::apphub::v1::DetachServiceProjectAttachmentRequest const&
            request),
@@ -96,13 +96,13 @@ class MockAppHubConnection : public apphub_v1::AppHubConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::apphub::v1::DiscoveredService>,
+      (StatusOr<google::cloud::apphub::v1::DiscoveredService>),
       GetDiscoveredService,
       (google::cloud::apphub::v1::GetDiscoveredServiceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::apphub::v1::LookupDiscoveredServiceResponse>,
+      (StatusOr<google::cloud::apphub::v1::LookupDiscoveredServiceResponse>),
       LookupDiscoveredService,
       (google::cloud::apphub::v1::LookupDiscoveredServiceRequest const&
            request),
@@ -112,21 +112,21 @@ class MockAppHubConnection : public apphub_v1::AppHubConnection {
               (google::cloud::apphub::v1::ListServicesRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::apphub::v1::Service>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::apphub::v1::Service>>),
               CreateService,
               (google::cloud::apphub::v1::CreateServiceRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::apphub::v1::Service>, GetService,
+  MOCK_METHOD((StatusOr<google::cloud::apphub::v1::Service>), GetService,
               (google::cloud::apphub::v1::GetServiceRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::apphub::v1::Service>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::apphub::v1::Service>>),
               UpdateService,
               (google::cloud::apphub::v1::UpdateServiceRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::apphub::v1::OperationMetadata>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::apphub::v1::OperationMetadata>>),
               DeleteService,
               (google::cloud::apphub::v1::DeleteServiceRequest const& request),
               (override));
@@ -138,13 +138,13 @@ class MockAppHubConnection : public apphub_v1::AppHubConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::apphub::v1::DiscoveredWorkload>,
+      (StatusOr<google::cloud::apphub::v1::DiscoveredWorkload>),
       GetDiscoveredWorkload,
       (google::cloud::apphub::v1::GetDiscoveredWorkloadRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::apphub::v1::LookupDiscoveredWorkloadResponse>,
+      (StatusOr<google::cloud::apphub::v1::LookupDiscoveredWorkloadResponse>),
       LookupDiscoveredWorkload,
       (google::cloud::apphub::v1::LookupDiscoveredWorkloadRequest const&
            request),
@@ -154,21 +154,21 @@ class MockAppHubConnection : public apphub_v1::AppHubConnection {
               (google::cloud::apphub::v1::ListWorkloadsRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::apphub::v1::Workload>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::apphub::v1::Workload>>),
               CreateWorkload,
               (google::cloud::apphub::v1::CreateWorkloadRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::apphub::v1::Workload>, GetWorkload,
+  MOCK_METHOD((StatusOr<google::cloud::apphub::v1::Workload>), GetWorkload,
               (google::cloud::apphub::v1::GetWorkloadRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::apphub::v1::Workload>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::apphub::v1::Workload>>),
               UpdateWorkload,
               (google::cloud::apphub::v1::UpdateWorkloadRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::apphub::v1::OperationMetadata>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::apphub::v1::OperationMetadata>>),
               DeleteWorkload,
               (google::cloud::apphub::v1::DeleteWorkloadRequest const& request),
               (override));
@@ -179,23 +179,24 @@ class MockAppHubConnection : public apphub_v1::AppHubConnection {
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::apphub::v1::Application>>,
+      (future<StatusOr<google::cloud::apphub::v1::Application>>),
       CreateApplication,
       (google::cloud::apphub::v1::CreateApplicationRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::apphub::v1::Application>, GetApplication,
+  MOCK_METHOD((StatusOr<google::cloud::apphub::v1::Application>),
+              GetApplication,
               (google::cloud::apphub::v1::GetApplicationRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::apphub::v1::Application>>,
+      (future<StatusOr<google::cloud::apphub::v1::Application>>),
       UpdateApplication,
       (google::cloud::apphub::v1::UpdateApplicationRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::apphub::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::apphub::v1::OperationMetadata>>),
       DeleteApplication,
       (google::cloud::apphub::v1::DeleteApplicationRequest const& request),
       (override));

--- a/google/cloud/artifactregistry/v1/mocks/mock_artifact_registry_connection.h
+++ b/google/cloud/artifactregistry/v1/mocks/mock_artifact_registry_connection.h
@@ -54,7 +54,7 @@ class MockArtifactRegistryConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::devtools::artifactregistry::v1::DockerImage>,
+      (StatusOr<google::devtools::artifactregistry::v1::DockerImage>),
       GetDockerImage,
       (google::devtools::artifactregistry::v1::GetDockerImageRequest const&
            request),
@@ -68,7 +68,7 @@ class MockArtifactRegistryConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::devtools::artifactregistry::v1::MavenArtifact>,
+      (StatusOr<google::devtools::artifactregistry::v1::MavenArtifact>),
       GetMavenArtifact,
       (google::devtools::artifactregistry::v1::GetMavenArtifactRequest const&
            request),
@@ -81,7 +81,7 @@ class MockArtifactRegistryConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::devtools::artifactregistry::v1::NpmPackage>,
+      (StatusOr<google::devtools::artifactregistry::v1::NpmPackage>),
       GetNpmPackage,
       (google::devtools::artifactregistry::v1::GetNpmPackageRequest const&
            request),
@@ -95,23 +95,23 @@ class MockArtifactRegistryConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::devtools::artifactregistry::v1::PythonPackage>,
+      (StatusOr<google::devtools::artifactregistry::v1::PythonPackage>),
       GetPythonPackage,
       (google::devtools::artifactregistry::v1::GetPythonPackageRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::devtools::artifactregistry::v1::ImportAptArtifactsResponse>>,
+      (future<StatusOr<google::devtools::artifactregistry::v1::
+                           ImportAptArtifactsResponse>>),
       ImportAptArtifacts,
       (google::devtools::artifactregistry::v1::ImportAptArtifactsRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::devtools::artifactregistry::v1::ImportYumArtifactsResponse>>,
+      (future<StatusOr<google::devtools::artifactregistry::v1::
+                           ImportYumArtifactsResponse>>),
       ImportYumArtifacts,
       (google::devtools::artifactregistry::v1::ImportYumArtifactsRequest const&
            request),
@@ -124,29 +124,29 @@ class MockArtifactRegistryConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::devtools::artifactregistry::v1::Repository>,
+      (StatusOr<google::devtools::artifactregistry::v1::Repository>),
       GetRepository,
       (google::devtools::artifactregistry::v1::GetRepositoryRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::devtools::artifactregistry::v1::Repository>>,
+      (future<StatusOr<google::devtools::artifactregistry::v1::Repository>>),
       CreateRepository,
       (google::devtools::artifactregistry::v1::CreateRepositoryRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::devtools::artifactregistry::v1::Repository>,
+      (StatusOr<google::devtools::artifactregistry::v1::Repository>),
       UpdateRepository,
       (google::devtools::artifactregistry::v1::UpdateRepositoryRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::devtools::artifactregistry::v1::OperationMetadata>>,
+      (future<
+          StatusOr<google::devtools::artifactregistry::v1::OperationMetadata>>),
       DeleteRepository,
       (google::devtools::artifactregistry::v1::DeleteRepositoryRequest const&
            request),
@@ -158,15 +158,15 @@ class MockArtifactRegistryConnection
       (google::devtools::artifactregistry::v1::ListPackagesRequest request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::devtools::artifactregistry::v1::Package>,
+  MOCK_METHOD((StatusOr<google::devtools::artifactregistry::v1::Package>),
               GetPackage,
               (google::devtools::artifactregistry::v1::GetPackageRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::devtools::artifactregistry::v1::OperationMetadata>>,
+      (future<
+          StatusOr<google::devtools::artifactregistry::v1::OperationMetadata>>),
       DeletePackage,
       (google::devtools::artifactregistry::v1::DeletePackageRequest const&
            request),
@@ -178,23 +178,23 @@ class MockArtifactRegistryConnection
       (google::devtools::artifactregistry::v1::ListVersionsRequest request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::devtools::artifactregistry::v1::Version>,
+  MOCK_METHOD((StatusOr<google::devtools::artifactregistry::v1::Version>),
               GetVersion,
               (google::devtools::artifactregistry::v1::GetVersionRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::devtools::artifactregistry::v1::OperationMetadata>>,
+      (future<
+          StatusOr<google::devtools::artifactregistry::v1::OperationMetadata>>),
       DeleteVersion,
       (google::devtools::artifactregistry::v1::DeleteVersionRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::devtools::artifactregistry::v1::BatchDeleteVersionsMetadata>>,
+      (future<StatusOr<google::devtools::artifactregistry::v1::
+                           BatchDeleteVersionsMetadata>>),
       BatchDeleteVersions,
       (google::devtools::artifactregistry::v1::BatchDeleteVersionsRequest const&
            request),
@@ -206,7 +206,7 @@ class MockArtifactRegistryConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::devtools::artifactregistry::v1::File>, GetFile,
+      (StatusOr<google::devtools::artifactregistry::v1::File>), GetFile,
       (google::devtools::artifactregistry::v1::GetFileRequest const& request),
       (override));
 
@@ -216,17 +216,17 @@ class MockArtifactRegistryConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::devtools::artifactregistry::v1::Tag>, GetTag,
+      (StatusOr<google::devtools::artifactregistry::v1::Tag>), GetTag,
       (google::devtools::artifactregistry::v1::GetTagRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::devtools::artifactregistry::v1::Tag>, CreateTag,
+      (StatusOr<google::devtools::artifactregistry::v1::Tag>), CreateTag,
       (google::devtools::artifactregistry::v1::CreateTagRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::devtools::artifactregistry::v1::Tag>, UpdateTag,
+      (StatusOr<google::devtools::artifactregistry::v1::Tag>), UpdateTag,
       (google::devtools::artifactregistry::v1::UpdateTagRequest const& request),
       (override));
 
@@ -235,41 +235,42 @@ class MockArtifactRegistryConnection
       (google::devtools::artifactregistry::v1::DeleteTagRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), SetIamPolicy,
               (google::iam::v1::SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), GetIamPolicy,
               (google::iam::v1::GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD((StatusOr<google::iam::v1::TestIamPermissionsResponse>),
               TestIamPermissions,
               (google::iam::v1::TestIamPermissionsRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::devtools::artifactregistry::v1::ProjectSettings>,
+      (StatusOr<google::devtools::artifactregistry::v1::ProjectSettings>),
       GetProjectSettings,
       (google::devtools::artifactregistry::v1::GetProjectSettingsRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::devtools::artifactregistry::v1::ProjectSettings>,
-              UpdateProjectSettings,
-              (google::devtools::artifactregistry::v1::
-                   UpdateProjectSettingsRequest const& request),
-              (override));
+  MOCK_METHOD(
+      (StatusOr<google::devtools::artifactregistry::v1::ProjectSettings>),
+      UpdateProjectSettings,
+      (google::devtools::artifactregistry::v1::
+           UpdateProjectSettingsRequest const& request),
+      (override));
 
   MOCK_METHOD(
-      StatusOr<google::devtools::artifactregistry::v1::VPCSCConfig>,
+      (StatusOr<google::devtools::artifactregistry::v1::VPCSCConfig>),
       GetVPCSCConfig,
       (google::devtools::artifactregistry::v1::GetVPCSCConfigRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::devtools::artifactregistry::v1::VPCSCConfig>,
+      (StatusOr<google::devtools::artifactregistry::v1::VPCSCConfig>),
       UpdateVPCSCConfig,
       (google::devtools::artifactregistry::v1::UpdateVPCSCConfigRequest const&
            request),

--- a/google/cloud/asset/v1/mocks/mock_asset_connection.h
+++ b/google/cloud/asset/v1/mocks/mock_asset_connection.h
@@ -46,34 +46,36 @@ class MockAssetServiceConnection : public asset_v1::AssetServiceConnection {
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::asset::v1::ExportAssetsResponse>>,
-              ExportAssets,
-              (google::cloud::asset::v1::ExportAssetsRequest const& request),
-              (override));
+  MOCK_METHOD(
+      (future<StatusOr<google::cloud::asset::v1::ExportAssetsResponse>>),
+      ExportAssets,
+      (google::cloud::asset::v1::ExportAssetsRequest const& request),
+      (override));
 
   MOCK_METHOD((StreamRange<google::cloud::asset::v1::Asset>), ListAssets,
               (google::cloud::asset::v1::ListAssetsRequest request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::asset::v1::BatchGetAssetsHistoryResponse>,
+      (StatusOr<google::cloud::asset::v1::BatchGetAssetsHistoryResponse>),
       BatchGetAssetsHistory,
       (google::cloud::asset::v1::BatchGetAssetsHistoryRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::asset::v1::Feed>, CreateFeed,
+  MOCK_METHOD((StatusOr<google::cloud::asset::v1::Feed>), CreateFeed,
               (google::cloud::asset::v1::CreateFeedRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::asset::v1::Feed>, GetFeed,
+  MOCK_METHOD((StatusOr<google::cloud::asset::v1::Feed>), GetFeed,
               (google::cloud::asset::v1::GetFeedRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::asset::v1::ListFeedsResponse>, ListFeeds,
+  MOCK_METHOD((StatusOr<google::cloud::asset::v1::ListFeedsResponse>),
+              ListFeeds,
               (google::cloud::asset::v1::ListFeedsRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::asset::v1::Feed>, UpdateFeed,
+  MOCK_METHOD((StatusOr<google::cloud::asset::v1::Feed>), UpdateFeed,
               (google::cloud::asset::v1::UpdateFeedRequest const& request),
               (override));
 
@@ -92,35 +94,35 @@ class MockAssetServiceConnection : public asset_v1::AssetServiceConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::asset::v1::AnalyzeIamPolicyResponse>,
+      (StatusOr<google::cloud::asset::v1::AnalyzeIamPolicyResponse>),
       AnalyzeIamPolicy,
       (google::cloud::asset::v1::AnalyzeIamPolicyRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::asset::v1::AnalyzeIamPolicyLongrunningResponse>>,
+      (future<StatusOr<
+           google::cloud::asset::v1::AnalyzeIamPolicyLongrunningResponse>>),
       AnalyzeIamPolicyLongrunning,
       (google::cloud::asset::v1::AnalyzeIamPolicyLongrunningRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::asset::v1::AnalyzeMoveResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::asset::v1::AnalyzeMoveResponse>),
               AnalyzeMove,
               (google::cloud::asset::v1::AnalyzeMoveRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::asset::v1::QueryAssetsResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::asset::v1::QueryAssetsResponse>),
               QueryAssets,
               (google::cloud::asset::v1::QueryAssetsRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::asset::v1::SavedQuery>, CreateSavedQuery,
+      (StatusOr<google::cloud::asset::v1::SavedQuery>), CreateSavedQuery,
       (google::cloud::asset::v1::CreateSavedQueryRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::asset::v1::SavedQuery>, GetSavedQuery,
+  MOCK_METHOD((StatusOr<google::cloud::asset::v1::SavedQuery>), GetSavedQuery,
               (google::cloud::asset::v1::GetSavedQueryRequest const& request),
               (override));
 
@@ -130,7 +132,7 @@ class MockAssetServiceConnection : public asset_v1::AssetServiceConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::asset::v1::SavedQuery>, UpdateSavedQuery,
+      (StatusOr<google::cloud::asset::v1::SavedQuery>), UpdateSavedQuery,
       (google::cloud::asset::v1::UpdateSavedQueryRequest const& request),
       (override));
 
@@ -140,7 +142,8 @@ class MockAssetServiceConnection : public asset_v1::AssetServiceConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::asset::v1::BatchGetEffectiveIamPoliciesResponse>,
+      (StatusOr<
+          google::cloud::asset::v1::BatchGetEffectiveIamPoliciesResponse>),
       BatchGetEffectiveIamPolicies,
       (google::cloud::asset::v1::BatchGetEffectiveIamPoliciesRequest const&
            request),

--- a/google/cloud/assuredworkloads/v1/mocks/mock_assured_workloads_connection.h
+++ b/google/cloud/assuredworkloads/v1/mocks/mock_assured_workloads_connection.h
@@ -47,20 +47,20 @@ class MockAssuredWorkloadsServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::assuredworkloads::v1::Workload>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::assuredworkloads::v1::Workload>>),
               CreateWorkload,
               (google::cloud::assuredworkloads::v1::CreateWorkloadRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::assuredworkloads::v1::Workload>,
+  MOCK_METHOD((StatusOr<google::cloud::assuredworkloads::v1::Workload>),
               UpdateWorkload,
               (google::cloud::assuredworkloads::v1::UpdateWorkloadRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::assuredworkloads::v1::
-                           RestrictAllowedResourcesResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::assuredworkloads::v1::
+                            RestrictAllowedResourcesResponse>),
               RestrictAllowedResources,
               (google::cloud::assuredworkloads::v1::
                    RestrictAllowedResourcesRequest const& request),
@@ -72,7 +72,7 @@ class MockAssuredWorkloadsServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::assuredworkloads::v1::Workload>, GetWorkload,
+      (StatusOr<google::cloud::assuredworkloads::v1::Workload>), GetWorkload,
       (google::cloud::assuredworkloads::v1::GetWorkloadRequest const& request),
       (override));
 
@@ -89,13 +89,13 @@ class MockAssuredWorkloadsServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::assuredworkloads::v1::Violation>, GetViolation,
+      (StatusOr<google::cloud::assuredworkloads::v1::Violation>), GetViolation,
       (google::cloud::assuredworkloads::v1::GetViolationRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::assuredworkloads::v1::AcknowledgeViolationResponse>,
+      (StatusOr<
+          google::cloud::assuredworkloads::v1::AcknowledgeViolationResponse>),
       AcknowledgeViolation,
       (google::cloud::assuredworkloads::v1::AcknowledgeViolationRequest const&
            request),

--- a/google/cloud/automl/v1/mocks/mock_auto_ml_connection.h
+++ b/google/cloud/automl/v1/mocks/mock_auto_ml_connection.h
@@ -46,12 +46,12 @@ class MockAutoMlConnection : public automl_v1::AutoMlConnection {
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::automl::v1::Dataset>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::automl::v1::Dataset>>),
               CreateDataset,
               (google::cloud::automl::v1::CreateDatasetRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::automl::v1::Dataset>, GetDataset,
+  MOCK_METHOD((StatusOr<google::cloud::automl::v1::Dataset>), GetDataset,
               (google::cloud::automl::v1::GetDatasetRequest const& request),
               (override));
 
@@ -59,35 +59,35 @@ class MockAutoMlConnection : public automl_v1::AutoMlConnection {
               (google::cloud::automl::v1::ListDatasetsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::automl::v1::Dataset>, UpdateDataset,
+  MOCK_METHOD((StatusOr<google::cloud::automl::v1::Dataset>), UpdateDataset,
               (google::cloud::automl::v1::UpdateDatasetRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::automl::v1::OperationMetadata>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::automl::v1::OperationMetadata>>),
               DeleteDataset,
               (google::cloud::automl::v1::DeleteDatasetRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::automl::v1::OperationMetadata>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::automl::v1::OperationMetadata>>),
               ImportData,
               (google::cloud::automl::v1::ImportDataRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::automl::v1::OperationMetadata>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::automl::v1::OperationMetadata>>),
               ExportData,
               (google::cloud::automl::v1::ExportDataRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::automl::v1::AnnotationSpec>, GetAnnotationSpec,
+      (StatusOr<google::cloud::automl::v1::AnnotationSpec>), GetAnnotationSpec,
       (google::cloud::automl::v1::GetAnnotationSpecRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::automl::v1::Model>>, CreateModel,
+  MOCK_METHOD((future<StatusOr<google::cloud::automl::v1::Model>>), CreateModel,
               (google::cloud::automl::v1::CreateModelRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::automl::v1::Model>, GetModel,
+  MOCK_METHOD((StatusOr<google::cloud::automl::v1::Model>), GetModel,
               (google::cloud::automl::v1::GetModelRequest const& request),
               (override));
 
@@ -95,32 +95,33 @@ class MockAutoMlConnection : public automl_v1::AutoMlConnection {
               (google::cloud::automl::v1::ListModelsRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::automl::v1::OperationMetadata>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::automl::v1::OperationMetadata>>),
               DeleteModel,
               (google::cloud::automl::v1::DeleteModelRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::automl::v1::Model>, UpdateModel,
+  MOCK_METHOD((StatusOr<google::cloud::automl::v1::Model>), UpdateModel,
               (google::cloud::automl::v1::UpdateModelRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::automl::v1::OperationMetadata>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::automl::v1::OperationMetadata>>),
               DeployModel,
               (google::cloud::automl::v1::DeployModelRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::automl::v1::OperationMetadata>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::automl::v1::OperationMetadata>>),
               UndeployModel,
               (google::cloud::automl::v1::UndeployModelRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::automl::v1::OperationMetadata>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::automl::v1::OperationMetadata>>),
               ExportModel,
               (google::cloud::automl::v1::ExportModelRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::automl::v1::ModelEvaluation>, GetModelEvaluation,
+      (StatusOr<google::cloud::automl::v1::ModelEvaluation>),
+      GetModelEvaluation,
       (google::cloud::automl::v1::GetModelEvaluationRequest const& request),
       (override));
 

--- a/google/cloud/automl/v1/mocks/mock_prediction_connection.h
+++ b/google/cloud/automl/v1/mocks/mock_prediction_connection.h
@@ -47,11 +47,11 @@ class MockPredictionServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::automl::v1::PredictResponse>, Predict,
+  MOCK_METHOD((StatusOr<google::cloud::automl::v1::PredictResponse>), Predict,
               (google::cloud::automl::v1::PredictRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::automl::v1::BatchPredictResult>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::automl::v1::BatchPredictResult>>),
               BatchPredict,
               (google::cloud::automl::v1::BatchPredictRequest const& request),
               (override));

--- a/google/cloud/backupdr/v1/mocks/mock_backup_dr_connection.h
+++ b/google/cloud/backupdr/v1/mocks/mock_backup_dr_connection.h
@@ -53,22 +53,23 @@ class MockBackupDRConnection : public backupdr_v1::BackupDRConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::backupdr::v1::ManagementServer>,
+      (StatusOr<google::cloud::backupdr::v1::ManagementServer>),
       GetManagementServer,
       (google::cloud::backupdr::v1::GetManagementServerRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::backupdr::v1::ManagementServer>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::backupdr::v1::ManagementServer>>),
               CreateManagementServer,
               (google::cloud::backupdr::v1::CreateManagementServerRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::backupdr::v1::OperationMetadata>>,
-              DeleteManagementServer,
-              (google::cloud::backupdr::v1::DeleteManagementServerRequest const&
-                   request),
-              (override));
+  MOCK_METHOD(
+      (future<StatusOr<google::cloud::backupdr::v1::OperationMetadata>>),
+      DeleteManagementServer,
+      (google::cloud::backupdr::v1::DeleteManagementServerRequest const&
+           request),
+      (override));
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/baremetalsolution/v2/mocks/mock_bare_metal_solution_connection.h
+++ b/google/cloud/baremetalsolution/v2/mocks/mock_bare_metal_solution_connection.h
@@ -54,61 +54,64 @@ class MockBareMetalSolutionConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::baremetalsolution::v2::Instance>, GetInstance,
+      (StatusOr<google::cloud::baremetalsolution::v2::Instance>), GetInstance,
       (google::cloud::baremetalsolution::v2::GetInstanceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::baremetalsolution::v2::Instance>>,
+      (future<StatusOr<google::cloud::baremetalsolution::v2::Instance>>),
       UpdateInstance,
       (google::cloud::baremetalsolution::v2::UpdateInstanceRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::baremetalsolution::v2::Instance>, RenameInstance,
+      (StatusOr<google::cloud::baremetalsolution::v2::Instance>),
+      RenameInstance,
       (google::cloud::baremetalsolution::v2::RenameInstanceRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<
-                  google::cloud::baremetalsolution::v2::ResetInstanceResponse>>,
-              ResetInstance,
-              (google::cloud::baremetalsolution::v2::ResetInstanceRequest const&
-                   request),
-              (override));
-
-  MOCK_METHOD(future<StatusOr<
-                  google::cloud::baremetalsolution::v2::StartInstanceResponse>>,
-              StartInstance,
-              (google::cloud::baremetalsolution::v2::StartInstanceRequest const&
-                   request),
-              (override));
+  MOCK_METHOD(
+      (future<StatusOr<
+           google::cloud::baremetalsolution::v2::ResetInstanceResponse>>),
+      ResetInstance,
+      (google::cloud::baremetalsolution::v2::ResetInstanceRequest const&
+           request),
+      (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::baremetalsolution::v2::StopInstanceResponse>>,
+      (future<StatusOr<
+           google::cloud::baremetalsolution::v2::StartInstanceResponse>>),
+      StartInstance,
+      (google::cloud::baremetalsolution::v2::StartInstanceRequest const&
+           request),
+      (override));
+
+  MOCK_METHOD(
+      (future<StatusOr<
+           google::cloud::baremetalsolution::v2::StopInstanceResponse>>),
       StopInstance,
       (google::cloud::baremetalsolution::v2::StopInstanceRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::baremetalsolution::v2::
-                                  EnableInteractiveSerialConsoleResponse>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::baremetalsolution::v2::
+                                   EnableInteractiveSerialConsoleResponse>>),
               EnableInteractiveSerialConsole,
               (google::cloud::baremetalsolution::v2::
                    EnableInteractiveSerialConsoleRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::baremetalsolution::v2::
-                                  DisableInteractiveSerialConsoleResponse>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::baremetalsolution::v2::
+                                   DisableInteractiveSerialConsoleResponse>>),
               DisableInteractiveSerialConsole,
               (google::cloud::baremetalsolution::v2::
                    DisableInteractiveSerialConsoleRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::baremetalsolution::v2::Instance>>,
+      (future<StatusOr<google::cloud::baremetalsolution::v2::Instance>>),
       DetachLun,
       (google::cloud::baremetalsolution::v2::DetachLunRequest const& request),
       (override));
@@ -118,7 +121,7 @@ class MockBareMetalSolutionConnection
       (google::cloud::baremetalsolution::v2::ListSSHKeysRequest request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::baremetalsolution::v2::SSHKey>,
+  MOCK_METHOD((StatusOr<google::cloud::baremetalsolution::v2::SSHKey>),
               CreateSSHKey,
               (google::cloud::baremetalsolution::v2::CreateSSHKeyRequest const&
                    request),
@@ -135,29 +138,30 @@ class MockBareMetalSolutionConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::baremetalsolution::v2::Volume>, GetVolume,
+      (StatusOr<google::cloud::baremetalsolution::v2::Volume>), GetVolume,
       (google::cloud::baremetalsolution::v2::GetVolumeRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::baremetalsolution::v2::Volume>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::baremetalsolution::v2::Volume>>),
               UpdateVolume,
               (google::cloud::baremetalsolution::v2::UpdateVolumeRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::baremetalsolution::v2::Volume>,
+  MOCK_METHOD((StatusOr<google::cloud::baremetalsolution::v2::Volume>),
               RenameVolume,
               (google::cloud::baremetalsolution::v2::RenameVolumeRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::baremetalsolution::v2::OperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::baremetalsolution::v2::OperationMetadata>>),
       EvictVolume,
       (google::cloud::baremetalsolution::v2::EvictVolumeRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::baremetalsolution::v2::Volume>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::baremetalsolution::v2::Volume>>),
               ResizeVolume,
               (google::cloud::baremetalsolution::v2::ResizeVolumeRequest const&
                    request),
@@ -170,32 +174,33 @@ class MockBareMetalSolutionConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::baremetalsolution::v2::ListNetworkUsageResponse>,
+      (StatusOr<
+          google::cloud::baremetalsolution::v2::ListNetworkUsageResponse>),
       ListNetworkUsage,
       (google::cloud::baremetalsolution::v2::ListNetworkUsageRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::baremetalsolution::v2::Network>, GetNetwork,
+      (StatusOr<google::cloud::baremetalsolution::v2::Network>), GetNetwork,
       (google::cloud::baremetalsolution::v2::GetNetworkRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::baremetalsolution::v2::Network>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::baremetalsolution::v2::Network>>),
               UpdateNetwork,
               (google::cloud::baremetalsolution::v2::UpdateNetworkRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::baremetalsolution::v2::VolumeSnapshot>,
+      (StatusOr<google::cloud::baremetalsolution::v2::VolumeSnapshot>),
       CreateVolumeSnapshot,
       (google::cloud::baremetalsolution::v2::CreateVolumeSnapshotRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::baremetalsolution::v2::VolumeSnapshot>>,
+      (future<StatusOr<google::cloud::baremetalsolution::v2::VolumeSnapshot>>),
       RestoreVolumeSnapshot,
       (google::cloud::baremetalsolution::v2::RestoreVolumeSnapshotRequest const&
            request),
@@ -208,7 +213,7 @@ class MockBareMetalSolutionConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::baremetalsolution::v2::VolumeSnapshot>,
+      (StatusOr<google::cloud::baremetalsolution::v2::VolumeSnapshot>),
       GetVolumeSnapshot,
       (google::cloud::baremetalsolution::v2::GetVolumeSnapshotRequest const&
            request),
@@ -222,7 +227,7 @@ class MockBareMetalSolutionConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::baremetalsolution::v2::Lun>, GetLun,
+      (StatusOr<google::cloud::baremetalsolution::v2::Lun>), GetLun,
       (google::cloud::baremetalsolution::v2::GetLunRequest const& request),
       (override));
 
@@ -232,13 +237,14 @@ class MockBareMetalSolutionConnection
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::baremetalsolution::v2::OperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::baremetalsolution::v2::OperationMetadata>>),
       EvictLun,
       (google::cloud::baremetalsolution::v2::EvictLunRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::baremetalsolution::v2::NfsShare>, GetNfsShare,
+      (StatusOr<google::cloud::baremetalsolution::v2::NfsShare>), GetNfsShare,
       (google::cloud::baremetalsolution::v2::GetNfsShareRequest const& request),
       (override));
 
@@ -249,27 +255,29 @@ class MockBareMetalSolutionConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::baremetalsolution::v2::NfsShare>>,
+      (future<StatusOr<google::cloud::baremetalsolution::v2::NfsShare>>),
       UpdateNfsShare,
       (google::cloud::baremetalsolution::v2::UpdateNfsShareRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::baremetalsolution::v2::NfsShare>>,
+      (future<StatusOr<google::cloud::baremetalsolution::v2::NfsShare>>),
       CreateNfsShare,
       (google::cloud::baremetalsolution::v2::CreateNfsShareRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::baremetalsolution::v2::NfsShare>, RenameNfsShare,
+      (StatusOr<google::cloud::baremetalsolution::v2::NfsShare>),
+      RenameNfsShare,
       (google::cloud::baremetalsolution::v2::RenameNfsShareRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::baremetalsolution::v2::OperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::baremetalsolution::v2::OperationMetadata>>),
       DeleteNfsShare,
       (google::cloud::baremetalsolution::v2::DeleteNfsShareRequest const&
            request),
@@ -282,35 +290,35 @@ class MockBareMetalSolutionConnection
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::baremetalsolution::v2::
-                           SubmitProvisioningConfigResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::baremetalsolution::v2::
+                            SubmitProvisioningConfigResponse>),
               SubmitProvisioningConfig,
               (google::cloud::baremetalsolution::v2::
                    SubmitProvisioningConfigRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::baremetalsolution::v2::ProvisioningConfig>,
+      (StatusOr<google::cloud::baremetalsolution::v2::ProvisioningConfig>),
       GetProvisioningConfig,
       (google::cloud::baremetalsolution::v2::GetProvisioningConfigRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::baremetalsolution::v2::ProvisioningConfig>,
+      (StatusOr<google::cloud::baremetalsolution::v2::ProvisioningConfig>),
       CreateProvisioningConfig,
       (google::cloud::baremetalsolution::v2::
            CreateProvisioningConfigRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::baremetalsolution::v2::ProvisioningConfig>,
+      (StatusOr<google::cloud::baremetalsolution::v2::ProvisioningConfig>),
       UpdateProvisioningConfig,
       (google::cloud::baremetalsolution::v2::
            UpdateProvisioningConfigRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::baremetalsolution::v2::Network>,
+  MOCK_METHOD((StatusOr<google::cloud::baremetalsolution::v2::Network>),
               RenameNetwork,
               (google::cloud::baremetalsolution::v2::RenameNetworkRequest const&
                    request),

--- a/google/cloud/batch/v1/mocks/mock_batch_connection.h
+++ b/google/cloud/batch/v1/mocks/mock_batch_connection.h
@@ -46,15 +46,15 @@ class MockBatchServiceConnection : public batch_v1::BatchServiceConnection {
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::batch::v1::Job>, CreateJob,
+  MOCK_METHOD((StatusOr<google::cloud::batch::v1::Job>), CreateJob,
               (google::cloud::batch::v1::CreateJobRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::batch::v1::Job>, GetJob,
+  MOCK_METHOD((StatusOr<google::cloud::batch::v1::Job>), GetJob,
               (google::cloud::batch::v1::GetJobRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::batch::v1::OperationMetadata>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::batch::v1::OperationMetadata>>),
               DeleteJob,
               (google::cloud::batch::v1::DeleteJobRequest const& request),
               (override));
@@ -62,7 +62,7 @@ class MockBatchServiceConnection : public batch_v1::BatchServiceConnection {
   MOCK_METHOD((StreamRange<google::cloud::batch::v1::Job>), ListJobs,
               (google::cloud::batch::v1::ListJobsRequest request), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::batch::v1::Task>, GetTask,
+  MOCK_METHOD((StatusOr<google::cloud::batch::v1::Task>), GetTask,
               (google::cloud::batch::v1::GetTaskRequest const& request),
               (override));
 

--- a/google/cloud/beyondcorp/appconnections/v1/mocks/mock_app_connections_connection.h
+++ b/google/cloud/beyondcorp/appconnections/v1/mocks/mock_app_connections_connection.h
@@ -57,30 +57,30 @@ class MockAppConnectionsServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::beyondcorp::appconnections::v1::AppConnection>,
+      (StatusOr<google::cloud::beyondcorp::appconnections::v1::AppConnection>),
       GetAppConnection,
       (google::cloud::beyondcorp::appconnections::v1::
            GetAppConnectionRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::beyondcorp::appconnections::v1::AppConnection>>,
+      (future<StatusOr<
+           google::cloud::beyondcorp::appconnections::v1::AppConnection>>),
       CreateAppConnection,
       (google::cloud::beyondcorp::appconnections::v1::
            CreateAppConnectionRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::beyondcorp::appconnections::v1::AppConnection>>,
+      (future<StatusOr<
+           google::cloud::beyondcorp::appconnections::v1::AppConnection>>),
       UpdateAppConnection,
       (google::cloud::beyondcorp::appconnections::v1::
            UpdateAppConnectionRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::beyondcorp::appconnections::v1::
-                                  AppConnectionOperationMetadata>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::beyondcorp::appconnections::v1::
+                                   AppConnectionOperationMetadata>>),
               DeleteAppConnection,
               (google::cloud::beyondcorp::appconnections::v1::
                    DeleteAppConnectionRequest const& request),

--- a/google/cloud/beyondcorp/appconnectors/v1/mocks/mock_app_connectors_connection.h
+++ b/google/cloud/beyondcorp/appconnectors/v1/mocks/mock_app_connectors_connection.h
@@ -55,38 +55,38 @@ class MockAppConnectorsServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::beyondcorp::appconnectors::v1::AppConnector>,
+      (StatusOr<google::cloud::beyondcorp::appconnectors::v1::AppConnector>),
       GetAppConnector,
       (google::cloud::beyondcorp::appconnectors::v1::
            GetAppConnectorRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::beyondcorp::appconnectors::v1::AppConnector>>,
+      (future<StatusOr<
+           google::cloud::beyondcorp::appconnectors::v1::AppConnector>>),
       CreateAppConnector,
       (google::cloud::beyondcorp::appconnectors::v1::
            CreateAppConnectorRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::beyondcorp::appconnectors::v1::AppConnector>>,
+      (future<StatusOr<
+           google::cloud::beyondcorp::appconnectors::v1::AppConnector>>),
       UpdateAppConnector,
       (google::cloud::beyondcorp::appconnectors::v1::
            UpdateAppConnectorRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::beyondcorp::appconnectors::v1::
-                                  AppConnectorOperationMetadata>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::beyondcorp::appconnectors::v1::
+                                   AppConnectorOperationMetadata>>),
               DeleteAppConnector,
               (google::cloud::beyondcorp::appconnectors::v1::
                    DeleteAppConnectorRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::beyondcorp::appconnectors::v1::AppConnector>>,
+      (future<StatusOr<
+           google::cloud::beyondcorp::appconnectors::v1::AppConnector>>),
       ReportStatus,
       (google::cloud::beyondcorp::appconnectors::v1::ReportStatusRequest const&
            request),

--- a/google/cloud/beyondcorp/appgateways/v1/mocks/mock_app_gateways_connection.h
+++ b/google/cloud/beyondcorp/appgateways/v1/mocks/mock_app_gateways_connection.h
@@ -55,21 +55,22 @@ class MockAppGatewaysServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::beyondcorp::appgateways::v1::AppGateway>,
+      (StatusOr<google::cloud::beyondcorp::appgateways::v1::AppGateway>),
       GetAppGateway,
       (google::cloud::beyondcorp::appgateways::v1::GetAppGatewayRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::beyondcorp::appgateways::v1::AppGateway>>,
+      (future<
+          StatusOr<google::cloud::beyondcorp::appgateways::v1::AppGateway>>),
       CreateAppGateway,
       (google::cloud::beyondcorp::appgateways::v1::
            CreateAppGatewayRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::beyondcorp::appgateways::v1::
-                                  AppGatewayOperationMetadata>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::beyondcorp::appgateways::v1::
+                                   AppGatewayOperationMetadata>>),
               DeleteAppGateway,
               (google::cloud::beyondcorp::appgateways::v1::
                    DeleteAppGatewayRequest const& request),

--- a/google/cloud/bigquery/analyticshub/v1/mocks/mock_analytics_hub_connection.h
+++ b/google/cloud/bigquery/analyticshub/v1/mocks/mock_analytics_hub_connection.h
@@ -62,23 +62,25 @@ class MockAnalyticsHubServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::analyticshub::v1::DataExchange>,
+      (StatusOr<google::cloud::bigquery::analyticshub::v1::DataExchange>),
       GetDataExchange,
       (google::cloud::bigquery::analyticshub::v1::GetDataExchangeRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::bigquery::analyticshub::v1::DataExchange>,
-              CreateDataExchange,
-              (google::cloud::bigquery::analyticshub::v1::
-                   CreateDataExchangeRequest const& request),
-              (override));
+  MOCK_METHOD(
+      (StatusOr<google::cloud::bigquery::analyticshub::v1::DataExchange>),
+      CreateDataExchange,
+      (google::cloud::bigquery::analyticshub::v1::
+           CreateDataExchangeRequest const& request),
+      (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::bigquery::analyticshub::v1::DataExchange>,
-              UpdateDataExchange,
-              (google::cloud::bigquery::analyticshub::v1::
-                   UpdateDataExchangeRequest const& request),
-              (override));
+  MOCK_METHOD(
+      (StatusOr<google::cloud::bigquery::analyticshub::v1::DataExchange>),
+      UpdateDataExchange,
+      (google::cloud::bigquery::analyticshub::v1::
+           UpdateDataExchangeRequest const& request),
+      (override));
 
   MOCK_METHOD(Status, DeleteDataExchange,
               (google::cloud::bigquery::analyticshub::v1::
@@ -92,20 +94,21 @@ class MockAnalyticsHubServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::analyticshub::v1::Listing>, GetListing,
+      (StatusOr<google::cloud::bigquery::analyticshub::v1::Listing>),
+      GetListing,
       (google::cloud::bigquery::analyticshub::v1::GetListingRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::analyticshub::v1::Listing>,
+      (StatusOr<google::cloud::bigquery::analyticshub::v1::Listing>),
       CreateListing,
       (google::cloud::bigquery::analyticshub::v1::CreateListingRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::analyticshub::v1::Listing>,
+      (StatusOr<google::cloud::bigquery::analyticshub::v1::Listing>),
       UpdateListing,
       (google::cloud::bigquery::analyticshub::v1::UpdateListingRequest const&
            request),
@@ -118,29 +121,29 @@ class MockAnalyticsHubServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::bigquery::analyticshub::v1::SubscribeListingResponse>,
+      (StatusOr<
+          google::cloud::bigquery::analyticshub::v1::SubscribeListingResponse>),
       SubscribeListing,
       (google::cloud::bigquery::analyticshub::v1::SubscribeListingRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::bigquery::analyticshub::v1::
-                                  SubscribeDataExchangeResponse>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::bigquery::analyticshub::v1::
+                                   SubscribeDataExchangeResponse>>),
               SubscribeDataExchange,
               (google::cloud::bigquery::analyticshub::v1::
                    SubscribeDataExchangeRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::bigquery::analyticshub::v1::
-                                  RefreshSubscriptionResponse>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::bigquery::analyticshub::v1::
+                                   RefreshSubscriptionResponse>>),
               RefreshSubscription,
               (google::cloud::bigquery::analyticshub::v1::
                    RefreshSubscriptionRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::analyticshub::v1::Subscription>,
+      (StatusOr<google::cloud::bigquery::analyticshub::v1::Subscription>),
       GetSubscription,
       (google::cloud::bigquery::analyticshub::v1::GetSubscriptionRequest const&
            request),
@@ -160,30 +163,30 @@ class MockAnalyticsHubServiceConnection
            ListSharedResourceSubscriptionsRequest request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::bigquery::analyticshub::v1::
-                           RevokeSubscriptionResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::bigquery::analyticshub::v1::
+                            RevokeSubscriptionResponse>),
               RevokeSubscription,
               (google::cloud::bigquery::analyticshub::v1::
                    RevokeSubscriptionRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::bigquery::analyticshub::v1::OperationMetadata>>,
+      (future<StatusOr<
+           google::cloud::bigquery::analyticshub::v1::OperationMetadata>>),
       DeleteSubscription,
       (google::cloud::bigquery::analyticshub::v1::
            DeleteSubscriptionRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), GetIamPolicy,
               (google::iam::v1::GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), SetIamPolicy,
               (google::iam::v1::SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD((StatusOr<google::iam::v1::TestIamPermissionsResponse>),
               TestIamPermissions,
               (google::iam::v1::TestIamPermissionsRequest const& request),
               (override));

--- a/google/cloud/bigquery/biglake/v1/mocks/mock_metastore_connection.h
+++ b/google/cloud/bigquery/biglake/v1/mocks/mock_metastore_connection.h
@@ -47,20 +47,20 @@ class MockMetastoreServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::bigquery::biglake::v1::Catalog>,
+  MOCK_METHOD((StatusOr<google::cloud::bigquery::biglake::v1::Catalog>),
               CreateCatalog,
               (google::cloud::bigquery::biglake::v1::CreateCatalogRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::bigquery::biglake::v1::Catalog>,
+  MOCK_METHOD((StatusOr<google::cloud::bigquery::biglake::v1::Catalog>),
               DeleteCatalog,
               (google::cloud::bigquery::biglake::v1::DeleteCatalogRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::biglake::v1::Catalog>, GetCatalog,
+      (StatusOr<google::cloud::bigquery::biglake::v1::Catalog>), GetCatalog,
       (google::cloud::bigquery::biglake::v1::GetCatalogRequest const& request),
       (override));
 
@@ -71,25 +71,28 @@ class MockMetastoreServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::biglake::v1::Database>, CreateDatabase,
+      (StatusOr<google::cloud::bigquery::biglake::v1::Database>),
+      CreateDatabase,
       (google::cloud::bigquery::biglake::v1::CreateDatabaseRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::biglake::v1::Database>, DeleteDatabase,
+      (StatusOr<google::cloud::bigquery::biglake::v1::Database>),
+      DeleteDatabase,
       (google::cloud::bigquery::biglake::v1::DeleteDatabaseRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::biglake::v1::Database>, UpdateDatabase,
+      (StatusOr<google::cloud::bigquery::biglake::v1::Database>),
+      UpdateDatabase,
       (google::cloud::bigquery::biglake::v1::UpdateDatabaseRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::biglake::v1::Database>, GetDatabase,
+      (StatusOr<google::cloud::bigquery::biglake::v1::Database>), GetDatabase,
       (google::cloud::bigquery::biglake::v1::GetDatabaseRequest const& request),
       (override));
 
@@ -100,27 +103,27 @@ class MockMetastoreServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::biglake::v1::Table>, CreateTable,
+      (StatusOr<google::cloud::bigquery::biglake::v1::Table>), CreateTable,
       (google::cloud::bigquery::biglake::v1::CreateTableRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::biglake::v1::Table>, DeleteTable,
+      (StatusOr<google::cloud::bigquery::biglake::v1::Table>), DeleteTable,
       (google::cloud::bigquery::biglake::v1::DeleteTableRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::biglake::v1::Table>, UpdateTable,
+      (StatusOr<google::cloud::bigquery::biglake::v1::Table>), UpdateTable,
       (google::cloud::bigquery::biglake::v1::UpdateTableRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::biglake::v1::Table>, RenameTable,
+      (StatusOr<google::cloud::bigquery::biglake::v1::Table>), RenameTable,
       (google::cloud::bigquery::biglake::v1::RenameTableRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::biglake::v1::Table>, GetTable,
+      (StatusOr<google::cloud::bigquery::biglake::v1::Table>), GetTable,
       (google::cloud::bigquery::biglake::v1::GetTableRequest const& request),
       (override));
 

--- a/google/cloud/bigquery/connection/v1/mocks/mock_connection_connection.h
+++ b/google/cloud/bigquery/connection/v1/mocks/mock_connection_connection.h
@@ -48,14 +48,14 @@ class MockConnectionServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::connection::v1::Connection>,
+      (StatusOr<google::cloud::bigquery::connection::v1::Connection>),
       CreateConnection,
       (google::cloud::bigquery::connection::v1::CreateConnectionRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::connection::v1::Connection>,
+      (StatusOr<google::cloud::bigquery::connection::v1::Connection>),
       GetConnection,
       (google::cloud::bigquery::connection::v1::GetConnectionRequest const&
            request),
@@ -68,7 +68,7 @@ class MockConnectionServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::connection::v1::Connection>,
+      (StatusOr<google::cloud::bigquery::connection::v1::Connection>),
       UpdateConnection,
       (google::cloud::bigquery::connection::v1::UpdateConnectionRequest const&
            request),
@@ -80,15 +80,15 @@ class MockConnectionServiceConnection
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), GetIamPolicy,
               (google::iam::v1::GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), SetIamPolicy,
               (google::iam::v1::SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD((StatusOr<google::iam::v1::TestIamPermissionsResponse>),
               TestIamPermissions,
               (google::iam::v1::TestIamPermissionsRequest const& request),
               (override));

--- a/google/cloud/bigquery/datapolicies/v1/mocks/mock_data_policy_connection.h
+++ b/google/cloud/bigquery/datapolicies/v1/mocks/mock_data_policy_connection.h
@@ -48,21 +48,21 @@ class MockDataPolicyServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::datapolicies::v1::DataPolicy>,
+      (StatusOr<google::cloud::bigquery::datapolicies::v1::DataPolicy>),
       CreateDataPolicy,
       (google::cloud::bigquery::datapolicies::v1::CreateDataPolicyRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::datapolicies::v1::DataPolicy>,
+      (StatusOr<google::cloud::bigquery::datapolicies::v1::DataPolicy>),
       UpdateDataPolicy,
       (google::cloud::bigquery::datapolicies::v1::UpdateDataPolicyRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::datapolicies::v1::DataPolicy>,
+      (StatusOr<google::cloud::bigquery::datapolicies::v1::DataPolicy>),
       RenameDataPolicy,
       (google::cloud::bigquery::datapolicies::v1::RenameDataPolicyRequest const&
            request),
@@ -75,7 +75,7 @@ class MockDataPolicyServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::datapolicies::v1::DataPolicy>,
+      (StatusOr<google::cloud::bigquery::datapolicies::v1::DataPolicy>),
       GetDataPolicy,
       (google::cloud::bigquery::datapolicies::v1::GetDataPolicyRequest const&
            request),
@@ -88,15 +88,15 @@ class MockDataPolicyServiceConnection
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), GetIamPolicy,
               (google::iam::v1::GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), SetIamPolicy,
               (google::iam::v1::SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD((StatusOr<google::iam::v1::TestIamPermissionsResponse>),
               TestIamPermissions,
               (google::iam::v1::TestIamPermissionsRequest const& request),
               (override));

--- a/google/cloud/bigquery/datatransfer/v1/mocks/mock_data_transfer_connection.h
+++ b/google/cloud/bigquery/datatransfer/v1/mocks/mock_data_transfer_connection.h
@@ -48,7 +48,7 @@ class MockDataTransferServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::datatransfer::v1::DataSource>,
+      (StatusOr<google::cloud::bigquery::datatransfer::v1::DataSource>),
       GetDataSource,
       (google::cloud::bigquery::datatransfer::v1::GetDataSourceRequest const&
            request),
@@ -62,14 +62,14 @@ class MockDataTransferServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::datatransfer::v1::TransferConfig>,
+      (StatusOr<google::cloud::bigquery::datatransfer::v1::TransferConfig>),
       CreateTransferConfig,
       (google::cloud::bigquery::datatransfer::v1::
            CreateTransferConfigRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::datatransfer::v1::TransferConfig>,
+      (StatusOr<google::cloud::bigquery::datatransfer::v1::TransferConfig>),
       UpdateTransferConfig,
       (google::cloud::bigquery::datatransfer::v1::
            UpdateTransferConfigRequest const& request),
@@ -81,7 +81,7 @@ class MockDataTransferServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::datatransfer::v1::TransferConfig>,
+      (StatusOr<google::cloud::bigquery::datatransfer::v1::TransferConfig>),
       GetTransferConfig,
       (google::cloud::bigquery::datatransfer::v1::
            GetTransferConfigRequest const& request),
@@ -94,22 +94,22 @@ class MockDataTransferServiceConnection
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::bigquery::datatransfer::v1::
-                           ScheduleTransferRunsResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::bigquery::datatransfer::v1::
+                            ScheduleTransferRunsResponse>),
               ScheduleTransferRuns,
               (google::cloud::bigquery::datatransfer::v1::
                    ScheduleTransferRunsRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::bigquery::datatransfer::v1::
-                           StartManualTransferRunsResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::bigquery::datatransfer::v1::
+                            StartManualTransferRunsResponse>),
               StartManualTransferRuns,
               (google::cloud::bigquery::datatransfer::v1::
                    StartManualTransferRunsRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::datatransfer::v1::TransferRun>,
+      (StatusOr<google::cloud::bigquery::datatransfer::v1::TransferRun>),
       GetTransferRun,
       (google::cloud::bigquery::datatransfer::v1::GetTransferRunRequest const&
            request),
@@ -135,8 +135,8 @@ class MockDataTransferServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::bigquery::datatransfer::v1::CheckValidCredsResponse>,
+      (StatusOr<
+          google::cloud::bigquery::datatransfer::v1::CheckValidCredsResponse>),
       CheckValidCreds,
       (google::cloud::bigquery::datatransfer::v1::CheckValidCredsRequest const&
            request),

--- a/google/cloud/bigquery/migration/v2/mocks/mock_migration_connection.h
+++ b/google/cloud/bigquery/migration/v2/mocks/mock_migration_connection.h
@@ -48,14 +48,14 @@ class MockMigrationServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::migration::v2::MigrationWorkflow>,
+      (StatusOr<google::cloud::bigquery::migration::v2::MigrationWorkflow>),
       CreateMigrationWorkflow,
       (google::cloud::bigquery::migration::v2::
            CreateMigrationWorkflowRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::migration::v2::MigrationWorkflow>,
+      (StatusOr<google::cloud::bigquery::migration::v2::MigrationWorkflow>),
       GetMigrationWorkflow,
       (google::cloud::bigquery::migration::v2::
            GetMigrationWorkflowRequest const& request),
@@ -79,7 +79,7 @@ class MockMigrationServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::migration::v2::MigrationSubtask>,
+      (StatusOr<google::cloud::bigquery::migration::v2::MigrationSubtask>),
       GetMigrationSubtask,
       (google::cloud::bigquery::migration::v2::GetMigrationSubtaskRequest const&
            request),

--- a/google/cloud/bigquery/reservation/v1/mocks/mock_reservation_connection.h
+++ b/google/cloud/bigquery/reservation/v1/mocks/mock_reservation_connection.h
@@ -48,7 +48,7 @@ class MockReservationServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::reservation::v1::Reservation>,
+      (StatusOr<google::cloud::bigquery::reservation::v1::Reservation>),
       CreateReservation,
       (google::cloud::bigquery::reservation::v1::CreateReservationRequest const&
            request),
@@ -62,7 +62,7 @@ class MockReservationServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::reservation::v1::Reservation>,
+      (StatusOr<google::cloud::bigquery::reservation::v1::Reservation>),
       GetReservation,
       (google::cloud::bigquery::reservation::v1::GetReservationRequest const&
            request),
@@ -75,14 +75,14 @@ class MockReservationServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::reservation::v1::Reservation>,
+      (StatusOr<google::cloud::bigquery::reservation::v1::Reservation>),
       UpdateReservation,
       (google::cloud::bigquery::reservation::v1::UpdateReservationRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::reservation::v1::CapacityCommitment>,
+      (StatusOr<google::cloud::bigquery::reservation::v1::CapacityCommitment>),
       CreateCapacityCommitment,
       (google::cloud::bigquery::reservation::v1::
            CreateCapacityCommitmentRequest const& request),
@@ -97,7 +97,7 @@ class MockReservationServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::reservation::v1::CapacityCommitment>,
+      (StatusOr<google::cloud::bigquery::reservation::v1::CapacityCommitment>),
       GetCapacityCommitment,
       (google::cloud::bigquery::reservation::v1::
            GetCapacityCommitmentRequest const& request),
@@ -109,28 +109,28 @@ class MockReservationServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::reservation::v1::CapacityCommitment>,
+      (StatusOr<google::cloud::bigquery::reservation::v1::CapacityCommitment>),
       UpdateCapacityCommitment,
       (google::cloud::bigquery::reservation::v1::
            UpdateCapacityCommitmentRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::bigquery::reservation::v1::
-                           SplitCapacityCommitmentResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::bigquery::reservation::v1::
+                            SplitCapacityCommitmentResponse>),
               SplitCapacityCommitment,
               (google::cloud::bigquery::reservation::v1::
                    SplitCapacityCommitmentRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::reservation::v1::CapacityCommitment>,
+      (StatusOr<google::cloud::bigquery::reservation::v1::CapacityCommitment>),
       MergeCapacityCommitments,
       (google::cloud::bigquery::reservation::v1::
            MergeCapacityCommitmentsRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::reservation::v1::Assignment>,
+      (StatusOr<google::cloud::bigquery::reservation::v1::Assignment>),
       CreateAssignment,
       (google::cloud::bigquery::reservation::v1::CreateAssignmentRequest const&
            request),
@@ -164,31 +164,32 @@ class MockReservationServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::reservation::v1::Assignment>,
+      (StatusOr<google::cloud::bigquery::reservation::v1::Assignment>),
       MoveAssignment,
       (google::cloud::bigquery::reservation::v1::MoveAssignmentRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::reservation::v1::Assignment>,
+      (StatusOr<google::cloud::bigquery::reservation::v1::Assignment>),
       UpdateAssignment,
       (google::cloud::bigquery::reservation::v1::UpdateAssignmentRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::reservation::v1::BiReservation>,
+      (StatusOr<google::cloud::bigquery::reservation::v1::BiReservation>),
       GetBiReservation,
       (google::cloud::bigquery::reservation::v1::GetBiReservationRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::bigquery::reservation::v1::BiReservation>,
-              UpdateBiReservation,
-              (google::cloud::bigquery::reservation::v1::
-                   UpdateBiReservationRequest const& request),
-              (override));
+  MOCK_METHOD(
+      (StatusOr<google::cloud::bigquery::reservation::v1::BiReservation>),
+      UpdateBiReservation,
+      (google::cloud::bigquery::reservation::v1::
+           UpdateBiReservationRequest const& request),
+      (override));
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/storage/v1/mocks/mock_bigquery_read_connection.h
+++ b/google/cloud/bigquery/storage/v1/mocks/mock_bigquery_read_connection.h
@@ -48,20 +48,20 @@ class MockBigQueryReadConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::storage::v1::ReadSession>,
+      (StatusOr<google::cloud::bigquery::storage::v1::ReadSession>),
       CreateReadSession,
       (google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse>,
+      (StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse>),
       ReadRows,
       (google::cloud::bigquery::storage::v1::ReadRowsRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::storage::v1::SplitReadStreamResponse>,
+      (StatusOr<google::cloud::bigquery::storage::v1::SplitReadStreamResponse>),
       SplitReadStream,
       (google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
            request),

--- a/google/cloud/bigquery/storage/v1/mocks/mock_bigquery_write_connection.h
+++ b/google/cloud/bigquery/storage/v1/mocks/mock_bigquery_write_connection.h
@@ -48,7 +48,7 @@ class MockBigQueryWriteConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::storage::v1::WriteStream>,
+      (StatusOr<google::cloud::bigquery::storage::v1::WriteStream>),
       CreateWriteStream,
       (google::cloud::bigquery::storage::v1::CreateWriteStreamRequest const&
            request),
@@ -60,29 +60,29 @@ class MockBigQueryWriteConnection
               AsyncAppendRows, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::storage::v1::WriteStream>,
+      (StatusOr<google::cloud::bigquery::storage::v1::WriteStream>),
       GetWriteStream,
       (google::cloud::bigquery::storage::v1::GetWriteStreamRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::bigquery::storage::v1::FinalizeWriteStreamResponse>,
+      (StatusOr<
+          google::cloud::bigquery::storage::v1::FinalizeWriteStreamResponse>),
       FinalizeWriteStream,
       (google::cloud::bigquery::storage::v1::FinalizeWriteStreamRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::bigquery::storage::v1::
-                           BatchCommitWriteStreamsResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::bigquery::storage::v1::
+                            BatchCommitWriteStreamsResponse>),
               BatchCommitWriteStreams,
               (google::cloud::bigquery::storage::v1::
                    BatchCommitWriteStreamsRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::bigquery::storage::v1::FlushRowsResponse>,
+      (StatusOr<google::cloud::bigquery::storage::v1::FlushRowsResponse>),
       FlushRows,
       (google::cloud::bigquery::storage::v1::FlushRowsRequest const& request),
       (override));

--- a/google/cloud/bigtable/admin/mocks/mock_bigtable_instance_admin_connection.h
+++ b/google/cloud/bigtable/admin/mocks/mock_bigtable_instance_admin_connection.h
@@ -48,25 +48,25 @@ class MockBigtableInstanceAdminConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::bigtable::admin::v2::Instance>>, CreateInstance,
+      (future<StatusOr<google::bigtable::admin::v2::Instance>>), CreateInstance,
       (google::bigtable::admin::v2::CreateInstanceRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::bigtable::admin::v2::Instance>, GetInstance,
+  MOCK_METHOD((StatusOr<google::bigtable::admin::v2::Instance>), GetInstance,
               (google::bigtable::admin::v2::GetInstanceRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::bigtable::admin::v2::ListInstancesResponse>,
+      (StatusOr<google::bigtable::admin::v2::ListInstancesResponse>),
       ListInstances,
       (google::bigtable::admin::v2::ListInstancesRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::bigtable::admin::v2::Instance>, UpdateInstance,
+  MOCK_METHOD((StatusOr<google::bigtable::admin::v2::Instance>), UpdateInstance,
               (google::bigtable::admin::v2::Instance const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::bigtable::admin::v2::Instance>>,
+  MOCK_METHOD((future<StatusOr<google::bigtable::admin::v2::Instance>>),
               PartialUpdateInstance,
               (google::bigtable::admin::v2::PartialUpdateInstanceRequest const&
                    request),
@@ -78,26 +78,26 @@ class MockBigtableInstanceAdminConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::bigtable::admin::v2::Cluster>>, CreateCluster,
+      (future<StatusOr<google::bigtable::admin::v2::Cluster>>), CreateCluster,
       (google::bigtable::admin::v2::CreateClusterRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::bigtable::admin::v2::Cluster>, GetCluster,
+  MOCK_METHOD((StatusOr<google::bigtable::admin::v2::Cluster>), GetCluster,
               (google::bigtable::admin::v2::GetClusterRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::bigtable::admin::v2::ListClustersResponse>,
+  MOCK_METHOD((StatusOr<google::bigtable::admin::v2::ListClustersResponse>),
               ListClusters,
               (google::bigtable::admin::v2::ListClustersRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::bigtable::admin::v2::Cluster>>,
+  MOCK_METHOD((future<StatusOr<google::bigtable::admin::v2::Cluster>>),
               UpdateCluster,
               (google::bigtable::admin::v2::Cluster const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::bigtable::admin::v2::Cluster>>,
+      (future<StatusOr<google::bigtable::admin::v2::Cluster>>),
       PartialUpdateCluster,
       (google::bigtable::admin::v2::PartialUpdateClusterRequest const& request),
       (override));
@@ -108,12 +108,12 @@ class MockBigtableInstanceAdminConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::bigtable::admin::v2::AppProfile>, CreateAppProfile,
+      (StatusOr<google::bigtable::admin::v2::AppProfile>), CreateAppProfile,
       (google::bigtable::admin::v2::CreateAppProfileRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::bigtable::admin::v2::AppProfile>, GetAppProfile,
+      (StatusOr<google::bigtable::admin::v2::AppProfile>), GetAppProfile,
       (google::bigtable::admin::v2::GetAppProfileRequest const& request),
       (override));
 
@@ -123,7 +123,7 @@ class MockBigtableInstanceAdminConnection
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::bigtable::admin::v2::AppProfile>>,
+      (future<StatusOr<google::bigtable::admin::v2::AppProfile>>),
       UpdateAppProfile,
       (google::bigtable::admin::v2::UpdateAppProfileRequest const& request),
       (override));
@@ -133,15 +133,15 @@ class MockBigtableInstanceAdminConnection
       (google::bigtable::admin::v2::DeleteAppProfileRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), GetIamPolicy,
               (google::iam::v1::GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), SetIamPolicy,
               (google::iam::v1::SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD((StatusOr<google::iam::v1::TestIamPermissionsResponse>),
               TestIamPermissions,
               (google::iam::v1::TestIamPermissionsRequest const& request),
               (override));

--- a/google/cloud/bigtable/admin/mocks/mock_bigtable_table_admin_connection.h
+++ b/google/cloud/bigtable/admin/mocks/mock_bigtable_table_admin_connection.h
@@ -47,7 +47,7 @@ class MockBigtableTableAdminConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::bigtable::admin::v2::Table>, CreateTable,
+  MOCK_METHOD((StatusOr<google::bigtable::admin::v2::Table>), CreateTable,
               (google::bigtable::admin::v2::CreateTableRequest const& request),
               (override));
 
@@ -55,11 +55,12 @@ class MockBigtableTableAdminConnection
               (google::bigtable::admin::v2::ListTablesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::bigtable::admin::v2::Table>, GetTable,
+  MOCK_METHOD((StatusOr<google::bigtable::admin::v2::Table>), GetTable,
               (google::bigtable::admin::v2::GetTableRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::bigtable::admin::v2::Table>>, UpdateTable,
+  MOCK_METHOD((future<StatusOr<google::bigtable::admin::v2::Table>>),
+              UpdateTable,
               (google::bigtable::admin::v2::UpdateTableRequest const& request),
               (override));
 
@@ -68,12 +69,12 @@ class MockBigtableTableAdminConnection
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::bigtable::admin::v2::Table>>, UndeleteTable,
+      (future<StatusOr<google::bigtable::admin::v2::Table>>), UndeleteTable,
       (google::bigtable::admin::v2::UndeleteTableRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::bigtable::admin::v2::AuthorizedView>>,
+      (future<StatusOr<google::bigtable::admin::v2::AuthorizedView>>),
       CreateAuthorizedView,
       (google::bigtable::admin::v2::CreateAuthorizedViewRequest const& request),
       (override));
@@ -84,12 +85,13 @@ class MockBigtableTableAdminConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::bigtable::admin::v2::AuthorizedView>, GetAuthorizedView,
+      (StatusOr<google::bigtable::admin::v2::AuthorizedView>),
+      GetAuthorizedView,
       (google::bigtable::admin::v2::GetAuthorizedViewRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::bigtable::admin::v2::AuthorizedView>>,
+      (future<StatusOr<google::bigtable::admin::v2::AuthorizedView>>),
       UpdateAuthorizedView,
       (google::bigtable::admin::v2::UpdateAuthorizedViewRequest const& request),
       (override));
@@ -100,7 +102,7 @@ class MockBigtableTableAdminConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::bigtable::admin::v2::Table>, ModifyColumnFamilies,
+      (StatusOr<google::bigtable::admin::v2::Table>), ModifyColumnFamilies,
       (google::bigtable::admin::v2::ModifyColumnFamiliesRequest const& request),
       (override));
 
@@ -109,28 +111,28 @@ class MockBigtableTableAdminConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::bigtable::admin::v2::GenerateConsistencyTokenResponse>,
+      (StatusOr<google::bigtable::admin::v2::GenerateConsistencyTokenResponse>),
       GenerateConsistencyToken,
       (google::bigtable::admin::v2::GenerateConsistencyTokenRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>,
+      (StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>),
       CheckConsistency,
       (google::bigtable::admin::v2::CheckConsistencyRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::bigtable::admin::v2::Backup>>,
+  MOCK_METHOD((future<StatusOr<google::bigtable::admin::v2::Backup>>),
               CreateBackup,
               (google::bigtable::admin::v2::CreateBackupRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::bigtable::admin::v2::Backup>, GetBackup,
+  MOCK_METHOD((StatusOr<google::bigtable::admin::v2::Backup>), GetBackup,
               (google::bigtable::admin::v2::GetBackupRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::bigtable::admin::v2::Backup>, UpdateBackup,
+  MOCK_METHOD((StatusOr<google::bigtable::admin::v2::Backup>), UpdateBackup,
               (google::bigtable::admin::v2::UpdateBackupRequest const& request),
               (override));
 
@@ -142,30 +144,31 @@ class MockBigtableTableAdminConnection
               (google::bigtable::admin::v2::ListBackupsRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::bigtable::admin::v2::Table>>,
+  MOCK_METHOD((future<StatusOr<google::bigtable::admin::v2::Table>>),
               RestoreTable,
               (google::bigtable::admin::v2::RestoreTableRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::bigtable::admin::v2::Backup>>, CopyBackup,
+  MOCK_METHOD((future<StatusOr<google::bigtable::admin::v2::Backup>>),
+              CopyBackup,
               (google::bigtable::admin::v2::CopyBackupRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), GetIamPolicy,
               (google::iam::v1::GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), SetIamPolicy,
               (google::iam::v1::SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD((StatusOr<google::iam::v1::TestIamPermissionsResponse>),
               TestIamPermissions,
               (google::iam::v1::TestIamPermissionsRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>>,
+      (future<StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>>),
       AsyncCheckConsistency,
       (google::bigtable::admin::v2::CheckConsistencyRequest const& request),
       (override));

--- a/google/cloud/billing/budgets/v1/mocks/mock_budget_connection.h
+++ b/google/cloud/billing/budgets/v1/mocks/mock_budget_connection.h
@@ -48,17 +48,17 @@ class MockBudgetServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::billing::budgets::v1::Budget>, CreateBudget,
+      (StatusOr<google::cloud::billing::budgets::v1::Budget>), CreateBudget,
       (google::cloud::billing::budgets::v1::CreateBudgetRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::billing::budgets::v1::Budget>, UpdateBudget,
+      (StatusOr<google::cloud::billing::budgets::v1::Budget>), UpdateBudget,
       (google::cloud::billing::budgets::v1::UpdateBudgetRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::billing::budgets::v1::Budget>, GetBudget,
+      (StatusOr<google::cloud::billing::budgets::v1::Budget>), GetBudget,
       (google::cloud::billing::budgets::v1::GetBudgetRequest const& request),
       (override));
 

--- a/google/cloud/billing/v1/mocks/mock_cloud_billing_connection.h
+++ b/google/cloud/billing/v1/mocks/mock_cloud_billing_connection.h
@@ -47,7 +47,7 @@ class MockCloudBillingConnection : public billing_v1::CloudBillingConnection {
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::billing::v1::BillingAccount>, GetBillingAccount,
+      (StatusOr<google::cloud::billing::v1::BillingAccount>), GetBillingAccount,
       (google::cloud::billing::v1::GetBillingAccountRequest const& request),
       (override));
 
@@ -57,13 +57,13 @@ class MockCloudBillingConnection : public billing_v1::CloudBillingConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::billing::v1::BillingAccount>,
+      (StatusOr<google::cloud::billing::v1::BillingAccount>),
       UpdateBillingAccount,
       (google::cloud::billing::v1::UpdateBillingAccountRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::billing::v1::BillingAccount>,
+      (StatusOr<google::cloud::billing::v1::BillingAccount>),
       CreateBillingAccount,
       (google::cloud::billing::v1::CreateBillingAccountRequest const& request),
       (override));
@@ -75,33 +75,34 @@ class MockCloudBillingConnection : public billing_v1::CloudBillingConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::billing::v1::ProjectBillingInfo>,
+      (StatusOr<google::cloud::billing::v1::ProjectBillingInfo>),
       GetProjectBillingInfo,
       (google::cloud::billing::v1::GetProjectBillingInfoRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::billing::v1::ProjectBillingInfo>,
+      (StatusOr<google::cloud::billing::v1::ProjectBillingInfo>),
       UpdateProjectBillingInfo,
       (google::cloud::billing::v1::UpdateProjectBillingInfoRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), GetIamPolicy,
               (google::iam::v1::GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), SetIamPolicy,
               (google::iam::v1::SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD((StatusOr<google::iam::v1::TestIamPermissionsResponse>),
               TestIamPermissions,
               (google::iam::v1::TestIamPermissionsRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::billing::v1::BillingAccount>, MoveBillingAccount,
+      (StatusOr<google::cloud::billing::v1::BillingAccount>),
+      MoveBillingAccount,
       (google::cloud::billing::v1::MoveBillingAccountRequest const& request),
       (override));
 };

--- a/google/cloud/binaryauthorization/v1/mocks/mock_binauthz_management_service_v1_connection.h
+++ b/google/cloud/binaryauthorization/v1/mocks/mock_binauthz_management_service_v1_connection.h
@@ -48,31 +48,31 @@ class MockBinauthzManagementServiceV1Connection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::binaryauthorization::v1::Policy>, GetPolicy,
+      (StatusOr<google::cloud::binaryauthorization::v1::Policy>), GetPolicy,
       (google::cloud::binaryauthorization::v1::GetPolicyRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::binaryauthorization::v1::Policy>, UpdatePolicy,
+      (StatusOr<google::cloud::binaryauthorization::v1::Policy>), UpdatePolicy,
       (google::cloud::binaryauthorization::v1::UpdatePolicyRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::binaryauthorization::v1::Attestor>,
+      (StatusOr<google::cloud::binaryauthorization::v1::Attestor>),
       CreateAttestor,
       (google::cloud::binaryauthorization::v1::CreateAttestorRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::binaryauthorization::v1::Attestor>,
+  MOCK_METHOD((StatusOr<google::cloud::binaryauthorization::v1::Attestor>),
               GetAttestor,
               (google::cloud::binaryauthorization::v1::GetAttestorRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::binaryauthorization::v1::Attestor>,
+      (StatusOr<google::cloud::binaryauthorization::v1::Attestor>),
       UpdateAttestor,
       (google::cloud::binaryauthorization::v1::UpdateAttestorRequest const&
            request),

--- a/google/cloud/binaryauthorization/v1/mocks/mock_system_policy_v1_connection.h
+++ b/google/cloud/binaryauthorization/v1/mocks/mock_system_policy_v1_connection.h
@@ -48,7 +48,8 @@ class MockSystemPolicyV1Connection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::binaryauthorization::v1::Policy>, GetSystemPolicy,
+      (StatusOr<google::cloud::binaryauthorization::v1::Policy>),
+      GetSystemPolicy,
       (google::cloud::binaryauthorization::v1::GetSystemPolicyRequest const&
            request),
       (override));

--- a/google/cloud/binaryauthorization/v1/mocks/mock_validation_helper_v1_connection.h
+++ b/google/cloud/binaryauthorization/v1/mocks/mock_validation_helper_v1_connection.h
@@ -47,8 +47,8 @@ class MockValidationHelperV1Connection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::binaryauthorization::v1::
-                           ValidateAttestationOccurrenceResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::binaryauthorization::v1::
+                            ValidateAttestationOccurrenceResponse>),
               ValidateAttestationOccurrence,
               (google::cloud::binaryauthorization::v1::
                    ValidateAttestationOccurrenceRequest const& request),

--- a/google/cloud/certificatemanager/v1/mocks/mock_certificate_manager_connection.h
+++ b/google/cloud/certificatemanager/v1/mocks/mock_certificate_manager_connection.h
@@ -54,29 +54,29 @@ class MockCertificateManagerConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::certificatemanager::v1::Certificate>,
+      (StatusOr<google::cloud::certificatemanager::v1::Certificate>),
       GetCertificate,
       (google::cloud::certificatemanager::v1::GetCertificateRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::certificatemanager::v1::Certificate>>,
+      (future<StatusOr<google::cloud::certificatemanager::v1::Certificate>>),
       CreateCertificate,
       (google::cloud::certificatemanager::v1::CreateCertificateRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::certificatemanager::v1::Certificate>>,
+      (future<StatusOr<google::cloud::certificatemanager::v1::Certificate>>),
       UpdateCertificate,
       (google::cloud::certificatemanager::v1::UpdateCertificateRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::certificatemanager::v1::OperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::certificatemanager::v1::OperationMetadata>>),
       DeleteCertificate,
       (google::cloud::certificatemanager::v1::DeleteCertificateRequest const&
            request),
@@ -90,29 +90,29 @@ class MockCertificateManagerConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::certificatemanager::v1::CertificateMap>,
+      (StatusOr<google::cloud::certificatemanager::v1::CertificateMap>),
       GetCertificateMap,
       (google::cloud::certificatemanager::v1::GetCertificateMapRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::certificatemanager::v1::CertificateMap>>,
+      (future<StatusOr<google::cloud::certificatemanager::v1::CertificateMap>>),
       CreateCertificateMap,
       (google::cloud::certificatemanager::v1::CreateCertificateMapRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::certificatemanager::v1::CertificateMap>>,
+      (future<StatusOr<google::cloud::certificatemanager::v1::CertificateMap>>),
       UpdateCertificateMap,
       (google::cloud::certificatemanager::v1::UpdateCertificateMapRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::certificatemanager::v1::OperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::certificatemanager::v1::OperationMetadata>>),
       DeleteCertificateMap,
       (google::cloud::certificatemanager::v1::DeleteCertificateMapRequest const&
            request),
@@ -126,31 +126,31 @@ class MockCertificateManagerConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::certificatemanager::v1::CertificateMapEntry>,
+      (StatusOr<google::cloud::certificatemanager::v1::CertificateMapEntry>),
       GetCertificateMapEntry,
       (google::cloud::certificatemanager::v1::
            GetCertificateMapEntryRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::certificatemanager::v1::CertificateMapEntry>>,
+      (future<StatusOr<
+           google::cloud::certificatemanager::v1::CertificateMapEntry>>),
       CreateCertificateMapEntry,
       (google::cloud::certificatemanager::v1::
            CreateCertificateMapEntryRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::certificatemanager::v1::CertificateMapEntry>>,
+      (future<StatusOr<
+           google::cloud::certificatemanager::v1::CertificateMapEntry>>),
       UpdateCertificateMapEntry,
       (google::cloud::certificatemanager::v1::
            UpdateCertificateMapEntryRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::certificatemanager::v1::OperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::certificatemanager::v1::OperationMetadata>>),
       DeleteCertificateMapEntry,
       (google::cloud::certificatemanager::v1::
            DeleteCertificateMapEntryRequest const& request),
@@ -164,29 +164,31 @@ class MockCertificateManagerConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::certificatemanager::v1::DnsAuthorization>,
+      (StatusOr<google::cloud::certificatemanager::v1::DnsAuthorization>),
       GetDnsAuthorization,
       (google::cloud::certificatemanager::v1::GetDnsAuthorizationRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::certificatemanager::v1::DnsAuthorization>>,
+      (future<
+          StatusOr<google::cloud::certificatemanager::v1::DnsAuthorization>>),
       CreateDnsAuthorization,
       (google::cloud::certificatemanager::v1::
            CreateDnsAuthorizationRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::certificatemanager::v1::DnsAuthorization>>,
+      (future<
+          StatusOr<google::cloud::certificatemanager::v1::DnsAuthorization>>),
       UpdateDnsAuthorization,
       (google::cloud::certificatemanager::v1::
            UpdateDnsAuthorizationRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::certificatemanager::v1::OperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::certificatemanager::v1::OperationMetadata>>),
       DeleteDnsAuthorization,
       (google::cloud::certificatemanager::v1::
            DeleteDnsAuthorizationRequest const& request),
@@ -201,24 +203,24 @@ class MockCertificateManagerConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::certificatemanager::v1::CertificateIssuanceConfig>,
+      (StatusOr<
+          google::cloud::certificatemanager::v1::CertificateIssuanceConfig>),
       GetCertificateIssuanceConfig,
       (google::cloud::certificatemanager::v1::
            GetCertificateIssuanceConfigRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::certificatemanager::v1::CertificateIssuanceConfig>>,
+      (future<StatusOr<
+           google::cloud::certificatemanager::v1::CertificateIssuanceConfig>>),
       CreateCertificateIssuanceConfig,
       (google::cloud::certificatemanager::v1::
            CreateCertificateIssuanceConfigRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::certificatemanager::v1::OperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::certificatemanager::v1::OperationMetadata>>),
       DeleteCertificateIssuanceConfig,
       (google::cloud::certificatemanager::v1::
            DeleteCertificateIssuanceConfigRequest const& request),
@@ -231,29 +233,29 @@ class MockCertificateManagerConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::certificatemanager::v1::TrustConfig>,
+      (StatusOr<google::cloud::certificatemanager::v1::TrustConfig>),
       GetTrustConfig,
       (google::cloud::certificatemanager::v1::GetTrustConfigRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::certificatemanager::v1::TrustConfig>>,
+      (future<StatusOr<google::cloud::certificatemanager::v1::TrustConfig>>),
       CreateTrustConfig,
       (google::cloud::certificatemanager::v1::CreateTrustConfigRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::certificatemanager::v1::TrustConfig>>,
+      (future<StatusOr<google::cloud::certificatemanager::v1::TrustConfig>>),
       UpdateTrustConfig,
       (google::cloud::certificatemanager::v1::UpdateTrustConfigRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::certificatemanager::v1::OperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::certificatemanager::v1::OperationMetadata>>),
       DeleteTrustConfig,
       (google::cloud::certificatemanager::v1::DeleteTrustConfigRequest const&
            request),

--- a/google/cloud/channel/v1/mocks/mock_cloud_channel_connection.h
+++ b/google/cloud/channel/v1/mocks/mock_cloud_channel_connection.h
@@ -52,25 +52,25 @@ class MockCloudChannelServiceConnection
               (google::cloud::channel::v1::ListCustomersRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::channel::v1::Customer>, GetCustomer,
+  MOCK_METHOD((StatusOr<google::cloud::channel::v1::Customer>), GetCustomer,
               (google::cloud::channel::v1::GetCustomerRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::channel::v1::CheckCloudIdentityAccountsExistResponse>,
+      (StatusOr<
+          google::cloud::channel::v1::CheckCloudIdentityAccountsExistResponse>),
       CheckCloudIdentityAccountsExist,
       (google::cloud::channel::v1::CheckCloudIdentityAccountsExistRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::channel::v1::Customer>, CreateCustomer,
+      (StatusOr<google::cloud::channel::v1::Customer>), CreateCustomer,
       (google::cloud::channel::v1::CreateCustomerRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::channel::v1::Customer>, UpdateCustomer,
+      (StatusOr<google::cloud::channel::v1::Customer>), UpdateCustomer,
       (google::cloud::channel::v1::UpdateCustomerRequest const& request),
       (override));
 
@@ -80,11 +80,11 @@ class MockCloudChannelServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::channel::v1::Customer>, ImportCustomer,
+      (StatusOr<google::cloud::channel::v1::Customer>), ImportCustomer,
       (google::cloud::channel::v1::ImportCustomerRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::channel::v1::Customer>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::channel::v1::Customer>>),
               ProvisionCloudIdentity,
               (google::cloud::channel::v1::ProvisionCloudIdentityRequest const&
                    request),
@@ -107,66 +107,66 @@ class MockCloudChannelServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::channel::v1::Entitlement>, GetEntitlement,
+      (StatusOr<google::cloud::channel::v1::Entitlement>), GetEntitlement,
       (google::cloud::channel::v1::GetEntitlementRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::channel::v1::Entitlement>>,
+      (future<StatusOr<google::cloud::channel::v1::Entitlement>>),
       CreateEntitlement,
       (google::cloud::channel::v1::CreateEntitlementRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::channel::v1::Entitlement>>,
+      (future<StatusOr<google::cloud::channel::v1::Entitlement>>),
       ChangeParameters,
       (google::cloud::channel::v1::ChangeParametersRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::channel::v1::Entitlement>>,
+      (future<StatusOr<google::cloud::channel::v1::Entitlement>>),
       ChangeRenewalSettings,
       (google::cloud::channel::v1::ChangeRenewalSettingsRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::channel::v1::Entitlement>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::channel::v1::Entitlement>>),
               ChangeOffer,
               (google::cloud::channel::v1::ChangeOfferRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::channel::v1::Entitlement>>,
+      (future<StatusOr<google::cloud::channel::v1::Entitlement>>),
       StartPaidService,
       (google::cloud::channel::v1::StartPaidServiceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::channel::v1::Entitlement>>,
+      (future<StatusOr<google::cloud::channel::v1::Entitlement>>),
       SuspendEntitlement,
       (google::cloud::channel::v1::SuspendEntitlementRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::channel::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::channel::v1::OperationMetadata>>),
       CancelEntitlement,
       (google::cloud::channel::v1::CancelEntitlementRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::channel::v1::Entitlement>>,
+      (future<StatusOr<google::cloud::channel::v1::Entitlement>>),
       ActivateEntitlement,
       (google::cloud::channel::v1::ActivateEntitlementRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::channel::v1::TransferEntitlementsResponse>>,
+      (future<
+          StatusOr<google::cloud::channel::v1::TransferEntitlementsResponse>>),
       TransferEntitlements,
       (google::cloud::channel::v1::TransferEntitlementsRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::channel::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::channel::v1::OperationMetadata>>),
       TransferEntitlementsToGoogle,
       (google::cloud::channel::v1::TransferEntitlementsToGoogleRequest const&
            request),
@@ -179,27 +179,27 @@ class MockCloudChannelServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::channel::v1::ChannelPartnerLink>,
+      (StatusOr<google::cloud::channel::v1::ChannelPartnerLink>),
       GetChannelPartnerLink,
       (google::cloud::channel::v1::GetChannelPartnerLinkRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::channel::v1::ChannelPartnerLink>,
+      (StatusOr<google::cloud::channel::v1::ChannelPartnerLink>),
       CreateChannelPartnerLink,
       (google::cloud::channel::v1::CreateChannelPartnerLinkRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::channel::v1::ChannelPartnerLink>,
+      (StatusOr<google::cloud::channel::v1::ChannelPartnerLink>),
       UpdateChannelPartnerLink,
       (google::cloud::channel::v1::UpdateChannelPartnerLinkRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::channel::v1::CustomerRepricingConfig>,
+      (StatusOr<google::cloud::channel::v1::CustomerRepricingConfig>),
       GetCustomerRepricingConfig,
       (google::cloud::channel::v1::GetCustomerRepricingConfigRequest const&
            request),
@@ -212,14 +212,14 @@ class MockCloudChannelServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::channel::v1::CustomerRepricingConfig>,
+      (StatusOr<google::cloud::channel::v1::CustomerRepricingConfig>),
       CreateCustomerRepricingConfig,
       (google::cloud::channel::v1::CreateCustomerRepricingConfigRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::channel::v1::CustomerRepricingConfig>,
+      (StatusOr<google::cloud::channel::v1::CustomerRepricingConfig>),
       UpdateCustomerRepricingConfig,
       (google::cloud::channel::v1::UpdateCustomerRepricingConfigRequest const&
            request),
@@ -232,7 +232,7 @@ class MockCloudChannelServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::channel::v1::ChannelPartnerRepricingConfig>,
+      (StatusOr<google::cloud::channel::v1::ChannelPartnerRepricingConfig>),
       GetChannelPartnerRepricingConfig,
       (google::cloud::channel::v1::
            GetChannelPartnerRepricingConfigRequest const& request),
@@ -246,14 +246,14 @@ class MockCloudChannelServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::channel::v1::ChannelPartnerRepricingConfig>,
+      (StatusOr<google::cloud::channel::v1::ChannelPartnerRepricingConfig>),
       CreateChannelPartnerRepricingConfig,
       (google::cloud::channel::v1::
            CreateChannelPartnerRepricingConfigRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::channel::v1::ChannelPartnerRepricingConfig>,
+      (StatusOr<google::cloud::channel::v1::ChannelPartnerRepricingConfig>),
       UpdateChannelPartnerRepricingConfig,
       (google::cloud::channel::v1::
            UpdateChannelPartnerRepricingConfigRequest const& request),
@@ -275,7 +275,7 @@ class MockCloudChannelServiceConnection
       (google::cloud::channel::v1::ListSkuGroupBillableSkusRequest request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::channel::v1::Offer>, LookupOffer,
+  MOCK_METHOD((StatusOr<google::cloud::channel::v1::Offer>), LookupOffer,
               (google::cloud::channel::v1::LookupOfferRequest const& request),
               (override));
 
@@ -303,21 +303,21 @@ class MockCloudChannelServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::channel::v1::QueryEligibleBillingAccountsResponse>,
+      (StatusOr<
+          google::cloud::channel::v1::QueryEligibleBillingAccountsResponse>),
       QueryEligibleBillingAccounts,
       (google::cloud::channel::v1::QueryEligibleBillingAccountsRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::channel::v1::RegisterSubscriberResponse>,
+      (StatusOr<google::cloud::channel::v1::RegisterSubscriberResponse>),
       RegisterSubscriber,
       (google::cloud::channel::v1::RegisterSubscriberRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::channel::v1::UnregisterSubscriberResponse>,
+      (StatusOr<google::cloud::channel::v1::UnregisterSubscriberResponse>),
       UnregisterSubscriber,
       (google::cloud::channel::v1::UnregisterSubscriberRequest const& request),
       (override));

--- a/google/cloud/channel/v1/mocks/mock_cloud_channel_reports_connection.h
+++ b/google/cloud/channel/v1/mocks/mock_cloud_channel_reports_connection.h
@@ -48,7 +48,7 @@ class MockCloudChannelReportsServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::channel::v1::RunReportJobResponse>>,
+      (future<StatusOr<google::cloud::channel::v1::RunReportJobResponse>>),
       RunReportJob,
       (google::cloud::channel::v1::RunReportJobRequest const& request),
       (override));

--- a/google/cloud/cloudbuild/v1/mocks/mock_cloud_build_connection.h
+++ b/google/cloud/cloudbuild/v1/mocks/mock_cloud_build_connection.h
@@ -47,12 +47,12 @@ class MockCloudBuildConnection : public cloudbuild_v1::CloudBuildConnection {
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::devtools::cloudbuild::v1::Build>>, CreateBuild,
+      (future<StatusOr<google::devtools::cloudbuild::v1::Build>>), CreateBuild,
       (google::devtools::cloudbuild::v1::CreateBuildRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::devtools::cloudbuild::v1::Build>, GetBuild,
+      (StatusOr<google::devtools::cloudbuild::v1::Build>), GetBuild,
       (google::devtools::cloudbuild::v1::GetBuildRequest const& request),
       (override));
 
@@ -62,29 +62,30 @@ class MockCloudBuildConnection : public cloudbuild_v1::CloudBuildConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::devtools::cloudbuild::v1::Build>, CancelBuild,
+      (StatusOr<google::devtools::cloudbuild::v1::Build>), CancelBuild,
       (google::devtools::cloudbuild::v1::CancelBuildRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::devtools::cloudbuild::v1::Build>>, RetryBuild,
+      (future<StatusOr<google::devtools::cloudbuild::v1::Build>>), RetryBuild,
       (google::devtools::cloudbuild::v1::RetryBuildRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::devtools::cloudbuild::v1::Build>>, ApproveBuild,
+      (future<StatusOr<google::devtools::cloudbuild::v1::Build>>), ApproveBuild,
       (google::devtools::cloudbuild::v1::ApproveBuildRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::devtools::cloudbuild::v1::BuildTrigger>,
+      (StatusOr<google::devtools::cloudbuild::v1::BuildTrigger>),
       CreateBuildTrigger,
       (google::devtools::cloudbuild::v1::CreateBuildTriggerRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::devtools::cloudbuild::v1::BuildTrigger>, GetBuildTrigger,
+      (StatusOr<google::devtools::cloudbuild::v1::BuildTrigger>),
+      GetBuildTrigger,
       (google::devtools::cloudbuild::v1::GetBuildTriggerRequest const& request),
       (override));
 
@@ -101,45 +102,45 @@ class MockCloudBuildConnection : public cloudbuild_v1::CloudBuildConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::devtools::cloudbuild::v1::BuildTrigger>,
+      (StatusOr<google::devtools::cloudbuild::v1::BuildTrigger>),
       UpdateBuildTrigger,
       (google::devtools::cloudbuild::v1::UpdateBuildTriggerRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::devtools::cloudbuild::v1::Build>>,
+      (future<StatusOr<google::devtools::cloudbuild::v1::Build>>),
       RunBuildTrigger,
       (google::devtools::cloudbuild::v1::RunBuildTriggerRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::devtools::cloudbuild::v1::ReceiveTriggerWebhookResponse>,
+      (StatusOr<
+          google::devtools::cloudbuild::v1::ReceiveTriggerWebhookResponse>),
       ReceiveTriggerWebhook,
       (google::devtools::cloudbuild::v1::ReceiveTriggerWebhookRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::devtools::cloudbuild::v1::WorkerPool>>,
+  MOCK_METHOD((future<StatusOr<google::devtools::cloudbuild::v1::WorkerPool>>),
               CreateWorkerPool,
               (google::devtools::cloudbuild::v1::CreateWorkerPoolRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::devtools::cloudbuild::v1::WorkerPool>, GetWorkerPool,
+      (StatusOr<google::devtools::cloudbuild::v1::WorkerPool>), GetWorkerPool,
       (google::devtools::cloudbuild::v1::GetWorkerPoolRequest const& request),
       (override));
 
-  MOCK_METHOD(
-      future<StatusOr<
-          google::devtools::cloudbuild::v1::DeleteWorkerPoolOperationMetadata>>,
-      DeleteWorkerPool,
-      (google::devtools::cloudbuild::v1::DeleteWorkerPoolRequest const&
-           request),
-      (override));
+  MOCK_METHOD((future<StatusOr<google::devtools::cloudbuild::v1::
+                                   DeleteWorkerPoolOperationMetadata>>),
+              DeleteWorkerPool,
+              (google::devtools::cloudbuild::v1::DeleteWorkerPoolRequest const&
+                   request),
+              (override));
 
-  MOCK_METHOD(future<StatusOr<google::devtools::cloudbuild::v1::WorkerPool>>,
+  MOCK_METHOD((future<StatusOr<google::devtools::cloudbuild::v1::WorkerPool>>),
               UpdateWorkerPool,
               (google::devtools::cloudbuild::v1::UpdateWorkerPoolRequest const&
                    request),

--- a/google/cloud/cloudbuild/v2/mocks/mock_repository_manager_connection.h
+++ b/google/cloud/cloudbuild/v2/mocks/mock_repository_manager_connection.h
@@ -47,14 +47,14 @@ class MockRepositoryManagerConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::devtools::cloudbuild::v2::Connection>>,
+  MOCK_METHOD((future<StatusOr<google::devtools::cloudbuild::v2::Connection>>),
               CreateConnection,
               (google::devtools::cloudbuild::v2::CreateConnectionRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::devtools::cloudbuild::v2::Connection>, GetConnection,
+      (StatusOr<google::devtools::cloudbuild::v2::Connection>), GetConnection,
       (google::devtools::cloudbuild::v2::GetConnectionRequest const& request),
       (override));
 
@@ -64,35 +64,35 @@ class MockRepositoryManagerConnection
       (google::devtools::cloudbuild::v2::ListConnectionsRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::devtools::cloudbuild::v2::Connection>>,
+  MOCK_METHOD((future<StatusOr<google::devtools::cloudbuild::v2::Connection>>),
               UpdateConnection,
               (google::devtools::cloudbuild::v2::UpdateConnectionRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::devtools::cloudbuild::v2::OperationMetadata>>,
+      (future<StatusOr<google::devtools::cloudbuild::v2::OperationMetadata>>),
       DeleteConnection,
       (google::devtools::cloudbuild::v2::DeleteConnectionRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::devtools::cloudbuild::v2::Repository>>,
+  MOCK_METHOD((future<StatusOr<google::devtools::cloudbuild::v2::Repository>>),
               CreateRepository,
               (google::devtools::cloudbuild::v2::CreateRepositoryRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::devtools::cloudbuild::v2::BatchCreateRepositoriesResponse>>,
+      (future<StatusOr<
+           google::devtools::cloudbuild::v2::BatchCreateRepositoriesResponse>>),
       BatchCreateRepositories,
       (google::devtools::cloudbuild::v2::BatchCreateRepositoriesRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::devtools::cloudbuild::v2::Repository>, GetRepository,
+      (StatusOr<google::devtools::cloudbuild::v2::Repository>), GetRepository,
       (google::devtools::cloudbuild::v2::GetRepositoryRequest const& request),
       (override));
 
@@ -103,21 +103,21 @@ class MockRepositoryManagerConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::devtools::cloudbuild::v2::OperationMetadata>>,
+      (future<StatusOr<google::devtools::cloudbuild::v2::OperationMetadata>>),
       DeleteRepository,
       (google::devtools::cloudbuild::v2::DeleteRepositoryRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::devtools::cloudbuild::v2::FetchReadWriteTokenResponse>,
+      (StatusOr<google::devtools::cloudbuild::v2::FetchReadWriteTokenResponse>),
       FetchReadWriteToken,
       (google::devtools::cloudbuild::v2::FetchReadWriteTokenRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::devtools::cloudbuild::v2::FetchReadTokenResponse>,
+      (StatusOr<google::devtools::cloudbuild::v2::FetchReadTokenResponse>),
       FetchReadToken,
       (google::devtools::cloudbuild::v2::FetchReadTokenRequest const& request),
       (override));
@@ -130,7 +130,7 @@ class MockRepositoryManagerConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::devtools::cloudbuild::v2::FetchGitRefsResponse>,
+      (StatusOr<google::devtools::cloudbuild::v2::FetchGitRefsResponse>),
       FetchGitRefs,
       (google::devtools::cloudbuild::v2::FetchGitRefsRequest const& request),
       (override));

--- a/google/cloud/cloudcontrolspartner/v1/mocks/mock_cloud_controls_partner_core_connection.h
+++ b/google/cloud/cloudcontrolspartner/v1/mocks/mock_cloud_controls_partner_core_connection.h
@@ -48,7 +48,8 @@ class MockCloudControlsPartnerCoreConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cloudcontrolspartner::v1::Workload>, GetWorkload,
+      (StatusOr<google::cloud::cloudcontrolspartner::v1::Workload>),
+      GetWorkload,
       (google::cloud::cloudcontrolspartner::v1::GetWorkloadRequest const&
            request),
       (override));
@@ -60,7 +61,8 @@ class MockCloudControlsPartnerCoreConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cloudcontrolspartner::v1::Customer>, GetCustomer,
+      (StatusOr<google::cloud::cloudcontrolspartner::v1::Customer>),
+      GetCustomer,
       (google::cloud::cloudcontrolspartner::v1::GetCustomerRequest const&
            request),
       (override));
@@ -72,14 +74,14 @@ class MockCloudControlsPartnerCoreConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cloudcontrolspartner::v1::EkmConnections>,
+      (StatusOr<google::cloud::cloudcontrolspartner::v1::EkmConnections>),
       GetEkmConnections,
       (google::cloud::cloudcontrolspartner::v1::GetEkmConnectionsRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cloudcontrolspartner::v1::PartnerPermissions>,
+      (StatusOr<google::cloud::cloudcontrolspartner::v1::PartnerPermissions>),
       GetPartnerPermissions,
       (google::cloud::cloudcontrolspartner::v1::
            GetPartnerPermissionsRequest const& request),
@@ -93,7 +95,7 @@ class MockCloudControlsPartnerCoreConnection
            ListAccessApprovalRequestsRequest request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cloudcontrolspartner::v1::Partner>,
+  MOCK_METHOD((StatusOr<google::cloud::cloudcontrolspartner::v1::Partner>),
               GetPartner,
               (google::cloud::cloudcontrolspartner::v1::GetPartnerRequest const&
                    request),

--- a/google/cloud/cloudcontrolspartner/v1/mocks/mock_cloud_controls_partner_monitoring_connection.h
+++ b/google/cloud/cloudcontrolspartner/v1/mocks/mock_cloud_controls_partner_monitoring_connection.h
@@ -54,7 +54,7 @@ class MockCloudControlsPartnerMonitoringConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cloudcontrolspartner::v1::Violation>,
+      (StatusOr<google::cloud::cloudcontrolspartner::v1::Violation>),
       GetViolation,
       (google::cloud::cloudcontrolspartner::v1::GetViolationRequest const&
            request),

--- a/google/cloud/cloudquotas/v1/mocks/mock_cloud_quotas_connection.h
+++ b/google/cloud/cloudquotas/v1/mocks/mock_cloud_quotas_connection.h
@@ -52,7 +52,7 @@ class MockCloudQuotasConnection : public cloudquotas_v1::CloudQuotasConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::api::cloudquotas::v1::QuotaInfo>, GetQuotaInfo,
+      (StatusOr<google::api::cloudquotas::v1::QuotaInfo>), GetQuotaInfo,
       (google::api::cloudquotas::v1::GetQuotaInfoRequest const& request),
       (override));
 
@@ -63,18 +63,18 @@ class MockCloudQuotasConnection : public cloudquotas_v1::CloudQuotasConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::api::cloudquotas::v1::QuotaPreference>,
+      (StatusOr<google::api::cloudquotas::v1::QuotaPreference>),
       GetQuotaPreference,
       (google::api::cloudquotas::v1::GetQuotaPreferenceRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::api::cloudquotas::v1::QuotaPreference>,
+  MOCK_METHOD((StatusOr<google::api::cloudquotas::v1::QuotaPreference>),
               CreateQuotaPreference,
               (google::api::cloudquotas::v1::CreateQuotaPreferenceRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::api::cloudquotas::v1::QuotaPreference>,
+  MOCK_METHOD((StatusOr<google::api::cloudquotas::v1::QuotaPreference>),
               UpdateQuotaPreference,
               (google::api::cloudquotas::v1::UpdateQuotaPreferenceRequest const&
                    request),

--- a/google/cloud/commerce/consumer/procurement/v1/mocks/mock_consumer_procurement_connection.h
+++ b/google/cloud/commerce/consumer/procurement/v1/mocks/mock_consumer_procurement_connection.h
@@ -50,15 +50,15 @@ class MockConsumerProcurementServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::commerce::consumer::procurement::v1::Order>>,
+      (future<
+          StatusOr<google::cloud::commerce::consumer::procurement::v1::Order>>),
       PlaceOrder,
       (google::cloud::commerce::consumer::procurement::v1::
            PlaceOrderRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::commerce::consumer::procurement::v1::Order>,
+      (StatusOr<google::cloud::commerce::consumer::procurement::v1::Order>),
       GetOrder,
       (google::cloud::commerce::consumer::procurement::v1::
            GetOrderRequest const& request),

--- a/google/cloud/composer/v1/mocks/mock_environments_connection.h
+++ b/google/cloud/composer/v1/mocks/mock_environments_connection.h
@@ -47,15 +47,16 @@ class MockEnvironmentsConnection : public composer_v1::EnvironmentsConnection {
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::orchestration::airflow::service::v1::Environment>>,
+      (future<StatusOr<
+           google::cloud::orchestration::airflow::service::v1::Environment>>),
       CreateEnvironment,
       (google::cloud::orchestration::airflow::service::v1::
            CreateEnvironmentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::orchestration::airflow::service::v1::Environment>,
+      (StatusOr<
+          google::cloud::orchestration::airflow::service::v1::Environment>),
       GetEnvironment,
       (google::cloud::orchestration::airflow::service::v1::
            GetEnvironmentRequest const& request),
@@ -70,36 +71,36 @@ class MockEnvironmentsConnection : public composer_v1::EnvironmentsConnection {
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::orchestration::airflow::service::v1::Environment>>,
+      (future<StatusOr<
+           google::cloud::orchestration::airflow::service::v1::Environment>>),
       UpdateEnvironment,
       (google::cloud::orchestration::airflow::service::v1::
            UpdateEnvironmentRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::orchestration::airflow::service::
-                                  v1::OperationMetadata>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::orchestration::airflow::service::
+                                   v1::OperationMetadata>>),
               DeleteEnvironment,
               (google::cloud::orchestration::airflow::service::v1::
                    DeleteEnvironmentRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::orchestration::airflow::service::v1::
-                           ExecuteAirflowCommandResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::orchestration::airflow::service::v1::
+                            ExecuteAirflowCommandResponse>),
               ExecuteAirflowCommand,
               (google::cloud::orchestration::airflow::service::v1::
                    ExecuteAirflowCommandRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::orchestration::airflow::service::v1::
-                           StopAirflowCommandResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::orchestration::airflow::service::v1::
+                            StopAirflowCommandResponse>),
               StopAirflowCommand,
               (google::cloud::orchestration::airflow::service::v1::
                    StopAirflowCommandRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::orchestration::airflow::service::v1::
-                           PollAirflowCommandResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::orchestration::airflow::service::v1::
+                            PollAirflowCommandResponse>),
               PollAirflowCommand,
               (google::cloud::orchestration::airflow::service::v1::
                    PollAirflowCommandRequest const& request),
@@ -113,15 +114,15 @@ class MockEnvironmentsConnection : public composer_v1::EnvironmentsConnection {
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::orchestration::airflow::service::v1::
-                           UserWorkloadsSecret>,
+  MOCK_METHOD((StatusOr<google::cloud::orchestration::airflow::service::v1::
+                            UserWorkloadsSecret>),
               CreateUserWorkloadsSecret,
               (google::cloud::orchestration::airflow::service::v1::
                    CreateUserWorkloadsSecretRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::orchestration::airflow::service::v1::
-                           UserWorkloadsSecret>,
+  MOCK_METHOD((StatusOr<google::cloud::orchestration::airflow::service::v1::
+                            UserWorkloadsSecret>),
               GetUserWorkloadsSecret,
               (google::cloud::orchestration::airflow::service::v1::
                    GetUserWorkloadsSecretRequest const& request),
@@ -134,8 +135,8 @@ class MockEnvironmentsConnection : public composer_v1::EnvironmentsConnection {
                    ListUserWorkloadsSecretsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::orchestration::airflow::service::v1::
-                           UserWorkloadsSecret>,
+  MOCK_METHOD((StatusOr<google::cloud::orchestration::airflow::service::v1::
+                            UserWorkloadsSecret>),
               UpdateUserWorkloadsSecret,
               (google::cloud::orchestration::airflow::service::v1::
                    UpdateUserWorkloadsSecretRequest const& request),
@@ -146,15 +147,15 @@ class MockEnvironmentsConnection : public composer_v1::EnvironmentsConnection {
                    DeleteUserWorkloadsSecretRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::orchestration::airflow::service::v1::
-                           UserWorkloadsConfigMap>,
+  MOCK_METHOD((StatusOr<google::cloud::orchestration::airflow::service::v1::
+                            UserWorkloadsConfigMap>),
               CreateUserWorkloadsConfigMap,
               (google::cloud::orchestration::airflow::service::v1::
                    CreateUserWorkloadsConfigMapRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::orchestration::airflow::service::v1::
-                           UserWorkloadsConfigMap>,
+  MOCK_METHOD((StatusOr<google::cloud::orchestration::airflow::service::v1::
+                            UserWorkloadsConfigMap>),
               GetUserWorkloadsConfigMap,
               (google::cloud::orchestration::airflow::service::v1::
                    GetUserWorkloadsConfigMapRequest const& request),
@@ -167,8 +168,8 @@ class MockEnvironmentsConnection : public composer_v1::EnvironmentsConnection {
                    ListUserWorkloadsConfigMapsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::orchestration::airflow::service::v1::
-                           UserWorkloadsConfigMap>,
+  MOCK_METHOD((StatusOr<google::cloud::orchestration::airflow::service::v1::
+                            UserWorkloadsConfigMap>),
               UpdateUserWorkloadsConfigMap,
               (google::cloud::orchestration::airflow::service::v1::
                    UpdateUserWorkloadsConfigMapRequest const& request),
@@ -179,29 +180,29 @@ class MockEnvironmentsConnection : public composer_v1::EnvironmentsConnection {
                    DeleteUserWorkloadsConfigMapRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::orchestration::airflow::service::
-                                  v1::SaveSnapshotResponse>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::orchestration::airflow::service::
+                                   v1::SaveSnapshotResponse>>),
               SaveSnapshot,
               (google::cloud::orchestration::airflow::service::v1::
                    SaveSnapshotRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::orchestration::airflow::service::
-                                  v1::LoadSnapshotResponse>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::orchestration::airflow::service::
+                                   v1::LoadSnapshotResponse>>),
               LoadSnapshot,
               (google::cloud::orchestration::airflow::service::v1::
                    LoadSnapshotRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::orchestration::airflow::service::
-                                  v1::DatabaseFailoverResponse>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::orchestration::airflow::service::
+                                   v1::DatabaseFailoverResponse>>),
               DatabaseFailover,
               (google::cloud::orchestration::airflow::service::v1::
                    DatabaseFailoverRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::orchestration::airflow::service::v1::
-                           FetchDatabasePropertiesResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::orchestration::airflow::service::v1::
+                            FetchDatabasePropertiesResponse>),
               FetchDatabaseProperties,
               (google::cloud::orchestration::airflow::service::v1::
                    FetchDatabasePropertiesRequest const& request),

--- a/google/cloud/compute/accelerator_types/v1/mocks/mock_accelerator_types_connection.h
+++ b/google/cloud/compute/accelerator_types/v1/mocks/mock_accelerator_types_connection.h
@@ -55,7 +55,7 @@ class MockAcceleratorTypesConnection
            AggregatedListAcceleratorTypesRequest request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::AcceleratorType>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::AcceleratorType>),
               GetAcceleratorType,
               (google::cloud::cpp::compute::accelerator_types::v1::
                    GetAcceleratorTypeRequest const& request),

--- a/google/cloud/compute/addresses/v1/mocks/mock_addresses_connection.h
+++ b/google/cloud/compute/addresses/v1/mocks/mock_addresses_connection.h
@@ -56,20 +56,20 @@ class MockAddressesConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       DeleteAddress,
       (google::cloud::cpp::compute::addresses::v1::DeleteAddressRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Address>, GetAddress,
+      (StatusOr<google::cloud::cpp::compute::v1::Address>), GetAddress,
       (google::cloud::cpp::compute::addresses::v1::GetAddressRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       InsertAddress,
       (google::cloud::cpp::compute::addresses::v1::InsertAddressRequest const&
            request),
@@ -82,12 +82,12 @@ class MockAddressesConnection
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, Move,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>), Move,
       (google::cloud::cpp::compute::addresses::v1::MoveRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, SetLabels,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>), SetLabels,
       (google::cloud::cpp::compute::addresses::v1::SetLabelsRequest const&
            request),
       (override));

--- a/google/cloud/compute/autoscalers/v1/mocks/mock_autoscalers_connection.h
+++ b/google/cloud/compute/autoscalers/v1/mocks/mock_autoscalers_connection.h
@@ -56,19 +56,19 @@ class MockAutoscalersConnection
            AggregatedListAutoscalersRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteAutoscaler,
               (google::cloud::cpp::compute::autoscalers::v1::
                    DeleteAutoscalerRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Autoscaler>, GetAutoscaler,
+      (StatusOr<google::cloud::cpp::compute::v1::Autoscaler>), GetAutoscaler,
       (google::cloud::cpp::compute::autoscalers::v1::GetAutoscalerRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertAutoscaler,
               (google::cloud::cpp::compute::autoscalers::v1::
                    InsertAutoscalerRequest const& request),
@@ -81,13 +81,13 @@ class MockAutoscalersConnection
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchAutoscaler,
               (google::cloud::cpp::compute::autoscalers::v1::
                    PatchAutoscalerRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               UpdateAutoscaler,
               (google::cloud::cpp::compute::autoscalers::v1::
                    UpdateAutoscalerRequest const& request),

--- a/google/cloud/compute/backend_buckets/v1/mocks/mock_backend_buckets_connection.h
+++ b/google/cloud/compute/backend_buckets/v1/mocks/mock_backend_buckets_connection.h
@@ -47,36 +47,36 @@ class MockBackendBucketsConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               AddSignedUrlKey,
               (google::cloud::cpp::compute::backend_buckets::v1::
                    AddSignedUrlKeyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteBackendBucket,
               (google::cloud::cpp::compute::backend_buckets::v1::
                    DeleteBackendBucketRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteSignedUrlKey,
               (google::cloud::cpp::compute::backend_buckets::v1::
                    DeleteSignedUrlKeyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::BackendBucket>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::BackendBucket>),
               GetBackendBucket,
               (google::cloud::cpp::compute::backend_buckets::v1::
                    GetBackendBucketRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Policy>), GetIamPolicy,
               (google::cloud::cpp::compute::backend_buckets::v1::
                    GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertBackendBucket,
               (google::cloud::cpp::compute::backend_buckets::v1::
                    InsertBackendBucketRequest const& request),
@@ -88,31 +88,31 @@ class MockBackendBucketsConnection
                    ListBackendBucketsRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchBackendBucket,
               (google::cloud::cpp::compute::backend_buckets::v1::
                    PatchBackendBucketRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetEdgeSecurityPolicy,
               (google::cloud::cpp::compute::backend_buckets::v1::
                    SetEdgeSecurityPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Policy>), SetIamPolicy,
               (google::cloud::cpp::compute::backend_buckets::v1::
                    SetIamPolicyRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>),
       TestIamPermissions,
       (google::cloud::cpp::compute::backend_buckets::v1::
            TestIamPermissionsRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               UpdateBackendBucket,
               (google::cloud::cpp::compute::backend_buckets::v1::
                    UpdateBackendBucketRequest const& request),

--- a/google/cloud/compute/backend_services/v1/mocks/mock_backend_services_connection.h
+++ b/google/cloud/compute/backend_services/v1/mocks/mock_backend_services_connection.h
@@ -47,7 +47,7 @@ class MockBackendServicesConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               AddSignedUrlKey,
               (google::cloud::cpp::compute::backend_services::v1::
                    AddSignedUrlKeyRequest const& request),
@@ -61,37 +61,37 @@ class MockBackendServicesConnection
            AggregatedListBackendServicesRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteBackendService,
               (google::cloud::cpp::compute::backend_services::v1::
                    DeleteBackendServiceRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteSignedUrlKey,
               (google::cloud::cpp::compute::backend_services::v1::
                    DeleteSignedUrlKeyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::BackendService>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::BackendService>),
               GetBackendService,
               (google::cloud::cpp::compute::backend_services::v1::
                    GetBackendServiceRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::BackendServiceGroupHealth>,
+      (StatusOr<google::cloud::cpp::compute::v1::BackendServiceGroupHealth>),
       GetHealth,
       (google::cloud::cpp::compute::backend_services::v1::
            GetHealthRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Policy>), GetIamPolicy,
               (google::cloud::cpp::compute::backend_services::v1::
                    GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertBackendService,
               (google::cloud::cpp::compute::backend_services::v1::
                    InsertBackendServiceRequest const& request),
@@ -110,37 +110,37 @@ class MockBackendServicesConnection
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchBackendService,
               (google::cloud::cpp::compute::backend_services::v1::
                    PatchBackendServiceRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetEdgeSecurityPolicy,
               (google::cloud::cpp::compute::backend_services::v1::
                    SetEdgeSecurityPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Policy>), SetIamPolicy,
               (google::cloud::cpp::compute::backend_services::v1::
                    SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetSecurityPolicy,
               (google::cloud::cpp::compute::backend_services::v1::
                    SetSecurityPolicyRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>),
       TestIamPermissions,
       (google::cloud::cpp::compute::backend_services::v1::
            TestIamPermissionsRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               UpdateBackendService,
               (google::cloud::cpp::compute::backend_services::v1::
                    UpdateBackendServiceRequest const& request),

--- a/google/cloud/compute/disk_types/v1/mocks/mock_disk_types_connection.h
+++ b/google/cloud/compute/disk_types/v1/mocks/mock_disk_types_connection.h
@@ -56,7 +56,7 @@ class MockDiskTypesConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::DiskType>, GetDiskType,
+      (StatusOr<google::cloud::cpp::compute::v1::DiskType>), GetDiskType,
       (google::cloud::cpp::compute::disk_types::v1::GetDiskTypeRequest const&
            request),
       (override));

--- a/google/cloud/compute/disks/v1/mocks/mock_disks_connection.h
+++ b/google/cloud/compute/disks/v1/mocks/mock_disks_connection.h
@@ -47,7 +47,7 @@ class MockDisksConnection : public compute_disks_v1::DisksConnection {
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       AddResourcePolicies,
       (google::cloud::cpp::compute::disks::v1::AddResourcePoliciesRequest const&
            request),
@@ -61,37 +61,37 @@ class MockDisksConnection : public compute_disks_v1::DisksConnection {
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               BulkInsert,
               (google::cloud::cpp::compute::disks::v1::BulkInsertRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       CreateSnapshot,
       (google::cloud::cpp::compute::disks::v1::CreateSnapshotRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteDisk,
               (google::cloud::cpp::compute::disks::v1::DeleteDiskRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Disk>, GetDisk,
+      (StatusOr<google::cloud::cpp::compute::v1::Disk>), GetDisk,
       (google::cloud::cpp::compute::disks::v1::GetDiskRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Policy>, GetIamPolicy,
+      (StatusOr<google::cloud::cpp::compute::v1::Policy>), GetIamPolicy,
       (google::cloud::cpp::compute::disks::v1::GetIamPolicyRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertDisk,
               (google::cloud::cpp::compute::disks::v1::InsertDiskRequest const&
                    request),
@@ -102,54 +102,54 @@ class MockDisksConnection : public compute_disks_v1::DisksConnection {
       (google::cloud::cpp::compute::disks::v1::ListDisksRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               RemoveResourcePolicies,
               (google::cloud::cpp::compute::disks::v1::
                    RemoveResourcePoliciesRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, Resize,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>), Resize,
       (google::cloud::cpp::compute::disks::v1::ResizeRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Policy>, SetIamPolicy,
+      (StatusOr<google::cloud::cpp::compute::v1::Policy>), SetIamPolicy,
       (google::cloud::cpp::compute::disks::v1::SetIamPolicyRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, SetLabels,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>), SetLabels,
       (google::cloud::cpp::compute::disks::v1::SetLabelsRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               StartAsyncReplication,
               (google::cloud::cpp::compute::disks::v1::
                    StartAsyncReplicationRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               StopAsyncReplication,
               (google::cloud::cpp::compute::disks::v1::
                    StopAsyncReplicationRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               StopGroupAsyncReplication,
               (google::cloud::cpp::compute::disks::v1::
                    StopGroupAsyncReplicationRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>),
       TestIamPermissions,
       (google::cloud::cpp::compute::disks::v1::TestIamPermissionsRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               UpdateDisk,
               (google::cloud::cpp::compute::disks::v1::UpdateDiskRequest const&
                    request),

--- a/google/cloud/compute/external_vpn_gateways/v1/mocks/mock_external_vpn_gateways_connection.h
+++ b/google/cloud/compute/external_vpn_gateways/v1/mocks/mock_external_vpn_gateways_connection.h
@@ -48,19 +48,19 @@ class MockExternalVpnGatewaysConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteExternalVpnGateway,
               (google::cloud::cpp::compute::external_vpn_gateways::v1::
                    DeleteExternalVpnGatewayRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::ExternalVpnGateway>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::ExternalVpnGateway>),
               GetExternalVpnGateway,
               (google::cloud::cpp::compute::external_vpn_gateways::v1::
                    GetExternalVpnGatewayRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertExternalVpnGateway,
               (google::cloud::cpp::compute::external_vpn_gateways::v1::
                    InsertExternalVpnGatewayRequest const& request),
@@ -73,14 +73,14 @@ class MockExternalVpnGatewaysConnection
            ListExternalVpnGatewaysRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetLabels,
               (google::cloud::cpp::compute::external_vpn_gateways::v1::
                    SetLabelsRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>),
       TestIamPermissions,
       (google::cloud::cpp::compute::external_vpn_gateways::v1::
            TestIamPermissionsRequest const& request),

--- a/google/cloud/compute/firewall_policies/v1/mocks/mock_firewall_policies_connection.h
+++ b/google/cloud/compute/firewall_policies/v1/mocks/mock_firewall_policies_connection.h
@@ -47,55 +47,55 @@ class MockFirewallPoliciesConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               AddAssociation,
               (google::cloud::cpp::compute::firewall_policies::v1::
                    AddAssociationRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, AddRule,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>), AddRule,
       (google::cloud::cpp::compute::firewall_policies::v1::AddRuleRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               CloneRules,
               (google::cloud::cpp::compute::firewall_policies::v1::
                    CloneRulesRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteFirewallPolicy,
               (google::cloud::cpp::compute::firewall_policies::v1::
                    DeleteFirewallPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::FirewallPolicy>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::FirewallPolicy>),
               GetFirewallPolicy,
               (google::cloud::cpp::compute::firewall_policies::v1::
                    GetFirewallPolicyRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::FirewallPolicyAssociation>,
+      (StatusOr<google::cloud::cpp::compute::v1::FirewallPolicyAssociation>),
       GetAssociation,
       (google::cloud::cpp::compute::firewall_policies::v1::
            GetAssociationRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Policy>), GetIamPolicy,
               (google::cloud::cpp::compute::firewall_policies::v1::
                    GetIamPolicyRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::FirewallPolicyRule>, GetRule,
+      (StatusOr<google::cloud::cpp::compute::v1::FirewallPolicyRule>), GetRule,
       (google::cloud::cpp::compute::firewall_policies::v1::GetRuleRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertFirewallPolicy,
               (google::cloud::cpp::compute::firewall_policies::v1::
                    InsertFirewallPolicyRequest const& request),
@@ -107,50 +107,50 @@ class MockFirewallPoliciesConnection
                    ListFirewallPoliciesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::
-                           FirewallPoliciesListAssociationsResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::
+                            FirewallPoliciesListAssociationsResponse>),
               ListAssociations,
               (google::cloud::cpp::compute::firewall_policies::v1::
                    ListAssociationsRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, Move,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>), Move,
       (google::cloud::cpp::compute::firewall_policies::v1::MoveRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchFirewallPolicy,
               (google::cloud::cpp::compute::firewall_policies::v1::
                    PatchFirewallPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchRule,
               (google::cloud::cpp::compute::firewall_policies::v1::
                    PatchRuleRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               RemoveAssociation,
               (google::cloud::cpp::compute::firewall_policies::v1::
                    RemoveAssociationRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               RemoveRule,
               (google::cloud::cpp::compute::firewall_policies::v1::
                    RemoveRuleRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Policy>), SetIamPolicy,
               (google::cloud::cpp::compute::firewall_policies::v1::
                    SetIamPolicyRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>),
       TestIamPermissions,
       (google::cloud::cpp::compute::firewall_policies::v1::
            TestIamPermissionsRequest const& request),

--- a/google/cloud/compute/firewalls/v1/mocks/mock_firewalls_connection.h
+++ b/google/cloud/compute/firewalls/v1/mocks/mock_firewalls_connection.h
@@ -48,20 +48,20 @@ class MockFirewallsConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       DeleteFirewall,
       (google::cloud::cpp::compute::firewalls::v1::DeleteFirewallRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Firewall>, GetFirewall,
+      (StatusOr<google::cloud::cpp::compute::v1::Firewall>), GetFirewall,
       (google::cloud::cpp::compute::firewalls::v1::GetFirewallRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       InsertFirewall,
       (google::cloud::cpp::compute::firewalls::v1::InsertFirewallRequest const&
            request),
@@ -74,14 +74,14 @@ class MockFirewallsConnection
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       PatchFirewall,
       (google::cloud::cpp::compute::firewalls::v1::PatchFirewallRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       UpdateFirewall,
       (google::cloud::cpp::compute::firewalls::v1::UpdateFirewallRequest const&
            request),

--- a/google/cloud/compute/forwarding_rules/v1/mocks/mock_forwarding_rules_connection.h
+++ b/google/cloud/compute/forwarding_rules/v1/mocks/mock_forwarding_rules_connection.h
@@ -55,19 +55,19 @@ class MockForwardingRulesConnection
            AggregatedListForwardingRulesRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteForwardingRule,
               (google::cloud::cpp::compute::forwarding_rules::v1::
                    DeleteForwardingRuleRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::ForwardingRule>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::ForwardingRule>),
               GetForwardingRule,
               (google::cloud::cpp::compute::forwarding_rules::v1::
                    GetForwardingRuleRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertForwardingRule,
               (google::cloud::cpp::compute::forwarding_rules::v1::
                    InsertForwardingRuleRequest const& request),
@@ -79,19 +79,19 @@ class MockForwardingRulesConnection
                    ListForwardingRulesRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchForwardingRule,
               (google::cloud::cpp::compute::forwarding_rules::v1::
                    PatchForwardingRuleRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetLabels,
               (google::cloud::cpp::compute::forwarding_rules::v1::
                    SetLabelsRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetTarget,
               (google::cloud::cpp::compute::forwarding_rules::v1::
                    SetTargetRequest const& request),

--- a/google/cloud/compute/global_addresses/v1/mocks/mock_global_addresses_connection.h
+++ b/google/cloud/compute/global_addresses/v1/mocks/mock_global_addresses_connection.h
@@ -47,18 +47,18 @@ class MockGlobalAddressesConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteAddress,
               (google::cloud::cpp::compute::global_addresses::v1::
                    DeleteAddressRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Address>, GetAddress,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Address>), GetAddress,
               (google::cloud::cpp::compute::global_addresses::v1::
                    GetAddressRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertAddress,
               (google::cloud::cpp::compute::global_addresses::v1::
                    InsertAddressRequest const& request),
@@ -71,12 +71,12 @@ class MockGlobalAddressesConnection
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, Move,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>), Move,
       (google::cloud::cpp::compute::global_addresses::v1::MoveRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetLabels,
               (google::cloud::cpp::compute::global_addresses::v1::
                    SetLabelsRequest const& request),

--- a/google/cloud/compute/global_forwarding_rules/v1/mocks/mock_global_forwarding_rules_connection.h
+++ b/google/cloud/compute/global_forwarding_rules/v1/mocks/mock_global_forwarding_rules_connection.h
@@ -49,19 +49,19 @@ class MockGlobalForwardingRulesConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteForwardingRule,
               (google::cloud::cpp::compute::global_forwarding_rules::v1::
                    DeleteForwardingRuleRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::ForwardingRule>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::ForwardingRule>),
               GetForwardingRule,
               (google::cloud::cpp::compute::global_forwarding_rules::v1::
                    GetForwardingRuleRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertForwardingRule,
               (google::cloud::cpp::compute::global_forwarding_rules::v1::
                    InsertForwardingRuleRequest const& request),
@@ -73,19 +73,19 @@ class MockGlobalForwardingRulesConnection
                    ListGlobalForwardingRulesRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchForwardingRule,
               (google::cloud::cpp::compute::global_forwarding_rules::v1::
                    PatchForwardingRuleRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetLabels,
               (google::cloud::cpp::compute::global_forwarding_rules::v1::
                    SetLabelsRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetTarget,
               (google::cloud::cpp::compute::global_forwarding_rules::v1::
                    SetTargetRequest const& request),

--- a/google/cloud/compute/global_network_endpoint_groups/v1/mocks/mock_global_network_endpoint_groups_connection.h
+++ b/google/cloud/compute/global_network_endpoint_groups/v1/mocks/mock_global_network_endpoint_groups_connection.h
@@ -49,31 +49,31 @@ class MockGlobalNetworkEndpointGroupsConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               AttachNetworkEndpoints,
               (google::cloud::cpp::compute::global_network_endpoint_groups::v1::
                    AttachNetworkEndpointsRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteNetworkEndpointGroup,
               (google::cloud::cpp::compute::global_network_endpoint_groups::v1::
                    DeleteNetworkEndpointGroupRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DetachNetworkEndpoints,
               (google::cloud::cpp::compute::global_network_endpoint_groups::v1::
                    DetachNetworkEndpointsRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::NetworkEndpointGroup>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::NetworkEndpointGroup>),
               GetNetworkEndpointGroup,
               (google::cloud::cpp::compute::global_network_endpoint_groups::v1::
                    GetNetworkEndpointGroupRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertNetworkEndpointGroup,
               (google::cloud::cpp::compute::global_network_endpoint_groups::v1::
                    InsertNetworkEndpointGroupRequest const& request),

--- a/google/cloud/compute/global_operations/v1/mocks/mock_global_operations_connection.h
+++ b/google/cloud/compute/global_operations/v1/mocks/mock_global_operations_connection.h
@@ -61,7 +61,7 @@ class MockGlobalOperationsConnection
                    DeleteOperationRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Operation>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Operation>),
               GetOperation,
               (google::cloud::cpp::compute::global_operations::v1::
                    GetOperationRequest const& request),
@@ -74,7 +74,7 @@ class MockGlobalOperationsConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Operation>, Wait,
+      (StatusOr<google::cloud::cpp::compute::v1::Operation>), Wait,
       (google::cloud::cpp::compute::global_operations::v1::WaitRequest const&
            request),
       (override));

--- a/google/cloud/compute/global_organization_operations/v1/mocks/mock_global_organization_operations_connection.h
+++ b/google/cloud/compute/global_organization_operations/v1/mocks/mock_global_organization_operations_connection.h
@@ -54,7 +54,7 @@ class MockGlobalOrganizationOperationsConnection
                    DeleteOperationRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Operation>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Operation>),
               GetOperation,
               (google::cloud::cpp::compute::global_organization_operations::v1::
                    GetOperationRequest const& request),

--- a/google/cloud/compute/global_public_delegated_prefixes/v1/mocks/mock_global_public_delegated_prefixes_connection.h
+++ b/google/cloud/compute/global_public_delegated_prefixes/v1/mocks/mock_global_public_delegated_prefixes_connection.h
@@ -49,19 +49,20 @@ class MockGlobalPublicDelegatedPrefixesConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeletePublicDelegatedPrefix,
               (google::cloud::cpp::compute::global_public_delegated_prefixes::
                    v1::DeletePublicDelegatedPrefixRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::PublicDelegatedPrefix>,
-              GetPublicDelegatedPrefix,
-              (google::cloud::cpp::compute::global_public_delegated_prefixes::
-                   v1::GetPublicDelegatedPrefixRequest const& request),
-              (override));
+  MOCK_METHOD(
+      (StatusOr<google::cloud::cpp::compute::v1::PublicDelegatedPrefix>),
+      GetPublicDelegatedPrefix,
+      (google::cloud::cpp::compute::global_public_delegated_prefixes::v1::
+           GetPublicDelegatedPrefixRequest const& request),
+      (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertPublicDelegatedPrefix,
               (google::cloud::cpp::compute::global_public_delegated_prefixes::
                    v1::InsertPublicDelegatedPrefixRequest const& request),
@@ -74,7 +75,7 @@ class MockGlobalPublicDelegatedPrefixesConnection
            ListGlobalPublicDelegatedPrefixesRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchPublicDelegatedPrefix,
               (google::cloud::cpp::compute::global_public_delegated_prefixes::
                    v1::PatchPublicDelegatedPrefixRequest const& request),

--- a/google/cloud/compute/health_checks/v1/mocks/mock_health_checks_connection.h
+++ b/google/cloud/compute/health_checks/v1/mocks/mock_health_checks_connection.h
@@ -56,19 +56,19 @@ class MockHealthChecksConnection
            AggregatedListHealthChecksRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteHealthCheck,
               (google::cloud::cpp::compute::health_checks::v1::
                    DeleteHealthCheckRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::HealthCheck>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::HealthCheck>),
               GetHealthCheck,
               (google::cloud::cpp::compute::health_checks::v1::
                    GetHealthCheckRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertHealthCheck,
               (google::cloud::cpp::compute::health_checks::v1::
                    InsertHealthCheckRequest const& request),
@@ -81,13 +81,13 @@ class MockHealthChecksConnection
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchHealthCheck,
               (google::cloud::cpp::compute::health_checks::v1::
                    PatchHealthCheckRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               UpdateHealthCheck,
               (google::cloud::cpp::compute::health_checks::v1::
                    UpdateHealthCheckRequest const& request),

--- a/google/cloud/compute/http_health_checks/v1/mocks/mock_http_health_checks_connection.h
+++ b/google/cloud/compute/http_health_checks/v1/mocks/mock_http_health_checks_connection.h
@@ -47,19 +47,19 @@ class MockHttpHealthChecksConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteHttpHealthCheck,
               (google::cloud::cpp::compute::http_health_checks::v1::
                    DeleteHttpHealthCheckRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::HttpHealthCheck>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::HttpHealthCheck>),
               GetHttpHealthCheck,
               (google::cloud::cpp::compute::http_health_checks::v1::
                    GetHttpHealthCheckRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertHttpHealthCheck,
               (google::cloud::cpp::compute::http_health_checks::v1::
                    InsertHttpHealthCheckRequest const& request),
@@ -71,13 +71,13 @@ class MockHttpHealthChecksConnection
                    ListHttpHealthChecksRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchHttpHealthCheck,
               (google::cloud::cpp::compute::http_health_checks::v1::
                    PatchHttpHealthCheckRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               UpdateHttpHealthCheck,
               (google::cloud::cpp::compute::http_health_checks::v1::
                    UpdateHttpHealthCheckRequest const& request),

--- a/google/cloud/compute/https_health_checks/v1/mocks/mock_https_health_checks_connection.h
+++ b/google/cloud/compute/https_health_checks/v1/mocks/mock_https_health_checks_connection.h
@@ -47,19 +47,19 @@ class MockHttpsHealthChecksConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteHttpsHealthCheck,
               (google::cloud::cpp::compute::https_health_checks::v1::
                    DeleteHttpsHealthCheckRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::HttpsHealthCheck>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::HttpsHealthCheck>),
               GetHttpsHealthCheck,
               (google::cloud::cpp::compute::https_health_checks::v1::
                    GetHttpsHealthCheckRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertHttpsHealthCheck,
               (google::cloud::cpp::compute::https_health_checks::v1::
                    InsertHttpsHealthCheckRequest const& request),
@@ -71,13 +71,13 @@ class MockHttpsHealthChecksConnection
                    ListHttpsHealthChecksRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchHttpsHealthCheck,
               (google::cloud::cpp::compute::https_health_checks::v1::
                    PatchHttpsHealthCheckRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               UpdateHttpsHealthCheck,
               (google::cloud::cpp::compute::https_health_checks::v1::
                    UpdateHttpsHealthCheckRequest const& request),

--- a/google/cloud/compute/image_family_views/v1/mocks/mock_image_family_views_connection.h
+++ b/google/cloud/compute/image_family_views/v1/mocks/mock_image_family_views_connection.h
@@ -47,7 +47,7 @@ class MockImageFamilyViewsConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::ImageFamilyView>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::ImageFamilyView>),
               GetImageFamilyView,
               (google::cloud::cpp::compute::image_family_views::v1::
                    GetImageFamilyViewRequest const& request),

--- a/google/cloud/compute/images/v1/mocks/mock_images_connection.h
+++ b/google/cloud/compute/images/v1/mocks/mock_images_connection.h
@@ -47,36 +47,38 @@ class MockImagesConnection : public compute_images_v1::ImagesConnection {
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, DeleteImage,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
+      DeleteImage,
       (google::cloud::cpp::compute::images::v1::DeleteImageRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               Deprecate,
               (google::cloud::cpp::compute::images::v1::DeprecateRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Image>, GetImage,
+      (StatusOr<google::cloud::cpp::compute::v1::Image>), GetImage,
       (google::cloud::cpp::compute::images::v1::GetImageRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Image>, GetFromFamily,
+      (StatusOr<google::cloud::cpp::compute::v1::Image>), GetFromFamily,
       (google::cloud::cpp::compute::images::v1::GetFromFamilyRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Policy>, GetIamPolicy,
+      (StatusOr<google::cloud::cpp::compute::v1::Policy>), GetIamPolicy,
       (google::cloud::cpp::compute::images::v1::GetIamPolicyRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, InsertImage,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
+      InsertImage,
       (google::cloud::cpp::compute::images::v1::InsertImageRequest const&
            request),
       (override));
@@ -86,26 +88,26 @@ class MockImagesConnection : public compute_images_v1::ImagesConnection {
       (google::cloud::cpp::compute::images::v1::ListImagesRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchImage,
               (google::cloud::cpp::compute::images::v1::PatchImageRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Policy>, SetIamPolicy,
+      (StatusOr<google::cloud::cpp::compute::v1::Policy>), SetIamPolicy,
       (google::cloud::cpp::compute::images::v1::SetIamPolicyRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetLabels,
               (google::cloud::cpp::compute::images::v1::SetLabelsRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>),
       TestIamPermissions,
       (google::cloud::cpp::compute::images::v1::TestIamPermissionsRequest const&
            request),

--- a/google/cloud/compute/instance_group_manager_resize_requests/v1/mocks/mock_instance_group_manager_resize_requests_connection.h
+++ b/google/cloud/compute/instance_group_manager_resize_requests/v1/mocks/mock_instance_group_manager_resize_requests_connection.h
@@ -51,28 +51,28 @@ class MockInstanceGroupManagerResizeRequestsConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, Cancel,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>), Cancel,
       (google::cloud::cpp::compute::instance_group_manager_resize_requests::v1::
            CancelRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       DeleteInstanceGroupManagerResizeRequest,
       (google::cloud::cpp::compute::instance_group_manager_resize_requests::v1::
            DeleteInstanceGroupManagerResizeRequestRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::cpp::compute::v1::InstanceGroupManagerResizeRequest>,
+      (StatusOr<
+          google::cloud::cpp::compute::v1::InstanceGroupManagerResizeRequest>),
       GetInstanceGroupManagerResizeRequest,
       (google::cloud::cpp::compute::instance_group_manager_resize_requests::v1::
            GetInstanceGroupManagerResizeRequestRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       InsertInstanceGroupManagerResizeRequest,
       (google::cloud::cpp::compute::instance_group_manager_resize_requests::v1::
            InsertInstanceGroupManagerResizeRequestRequest const& request),

--- a/google/cloud/compute/instance_group_managers/v1/mocks/mock_instance_group_managers_connection.h
+++ b/google/cloud/compute/instance_group_managers/v1/mocks/mock_instance_group_managers_connection.h
@@ -49,7 +49,7 @@ class MockInstanceGroupManagersConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               AbandonInstances,
               (google::cloud::cpp::compute::instance_group_managers::v1::
                    AbandonInstancesRequest const& request),
@@ -64,43 +64,43 @@ class MockInstanceGroupManagersConnection
            AggregatedListInstanceGroupManagersRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               ApplyUpdatesToInstances,
               (google::cloud::cpp::compute::instance_group_managers::v1::
                    ApplyUpdatesToInstancesRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               CreateInstances,
               (google::cloud::cpp::compute::instance_group_managers::v1::
                    CreateInstancesRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteInstanceGroupManager,
               (google::cloud::cpp::compute::instance_group_managers::v1::
                    DeleteInstanceGroupManagerRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteInstances,
               (google::cloud::cpp::compute::instance_group_managers::v1::
                    DeleteInstancesRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeletePerInstanceConfigs,
               (google::cloud::cpp::compute::instance_group_managers::v1::
                    DeletePerInstanceConfigsRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::InstanceGroupManager>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::InstanceGroupManager>),
               GetInstanceGroupManager,
               (google::cloud::cpp::compute::instance_group_managers::v1::
                    GetInstanceGroupManagerRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertInstanceGroupManager,
               (google::cloud::cpp::compute::instance_group_managers::v1::
                    InsertInstanceGroupManagerRequest const& request),
@@ -120,8 +120,8 @@ class MockInstanceGroupManagersConnection
            ListErrorsRequest request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::
-                           InstanceGroupManagersListManagedInstancesResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::
+                            InstanceGroupManagersListManagedInstancesResponse>),
               ListManagedInstances,
               (google::cloud::cpp::compute::instance_group_managers::v1::
                    ListManagedInstancesRequest const& request),
@@ -133,43 +133,43 @@ class MockInstanceGroupManagersConnection
                    ListPerInstanceConfigsRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchInstanceGroupManager,
               (google::cloud::cpp::compute::instance_group_managers::v1::
                    PatchInstanceGroupManagerRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchPerInstanceConfigs,
               (google::cloud::cpp::compute::instance_group_managers::v1::
                    PatchPerInstanceConfigsRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               RecreateInstances,
               (google::cloud::cpp::compute::instance_group_managers::v1::
                    RecreateInstancesRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               Resize,
               (google::cloud::cpp::compute::instance_group_managers::v1::
                    ResizeRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetInstanceTemplate,
               (google::cloud::cpp::compute::instance_group_managers::v1::
                    SetInstanceTemplateRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetTargetPools,
               (google::cloud::cpp::compute::instance_group_managers::v1::
                    SetTargetPoolsRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               UpdatePerInstanceConfigs,
               (google::cloud::cpp::compute::instance_group_managers::v1::
                    UpdatePerInstanceConfigsRequest const& request),

--- a/google/cloud/compute/instance_groups/v1/mocks/mock_instance_groups_connection.h
+++ b/google/cloud/compute/instance_groups/v1/mocks/mock_instance_groups_connection.h
@@ -47,7 +47,7 @@ class MockInstanceGroupsConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               AddInstances,
               (google::cloud::cpp::compute::instance_groups::v1::
                    AddInstancesRequest const& request),
@@ -61,19 +61,19 @@ class MockInstanceGroupsConnection
            AggregatedListInstanceGroupsRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteInstanceGroup,
               (google::cloud::cpp::compute::instance_groups::v1::
                    DeleteInstanceGroupRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::InstanceGroup>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::InstanceGroup>),
               GetInstanceGroup,
               (google::cloud::cpp::compute::instance_groups::v1::
                    GetInstanceGroupRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertInstanceGroup,
               (google::cloud::cpp::compute::instance_groups::v1::
                    InsertInstanceGroupRequest const& request),
@@ -92,13 +92,13 @@ class MockInstanceGroupsConnection
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               RemoveInstances,
               (google::cloud::cpp::compute::instance_groups::v1::
                    RemoveInstancesRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetNamedPorts,
               (google::cloud::cpp::compute::instance_groups::v1::
                    SetNamedPortsRequest const& request),

--- a/google/cloud/compute/instance_templates/v1/mocks/mock_instance_templates_connection.h
+++ b/google/cloud/compute/instance_templates/v1/mocks/mock_instance_templates_connection.h
@@ -55,24 +55,24 @@ class MockInstanceTemplatesConnection
            AggregatedListInstanceTemplatesRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteInstanceTemplate,
               (google::cloud::cpp::compute::instance_templates::v1::
                    DeleteInstanceTemplateRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::InstanceTemplate>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::InstanceTemplate>),
               GetInstanceTemplate,
               (google::cloud::cpp::compute::instance_templates::v1::
                    GetInstanceTemplateRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Policy>), GetIamPolicy,
               (google::cloud::cpp::compute::instance_templates::v1::
                    GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertInstanceTemplate,
               (google::cloud::cpp::compute::instance_templates::v1::
                    InsertInstanceTemplateRequest const& request),
@@ -84,13 +84,13 @@ class MockInstanceTemplatesConnection
                    ListInstanceTemplatesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Policy>), SetIamPolicy,
               (google::cloud::cpp::compute::instance_templates::v1::
                    SetIamPolicyRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>),
       TestIamPermissions,
       (google::cloud::cpp::compute::instance_templates::v1::
            TestIamPermissionsRequest const& request),

--- a/google/cloud/compute/instances/v1/mocks/mock_instances_connection.h
+++ b/google/cloud/compute/instances/v1/mocks/mock_instances_connection.h
@@ -48,13 +48,13 @@ class MockInstancesConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       AddAccessConfig,
       (google::cloud::cpp::compute::instances::v1::AddAccessConfigRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               AddResourcePolicies,
               (google::cloud::cpp::compute::instances::v1::
                    AddResourcePoliciesRequest const& request),
@@ -69,82 +69,85 @@ class MockInstancesConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, AttachDisk,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
+      AttachDisk,
       (google::cloud::cpp::compute::instances::v1::AttachDiskRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, BulkInsert,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
+      BulkInsert,
       (google::cloud::cpp::compute::instances::v1::BulkInsertRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       DeleteInstance,
       (google::cloud::cpp::compute::instances::v1::DeleteInstanceRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteAccessConfig,
               (google::cloud::cpp::compute::instances::v1::
                    DeleteAccessConfigRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, DetachDisk,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
+      DetachDisk,
       (google::cloud::cpp::compute::instances::v1::DetachDiskRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Instance>, GetInstance,
+      (StatusOr<google::cloud::cpp::compute::v1::Instance>), GetInstance,
       (google::cloud::cpp::compute::instances::v1::GetInstanceRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::
-                           InstancesGetEffectiveFirewallsResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::
+                            InstancesGetEffectiveFirewallsResponse>),
               GetEffectiveFirewalls,
               (google::cloud::cpp::compute::instances::v1::
                    GetEffectiveFirewallsRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::GuestAttributes>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::GuestAttributes>),
               GetGuestAttributes,
               (google::cloud::cpp::compute::instances::v1::
                    GetGuestAttributesRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Policy>, GetIamPolicy,
+      (StatusOr<google::cloud::cpp::compute::v1::Policy>), GetIamPolicy,
       (google::cloud::cpp::compute::instances::v1::GetIamPolicyRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Screenshot>, GetScreenshot,
+      (StatusOr<google::cloud::cpp::compute::v1::Screenshot>), GetScreenshot,
       (google::cloud::cpp::compute::instances::v1::GetScreenshotRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::SerialPortOutput>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::SerialPortOutput>),
               GetSerialPortOutput,
               (google::cloud::cpp::compute::instances::v1::
                    GetSerialPortOutputRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::ShieldedInstanceIdentity>,
+      (StatusOr<google::cloud::cpp::compute::v1::ShieldedInstanceIdentity>),
       GetShieldedInstanceIdentity,
       (google::cloud::cpp::compute::instances::v1::
            GetShieldedInstanceIdentityRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       InsertInstance,
       (google::cloud::cpp::compute::instances::v1::InsertInstanceRequest const&
            request),
@@ -162,24 +165,24 @@ class MockInstancesConnection
                    request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PerformMaintenance,
               (google::cloud::cpp::compute::instances::v1::
                    PerformMaintenanceRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               RemoveResourcePolicies,
               (google::cloud::cpp::compute::instances::v1::
                    RemoveResourcePoliciesRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, Reset,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>), Reset,
       (google::cloud::cpp::compute::instances::v1::ResetRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               Resume,
               (google::cloud::cpp::compute::instances::v1::ResumeRequest const&
                    request),
@@ -190,153 +193,154 @@ class MockInstancesConnection
                    SendDiagnosticInterruptRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetDeletionProtection,
               (google::cloud::cpp::compute::instances::v1::
                    SetDeletionProtectionRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetDiskAutoDelete,
               (google::cloud::cpp::compute::instances::v1::
                    SetDiskAutoDeleteRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Policy>, SetIamPolicy,
+      (StatusOr<google::cloud::cpp::compute::v1::Policy>), SetIamPolicy,
       (google::cloud::cpp::compute::instances::v1::SetIamPolicyRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, SetLabels,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>), SetLabels,
       (google::cloud::cpp::compute::instances::v1::SetLabelsRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetMachineResources,
               (google::cloud::cpp::compute::instances::v1::
                    SetMachineResourcesRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       SetMachineType,
       (google::cloud::cpp::compute::instances::v1::SetMachineTypeRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, SetMetadata,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
+      SetMetadata,
       (google::cloud::cpp::compute::instances::v1::SetMetadataRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetMinCpuPlatform,
               (google::cloud::cpp::compute::instances::v1::
                    SetMinCpuPlatformRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetName,
               (google::cloud::cpp::compute::instances::v1::SetNameRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       SetScheduling,
       (google::cloud::cpp::compute::instances::v1::SetSchedulingRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetSecurityPolicy,
               (google::cloud::cpp::compute::instances::v1::
                    SetSecurityPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetServiceAccount,
               (google::cloud::cpp::compute::instances::v1::
                    SetServiceAccountRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetShieldedInstanceIntegrityPolicy,
               (google::cloud::cpp::compute::instances::v1::
                    SetShieldedInstanceIntegrityPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetTags,
               (google::cloud::cpp::compute::instances::v1::SetTagsRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SimulateMaintenanceEvent,
               (google::cloud::cpp::compute::instances::v1::
                    SimulateMaintenanceEventRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, Start,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>), Start,
       (google::cloud::cpp::compute::instances::v1::StartRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               StartWithEncryptionKey,
               (google::cloud::cpp::compute::instances::v1::
                    StartWithEncryptionKeyRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, Stop,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>), Stop,
       (google::cloud::cpp::compute::instances::v1::StopRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               Suspend,
               (google::cloud::cpp::compute::instances::v1::SuspendRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>),
       TestIamPermissions,
       (google::cloud::cpp::compute::instances::v1::
            TestIamPermissionsRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       UpdateInstance,
       (google::cloud::cpp::compute::instances::v1::UpdateInstanceRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               UpdateAccessConfig,
               (google::cloud::cpp::compute::instances::v1::
                    UpdateAccessConfigRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               UpdateDisplayDevice,
               (google::cloud::cpp::compute::instances::v1::
                    UpdateDisplayDeviceRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               UpdateNetworkInterface,
               (google::cloud::cpp::compute::instances::v1::
                    UpdateNetworkInterfaceRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               UpdateShieldedInstanceConfig,
               (google::cloud::cpp::compute::instances::v1::
                    UpdateShieldedInstanceConfigRequest const& request),

--- a/google/cloud/compute/interconnect_attachments/v1/mocks/mock_interconnect_attachments_connection.h
+++ b/google/cloud/compute/interconnect_attachments/v1/mocks/mock_interconnect_attachments_connection.h
@@ -57,19 +57,20 @@ class MockInterconnectAttachmentsConnection
                    AggregatedListInterconnectAttachmentsRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteInterconnectAttachment,
               (google::cloud::cpp::compute::interconnect_attachments::v1::
                    DeleteInterconnectAttachmentRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::InterconnectAttachment>,
-              GetInterconnectAttachment,
-              (google::cloud::cpp::compute::interconnect_attachments::v1::
-                   GetInterconnectAttachmentRequest const& request),
-              (override));
+  MOCK_METHOD(
+      (StatusOr<google::cloud::cpp::compute::v1::InterconnectAttachment>),
+      GetInterconnectAttachment,
+      (google::cloud::cpp::compute::interconnect_attachments::v1::
+           GetInterconnectAttachmentRequest const& request),
+      (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertInterconnectAttachment,
               (google::cloud::cpp::compute::interconnect_attachments::v1::
                    InsertInterconnectAttachmentRequest const& request),
@@ -82,13 +83,13 @@ class MockInterconnectAttachmentsConnection
            ListInterconnectAttachmentsRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchInterconnectAttachment,
               (google::cloud::cpp::compute::interconnect_attachments::v1::
                    PatchInterconnectAttachmentRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetLabels,
               (google::cloud::cpp::compute::interconnect_attachments::v1::
                    SetLabelsRequest const& request),

--- a/google/cloud/compute/interconnect_locations/v1/mocks/mock_interconnect_locations_connection.h
+++ b/google/cloud/compute/interconnect_locations/v1/mocks/mock_interconnect_locations_connection.h
@@ -49,7 +49,7 @@ class MockInterconnectLocationsConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::InterconnectLocation>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::InterconnectLocation>),
               GetInterconnectLocation,
               (google::cloud::cpp::compute::interconnect_locations::v1::
                    GetInterconnectLocationRequest const& request),

--- a/google/cloud/compute/interconnect_remote_locations/v1/mocks/mock_interconnect_remote_locations_connection.h
+++ b/google/cloud/compute/interconnect_remote_locations/v1/mocks/mock_interconnect_remote_locations_connection.h
@@ -50,7 +50,7 @@ class MockInterconnectRemoteLocationsConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::InterconnectRemoteLocation>,
+      (StatusOr<google::cloud::cpp::compute::v1::InterconnectRemoteLocation>),
       GetInterconnectRemoteLocation,
       (google::cloud::cpp::compute::interconnect_remote_locations::v1::
            GetInterconnectRemoteLocationRequest const& request),

--- a/google/cloud/compute/interconnects/v1/mocks/mock_interconnects_connection.h
+++ b/google/cloud/compute/interconnects/v1/mocks/mock_interconnects_connection.h
@@ -47,34 +47,33 @@ class MockInterconnectsConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteInterconnect,
               (google::cloud::cpp::compute::interconnects::v1::
                    DeleteInterconnectRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Interconnect>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Interconnect>),
               GetInterconnect,
               (google::cloud::cpp::compute::interconnects::v1::
                    GetInterconnectRequest const& request),
               (override));
 
-  MOCK_METHOD(
-      StatusOr<
-          google::cloud::cpp::compute::v1::InterconnectsGetDiagnosticsResponse>,
-      GetDiagnostics,
-      (google::cloud::cpp::compute::interconnects::v1::
-           GetDiagnosticsRequest const& request),
-      (override));
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::
+                            InterconnectsGetDiagnosticsResponse>),
+              GetDiagnostics,
+              (google::cloud::cpp::compute::interconnects::v1::
+                   GetDiagnosticsRequest const& request),
+              (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::
-                           InterconnectsGetMacsecConfigResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::
+                            InterconnectsGetMacsecConfigResponse>),
               GetMacsecConfig,
               (google::cloud::cpp::compute::interconnects::v1::
                    GetMacsecConfigRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertInterconnect,
               (google::cloud::cpp::compute::interconnects::v1::
                    InsertInterconnectRequest const& request),
@@ -87,14 +86,14 @@ class MockInterconnectsConnection
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchInterconnect,
               (google::cloud::cpp::compute::interconnects::v1::
                    PatchInterconnectRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, SetLabels,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>), SetLabels,
       (google::cloud::cpp::compute::interconnects::v1::SetLabelsRequest const&
            request),
       (override));

--- a/google/cloud/compute/license_codes/v1/mocks/mock_license_codes_connection.h
+++ b/google/cloud/compute/license_codes/v1/mocks/mock_license_codes_connection.h
@@ -47,14 +47,14 @@ class MockLicenseCodesConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::LicenseCode>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::LicenseCode>),
               GetLicenseCode,
               (google::cloud::cpp::compute::license_codes::v1::
                    GetLicenseCodeRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>),
       TestIamPermissions,
       (google::cloud::cpp::compute::license_codes::v1::
            TestIamPermissionsRequest const& request),

--- a/google/cloud/compute/licenses/v1/mocks/mock_licenses_connection.h
+++ b/google/cloud/compute/licenses/v1/mocks/mock_licenses_connection.h
@@ -47,26 +47,26 @@ class MockLicensesConnection : public compute_licenses_v1::LicensesConnection {
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       DeleteLicense,
       (google::cloud::cpp::compute::licenses::v1::DeleteLicenseRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::License>, GetLicense,
+      (StatusOr<google::cloud::cpp::compute::v1::License>), GetLicense,
       (google::cloud::cpp::compute::licenses::v1::GetLicenseRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Policy>, GetIamPolicy,
+      (StatusOr<google::cloud::cpp::compute::v1::Policy>), GetIamPolicy,
       (google::cloud::cpp::compute::licenses::v1::GetIamPolicyRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       InsertLicense,
       (google::cloud::cpp::compute::licenses::v1::InsertLicenseRequest const&
            request),
@@ -78,13 +78,13 @@ class MockLicensesConnection : public compute_licenses_v1::LicensesConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Policy>, SetIamPolicy,
+      (StatusOr<google::cloud::cpp::compute::v1::Policy>), SetIamPolicy,
       (google::cloud::cpp::compute::licenses::v1::SetIamPolicyRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>),
       TestIamPermissions,
       (google::cloud::cpp::compute::licenses::v1::
            TestIamPermissionsRequest const& request),

--- a/google/cloud/compute/machine_images/v1/mocks/mock_machine_images_connection.h
+++ b/google/cloud/compute/machine_images/v1/mocks/mock_machine_images_connection.h
@@ -47,24 +47,24 @@ class MockMachineImagesConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteMachineImage,
               (google::cloud::cpp::compute::machine_images::v1::
                    DeleteMachineImageRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::MachineImage>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::MachineImage>),
               GetMachineImage,
               (google::cloud::cpp::compute::machine_images::v1::
                    GetMachineImageRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Policy>), GetIamPolicy,
               (google::cloud::cpp::compute::machine_images::v1::
                    GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertMachineImage,
               (google::cloud::cpp::compute::machine_images::v1::
                    InsertMachineImageRequest const& request),
@@ -77,13 +77,13 @@ class MockMachineImagesConnection
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Policy>), SetIamPolicy,
               (google::cloud::cpp::compute::machine_images::v1::
                    SetIamPolicyRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>),
       TestIamPermissions,
       (google::cloud::cpp::compute::machine_images::v1::
            TestIamPermissionsRequest const& request),

--- a/google/cloud/compute/machine_types/v1/mocks/mock_machine_types_connection.h
+++ b/google/cloud/compute/machine_types/v1/mocks/mock_machine_types_connection.h
@@ -56,7 +56,7 @@ class MockMachineTypesConnection
            AggregatedListMachineTypesRequest request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::MachineType>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::MachineType>),
               GetMachineType,
               (google::cloud::cpp::compute::machine_types::v1::
                    GetMachineTypeRequest const& request),

--- a/google/cloud/compute/network_attachments/v1/mocks/mock_network_attachments_connection.h
+++ b/google/cloud/compute/network_attachments/v1/mocks/mock_network_attachments_connection.h
@@ -55,24 +55,24 @@ class MockNetworkAttachmentsConnection
            AggregatedListNetworkAttachmentsRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteNetworkAttachment,
               (google::cloud::cpp::compute::network_attachments::v1::
                    DeleteNetworkAttachmentRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::NetworkAttachment>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::NetworkAttachment>),
               GetNetworkAttachment,
               (google::cloud::cpp::compute::network_attachments::v1::
                    GetNetworkAttachmentRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Policy>), GetIamPolicy,
               (google::cloud::cpp::compute::network_attachments::v1::
                    GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertNetworkAttachment,
               (google::cloud::cpp::compute::network_attachments::v1::
                    InsertNetworkAttachmentRequest const& request),
@@ -84,19 +84,19 @@ class MockNetworkAttachmentsConnection
                    ListNetworkAttachmentsRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchNetworkAttachment,
               (google::cloud::cpp::compute::network_attachments::v1::
                    PatchNetworkAttachmentRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Policy>), SetIamPolicy,
               (google::cloud::cpp::compute::network_attachments::v1::
                    SetIamPolicyRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>),
       TestIamPermissions,
       (google::cloud::cpp::compute::network_attachments::v1::
            TestIamPermissionsRequest const& request),

--- a/google/cloud/compute/network_edge_security_services/v1/mocks/mock_network_edge_security_services_connection.h
+++ b/google/cloud/compute/network_edge_security_services/v1/mocks/mock_network_edge_security_services_connection.h
@@ -58,26 +58,26 @@ class MockNetworkEdgeSecurityServicesConnection
            AggregatedListNetworkEdgeSecurityServicesRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteNetworkEdgeSecurityService,
               (google::cloud::cpp::compute::network_edge_security_services::v1::
                    DeleteNetworkEdgeSecurityServiceRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::NetworkEdgeSecurityService>,
+      (StatusOr<google::cloud::cpp::compute::v1::NetworkEdgeSecurityService>),
       GetNetworkEdgeSecurityService,
       (google::cloud::cpp::compute::network_edge_security_services::v1::
            GetNetworkEdgeSecurityServiceRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertNetworkEdgeSecurityService,
               (google::cloud::cpp::compute::network_edge_security_services::v1::
                    InsertNetworkEdgeSecurityServiceRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchNetworkEdgeSecurityService,
               (google::cloud::cpp::compute::network_edge_security_services::v1::
                    PatchNetworkEdgeSecurityServiceRequest const& request),

--- a/google/cloud/compute/network_endpoint_groups/v1/mocks/mock_network_endpoint_groups_connection.h
+++ b/google/cloud/compute/network_endpoint_groups/v1/mocks/mock_network_endpoint_groups_connection.h
@@ -58,31 +58,31 @@ class MockNetworkEndpointGroupsConnection
            AggregatedListNetworkEndpointGroupsRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               AttachNetworkEndpoints,
               (google::cloud::cpp::compute::network_endpoint_groups::v1::
                    AttachNetworkEndpointsRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteNetworkEndpointGroup,
               (google::cloud::cpp::compute::network_endpoint_groups::v1::
                    DeleteNetworkEndpointGroupRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DetachNetworkEndpoints,
               (google::cloud::cpp::compute::network_endpoint_groups::v1::
                    DetachNetworkEndpointsRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::NetworkEndpointGroup>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::NetworkEndpointGroup>),
               GetNetworkEndpointGroup,
               (google::cloud::cpp::compute::network_endpoint_groups::v1::
                    GetNetworkEndpointGroupRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertNetworkEndpointGroup,
               (google::cloud::cpp::compute::network_endpoint_groups::v1::
                    InsertNetworkEndpointGroupRequest const& request),
@@ -104,7 +104,7 @@ class MockNetworkEndpointGroupsConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>),
       TestIamPermissions,
       (google::cloud::cpp::compute::network_endpoint_groups::v1::
            TestIamPermissionsRequest const& request),

--- a/google/cloud/compute/network_firewall_policies/v1/mocks/mock_network_firewall_policies_connection.h
+++ b/google/cloud/compute/network_firewall_policies/v1/mocks/mock_network_firewall_policies_connection.h
@@ -49,55 +49,55 @@ class MockNetworkFirewallPoliciesConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               AddAssociation,
               (google::cloud::cpp::compute::network_firewall_policies::v1::
                    AddAssociationRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               AddRule,
               (google::cloud::cpp::compute::network_firewall_policies::v1::
                    AddRuleRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               CloneRules,
               (google::cloud::cpp::compute::network_firewall_policies::v1::
                    CloneRulesRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteFirewallPolicy,
               (google::cloud::cpp::compute::network_firewall_policies::v1::
                    DeleteFirewallPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::FirewallPolicy>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::FirewallPolicy>),
               GetFirewallPolicy,
               (google::cloud::cpp::compute::network_firewall_policies::v1::
                    GetFirewallPolicyRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::FirewallPolicyAssociation>,
+      (StatusOr<google::cloud::cpp::compute::v1::FirewallPolicyAssociation>),
       GetAssociation,
       (google::cloud::cpp::compute::network_firewall_policies::v1::
            GetAssociationRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Policy>), GetIamPolicy,
               (google::cloud::cpp::compute::network_firewall_policies::v1::
                    GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::FirewallPolicyRule>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::FirewallPolicyRule>),
               GetRule,
               (google::cloud::cpp::compute::network_firewall_policies::v1::
                    GetRuleRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertFirewallPolicy,
               (google::cloud::cpp::compute::network_firewall_policies::v1::
                    InsertFirewallPolicyRequest const& request),
@@ -109,37 +109,37 @@ class MockNetworkFirewallPoliciesConnection
                    ListNetworkFirewallPoliciesRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchFirewallPolicy,
               (google::cloud::cpp::compute::network_firewall_policies::v1::
                    PatchFirewallPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchRule,
               (google::cloud::cpp::compute::network_firewall_policies::v1::
                    PatchRuleRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               RemoveAssociation,
               (google::cloud::cpp::compute::network_firewall_policies::v1::
                    RemoveAssociationRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               RemoveRule,
               (google::cloud::cpp::compute::network_firewall_policies::v1::
                    RemoveRuleRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Policy>), SetIamPolicy,
               (google::cloud::cpp::compute::network_firewall_policies::v1::
                    SetIamPolicyRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>),
       TestIamPermissions,
       (google::cloud::cpp::compute::network_firewall_policies::v1::
            TestIamPermissionsRequest const& request),

--- a/google/cloud/compute/networks/v1/mocks/mock_networks_connection.h
+++ b/google/cloud/compute/networks/v1/mocks/mock_networks_connection.h
@@ -47,33 +47,34 @@ class MockNetworksConnection : public compute_networks_v1::NetworksConnection {
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, AddPeering,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
+      AddPeering,
       (google::cloud::cpp::compute::networks::v1::AddPeeringRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       DeleteNetwork,
       (google::cloud::cpp::compute::networks::v1::DeleteNetworkRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Network>, GetNetwork,
+      (StatusOr<google::cloud::cpp::compute::v1::Network>), GetNetwork,
       (google::cloud::cpp::compute::networks::v1::GetNetworkRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::
-                           NetworksGetEffectiveFirewallsResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::
+                            NetworksGetEffectiveFirewallsResponse>),
               GetEffectiveFirewalls,
               (google::cloud::cpp::compute::networks::v1::
                    GetEffectiveFirewallsRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       InsertNetwork,
       (google::cloud::cpp::compute::networks::v1::InsertNetworkRequest const&
            request),
@@ -92,27 +93,27 @@ class MockNetworksConnection : public compute_networks_v1::NetworksConnection {
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       PatchNetwork,
       (google::cloud::cpp::compute::networks::v1::PatchNetworkRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       RemovePeering,
       (google::cloud::cpp::compute::networks::v1::RemovePeeringRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SwitchToCustomMode,
               (google::cloud::cpp::compute::networks::v1::
                    SwitchToCustomModeRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       UpdatePeering,
       (google::cloud::cpp::compute::networks::v1::UpdatePeeringRequest const&
            request),

--- a/google/cloud/compute/node_groups/v1/mocks/mock_node_groups_connection.h
+++ b/google/cloud/compute/node_groups/v1/mocks/mock_node_groups_connection.h
@@ -48,7 +48,7 @@ class MockNodeGroupsConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, AddNodes,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>), AddNodes,
       (google::cloud::cpp::compute::node_groups::v1::AddNodesRequest const&
            request),
       (override));
@@ -62,31 +62,32 @@ class MockNodeGroupsConnection
            AggregatedListNodeGroupsRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteNodeGroup,
               (google::cloud::cpp::compute::node_groups::v1::
                    DeleteNodeGroupRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, DeleteNodes,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
+      DeleteNodes,
       (google::cloud::cpp::compute::node_groups::v1::DeleteNodesRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::NodeGroup>, GetNodeGroup,
+      (StatusOr<google::cloud::cpp::compute::v1::NodeGroup>), GetNodeGroup,
       (google::cloud::cpp::compute::node_groups::v1::GetNodeGroupRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Policy>, GetIamPolicy,
+      (StatusOr<google::cloud::cpp::compute::v1::Policy>), GetIamPolicy,
       (google::cloud::cpp::compute::node_groups::v1::GetIamPolicyRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertNodeGroup,
               (google::cloud::cpp::compute::node_groups::v1::
                    InsertNodeGroupRequest const& request),
@@ -103,32 +104,32 @@ class MockNodeGroupsConnection
       (google::cloud::cpp::compute::node_groups::v1::ListNodesRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchNodeGroup,
               (google::cloud::cpp::compute::node_groups::v1::
                    PatchNodeGroupRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Policy>, SetIamPolicy,
+      (StatusOr<google::cloud::cpp::compute::v1::Policy>), SetIamPolicy,
       (google::cloud::cpp::compute::node_groups::v1::SetIamPolicyRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetNodeTemplate,
               (google::cloud::cpp::compute::node_groups::v1::
                    SetNodeTemplateRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SimulateMaintenanceEvent,
               (google::cloud::cpp::compute::node_groups::v1::
                    SimulateMaintenanceEventRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>),
       TestIamPermissions,
       (google::cloud::cpp::compute::node_groups::v1::
            TestIamPermissionsRequest const& request),

--- a/google/cloud/compute/node_templates/v1/mocks/mock_node_templates_connection.h
+++ b/google/cloud/compute/node_templates/v1/mocks/mock_node_templates_connection.h
@@ -56,24 +56,24 @@ class MockNodeTemplatesConnection
            AggregatedListNodeTemplatesRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteNodeTemplate,
               (google::cloud::cpp::compute::node_templates::v1::
                    DeleteNodeTemplateRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::NodeTemplate>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::NodeTemplate>),
               GetNodeTemplate,
               (google::cloud::cpp::compute::node_templates::v1::
                    GetNodeTemplateRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Policy>), GetIamPolicy,
               (google::cloud::cpp::compute::node_templates::v1::
                    GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertNodeTemplate,
               (google::cloud::cpp::compute::node_templates::v1::
                    InsertNodeTemplateRequest const& request),
@@ -86,13 +86,13 @@ class MockNodeTemplatesConnection
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Policy>), SetIamPolicy,
               (google::cloud::cpp::compute::node_templates::v1::
                    SetIamPolicyRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>),
       TestIamPermissions,
       (google::cloud::cpp::compute::node_templates::v1::
            TestIamPermissionsRequest const& request),

--- a/google/cloud/compute/node_types/v1/mocks/mock_node_types_connection.h
+++ b/google/cloud/compute/node_types/v1/mocks/mock_node_types_connection.h
@@ -56,7 +56,7 @@ class MockNodeTypesConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::NodeType>, GetNodeType,
+      (StatusOr<google::cloud::cpp::compute::v1::NodeType>), GetNodeType,
       (google::cloud::cpp::compute::node_types::v1::GetNodeTypeRequest const&
            request),
       (override));

--- a/google/cloud/compute/packet_mirrorings/v1/mocks/mock_packet_mirrorings_connection.h
+++ b/google/cloud/compute/packet_mirrorings/v1/mocks/mock_packet_mirrorings_connection.h
@@ -55,19 +55,19 @@ class MockPacketMirroringsConnection
            AggregatedListPacketMirroringsRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeletePacketMirroring,
               (google::cloud::cpp::compute::packet_mirrorings::v1::
                    DeletePacketMirroringRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::PacketMirroring>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::PacketMirroring>),
               GetPacketMirroring,
               (google::cloud::cpp::compute::packet_mirrorings::v1::
                    GetPacketMirroringRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertPacketMirroring,
               (google::cloud::cpp::compute::packet_mirrorings::v1::
                    InsertPacketMirroringRequest const& request),
@@ -79,14 +79,14 @@ class MockPacketMirroringsConnection
                    ListPacketMirroringsRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchPacketMirroring,
               (google::cloud::cpp::compute::packet_mirrorings::v1::
                    PatchPacketMirroringRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>),
       TestIamPermissions,
       (google::cloud::cpp::compute::packet_mirrorings::v1::
            TestIamPermissionsRequest const& request),

--- a/google/cloud/compute/projects/v1/mocks/mock_projects_connection.h
+++ b/google/cloud/compute/projects/v1/mocks/mock_projects_connection.h
@@ -47,45 +47,45 @@ class MockProjectsConnection : public compute_projects_v1::ProjectsConnection {
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       DisableXpnHost,
       (google::cloud::cpp::compute::projects::v1::DisableXpnHostRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DisableXpnResource,
               (google::cloud::cpp::compute::projects::v1::
                    DisableXpnResourceRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       EnableXpnHost,
       (google::cloud::cpp::compute::projects::v1::EnableXpnHostRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               EnableXpnResource,
               (google::cloud::cpp::compute::projects::v1::
                    EnableXpnResourceRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Project>, GetProject,
+      (StatusOr<google::cloud::cpp::compute::v1::Project>), GetProject,
       (google::cloud::cpp::compute::projects::v1::GetProjectRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Project>, GetXpnHost,
+      (StatusOr<google::cloud::cpp::compute::v1::Project>), GetXpnHost,
       (google::cloud::cpp::compute::projects::v1::GetXpnHostRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::ProjectsGetXpnResources>,
+      (StatusOr<google::cloud::cpp::compute::v1::ProjectsGetXpnResources>),
       GetXpnResources,
       (google::cloud::cpp::compute::projects::v1::GetXpnResourcesRequest const&
            request),
@@ -96,38 +96,38 @@ class MockProjectsConnection : public compute_projects_v1::ProjectsConnection {
       (google::cloud::cpp::compute::projects::v1::ListXpnHostsRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               MoveDisk,
               (google::cloud::cpp::compute::projects::v1::MoveDiskRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       MoveInstance,
       (google::cloud::cpp::compute::projects::v1::MoveInstanceRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetCloudArmorTier,
               (google::cloud::cpp::compute::projects::v1::
                    SetCloudArmorTierRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetCommonInstanceMetadata,
               (google::cloud::cpp::compute::projects::v1::
                    SetCommonInstanceMetadataRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetDefaultNetworkTier,
               (google::cloud::cpp::compute::projects::v1::
                    SetDefaultNetworkTierRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetUsageExportBucket,
               (google::cloud::cpp::compute::projects::v1::
                    SetUsageExportBucketRequest const& request),

--- a/google/cloud/compute/public_advertised_prefixes/v1/mocks/mock_public_advertised_prefixes_connection.h
+++ b/google/cloud/compute/public_advertised_prefixes/v1/mocks/mock_public_advertised_prefixes_connection.h
@@ -49,25 +49,26 @@ class MockPublicAdvertisedPrefixesConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               Announce,
               (google::cloud::cpp::compute::public_advertised_prefixes::v1::
                    AnnounceRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeletePublicAdvertisedPrefix,
               (google::cloud::cpp::compute::public_advertised_prefixes::v1::
                    DeletePublicAdvertisedPrefixRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::PublicAdvertisedPrefix>,
-              GetPublicAdvertisedPrefix,
-              (google::cloud::cpp::compute::public_advertised_prefixes::v1::
-                   GetPublicAdvertisedPrefixRequest const& request),
-              (override));
+  MOCK_METHOD(
+      (StatusOr<google::cloud::cpp::compute::v1::PublicAdvertisedPrefix>),
+      GetPublicAdvertisedPrefix,
+      (google::cloud::cpp::compute::public_advertised_prefixes::v1::
+           GetPublicAdvertisedPrefixRequest const& request),
+      (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertPublicAdvertisedPrefix,
               (google::cloud::cpp::compute::public_advertised_prefixes::v1::
                    InsertPublicAdvertisedPrefixRequest const& request),
@@ -80,13 +81,13 @@ class MockPublicAdvertisedPrefixesConnection
            ListPublicAdvertisedPrefixesRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchPublicAdvertisedPrefix,
               (google::cloud::cpp::compute::public_advertised_prefixes::v1::
                    PatchPublicAdvertisedPrefixRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               Withdraw,
               (google::cloud::cpp::compute::public_advertised_prefixes::v1::
                    WithdrawRequest const& request),

--- a/google/cloud/compute/public_delegated_prefixes/v1/mocks/mock_public_delegated_prefixes_connection.h
+++ b/google/cloud/compute/public_delegated_prefixes/v1/mocks/mock_public_delegated_prefixes_connection.h
@@ -57,25 +57,26 @@ class MockPublicDelegatedPrefixesConnection
                    AggregatedListPublicDelegatedPrefixesRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               Announce,
               (google::cloud::cpp::compute::public_delegated_prefixes::v1::
                    AnnounceRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeletePublicDelegatedPrefix,
               (google::cloud::cpp::compute::public_delegated_prefixes::v1::
                    DeletePublicDelegatedPrefixRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::PublicDelegatedPrefix>,
-              GetPublicDelegatedPrefix,
-              (google::cloud::cpp::compute::public_delegated_prefixes::v1::
-                   GetPublicDelegatedPrefixRequest const& request),
-              (override));
+  MOCK_METHOD(
+      (StatusOr<google::cloud::cpp::compute::v1::PublicDelegatedPrefix>),
+      GetPublicDelegatedPrefix,
+      (google::cloud::cpp::compute::public_delegated_prefixes::v1::
+           GetPublicDelegatedPrefixRequest const& request),
+      (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertPublicDelegatedPrefix,
               (google::cloud::cpp::compute::public_delegated_prefixes::v1::
                    InsertPublicDelegatedPrefixRequest const& request),
@@ -88,13 +89,13 @@ class MockPublicDelegatedPrefixesConnection
            ListPublicDelegatedPrefixesRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchPublicDelegatedPrefix,
               (google::cloud::cpp::compute::public_delegated_prefixes::v1::
                    PatchPublicDelegatedPrefixRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               Withdraw,
               (google::cloud::cpp::compute::public_delegated_prefixes::v1::
                    WithdrawRequest const& request),

--- a/google/cloud/compute/region_autoscalers/v1/mocks/mock_region_autoscalers_connection.h
+++ b/google/cloud/compute/region_autoscalers/v1/mocks/mock_region_autoscalers_connection.h
@@ -47,19 +47,19 @@ class MockRegionAutoscalersConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteAutoscaler,
               (google::cloud::cpp::compute::region_autoscalers::v1::
                    DeleteAutoscalerRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Autoscaler>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Autoscaler>),
               GetAutoscaler,
               (google::cloud::cpp::compute::region_autoscalers::v1::
                    GetAutoscalerRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertAutoscaler,
               (google::cloud::cpp::compute::region_autoscalers::v1::
                    InsertAutoscalerRequest const& request),
@@ -71,13 +71,13 @@ class MockRegionAutoscalersConnection
                    ListRegionAutoscalersRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchAutoscaler,
               (google::cloud::cpp::compute::region_autoscalers::v1::
                    PatchAutoscalerRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               UpdateAutoscaler,
               (google::cloud::cpp::compute::region_autoscalers::v1::
                    UpdateAutoscalerRequest const& request),

--- a/google/cloud/compute/region_backend_services/v1/mocks/mock_region_backend_services_connection.h
+++ b/google/cloud/compute/region_backend_services/v1/mocks/mock_region_backend_services_connection.h
@@ -49,31 +49,31 @@ class MockRegionBackendServicesConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteBackendService,
               (google::cloud::cpp::compute::region_backend_services::v1::
                    DeleteBackendServiceRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::BackendService>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::BackendService>),
               GetBackendService,
               (google::cloud::cpp::compute::region_backend_services::v1::
                    GetBackendServiceRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::BackendServiceGroupHealth>,
+      (StatusOr<google::cloud::cpp::compute::v1::BackendServiceGroupHealth>),
       GetHealth,
       (google::cloud::cpp::compute::region_backend_services::v1::
            GetHealthRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Policy>), GetIamPolicy,
               (google::cloud::cpp::compute::region_backend_services::v1::
                    GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertBackendService,
               (google::cloud::cpp::compute::region_backend_services::v1::
                    InsertBackendServiceRequest const& request),
@@ -91,31 +91,31 @@ class MockRegionBackendServicesConnection
                    ListUsableRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchBackendService,
               (google::cloud::cpp::compute::region_backend_services::v1::
                    PatchBackendServiceRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Policy>), SetIamPolicy,
               (google::cloud::cpp::compute::region_backend_services::v1::
                    SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetSecurityPolicy,
               (google::cloud::cpp::compute::region_backend_services::v1::
                    SetSecurityPolicyRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>),
       TestIamPermissions,
       (google::cloud::cpp::compute::region_backend_services::v1::
            TestIamPermissionsRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               UpdateBackendService,
               (google::cloud::cpp::compute::region_backend_services::v1::
                    UpdateBackendServiceRequest const& request),

--- a/google/cloud/compute/region_commitments/v1/mocks/mock_region_commitments_connection.h
+++ b/google/cloud/compute/region_commitments/v1/mocks/mock_region_commitments_connection.h
@@ -56,13 +56,13 @@ class MockRegionCommitmentsConnection
            AggregatedListRegionCommitmentsRequest request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Commitment>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Commitment>),
               GetCommitment,
               (google::cloud::cpp::compute::region_commitments::v1::
                    GetCommitmentRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertCommitment,
               (google::cloud::cpp::compute::region_commitments::v1::
                    InsertCommitmentRequest const& request),
@@ -74,7 +74,7 @@ class MockRegionCommitmentsConnection
                    ListRegionCommitmentsRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               UpdateCommitment,
               (google::cloud::cpp::compute::region_commitments::v1::
                    UpdateCommitmentRequest const& request),

--- a/google/cloud/compute/region_disk_types/v1/mocks/mock_region_disk_types_connection.h
+++ b/google/cloud/compute/region_disk_types/v1/mocks/mock_region_disk_types_connection.h
@@ -47,7 +47,8 @@ class MockRegionDiskTypesConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::DiskType>, GetDiskType,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::DiskType>),
+              GetDiskType,
               (google::cloud::cpp::compute::region_disk_types::v1::
                    GetDiskTypeRequest const& request),
               (override));

--- a/google/cloud/compute/region_disks/v1/mocks/mock_region_disks_connection.h
+++ b/google/cloud/compute/region_disks/v1/mocks/mock_region_disks_connection.h
@@ -47,44 +47,47 @@ class MockRegionDisksConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               AddResourcePolicies,
               (google::cloud::cpp::compute::region_disks::v1::
                    AddResourcePoliciesRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, BulkInsert,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
+      BulkInsert,
       (google::cloud::cpp::compute::region_disks::v1::BulkInsertRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               CreateSnapshot,
               (google::cloud::cpp::compute::region_disks::v1::
                    CreateSnapshotRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, DeleteDisk,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
+      DeleteDisk,
       (google::cloud::cpp::compute::region_disks::v1::DeleteDiskRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Disk>, GetDisk,
+      (StatusOr<google::cloud::cpp::compute::v1::Disk>), GetDisk,
       (google::cloud::cpp::compute::region_disks::v1::GetDiskRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Policy>, GetIamPolicy,
+      (StatusOr<google::cloud::cpp::compute::v1::Policy>), GetIamPolicy,
       (google::cloud::cpp::compute::region_disks::v1::GetIamPolicyRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, InsertDisk,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
+      InsertDisk,
       (google::cloud::cpp::compute::region_disks::v1::InsertDiskRequest const&
            request),
       (override));
@@ -95,57 +98,58 @@ class MockRegionDisksConnection
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               RemoveResourcePolicies,
               (google::cloud::cpp::compute::region_disks::v1::
                    RemoveResourcePoliciesRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, Resize,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>), Resize,
       (google::cloud::cpp::compute::region_disks::v1::ResizeRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Policy>, SetIamPolicy,
+      (StatusOr<google::cloud::cpp::compute::v1::Policy>), SetIamPolicy,
       (google::cloud::cpp::compute::region_disks::v1::SetIamPolicyRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, SetLabels,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>), SetLabels,
       (google::cloud::cpp::compute::region_disks::v1::SetLabelsRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               StartAsyncReplication,
               (google::cloud::cpp::compute::region_disks::v1::
                    StartAsyncReplicationRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               StopAsyncReplication,
               (google::cloud::cpp::compute::region_disks::v1::
                    StopAsyncReplicationRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               StopGroupAsyncReplication,
               (google::cloud::cpp::compute::region_disks::v1::
                    StopGroupAsyncReplicationRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>),
       TestIamPermissions,
       (google::cloud::cpp::compute::region_disks::v1::
            TestIamPermissionsRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, UpdateDisk,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
+      UpdateDisk,
       (google::cloud::cpp::compute::region_disks::v1::UpdateDiskRequest const&
            request),
       (override));

--- a/google/cloud/compute/region_health_check_services/v1/mocks/mock_region_health_check_services_connection.h
+++ b/google/cloud/compute/region_health_check_services/v1/mocks/mock_region_health_check_services_connection.h
@@ -49,19 +49,19 @@ class MockRegionHealthCheckServicesConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteHealthCheckService,
               (google::cloud::cpp::compute::region_health_check_services::v1::
                    DeleteHealthCheckServiceRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::HealthCheckService>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::HealthCheckService>),
               GetHealthCheckService,
               (google::cloud::cpp::compute::region_health_check_services::v1::
                    GetHealthCheckServiceRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertHealthCheckService,
               (google::cloud::cpp::compute::region_health_check_services::v1::
                    InsertHealthCheckServiceRequest const& request),
@@ -74,7 +74,7 @@ class MockRegionHealthCheckServicesConnection
            ListRegionHealthCheckServicesRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchHealthCheckService,
               (google::cloud::cpp::compute::region_health_check_services::v1::
                    PatchHealthCheckServiceRequest const& request),

--- a/google/cloud/compute/region_health_checks/v1/mocks/mock_region_health_checks_connection.h
+++ b/google/cloud/compute/region_health_checks/v1/mocks/mock_region_health_checks_connection.h
@@ -48,19 +48,19 @@ class MockRegionHealthChecksConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteHealthCheck,
               (google::cloud::cpp::compute::region_health_checks::v1::
                    DeleteHealthCheckRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::HealthCheck>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::HealthCheck>),
               GetHealthCheck,
               (google::cloud::cpp::compute::region_health_checks::v1::
                    GetHealthCheckRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertHealthCheck,
               (google::cloud::cpp::compute::region_health_checks::v1::
                    InsertHealthCheckRequest const& request),
@@ -72,13 +72,13 @@ class MockRegionHealthChecksConnection
                    ListRegionHealthChecksRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchHealthCheck,
               (google::cloud::cpp::compute::region_health_checks::v1::
                    PatchHealthCheckRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               UpdateHealthCheck,
               (google::cloud::cpp::compute::region_health_checks::v1::
                    UpdateHealthCheckRequest const& request),

--- a/google/cloud/compute/region_instance_group_managers/v1/mocks/mock_region_instance_group_managers_connection.h
+++ b/google/cloud/compute/region_instance_group_managers/v1/mocks/mock_region_instance_group_managers_connection.h
@@ -49,49 +49,49 @@ class MockRegionInstanceGroupManagersConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               AbandonInstances,
               (google::cloud::cpp::compute::region_instance_group_managers::v1::
                    AbandonInstancesRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               ApplyUpdatesToInstances,
               (google::cloud::cpp::compute::region_instance_group_managers::v1::
                    ApplyUpdatesToInstancesRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               CreateInstances,
               (google::cloud::cpp::compute::region_instance_group_managers::v1::
                    CreateInstancesRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteInstanceGroupManager,
               (google::cloud::cpp::compute::region_instance_group_managers::v1::
                    DeleteInstanceGroupManagerRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteInstances,
               (google::cloud::cpp::compute::region_instance_group_managers::v1::
                    DeleteInstancesRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeletePerInstanceConfigs,
               (google::cloud::cpp::compute::region_instance_group_managers::v1::
                    DeletePerInstanceConfigsRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::InstanceGroupManager>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::InstanceGroupManager>),
               GetInstanceGroupManager,
               (google::cloud::cpp::compute::region_instance_group_managers::v1::
                    GetInstanceGroupManagerRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertInstanceGroupManager,
               (google::cloud::cpp::compute::region_instance_group_managers::v1::
                    InsertInstanceGroupManagerRequest const& request),
@@ -111,8 +111,8 @@ class MockRegionInstanceGroupManagersConnection
            ListErrorsRequest request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::
-                           RegionInstanceGroupManagersListInstancesResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::
+                            RegionInstanceGroupManagersListInstancesResponse>),
               ListManagedInstances,
               (google::cloud::cpp::compute::region_instance_group_managers::v1::
                    ListManagedInstancesRequest const& request),
@@ -124,43 +124,43 @@ class MockRegionInstanceGroupManagersConnection
                    ListPerInstanceConfigsRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchInstanceGroupManager,
               (google::cloud::cpp::compute::region_instance_group_managers::v1::
                    PatchInstanceGroupManagerRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchPerInstanceConfigs,
               (google::cloud::cpp::compute::region_instance_group_managers::v1::
                    PatchPerInstanceConfigsRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               RecreateInstances,
               (google::cloud::cpp::compute::region_instance_group_managers::v1::
                    RecreateInstancesRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               Resize,
               (google::cloud::cpp::compute::region_instance_group_managers::v1::
                    ResizeRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetInstanceTemplate,
               (google::cloud::cpp::compute::region_instance_group_managers::v1::
                    SetInstanceTemplateRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetTargetPools,
               (google::cloud::cpp::compute::region_instance_group_managers::v1::
                    SetTargetPoolsRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               UpdatePerInstanceConfigs,
               (google::cloud::cpp::compute::region_instance_group_managers::v1::
                    UpdatePerInstanceConfigsRequest const& request),

--- a/google/cloud/compute/region_instance_groups/v1/mocks/mock_region_instance_groups_connection.h
+++ b/google/cloud/compute/region_instance_groups/v1/mocks/mock_region_instance_groups_connection.h
@@ -48,7 +48,7 @@ class MockRegionInstanceGroupsConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::InstanceGroup>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::InstanceGroup>),
               GetInstanceGroup,
               (google::cloud::cpp::compute::region_instance_groups::v1::
                    GetInstanceGroupRequest const& request),
@@ -67,7 +67,7 @@ class MockRegionInstanceGroupsConnection
            ListInstancesRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetNamedPorts,
               (google::cloud::cpp::compute::region_instance_groups::v1::
                    SetNamedPortsRequest const& request),

--- a/google/cloud/compute/region_instance_templates/v1/mocks/mock_region_instance_templates_connection.h
+++ b/google/cloud/compute/region_instance_templates/v1/mocks/mock_region_instance_templates_connection.h
@@ -49,19 +49,19 @@ class MockRegionInstanceTemplatesConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteInstanceTemplate,
               (google::cloud::cpp::compute::region_instance_templates::v1::
                    DeleteInstanceTemplateRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::InstanceTemplate>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::InstanceTemplate>),
               GetInstanceTemplate,
               (google::cloud::cpp::compute::region_instance_templates::v1::
                    GetInstanceTemplateRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertInstanceTemplate,
               (google::cloud::cpp::compute::region_instance_templates::v1::
                    InsertInstanceTemplateRequest const& request),

--- a/google/cloud/compute/region_instances/v1/mocks/mock_region_instances_connection.h
+++ b/google/cloud/compute/region_instances/v1/mocks/mock_region_instances_connection.h
@@ -47,7 +47,7 @@ class MockRegionInstancesConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               BulkInsert,
               (google::cloud::cpp::compute::region_instances::v1::
                    BulkInsertRequest const& request),

--- a/google/cloud/compute/region_network_endpoint_groups/v1/mocks/mock_region_network_endpoint_groups_connection.h
+++ b/google/cloud/compute/region_network_endpoint_groups/v1/mocks/mock_region_network_endpoint_groups_connection.h
@@ -49,31 +49,31 @@ class MockRegionNetworkEndpointGroupsConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               AttachNetworkEndpoints,
               (google::cloud::cpp::compute::region_network_endpoint_groups::v1::
                    AttachNetworkEndpointsRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteNetworkEndpointGroup,
               (google::cloud::cpp::compute::region_network_endpoint_groups::v1::
                    DeleteNetworkEndpointGroupRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DetachNetworkEndpoints,
               (google::cloud::cpp::compute::region_network_endpoint_groups::v1::
                    DetachNetworkEndpointsRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::NetworkEndpointGroup>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::NetworkEndpointGroup>),
               GetNetworkEndpointGroup,
               (google::cloud::cpp::compute::region_network_endpoint_groups::v1::
                    GetNetworkEndpointGroupRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertNetworkEndpointGroup,
               (google::cloud::cpp::compute::region_network_endpoint_groups::v1::
                    InsertNetworkEndpointGroupRequest const& request),

--- a/google/cloud/compute/region_network_firewall_policies/v1/mocks/mock_region_network_firewall_policies_connection.h
+++ b/google/cloud/compute/region_network_firewall_policies/v1/mocks/mock_region_network_firewall_policies_connection.h
@@ -49,63 +49,64 @@ class MockRegionNetworkFirewallPoliciesConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               AddAssociation,
               (google::cloud::cpp::compute::region_network_firewall_policies::
                    v1::AddAssociationRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               AddRule,
               (google::cloud::cpp::compute::region_network_firewall_policies::
                    v1::AddRuleRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               CloneRules,
               (google::cloud::cpp::compute::region_network_firewall_policies::
                    v1::CloneRulesRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteFirewallPolicy,
               (google::cloud::cpp::compute::region_network_firewall_policies::
                    v1::DeleteFirewallPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::FirewallPolicy>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::FirewallPolicy>),
               GetFirewallPolicy,
               (google::cloud::cpp::compute::region_network_firewall_policies::
                    v1::GetFirewallPolicyRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::FirewallPolicyAssociation>,
+      (StatusOr<google::cloud::cpp::compute::v1::FirewallPolicyAssociation>),
       GetAssociation,
       (google::cloud::cpp::compute::region_network_firewall_policies::v1::
            GetAssociationRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::
-                   RegionNetworkFirewallPoliciesGetEffectiveFirewallsResponse>,
+      (StatusOr<
+          google::cloud::cpp::compute::v1::
+              RegionNetworkFirewallPoliciesGetEffectiveFirewallsResponse>),
       GetEffectiveFirewalls,
       (google::cloud::cpp::compute::region_network_firewall_policies::v1::
            GetEffectiveFirewallsRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Policy>), GetIamPolicy,
               (google::cloud::cpp::compute::region_network_firewall_policies::
                    v1::GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::FirewallPolicyRule>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::FirewallPolicyRule>),
               GetRule,
               (google::cloud::cpp::compute::region_network_firewall_policies::
                    v1::GetRuleRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertFirewallPolicy,
               (google::cloud::cpp::compute::region_network_firewall_policies::
                    v1::InsertFirewallPolicyRequest const& request),
@@ -117,37 +118,37 @@ class MockRegionNetworkFirewallPoliciesConnection
                    v1::ListRegionNetworkFirewallPoliciesRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchFirewallPolicy,
               (google::cloud::cpp::compute::region_network_firewall_policies::
                    v1::PatchFirewallPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchRule,
               (google::cloud::cpp::compute::region_network_firewall_policies::
                    v1::PatchRuleRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               RemoveAssociation,
               (google::cloud::cpp::compute::region_network_firewall_policies::
                    v1::RemoveAssociationRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               RemoveRule,
               (google::cloud::cpp::compute::region_network_firewall_policies::
                    v1::RemoveRuleRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Policy>), SetIamPolicy,
               (google::cloud::cpp::compute::region_network_firewall_policies::
                    v1::SetIamPolicyRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>),
       TestIamPermissions,
       (google::cloud::cpp::compute::region_network_firewall_policies::v1::
            TestIamPermissionsRequest const& request),

--- a/google/cloud/compute/region_notification_endpoints/v1/mocks/mock_region_notification_endpoints_connection.h
+++ b/google/cloud/compute/region_notification_endpoints/v1/mocks/mock_region_notification_endpoints_connection.h
@@ -49,19 +49,19 @@ class MockRegionNotificationEndpointsConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteNotificationEndpoint,
               (google::cloud::cpp::compute::region_notification_endpoints::v1::
                    DeleteNotificationEndpointRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::NotificationEndpoint>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::NotificationEndpoint>),
               GetNotificationEndpoint,
               (google::cloud::cpp::compute::region_notification_endpoints::v1::
                    GetNotificationEndpointRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertNotificationEndpoint,
               (google::cloud::cpp::compute::region_notification_endpoints::v1::
                    InsertNotificationEndpointRequest const& request),

--- a/google/cloud/compute/region_operations/v1/mocks/mock_region_operations_connection.h
+++ b/google/cloud/compute/region_operations/v1/mocks/mock_region_operations_connection.h
@@ -52,7 +52,7 @@ class MockRegionOperationsConnection
                    DeleteOperationRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Operation>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Operation>),
               GetOperation,
               (google::cloud::cpp::compute::region_operations::v1::
                    GetOperationRequest const& request),
@@ -65,7 +65,7 @@ class MockRegionOperationsConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Operation>, Wait,
+      (StatusOr<google::cloud::cpp::compute::v1::Operation>), Wait,
       (google::cloud::cpp::compute::region_operations::v1::WaitRequest const&
            request),
       (override));

--- a/google/cloud/compute/region_security_policies/v1/mocks/mock_region_security_policies_connection.h
+++ b/google/cloud/compute/region_security_policies/v1/mocks/mock_region_security_policies_connection.h
@@ -49,31 +49,31 @@ class MockRegionSecurityPoliciesConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               AddRule,
               (google::cloud::cpp::compute::region_security_policies::v1::
                    AddRuleRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteSecurityPolicy,
               (google::cloud::cpp::compute::region_security_policies::v1::
                    DeleteSecurityPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::SecurityPolicy>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::SecurityPolicy>),
               GetSecurityPolicy,
               (google::cloud::cpp::compute::region_security_policies::v1::
                    GetSecurityPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::SecurityPolicyRule>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::SecurityPolicyRule>),
               GetRule,
               (google::cloud::cpp::compute::region_security_policies::v1::
                    GetRuleRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertSecurityPolicy,
               (google::cloud::cpp::compute::region_security_policies::v1::
                    InsertSecurityPolicyRequest const& request),
@@ -85,19 +85,19 @@ class MockRegionSecurityPoliciesConnection
                    ListRegionSecurityPoliciesRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchSecurityPolicy,
               (google::cloud::cpp::compute::region_security_policies::v1::
                    PatchSecurityPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchRule,
               (google::cloud::cpp::compute::region_security_policies::v1::
                    PatchRuleRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               RemoveRule,
               (google::cloud::cpp::compute::region_security_policies::v1::
                    RemoveRuleRequest const& request),

--- a/google/cloud/compute/region_ssl_certificates/v1/mocks/mock_region_ssl_certificates_connection.h
+++ b/google/cloud/compute/region_ssl_certificates/v1/mocks/mock_region_ssl_certificates_connection.h
@@ -49,19 +49,19 @@ class MockRegionSslCertificatesConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteSslCertificate,
               (google::cloud::cpp::compute::region_ssl_certificates::v1::
                    DeleteSslCertificateRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::SslCertificate>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::SslCertificate>),
               GetSslCertificate,
               (google::cloud::cpp::compute::region_ssl_certificates::v1::
                    GetSslCertificateRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertSslCertificate,
               (google::cloud::cpp::compute::region_ssl_certificates::v1::
                    InsertSslCertificateRequest const& request),

--- a/google/cloud/compute/region_ssl_policies/v1/mocks/mock_region_ssl_policies_connection.h
+++ b/google/cloud/compute/region_ssl_policies/v1/mocks/mock_region_ssl_policies_connection.h
@@ -47,19 +47,19 @@ class MockRegionSslPoliciesConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteSslPolicy,
               (google::cloud::cpp::compute::region_ssl_policies::v1::
                    DeleteSslPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::SslPolicy>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::SslPolicy>),
               GetSslPolicy,
               (google::cloud::cpp::compute::region_ssl_policies::v1::
                    GetSslPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertSslPolicy,
               (google::cloud::cpp::compute::region_ssl_policies::v1::
                    InsertSslPolicyRequest const& request),
@@ -71,14 +71,14 @@ class MockRegionSslPoliciesConnection
                    ListRegionSslPoliciesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::
-                           SslPoliciesListAvailableFeaturesResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::
+                            SslPoliciesListAvailableFeaturesResponse>),
               ListAvailableFeatures,
               (google::cloud::cpp::compute::region_ssl_policies::v1::
                    ListAvailableFeaturesRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchSslPolicy,
               (google::cloud::cpp::compute::region_ssl_policies::v1::
                    PatchSslPolicyRequest const& request),

--- a/google/cloud/compute/region_target_http_proxies/v1/mocks/mock_region_target_http_proxies_connection.h
+++ b/google/cloud/compute/region_target_http_proxies/v1/mocks/mock_region_target_http_proxies_connection.h
@@ -49,19 +49,19 @@ class MockRegionTargetHttpProxiesConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteTargetHttpProxy,
               (google::cloud::cpp::compute::region_target_http_proxies::v1::
                    DeleteTargetHttpProxyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::TargetHttpProxy>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::TargetHttpProxy>),
               GetTargetHttpProxy,
               (google::cloud::cpp::compute::region_target_http_proxies::v1::
                    GetTargetHttpProxyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertTargetHttpProxy,
               (google::cloud::cpp::compute::region_target_http_proxies::v1::
                    InsertTargetHttpProxyRequest const& request),
@@ -73,7 +73,7 @@ class MockRegionTargetHttpProxiesConnection
                    ListRegionTargetHttpProxiesRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetUrlMap,
               (google::cloud::cpp::compute::region_target_http_proxies::v1::
                    SetUrlMapRequest const& request),

--- a/google/cloud/compute/region_target_https_proxies/v1/mocks/mock_region_target_https_proxies_connection.h
+++ b/google/cloud/compute/region_target_https_proxies/v1/mocks/mock_region_target_https_proxies_connection.h
@@ -49,19 +49,19 @@ class MockRegionTargetHttpsProxiesConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteTargetHttpsProxy,
               (google::cloud::cpp::compute::region_target_https_proxies::v1::
                    DeleteTargetHttpsProxyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::TargetHttpsProxy>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::TargetHttpsProxy>),
               GetTargetHttpsProxy,
               (google::cloud::cpp::compute::region_target_https_proxies::v1::
                    GetTargetHttpsProxyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertTargetHttpsProxy,
               (google::cloud::cpp::compute::region_target_https_proxies::v1::
                    InsertTargetHttpsProxyRequest const& request),
@@ -73,19 +73,19 @@ class MockRegionTargetHttpsProxiesConnection
                    ListRegionTargetHttpsProxiesRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchTargetHttpsProxy,
               (google::cloud::cpp::compute::region_target_https_proxies::v1::
                    PatchTargetHttpsProxyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetSslCertificates,
               (google::cloud::cpp::compute::region_target_https_proxies::v1::
                    SetSslCertificatesRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetUrlMap,
               (google::cloud::cpp::compute::region_target_https_proxies::v1::
                    SetUrlMapRequest const& request),

--- a/google/cloud/compute/region_target_tcp_proxies/v1/mocks/mock_region_target_tcp_proxies_connection.h
+++ b/google/cloud/compute/region_target_tcp_proxies/v1/mocks/mock_region_target_tcp_proxies_connection.h
@@ -49,19 +49,19 @@ class MockRegionTargetTcpProxiesConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteTargetTcpProxy,
               (google::cloud::cpp::compute::region_target_tcp_proxies::v1::
                    DeleteTargetTcpProxyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::TargetTcpProxy>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::TargetTcpProxy>),
               GetTargetTcpProxy,
               (google::cloud::cpp::compute::region_target_tcp_proxies::v1::
                    GetTargetTcpProxyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertTargetTcpProxy,
               (google::cloud::cpp::compute::region_target_tcp_proxies::v1::
                    InsertTargetTcpProxyRequest const& request),

--- a/google/cloud/compute/region_url_maps/v1/mocks/mock_region_url_maps_connection.h
+++ b/google/cloud/compute/region_url_maps/v1/mocks/mock_region_url_maps_connection.h
@@ -47,19 +47,19 @@ class MockRegionUrlMapsConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteUrlMap,
               (google::cloud::cpp::compute::region_url_maps::v1::
                    DeleteUrlMapRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::UrlMap>, GetUrlMap,
+      (StatusOr<google::cloud::cpp::compute::v1::UrlMap>), GetUrlMap,
       (google::cloud::cpp::compute::region_url_maps::v1::GetUrlMapRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertUrlMap,
               (google::cloud::cpp::compute::region_url_maps::v1::
                    InsertUrlMapRequest const& request),
@@ -71,20 +71,20 @@ class MockRegionUrlMapsConnection
                    ListRegionUrlMapsRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchUrlMap,
               (google::cloud::cpp::compute::region_url_maps::v1::
                    PatchUrlMapRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               UpdateUrlMap,
               (google::cloud::cpp::compute::region_url_maps::v1::
                    UpdateUrlMapRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::UrlMapsValidateResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::UrlMapsValidateResponse>),
       Validate,
       (google::cloud::cpp::compute::region_url_maps::v1::ValidateRequest const&
            request),

--- a/google/cloud/compute/regions/v1/mocks/mock_regions_connection.h
+++ b/google/cloud/compute/regions/v1/mocks/mock_regions_connection.h
@@ -46,7 +46,7 @@ class MockRegionsConnection : public compute_regions_v1::RegionsConnection {
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Region>, GetRegion,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Region>), GetRegion,
               (google::cloud::cpp::compute::regions::v1::GetRegionRequest const&
                    request),
               (override));

--- a/google/cloud/compute/reservations/v1/mocks/mock_reservations_connection.h
+++ b/google/cloud/compute/reservations/v1/mocks/mock_reservations_connection.h
@@ -56,25 +56,25 @@ class MockReservationsConnection
            AggregatedListReservationsRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteReservation,
               (google::cloud::cpp::compute::reservations::v1::
                    DeleteReservationRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Reservation>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Reservation>),
               GetReservation,
               (google::cloud::cpp::compute::reservations::v1::
                    GetReservationRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Policy>, GetIamPolicy,
+      (StatusOr<google::cloud::cpp::compute::v1::Policy>), GetIamPolicy,
       (google::cloud::cpp::compute::reservations::v1::GetIamPolicyRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertReservation,
               (google::cloud::cpp::compute::reservations::v1::
                    InsertReservationRequest const& request),
@@ -88,25 +88,25 @@ class MockReservationsConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, Resize,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>), Resize,
       (google::cloud::cpp::compute::reservations::v1::ResizeRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Policy>, SetIamPolicy,
+      (StatusOr<google::cloud::cpp::compute::v1::Policy>), SetIamPolicy,
       (google::cloud::cpp::compute::reservations::v1::SetIamPolicyRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>),
       TestIamPermissions,
       (google::cloud::cpp::compute::reservations::v1::
            TestIamPermissionsRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               UpdateReservation,
               (google::cloud::cpp::compute::reservations::v1::
                    UpdateReservationRequest const& request),

--- a/google/cloud/compute/resource_policies/v1/mocks/mock_resource_policies_connection.h
+++ b/google/cloud/compute/resource_policies/v1/mocks/mock_resource_policies_connection.h
@@ -55,24 +55,24 @@ class MockResourcePoliciesConnection
            AggregatedListResourcePoliciesRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteResourcePolicy,
               (google::cloud::cpp::compute::resource_policies::v1::
                    DeleteResourcePolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::ResourcePolicy>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::ResourcePolicy>),
               GetResourcePolicy,
               (google::cloud::cpp::compute::resource_policies::v1::
                    GetResourcePolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Policy>), GetIamPolicy,
               (google::cloud::cpp::compute::resource_policies::v1::
                    GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertResourcePolicy,
               (google::cloud::cpp::compute::resource_policies::v1::
                    InsertResourcePolicyRequest const& request),
@@ -84,19 +84,19 @@ class MockResourcePoliciesConnection
                    ListResourcePoliciesRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchResourcePolicy,
               (google::cloud::cpp::compute::resource_policies::v1::
                    PatchResourcePolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Policy>), SetIamPolicy,
               (google::cloud::cpp::compute::resource_policies::v1::
                    SetIamPolicyRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>),
       TestIamPermissions,
       (google::cloud::cpp::compute::resource_policies::v1::
            TestIamPermissionsRequest const& request),

--- a/google/cloud/compute/routers/v1/mocks/mock_routers_connection.h
+++ b/google/cloud/compute/routers/v1/mocks/mock_routers_connection.h
@@ -55,40 +55,40 @@ class MockRoutersConnection : public compute_routers_v1::RoutersConnection {
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       DeleteRouter,
       (google::cloud::cpp::compute::routers::v1::DeleteRouterRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Router>, GetRouter,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Router>), GetRouter,
               (google::cloud::cpp::compute::routers::v1::GetRouterRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::NatIpInfoResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::NatIpInfoResponse>),
       GetNatIpInfo,
       (google::cloud::cpp::compute::routers::v1::GetNatIpInfoRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::VmEndpointNatMappingsList>,
+      (StatusOr<google::cloud::cpp::compute::v1::VmEndpointNatMappingsList>),
       GetNatMappingInfo,
       (google::cloud::cpp::compute::routers::v1::GetNatMappingInfoRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::RouterStatusResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::RouterStatusResponse>),
       GetRouterStatus,
       (google::cloud::cpp::compute::routers::v1::GetRouterStatusRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       InsertRouter,
       (google::cloud::cpp::compute::routers::v1::InsertRouterRequest const&
            request),
@@ -100,19 +100,20 @@ class MockRoutersConnection : public compute_routers_v1::RoutersConnection {
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, PatchRouter,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
+      PatchRouter,
       (google::cloud::cpp::compute::routers::v1::PatchRouterRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::RoutersPreviewResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::RoutersPreviewResponse>),
       Preview,
       (google::cloud::cpp::compute::routers::v1::PreviewRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       UpdateRouter,
       (google::cloud::cpp::compute::routers::v1::UpdateRouterRequest const&
            request),

--- a/google/cloud/compute/routes/v1/mocks/mock_routes_connection.h
+++ b/google/cloud/compute/routes/v1/mocks/mock_routes_connection.h
@@ -47,18 +47,20 @@ class MockRoutesConnection : public compute_routes_v1::RoutesConnection {
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, DeleteRoute,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
+      DeleteRoute,
       (google::cloud::cpp::compute::routes::v1::DeleteRouteRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Route>, GetRoute,
+      (StatusOr<google::cloud::cpp::compute::v1::Route>), GetRoute,
       (google::cloud::cpp::compute::routes::v1::GetRouteRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, InsertRoute,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
+      InsertRoute,
       (google::cloud::cpp::compute::routes::v1::InsertRouteRequest const&
            request),
       (override));

--- a/google/cloud/compute/security_policies/v1/mocks/mock_security_policies_connection.h
+++ b/google/cloud/compute/security_policies/v1/mocks/mock_security_policies_connection.h
@@ -48,7 +48,7 @@ class MockSecurityPoliciesConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, AddRule,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>), AddRule,
       (google::cloud::cpp::compute::security_policies::v1::AddRuleRequest const&
            request),
       (override));
@@ -61,25 +61,25 @@ class MockSecurityPoliciesConnection
            AggregatedListSecurityPoliciesRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteSecurityPolicy,
               (google::cloud::cpp::compute::security_policies::v1::
                    DeleteSecurityPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::SecurityPolicy>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::SecurityPolicy>),
               GetSecurityPolicy,
               (google::cloud::cpp::compute::security_policies::v1::
                    GetSecurityPolicyRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::SecurityPolicyRule>, GetRule,
+      (StatusOr<google::cloud::cpp::compute::v1::SecurityPolicyRule>), GetRule,
       (google::cloud::cpp::compute::security_policies::v1::GetRuleRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertSecurityPolicy,
               (google::cloud::cpp::compute::security_policies::v1::
                    InsertSecurityPolicyRequest const& request),
@@ -92,32 +92,32 @@ class MockSecurityPoliciesConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::
-                   SecurityPoliciesListPreconfiguredExpressionSetsResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::
+                    SecurityPoliciesListPreconfiguredExpressionSetsResponse>),
       ListPreconfiguredExpressionSets,
       (google::cloud::cpp::compute::security_policies::v1::
            ListPreconfiguredExpressionSetsRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchSecurityPolicy,
               (google::cloud::cpp::compute::security_policies::v1::
                    PatchSecurityPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchRule,
               (google::cloud::cpp::compute::security_policies::v1::
                    PatchRuleRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               RemoveRule,
               (google::cloud::cpp::compute::security_policies::v1::
                    RemoveRuleRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetLabels,
               (google::cloud::cpp::compute::security_policies::v1::
                    SetLabelsRequest const& request),

--- a/google/cloud/compute/service_attachments/v1/mocks/mock_service_attachments_connection.h
+++ b/google/cloud/compute/service_attachments/v1/mocks/mock_service_attachments_connection.h
@@ -55,24 +55,24 @@ class MockServiceAttachmentsConnection
            AggregatedListServiceAttachmentsRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteServiceAttachment,
               (google::cloud::cpp::compute::service_attachments::v1::
                    DeleteServiceAttachmentRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::ServiceAttachment>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::ServiceAttachment>),
               GetServiceAttachment,
               (google::cloud::cpp::compute::service_attachments::v1::
                    GetServiceAttachmentRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Policy>), GetIamPolicy,
               (google::cloud::cpp::compute::service_attachments::v1::
                    GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertServiceAttachment,
               (google::cloud::cpp::compute::service_attachments::v1::
                    InsertServiceAttachmentRequest const& request),
@@ -84,19 +84,19 @@ class MockServiceAttachmentsConnection
                    ListServiceAttachmentsRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchServiceAttachment,
               (google::cloud::cpp::compute::service_attachments::v1::
                    PatchServiceAttachmentRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Policy>), SetIamPolicy,
               (google::cloud::cpp::compute::service_attachments::v1::
                    SetIamPolicyRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>),
       TestIamPermissions,
       (google::cloud::cpp::compute::service_attachments::v1::
            TestIamPermissionsRequest const& request),

--- a/google/cloud/compute/snapshot_settings/v1/mocks/mock_snapshot_settings_connection.h
+++ b/google/cloud/compute/snapshot_settings/v1/mocks/mock_snapshot_settings_connection.h
@@ -47,13 +47,13 @@ class MockSnapshotSettingsConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::SnapshotSettings>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::SnapshotSettings>),
               GetSnapshotSettings,
               (google::cloud::cpp::compute::snapshot_settings::v1::
                    GetSnapshotSettingsRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchSnapshotSettings,
               (google::cloud::cpp::compute::snapshot_settings::v1::
                    PatchSnapshotSettingsRequest const& request),

--- a/google/cloud/compute/snapshots/v1/mocks/mock_snapshots_connection.h
+++ b/google/cloud/compute/snapshots/v1/mocks/mock_snapshots_connection.h
@@ -48,26 +48,26 @@ class MockSnapshotsConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       DeleteSnapshot,
       (google::cloud::cpp::compute::snapshots::v1::DeleteSnapshotRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Snapshot>, GetSnapshot,
+      (StatusOr<google::cloud::cpp::compute::v1::Snapshot>), GetSnapshot,
       (google::cloud::cpp::compute::snapshots::v1::GetSnapshotRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Policy>, GetIamPolicy,
+      (StatusOr<google::cloud::cpp::compute::v1::Policy>), GetIamPolicy,
       (google::cloud::cpp::compute::snapshots::v1::GetIamPolicyRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       InsertSnapshot,
       (google::cloud::cpp::compute::snapshots::v1::InsertSnapshotRequest const&
            request),
@@ -80,19 +80,19 @@ class MockSnapshotsConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Policy>, SetIamPolicy,
+      (StatusOr<google::cloud::cpp::compute::v1::Policy>), SetIamPolicy,
       (google::cloud::cpp::compute::snapshots::v1::SetIamPolicyRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, SetLabels,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>), SetLabels,
       (google::cloud::cpp::compute::snapshots::v1::SetLabelsRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>),
       TestIamPermissions,
       (google::cloud::cpp::compute::snapshots::v1::
            TestIamPermissionsRequest const& request),

--- a/google/cloud/compute/ssl_certificates/v1/mocks/mock_ssl_certificates_connection.h
+++ b/google/cloud/compute/ssl_certificates/v1/mocks/mock_ssl_certificates_connection.h
@@ -55,19 +55,19 @@ class MockSslCertificatesConnection
            AggregatedListSslCertificatesRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteSslCertificate,
               (google::cloud::cpp::compute::ssl_certificates::v1::
                    DeleteSslCertificateRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::SslCertificate>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::SslCertificate>),
               GetSslCertificate,
               (google::cloud::cpp::compute::ssl_certificates::v1::
                    GetSslCertificateRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertSslCertificate,
               (google::cloud::cpp::compute::ssl_certificates::v1::
                    InsertSslCertificateRequest const& request),

--- a/google/cloud/compute/ssl_policies/v1/mocks/mock_ssl_policies_connection.h
+++ b/google/cloud/compute/ssl_policies/v1/mocks/mock_ssl_policies_connection.h
@@ -56,19 +56,19 @@ class MockSslPoliciesConnection
            AggregatedListSslPoliciesRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteSslPolicy,
               (google::cloud::cpp::compute::ssl_policies::v1::
                    DeleteSslPolicyRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::SslPolicy>, GetSslPolicy,
+      (StatusOr<google::cloud::cpp::compute::v1::SslPolicy>), GetSslPolicy,
       (google::cloud::cpp::compute::ssl_policies::v1::GetSslPolicyRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertSslPolicy,
               (google::cloud::cpp::compute::ssl_policies::v1::
                    InsertSslPolicyRequest const& request),
@@ -81,14 +81,14 @@ class MockSslPoliciesConnection
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::
-                           SslPoliciesListAvailableFeaturesResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::
+                            SslPoliciesListAvailableFeaturesResponse>),
               ListAvailableFeatures,
               (google::cloud::cpp::compute::ssl_policies::v1::
                    ListAvailableFeaturesRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchSslPolicy,
               (google::cloud::cpp::compute::ssl_policies::v1::
                    PatchSslPolicyRequest const& request),

--- a/google/cloud/compute/storage_pool_types/v1/mocks/mock_storage_pool_types_connection.h
+++ b/google/cloud/compute/storage_pool_types/v1/mocks/mock_storage_pool_types_connection.h
@@ -55,7 +55,7 @@ class MockStoragePoolTypesConnection
            AggregatedListStoragePoolTypesRequest request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::StoragePoolType>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::StoragePoolType>),
               GetStoragePoolType,
               (google::cloud::cpp::compute::storage_pool_types::v1::
                    GetStoragePoolTypeRequest const& request),

--- a/google/cloud/compute/storage_pools/v1/mocks/mock_storage_pools_connection.h
+++ b/google/cloud/compute/storage_pools/v1/mocks/mock_storage_pools_connection.h
@@ -56,24 +56,24 @@ class MockStoragePoolsConnection
            AggregatedListStoragePoolsRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteStoragePool,
               (google::cloud::cpp::compute::storage_pools::v1::
                    DeleteStoragePoolRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::StoragePool>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::StoragePool>),
               GetStoragePool,
               (google::cloud::cpp::compute::storage_pools::v1::
                    GetStoragePoolRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Policy>), GetIamPolicy,
               (google::cloud::cpp::compute::storage_pools::v1::
                    GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertStoragePool,
               (google::cloud::cpp::compute::storage_pools::v1::
                    InsertStoragePoolRequest const& request),
@@ -92,19 +92,19 @@ class MockStoragePoolsConnection
                    request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Policy>), SetIamPolicy,
               (google::cloud::cpp::compute::storage_pools::v1::
                    SetIamPolicyRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>),
       TestIamPermissions,
       (google::cloud::cpp::compute::storage_pools::v1::
            TestIamPermissionsRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               UpdateStoragePool,
               (google::cloud::cpp::compute::storage_pools::v1::
                    UpdateStoragePoolRequest const& request),

--- a/google/cloud/compute/subnetworks/v1/mocks/mock_subnetworks_connection.h
+++ b/google/cloud/compute/subnetworks/v1/mocks/mock_subnetworks_connection.h
@@ -56,31 +56,31 @@ class MockSubnetworksConnection
            AggregatedListSubnetworksRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteSubnetwork,
               (google::cloud::cpp::compute::subnetworks::v1::
                    DeleteSubnetworkRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               ExpandIpCidrRange,
               (google::cloud::cpp::compute::subnetworks::v1::
                    ExpandIpCidrRangeRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Subnetwork>, GetSubnetwork,
+      (StatusOr<google::cloud::cpp::compute::v1::Subnetwork>), GetSubnetwork,
       (google::cloud::cpp::compute::subnetworks::v1::GetSubnetworkRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Policy>, GetIamPolicy,
+      (StatusOr<google::cloud::cpp::compute::v1::Policy>), GetIamPolicy,
       (google::cloud::cpp::compute::subnetworks::v1::GetIamPolicyRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertSubnetwork,
               (google::cloud::cpp::compute::subnetworks::v1::
                    InsertSubnetworkRequest const& request),
@@ -99,26 +99,26 @@ class MockSubnetworksConnection
       (google::cloud::cpp::compute::subnetworks::v1::ListUsableRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchSubnetwork,
               (google::cloud::cpp::compute::subnetworks::v1::
                    PatchSubnetworkRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Policy>, SetIamPolicy,
+      (StatusOr<google::cloud::cpp::compute::v1::Policy>), SetIamPolicy,
       (google::cloud::cpp::compute::subnetworks::v1::SetIamPolicyRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetPrivateIpGoogleAccess,
               (google::cloud::cpp::compute::subnetworks::v1::
                    SetPrivateIpGoogleAccessRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>),
       TestIamPermissions,
       (google::cloud::cpp::compute::subnetworks::v1::
            TestIamPermissionsRequest const& request),

--- a/google/cloud/compute/target_grpc_proxies/v1/mocks/mock_target_grpc_proxies_connection.h
+++ b/google/cloud/compute/target_grpc_proxies/v1/mocks/mock_target_grpc_proxies_connection.h
@@ -47,19 +47,19 @@ class MockTargetGrpcProxiesConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteTargetGrpcProxy,
               (google::cloud::cpp::compute::target_grpc_proxies::v1::
                    DeleteTargetGrpcProxyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::TargetGrpcProxy>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::TargetGrpcProxy>),
               GetTargetGrpcProxy,
               (google::cloud::cpp::compute::target_grpc_proxies::v1::
                    GetTargetGrpcProxyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertTargetGrpcProxy,
               (google::cloud::cpp::compute::target_grpc_proxies::v1::
                    InsertTargetGrpcProxyRequest const& request),
@@ -71,7 +71,7 @@ class MockTargetGrpcProxiesConnection
                    ListTargetGrpcProxiesRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchTargetGrpcProxy,
               (google::cloud::cpp::compute::target_grpc_proxies::v1::
                    PatchTargetGrpcProxyRequest const& request),

--- a/google/cloud/compute/target_http_proxies/v1/mocks/mock_target_http_proxies_connection.h
+++ b/google/cloud/compute/target_http_proxies/v1/mocks/mock_target_http_proxies_connection.h
@@ -55,19 +55,19 @@ class MockTargetHttpProxiesConnection
            AggregatedListTargetHttpProxiesRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteTargetHttpProxy,
               (google::cloud::cpp::compute::target_http_proxies::v1::
                    DeleteTargetHttpProxyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::TargetHttpProxy>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::TargetHttpProxy>),
               GetTargetHttpProxy,
               (google::cloud::cpp::compute::target_http_proxies::v1::
                    GetTargetHttpProxyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertTargetHttpProxy,
               (google::cloud::cpp::compute::target_http_proxies::v1::
                    InsertTargetHttpProxyRequest const& request),
@@ -79,13 +79,13 @@ class MockTargetHttpProxiesConnection
                    ListTargetHttpProxiesRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchTargetHttpProxy,
               (google::cloud::cpp::compute::target_http_proxies::v1::
                    PatchTargetHttpProxyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetUrlMap,
               (google::cloud::cpp::compute::target_http_proxies::v1::
                    SetUrlMapRequest const& request),

--- a/google/cloud/compute/target_https_proxies/v1/mocks/mock_target_https_proxies_connection.h
+++ b/google/cloud/compute/target_https_proxies/v1/mocks/mock_target_https_proxies_connection.h
@@ -56,19 +56,19 @@ class MockTargetHttpsProxiesConnection
            AggregatedListTargetHttpsProxiesRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteTargetHttpsProxy,
               (google::cloud::cpp::compute::target_https_proxies::v1::
                    DeleteTargetHttpsProxyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::TargetHttpsProxy>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::TargetHttpsProxy>),
               GetTargetHttpsProxy,
               (google::cloud::cpp::compute::target_https_proxies::v1::
                    GetTargetHttpsProxyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertTargetHttpsProxy,
               (google::cloud::cpp::compute::target_https_proxies::v1::
                    InsertTargetHttpsProxyRequest const& request),
@@ -80,37 +80,37 @@ class MockTargetHttpsProxiesConnection
                    ListTargetHttpsProxiesRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               PatchTargetHttpsProxy,
               (google::cloud::cpp::compute::target_https_proxies::v1::
                    PatchTargetHttpsProxyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetCertificateMap,
               (google::cloud::cpp::compute::target_https_proxies::v1::
                    SetCertificateMapRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetQuicOverride,
               (google::cloud::cpp::compute::target_https_proxies::v1::
                    SetQuicOverrideRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetSslCertificates,
               (google::cloud::cpp::compute::target_https_proxies::v1::
                    SetSslCertificatesRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetSslPolicy,
               (google::cloud::cpp::compute::target_https_proxies::v1::
                    SetSslPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetUrlMap,
               (google::cloud::cpp::compute::target_https_proxies::v1::
                    SetUrlMapRequest const& request),

--- a/google/cloud/compute/target_instances/v1/mocks/mock_target_instances_connection.h
+++ b/google/cloud/compute/target_instances/v1/mocks/mock_target_instances_connection.h
@@ -55,19 +55,19 @@ class MockTargetInstancesConnection
            AggregatedListTargetInstancesRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteTargetInstance,
               (google::cloud::cpp::compute::target_instances::v1::
                    DeleteTargetInstanceRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::TargetInstance>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::TargetInstance>),
               GetTargetInstance,
               (google::cloud::cpp::compute::target_instances::v1::
                    GetTargetInstanceRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertTargetInstance,
               (google::cloud::cpp::compute::target_instances::v1::
                    InsertTargetInstanceRequest const& request),
@@ -79,7 +79,7 @@ class MockTargetInstancesConnection
                    ListTargetInstancesRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetSecurityPolicy,
               (google::cloud::cpp::compute::target_instances::v1::
                    SetSecurityPolicyRequest const& request),

--- a/google/cloud/compute/target_pools/v1/mocks/mock_target_pools_connection.h
+++ b/google/cloud/compute/target_pools/v1/mocks/mock_target_pools_connection.h
@@ -47,14 +47,15 @@ class MockTargetPoolsConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               AddHealthCheck,
               (google::cloud::cpp::compute::target_pools::v1::
                    AddHealthCheckRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, AddInstance,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
+      AddInstance,
       (google::cloud::cpp::compute::target_pools::v1::AddInstanceRequest const&
            request),
       (override));
@@ -68,26 +69,26 @@ class MockTargetPoolsConnection
            AggregatedListTargetPoolsRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteTargetPool,
               (google::cloud::cpp::compute::target_pools::v1::
                    DeleteTargetPoolRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::TargetPool>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::TargetPool>),
               GetTargetPool,
               (google::cloud::cpp::compute::target_pools::v1::
                    GetTargetPoolRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::TargetPoolInstanceHealth>,
+      (StatusOr<google::cloud::cpp::compute::v1::TargetPoolInstanceHealth>),
       GetHealth,
       (google::cloud::cpp::compute::target_pools::v1::GetHealthRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertTargetPool,
               (google::cloud::cpp::compute::target_pools::v1::
                    InsertTargetPoolRequest const& request),
@@ -100,25 +101,25 @@ class MockTargetPoolsConnection
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               RemoveHealthCheck,
               (google::cloud::cpp::compute::target_pools::v1::
                    RemoveHealthCheckRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               RemoveInstance,
               (google::cloud::cpp::compute::target_pools::v1::
                    RemoveInstanceRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, SetBackup,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>), SetBackup,
       (google::cloud::cpp::compute::target_pools::v1::SetBackupRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetSecurityPolicy,
               (google::cloud::cpp::compute::target_pools::v1::
                    SetSecurityPolicyRequest const& request),

--- a/google/cloud/compute/target_ssl_proxies/v1/mocks/mock_target_ssl_proxies_connection.h
+++ b/google/cloud/compute/target_ssl_proxies/v1/mocks/mock_target_ssl_proxies_connection.h
@@ -47,19 +47,19 @@ class MockTargetSslProxiesConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteTargetSslProxy,
               (google::cloud::cpp::compute::target_ssl_proxies::v1::
                    DeleteTargetSslProxyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::TargetSslProxy>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::TargetSslProxy>),
               GetTargetSslProxy,
               (google::cloud::cpp::compute::target_ssl_proxies::v1::
                    GetTargetSslProxyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertTargetSslProxy,
               (google::cloud::cpp::compute::target_ssl_proxies::v1::
                    InsertTargetSslProxyRequest const& request),
@@ -71,31 +71,31 @@ class MockTargetSslProxiesConnection
                    ListTargetSslProxiesRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetBackendService,
               (google::cloud::cpp::compute::target_ssl_proxies::v1::
                    SetBackendServiceRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetCertificateMap,
               (google::cloud::cpp::compute::target_ssl_proxies::v1::
                    SetCertificateMapRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetProxyHeader,
               (google::cloud::cpp::compute::target_ssl_proxies::v1::
                    SetProxyHeaderRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetSslCertificates,
               (google::cloud::cpp::compute::target_ssl_proxies::v1::
                    SetSslCertificatesRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetSslPolicy,
               (google::cloud::cpp::compute::target_ssl_proxies::v1::
                    SetSslPolicyRequest const& request),

--- a/google/cloud/compute/target_tcp_proxies/v1/mocks/mock_target_tcp_proxies_connection.h
+++ b/google/cloud/compute/target_tcp_proxies/v1/mocks/mock_target_tcp_proxies_connection.h
@@ -55,19 +55,19 @@ class MockTargetTcpProxiesConnection
            AggregatedListTargetTcpProxiesRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteTargetTcpProxy,
               (google::cloud::cpp::compute::target_tcp_proxies::v1::
                    DeleteTargetTcpProxyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::TargetTcpProxy>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::TargetTcpProxy>),
               GetTargetTcpProxy,
               (google::cloud::cpp::compute::target_tcp_proxies::v1::
                    GetTargetTcpProxyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertTargetTcpProxy,
               (google::cloud::cpp::compute::target_tcp_proxies::v1::
                    InsertTargetTcpProxyRequest const& request),
@@ -79,13 +79,13 @@ class MockTargetTcpProxiesConnection
                    ListTargetTcpProxiesRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetBackendService,
               (google::cloud::cpp::compute::target_tcp_proxies::v1::
                    SetBackendServiceRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetProxyHeader,
               (google::cloud::cpp::compute::target_tcp_proxies::v1::
                    SetProxyHeaderRequest const& request),

--- a/google/cloud/compute/target_vpn_gateways/v1/mocks/mock_target_vpn_gateways_connection.h
+++ b/google/cloud/compute/target_vpn_gateways/v1/mocks/mock_target_vpn_gateways_connection.h
@@ -55,19 +55,19 @@ class MockTargetVpnGatewaysConnection
            AggregatedListTargetVpnGatewaysRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteTargetVpnGateway,
               (google::cloud::cpp::compute::target_vpn_gateways::v1::
                    DeleteTargetVpnGatewayRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::TargetVpnGateway>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::TargetVpnGateway>),
               GetTargetVpnGateway,
               (google::cloud::cpp::compute::target_vpn_gateways::v1::
                    GetTargetVpnGatewayRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertTargetVpnGateway,
               (google::cloud::cpp::compute::target_vpn_gateways::v1::
                    InsertTargetVpnGatewayRequest const& request),
@@ -79,7 +79,7 @@ class MockTargetVpnGatewaysConnection
                    ListTargetVpnGatewaysRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               SetLabels,
               (google::cloud::cpp::compute::target_vpn_gateways::v1::
                    SetLabelsRequest const& request),

--- a/google/cloud/compute/url_maps/v1/mocks/mock_url_maps_connection.h
+++ b/google/cloud/compute/url_maps/v1/mocks/mock_url_maps_connection.h
@@ -55,27 +55,27 @@ class MockUrlMapsConnection : public compute_url_maps_v1::UrlMapsConnection {
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       DeleteUrlMap,
       (google::cloud::cpp::compute::url_maps::v1::DeleteUrlMapRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::UrlMap>, GetUrlMap,
+      (StatusOr<google::cloud::cpp::compute::v1::UrlMap>), GetUrlMap,
       (google::cloud::cpp::compute::url_maps::v1::GetUrlMapRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       InsertUrlMap,
       (google::cloud::cpp::compute::url_maps::v1::InsertUrlMapRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       InvalidateCache,
       (google::cloud::cpp::compute::url_maps::v1::InvalidateCacheRequest const&
            request),
@@ -87,20 +87,21 @@ class MockUrlMapsConnection : public compute_url_maps_v1::UrlMapsConnection {
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, PatchUrlMap,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
+      PatchUrlMap,
       (google::cloud::cpp::compute::url_maps::v1::PatchUrlMapRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
       UpdateUrlMap,
       (google::cloud::cpp::compute::url_maps::v1::UpdateUrlMapRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::UrlMapsValidateResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::UrlMapsValidateResponse>),
       Validate,
       (google::cloud::cpp::compute::url_maps::v1::ValidateRequest const&
            request),

--- a/google/cloud/compute/vpn_gateways/v1/mocks/mock_vpn_gateways_connection.h
+++ b/google/cloud/compute/vpn_gateways/v1/mocks/mock_vpn_gateways_connection.h
@@ -56,26 +56,26 @@ class MockVpnGatewaysConnection
            AggregatedListVpnGatewaysRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteVpnGateway,
               (google::cloud::cpp::compute::vpn_gateways::v1::
                    DeleteVpnGatewayRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::VpnGateway>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::VpnGateway>),
               GetVpnGateway,
               (google::cloud::cpp::compute::vpn_gateways::v1::
                    GetVpnGatewayRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::VpnGatewaysGetStatusResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::VpnGatewaysGetStatusResponse>),
       GetStatus,
       (google::cloud::cpp::compute::vpn_gateways::v1::GetStatusRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertVpnGateway,
               (google::cloud::cpp::compute::vpn_gateways::v1::
                    InsertVpnGatewayRequest const& request),
@@ -89,13 +89,13 @@ class MockVpnGatewaysConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, SetLabels,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>), SetLabels,
       (google::cloud::cpp::compute::vpn_gateways::v1::SetLabelsRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>,
+      (StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>),
       TestIamPermissions,
       (google::cloud::cpp::compute::vpn_gateways::v1::
            TestIamPermissionsRequest const& request),

--- a/google/cloud/compute/vpn_tunnels/v1/mocks/mock_vpn_tunnels_connection.h
+++ b/google/cloud/compute/vpn_tunnels/v1/mocks/mock_vpn_tunnels_connection.h
@@ -56,19 +56,19 @@ class MockVpnTunnelsConnection
            AggregatedListVpnTunnelsRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               DeleteVpnTunnel,
               (google::cloud::cpp::compute::vpn_tunnels::v1::
                    DeleteVpnTunnelRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::VpnTunnel>, GetVpnTunnel,
+      (StatusOr<google::cloud::cpp::compute::v1::VpnTunnel>), GetVpnTunnel,
       (google::cloud::cpp::compute::vpn_tunnels::v1::GetVpnTunnelRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::cpp::compute::v1::Operation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::cpp::compute::v1::Operation>>),
               InsertVpnTunnel,
               (google::cloud::cpp::compute::vpn_tunnels::v1::
                    InsertVpnTunnelRequest const& request),
@@ -81,7 +81,7 @@ class MockVpnTunnelsConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::cpp::compute::v1::Operation>>, SetLabels,
+      (future<StatusOr<google::cloud::cpp::compute::v1::Operation>>), SetLabels,
       (google::cloud::cpp::compute::vpn_tunnels::v1::SetLabelsRequest const&
            request),
       (override));

--- a/google/cloud/compute/zone_operations/v1/mocks/mock_zone_operations_connection.h
+++ b/google/cloud/compute/zone_operations/v1/mocks/mock_zone_operations_connection.h
@@ -52,7 +52,7 @@ class MockZoneOperationsConnection
                    DeleteOperationRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::cpp::compute::v1::Operation>,
+  MOCK_METHOD((StatusOr<google::cloud::cpp::compute::v1::Operation>),
               GetOperation,
               (google::cloud::cpp::compute::zone_operations::v1::
                    GetOperationRequest const& request),
@@ -65,7 +65,7 @@ class MockZoneOperationsConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Operation>, Wait,
+      (StatusOr<google::cloud::cpp::compute::v1::Operation>), Wait,
       (google::cloud::cpp::compute::zone_operations::v1::WaitRequest const&
            request),
       (override));

--- a/google/cloud/compute/zones/v1/mocks/mock_zones_connection.h
+++ b/google/cloud/compute/zones/v1/mocks/mock_zones_connection.h
@@ -47,7 +47,7 @@ class MockZonesConnection : public compute_zones_v1::ZonesConnection {
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::cpp::compute::v1::Zone>, GetZone,
+      (StatusOr<google::cloud::cpp::compute::v1::Zone>), GetZone,
       (google::cloud::cpp::compute::zones::v1::GetZoneRequest const& request),
       (override));
 

--- a/google/cloud/confidentialcomputing/v1/mocks/mock_confidential_computing_connection.h
+++ b/google/cloud/confidentialcomputing/v1/mocks/mock_confidential_computing_connection.h
@@ -48,15 +48,15 @@ class MockConfidentialComputingConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::confidentialcomputing::v1::Challenge>,
+      (StatusOr<google::cloud::confidentialcomputing::v1::Challenge>),
       CreateChallenge,
       (google::cloud::confidentialcomputing::v1::CreateChallengeRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::confidentialcomputing::v1::VerifyAttestationResponse>,
+      (StatusOr<
+          google::cloud::confidentialcomputing::v1::VerifyAttestationResponse>),
       VerifyAttestation,
       (google::cloud::confidentialcomputing::v1::VerifyAttestationRequest const&
            request),

--- a/google/cloud/config/v1/mocks/mock_config_connection.h
+++ b/google/cloud/config/v1/mocks/mock_config_connection.h
@@ -51,22 +51,25 @@ class MockConfigConnection : public config_v1::ConfigConnection {
               (google::cloud::config::v1::ListDeploymentsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::config::v1::Deployment>, GetDeployment,
+  MOCK_METHOD((StatusOr<google::cloud::config::v1::Deployment>), GetDeployment,
               (google::cloud::config::v1::GetDeploymentRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::config::v1::Deployment>>, CreateDeployment,
+      (future<StatusOr<google::cloud::config::v1::Deployment>>),
+      CreateDeployment,
       (google::cloud::config::v1::CreateDeploymentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::config::v1::Deployment>>, UpdateDeployment,
+      (future<StatusOr<google::cloud::config::v1::Deployment>>),
+      UpdateDeployment,
       (google::cloud::config::v1::UpdateDeploymentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::config::v1::Deployment>>, DeleteDeployment,
+      (future<StatusOr<google::cloud::config::v1::Deployment>>),
+      DeleteDeployment,
       (google::cloud::config::v1::DeleteDeploymentRequest const& request),
       (override));
 
@@ -74,11 +77,11 @@ class MockConfigConnection : public config_v1::ConfigConnection {
               (google::cloud::config::v1::ListRevisionsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::config::v1::Revision>, GetRevision,
+  MOCK_METHOD((StatusOr<google::cloud::config::v1::Revision>), GetRevision,
               (google::cloud::config::v1::GetRevisionRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::config::v1::Resource>, GetResource,
+  MOCK_METHOD((StatusOr<google::cloud::config::v1::Resource>), GetResource,
               (google::cloud::config::v1::GetResourceRequest const& request),
               (override));
 
@@ -87,19 +90,20 @@ class MockConfigConnection : public config_v1::ConfigConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::config::v1::Statefile>, ExportDeploymentStatefile,
+      (StatusOr<google::cloud::config::v1::Statefile>),
+      ExportDeploymentStatefile,
       (google::cloud::config::v1::ExportDeploymentStatefileRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::config::v1::Statefile>,
+  MOCK_METHOD((StatusOr<google::cloud::config::v1::Statefile>),
               ExportRevisionStatefile,
               (google::cloud::config::v1::ExportRevisionStatefileRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::config::v1::Statefile>, ImportStatefile,
+      (StatusOr<google::cloud::config::v1::Statefile>), ImportStatefile,
       (google::cloud::config::v1::ImportStatefileRequest const& request),
       (override));
 
@@ -108,26 +112,27 @@ class MockConfigConnection : public config_v1::ConfigConnection {
       (google::cloud::config::v1::DeleteStatefileRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::config::v1::Deployment>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::config::v1::Deployment>>),
               LockDeployment,
               (google::cloud::config::v1::LockDeploymentRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::config::v1::Deployment>>, UnlockDeployment,
+      (future<StatusOr<google::cloud::config::v1::Deployment>>),
+      UnlockDeployment,
       (google::cloud::config::v1::UnlockDeploymentRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::config::v1::LockInfo>, ExportLockInfo,
+  MOCK_METHOD((StatusOr<google::cloud::config::v1::LockInfo>), ExportLockInfo,
               (google::cloud::config::v1::ExportLockInfoRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::config::v1::Preview>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::config::v1::Preview>>),
               CreatePreview,
               (google::cloud::config::v1::CreatePreviewRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::config::v1::Preview>, GetPreview,
+  MOCK_METHOD((StatusOr<google::cloud::config::v1::Preview>), GetPreview,
               (google::cloud::config::v1::GetPreviewRequest const& request),
               (override));
 
@@ -135,13 +140,13 @@ class MockConfigConnection : public config_v1::ConfigConnection {
               (google::cloud::config::v1::ListPreviewsRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::config::v1::Preview>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::config::v1::Preview>>),
               DeletePreview,
               (google::cloud::config::v1::DeletePreviewRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::config::v1::ExportPreviewResultResponse>,
+      (StatusOr<google::cloud::config::v1::ExportPreviewResultResponse>),
       ExportPreviewResult,
       (google::cloud::config::v1::ExportPreviewResultRequest const& request),
       (override));
@@ -152,7 +157,7 @@ class MockConfigConnection : public config_v1::ConfigConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::config::v1::TerraformVersion>,
+      (StatusOr<google::cloud::config::v1::TerraformVersion>),
       GetTerraformVersion,
       (google::cloud::config::v1::GetTerraformVersionRequest const& request),
       (override));

--- a/google/cloud/connectors/v1/mocks/mock_connectors_connection.h
+++ b/google/cloud/connectors/v1/mocks/mock_connectors_connection.h
@@ -52,24 +52,24 @@ class MockConnectorsConnection : public connectors_v1::ConnectorsConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::connectors::v1::Connection>, GetConnection,
+      (StatusOr<google::cloud::connectors::v1::Connection>), GetConnection,
       (google::cloud::connectors::v1::GetConnectionRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::connectors::v1::Connection>>,
+      (future<StatusOr<google::cloud::connectors::v1::Connection>>),
       CreateConnection,
       (google::cloud::connectors::v1::CreateConnectionRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::connectors::v1::Connection>>,
+      (future<StatusOr<google::cloud::connectors::v1::Connection>>),
       UpdateConnection,
       (google::cloud::connectors::v1::UpdateConnectionRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::connectors::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::connectors::v1::OperationMetadata>>),
       DeleteConnection,
       (google::cloud::connectors::v1::DeleteConnectionRequest const& request),
       (override));
@@ -80,7 +80,7 @@ class MockConnectorsConnection : public connectors_v1::ConnectorsConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::connectors::v1::Provider>, GetProvider,
+      (StatusOr<google::cloud::connectors::v1::Provider>), GetProvider,
       (google::cloud::connectors::v1::GetProviderRequest const& request),
       (override));
 
@@ -90,7 +90,7 @@ class MockConnectorsConnection : public connectors_v1::ConnectorsConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::connectors::v1::Connector>, GetConnector,
+      (StatusOr<google::cloud::connectors::v1::Connector>), GetConnector,
       (google::cloud::connectors::v1::GetConnectorRequest const& request),
       (override));
 
@@ -100,21 +100,22 @@ class MockConnectorsConnection : public connectors_v1::ConnectorsConnection {
       (google::cloud::connectors::v1::ListConnectorVersionsRequest request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::connectors::v1::ConnectorVersion>,
+  MOCK_METHOD((StatusOr<google::cloud::connectors::v1::ConnectorVersion>),
               GetConnectorVersion,
               (google::cloud::connectors::v1::GetConnectorVersionRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::connectors::v1::ConnectionSchemaMetadata>,
+      (StatusOr<google::cloud::connectors::v1::ConnectionSchemaMetadata>),
       GetConnectionSchemaMetadata,
       (google::cloud::connectors::v1::GetConnectionSchemaMetadataRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::connectors::v1::ConnectionSchemaMetadata>>,
+      (future<
+          StatusOr<google::cloud::connectors::v1::ConnectionSchemaMetadata>>),
       RefreshConnectionSchemaMetadata,
       (google::cloud::connectors::v1::
            RefreshConnectionSchemaMetadataRequest const& request),
@@ -133,12 +134,13 @@ class MockConnectorsConnection : public connectors_v1::ConnectorsConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::connectors::v1::RuntimeConfig>, GetRuntimeConfig,
+      (StatusOr<google::cloud::connectors::v1::RuntimeConfig>),
+      GetRuntimeConfig,
       (google::cloud::connectors::v1::GetRuntimeConfigRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::connectors::v1::Settings>, GetGlobalSettings,
+      (StatusOr<google::cloud::connectors::v1::Settings>), GetGlobalSettings,
       (google::cloud::connectors::v1::GetGlobalSettingsRequest const& request),
       (override));
 };

--- a/google/cloud/contactcenterinsights/v1/mocks/mock_contact_center_insights_connection.h
+++ b/google/cloud/contactcenterinsights/v1/mocks/mock_contact_center_insights_connection.h
@@ -47,27 +47,30 @@ class MockContactCenterInsightsConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::contactcenterinsights::v1::Conversation>,
-              CreateConversation,
-              (google::cloud::contactcenterinsights::v1::
-                   CreateConversationRequest const& request),
-              (override));
+  MOCK_METHOD(
+      (StatusOr<google::cloud::contactcenterinsights::v1::Conversation>),
+      CreateConversation,
+      (google::cloud::contactcenterinsights::v1::
+           CreateConversationRequest const& request),
+      (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::contactcenterinsights::v1::Conversation>>,
+      (future<
+          StatusOr<google::cloud::contactcenterinsights::v1::Conversation>>),
       UploadConversation,
       (google::cloud::contactcenterinsights::v1::
            UploadConversationRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::contactcenterinsights::v1::Conversation>,
-              UpdateConversation,
-              (google::cloud::contactcenterinsights::v1::
-                   UpdateConversationRequest const& request),
-              (override));
+  MOCK_METHOD(
+      (StatusOr<google::cloud::contactcenterinsights::v1::Conversation>),
+      UpdateConversation,
+      (google::cloud::contactcenterinsights::v1::
+           UpdateConversationRequest const& request),
+      (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::contactcenterinsights::v1::Conversation>,
+      (StatusOr<google::cloud::contactcenterinsights::v1::Conversation>),
       GetConversation,
       (google::cloud::contactcenterinsights::v1::GetConversationRequest const&
            request),
@@ -86,14 +89,15 @@ class MockContactCenterInsightsConnection
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::contactcenterinsights::v1::Analysis>>,
+      (future<StatusOr<google::cloud::contactcenterinsights::v1::Analysis>>),
       CreateAnalysis,
       (google::cloud::contactcenterinsights::v1::CreateAnalysisRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::contactcenterinsights::v1::Analysis>, GetAnalysis,
+      (StatusOr<google::cloud::contactcenterinsights::v1::Analysis>),
+      GetAnalysis,
       (google::cloud::contactcenterinsights::v1::GetAnalysisRequest const&
            request),
       (override));
@@ -110,101 +114,101 @@ class MockContactCenterInsightsConnection
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::contactcenterinsights::v1::
-                                  BulkAnalyzeConversationsResponse>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::contactcenterinsights::v1::
+                                   BulkAnalyzeConversationsResponse>>),
               BulkAnalyzeConversations,
               (google::cloud::contactcenterinsights::v1::
                    BulkAnalyzeConversationsRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::contactcenterinsights::v1::
-                                  BulkDeleteConversationsResponse>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::contactcenterinsights::v1::
+                                   BulkDeleteConversationsResponse>>),
               BulkDeleteConversations,
               (google::cloud::contactcenterinsights::v1::
                    BulkDeleteConversationsRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::contactcenterinsights::v1::
-                                  IngestConversationsResponse>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::contactcenterinsights::v1::
+                                   IngestConversationsResponse>>),
               IngestConversations,
               (google::cloud::contactcenterinsights::v1::
                    IngestConversationsRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::contactcenterinsights::v1::
-                                  ExportInsightsDataResponse>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::contactcenterinsights::v1::
+                                   ExportInsightsDataResponse>>),
               ExportInsightsData,
               (google::cloud::contactcenterinsights::v1::
                    ExportInsightsDataRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::contactcenterinsights::v1::IssueModel>>,
+      (future<StatusOr<google::cloud::contactcenterinsights::v1::IssueModel>>),
       CreateIssueModel,
       (google::cloud::contactcenterinsights::v1::CreateIssueModelRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::contactcenterinsights::v1::IssueModel>,
+      (StatusOr<google::cloud::contactcenterinsights::v1::IssueModel>),
       UpdateIssueModel,
       (google::cloud::contactcenterinsights::v1::UpdateIssueModelRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::contactcenterinsights::v1::IssueModel>,
+      (StatusOr<google::cloud::contactcenterinsights::v1::IssueModel>),
       GetIssueModel,
       (google::cloud::contactcenterinsights::v1::GetIssueModelRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::contactcenterinsights::v1::ListIssueModelsResponse>,
+      (StatusOr<
+          google::cloud::contactcenterinsights::v1::ListIssueModelsResponse>),
       ListIssueModels,
       (google::cloud::contactcenterinsights::v1::ListIssueModelsRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::contactcenterinsights::v1::DeleteIssueModelMetadata>>,
+      (future<StatusOr<google::cloud::contactcenterinsights::v1::
+                           DeleteIssueModelMetadata>>),
       DeleteIssueModel,
       (google::cloud::contactcenterinsights::v1::DeleteIssueModelRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::contactcenterinsights::v1::DeployIssueModelResponse>>,
+      (future<StatusOr<google::cloud::contactcenterinsights::v1::
+                           DeployIssueModelResponse>>),
       DeployIssueModel,
       (google::cloud::contactcenterinsights::v1::DeployIssueModelRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::contactcenterinsights::v1::
-                                  UndeployIssueModelResponse>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::contactcenterinsights::v1::
+                                   UndeployIssueModelResponse>>),
               UndeployIssueModel,
               (google::cloud::contactcenterinsights::v1::
                    UndeployIssueModelRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::contactcenterinsights::v1::Issue>,
+  MOCK_METHOD((StatusOr<google::cloud::contactcenterinsights::v1::Issue>),
               GetIssue,
               (google::cloud::contactcenterinsights::v1::GetIssueRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::contactcenterinsights::v1::ListIssuesResponse>,
+      (StatusOr<google::cloud::contactcenterinsights::v1::ListIssuesResponse>),
       ListIssues,
       (google::cloud::contactcenterinsights::v1::ListIssuesRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::contactcenterinsights::v1::Issue>, UpdateIssue,
+      (StatusOr<google::cloud::contactcenterinsights::v1::Issue>), UpdateIssue,
       (google::cloud::contactcenterinsights::v1::UpdateIssueRequest const&
            request),
       (override));
@@ -215,21 +219,22 @@ class MockContactCenterInsightsConnection
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::contactcenterinsights::v1::
-                           CalculateIssueModelStatsResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::contactcenterinsights::v1::
+                            CalculateIssueModelStatsResponse>),
               CalculateIssueModelStats,
               (google::cloud::contactcenterinsights::v1::
                    CalculateIssueModelStatsRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::contactcenterinsights::v1::PhraseMatcher>,
-              CreatePhraseMatcher,
-              (google::cloud::contactcenterinsights::v1::
-                   CreatePhraseMatcherRequest const& request),
-              (override));
+  MOCK_METHOD(
+      (StatusOr<google::cloud::contactcenterinsights::v1::PhraseMatcher>),
+      CreatePhraseMatcher,
+      (google::cloud::contactcenterinsights::v1::
+           CreatePhraseMatcherRequest const& request),
+      (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::contactcenterinsights::v1::PhraseMatcher>,
+      (StatusOr<google::cloud::contactcenterinsights::v1::PhraseMatcher>),
       GetPhraseMatcher,
       (google::cloud::contactcenterinsights::v1::GetPhraseMatcherRequest const&
            request),
@@ -247,41 +252,43 @@ class MockContactCenterInsightsConnection
                    DeletePhraseMatcherRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::contactcenterinsights::v1::PhraseMatcher>,
-              UpdatePhraseMatcher,
-              (google::cloud::contactcenterinsights::v1::
-                   UpdatePhraseMatcherRequest const& request),
-              (override));
+  MOCK_METHOD(
+      (StatusOr<google::cloud::contactcenterinsights::v1::PhraseMatcher>),
+      UpdatePhraseMatcher,
+      (google::cloud::contactcenterinsights::v1::
+           UpdatePhraseMatcherRequest const& request),
+      (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::contactcenterinsights::v1::CalculateStatsResponse>,
+      (StatusOr<
+          google::cloud::contactcenterinsights::v1::CalculateStatsResponse>),
       CalculateStats,
       (google::cloud::contactcenterinsights::v1::CalculateStatsRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::contactcenterinsights::v1::Settings>, GetSettings,
+      (StatusOr<google::cloud::contactcenterinsights::v1::Settings>),
+      GetSettings,
       (google::cloud::contactcenterinsights::v1::GetSettingsRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::contactcenterinsights::v1::Settings>,
+      (StatusOr<google::cloud::contactcenterinsights::v1::Settings>),
       UpdateSettings,
       (google::cloud::contactcenterinsights::v1::UpdateSettingsRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::contactcenterinsights::v1::View>, CreateView,
+      (StatusOr<google::cloud::contactcenterinsights::v1::View>), CreateView,
       (google::cloud::contactcenterinsights::v1::CreateViewRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::contactcenterinsights::v1::View>, GetView,
+      (StatusOr<google::cloud::contactcenterinsights::v1::View>), GetView,
       (google::cloud::contactcenterinsights::v1::GetViewRequest const& request),
       (override));
 
@@ -291,7 +298,7 @@ class MockContactCenterInsightsConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::contactcenterinsights::v1::View>, UpdateView,
+      (StatusOr<google::cloud::contactcenterinsights::v1::View>), UpdateView,
       (google::cloud::contactcenterinsights::v1::UpdateViewRequest const&
            request),
       (override));

--- a/google/cloud/container/v1/mocks/mock_cluster_manager_connection.h
+++ b/google/cloud/container/v1/mocks/mock_cluster_manager_connection.h
@@ -47,67 +47,67 @@ class MockClusterManagerConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::container::v1::ListClustersResponse>,
+  MOCK_METHOD((StatusOr<google::container::v1::ListClustersResponse>),
               ListClusters,
               (google::container::v1::ListClustersRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::container::v1::Cluster>, GetCluster,
+  MOCK_METHOD((StatusOr<google::container::v1::Cluster>), GetCluster,
               (google::container::v1::GetClusterRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::container::v1::Operation>, CreateCluster,
+  MOCK_METHOD((StatusOr<google::container::v1::Operation>), CreateCluster,
               (google::container::v1::CreateClusterRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::container::v1::Operation>, UpdateCluster,
+  MOCK_METHOD((StatusOr<google::container::v1::Operation>), UpdateCluster,
               (google::container::v1::UpdateClusterRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::container::v1::Operation>, UpdateNodePool,
+  MOCK_METHOD((StatusOr<google::container::v1::Operation>), UpdateNodePool,
               (google::container::v1::UpdateNodePoolRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::container::v1::Operation>, SetNodePoolAutoscaling,
+      (StatusOr<google::container::v1::Operation>), SetNodePoolAutoscaling,
       (google::container::v1::SetNodePoolAutoscalingRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::container::v1::Operation>, SetLoggingService,
+  MOCK_METHOD((StatusOr<google::container::v1::Operation>), SetLoggingService,
               (google::container::v1::SetLoggingServiceRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::container::v1::Operation>, SetMonitoringService,
+      (StatusOr<google::container::v1::Operation>), SetMonitoringService,
       (google::container::v1::SetMonitoringServiceRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::container::v1::Operation>, SetAddonsConfig,
+  MOCK_METHOD((StatusOr<google::container::v1::Operation>), SetAddonsConfig,
               (google::container::v1::SetAddonsConfigRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::container::v1::Operation>, SetLocations,
+  MOCK_METHOD((StatusOr<google::container::v1::Operation>), SetLocations,
               (google::container::v1::SetLocationsRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::container::v1::Operation>, UpdateMaster,
+  MOCK_METHOD((StatusOr<google::container::v1::Operation>), UpdateMaster,
               (google::container::v1::UpdateMasterRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::container::v1::Operation>, SetMasterAuth,
+  MOCK_METHOD((StatusOr<google::container::v1::Operation>), SetMasterAuth,
               (google::container::v1::SetMasterAuthRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::container::v1::Operation>, DeleteCluster,
+  MOCK_METHOD((StatusOr<google::container::v1::Operation>), DeleteCluster,
               (google::container::v1::DeleteClusterRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::container::v1::ListOperationsResponse>,
+  MOCK_METHOD((StatusOr<google::container::v1::ListOperationsResponse>),
               ListOperations,
               (google::container::v1::ListOperationsRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::container::v1::Operation>, GetOperation,
+  MOCK_METHOD((StatusOr<google::container::v1::Operation>), GetOperation,
               (google::container::v1::GetOperationRequest const& request),
               (override));
 
@@ -115,29 +115,29 @@ class MockClusterManagerConnection
               (google::container::v1::CancelOperationRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::container::v1::ServerConfig>, GetServerConfig,
+  MOCK_METHOD((StatusOr<google::container::v1::ServerConfig>), GetServerConfig,
               (google::container::v1::GetServerConfigRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::container::v1::GetJSONWebKeysResponse>,
+  MOCK_METHOD((StatusOr<google::container::v1::GetJSONWebKeysResponse>),
               GetJSONWebKeys,
               (google::container::v1::GetJSONWebKeysRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::container::v1::ListNodePoolsResponse>,
+  MOCK_METHOD((StatusOr<google::container::v1::ListNodePoolsResponse>),
               ListNodePools,
               (google::container::v1::ListNodePoolsRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::container::v1::NodePool>, GetNodePool,
+  MOCK_METHOD((StatusOr<google::container::v1::NodePool>), GetNodePool,
               (google::container::v1::GetNodePoolRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::container::v1::Operation>, CreateNodePool,
+  MOCK_METHOD((StatusOr<google::container::v1::Operation>), CreateNodePool,
               (google::container::v1::CreateNodePoolRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::container::v1::Operation>, DeleteNodePool,
+  MOCK_METHOD((StatusOr<google::container::v1::Operation>), DeleteNodePool,
               (google::container::v1::DeleteNodePoolRequest const& request),
               (override));
 
@@ -147,41 +147,41 @@ class MockClusterManagerConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::container::v1::Operation>, RollbackNodePoolUpgrade,
+      (StatusOr<google::container::v1::Operation>), RollbackNodePoolUpgrade,
       (google::container::v1::RollbackNodePoolUpgradeRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::container::v1::Operation>, SetNodePoolManagement,
+      (StatusOr<google::container::v1::Operation>), SetNodePoolManagement,
       (google::container::v1::SetNodePoolManagementRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::container::v1::Operation>, SetLabels,
+  MOCK_METHOD((StatusOr<google::container::v1::Operation>), SetLabels,
               (google::container::v1::SetLabelsRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::container::v1::Operation>, SetLegacyAbac,
+  MOCK_METHOD((StatusOr<google::container::v1::Operation>), SetLegacyAbac,
               (google::container::v1::SetLegacyAbacRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::container::v1::Operation>, StartIPRotation,
+  MOCK_METHOD((StatusOr<google::container::v1::Operation>), StartIPRotation,
               (google::container::v1::StartIPRotationRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::container::v1::Operation>, CompleteIPRotation,
+  MOCK_METHOD((StatusOr<google::container::v1::Operation>), CompleteIPRotation,
               (google::container::v1::CompleteIPRotationRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::container::v1::Operation>, SetNodePoolSize,
+  MOCK_METHOD((StatusOr<google::container::v1::Operation>), SetNodePoolSize,
               (google::container::v1::SetNodePoolSizeRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::container::v1::Operation>, SetNetworkPolicy,
+  MOCK_METHOD((StatusOr<google::container::v1::Operation>), SetNetworkPolicy,
               (google::container::v1::SetNetworkPolicyRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::container::v1::Operation>, SetMaintenancePolicy,
+      (StatusOr<google::container::v1::Operation>), SetMaintenancePolicy,
       (google::container::v1::SetMaintenancePolicyRequest const& request),
       (override));
 
@@ -191,7 +191,7 @@ class MockClusterManagerConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::container::v1::CheckAutopilotCompatibilityResponse>,
+      (StatusOr<google::container::v1::CheckAutopilotCompatibilityResponse>),
       CheckAutopilotCompatibility,
       (google::container::v1::CheckAutopilotCompatibilityRequest const&
            request),

--- a/google/cloud/containeranalysis/v1/mocks/mock_container_analysis_connection.h
+++ b/google/cloud/containeranalysis/v1/mocks/mock_container_analysis_connection.h
@@ -47,21 +47,21 @@ class MockContainerAnalysisConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), SetIamPolicy,
               (google::iam::v1::SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), GetIamPolicy,
               (google::iam::v1::GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD((StatusOr<google::iam::v1::TestIamPermissionsResponse>),
               TestIamPermissions,
               (google::iam::v1::TestIamPermissionsRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::devtools::containeranalysis::v1::
-                           VulnerabilityOccurrencesSummary>,
+  MOCK_METHOD((StatusOr<google::devtools::containeranalysis::v1::
+                            VulnerabilityOccurrencesSummary>),
               GetVulnerabilityOccurrencesSummary,
               (google::devtools::containeranalysis::v1::
                    GetVulnerabilityOccurrencesSummaryRequest const& request),

--- a/google/cloud/containeranalysis/v1/mocks/mock_grafeas_connection.h
+++ b/google/cloud/containeranalysis/v1/mocks/mock_grafeas_connection.h
@@ -46,7 +46,7 @@ class MockGrafeasConnection : public containeranalysis_v1::GrafeasConnection {
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<grafeas::v1::Occurrence>, GetOccurrence,
+  MOCK_METHOD((StatusOr<grafeas::v1::Occurrence>), GetOccurrence,
               (grafeas::v1::GetOccurrenceRequest const& request), (override));
 
   MOCK_METHOD((StreamRange<grafeas::v1::Occurrence>), ListOccurrences,
@@ -56,24 +56,24 @@ class MockGrafeasConnection : public containeranalysis_v1::GrafeasConnection {
               (grafeas::v1::DeleteOccurrenceRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<grafeas::v1::Occurrence>, CreateOccurrence,
+  MOCK_METHOD((StatusOr<grafeas::v1::Occurrence>), CreateOccurrence,
               (grafeas::v1::CreateOccurrenceRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<grafeas::v1::BatchCreateOccurrencesResponse>,
+  MOCK_METHOD((StatusOr<grafeas::v1::BatchCreateOccurrencesResponse>),
               BatchCreateOccurrences,
               (grafeas::v1::BatchCreateOccurrencesRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<grafeas::v1::Occurrence>, UpdateOccurrence,
+  MOCK_METHOD((StatusOr<grafeas::v1::Occurrence>), UpdateOccurrence,
               (grafeas::v1::UpdateOccurrenceRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<grafeas::v1::Note>, GetOccurrenceNote,
+  MOCK_METHOD((StatusOr<grafeas::v1::Note>), GetOccurrenceNote,
               (grafeas::v1::GetOccurrenceNoteRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<grafeas::v1::Note>, GetNote,
+  MOCK_METHOD((StatusOr<grafeas::v1::Note>), GetNote,
               (grafeas::v1::GetNoteRequest const& request), (override));
 
   MOCK_METHOD((StreamRange<grafeas::v1::Note>), ListNotes,
@@ -82,14 +82,15 @@ class MockGrafeasConnection : public containeranalysis_v1::GrafeasConnection {
   MOCK_METHOD(Status, DeleteNote,
               (grafeas::v1::DeleteNoteRequest const& request), (override));
 
-  MOCK_METHOD(StatusOr<grafeas::v1::Note>, CreateNote,
+  MOCK_METHOD((StatusOr<grafeas::v1::Note>), CreateNote,
               (grafeas::v1::CreateNoteRequest const& request), (override));
 
-  MOCK_METHOD(StatusOr<grafeas::v1::BatchCreateNotesResponse>, BatchCreateNotes,
+  MOCK_METHOD((StatusOr<grafeas::v1::BatchCreateNotesResponse>),
+              BatchCreateNotes,
               (grafeas::v1::BatchCreateNotesRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<grafeas::v1::Note>, UpdateNote,
+  MOCK_METHOD((StatusOr<grafeas::v1::Note>), UpdateNote,
               (grafeas::v1::UpdateNoteRequest const& request), (override));
 
   MOCK_METHOD((StreamRange<grafeas::v1::Occurrence>), ListNoteOccurrences,

--- a/google/cloud/contentwarehouse/v1/mocks/mock_document_connection.h
+++ b/google/cloud/contentwarehouse/v1/mocks/mock_document_connection.h
@@ -48,19 +48,19 @@ class MockDocumentServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::contentwarehouse::v1::CreateDocumentResponse>,
+      (StatusOr<google::cloud::contentwarehouse::v1::CreateDocumentResponse>),
       CreateDocument,
       (google::cloud::contentwarehouse::v1::CreateDocumentRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::contentwarehouse::v1::Document>, GetDocument,
+      (StatusOr<google::cloud::contentwarehouse::v1::Document>), GetDocument,
       (google::cloud::contentwarehouse::v1::GetDocumentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::contentwarehouse::v1::UpdateDocumentResponse>,
+      (StatusOr<google::cloud::contentwarehouse::v1::UpdateDocumentResponse>),
       UpdateDocument,
       (google::cloud::contentwarehouse::v1::UpdateDocumentRequest const&
            request),
@@ -79,17 +79,18 @@ class MockDocumentServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::contentwarehouse::v1::Document>, LockDocument,
+      (StatusOr<google::cloud::contentwarehouse::v1::Document>), LockDocument,
       (google::cloud::contentwarehouse::v1::LockDocumentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::contentwarehouse::v1::FetchAclResponse>, FetchAcl,
+      (StatusOr<google::cloud::contentwarehouse::v1::FetchAclResponse>),
+      FetchAcl,
       (google::cloud::contentwarehouse::v1::FetchAclRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::contentwarehouse::v1::SetAclResponse>, SetAcl,
+      (StatusOr<google::cloud::contentwarehouse::v1::SetAclResponse>), SetAcl,
       (google::cloud::contentwarehouse::v1::SetAclRequest const& request),
       (override));
 };

--- a/google/cloud/contentwarehouse/v1/mocks/mock_document_link_connection.h
+++ b/google/cloud/contentwarehouse/v1/mocks/mock_document_link_connection.h
@@ -48,7 +48,8 @@ class MockDocumentLinkServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::contentwarehouse::v1::ListLinkedTargetsResponse>,
+      (StatusOr<
+          google::cloud::contentwarehouse::v1::ListLinkedTargetsResponse>),
       ListLinkedTargets,
       (google::cloud::contentwarehouse::v1::ListLinkedTargetsRequest const&
            request),
@@ -61,7 +62,7 @@ class MockDocumentLinkServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::contentwarehouse::v1::DocumentLink>,
+      (StatusOr<google::cloud::contentwarehouse::v1::DocumentLink>),
       CreateDocumentLink,
       (google::cloud::contentwarehouse::v1::CreateDocumentLinkRequest const&
            request),

--- a/google/cloud/contentwarehouse/v1/mocks/mock_document_schema_connection.h
+++ b/google/cloud/contentwarehouse/v1/mocks/mock_document_schema_connection.h
@@ -48,21 +48,21 @@ class MockDocumentSchemaServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::contentwarehouse::v1::DocumentSchema>,
+      (StatusOr<google::cloud::contentwarehouse::v1::DocumentSchema>),
       CreateDocumentSchema,
       (google::cloud::contentwarehouse::v1::CreateDocumentSchemaRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::contentwarehouse::v1::DocumentSchema>,
+      (StatusOr<google::cloud::contentwarehouse::v1::DocumentSchema>),
       UpdateDocumentSchema,
       (google::cloud::contentwarehouse::v1::UpdateDocumentSchemaRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::contentwarehouse::v1::DocumentSchema>,
+      (StatusOr<google::cloud::contentwarehouse::v1::DocumentSchema>),
       GetDocumentSchema,
       (google::cloud::contentwarehouse::v1::GetDocumentSchemaRequest const&
            request),

--- a/google/cloud/contentwarehouse/v1/mocks/mock_rule_set_connection.h
+++ b/google/cloud/contentwarehouse/v1/mocks/mock_rule_set_connection.h
@@ -47,18 +47,18 @@ class MockRuleSetServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::contentwarehouse::v1::RuleSet>,
+  MOCK_METHOD((StatusOr<google::cloud::contentwarehouse::v1::RuleSet>),
               CreateRuleSet,
               (google::cloud::contentwarehouse::v1::CreateRuleSetRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::contentwarehouse::v1::RuleSet>, GetRuleSet,
+      (StatusOr<google::cloud::contentwarehouse::v1::RuleSet>), GetRuleSet,
       (google::cloud::contentwarehouse::v1::GetRuleSetRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::contentwarehouse::v1::RuleSet>,
+  MOCK_METHOD((StatusOr<google::cloud::contentwarehouse::v1::RuleSet>),
               UpdateRuleSet,
               (google::cloud::contentwarehouse::v1::UpdateRuleSetRequest const&
                    request),

--- a/google/cloud/contentwarehouse/v1/mocks/mock_synonym_set_connection.h
+++ b/google/cloud/contentwarehouse/v1/mocks/mock_synonym_set_connection.h
@@ -48,20 +48,20 @@ class MockSynonymSetServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::contentwarehouse::v1::SynonymSet>,
+      (StatusOr<google::cloud::contentwarehouse::v1::SynonymSet>),
       CreateSynonymSet,
       (google::cloud::contentwarehouse::v1::CreateSynonymSetRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::contentwarehouse::v1::SynonymSet>,
+  MOCK_METHOD((StatusOr<google::cloud::contentwarehouse::v1::SynonymSet>),
               GetSynonymSet,
               (google::cloud::contentwarehouse::v1::GetSynonymSetRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::contentwarehouse::v1::SynonymSet>,
+      (StatusOr<google::cloud::contentwarehouse::v1::SynonymSet>),
       UpdateSynonymSet,
       (google::cloud::contentwarehouse::v1::UpdateSynonymSetRequest const&
            request),

--- a/google/cloud/datacatalog/lineage/v1/mocks/mock_lineage_connection.h
+++ b/google/cloud/datacatalog/lineage/v1/mocks/mock_lineage_connection.h
@@ -46,26 +46,28 @@ class MockLineageConnection : public datacatalog_lineage_v1::LineageConnection {
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::datacatalog::lineage::v1::
-                           ProcessOpenLineageRunEventResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::datacatalog::lineage::v1::
+                            ProcessOpenLineageRunEventResponse>),
               ProcessOpenLineageRunEvent,
               (google::cloud::datacatalog::lineage::v1::
                    ProcessOpenLineageRunEventRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::datacatalog::lineage::v1::Process>, CreateProcess,
+      (StatusOr<google::cloud::datacatalog::lineage::v1::Process>),
+      CreateProcess,
       (google::cloud::datacatalog::lineage::v1::CreateProcessRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::datacatalog::lineage::v1::Process>, UpdateProcess,
+      (StatusOr<google::cloud::datacatalog::lineage::v1::Process>),
+      UpdateProcess,
       (google::cloud::datacatalog::lineage::v1::UpdateProcessRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::datacatalog::lineage::v1::Process>,
+  MOCK_METHOD((StatusOr<google::cloud::datacatalog::lineage::v1::Process>),
               GetProcess,
               (google::cloud::datacatalog::lineage::v1::GetProcessRequest const&
                    request),
@@ -78,25 +80,27 @@ class MockLineageConnection : public datacatalog_lineage_v1::LineageConnection {
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::datacatalog::lineage::v1::OperationMetadata>>,
+      (future<StatusOr<
+           google::cloud::datacatalog::lineage::v1::OperationMetadata>>),
       DeleteProcess,
       (google::cloud::datacatalog::lineage::v1::DeleteProcessRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::datacatalog::lineage::v1::Run>, CreateRun,
+  MOCK_METHOD((StatusOr<google::cloud::datacatalog::lineage::v1::Run>),
+              CreateRun,
               (google::cloud::datacatalog::lineage::v1::CreateRunRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::datacatalog::lineage::v1::Run>, UpdateRun,
+  MOCK_METHOD((StatusOr<google::cloud::datacatalog::lineage::v1::Run>),
+              UpdateRun,
               (google::cloud::datacatalog::lineage::v1::UpdateRunRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::datacatalog::lineage::v1::Run>, GetRun,
+      (StatusOr<google::cloud::datacatalog::lineage::v1::Run>), GetRun,
       (google::cloud::datacatalog::lineage::v1::GetRunRequest const& request),
       (override));
 
@@ -106,22 +110,22 @@ class MockLineageConnection : public datacatalog_lineage_v1::LineageConnection {
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::datacatalog::lineage::v1::OperationMetadata>>,
+      (future<StatusOr<
+           google::cloud::datacatalog::lineage::v1::OperationMetadata>>),
       DeleteRun,
       (google::cloud::datacatalog::lineage::v1::DeleteRunRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::datacatalog::lineage::v1::LineageEvent>,
+      (StatusOr<google::cloud::datacatalog::lineage::v1::LineageEvent>),
       CreateLineageEvent,
       (google::cloud::datacatalog::lineage::v1::CreateLineageEventRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::datacatalog::lineage::v1::LineageEvent>,
+      (StatusOr<google::cloud::datacatalog::lineage::v1::LineageEvent>),
       GetLineageEvent,
       (google::cloud::datacatalog::lineage::v1::GetLineageEventRequest const&
            request),

--- a/google/cloud/datacatalog/v1/mocks/mock_data_catalog_connection.h
+++ b/google/cloud/datacatalog/v1/mocks/mock_data_catalog_connection.h
@@ -53,17 +53,17 @@ class MockDataCatalogConnection : public datacatalog_v1::DataCatalogConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::datacatalog::v1::EntryGroup>, CreateEntryGroup,
+      (StatusOr<google::cloud::datacatalog::v1::EntryGroup>), CreateEntryGroup,
       (google::cloud::datacatalog::v1::CreateEntryGroupRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::datacatalog::v1::EntryGroup>, GetEntryGroup,
+      (StatusOr<google::cloud::datacatalog::v1::EntryGroup>), GetEntryGroup,
       (google::cloud::datacatalog::v1::GetEntryGroupRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::datacatalog::v1::EntryGroup>, UpdateEntryGroup,
+      (StatusOr<google::cloud::datacatalog::v1::EntryGroup>), UpdateEntryGroup,
       (google::cloud::datacatalog::v1::UpdateEntryGroupRequest const& request),
       (override));
 
@@ -78,12 +78,12 @@ class MockDataCatalogConnection : public datacatalog_v1::DataCatalogConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::datacatalog::v1::Entry>, CreateEntry,
+      (StatusOr<google::cloud::datacatalog::v1::Entry>), CreateEntry,
       (google::cloud::datacatalog::v1::CreateEntryRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::datacatalog::v1::Entry>, UpdateEntry,
+      (StatusOr<google::cloud::datacatalog::v1::Entry>), UpdateEntry,
       (google::cloud::datacatalog::v1::UpdateEntryRequest const& request),
       (override));
 
@@ -92,12 +92,12 @@ class MockDataCatalogConnection : public datacatalog_v1::DataCatalogConnection {
       (google::cloud::datacatalog::v1::DeleteEntryRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::datacatalog::v1::Entry>, GetEntry,
+  MOCK_METHOD((StatusOr<google::cloud::datacatalog::v1::Entry>), GetEntry,
               (google::cloud::datacatalog::v1::GetEntryRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::datacatalog::v1::Entry>, LookupEntry,
+      (StatusOr<google::cloud::datacatalog::v1::Entry>), LookupEntry,
       (google::cloud::datacatalog::v1::LookupEntryRequest const& request),
       (override));
 
@@ -105,30 +105,32 @@ class MockDataCatalogConnection : public datacatalog_v1::DataCatalogConnection {
               (google::cloud::datacatalog::v1::ListEntriesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::datacatalog::v1::EntryOverview>,
+  MOCK_METHOD((StatusOr<google::cloud::datacatalog::v1::EntryOverview>),
               ModifyEntryOverview,
               (google::cloud::datacatalog::v1::ModifyEntryOverviewRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::datacatalog::v1::Contacts>,
+  MOCK_METHOD((StatusOr<google::cloud::datacatalog::v1::Contacts>),
               ModifyEntryContacts,
               (google::cloud::datacatalog::v1::ModifyEntryContactsRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::datacatalog::v1::TagTemplate>, CreateTagTemplate,
+      (StatusOr<google::cloud::datacatalog::v1::TagTemplate>),
+      CreateTagTemplate,
       (google::cloud::datacatalog::v1::CreateTagTemplateRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::datacatalog::v1::TagTemplate>, GetTagTemplate,
+      (StatusOr<google::cloud::datacatalog::v1::TagTemplate>), GetTagTemplate,
       (google::cloud::datacatalog::v1::GetTagTemplateRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::datacatalog::v1::TagTemplate>, UpdateTagTemplate,
+      (StatusOr<google::cloud::datacatalog::v1::TagTemplate>),
+      UpdateTagTemplate,
       (google::cloud::datacatalog::v1::UpdateTagTemplateRequest const& request),
       (override));
 
@@ -138,27 +140,27 @@ class MockDataCatalogConnection : public datacatalog_v1::DataCatalogConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::datacatalog::v1::TagTemplateField>,
+      (StatusOr<google::cloud::datacatalog::v1::TagTemplateField>),
       CreateTagTemplateField,
       (google::cloud::datacatalog::v1::CreateTagTemplateFieldRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::datacatalog::v1::TagTemplateField>,
+      (StatusOr<google::cloud::datacatalog::v1::TagTemplateField>),
       UpdateTagTemplateField,
       (google::cloud::datacatalog::v1::UpdateTagTemplateFieldRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::datacatalog::v1::TagTemplateField>,
+      (StatusOr<google::cloud::datacatalog::v1::TagTemplateField>),
       RenameTagTemplateField,
       (google::cloud::datacatalog::v1::RenameTagTemplateFieldRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::datacatalog::v1::TagTemplateField>,
+  MOCK_METHOD((StatusOr<google::cloud::datacatalog::v1::TagTemplateField>),
               RenameTagTemplateFieldEnumValue,
               (google::cloud::datacatalog::v1::
                    RenameTagTemplateFieldEnumValueRequest const& request),
@@ -170,11 +172,11 @@ class MockDataCatalogConnection : public datacatalog_v1::DataCatalogConnection {
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::datacatalog::v1::Tag>, CreateTag,
+  MOCK_METHOD((StatusOr<google::cloud::datacatalog::v1::Tag>), CreateTag,
               (google::cloud::datacatalog::v1::CreateTagRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::datacatalog::v1::Tag>, UpdateTag,
+  MOCK_METHOD((StatusOr<google::cloud::datacatalog::v1::Tag>), UpdateTag,
               (google::cloud::datacatalog::v1::UpdateTagRequest const& request),
               (override));
 
@@ -187,37 +189,37 @@ class MockDataCatalogConnection : public datacatalog_v1::DataCatalogConnection {
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::datacatalog::v1::ReconcileTagsResponse>>,
+      (future<StatusOr<google::cloud::datacatalog::v1::ReconcileTagsResponse>>),
       ReconcileTags,
       (google::cloud::datacatalog::v1::ReconcileTagsRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::datacatalog::v1::StarEntryResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::datacatalog::v1::StarEntryResponse>),
               StarEntry,
               (google::cloud::datacatalog::v1::StarEntryRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::datacatalog::v1::UnstarEntryResponse>,
+      (StatusOr<google::cloud::datacatalog::v1::UnstarEntryResponse>),
       UnstarEntry,
       (google::cloud::datacatalog::v1::UnstarEntryRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), SetIamPolicy,
               (google::iam::v1::SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), GetIamPolicy,
               (google::iam::v1::GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD((StatusOr<google::iam::v1::TestIamPermissionsResponse>),
               TestIamPermissions,
               (google::iam::v1::TestIamPermissionsRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::datacatalog::v1::ImportEntriesResponse>>,
+      (future<StatusOr<google::cloud::datacatalog::v1::ImportEntriesResponse>>),
       ImportEntries,
       (google::cloud::datacatalog::v1::ImportEntriesRequest const& request),
       (override));

--- a/google/cloud/datacatalog/v1/mocks/mock_policy_tag_manager_connection.h
+++ b/google/cloud/datacatalog/v1/mocks/mock_policy_tag_manager_connection.h
@@ -48,7 +48,7 @@ class MockPolicyTagManagerConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::datacatalog::v1::Taxonomy>, CreateTaxonomy,
+      (StatusOr<google::cloud::datacatalog::v1::Taxonomy>), CreateTaxonomy,
       (google::cloud::datacatalog::v1::CreateTaxonomyRequest const& request),
       (override));
 
@@ -58,7 +58,7 @@ class MockPolicyTagManagerConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::datacatalog::v1::Taxonomy>, UpdateTaxonomy,
+      (StatusOr<google::cloud::datacatalog::v1::Taxonomy>), UpdateTaxonomy,
       (google::cloud::datacatalog::v1::UpdateTaxonomyRequest const& request),
       (override));
 
@@ -68,12 +68,12 @@ class MockPolicyTagManagerConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::datacatalog::v1::Taxonomy>, GetTaxonomy,
+      (StatusOr<google::cloud::datacatalog::v1::Taxonomy>), GetTaxonomy,
       (google::cloud::datacatalog::v1::GetTaxonomyRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::datacatalog::v1::PolicyTag>, CreatePolicyTag,
+      (StatusOr<google::cloud::datacatalog::v1::PolicyTag>), CreatePolicyTag,
       (google::cloud::datacatalog::v1::CreatePolicyTagRequest const& request),
       (override));
 
@@ -83,7 +83,7 @@ class MockPolicyTagManagerConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::datacatalog::v1::PolicyTag>, UpdatePolicyTag,
+      (StatusOr<google::cloud::datacatalog::v1::PolicyTag>), UpdatePolicyTag,
       (google::cloud::datacatalog::v1::UpdatePolicyTagRequest const& request),
       (override));
 
@@ -93,19 +93,19 @@ class MockPolicyTagManagerConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::datacatalog::v1::PolicyTag>, GetPolicyTag,
+      (StatusOr<google::cloud::datacatalog::v1::PolicyTag>), GetPolicyTag,
       (google::cloud::datacatalog::v1::GetPolicyTagRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), GetIamPolicy,
               (google::iam::v1::GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), SetIamPolicy,
               (google::iam::v1::SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD((StatusOr<google::iam::v1::TestIamPermissionsResponse>),
               TestIamPermissions,
               (google::iam::v1::TestIamPermissionsRequest const& request),
               (override));

--- a/google/cloud/datacatalog/v1/mocks/mock_policy_tag_manager_serialization_connection.h
+++ b/google/cloud/datacatalog/v1/mocks/mock_policy_tag_manager_serialization_connection.h
@@ -48,18 +48,18 @@ class MockPolicyTagManagerSerializationConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::datacatalog::v1::Taxonomy>, ReplaceTaxonomy,
+      (StatusOr<google::cloud::datacatalog::v1::Taxonomy>), ReplaceTaxonomy,
       (google::cloud::datacatalog::v1::ReplaceTaxonomyRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::datacatalog::v1::ImportTaxonomiesResponse>,
+      (StatusOr<google::cloud::datacatalog::v1::ImportTaxonomiesResponse>),
       ImportTaxonomies,
       (google::cloud::datacatalog::v1::ImportTaxonomiesRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::datacatalog::v1::ExportTaxonomiesResponse>,
+      (StatusOr<google::cloud::datacatalog::v1::ExportTaxonomiesResponse>),
       ExportTaxonomies,
       (google::cloud::datacatalog::v1::ExportTaxonomiesRequest const& request),
       (override));

--- a/google/cloud/datafusion/v1/mocks/mock_data_fusion_connection.h
+++ b/google/cloud/datafusion/v1/mocks/mock_data_fusion_connection.h
@@ -58,28 +58,30 @@ class MockDataFusionConnection : public datafusion_v1::DataFusionConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::datafusion::v1::Instance>, GetInstance,
+      (StatusOr<google::cloud::datafusion::v1::Instance>), GetInstance,
       (google::cloud::datafusion::v1::GetInstanceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::datafusion::v1::Instance>>, CreateInstance,
+      (future<StatusOr<google::cloud::datafusion::v1::Instance>>),
+      CreateInstance,
       (google::cloud::datafusion::v1::CreateInstanceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::datafusion::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::datafusion::v1::OperationMetadata>>),
       DeleteInstance,
       (google::cloud::datafusion::v1::DeleteInstanceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::datafusion::v1::Instance>>, UpdateInstance,
+      (future<StatusOr<google::cloud::datafusion::v1::Instance>>),
+      UpdateInstance,
       (google::cloud::datafusion::v1::UpdateInstanceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::datafusion::v1::Instance>>,
+      (future<StatusOr<google::cloud::datafusion::v1::Instance>>),
       RestartInstance,
       (google::cloud::datafusion::v1::RestartInstanceRequest const& request),
       (override));

--- a/google/cloud/datamigration/v1/mocks/mock_data_migration_connection.h
+++ b/google/cloud/datamigration/v1/mocks/mock_data_migration_connection.h
@@ -53,70 +53,70 @@ class MockDataMigrationServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::clouddms::v1::MigrationJob>, GetMigrationJob,
+      (StatusOr<google::cloud::clouddms::v1::MigrationJob>), GetMigrationJob,
       (google::cloud::clouddms::v1::GetMigrationJobRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>,
+      (future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>),
       CreateMigrationJob,
       (google::cloud::clouddms::v1::CreateMigrationJobRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>,
+      (future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>),
       UpdateMigrationJob,
       (google::cloud::clouddms::v1::UpdateMigrationJobRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::clouddms::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::clouddms::v1::OperationMetadata>>),
       DeleteMigrationJob,
       (google::cloud::clouddms::v1::DeleteMigrationJobRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>,
+      (future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>),
       StartMigrationJob,
       (google::cloud::clouddms::v1::StartMigrationJobRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>,
+      (future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>),
       StopMigrationJob,
       (google::cloud::clouddms::v1::StopMigrationJobRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>,
+      (future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>),
       ResumeMigrationJob,
       (google::cloud::clouddms::v1::ResumeMigrationJobRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>,
+      (future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>),
       PromoteMigrationJob,
       (google::cloud::clouddms::v1::PromoteMigrationJobRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>,
+      (future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>),
       VerifyMigrationJob,
       (google::cloud::clouddms::v1::VerifyMigrationJobRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>,
+      (future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>),
       RestartMigrationJob,
       (google::cloud::clouddms::v1::RestartMigrationJobRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::clouddms::v1::SshScript>, GenerateSshScript,
+      (StatusOr<google::cloud::clouddms::v1::SshScript>), GenerateSshScript,
       (google::cloud::clouddms::v1::GenerateSshScriptRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::clouddms::v1::TcpProxyScript>,
+  MOCK_METHOD((StatusOr<google::cloud::clouddms::v1::TcpProxyScript>),
               GenerateTcpProxyScript,
               (google::cloud::clouddms::v1::GenerateTcpProxyScriptRequest const&
                    request),
@@ -129,41 +129,41 @@ class MockDataMigrationServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::clouddms::v1::ConnectionProfile>,
+      (StatusOr<google::cloud::clouddms::v1::ConnectionProfile>),
       GetConnectionProfile,
       (google::cloud::clouddms::v1::GetConnectionProfileRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::clouddms::v1::ConnectionProfile>>,
+      (future<StatusOr<google::cloud::clouddms::v1::ConnectionProfile>>),
       CreateConnectionProfile,
       (google::cloud::clouddms::v1::CreateConnectionProfileRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::clouddms::v1::ConnectionProfile>>,
+      (future<StatusOr<google::cloud::clouddms::v1::ConnectionProfile>>),
       UpdateConnectionProfile,
       (google::cloud::clouddms::v1::UpdateConnectionProfileRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::clouddms::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::clouddms::v1::OperationMetadata>>),
       DeleteConnectionProfile,
       (google::cloud::clouddms::v1::DeleteConnectionProfileRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::clouddms::v1::PrivateConnection>>,
+      (future<StatusOr<google::cloud::clouddms::v1::PrivateConnection>>),
       CreatePrivateConnection,
       (google::cloud::clouddms::v1::CreatePrivateConnectionRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::clouddms::v1::PrivateConnection>,
+      (StatusOr<google::cloud::clouddms::v1::PrivateConnection>),
       GetPrivateConnection,
       (google::cloud::clouddms::v1::GetPrivateConnectionRequest const& request),
       (override));
@@ -175,13 +175,13 @@ class MockDataMigrationServiceConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::clouddms::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::clouddms::v1::OperationMetadata>>),
       DeletePrivateConnection,
       (google::cloud::clouddms::v1::DeletePrivateConnectionRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::clouddms::v1::ConversionWorkspace>,
+  MOCK_METHOD((StatusOr<google::cloud::clouddms::v1::ConversionWorkspace>),
               GetConversionWorkspace,
               (google::cloud::clouddms::v1::GetConversionWorkspaceRequest const&
                    request),
@@ -194,28 +194,28 @@ class MockDataMigrationServiceConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::clouddms::v1::ConversionWorkspace>>,
+      (future<StatusOr<google::cloud::clouddms::v1::ConversionWorkspace>>),
       CreateConversionWorkspace,
       (google::cloud::clouddms::v1::CreateConversionWorkspaceRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::clouddms::v1::ConversionWorkspace>>,
+      (future<StatusOr<google::cloud::clouddms::v1::ConversionWorkspace>>),
       UpdateConversionWorkspace,
       (google::cloud::clouddms::v1::UpdateConversionWorkspaceRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::clouddms::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::clouddms::v1::OperationMetadata>>),
       DeleteConversionWorkspace,
       (google::cloud::clouddms::v1::DeleteConversionWorkspaceRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::clouddms::v1::MappingRule>, CreateMappingRule,
+      (StatusOr<google::cloud::clouddms::v1::MappingRule>), CreateMappingRule,
       (google::cloud::clouddms::v1::CreateMappingRuleRequest const& request),
       (override));
 
@@ -230,46 +230,46 @@ class MockDataMigrationServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::clouddms::v1::MappingRule>, GetMappingRule,
+      (StatusOr<google::cloud::clouddms::v1::MappingRule>), GetMappingRule,
       (google::cloud::clouddms::v1::GetMappingRuleRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::clouddms::v1::ConversionWorkspace>>,
+      (future<StatusOr<google::cloud::clouddms::v1::ConversionWorkspace>>),
       SeedConversionWorkspace,
       (google::cloud::clouddms::v1::SeedConversionWorkspaceRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::clouddms::v1::ConversionWorkspace>>,
+      (future<StatusOr<google::cloud::clouddms::v1::ConversionWorkspace>>),
       ImportMappingRules,
       (google::cloud::clouddms::v1::ImportMappingRulesRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::clouddms::v1::ConversionWorkspace>>,
+      (future<StatusOr<google::cloud::clouddms::v1::ConversionWorkspace>>),
       ConvertConversionWorkspace,
       (google::cloud::clouddms::v1::ConvertConversionWorkspaceRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::clouddms::v1::ConversionWorkspace>>,
+      (future<StatusOr<google::cloud::clouddms::v1::ConversionWorkspace>>),
       CommitConversionWorkspace,
       (google::cloud::clouddms::v1::CommitConversionWorkspaceRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::clouddms::v1::ConversionWorkspace>>,
+      (future<StatusOr<google::cloud::clouddms::v1::ConversionWorkspace>>),
       RollbackConversionWorkspace,
       (google::cloud::clouddms::v1::RollbackConversionWorkspaceRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::clouddms::v1::ConversionWorkspace>>,
+      (future<StatusOr<google::cloud::clouddms::v1::ConversionWorkspace>>),
       ApplyConversionWorkspace,
       (google::cloud::clouddms::v1::ApplyConversionWorkspaceRequest const&
            request),
@@ -282,13 +282,13 @@ class MockDataMigrationServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::clouddms::v1::SearchBackgroundJobsResponse>,
+      (StatusOr<google::cloud::clouddms::v1::SearchBackgroundJobsResponse>),
       SearchBackgroundJobs,
       (google::cloud::clouddms::v1::SearchBackgroundJobsRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::clouddms::v1::
-                           DescribeConversionWorkspaceRevisionsResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::clouddms::v1::
+                            DescribeConversionWorkspaceRevisionsResponse>),
               DescribeConversionWorkspaceRevisions,
               (google::cloud::clouddms::v1::
                    DescribeConversionWorkspaceRevisionsRequest const& request),

--- a/google/cloud/dataplex/v1/mocks/mock_catalog_connection.h
+++ b/google/cloud/dataplex/v1/mocks/mock_catalog_connection.h
@@ -48,17 +48,19 @@ class MockCatalogServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dataplex::v1::EntryType>>, CreateEntryType,
+      (future<StatusOr<google::cloud::dataplex::v1::EntryType>>),
+      CreateEntryType,
       (google::cloud::dataplex::v1::CreateEntryTypeRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dataplex::v1::EntryType>>, UpdateEntryType,
+      (future<StatusOr<google::cloud::dataplex::v1::EntryType>>),
+      UpdateEntryType,
       (google::cloud::dataplex::v1::UpdateEntryTypeRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dataplex::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::dataplex::v1::OperationMetadata>>),
       DeleteEntryType,
       (google::cloud::dataplex::v1::DeleteEntryTypeRequest const& request),
       (override));
@@ -68,24 +70,24 @@ class MockCatalogServiceConnection
               (google::cloud::dataplex::v1::ListEntryTypesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dataplex::v1::EntryType>, GetEntryType,
+  MOCK_METHOD((StatusOr<google::cloud::dataplex::v1::EntryType>), GetEntryType,
               (google::cloud::dataplex::v1::GetEntryTypeRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dataplex::v1::AspectType>>,
+      (future<StatusOr<google::cloud::dataplex::v1::AspectType>>),
       CreateAspectType,
       (google::cloud::dataplex::v1::CreateAspectTypeRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dataplex::v1::AspectType>>,
+      (future<StatusOr<google::cloud::dataplex::v1::AspectType>>),
       UpdateAspectType,
       (google::cloud::dataplex::v1::UpdateAspectTypeRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dataplex::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::dataplex::v1::OperationMetadata>>),
       DeleteAspectType,
       (google::cloud::dataplex::v1::DeleteAspectTypeRequest const& request),
       (override));
@@ -96,24 +98,24 @@ class MockCatalogServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dataplex::v1::AspectType>, GetAspectType,
+      (StatusOr<google::cloud::dataplex::v1::AspectType>), GetAspectType,
       (google::cloud::dataplex::v1::GetAspectTypeRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dataplex::v1::EntryGroup>>,
+      (future<StatusOr<google::cloud::dataplex::v1::EntryGroup>>),
       CreateEntryGroup,
       (google::cloud::dataplex::v1::CreateEntryGroupRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dataplex::v1::EntryGroup>>,
+      (future<StatusOr<google::cloud::dataplex::v1::EntryGroup>>),
       UpdateEntryGroup,
       (google::cloud::dataplex::v1::UpdateEntryGroupRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dataplex::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::dataplex::v1::OperationMetadata>>),
       DeleteEntryGroup,
       (google::cloud::dataplex::v1::DeleteEntryGroupRequest const& request),
       (override));
@@ -124,19 +126,19 @@ class MockCatalogServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dataplex::v1::EntryGroup>, GetEntryGroup,
+      (StatusOr<google::cloud::dataplex::v1::EntryGroup>), GetEntryGroup,
       (google::cloud::dataplex::v1::GetEntryGroupRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dataplex::v1::Entry>, CreateEntry,
+  MOCK_METHOD((StatusOr<google::cloud::dataplex::v1::Entry>), CreateEntry,
               (google::cloud::dataplex::v1::CreateEntryRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dataplex::v1::Entry>, UpdateEntry,
+  MOCK_METHOD((StatusOr<google::cloud::dataplex::v1::Entry>), UpdateEntry,
               (google::cloud::dataplex::v1::UpdateEntryRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dataplex::v1::Entry>, DeleteEntry,
+  MOCK_METHOD((StatusOr<google::cloud::dataplex::v1::Entry>), DeleteEntry,
               (google::cloud::dataplex::v1::DeleteEntryRequest const& request),
               (override));
 
@@ -144,11 +146,11 @@ class MockCatalogServiceConnection
               (google::cloud::dataplex::v1::ListEntriesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dataplex::v1::Entry>, GetEntry,
+  MOCK_METHOD((StatusOr<google::cloud::dataplex::v1::Entry>), GetEntry,
               (google::cloud::dataplex::v1::GetEntryRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dataplex::v1::Entry>, LookupEntry,
+  MOCK_METHOD((StatusOr<google::cloud::dataplex::v1::Entry>), LookupEntry,
               (google::cloud::dataplex::v1::LookupEntryRequest const& request),
               (override));
 

--- a/google/cloud/dataplex/v1/mocks/mock_content_connection.h
+++ b/google/cloud/dataplex/v1/mocks/mock_content_connection.h
@@ -48,12 +48,12 @@ class MockContentServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dataplex::v1::Content>, CreateContent,
+      (StatusOr<google::cloud::dataplex::v1::Content>), CreateContent,
       (google::cloud::dataplex::v1::CreateContentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dataplex::v1::Content>, UpdateContent,
+      (StatusOr<google::cloud::dataplex::v1::Content>), UpdateContent,
       (google::cloud::dataplex::v1::UpdateContentRequest const& request),
       (override));
 
@@ -62,19 +62,19 @@ class MockContentServiceConnection
       (google::cloud::dataplex::v1::DeleteContentRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dataplex::v1::Content>, GetContent,
+  MOCK_METHOD((StatusOr<google::cloud::dataplex::v1::Content>), GetContent,
               (google::cloud::dataplex::v1::GetContentRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), GetIamPolicy,
               (google::iam::v1::GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), SetIamPolicy,
               (google::iam::v1::SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD((StatusOr<google::iam::v1::TestIamPermissionsResponse>),
               TestIamPermissions,
               (google::iam::v1::TestIamPermissionsRequest const& request),
               (override));

--- a/google/cloud/dataplex/v1/mocks/mock_dataplex_connection.h
+++ b/google/cloud/dataplex/v1/mocks/mock_dataplex_connection.h
@@ -47,24 +47,25 @@ class MockDataplexServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::dataplex::v1::Lake>>, CreateLake,
+  MOCK_METHOD((future<StatusOr<google::cloud::dataplex::v1::Lake>>), CreateLake,
               (google::cloud::dataplex::v1::CreateLakeRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::dataplex::v1::Lake>>, UpdateLake,
+  MOCK_METHOD((future<StatusOr<google::cloud::dataplex::v1::Lake>>), UpdateLake,
               (google::cloud::dataplex::v1::UpdateLakeRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::dataplex::v1::OperationMetadata>>,
-              DeleteLake,
-              (google::cloud::dataplex::v1::DeleteLakeRequest const& request),
-              (override));
+  MOCK_METHOD(
+      (future<StatusOr<google::cloud::dataplex::v1::OperationMetadata>>),
+      DeleteLake,
+      (google::cloud::dataplex::v1::DeleteLakeRequest const& request),
+      (override));
 
   MOCK_METHOD((StreamRange<google::cloud::dataplex::v1::Lake>), ListLakes,
               (google::cloud::dataplex::v1::ListLakesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dataplex::v1::Lake>, GetLake,
+  MOCK_METHOD((StatusOr<google::cloud::dataplex::v1::Lake>), GetLake,
               (google::cloud::dataplex::v1::GetLakeRequest const& request),
               (override));
 
@@ -73,24 +74,25 @@ class MockDataplexServiceConnection
               (google::cloud::dataplex::v1::ListLakeActionsRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::dataplex::v1::Zone>>, CreateZone,
+  MOCK_METHOD((future<StatusOr<google::cloud::dataplex::v1::Zone>>), CreateZone,
               (google::cloud::dataplex::v1::CreateZoneRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::dataplex::v1::Zone>>, UpdateZone,
+  MOCK_METHOD((future<StatusOr<google::cloud::dataplex::v1::Zone>>), UpdateZone,
               (google::cloud::dataplex::v1::UpdateZoneRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::dataplex::v1::OperationMetadata>>,
-              DeleteZone,
-              (google::cloud::dataplex::v1::DeleteZoneRequest const& request),
-              (override));
+  MOCK_METHOD(
+      (future<StatusOr<google::cloud::dataplex::v1::OperationMetadata>>),
+      DeleteZone,
+      (google::cloud::dataplex::v1::DeleteZoneRequest const& request),
+      (override));
 
   MOCK_METHOD((StreamRange<google::cloud::dataplex::v1::Zone>), ListZones,
               (google::cloud::dataplex::v1::ListZonesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dataplex::v1::Zone>, GetZone,
+  MOCK_METHOD((StatusOr<google::cloud::dataplex::v1::Zone>), GetZone,
               (google::cloud::dataplex::v1::GetZoneRequest const& request),
               (override));
 
@@ -99,24 +101,27 @@ class MockDataplexServiceConnection
               (google::cloud::dataplex::v1::ListZoneActionsRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::dataplex::v1::Asset>>, CreateAsset,
+  MOCK_METHOD((future<StatusOr<google::cloud::dataplex::v1::Asset>>),
+              CreateAsset,
               (google::cloud::dataplex::v1::CreateAssetRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::dataplex::v1::Asset>>, UpdateAsset,
+  MOCK_METHOD((future<StatusOr<google::cloud::dataplex::v1::Asset>>),
+              UpdateAsset,
               (google::cloud::dataplex::v1::UpdateAssetRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::dataplex::v1::OperationMetadata>>,
-              DeleteAsset,
-              (google::cloud::dataplex::v1::DeleteAssetRequest const& request),
-              (override));
+  MOCK_METHOD(
+      (future<StatusOr<google::cloud::dataplex::v1::OperationMetadata>>),
+      DeleteAsset,
+      (google::cloud::dataplex::v1::DeleteAssetRequest const& request),
+      (override));
 
   MOCK_METHOD((StreamRange<google::cloud::dataplex::v1::Asset>), ListAssets,
               (google::cloud::dataplex::v1::ListAssetsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dataplex::v1::Asset>, GetAsset,
+  MOCK_METHOD((StatusOr<google::cloud::dataplex::v1::Asset>), GetAsset,
               (google::cloud::dataplex::v1::GetAssetRequest const& request),
               (override));
 
@@ -125,24 +130,25 @@ class MockDataplexServiceConnection
               (google::cloud::dataplex::v1::ListAssetActionsRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::dataplex::v1::Task>>, CreateTask,
+  MOCK_METHOD((future<StatusOr<google::cloud::dataplex::v1::Task>>), CreateTask,
               (google::cloud::dataplex::v1::CreateTaskRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::dataplex::v1::Task>>, UpdateTask,
+  MOCK_METHOD((future<StatusOr<google::cloud::dataplex::v1::Task>>), UpdateTask,
               (google::cloud::dataplex::v1::UpdateTaskRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::dataplex::v1::OperationMetadata>>,
-              DeleteTask,
-              (google::cloud::dataplex::v1::DeleteTaskRequest const& request),
-              (override));
+  MOCK_METHOD(
+      (future<StatusOr<google::cloud::dataplex::v1::OperationMetadata>>),
+      DeleteTask,
+      (google::cloud::dataplex::v1::DeleteTaskRequest const& request),
+      (override));
 
   MOCK_METHOD((StreamRange<google::cloud::dataplex::v1::Task>), ListTasks,
               (google::cloud::dataplex::v1::ListTasksRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dataplex::v1::Task>, GetTask,
+  MOCK_METHOD((StatusOr<google::cloud::dataplex::v1::Task>), GetTask,
               (google::cloud::dataplex::v1::GetTaskRequest const& request),
               (override));
 
@@ -150,11 +156,11 @@ class MockDataplexServiceConnection
               (google::cloud::dataplex::v1::ListJobsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dataplex::v1::RunTaskResponse>, RunTask,
+  MOCK_METHOD((StatusOr<google::cloud::dataplex::v1::RunTaskResponse>), RunTask,
               (google::cloud::dataplex::v1::RunTaskRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dataplex::v1::Job>, GetJob,
+  MOCK_METHOD((StatusOr<google::cloud::dataplex::v1::Job>), GetJob,
               (google::cloud::dataplex::v1::GetJobRequest const& request),
               (override));
 
@@ -163,19 +169,19 @@ class MockDataplexServiceConnection
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dataplex::v1::Environment>>,
+      (future<StatusOr<google::cloud::dataplex::v1::Environment>>),
       CreateEnvironment,
       (google::cloud::dataplex::v1::CreateEnvironmentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dataplex::v1::Environment>>,
+      (future<StatusOr<google::cloud::dataplex::v1::Environment>>),
       UpdateEnvironment,
       (google::cloud::dataplex::v1::UpdateEnvironmentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dataplex::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::dataplex::v1::OperationMetadata>>),
       DeleteEnvironment,
       (google::cloud::dataplex::v1::DeleteEnvironmentRequest const& request),
       (override));
@@ -186,7 +192,7 @@ class MockDataplexServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dataplex::v1::Environment>, GetEnvironment,
+      (StatusOr<google::cloud::dataplex::v1::Environment>), GetEnvironment,
       (google::cloud::dataplex::v1::GetEnvironmentRequest const& request),
       (override));
 

--- a/google/cloud/dataplex/v1/mocks/mock_metadata_connection.h
+++ b/google/cloud/dataplex/v1/mocks/mock_metadata_connection.h
@@ -47,11 +47,11 @@ class MockMetadataServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dataplex::v1::Entity>, CreateEntity,
+  MOCK_METHOD((StatusOr<google::cloud::dataplex::v1::Entity>), CreateEntity,
               (google::cloud::dataplex::v1::CreateEntityRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dataplex::v1::Entity>, UpdateEntity,
+  MOCK_METHOD((StatusOr<google::cloud::dataplex::v1::Entity>), UpdateEntity,
               (google::cloud::dataplex::v1::UpdateEntityRequest const& request),
               (override));
 
@@ -59,7 +59,7 @@ class MockMetadataServiceConnection
               (google::cloud::dataplex::v1::DeleteEntityRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dataplex::v1::Entity>, GetEntity,
+  MOCK_METHOD((StatusOr<google::cloud::dataplex::v1::Entity>), GetEntity,
               (google::cloud::dataplex::v1::GetEntityRequest const& request),
               (override));
 
@@ -68,7 +68,7 @@ class MockMetadataServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dataplex::v1::Partition>, CreatePartition,
+      (StatusOr<google::cloud::dataplex::v1::Partition>), CreatePartition,
       (google::cloud::dataplex::v1::CreatePartitionRequest const& request),
       (override));
 
@@ -77,7 +77,7 @@ class MockMetadataServiceConnection
       (google::cloud::dataplex::v1::DeletePartitionRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dataplex::v1::Partition>, GetPartition,
+  MOCK_METHOD((StatusOr<google::cloud::dataplex::v1::Partition>), GetPartition,
               (google::cloud::dataplex::v1::GetPartitionRequest const& request),
               (override));
 

--- a/google/cloud/dataproc/v1/mocks/mock_autoscaling_policy_connection.h
+++ b/google/cloud/dataproc/v1/mocks/mock_autoscaling_policy_connection.h
@@ -48,21 +48,21 @@ class MockAutoscalingPolicyServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dataproc::v1::AutoscalingPolicy>,
+      (StatusOr<google::cloud::dataproc::v1::AutoscalingPolicy>),
       CreateAutoscalingPolicy,
       (google::cloud::dataproc::v1::CreateAutoscalingPolicyRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dataproc::v1::AutoscalingPolicy>,
+      (StatusOr<google::cloud::dataproc::v1::AutoscalingPolicy>),
       UpdateAutoscalingPolicy,
       (google::cloud::dataproc::v1::UpdateAutoscalingPolicyRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dataproc::v1::AutoscalingPolicy>,
+      (StatusOr<google::cloud::dataproc::v1::AutoscalingPolicy>),
       GetAutoscalingPolicy,
       (google::cloud::dataproc::v1::GetAutoscalingPolicyRequest const& request),
       (override));

--- a/google/cloud/dataproc/v1/mocks/mock_batch_controller_connection.h
+++ b/google/cloud/dataproc/v1/mocks/mock_batch_controller_connection.h
@@ -47,11 +47,12 @@ class MockBatchControllerConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::dataproc::v1::Batch>>, CreateBatch,
+  MOCK_METHOD((future<StatusOr<google::cloud::dataproc::v1::Batch>>),
+              CreateBatch,
               (google::cloud::dataproc::v1::CreateBatchRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dataproc::v1::Batch>, GetBatch,
+  MOCK_METHOD((StatusOr<google::cloud::dataproc::v1::Batch>), GetBatch,
               (google::cloud::dataproc::v1::GetBatchRequest const& request),
               (override));
 

--- a/google/cloud/dataproc/v1/mocks/mock_cluster_controller_connection.h
+++ b/google/cloud/dataproc/v1/mocks/mock_cluster_controller_connection.h
@@ -48,32 +48,32 @@ class MockClusterControllerConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dataproc::v1::Cluster>>, CreateCluster,
+      (future<StatusOr<google::cloud::dataproc::v1::Cluster>>), CreateCluster,
       (google::cloud::dataproc::v1::CreateClusterRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dataproc::v1::Cluster>>, UpdateCluster,
+      (future<StatusOr<google::cloud::dataproc::v1::Cluster>>), UpdateCluster,
       (google::cloud::dataproc::v1::UpdateClusterRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::dataproc::v1::Cluster>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::dataproc::v1::Cluster>>),
               StopCluster,
               (google::cloud::dataproc::v1::StopClusterRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::dataproc::v1::Cluster>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::dataproc::v1::Cluster>>),
               StartCluster,
               (google::cloud::dataproc::v1::StartClusterRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dataproc::v1::ClusterOperationMetadata>>,
+      (future<StatusOr<google::cloud::dataproc::v1::ClusterOperationMetadata>>),
       DeleteCluster,
       (google::cloud::dataproc::v1::DeleteClusterRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dataproc::v1::Cluster>, GetCluster,
+  MOCK_METHOD((StatusOr<google::cloud::dataproc::v1::Cluster>), GetCluster,
               (google::cloud::dataproc::v1::GetClusterRequest const& request),
               (override));
 
@@ -82,7 +82,7 @@ class MockClusterControllerConnection
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dataproc::v1::DiagnoseClusterResults>>,
+      (future<StatusOr<google::cloud::dataproc::v1::DiagnoseClusterResults>>),
       DiagnoseCluster,
       (google::cloud::dataproc::v1::DiagnoseClusterRequest const& request),
       (override));

--- a/google/cloud/dataproc/v1/mocks/mock_job_controller_connection.h
+++ b/google/cloud/dataproc/v1/mocks/mock_job_controller_connection.h
@@ -47,16 +47,16 @@ class MockJobControllerConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dataproc::v1::Job>, SubmitJob,
+  MOCK_METHOD((StatusOr<google::cloud::dataproc::v1::Job>), SubmitJob,
               (google::cloud::dataproc::v1::SubmitJobRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::dataproc::v1::Job>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::dataproc::v1::Job>>),
               SubmitJobAsOperation,
               (google::cloud::dataproc::v1::SubmitJobRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dataproc::v1::Job>, GetJob,
+  MOCK_METHOD((StatusOr<google::cloud::dataproc::v1::Job>), GetJob,
               (google::cloud::dataproc::v1::GetJobRequest const& request),
               (override));
 
@@ -64,11 +64,11 @@ class MockJobControllerConnection
               (google::cloud::dataproc::v1::ListJobsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dataproc::v1::Job>, UpdateJob,
+  MOCK_METHOD((StatusOr<google::cloud::dataproc::v1::Job>), UpdateJob,
               (google::cloud::dataproc::v1::UpdateJobRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dataproc::v1::Job>, CancelJob,
+  MOCK_METHOD((StatusOr<google::cloud::dataproc::v1::Job>), CancelJob,
               (google::cloud::dataproc::v1::CancelJobRequest const& request),
               (override));
 

--- a/google/cloud/dataproc/v1/mocks/mock_node_group_controller_connection.h
+++ b/google/cloud/dataproc/v1/mocks/mock_node_group_controller_connection.h
@@ -48,16 +48,18 @@ class MockNodeGroupControllerConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dataproc::v1::NodeGroup>>, CreateNodeGroup,
+      (future<StatusOr<google::cloud::dataproc::v1::NodeGroup>>),
+      CreateNodeGroup,
       (google::cloud::dataproc::v1::CreateNodeGroupRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dataproc::v1::NodeGroup>>, ResizeNodeGroup,
+      (future<StatusOr<google::cloud::dataproc::v1::NodeGroup>>),
+      ResizeNodeGroup,
       (google::cloud::dataproc::v1::ResizeNodeGroupRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dataproc::v1::NodeGroup>, GetNodeGroup,
+  MOCK_METHOD((StatusOr<google::cloud::dataproc::v1::NodeGroup>), GetNodeGroup,
               (google::cloud::dataproc::v1::GetNodeGroupRequest const& request),
               (override));
 };

--- a/google/cloud/dataproc/v1/mocks/mock_workflow_template_connection.h
+++ b/google/cloud/dataproc/v1/mocks/mock_workflow_template_connection.h
@@ -47,32 +47,32 @@ class MockWorkflowTemplateServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dataproc::v1::WorkflowTemplate>,
+  MOCK_METHOD((StatusOr<google::cloud::dataproc::v1::WorkflowTemplate>),
               CreateWorkflowTemplate,
               (google::cloud::dataproc::v1::CreateWorkflowTemplateRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dataproc::v1::WorkflowTemplate>,
+      (StatusOr<google::cloud::dataproc::v1::WorkflowTemplate>),
       GetWorkflowTemplate,
       (google::cloud::dataproc::v1::GetWorkflowTemplateRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dataproc::v1::WorkflowMetadata>>,
+      (future<StatusOr<google::cloud::dataproc::v1::WorkflowMetadata>>),
       InstantiateWorkflowTemplate,
       (google::cloud::dataproc::v1::InstantiateWorkflowTemplateRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::dataproc::v1::WorkflowMetadata>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::dataproc::v1::WorkflowMetadata>>),
               InstantiateInlineWorkflowTemplate,
               (google::cloud::dataproc::v1::
                    InstantiateInlineWorkflowTemplateRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dataproc::v1::WorkflowTemplate>,
+  MOCK_METHOD((StatusOr<google::cloud::dataproc::v1::WorkflowTemplate>),
               UpdateWorkflowTemplate,
               (google::cloud::dataproc::v1::UpdateWorkflowTemplateRequest const&
                    request),

--- a/google/cloud/datastore/admin/v1/mocks/mock_datastore_admin_connection.h
+++ b/google/cloud/datastore/admin/v1/mocks/mock_datastore_admin_connection.h
@@ -48,28 +48,28 @@ class MockDatastoreAdminConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::datastore::admin::v1::ExportEntitiesResponse>>,
+      (future<StatusOr<google::datastore::admin::v1::ExportEntitiesResponse>>),
       ExportEntities,
       (google::datastore::admin::v1::ExportEntitiesRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::datastore::admin::v1::ImportEntitiesMetadata>>,
+      (future<StatusOr<google::datastore::admin::v1::ImportEntitiesMetadata>>),
       ImportEntities,
       (google::datastore::admin::v1::ImportEntitiesRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::datastore::admin::v1::Index>>,
+  MOCK_METHOD((future<StatusOr<google::datastore::admin::v1::Index>>),
               CreateIndex,
               (google::datastore::admin::v1::CreateIndexRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::datastore::admin::v1::Index>>,
+  MOCK_METHOD((future<StatusOr<google::datastore::admin::v1::Index>>),
               DeleteIndex,
               (google::datastore::admin::v1::DeleteIndexRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::datastore::admin::v1::Index>, GetIndex,
+  MOCK_METHOD((StatusOr<google::datastore::admin::v1::Index>), GetIndex,
               (google::datastore::admin::v1::GetIndexRequest const& request),
               (override));
 

--- a/google/cloud/datastore/v1/mocks/mock_datastore_connection.h
+++ b/google/cloud/datastore/v1/mocks/mock_datastore_connection.h
@@ -46,38 +46,39 @@ class MockDatastoreConnection : public datastore_v1::DatastoreConnection {
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::datastore::v1::LookupResponse>, Lookup,
+  MOCK_METHOD((StatusOr<google::datastore::v1::LookupResponse>), Lookup,
               (google::datastore::v1::LookupRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::datastore::v1::RunQueryResponse>, RunQuery,
+  MOCK_METHOD((StatusOr<google::datastore::v1::RunQueryResponse>), RunQuery,
               (google::datastore::v1::RunQueryRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::datastore::v1::RunAggregationQueryResponse>,
+      (StatusOr<google::datastore::v1::RunAggregationQueryResponse>),
       RunAggregationQuery,
       (google::datastore::v1::RunAggregationQueryRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::datastore::v1::BeginTransactionResponse>,
+  MOCK_METHOD((StatusOr<google::datastore::v1::BeginTransactionResponse>),
               BeginTransaction,
               (google::datastore::v1::BeginTransactionRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::datastore::v1::CommitResponse>, Commit,
+  MOCK_METHOD((StatusOr<google::datastore::v1::CommitResponse>), Commit,
               (google::datastore::v1::CommitRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::datastore::v1::RollbackResponse>, Rollback,
+  MOCK_METHOD((StatusOr<google::datastore::v1::RollbackResponse>), Rollback,
               (google::datastore::v1::RollbackRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::datastore::v1::AllocateIdsResponse>, AllocateIds,
+  MOCK_METHOD((StatusOr<google::datastore::v1::AllocateIdsResponse>),
+              AllocateIds,
               (google::datastore::v1::AllocateIdsRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::datastore::v1::ReserveIdsResponse>, ReserveIds,
+  MOCK_METHOD((StatusOr<google::datastore::v1::ReserveIdsResponse>), ReserveIds,
               (google::datastore::v1::ReserveIdsRequest const& request),
               (override));
 };

--- a/google/cloud/datastream/v1/mocks/mock_datastream_connection.h
+++ b/google/cloud/datastream/v1/mocks/mock_datastream_connection.h
@@ -52,36 +52,36 @@ class MockDatastreamConnection : public datastream_v1::DatastreamConnection {
       (google::cloud::datastream::v1::ListConnectionProfilesRequest request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::datastream::v1::ConnectionProfile>,
+  MOCK_METHOD((StatusOr<google::cloud::datastream::v1::ConnectionProfile>),
               GetConnectionProfile,
               (google::cloud::datastream::v1::GetConnectionProfileRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::datastream::v1::ConnectionProfile>>,
+      (future<StatusOr<google::cloud::datastream::v1::ConnectionProfile>>),
       CreateConnectionProfile,
       (google::cloud::datastream::v1::CreateConnectionProfileRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::datastream::v1::ConnectionProfile>>,
+      (future<StatusOr<google::cloud::datastream::v1::ConnectionProfile>>),
       UpdateConnectionProfile,
       (google::cloud::datastream::v1::UpdateConnectionProfileRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::datastream::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::datastream::v1::OperationMetadata>>),
       DeleteConnectionProfile,
       (google::cloud::datastream::v1::DeleteConnectionProfileRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::datastream::v1::DiscoverConnectionProfileResponse>,
+      (StatusOr<
+          google::cloud::datastream::v1::DiscoverConnectionProfileResponse>),
       DiscoverConnectionProfile,
       (google::cloud::datastream::v1::DiscoverConnectionProfileRequest const&
            request),
@@ -91,33 +91,34 @@ class MockDatastreamConnection : public datastream_v1::DatastreamConnection {
               (google::cloud::datastream::v1::ListStreamsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::datastream::v1::Stream>, GetStream,
+  MOCK_METHOD((StatusOr<google::cloud::datastream::v1::Stream>), GetStream,
               (google::cloud::datastream::v1::GetStreamRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::datastream::v1::Stream>>, CreateStream,
+      (future<StatusOr<google::cloud::datastream::v1::Stream>>), CreateStream,
       (google::cloud::datastream::v1::CreateStreamRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::datastream::v1::Stream>>, UpdateStream,
+      (future<StatusOr<google::cloud::datastream::v1::Stream>>), UpdateStream,
       (google::cloud::datastream::v1::UpdateStreamRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::datastream::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::datastream::v1::OperationMetadata>>),
       DeleteStream,
       (google::cloud::datastream::v1::DeleteStreamRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::datastream::v1::StreamObject>, GetStreamObject,
+      (StatusOr<google::cloud::datastream::v1::StreamObject>), GetStreamObject,
       (google::cloud::datastream::v1::GetStreamObjectRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::datastream::v1::StreamObject>, LookupStreamObject,
+      (StatusOr<google::cloud::datastream::v1::StreamObject>),
+      LookupStreamObject,
       (google::cloud::datastream::v1::LookupStreamObjectRequest const& request),
       (override));
 
@@ -127,13 +128,13 @@ class MockDatastreamConnection : public datastream_v1::DatastreamConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::datastream::v1::StartBackfillJobResponse>,
+      (StatusOr<google::cloud::datastream::v1::StartBackfillJobResponse>),
       StartBackfillJob,
       (google::cloud::datastream::v1::StartBackfillJobRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::datastream::v1::StopBackfillJobResponse>,
+      (StatusOr<google::cloud::datastream::v1::StopBackfillJobResponse>),
       StopBackfillJob,
       (google::cloud::datastream::v1::StopBackfillJobRequest const& request),
       (override));
@@ -143,13 +144,13 @@ class MockDatastreamConnection : public datastream_v1::DatastreamConnection {
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::datastream::v1::PrivateConnection>>,
+      (future<StatusOr<google::cloud::datastream::v1::PrivateConnection>>),
       CreatePrivateConnection,
       (google::cloud::datastream::v1::CreatePrivateConnectionRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::datastream::v1::PrivateConnection>,
+  MOCK_METHOD((StatusOr<google::cloud::datastream::v1::PrivateConnection>),
               GetPrivateConnection,
               (google::cloud::datastream::v1::GetPrivateConnectionRequest const&
                    request),
@@ -162,18 +163,18 @@ class MockDatastreamConnection : public datastream_v1::DatastreamConnection {
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::datastream::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::datastream::v1::OperationMetadata>>),
       DeletePrivateConnection,
       (google::cloud::datastream::v1::DeletePrivateConnectionRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::datastream::v1::Route>>, CreateRoute,
+      (future<StatusOr<google::cloud::datastream::v1::Route>>), CreateRoute,
       (google::cloud::datastream::v1::CreateRouteRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::datastream::v1::Route>, GetRoute,
+  MOCK_METHOD((StatusOr<google::cloud::datastream::v1::Route>), GetRoute,
               (google::cloud::datastream::v1::GetRouteRequest const& request),
               (override));
 
@@ -182,7 +183,7 @@ class MockDatastreamConnection : public datastream_v1::DatastreamConnection {
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::datastream::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::datastream::v1::OperationMetadata>>),
       DeleteRoute,
       (google::cloud::datastream::v1::DeleteRouteRequest const& request),
       (override));

--- a/google/cloud/deploy/v1/mocks/mock_cloud_deploy_connection.h
+++ b/google/cloud/deploy/v1/mocks/mock_cloud_deploy_connection.h
@@ -52,25 +52,25 @@ class MockCloudDeployConnection : public deploy_v1::CloudDeployConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::deploy::v1::DeliveryPipeline>,
+      (StatusOr<google::cloud::deploy::v1::DeliveryPipeline>),
       GetDeliveryPipeline,
       (google::cloud::deploy::v1::GetDeliveryPipelineRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::deploy::v1::DeliveryPipeline>>,
+      (future<StatusOr<google::cloud::deploy::v1::DeliveryPipeline>>),
       CreateDeliveryPipeline,
       (google::cloud::deploy::v1::CreateDeliveryPipelineRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::deploy::v1::DeliveryPipeline>>,
+      (future<StatusOr<google::cloud::deploy::v1::DeliveryPipeline>>),
       UpdateDeliveryPipeline,
       (google::cloud::deploy::v1::UpdateDeliveryPipelineRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::deploy::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::deploy::v1::OperationMetadata>>),
       DeleteDeliveryPipeline,
       (google::cloud::deploy::v1::DeleteDeliveryPipelineRequest const& request),
       (override));
@@ -79,24 +79,26 @@ class MockCloudDeployConnection : public deploy_v1::CloudDeployConnection {
               (google::cloud::deploy::v1::ListTargetsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::deploy::v1::RollbackTargetResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::deploy::v1::RollbackTargetResponse>),
               RollbackTarget,
               (google::cloud::deploy::v1::RollbackTargetRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::deploy::v1::Target>, GetTarget,
+  MOCK_METHOD((StatusOr<google::cloud::deploy::v1::Target>), GetTarget,
               (google::cloud::deploy::v1::GetTargetRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::deploy::v1::Target>>, CreateTarget,
+  MOCK_METHOD((future<StatusOr<google::cloud::deploy::v1::Target>>),
+              CreateTarget,
               (google::cloud::deploy::v1::CreateTargetRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::deploy::v1::Target>>, UpdateTarget,
+  MOCK_METHOD((future<StatusOr<google::cloud::deploy::v1::Target>>),
+              UpdateTarget,
               (google::cloud::deploy::v1::UpdateTargetRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::deploy::v1::OperationMetadata>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::deploy::v1::OperationMetadata>>),
               DeleteTarget,
               (google::cloud::deploy::v1::DeleteTargetRequest const& request),
               (override));
@@ -107,25 +109,25 @@ class MockCloudDeployConnection : public deploy_v1::CloudDeployConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::deploy::v1::CustomTargetType>,
+      (StatusOr<google::cloud::deploy::v1::CustomTargetType>),
       GetCustomTargetType,
       (google::cloud::deploy::v1::GetCustomTargetTypeRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::deploy::v1::CustomTargetType>>,
+      (future<StatusOr<google::cloud::deploy::v1::CustomTargetType>>),
       CreateCustomTargetType,
       (google::cloud::deploy::v1::CreateCustomTargetTypeRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::deploy::v1::CustomTargetType>>,
+      (future<StatusOr<google::cloud::deploy::v1::CustomTargetType>>),
       UpdateCustomTargetType,
       (google::cloud::deploy::v1::UpdateCustomTargetTypeRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::deploy::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::deploy::v1::OperationMetadata>>),
       DeleteCustomTargetType,
       (google::cloud::deploy::v1::DeleteCustomTargetTypeRequest const& request),
       (override));
@@ -134,31 +136,31 @@ class MockCloudDeployConnection : public deploy_v1::CloudDeployConnection {
               (google::cloud::deploy::v1::ListReleasesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::deploy::v1::Release>, GetRelease,
+  MOCK_METHOD((StatusOr<google::cloud::deploy::v1::Release>), GetRelease,
               (google::cloud::deploy::v1::GetReleaseRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::deploy::v1::Release>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::deploy::v1::Release>>),
               CreateRelease,
               (google::cloud::deploy::v1::CreateReleaseRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::deploy::v1::AbandonReleaseResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::deploy::v1::AbandonReleaseResponse>),
               AbandonRelease,
               (google::cloud::deploy::v1::AbandonReleaseRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::deploy::v1::ApproveRolloutResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::deploy::v1::ApproveRolloutResponse>),
               ApproveRollout,
               (google::cloud::deploy::v1::ApproveRolloutRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::deploy::v1::AdvanceRolloutResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::deploy::v1::AdvanceRolloutResponse>),
               AdvanceRollout,
               (google::cloud::deploy::v1::AdvanceRolloutRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::deploy::v1::CancelRolloutResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::deploy::v1::CancelRolloutResponse>),
               CancelRollout,
               (google::cloud::deploy::v1::CancelRolloutRequest const& request),
               (override));
@@ -167,20 +169,21 @@ class MockCloudDeployConnection : public deploy_v1::CloudDeployConnection {
               (google::cloud::deploy::v1::ListRolloutsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::deploy::v1::Rollout>, GetRollout,
+  MOCK_METHOD((StatusOr<google::cloud::deploy::v1::Rollout>), GetRollout,
               (google::cloud::deploy::v1::GetRolloutRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::deploy::v1::Rollout>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::deploy::v1::Rollout>>),
               CreateRollout,
               (google::cloud::deploy::v1::CreateRolloutRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::deploy::v1::IgnoreJobResponse>, IgnoreJob,
+  MOCK_METHOD((StatusOr<google::cloud::deploy::v1::IgnoreJobResponse>),
+              IgnoreJob,
               (google::cloud::deploy::v1::IgnoreJobRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::deploy::v1::RetryJobResponse>, RetryJob,
+  MOCK_METHOD((StatusOr<google::cloud::deploy::v1::RetryJobResponse>), RetryJob,
               (google::cloud::deploy::v1::RetryJobRequest const& request),
               (override));
 
@@ -188,37 +191,39 @@ class MockCloudDeployConnection : public deploy_v1::CloudDeployConnection {
               (google::cloud::deploy::v1::ListJobRunsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::deploy::v1::JobRun>, GetJobRun,
+  MOCK_METHOD((StatusOr<google::cloud::deploy::v1::JobRun>), GetJobRun,
               (google::cloud::deploy::v1::GetJobRunRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::deploy::v1::TerminateJobRunResponse>,
+      (StatusOr<google::cloud::deploy::v1::TerminateJobRunResponse>),
       TerminateJobRun,
       (google::cloud::deploy::v1::TerminateJobRunRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::deploy::v1::Config>, GetConfig,
+  MOCK_METHOD((StatusOr<google::cloud::deploy::v1::Config>), GetConfig,
               (google::cloud::deploy::v1::GetConfigRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::deploy::v1::Automation>>, CreateAutomation,
+      (future<StatusOr<google::cloud::deploy::v1::Automation>>),
+      CreateAutomation,
       (google::cloud::deploy::v1::CreateAutomationRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::deploy::v1::Automation>>, UpdateAutomation,
+      (future<StatusOr<google::cloud::deploy::v1::Automation>>),
+      UpdateAutomation,
       (google::cloud::deploy::v1::UpdateAutomationRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::deploy::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::deploy::v1::OperationMetadata>>),
       DeleteAutomation,
       (google::cloud::deploy::v1::DeleteAutomationRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::deploy::v1::Automation>, GetAutomation,
+  MOCK_METHOD((StatusOr<google::cloud::deploy::v1::Automation>), GetAutomation,
               (google::cloud::deploy::v1::GetAutomationRequest const& request),
               (override));
 
@@ -228,7 +233,7 @@ class MockCloudDeployConnection : public deploy_v1::CloudDeployConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::deploy::v1::AutomationRun>, GetAutomationRun,
+      (StatusOr<google::cloud::deploy::v1::AutomationRun>), GetAutomationRun,
       (google::cloud::deploy::v1::GetAutomationRunRequest const& request),
       (override));
 
@@ -238,7 +243,7 @@ class MockCloudDeployConnection : public deploy_v1::CloudDeployConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::deploy::v1::CancelAutomationRunResponse>,
+      (StatusOr<google::cloud::deploy::v1::CancelAutomationRunResponse>),
       CancelAutomationRun,
       (google::cloud::deploy::v1::CancelAutomationRunRequest const& request),
       (override));

--- a/google/cloud/dialogflow_cx/mocks/mock_agents_connection.h
+++ b/google/cloud/dialogflow_cx/mocks/mock_agents_connection.h
@@ -52,17 +52,17 @@ class MockAgentsConnection : public dialogflow_cx::AgentsConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::Agent>, GetAgent,
+      (StatusOr<google::cloud::dialogflow::cx::v3::Agent>), GetAgent,
       (google::cloud::dialogflow::cx::v3::GetAgentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::Agent>, CreateAgent,
+      (StatusOr<google::cloud::dialogflow::cx::v3::Agent>), CreateAgent,
       (google::cloud::dialogflow::cx::v3::CreateAgentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::Agent>, UpdateAgent,
+      (StatusOr<google::cloud::dialogflow::cx::v3::Agent>), UpdateAgent,
       (google::cloud::dialogflow::cx::v3::UpdateAgentRequest const& request),
       (override));
 
@@ -72,38 +72,39 @@ class MockAgentsConnection : public dialogflow_cx::AgentsConnection {
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dialogflow::cx::v3::ExportAgentResponse>>,
+      (future<
+          StatusOr<google::cloud::dialogflow::cx::v3::ExportAgentResponse>>),
       ExportAgent,
       (google::cloud::dialogflow::cx::v3::ExportAgentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::protobuf::Struct>>, RestoreAgent,
+      (future<StatusOr<google::protobuf::Struct>>), RestoreAgent,
       (google::cloud::dialogflow::cx::v3::RestoreAgentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::AgentValidationResult>,
+      (StatusOr<google::cloud::dialogflow::cx::v3::AgentValidationResult>),
       ValidateAgent,
       (google::cloud::dialogflow::cx::v3::ValidateAgentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::AgentValidationResult>,
+      (StatusOr<google::cloud::dialogflow::cx::v3::AgentValidationResult>),
       GetAgentValidationResult,
       (google::cloud::dialogflow::cx::v3::GetAgentValidationResultRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::GenerativeSettings>,
+      (StatusOr<google::cloud::dialogflow::cx::v3::GenerativeSettings>),
       GetGenerativeSettings,
       (google::cloud::dialogflow::cx::v3::GetGenerativeSettingsRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::GenerativeSettings>,
+      (StatusOr<google::cloud::dialogflow::cx::v3::GenerativeSettings>),
       UpdateGenerativeSettings,
       (google::cloud::dialogflow::cx::v3::UpdateGenerativeSettingsRequest const&
            request),

--- a/google/cloud/dialogflow_cx/mocks/mock_changelogs_connection.h
+++ b/google/cloud/dialogflow_cx/mocks/mock_changelogs_connection.h
@@ -53,7 +53,7 @@ class MockChangelogsConnection : public dialogflow_cx::ChangelogsConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::Changelog>, GetChangelog,
+      (StatusOr<google::cloud::dialogflow::cx::v3::Changelog>), GetChangelog,
       (google::cloud::dialogflow::cx::v3::GetChangelogRequest const& request),
       (override));
 };

--- a/google/cloud/dialogflow_cx/mocks/mock_deployments_connection.h
+++ b/google/cloud/dialogflow_cx/mocks/mock_deployments_connection.h
@@ -53,7 +53,7 @@ class MockDeploymentsConnection : public dialogflow_cx::DeploymentsConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::Deployment>, GetDeployment,
+      (StatusOr<google::cloud::dialogflow::cx::v3::Deployment>), GetDeployment,
       (google::cloud::dialogflow::cx::v3::GetDeploymentRequest const& request),
       (override));
 };

--- a/google/cloud/dialogflow_cx/mocks/mock_entity_types_connection.h
+++ b/google/cloud/dialogflow_cx/mocks/mock_entity_types_connection.h
@@ -47,17 +47,17 @@ class MockEntityTypesConnection : public dialogflow_cx::EntityTypesConnection {
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::EntityType>, GetEntityType,
+      (StatusOr<google::cloud::dialogflow::cx::v3::EntityType>), GetEntityType,
       (google::cloud::dialogflow::cx::v3::GetEntityTypeRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dialogflow::cx::v3::EntityType>,
+  MOCK_METHOD((StatusOr<google::cloud::dialogflow::cx::v3::EntityType>),
               CreateEntityType,
               (google::cloud::dialogflow::cx::v3::CreateEntityTypeRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dialogflow::cx::v3::EntityType>,
+  MOCK_METHOD((StatusOr<google::cloud::dialogflow::cx::v3::EntityType>),
               UpdateEntityType,
               (google::cloud::dialogflow::cx::v3::UpdateEntityTypeRequest const&
                    request),
@@ -75,16 +75,16 @@ class MockEntityTypesConnection : public dialogflow_cx::EntityTypesConnection {
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::dialogflow::cx::v3::ExportEntityTypesResponse>>,
+      (future<StatusOr<
+           google::cloud::dialogflow::cx::v3::ExportEntityTypesResponse>>),
       ExportEntityTypes,
       (google::cloud::dialogflow::cx::v3::ExportEntityTypesRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::dialogflow::cx::v3::ImportEntityTypesResponse>>,
+      (future<StatusOr<
+           google::cloud::dialogflow::cx::v3::ImportEntityTypesResponse>>),
       ImportEntityTypes,
       (google::cloud::dialogflow::cx::v3::ImportEntityTypesRequest const&
            request),

--- a/google/cloud/dialogflow_cx/mocks/mock_environments_connection.h
+++ b/google/cloud/dialogflow_cx/mocks/mock_environments_connection.h
@@ -54,19 +54,20 @@ class MockEnvironmentsConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::Environment>, GetEnvironment,
+      (StatusOr<google::cloud::dialogflow::cx::v3::Environment>),
+      GetEnvironment,
       (google::cloud::dialogflow::cx::v3::GetEnvironmentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dialogflow::cx::v3::Environment>>,
+      (future<StatusOr<google::cloud::dialogflow::cx::v3::Environment>>),
       CreateEnvironment,
       (google::cloud::dialogflow::cx::v3::CreateEnvironmentRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dialogflow::cx::v3::Environment>>,
+      (future<StatusOr<google::cloud::dialogflow::cx::v3::Environment>>),
       UpdateEnvironment,
       (google::cloud::dialogflow::cx::v3::UpdateEnvironmentRequest const&
            request),
@@ -86,8 +87,8 @@ class MockEnvironmentsConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::dialogflow::cx::v3::RunContinuousTestResponse>>,
+      (future<StatusOr<
+           google::cloud::dialogflow::cx::v3::RunContinuousTestResponse>>),
       RunContinuousTest,
       (google::cloud::dialogflow::cx::v3::RunContinuousTestRequest const&
            request),
@@ -101,7 +102,7 @@ class MockEnvironmentsConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dialogflow::cx::v3::DeployFlowResponse>>,
+      (future<StatusOr<google::cloud::dialogflow::cx::v3::DeployFlowResponse>>),
       DeployFlow,
       (google::cloud::dialogflow::cx::v3::DeployFlowRequest const& request),
       (override));

--- a/google/cloud/dialogflow_cx/mocks/mock_experiments_connection.h
+++ b/google/cloud/dialogflow_cx/mocks/mock_experiments_connection.h
@@ -53,17 +53,17 @@ class MockExperimentsConnection : public dialogflow_cx::ExperimentsConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::Experiment>, GetExperiment,
+      (StatusOr<google::cloud::dialogflow::cx::v3::Experiment>), GetExperiment,
       (google::cloud::dialogflow::cx::v3::GetExperimentRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dialogflow::cx::v3::Experiment>,
+  MOCK_METHOD((StatusOr<google::cloud::dialogflow::cx::v3::Experiment>),
               CreateExperiment,
               (google::cloud::dialogflow::cx::v3::CreateExperimentRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dialogflow::cx::v3::Experiment>,
+  MOCK_METHOD((StatusOr<google::cloud::dialogflow::cx::v3::Experiment>),
               UpdateExperiment,
               (google::cloud::dialogflow::cx::v3::UpdateExperimentRequest const&
                    request),
@@ -74,14 +74,14 @@ class MockExperimentsConnection : public dialogflow_cx::ExperimentsConnection {
                    request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dialogflow::cx::v3::Experiment>,
+  MOCK_METHOD((StatusOr<google::cloud::dialogflow::cx::v3::Experiment>),
               StartExperiment,
               (google::cloud::dialogflow::cx::v3::StartExperimentRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::Experiment>, StopExperiment,
+      (StatusOr<google::cloud::dialogflow::cx::v3::Experiment>), StopExperiment,
       (google::cloud::dialogflow::cx::v3::StopExperimentRequest const& request),
       (override));
 };

--- a/google/cloud/dialogflow_cx/mocks/mock_flows_connection.h
+++ b/google/cloud/dialogflow_cx/mocks/mock_flows_connection.h
@@ -47,7 +47,7 @@ class MockFlowsConnection : public dialogflow_cx::FlowsConnection {
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::Flow>, CreateFlow,
+      (StatusOr<google::cloud::dialogflow::cx::v3::Flow>), CreateFlow,
       (google::cloud::dialogflow::cx::v3::CreateFlowRequest const& request),
       (override));
 
@@ -61,41 +61,41 @@ class MockFlowsConnection : public dialogflow_cx::FlowsConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::Flow>, GetFlow,
+      (StatusOr<google::cloud::dialogflow::cx::v3::Flow>), GetFlow,
       (google::cloud::dialogflow::cx::v3::GetFlowRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::Flow>, UpdateFlow,
+      (StatusOr<google::cloud::dialogflow::cx::v3::Flow>), UpdateFlow,
       (google::cloud::dialogflow::cx::v3::UpdateFlowRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::protobuf::Struct>>, TrainFlow,
+      (future<StatusOr<google::protobuf::Struct>>), TrainFlow,
       (google::cloud::dialogflow::cx::v3::TrainFlowRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::FlowValidationResult>,
+      (StatusOr<google::cloud::dialogflow::cx::v3::FlowValidationResult>),
       ValidateFlow,
       (google::cloud::dialogflow::cx::v3::ValidateFlowRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::FlowValidationResult>,
+      (StatusOr<google::cloud::dialogflow::cx::v3::FlowValidationResult>),
       GetFlowValidationResult,
       (google::cloud::dialogflow::cx::v3::GetFlowValidationResultRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dialogflow::cx::v3::ImportFlowResponse>>,
+      (future<StatusOr<google::cloud::dialogflow::cx::v3::ImportFlowResponse>>),
       ImportFlow,
       (google::cloud::dialogflow::cx::v3::ImportFlowRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dialogflow::cx::v3::ExportFlowResponse>>,
+      (future<StatusOr<google::cloud::dialogflow::cx::v3::ExportFlowResponse>>),
       ExportFlow,
       (google::cloud::dialogflow::cx::v3::ExportFlowRequest const& request),
       (override));

--- a/google/cloud/dialogflow_cx/mocks/mock_intents_connection.h
+++ b/google/cloud/dialogflow_cx/mocks/mock_intents_connection.h
@@ -52,17 +52,17 @@ class MockIntentsConnection : public dialogflow_cx::IntentsConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::Intent>, GetIntent,
+      (StatusOr<google::cloud::dialogflow::cx::v3::Intent>), GetIntent,
       (google::cloud::dialogflow::cx::v3::GetIntentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::Intent>, CreateIntent,
+      (StatusOr<google::cloud::dialogflow::cx::v3::Intent>), CreateIntent,
       (google::cloud::dialogflow::cx::v3::CreateIntentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::Intent>, UpdateIntent,
+      (StatusOr<google::cloud::dialogflow::cx::v3::Intent>), UpdateIntent,
       (google::cloud::dialogflow::cx::v3::UpdateIntentRequest const& request),
       (override));
 
@@ -72,15 +72,15 @@ class MockIntentsConnection : public dialogflow_cx::IntentsConnection {
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::dialogflow::cx::v3::ImportIntentsResponse>>,
+      (future<
+          StatusOr<google::cloud::dialogflow::cx::v3::ImportIntentsResponse>>),
       ImportIntents,
       (google::cloud::dialogflow::cx::v3::ImportIntentsRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::dialogflow::cx::v3::ExportIntentsResponse>>,
+      (future<
+          StatusOr<google::cloud::dialogflow::cx::v3::ExportIntentsResponse>>),
       ExportIntents,
       (google::cloud::dialogflow::cx::v3::ExportIntentsRequest const& request),
       (override));

--- a/google/cloud/dialogflow_cx/mocks/mock_pages_connection.h
+++ b/google/cloud/dialogflow_cx/mocks/mock_pages_connection.h
@@ -51,17 +51,17 @@ class MockPagesConnection : public dialogflow_cx::PagesConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::Page>, GetPage,
+      (StatusOr<google::cloud::dialogflow::cx::v3::Page>), GetPage,
       (google::cloud::dialogflow::cx::v3::GetPageRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::Page>, CreatePage,
+      (StatusOr<google::cloud::dialogflow::cx::v3::Page>), CreatePage,
       (google::cloud::dialogflow::cx::v3::CreatePageRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::Page>, UpdatePage,
+      (StatusOr<google::cloud::dialogflow::cx::v3::Page>), UpdatePage,
       (google::cloud::dialogflow::cx::v3::UpdatePageRequest const& request),
       (override));
 

--- a/google/cloud/dialogflow_cx/mocks/mock_security_settings_connection.h
+++ b/google/cloud/dialogflow_cx/mocks/mock_security_settings_connection.h
@@ -48,21 +48,21 @@ class MockSecuritySettingsServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::SecuritySettings>,
+      (StatusOr<google::cloud::dialogflow::cx::v3::SecuritySettings>),
       CreateSecuritySettings,
       (google::cloud::dialogflow::cx::v3::CreateSecuritySettingsRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::SecuritySettings>,
+      (StatusOr<google::cloud::dialogflow::cx::v3::SecuritySettings>),
       GetSecuritySettings,
       (google::cloud::dialogflow::cx::v3::GetSecuritySettingsRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::SecuritySettings>,
+      (StatusOr<google::cloud::dialogflow::cx::v3::SecuritySettings>),
       UpdateSecuritySettings,
       (google::cloud::dialogflow::cx::v3::UpdateSecuritySettingsRequest const&
            request),

--- a/google/cloud/dialogflow_cx/mocks/mock_session_entity_types_connection.h
+++ b/google/cloud/dialogflow_cx/mocks/mock_session_entity_types_connection.h
@@ -55,21 +55,21 @@ class MockSessionEntityTypesConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::SessionEntityType>,
+      (StatusOr<google::cloud::dialogflow::cx::v3::SessionEntityType>),
       GetSessionEntityType,
       (google::cloud::dialogflow::cx::v3::GetSessionEntityTypeRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::SessionEntityType>,
+      (StatusOr<google::cloud::dialogflow::cx::v3::SessionEntityType>),
       CreateSessionEntityType,
       (google::cloud::dialogflow::cx::v3::CreateSessionEntityTypeRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::SessionEntityType>,
+      (StatusOr<google::cloud::dialogflow::cx::v3::SessionEntityType>),
       UpdateSessionEntityType,
       (google::cloud::dialogflow::cx::v3::UpdateSessionEntityTypeRequest const&
            request),

--- a/google/cloud/dialogflow_cx/mocks/mock_sessions_connection.h
+++ b/google/cloud/dialogflow_cx/mocks/mock_sessions_connection.h
@@ -47,13 +47,13 @@ class MockSessionsConnection : public dialogflow_cx::SessionsConnection {
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::DetectIntentResponse>,
+      (StatusOr<google::cloud::dialogflow::cx::v3::DetectIntentResponse>),
       DetectIntent,
       (google::cloud::dialogflow::cx::v3::DetectIntentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StreamRange<google::cloud::dialogflow::cx::v3::DetectIntentResponse>,
+      (StreamRange<google::cloud::dialogflow::cx::v3::DetectIntentResponse>),
       ServerStreamingDetectIntent,
       (google::cloud::dialogflow::cx::v3::DetectIntentRequest const& request),
       (override));
@@ -65,19 +65,19 @@ class MockSessionsConnection : public dialogflow_cx::SessionsConnection {
       AsyncStreamingDetectIntent, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::MatchIntentResponse>,
+      (StatusOr<google::cloud::dialogflow::cx::v3::MatchIntentResponse>),
       MatchIntent,
       (google::cloud::dialogflow::cx::v3::MatchIntentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::FulfillIntentResponse>,
+      (StatusOr<google::cloud::dialogflow::cx::v3::FulfillIntentResponse>),
       FulfillIntent,
       (google::cloud::dialogflow::cx::v3::FulfillIntentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::AnswerFeedback>,
+      (StatusOr<google::cloud::dialogflow::cx::v3::AnswerFeedback>),
       SubmitAnswerFeedback,
       (google::cloud::dialogflow::cx::v3::SubmitAnswerFeedbackRequest const&
            request),

--- a/google/cloud/dialogflow_cx/mocks/mock_test_cases_connection.h
+++ b/google/cloud/dialogflow_cx/mocks/mock_test_cases_connection.h
@@ -58,52 +58,53 @@ class MockTestCasesConnection : public dialogflow_cx::TestCasesConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::TestCase>, GetTestCase,
+      (StatusOr<google::cloud::dialogflow::cx::v3::TestCase>), GetTestCase,
       (google::cloud::dialogflow::cx::v3::GetTestCaseRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::TestCase>, CreateTestCase,
+      (StatusOr<google::cloud::dialogflow::cx::v3::TestCase>), CreateTestCase,
       (google::cloud::dialogflow::cx::v3::CreateTestCaseRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::TestCase>, UpdateTestCase,
+      (StatusOr<google::cloud::dialogflow::cx::v3::TestCase>), UpdateTestCase,
       (google::cloud::dialogflow::cx::v3::UpdateTestCaseRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dialogflow::cx::v3::RunTestCaseResponse>>,
+      (future<
+          StatusOr<google::cloud::dialogflow::cx::v3::RunTestCaseResponse>>),
       RunTestCase,
       (google::cloud::dialogflow::cx::v3::RunTestCaseRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::dialogflow::cx::v3::BatchRunTestCasesResponse>>,
+      (future<StatusOr<
+           google::cloud::dialogflow::cx::v3::BatchRunTestCasesResponse>>),
       BatchRunTestCases,
       (google::cloud::dialogflow::cx::v3::BatchRunTestCasesRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::CalculateCoverageResponse>,
+      (StatusOr<google::cloud::dialogflow::cx::v3::CalculateCoverageResponse>),
       CalculateCoverage,
       (google::cloud::dialogflow::cx::v3::CalculateCoverageRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::dialogflow::cx::v3::ImportTestCasesResponse>>,
+      (future<StatusOr<
+           google::cloud::dialogflow::cx::v3::ImportTestCasesResponse>>),
       ImportTestCases,
       (google::cloud::dialogflow::cx::v3::ImportTestCasesRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::dialogflow::cx::v3::ExportTestCasesResponse>>,
+      (future<StatusOr<
+           google::cloud::dialogflow::cx::v3::ExportTestCasesResponse>>),
       ExportTestCases,
       (google::cloud::dialogflow::cx::v3::ExportTestCasesRequest const&
            request),
@@ -116,7 +117,7 @@ class MockTestCasesConnection : public dialogflow_cx::TestCasesConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::TestCaseResult>,
+      (StatusOr<google::cloud::dialogflow::cx::v3::TestCaseResult>),
       GetTestCaseResult,
       (google::cloud::dialogflow::cx::v3::GetTestCaseResultRequest const&
            request),

--- a/google/cloud/dialogflow_cx/mocks/mock_transition_route_groups_connection.h
+++ b/google/cloud/dialogflow_cx/mocks/mock_transition_route_groups_connection.h
@@ -55,23 +55,25 @@ class MockTransitionRouteGroupsConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::TransitionRouteGroup>,
+      (StatusOr<google::cloud::dialogflow::cx::v3::TransitionRouteGroup>),
       GetTransitionRouteGroup,
       (google::cloud::dialogflow::cx::v3::GetTransitionRouteGroupRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dialogflow::cx::v3::TransitionRouteGroup>,
-              CreateTransitionRouteGroup,
-              (google::cloud::dialogflow::cx::v3::
-                   CreateTransitionRouteGroupRequest const& request),
-              (override));
+  MOCK_METHOD(
+      (StatusOr<google::cloud::dialogflow::cx::v3::TransitionRouteGroup>),
+      CreateTransitionRouteGroup,
+      (google::cloud::dialogflow::cx::v3::
+           CreateTransitionRouteGroupRequest const& request),
+      (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dialogflow::cx::v3::TransitionRouteGroup>,
-              UpdateTransitionRouteGroup,
-              (google::cloud::dialogflow::cx::v3::
-                   UpdateTransitionRouteGroupRequest const& request),
-              (override));
+  MOCK_METHOD(
+      (StatusOr<google::cloud::dialogflow::cx::v3::TransitionRouteGroup>),
+      UpdateTransitionRouteGroup,
+      (google::cloud::dialogflow::cx::v3::
+           UpdateTransitionRouteGroupRequest const& request),
+      (override));
 
   MOCK_METHOD(Status, DeleteTransitionRouteGroup,
               (google::cloud::dialogflow::cx::v3::

--- a/google/cloud/dialogflow_cx/mocks/mock_versions_connection.h
+++ b/google/cloud/dialogflow_cx/mocks/mock_versions_connection.h
@@ -52,18 +52,18 @@ class MockVersionsConnection : public dialogflow_cx::VersionsConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::Version>, GetVersion,
+      (StatusOr<google::cloud::dialogflow::cx::v3::Version>), GetVersion,
       (google::cloud::dialogflow::cx::v3::GetVersionRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dialogflow::cx::v3::Version>>,
+      (future<StatusOr<google::cloud::dialogflow::cx::v3::Version>>),
       CreateVersion,
       (google::cloud::dialogflow::cx::v3::CreateVersionRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::Version>, UpdateVersion,
+      (StatusOr<google::cloud::dialogflow::cx::v3::Version>), UpdateVersion,
       (google::cloud::dialogflow::cx::v3::UpdateVersionRequest const& request),
       (override));
 
@@ -73,12 +73,12 @@ class MockVersionsConnection : public dialogflow_cx::VersionsConnection {
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::protobuf::Struct>>, LoadVersion,
+      (future<StatusOr<google::protobuf::Struct>>), LoadVersion,
       (google::cloud::dialogflow::cx::v3::LoadVersionRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::CompareVersionsResponse>,
+      (StatusOr<google::cloud::dialogflow::cx::v3::CompareVersionsResponse>),
       CompareVersions,
       (google::cloud::dialogflow::cx::v3::CompareVersionsRequest const&
            request),

--- a/google/cloud/dialogflow_cx/mocks/mock_webhooks_connection.h
+++ b/google/cloud/dialogflow_cx/mocks/mock_webhooks_connection.h
@@ -52,17 +52,17 @@ class MockWebhooksConnection : public dialogflow_cx::WebhooksConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::Webhook>, GetWebhook,
+      (StatusOr<google::cloud::dialogflow::cx::v3::Webhook>), GetWebhook,
       (google::cloud::dialogflow::cx::v3::GetWebhookRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::Webhook>, CreateWebhook,
+      (StatusOr<google::cloud::dialogflow::cx::v3::Webhook>), CreateWebhook,
       (google::cloud::dialogflow::cx::v3::CreateWebhookRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::cx::v3::Webhook>, UpdateWebhook,
+      (StatusOr<google::cloud::dialogflow::cx::v3::Webhook>), UpdateWebhook,
       (google::cloud::dialogflow::cx::v3::UpdateWebhookRequest const& request),
       (override));
 

--- a/google/cloud/dialogflow_es/mocks/mock_agents_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_agents_connection.h
@@ -46,11 +46,11 @@ class MockAgentsConnection : public dialogflow_es::AgentsConnection {
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dialogflow::v2::Agent>, GetAgent,
+  MOCK_METHOD((StatusOr<google::cloud::dialogflow::v2::Agent>), GetAgent,
               (google::cloud::dialogflow::v2::GetAgentRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dialogflow::v2::Agent>, SetAgent,
+  MOCK_METHOD((StatusOr<google::cloud::dialogflow::v2::Agent>), SetAgent,
               (google::cloud::dialogflow::v2::SetAgentRequest const& request),
               (override));
 
@@ -63,27 +63,27 @@ class MockAgentsConnection : public dialogflow_es::AgentsConnection {
               (google::cloud::dialogflow::v2::SearchAgentsRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::protobuf::Struct>>, TrainAgent,
+  MOCK_METHOD((future<StatusOr<google::protobuf::Struct>>), TrainAgent,
               (google::cloud::dialogflow::v2::TrainAgentRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dialogflow::v2::ExportAgentResponse>>,
+      (future<StatusOr<google::cloud::dialogflow::v2::ExportAgentResponse>>),
       ExportAgent,
       (google::cloud::dialogflow::v2::ExportAgentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::protobuf::Struct>>, ImportAgent,
+      (future<StatusOr<google::protobuf::Struct>>), ImportAgent,
       (google::cloud::dialogflow::v2::ImportAgentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::protobuf::Struct>>, RestoreAgent,
+      (future<StatusOr<google::protobuf::Struct>>), RestoreAgent,
       (google::cloud::dialogflow::v2::RestoreAgentRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dialogflow::v2::ValidationResult>,
+  MOCK_METHOD((StatusOr<google::cloud::dialogflow::v2::ValidationResult>),
               GetValidationResult,
               (google::cloud::dialogflow::v2::GetValidationResultRequest const&
                    request),

--- a/google/cloud/dialogflow_es/mocks/mock_answer_records_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_answer_records_connection.h
@@ -53,7 +53,8 @@ class MockAnswerRecordsConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::AnswerRecord>, UpdateAnswerRecord,
+      (StatusOr<google::cloud::dialogflow::v2::AnswerRecord>),
+      UpdateAnswerRecord,
       (google::cloud::dialogflow::v2::UpdateAnswerRecordRequest const& request),
       (override));
 };

--- a/google/cloud/dialogflow_es/mocks/mock_contexts_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_contexts_connection.h
@@ -51,17 +51,17 @@ class MockContextsConnection : public dialogflow_es::ContextsConnection {
               (google::cloud::dialogflow::v2::ListContextsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dialogflow::v2::Context>, GetContext,
+  MOCK_METHOD((StatusOr<google::cloud::dialogflow::v2::Context>), GetContext,
               (google::cloud::dialogflow::v2::GetContextRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::Context>, CreateContext,
+      (StatusOr<google::cloud::dialogflow::v2::Context>), CreateContext,
       (google::cloud::dialogflow::v2::CreateContextRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::Context>, UpdateContext,
+      (StatusOr<google::cloud::dialogflow::v2::Context>), UpdateContext,
       (google::cloud::dialogflow::v2::UpdateContextRequest const& request),
       (override));
 

--- a/google/cloud/dialogflow_es/mocks/mock_conversation_datasets_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_conversation_datasets_connection.h
@@ -48,14 +48,14 @@ class MockConversationDatasetsConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dialogflow::v2::ConversationDataset>>,
+      (future<StatusOr<google::cloud::dialogflow::v2::ConversationDataset>>),
       CreateConversationDataset,
       (google::cloud::dialogflow::v2::CreateConversationDatasetRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::ConversationDataset>,
+      (StatusOr<google::cloud::dialogflow::v2::ConversationDataset>),
       GetConversationDataset,
       (google::cloud::dialogflow::v2::GetConversationDatasetRequest const&
            request),
@@ -68,16 +68,16 @@ class MockConversationDatasetsConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dialogflow::v2::
-                          DeleteConversationDatasetOperationMetadata>>,
+      (future<StatusOr<google::cloud::dialogflow::v2::
+                           DeleteConversationDatasetOperationMetadata>>),
       DeleteConversationDataset,
       (google::cloud::dialogflow::v2::DeleteConversationDatasetRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dialogflow::v2::
-                          ImportConversationDataOperationResponse>>,
+      (future<StatusOr<google::cloud::dialogflow::v2::
+                           ImportConversationDataOperationResponse>>),
       ImportConversationData,
       (google::cloud::dialogflow::v2::ImportConversationDataRequest const&
            request),

--- a/google/cloud/dialogflow_es/mocks/mock_conversation_models_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_conversation_models_connection.h
@@ -48,13 +48,13 @@ class MockConversationModelsConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dialogflow::v2::ConversationModel>>,
+      (future<StatusOr<google::cloud::dialogflow::v2::ConversationModel>>),
       CreateConversationModel,
       (google::cloud::dialogflow::v2::CreateConversationModelRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dialogflow::v2::ConversationModel>,
+  MOCK_METHOD((StatusOr<google::cloud::dialogflow::v2::ConversationModel>),
               GetConversationModel,
               (google::cloud::dialogflow::v2::GetConversationModelRequest const&
                    request),
@@ -67,31 +67,31 @@ class MockConversationModelsConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dialogflow::v2::
-                          DeleteConversationModelOperationMetadata>>,
+      (future<StatusOr<google::cloud::dialogflow::v2::
+                           DeleteConversationModelOperationMetadata>>),
       DeleteConversationModel,
       (google::cloud::dialogflow::v2::DeleteConversationModelRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dialogflow::v2::
-                          DeployConversationModelOperationMetadata>>,
+      (future<StatusOr<google::cloud::dialogflow::v2::
+                           DeployConversationModelOperationMetadata>>),
       DeployConversationModel,
       (google::cloud::dialogflow::v2::DeployConversationModelRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dialogflow::v2::
-                          UndeployConversationModelOperationMetadata>>,
+      (future<StatusOr<google::cloud::dialogflow::v2::
+                           UndeployConversationModelOperationMetadata>>),
       UndeployConversationModel,
       (google::cloud::dialogflow::v2::UndeployConversationModelRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::ConversationModelEvaluation>,
+      (StatusOr<google::cloud::dialogflow::v2::ConversationModelEvaluation>),
       GetConversationModelEvaluation,
       (google::cloud::dialogflow::v2::
            GetConversationModelEvaluationRequest const& request),
@@ -105,8 +105,8 @@ class MockConversationModelsConnection
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::dialogflow::v2::ConversationModelEvaluation>>,
+      (future<StatusOr<
+           google::cloud::dialogflow::v2::ConversationModelEvaluation>>),
       CreateConversationModelEvaluation,
       (google::cloud::dialogflow::v2::
            CreateConversationModelEvaluationRequest const& request),

--- a/google/cloud/dialogflow_es/mocks/mock_conversation_profiles_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_conversation_profiles_connection.h
@@ -54,21 +54,21 @@ class MockConversationProfilesConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::ConversationProfile>,
+      (StatusOr<google::cloud::dialogflow::v2::ConversationProfile>),
       GetConversationProfile,
       (google::cloud::dialogflow::v2::GetConversationProfileRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::ConversationProfile>,
+      (StatusOr<google::cloud::dialogflow::v2::ConversationProfile>),
       CreateConversationProfile,
       (google::cloud::dialogflow::v2::CreateConversationProfileRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::ConversationProfile>,
+      (StatusOr<google::cloud::dialogflow::v2::ConversationProfile>),
       UpdateConversationProfile,
       (google::cloud::dialogflow::v2::UpdateConversationProfileRequest const&
            request),
@@ -81,14 +81,14 @@ class MockConversationProfilesConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dialogflow::v2::ConversationProfile>>,
+      (future<StatusOr<google::cloud::dialogflow::v2::ConversationProfile>>),
       SetSuggestionFeatureConfig,
       (google::cloud::dialogflow::v2::SetSuggestionFeatureConfigRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dialogflow::v2::ConversationProfile>>,
+      (future<StatusOr<google::cloud::dialogflow::v2::ConversationProfile>>),
       ClearSuggestionFeatureConfig,
       (google::cloud::dialogflow::v2::ClearSuggestionFeatureConfigRequest const&
            request),

--- a/google/cloud/dialogflow_es/mocks/mock_conversations_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_conversations_connection.h
@@ -48,7 +48,8 @@ class MockConversationsConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::Conversation>, CreateConversation,
+      (StatusOr<google::cloud::dialogflow::v2::Conversation>),
+      CreateConversation,
       (google::cloud::dialogflow::v2::CreateConversationRequest const& request),
       (override));
 
@@ -58,11 +59,11 @@ class MockConversationsConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::Conversation>, GetConversation,
+      (StatusOr<google::cloud::dialogflow::v2::Conversation>), GetConversation,
       (google::cloud::dialogflow::v2::GetConversationRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dialogflow::v2::Conversation>,
+  MOCK_METHOD((StatusOr<google::cloud::dialogflow::v2::Conversation>),
               CompleteConversation,
               (google::cloud::dialogflow::v2::CompleteConversationRequest const&
                    request),
@@ -74,22 +75,23 @@ class MockConversationsConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::dialogflow::v2::SuggestConversationSummaryResponse>,
+      (StatusOr<
+          google::cloud::dialogflow::v2::SuggestConversationSummaryResponse>),
       SuggestConversationSummary,
       (google::cloud::dialogflow::v2::SuggestConversationSummaryRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::GenerateStatelessSummaryResponse>,
+      (StatusOr<
+          google::cloud::dialogflow::v2::GenerateStatelessSummaryResponse>),
       GenerateStatelessSummary,
       (google::cloud::dialogflow::v2::GenerateStatelessSummaryRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::SearchKnowledgeResponse>,
+      (StatusOr<google::cloud::dialogflow::v2::SearchKnowledgeResponse>),
       SearchKnowledge,
       (google::cloud::dialogflow::v2::SearchKnowledgeRequest const& request),
       (override));

--- a/google/cloud/dialogflow_es/mocks/mock_documents_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_documents_connection.h
@@ -52,40 +52,45 @@ class MockDocumentsConnection : public dialogflow_es::DocumentsConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::Document>, GetDocument,
+      (StatusOr<google::cloud::dialogflow::v2::Document>), GetDocument,
       (google::cloud::dialogflow::v2::GetDocumentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dialogflow::v2::Document>>, CreateDocument,
+      (future<StatusOr<google::cloud::dialogflow::v2::Document>>),
+      CreateDocument,
       (google::cloud::dialogflow::v2::CreateDocumentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dialogflow::v2::ImportDocumentsResponse>>,
+      (future<
+          StatusOr<google::cloud::dialogflow::v2::ImportDocumentsResponse>>),
       ImportDocuments,
       (google::cloud::dialogflow::v2::ImportDocumentsRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::dialogflow::v2::KnowledgeOperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::dialogflow::v2::KnowledgeOperationMetadata>>),
       DeleteDocument,
       (google::cloud::dialogflow::v2::DeleteDocumentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dialogflow::v2::Document>>, UpdateDocument,
+      (future<StatusOr<google::cloud::dialogflow::v2::Document>>),
+      UpdateDocument,
       (google::cloud::dialogflow::v2::UpdateDocumentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dialogflow::v2::Document>>, ReloadDocument,
+      (future<StatusOr<google::cloud::dialogflow::v2::Document>>),
+      ReloadDocument,
       (google::cloud::dialogflow::v2::ReloadDocumentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::dialogflow::v2::Document>>, ExportDocument,
+      (future<StatusOr<google::cloud::dialogflow::v2::Document>>),
+      ExportDocument,
       (google::cloud::dialogflow::v2::ExportDocumentRequest const& request),
       (override));
 };

--- a/google/cloud/dialogflow_es/mocks/mock_entity_types_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_entity_types_connection.h
@@ -52,17 +52,17 @@ class MockEntityTypesConnection : public dialogflow_es::EntityTypesConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::EntityType>, GetEntityType,
+      (StatusOr<google::cloud::dialogflow::v2::EntityType>), GetEntityType,
       (google::cloud::dialogflow::v2::GetEntityTypeRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::EntityType>, CreateEntityType,
+      (StatusOr<google::cloud::dialogflow::v2::EntityType>), CreateEntityType,
       (google::cloud::dialogflow::v2::CreateEntityTypeRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::EntityType>, UpdateEntityType,
+      (StatusOr<google::cloud::dialogflow::v2::EntityType>), UpdateEntityType,
       (google::cloud::dialogflow::v2::UpdateEntityTypeRequest const& request),
       (override));
 
@@ -72,30 +72,30 @@ class MockEntityTypesConnection : public dialogflow_es::EntityTypesConnection {
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::dialogflow::v2::BatchUpdateEntityTypesResponse>>,
+      (future<StatusOr<
+           google::cloud::dialogflow::v2::BatchUpdateEntityTypesResponse>>),
       BatchUpdateEntityTypes,
       (google::cloud::dialogflow::v2::BatchUpdateEntityTypesRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::protobuf::Struct>>, BatchDeleteEntityTypes,
+      (future<StatusOr<google::protobuf::Struct>>), BatchDeleteEntityTypes,
       (google::cloud::dialogflow::v2::BatchDeleteEntityTypesRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::protobuf::Struct>>, BatchCreateEntities,
+  MOCK_METHOD((future<StatusOr<google::protobuf::Struct>>), BatchCreateEntities,
               (google::cloud::dialogflow::v2::BatchCreateEntitiesRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::protobuf::Struct>>, BatchUpdateEntities,
+  MOCK_METHOD((future<StatusOr<google::protobuf::Struct>>), BatchUpdateEntities,
               (google::cloud::dialogflow::v2::BatchUpdateEntitiesRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::protobuf::Struct>>, BatchDeleteEntities,
+  MOCK_METHOD((future<StatusOr<google::protobuf::Struct>>), BatchDeleteEntities,
               (google::cloud::dialogflow::v2::BatchDeleteEntitiesRequest const&
                    request),
               (override));

--- a/google/cloud/dialogflow_es/mocks/mock_environments_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_environments_connection.h
@@ -53,17 +53,17 @@ class MockEnvironmentsConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::Environment>, GetEnvironment,
+      (StatusOr<google::cloud::dialogflow::v2::Environment>), GetEnvironment,
       (google::cloud::dialogflow::v2::GetEnvironmentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::Environment>, CreateEnvironment,
+      (StatusOr<google::cloud::dialogflow::v2::Environment>), CreateEnvironment,
       (google::cloud::dialogflow::v2::CreateEnvironmentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::Environment>, UpdateEnvironment,
+      (StatusOr<google::cloud::dialogflow::v2::Environment>), UpdateEnvironment,
       (google::cloud::dialogflow::v2::UpdateEnvironmentRequest const& request),
       (override));
 

--- a/google/cloud/dialogflow_es/mocks/mock_fulfillments_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_fulfillments_connection.h
@@ -48,12 +48,12 @@ class MockFulfillmentsConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::Fulfillment>, GetFulfillment,
+      (StatusOr<google::cloud::dialogflow::v2::Fulfillment>), GetFulfillment,
       (google::cloud::dialogflow::v2::GetFulfillmentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::Fulfillment>, UpdateFulfillment,
+      (StatusOr<google::cloud::dialogflow::v2::Fulfillment>), UpdateFulfillment,
       (google::cloud::dialogflow::v2::UpdateFulfillmentRequest const& request),
       (override));
 };

--- a/google/cloud/dialogflow_es/mocks/mock_intents_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_intents_connection.h
@@ -50,17 +50,17 @@ class MockIntentsConnection : public dialogflow_es::IntentsConnection {
               (google::cloud::dialogflow::v2::ListIntentsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dialogflow::v2::Intent>, GetIntent,
+  MOCK_METHOD((StatusOr<google::cloud::dialogflow::v2::Intent>), GetIntent,
               (google::cloud::dialogflow::v2::GetIntentRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::Intent>, CreateIntent,
+      (StatusOr<google::cloud::dialogflow::v2::Intent>), CreateIntent,
       (google::cloud::dialogflow::v2::CreateIntentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::Intent>, UpdateIntent,
+      (StatusOr<google::cloud::dialogflow::v2::Intent>), UpdateIntent,
       (google::cloud::dialogflow::v2::UpdateIntentRequest const& request),
       (override));
 
@@ -70,14 +70,14 @@ class MockIntentsConnection : public dialogflow_es::IntentsConnection {
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::dialogflow::v2::BatchUpdateIntentsResponse>>,
+      (future<
+          StatusOr<google::cloud::dialogflow::v2::BatchUpdateIntentsResponse>>),
       BatchUpdateIntents,
       (google::cloud::dialogflow::v2::BatchUpdateIntentsRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::protobuf::Struct>>, BatchDeleteIntents,
+      (future<StatusOr<google::protobuf::Struct>>), BatchDeleteIntents,
       (google::cloud::dialogflow::v2::BatchDeleteIntentsRequest const& request),
       (override));
 };

--- a/google/cloud/dialogflow_es/mocks/mock_knowledge_bases_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_knowledge_bases_connection.h
@@ -54,11 +54,12 @@ class MockKnowledgeBasesConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::KnowledgeBase>, GetKnowledgeBase,
+      (StatusOr<google::cloud::dialogflow::v2::KnowledgeBase>),
+      GetKnowledgeBase,
       (google::cloud::dialogflow::v2::GetKnowledgeBaseRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dialogflow::v2::KnowledgeBase>,
+  MOCK_METHOD((StatusOr<google::cloud::dialogflow::v2::KnowledgeBase>),
               CreateKnowledgeBase,
               (google::cloud::dialogflow::v2::CreateKnowledgeBaseRequest const&
                    request),
@@ -69,7 +70,7 @@ class MockKnowledgeBasesConnection
                    request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dialogflow::v2::KnowledgeBase>,
+  MOCK_METHOD((StatusOr<google::cloud::dialogflow::v2::KnowledgeBase>),
               UpdateKnowledgeBase,
               (google::cloud::dialogflow::v2::UpdateKnowledgeBaseRequest const&
                    request),

--- a/google/cloud/dialogflow_es/mocks/mock_participants_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_participants_connection.h
@@ -48,12 +48,12 @@ class MockParticipantsConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::Participant>, CreateParticipant,
+      (StatusOr<google::cloud::dialogflow::v2::Participant>), CreateParticipant,
       (google::cloud::dialogflow::v2::CreateParticipantRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::Participant>, GetParticipant,
+      (StatusOr<google::cloud::dialogflow::v2::Participant>), GetParticipant,
       (google::cloud::dialogflow::v2::GetParticipantRequest const& request),
       (override));
 
@@ -63,12 +63,12 @@ class MockParticipantsConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::Participant>, UpdateParticipant,
+      (StatusOr<google::cloud::dialogflow::v2::Participant>), UpdateParticipant,
       (google::cloud::dialogflow::v2::UpdateParticipantRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::AnalyzeContentResponse>,
+      (StatusOr<google::cloud::dialogflow::v2::AnalyzeContentResponse>),
       AnalyzeContent,
       (google::cloud::dialogflow::v2::AnalyzeContentRequest const& request),
       (override));
@@ -80,19 +80,19 @@ class MockParticipantsConnection
       AsyncStreamingAnalyzeContent, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::SuggestArticlesResponse>,
+      (StatusOr<google::cloud::dialogflow::v2::SuggestArticlesResponse>),
       SuggestArticles,
       (google::cloud::dialogflow::v2::SuggestArticlesRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::SuggestFaqAnswersResponse>,
+      (StatusOr<google::cloud::dialogflow::v2::SuggestFaqAnswersResponse>),
       SuggestFaqAnswers,
       (google::cloud::dialogflow::v2::SuggestFaqAnswersRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::SuggestSmartRepliesResponse>,
+      (StatusOr<google::cloud::dialogflow::v2::SuggestSmartRepliesResponse>),
       SuggestSmartReplies,
       (google::cloud::dialogflow::v2::SuggestSmartRepliesRequest const&
            request),

--- a/google/cloud/dialogflow_es/mocks/mock_session_entity_types_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_session_entity_types_connection.h
@@ -53,21 +53,21 @@ class MockSessionEntityTypesConnection
       (google::cloud::dialogflow::v2::ListSessionEntityTypesRequest request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dialogflow::v2::SessionEntityType>,
+  MOCK_METHOD((StatusOr<google::cloud::dialogflow::v2::SessionEntityType>),
               GetSessionEntityType,
               (google::cloud::dialogflow::v2::GetSessionEntityTypeRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::SessionEntityType>,
+      (StatusOr<google::cloud::dialogflow::v2::SessionEntityType>),
       CreateSessionEntityType,
       (google::cloud::dialogflow::v2::CreateSessionEntityTypeRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::SessionEntityType>,
+      (StatusOr<google::cloud::dialogflow::v2::SessionEntityType>),
       UpdateSessionEntityType,
       (google::cloud::dialogflow::v2::UpdateSessionEntityTypeRequest const&
            request),

--- a/google/cloud/dialogflow_es/mocks/mock_sessions_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_sessions_connection.h
@@ -47,7 +47,7 @@ class MockSessionsConnection : public dialogflow_es::SessionsConnection {
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::DetectIntentResponse>,
+      (StatusOr<google::cloud::dialogflow::v2::DetectIntentResponse>),
       DetectIntent,
       (google::cloud::dialogflow::v2::DetectIntentRequest const& request),
       (override));

--- a/google/cloud/dialogflow_es/mocks/mock_versions_connection.h
+++ b/google/cloud/dialogflow_es/mocks/mock_versions_connection.h
@@ -51,17 +51,17 @@ class MockVersionsConnection : public dialogflow_es::VersionsConnection {
               (google::cloud::dialogflow::v2::ListVersionsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::dialogflow::v2::Version>, GetVersion,
+  MOCK_METHOD((StatusOr<google::cloud::dialogflow::v2::Version>), GetVersion,
               (google::cloud::dialogflow::v2::GetVersionRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::Version>, CreateVersion,
+      (StatusOr<google::cloud::dialogflow::v2::Version>), CreateVersion,
       (google::cloud::dialogflow::v2::CreateVersionRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::dialogflow::v2::Version>, UpdateVersion,
+      (StatusOr<google::cloud::dialogflow::v2::Version>), UpdateVersion,
       (google::cloud::dialogflow::v2::UpdateVersionRequest const& request),
       (override));
 

--- a/google/cloud/discoveryengine/v1/mocks/mock_completion_connection.h
+++ b/google/cloud/discoveryengine/v1/mocks/mock_completion_connection.h
@@ -48,20 +48,20 @@ class MockCompletionServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::discoveryengine::v1::CompleteQueryResponse>,
+      (StatusOr<google::cloud::discoveryengine::v1::CompleteQueryResponse>),
       CompleteQuery,
       (google::cloud::discoveryengine::v1::CompleteQueryRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::discoveryengine::v1::
-                                  ImportSuggestionDenyListEntriesResponse>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::discoveryengine::v1::
+                                   ImportSuggestionDenyListEntriesResponse>>),
               ImportSuggestionDenyListEntries,
               (google::cloud::discoveryengine::v1::
                    ImportSuggestionDenyListEntriesRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::discoveryengine::v1::
-                                  PurgeSuggestionDenyListEntriesResponse>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::discoveryengine::v1::
+                                   PurgeSuggestionDenyListEntriesResponse>>),
               PurgeSuggestionDenyListEntries,
               (google::cloud::discoveryengine::v1::
                    PurgeSuggestionDenyListEntriesRequest const& request),

--- a/google/cloud/discoveryengine/v1/mocks/mock_conversational_search_connection.h
+++ b/google/cloud/discoveryengine/v1/mocks/mock_conversational_search_connection.h
@@ -48,15 +48,15 @@ class MockConversationalSearchServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::discoveryengine::v1::ConverseConversationResponse>,
+      (StatusOr<
+          google::cloud::discoveryengine::v1::ConverseConversationResponse>),
       ConverseConversation,
       (google::cloud::discoveryengine::v1::ConverseConversationRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::discoveryengine::v1::Conversation>,
+      (StatusOr<google::cloud::discoveryengine::v1::Conversation>),
       CreateConversation,
       (google::cloud::discoveryengine::v1::CreateConversationRequest const&
            request),
@@ -69,13 +69,13 @@ class MockConversationalSearchServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::discoveryengine::v1::Conversation>,
+      (StatusOr<google::cloud::discoveryengine::v1::Conversation>),
       UpdateConversation,
       (google::cloud::discoveryengine::v1::UpdateConversationRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::discoveryengine::v1::Conversation>,
+  MOCK_METHOD((StatusOr<google::cloud::discoveryengine::v1::Conversation>),
               GetConversation,
               (google::cloud::discoveryengine::v1::GetConversationRequest const&
                    request),

--- a/google/cloud/discoveryengine/v1/mocks/mock_document_connection.h
+++ b/google/cloud/discoveryengine/v1/mocks/mock_document_connection.h
@@ -48,7 +48,7 @@ class MockDocumentServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::discoveryengine::v1::Document>, GetDocument,
+      (StatusOr<google::cloud::discoveryengine::v1::Document>), GetDocument,
       (google::cloud::discoveryengine::v1::GetDocumentRequest const& request),
       (override));
 
@@ -58,13 +58,13 @@ class MockDocumentServiceConnection
       (google::cloud::discoveryengine::v1::ListDocumentsRequest request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::discoveryengine::v1::Document>,
+  MOCK_METHOD((StatusOr<google::cloud::discoveryengine::v1::Document>),
               CreateDocument,
               (google::cloud::discoveryengine::v1::CreateDocumentRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::discoveryengine::v1::Document>,
+  MOCK_METHOD((StatusOr<google::cloud::discoveryengine::v1::Document>),
               UpdateDocument,
               (google::cloud::discoveryengine::v1::UpdateDocumentRequest const&
                    request),
@@ -75,16 +75,17 @@ class MockDocumentServiceConnection
                    request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<
-                  google::cloud::discoveryengine::v1::ImportDocumentsResponse>>,
-              ImportDocuments,
-              (google::cloud::discoveryengine::v1::ImportDocumentsRequest const&
-                   request),
-              (override));
+  MOCK_METHOD(
+      (future<StatusOr<
+           google::cloud::discoveryengine::v1::ImportDocumentsResponse>>),
+      ImportDocuments,
+      (google::cloud::discoveryengine::v1::ImportDocumentsRequest const&
+           request),
+      (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::discoveryengine::v1::PurgeDocumentsResponse>>,
+      (future<StatusOr<
+           google::cloud::discoveryengine::v1::PurgeDocumentsResponse>>),
       PurgeDocuments,
       (google::cloud::discoveryengine::v1::PurgeDocumentsRequest const&
            request),

--- a/google/cloud/discoveryengine/v1/mocks/mock_schema_connection.h
+++ b/google/cloud/discoveryengine/v1/mocks/mock_schema_connection.h
@@ -48,7 +48,7 @@ class MockSchemaServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::discoveryengine::v1::Schema>, GetSchema,
+      (StatusOr<google::cloud::discoveryengine::v1::Schema>), GetSchema,
       (google::cloud::discoveryengine::v1::GetSchemaRequest const& request),
       (override));
 
@@ -58,20 +58,20 @@ class MockSchemaServiceConnection
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::discoveryengine::v1::Schema>>,
+      (future<StatusOr<google::cloud::discoveryengine::v1::Schema>>),
       CreateSchema,
       (google::cloud::discoveryengine::v1::CreateSchemaRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::discoveryengine::v1::Schema>>,
+      (future<StatusOr<google::cloud::discoveryengine::v1::Schema>>),
       UpdateSchema,
       (google::cloud::discoveryengine::v1::UpdateSchemaRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::discoveryengine::v1::DeleteSchemaMetadata>>,
+      (future<
+          StatusOr<google::cloud::discoveryengine::v1::DeleteSchemaMetadata>>),
       DeleteSchema,
       (google::cloud::discoveryengine::v1::DeleteSchemaRequest const& request),
       (override));

--- a/google/cloud/discoveryengine/v1/mocks/mock_user_event_connection.h
+++ b/google/cloud/discoveryengine/v1/mocks/mock_user_event_connection.h
@@ -47,21 +47,21 @@ class MockUserEventServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::discoveryengine::v1::UserEvent>,
+  MOCK_METHOD((StatusOr<google::cloud::discoveryengine::v1::UserEvent>),
               WriteUserEvent,
               (google::cloud::discoveryengine::v1::WriteUserEventRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::api::HttpBody>, CollectUserEvent,
+      (StatusOr<google::api::HttpBody>), CollectUserEvent,
       (google::cloud::discoveryengine::v1::CollectUserEventRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::discoveryengine::v1::ImportUserEventsResponse>>,
+      (future<StatusOr<
+           google::cloud::discoveryengine::v1::ImportUserEventsResponse>>),
       ImportUserEvents,
       (google::cloud::discoveryengine::v1::ImportUserEventsRequest const&
            request),

--- a/google/cloud/dlp/v2/mocks/mock_dlp_connection.h
+++ b/google/cloud/dlp/v2/mocks/mock_dlp_connection.h
@@ -46,47 +46,47 @@ class MockDlpServiceConnection : public dlp_v2::DlpServiceConnection {
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::privacy::dlp::v2::InspectContentResponse>,
+  MOCK_METHOD((StatusOr<google::privacy::dlp::v2::InspectContentResponse>),
               InspectContent,
               (google::privacy::dlp::v2::InspectContentRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::privacy::dlp::v2::RedactImageResponse>,
+  MOCK_METHOD((StatusOr<google::privacy::dlp::v2::RedactImageResponse>),
               RedactImage,
               (google::privacy::dlp::v2::RedactImageRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::privacy::dlp::v2::DeidentifyContentResponse>,
+      (StatusOr<google::privacy::dlp::v2::DeidentifyContentResponse>),
       DeidentifyContent,
       (google::privacy::dlp::v2::DeidentifyContentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::privacy::dlp::v2::ReidentifyContentResponse>,
+      (StatusOr<google::privacy::dlp::v2::ReidentifyContentResponse>),
       ReidentifyContent,
       (google::privacy::dlp::v2::ReidentifyContentRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::privacy::dlp::v2::ListInfoTypesResponse>,
+  MOCK_METHOD((StatusOr<google::privacy::dlp::v2::ListInfoTypesResponse>),
               ListInfoTypes,
               (google::privacy::dlp::v2::ListInfoTypesRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::privacy::dlp::v2::InspectTemplate>,
+      (StatusOr<google::privacy::dlp::v2::InspectTemplate>),
       CreateInspectTemplate,
       (google::privacy::dlp::v2::CreateInspectTemplateRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::privacy::dlp::v2::InspectTemplate>,
+      (StatusOr<google::privacy::dlp::v2::InspectTemplate>),
       UpdateInspectTemplate,
       (google::privacy::dlp::v2::UpdateInspectTemplateRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::privacy::dlp::v2::InspectTemplate>, GetInspectTemplate,
+      (StatusOr<google::privacy::dlp::v2::InspectTemplate>), GetInspectTemplate,
       (google::privacy::dlp::v2::GetInspectTemplateRequest const& request),
       (override));
 
@@ -100,20 +100,20 @@ class MockDlpServiceConnection : public dlp_v2::DlpServiceConnection {
       (google::privacy::dlp::v2::DeleteInspectTemplateRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::privacy::dlp::v2::DeidentifyTemplate>,
+  MOCK_METHOD((StatusOr<google::privacy::dlp::v2::DeidentifyTemplate>),
               CreateDeidentifyTemplate,
               (google::privacy::dlp::v2::CreateDeidentifyTemplateRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::privacy::dlp::v2::DeidentifyTemplate>,
+  MOCK_METHOD((StatusOr<google::privacy::dlp::v2::DeidentifyTemplate>),
               UpdateDeidentifyTemplate,
               (google::privacy::dlp::v2::UpdateDeidentifyTemplateRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::privacy::dlp::v2::DeidentifyTemplate>,
+      (StatusOr<google::privacy::dlp::v2::DeidentifyTemplate>),
       GetDeidentifyTemplate,
       (google::privacy::dlp::v2::GetDeidentifyTemplateRequest const& request),
       (override));
@@ -130,22 +130,22 @@ class MockDlpServiceConnection : public dlp_v2::DlpServiceConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::privacy::dlp::v2::JobTrigger>, CreateJobTrigger,
+      (StatusOr<google::privacy::dlp::v2::JobTrigger>), CreateJobTrigger,
       (google::privacy::dlp::v2::CreateJobTriggerRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::privacy::dlp::v2::JobTrigger>, UpdateJobTrigger,
+      (StatusOr<google::privacy::dlp::v2::JobTrigger>), UpdateJobTrigger,
       (google::privacy::dlp::v2::UpdateJobTriggerRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::privacy::dlp::v2::HybridInspectResponse>,
+      (StatusOr<google::privacy::dlp::v2::HybridInspectResponse>),
       HybridInspectJobTrigger,
       (google::privacy::dlp::v2::HybridInspectJobTriggerRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::privacy::dlp::v2::JobTrigger>, GetJobTrigger,
+  MOCK_METHOD((StatusOr<google::privacy::dlp::v2::JobTrigger>), GetJobTrigger,
               (google::privacy::dlp::v2::GetJobTriggerRequest const& request),
               (override));
 
@@ -160,24 +160,24 @@ class MockDlpServiceConnection : public dlp_v2::DlpServiceConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::privacy::dlp::v2::DlpJob>, ActivateJobTrigger,
+      (StatusOr<google::privacy::dlp::v2::DlpJob>), ActivateJobTrigger,
       (google::privacy::dlp::v2::ActivateJobTriggerRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::privacy::dlp::v2::DiscoveryConfig>,
+      (StatusOr<google::privacy::dlp::v2::DiscoveryConfig>),
       CreateDiscoveryConfig,
       (google::privacy::dlp::v2::CreateDiscoveryConfigRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::privacy::dlp::v2::DiscoveryConfig>,
+      (StatusOr<google::privacy::dlp::v2::DiscoveryConfig>),
       UpdateDiscoveryConfig,
       (google::privacy::dlp::v2::UpdateDiscoveryConfigRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::privacy::dlp::v2::DiscoveryConfig>, GetDiscoveryConfig,
+      (StatusOr<google::privacy::dlp::v2::DiscoveryConfig>), GetDiscoveryConfig,
       (google::privacy::dlp::v2::GetDiscoveryConfigRequest const& request),
       (override));
 
@@ -191,7 +191,7 @@ class MockDlpServiceConnection : public dlp_v2::DlpServiceConnection {
       (google::privacy::dlp::v2::DeleteDiscoveryConfigRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::privacy::dlp::v2::DlpJob>, CreateDlpJob,
+  MOCK_METHOD((StatusOr<google::privacy::dlp::v2::DlpJob>), CreateDlpJob,
               (google::privacy::dlp::v2::CreateDlpJobRequest const& request),
               (override));
 
@@ -199,7 +199,7 @@ class MockDlpServiceConnection : public dlp_v2::DlpServiceConnection {
               (google::privacy::dlp::v2::ListDlpJobsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::privacy::dlp::v2::DlpJob>, GetDlpJob,
+  MOCK_METHOD((StatusOr<google::privacy::dlp::v2::DlpJob>), GetDlpJob,
               (google::privacy::dlp::v2::GetDlpJobRequest const& request),
               (override));
 
@@ -212,17 +212,19 @@ class MockDlpServiceConnection : public dlp_v2::DlpServiceConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::privacy::dlp::v2::StoredInfoType>, CreateStoredInfoType,
+      (StatusOr<google::privacy::dlp::v2::StoredInfoType>),
+      CreateStoredInfoType,
       (google::privacy::dlp::v2::CreateStoredInfoTypeRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::privacy::dlp::v2::StoredInfoType>, UpdateStoredInfoType,
+      (StatusOr<google::privacy::dlp::v2::StoredInfoType>),
+      UpdateStoredInfoType,
       (google::privacy::dlp::v2::UpdateStoredInfoTypeRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::privacy::dlp::v2::StoredInfoType>, GetStoredInfoType,
+      (StatusOr<google::privacy::dlp::v2::StoredInfoType>), GetStoredInfoType,
       (google::privacy::dlp::v2::GetStoredInfoTypeRequest const& request),
       (override));
 
@@ -253,24 +255,25 @@ class MockDlpServiceConnection : public dlp_v2::DlpServiceConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::privacy::dlp::v2::ProjectDataProfile>,
+      (StatusOr<google::privacy::dlp::v2::ProjectDataProfile>),
       GetProjectDataProfile,
       (google::privacy::dlp::v2::GetProjectDataProfileRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::privacy::dlp::v2::TableDataProfile>, GetTableDataProfile,
+      (StatusOr<google::privacy::dlp::v2::TableDataProfile>),
+      GetTableDataProfile,
       (google::privacy::dlp::v2::GetTableDataProfileRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::privacy::dlp::v2::ColumnDataProfile>,
+      (StatusOr<google::privacy::dlp::v2::ColumnDataProfile>),
       GetColumnDataProfile,
       (google::privacy::dlp::v2::GetColumnDataProfileRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::privacy::dlp::v2::HybridInspectResponse>,
+      (StatusOr<google::privacy::dlp::v2::HybridInspectResponse>),
       HybridInspectDlpJob,
       (google::privacy::dlp::v2::HybridInspectDlpJobRequest const& request),
       (override));

--- a/google/cloud/documentai/v1/mocks/mock_document_processor_connection.h
+++ b/google/cloud/documentai/v1/mocks/mock_document_processor_connection.h
@@ -47,19 +47,19 @@ class MockDocumentProcessorServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::documentai::v1::ProcessResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::documentai::v1::ProcessResponse>),
               ProcessDocument,
               (google::cloud::documentai::v1::ProcessRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::documentai::v1::BatchProcessResponse>>,
+      (future<StatusOr<google::cloud::documentai::v1::BatchProcessResponse>>),
       BatchProcessDocuments,
       (google::cloud::documentai::v1::BatchProcessRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::documentai::v1::FetchProcessorTypesResponse>,
+      (StatusOr<google::cloud::documentai::v1::FetchProcessorTypesResponse>),
       FetchProcessorTypes,
       (google::cloud::documentai::v1::FetchProcessorTypesRequest const&
            request),
@@ -72,7 +72,8 @@ class MockDocumentProcessorServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::documentai::v1::ProcessorType>, GetProcessorType,
+      (StatusOr<google::cloud::documentai::v1::ProcessorType>),
+      GetProcessorType,
       (google::cloud::documentai::v1::GetProcessorTypeRequest const& request),
       (override));
 
@@ -82,19 +83,19 @@ class MockDocumentProcessorServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::documentai::v1::Processor>, GetProcessor,
+      (StatusOr<google::cloud::documentai::v1::Processor>), GetProcessor,
       (google::cloud::documentai::v1::GetProcessorRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::documentai::v1::TrainProcessorVersionResponse>>,
+      (future<StatusOr<
+           google::cloud::documentai::v1::TrainProcessorVersionResponse>>),
       TrainProcessorVersion,
       (google::cloud::documentai::v1::TrainProcessorVersionRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::documentai::v1::ProcessorVersion>,
+  MOCK_METHOD((StatusOr<google::cloud::documentai::v1::ProcessorVersion>),
               GetProcessorVersion,
               (google::cloud::documentai::v1::GetProcessorVersionRequest const&
                    request),
@@ -107,76 +108,79 @@ class MockDocumentProcessorServiceConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::documentai::v1::DeleteProcessorVersionMetadata>>,
+      (future<StatusOr<
+           google::cloud::documentai::v1::DeleteProcessorVersionMetadata>>),
       DeleteProcessorVersion,
       (google::cloud::documentai::v1::DeleteProcessorVersionRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::documentai::v1::DeployProcessorVersionResponse>>,
+      (future<StatusOr<
+           google::cloud::documentai::v1::DeployProcessorVersionResponse>>),
       DeployProcessorVersion,
       (google::cloud::documentai::v1::DeployProcessorVersionRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::documentai::v1::UndeployProcessorVersionResponse>>,
+      (future<StatusOr<
+           google::cloud::documentai::v1::UndeployProcessorVersionResponse>>),
       UndeployProcessorVersion,
       (google::cloud::documentai::v1::UndeployProcessorVersionRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::documentai::v1::Processor>, CreateProcessor,
+      (StatusOr<google::cloud::documentai::v1::Processor>), CreateProcessor,
       (google::cloud::documentai::v1::CreateProcessorRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::documentai::v1::DeleteProcessorMetadata>>,
+      (future<
+          StatusOr<google::cloud::documentai::v1::DeleteProcessorMetadata>>),
       DeleteProcessor,
       (google::cloud::documentai::v1::DeleteProcessorRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::documentai::v1::EnableProcessorResponse>>,
+      (future<
+          StatusOr<google::cloud::documentai::v1::EnableProcessorResponse>>),
       EnableProcessor,
       (google::cloud::documentai::v1::EnableProcessorRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::documentai::v1::DisableProcessorResponse>>,
+      (future<
+          StatusOr<google::cloud::documentai::v1::DisableProcessorResponse>>),
       DisableProcessor,
       (google::cloud::documentai::v1::DisableProcessorRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::documentai::v1::SetDefaultProcessorVersionResponse>>,
+      (future<StatusOr<
+           google::cloud::documentai::v1::SetDefaultProcessorVersionResponse>>),
       SetDefaultProcessorVersion,
       (google::cloud::documentai::v1::SetDefaultProcessorVersionRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::documentai::v1::ReviewDocumentResponse>>,
+      (future<StatusOr<google::cloud::documentai::v1::ReviewDocumentResponse>>),
       ReviewDocument,
       (google::cloud::documentai::v1::ReviewDocumentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::documentai::v1::EvaluateProcessorVersionResponse>>,
+      (future<StatusOr<
+           google::cloud::documentai::v1::EvaluateProcessorVersionResponse>>),
       EvaluateProcessorVersion,
       (google::cloud::documentai::v1::EvaluateProcessorVersionRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::documentai::v1::Evaluation>, GetEvaluation,
+      (StatusOr<google::cloud::documentai::v1::Evaluation>), GetEvaluation,
       (google::cloud::documentai::v1::GetEvaluationRequest const& request),
       (override));
 

--- a/google/cloud/domains/v1/mocks/mock_domains_connection.h
+++ b/google/cloud/domains/v1/mocks/mock_domains_connection.h
@@ -46,33 +46,35 @@ class MockDomainsConnection : public domains_v1::DomainsConnection {
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::domains::v1::SearchDomainsResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::domains::v1::SearchDomainsResponse>),
               SearchDomains,
               (google::cloud::domains::v1::SearchDomainsRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::domains::v1::RetrieveRegisterParametersResponse>,
+      (StatusOr<
+          google::cloud::domains::v1::RetrieveRegisterParametersResponse>),
       RetrieveRegisterParameters,
       (google::cloud::domains::v1::RetrieveRegisterParametersRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::domains::v1::Registration>>,
+      (future<StatusOr<google::cloud::domains::v1::Registration>>),
       RegisterDomain,
       (google::cloud::domains::v1::RegisterDomainRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::domains::v1::RetrieveTransferParametersResponse>,
+      (StatusOr<
+          google::cloud::domains::v1::RetrieveTransferParametersResponse>),
       RetrieveTransferParameters,
       (google::cloud::domains::v1::RetrieveTransferParametersRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::domains::v1::Registration>>,
+      (future<StatusOr<google::cloud::domains::v1::Registration>>),
       TransferDomain,
       (google::cloud::domains::v1::TransferDomainRequest const& request),
       (override));
@@ -83,56 +85,56 @@ class MockDomainsConnection : public domains_v1::DomainsConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::domains::v1::Registration>, GetRegistration,
+      (StatusOr<google::cloud::domains::v1::Registration>), GetRegistration,
       (google::cloud::domains::v1::GetRegistrationRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::domains::v1::Registration>>,
+      (future<StatusOr<google::cloud::domains::v1::Registration>>),
       UpdateRegistration,
       (google::cloud::domains::v1::UpdateRegistrationRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::domains::v1::Registration>>,
+      (future<StatusOr<google::cloud::domains::v1::Registration>>),
       ConfigureManagementSettings,
       (google::cloud::domains::v1::ConfigureManagementSettingsRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::domains::v1::Registration>>,
+      (future<StatusOr<google::cloud::domains::v1::Registration>>),
       ConfigureDnsSettings,
       (google::cloud::domains::v1::ConfigureDnsSettingsRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::domains::v1::Registration>>,
+      (future<StatusOr<google::cloud::domains::v1::Registration>>),
       ConfigureContactSettings,
       (google::cloud::domains::v1::ConfigureContactSettingsRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::domains::v1::Registration>>,
+      (future<StatusOr<google::cloud::domains::v1::Registration>>),
       ExportRegistration,
       (google::cloud::domains::v1::ExportRegistrationRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::domains::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::domains::v1::OperationMetadata>>),
       DeleteRegistration,
       (google::cloud::domains::v1::DeleteRegistrationRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::domains::v1::AuthorizationCode>,
+      (StatusOr<google::cloud::domains::v1::AuthorizationCode>),
       RetrieveAuthorizationCode,
       (google::cloud::domains::v1::RetrieveAuthorizationCodeRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::domains::v1::AuthorizationCode>,
+  MOCK_METHOD((StatusOr<google::cloud::domains::v1::AuthorizationCode>),
               ResetAuthorizationCode,
               (google::cloud::domains::v1::ResetAuthorizationCodeRequest const&
                    request),

--- a/google/cloud/edgecontainer/v1/mocks/mock_edge_container_connection.h
+++ b/google/cloud/edgecontainer/v1/mocks/mock_edge_container_connection.h
@@ -53,44 +53,44 @@ class MockEdgeContainerConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::edgecontainer::v1::Cluster>, GetCluster,
+      (StatusOr<google::cloud::edgecontainer::v1::Cluster>), GetCluster,
       (google::cloud::edgecontainer::v1::GetClusterRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::edgecontainer::v1::Cluster>>,
+      (future<StatusOr<google::cloud::edgecontainer::v1::Cluster>>),
       CreateCluster,
       (google::cloud::edgecontainer::v1::CreateClusterRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::edgecontainer::v1::Cluster>>,
+      (future<StatusOr<google::cloud::edgecontainer::v1::Cluster>>),
       UpdateCluster,
       (google::cloud::edgecontainer::v1::UpdateClusterRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::edgecontainer::v1::Cluster>>,
+      (future<StatusOr<google::cloud::edgecontainer::v1::Cluster>>),
       UpgradeCluster,
       (google::cloud::edgecontainer::v1::UpgradeClusterRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::edgecontainer::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::edgecontainer::v1::OperationMetadata>>),
       DeleteCluster,
       (google::cloud::edgecontainer::v1::DeleteClusterRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::edgecontainer::v1::GenerateAccessTokenResponse>,
+      (StatusOr<google::cloud::edgecontainer::v1::GenerateAccessTokenResponse>),
       GenerateAccessToken,
       (google::cloud::edgecontainer::v1::GenerateAccessTokenRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::edgecontainer::v1::GenerateOfflineCredentialResponse>,
+      (StatusOr<
+          google::cloud::edgecontainer::v1::GenerateOfflineCredentialResponse>),
       GenerateOfflineCredential,
       (google::cloud::edgecontainer::v1::GenerateOfflineCredentialRequest const&
            request),
@@ -102,24 +102,24 @@ class MockEdgeContainerConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::edgecontainer::v1::NodePool>, GetNodePool,
+      (StatusOr<google::cloud::edgecontainer::v1::NodePool>), GetNodePool,
       (google::cloud::edgecontainer::v1::GetNodePoolRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::edgecontainer::v1::NodePool>>,
+      (future<StatusOr<google::cloud::edgecontainer::v1::NodePool>>),
       CreateNodePool,
       (google::cloud::edgecontainer::v1::CreateNodePoolRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::edgecontainer::v1::NodePool>>,
+      (future<StatusOr<google::cloud::edgecontainer::v1::NodePool>>),
       UpdateNodePool,
       (google::cloud::edgecontainer::v1::UpdateNodePoolRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::edgecontainer::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::edgecontainer::v1::OperationMetadata>>),
       DeleteNodePool,
       (google::cloud::edgecontainer::v1::DeleteNodePoolRequest const& request),
       (override));
@@ -130,7 +130,7 @@ class MockEdgeContainerConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::edgecontainer::v1::Machine>, GetMachine,
+      (StatusOr<google::cloud::edgecontainer::v1::Machine>), GetMachine,
       (google::cloud::edgecontainer::v1::GetMachineRequest const& request),
       (override));
 
@@ -140,28 +140,29 @@ class MockEdgeContainerConnection
       (google::cloud::edgecontainer::v1::ListVpnConnectionsRequest request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::edgecontainer::v1::VpnConnection>,
+  MOCK_METHOD((StatusOr<google::cloud::edgecontainer::v1::VpnConnection>),
               GetVpnConnection,
               (google::cloud::edgecontainer::v1::GetVpnConnectionRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::edgecontainer::v1::VpnConnection>>,
+      (future<StatusOr<google::cloud::edgecontainer::v1::VpnConnection>>),
       CreateVpnConnection,
       (google::cloud::edgecontainer::v1::CreateVpnConnectionRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::edgecontainer::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::edgecontainer::v1::OperationMetadata>>),
       DeleteVpnConnection,
       (google::cloud::edgecontainer::v1::DeleteVpnConnectionRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::edgecontainer::v1::ServerConfig>, GetServerConfig,
+      (StatusOr<google::cloud::edgecontainer::v1::ServerConfig>),
+      GetServerConfig,
       (google::cloud::edgecontainer::v1::GetServerConfigRequest const& request),
       (override));
 };

--- a/google/cloud/edgenetwork/v1/mocks/mock_edge_network_connection.h
+++ b/google/cloud/edgenetwork/v1/mocks/mock_edge_network_connection.h
@@ -47,7 +47,7 @@ class MockEdgeNetworkConnection : public edgenetwork_v1::EdgeNetworkConnection {
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::edgenetwork::v1::InitializeZoneResponse>,
+      (StatusOr<google::cloud::edgenetwork::v1::InitializeZoneResponse>),
       InitializeZone,
       (google::cloud::edgenetwork::v1::InitializeZoneRequest const& request),
       (override));
@@ -56,7 +56,7 @@ class MockEdgeNetworkConnection : public edgenetwork_v1::EdgeNetworkConnection {
               (google::cloud::edgenetwork::v1::ListZonesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::edgenetwork::v1::Zone>, GetZone,
+  MOCK_METHOD((StatusOr<google::cloud::edgenetwork::v1::Zone>), GetZone,
               (google::cloud::edgenetwork::v1::GetZoneRequest const& request),
               (override));
 
@@ -66,23 +66,24 @@ class MockEdgeNetworkConnection : public edgenetwork_v1::EdgeNetworkConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::edgenetwork::v1::Network>, GetNetwork,
+      (StatusOr<google::cloud::edgenetwork::v1::Network>), GetNetwork,
       (google::cloud::edgenetwork::v1::GetNetworkRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::edgenetwork::v1::DiagnoseNetworkResponse>,
+      (StatusOr<google::cloud::edgenetwork::v1::DiagnoseNetworkResponse>),
       DiagnoseNetwork,
       (google::cloud::edgenetwork::v1::DiagnoseNetworkRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::edgenetwork::v1::Network>>, CreateNetwork,
+      (future<StatusOr<google::cloud::edgenetwork::v1::Network>>),
+      CreateNetwork,
       (google::cloud::edgenetwork::v1::CreateNetworkRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::edgenetwork::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::edgenetwork::v1::OperationMetadata>>),
       DeleteNetwork,
       (google::cloud::edgenetwork::v1::DeleteNetworkRequest const& request),
       (override));
@@ -92,22 +93,22 @@ class MockEdgeNetworkConnection : public edgenetwork_v1::EdgeNetworkConnection {
               (google::cloud::edgenetwork::v1::ListSubnetsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::edgenetwork::v1::Subnet>, GetSubnet,
+  MOCK_METHOD((StatusOr<google::cloud::edgenetwork::v1::Subnet>), GetSubnet,
               (google::cloud::edgenetwork::v1::GetSubnetRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::edgenetwork::v1::Subnet>>, CreateSubnet,
+      (future<StatusOr<google::cloud::edgenetwork::v1::Subnet>>), CreateSubnet,
       (google::cloud::edgenetwork::v1::CreateSubnetRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::edgenetwork::v1::Subnet>>, UpdateSubnet,
+      (future<StatusOr<google::cloud::edgenetwork::v1::Subnet>>), UpdateSubnet,
       (google::cloud::edgenetwork::v1::UpdateSubnetRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::edgenetwork::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::edgenetwork::v1::OperationMetadata>>),
       DeleteSubnet,
       (google::cloud::edgenetwork::v1::DeleteSubnetRequest const& request),
       (override));
@@ -119,12 +120,12 @@ class MockEdgeNetworkConnection : public edgenetwork_v1::EdgeNetworkConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::edgenetwork::v1::Interconnect>, GetInterconnect,
+      (StatusOr<google::cloud::edgenetwork::v1::Interconnect>), GetInterconnect,
       (google::cloud::edgenetwork::v1::GetInterconnectRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::edgenetwork::v1::DiagnoseInterconnectResponse>,
+      (StatusOr<google::cloud::edgenetwork::v1::DiagnoseInterconnectResponse>),
       DiagnoseInterconnect,
       (google::cloud::edgenetwork::v1::DiagnoseInterconnectRequest const&
            request),
@@ -138,21 +139,22 @@ class MockEdgeNetworkConnection : public edgenetwork_v1::EdgeNetworkConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::edgenetwork::v1::InterconnectAttachment>,
+      (StatusOr<google::cloud::edgenetwork::v1::InterconnectAttachment>),
       GetInterconnectAttachment,
       (google::cloud::edgenetwork::v1::GetInterconnectAttachmentRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::edgenetwork::v1::InterconnectAttachment>>,
+      (future<
+          StatusOr<google::cloud::edgenetwork::v1::InterconnectAttachment>>),
       CreateInterconnectAttachment,
       (google::cloud::edgenetwork::v1::
            CreateInterconnectAttachmentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::edgenetwork::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::edgenetwork::v1::OperationMetadata>>),
       DeleteInterconnectAttachment,
       (google::cloud::edgenetwork::v1::
            DeleteInterconnectAttachmentRequest const& request),
@@ -163,28 +165,28 @@ class MockEdgeNetworkConnection : public edgenetwork_v1::EdgeNetworkConnection {
               (google::cloud::edgenetwork::v1::ListRoutersRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::edgenetwork::v1::Router>, GetRouter,
+  MOCK_METHOD((StatusOr<google::cloud::edgenetwork::v1::Router>), GetRouter,
               (google::cloud::edgenetwork::v1::GetRouterRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::edgenetwork::v1::DiagnoseRouterResponse>,
+      (StatusOr<google::cloud::edgenetwork::v1::DiagnoseRouterResponse>),
       DiagnoseRouter,
       (google::cloud::edgenetwork::v1::DiagnoseRouterRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::edgenetwork::v1::Router>>, CreateRouter,
+      (future<StatusOr<google::cloud::edgenetwork::v1::Router>>), CreateRouter,
       (google::cloud::edgenetwork::v1::CreateRouterRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::edgenetwork::v1::Router>>, UpdateRouter,
+      (future<StatusOr<google::cloud::edgenetwork::v1::Router>>), UpdateRouter,
       (google::cloud::edgenetwork::v1::UpdateRouterRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::edgenetwork::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::edgenetwork::v1::OperationMetadata>>),
       DeleteRouter,
       (google::cloud::edgenetwork::v1::DeleteRouterRequest const& request),
       (override));

--- a/google/cloud/essentialcontacts/v1/mocks/mock_essential_contacts_connection.h
+++ b/google/cloud/essentialcontacts/v1/mocks/mock_essential_contacts_connection.h
@@ -47,13 +47,13 @@ class MockEssentialContactsServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::essentialcontacts::v1::Contact>,
+  MOCK_METHOD((StatusOr<google::cloud::essentialcontacts::v1::Contact>),
               CreateContact,
               (google::cloud::essentialcontacts::v1::CreateContactRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::essentialcontacts::v1::Contact>,
+  MOCK_METHOD((StatusOr<google::cloud::essentialcontacts::v1::Contact>),
               UpdateContact,
               (google::cloud::essentialcontacts::v1::UpdateContactRequest const&
                    request),
@@ -66,7 +66,7 @@ class MockEssentialContactsServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::essentialcontacts::v1::Contact>, GetContact,
+      (StatusOr<google::cloud::essentialcontacts::v1::Contact>), GetContact,
       (google::cloud::essentialcontacts::v1::GetContactRequest const& request),
       (override));
 

--- a/google/cloud/eventarc/publishing/v1/mocks/mock_publisher_connection.h
+++ b/google/cloud/eventarc/publishing/v1/mocks/mock_publisher_connection.h
@@ -47,15 +47,16 @@ class MockPublisherConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::eventarc::publishing::v1::
-                           PublishChannelConnectionEventsResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::eventarc::publishing::v1::
+                            PublishChannelConnectionEventsResponse>),
               PublishChannelConnectionEvents,
               (google::cloud::eventarc::publishing::v1::
                    PublishChannelConnectionEventsRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::eventarc::publishing::v1::PublishEventsResponse>,
+      (StatusOr<
+          google::cloud::eventarc::publishing::v1::PublishEventsResponse>),
       PublishEvents,
       (google::cloud::eventarc::publishing::v1::PublishEventsRequest const&
            request),

--- a/google/cloud/eventarc/v1/mocks/mock_eventarc_connection.h
+++ b/google/cloud/eventarc/v1/mocks/mock_eventarc_connection.h
@@ -46,7 +46,7 @@ class MockEventarcConnection : public eventarc_v1::EventarcConnection {
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::eventarc::v1::Trigger>, GetTrigger,
+  MOCK_METHOD((StatusOr<google::cloud::eventarc::v1::Trigger>), GetTrigger,
               (google::cloud::eventarc::v1::GetTriggerRequest const& request),
               (override));
 
@@ -55,21 +55,21 @@ class MockEventarcConnection : public eventarc_v1::EventarcConnection {
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::eventarc::v1::Trigger>>, CreateTrigger,
+      (future<StatusOr<google::cloud::eventarc::v1::Trigger>>), CreateTrigger,
       (google::cloud::eventarc::v1::CreateTriggerRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::eventarc::v1::Trigger>>, UpdateTrigger,
+      (future<StatusOr<google::cloud::eventarc::v1::Trigger>>), UpdateTrigger,
       (google::cloud::eventarc::v1::UpdateTriggerRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::eventarc::v1::Trigger>>, DeleteTrigger,
+      (future<StatusOr<google::cloud::eventarc::v1::Trigger>>), DeleteTrigger,
       (google::cloud::eventarc::v1::DeleteTriggerRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::eventarc::v1::Channel>, GetChannel,
+  MOCK_METHOD((StatusOr<google::cloud::eventarc::v1::Channel>), GetChannel,
               (google::cloud::eventarc::v1::GetChannelRequest const& request),
               (override));
 
@@ -78,21 +78,21 @@ class MockEventarcConnection : public eventarc_v1::EventarcConnection {
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::eventarc::v1::Channel>>, CreateChannel,
+      (future<StatusOr<google::cloud::eventarc::v1::Channel>>), CreateChannel,
       (google::cloud::eventarc::v1::CreateChannelRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::eventarc::v1::Channel>>, UpdateChannel,
+      (future<StatusOr<google::cloud::eventarc::v1::Channel>>), UpdateChannel,
       (google::cloud::eventarc::v1::UpdateChannelRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::eventarc::v1::Channel>>, DeleteChannel,
+      (future<StatusOr<google::cloud::eventarc::v1::Channel>>), DeleteChannel,
       (google::cloud::eventarc::v1::DeleteChannelRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::eventarc::v1::Provider>, GetProvider,
+  MOCK_METHOD((StatusOr<google::cloud::eventarc::v1::Provider>), GetProvider,
               (google::cloud::eventarc::v1::GetProviderRequest const& request),
               (override));
 
@@ -102,7 +102,7 @@ class MockEventarcConnection : public eventarc_v1::EventarcConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::eventarc::v1::ChannelConnection>,
+      (StatusOr<google::cloud::eventarc::v1::ChannelConnection>),
       GetChannelConnection,
       (google::cloud::eventarc::v1::GetChannelConnectionRequest const& request),
       (override));
@@ -114,27 +114,27 @@ class MockEventarcConnection : public eventarc_v1::EventarcConnection {
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::eventarc::v1::ChannelConnection>>,
+      (future<StatusOr<google::cloud::eventarc::v1::ChannelConnection>>),
       CreateChannelConnection,
       (google::cloud::eventarc::v1::CreateChannelConnectionRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::eventarc::v1::ChannelConnection>>,
+      (future<StatusOr<google::cloud::eventarc::v1::ChannelConnection>>),
       DeleteChannelConnection,
       (google::cloud::eventarc::v1::DeleteChannelConnectionRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::eventarc::v1::GoogleChannelConfig>,
+  MOCK_METHOD((StatusOr<google::cloud::eventarc::v1::GoogleChannelConfig>),
               GetGoogleChannelConfig,
               (google::cloud::eventarc::v1::GetGoogleChannelConfigRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::eventarc::v1::GoogleChannelConfig>,
+      (StatusOr<google::cloud::eventarc::v1::GoogleChannelConfig>),
       UpdateGoogleChannelConfig,
       (google::cloud::eventarc::v1::UpdateGoogleChannelConfigRequest const&
            request),

--- a/google/cloud/filestore/v1/mocks/mock_cloud_filestore_manager_connection.h
+++ b/google/cloud/filestore/v1/mocks/mock_cloud_filestore_manager_connection.h
@@ -52,32 +52,36 @@ class MockCloudFilestoreManagerConnection
               (google::cloud::filestore::v1::ListInstancesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::filestore::v1::Instance>, GetInstance,
+  MOCK_METHOD((StatusOr<google::cloud::filestore::v1::Instance>), GetInstance,
               (google::cloud::filestore::v1::GetInstanceRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::filestore::v1::Instance>>, CreateInstance,
+      (future<StatusOr<google::cloud::filestore::v1::Instance>>),
+      CreateInstance,
       (google::cloud::filestore::v1::CreateInstanceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::filestore::v1::Instance>>, UpdateInstance,
+      (future<StatusOr<google::cloud::filestore::v1::Instance>>),
+      UpdateInstance,
       (google::cloud::filestore::v1::UpdateInstanceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::filestore::v1::Instance>>, RestoreInstance,
+      (future<StatusOr<google::cloud::filestore::v1::Instance>>),
+      RestoreInstance,
       (google::cloud::filestore::v1::RestoreInstanceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::filestore::v1::Instance>>, RevertInstance,
+      (future<StatusOr<google::cloud::filestore::v1::Instance>>),
+      RevertInstance,
       (google::cloud::filestore::v1::RevertInstanceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::common::OperationMetadata>>,
+      (future<StatusOr<google::cloud::common::OperationMetadata>>),
       DeleteInstance,
       (google::cloud::filestore::v1::DeleteInstanceRequest const& request),
       (override));
@@ -87,23 +91,25 @@ class MockCloudFilestoreManagerConnection
               (google::cloud::filestore::v1::ListSnapshotsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::filestore::v1::Snapshot>, GetSnapshot,
+  MOCK_METHOD((StatusOr<google::cloud::filestore::v1::Snapshot>), GetSnapshot,
               (google::cloud::filestore::v1::GetSnapshotRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::filestore::v1::Snapshot>>, CreateSnapshot,
+      (future<StatusOr<google::cloud::filestore::v1::Snapshot>>),
+      CreateSnapshot,
       (google::cloud::filestore::v1::CreateSnapshotRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::common::OperationMetadata>>,
+      (future<StatusOr<google::cloud::common::OperationMetadata>>),
       DeleteSnapshot,
       (google::cloud::filestore::v1::DeleteSnapshotRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::filestore::v1::Snapshot>>, UpdateSnapshot,
+      (future<StatusOr<google::cloud::filestore::v1::Snapshot>>),
+      UpdateSnapshot,
       (google::cloud::filestore::v1::UpdateSnapshotRequest const& request),
       (override));
 
@@ -111,22 +117,23 @@ class MockCloudFilestoreManagerConnection
               (google::cloud::filestore::v1::ListBackupsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::filestore::v1::Backup>, GetBackup,
+  MOCK_METHOD((StatusOr<google::cloud::filestore::v1::Backup>), GetBackup,
               (google::cloud::filestore::v1::GetBackupRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::filestore::v1::Backup>>, CreateBackup,
+      (future<StatusOr<google::cloud::filestore::v1::Backup>>), CreateBackup,
       (google::cloud::filestore::v1::CreateBackupRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::common::OperationMetadata>>, DeleteBackup,
+      (future<StatusOr<google::cloud::common::OperationMetadata>>),
+      DeleteBackup,
       (google::cloud::filestore::v1::DeleteBackupRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::filestore::v1::Backup>>, UpdateBackup,
+      (future<StatusOr<google::cloud::filestore::v1::Backup>>), UpdateBackup,
       (google::cloud::filestore::v1::UpdateBackupRequest const& request),
       (override));
 };

--- a/google/cloud/functions/v1/mocks/mock_cloud_functions_connection.h
+++ b/google/cloud/functions/v1/mocks/mock_cloud_functions_connection.h
@@ -52,56 +52,56 @@ class MockCloudFunctionsServiceConnection
               (google::cloud::functions::v1::ListFunctionsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::functions::v1::CloudFunction>,
+  MOCK_METHOD((StatusOr<google::cloud::functions::v1::CloudFunction>),
               GetFunction,
               (google::cloud::functions::v1::GetFunctionRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::functions::v1::CloudFunction>>,
+      (future<StatusOr<google::cloud::functions::v1::CloudFunction>>),
       CreateFunction,
       (google::cloud::functions::v1::CreateFunctionRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::functions::v1::CloudFunction>>,
+      (future<StatusOr<google::cloud::functions::v1::CloudFunction>>),
       UpdateFunction,
       (google::cloud::functions::v1::UpdateFunctionRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::functions::v1::OperationMetadataV1>>,
+      (future<StatusOr<google::cloud::functions::v1::OperationMetadataV1>>),
       DeleteFunction,
       (google::cloud::functions::v1::DeleteFunctionRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::functions::v1::CallFunctionResponse>,
+      (StatusOr<google::cloud::functions::v1::CallFunctionResponse>),
       CallFunction,
       (google::cloud::functions::v1::CallFunctionRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::functions::v1::GenerateUploadUrlResponse>,
+      (StatusOr<google::cloud::functions::v1::GenerateUploadUrlResponse>),
       GenerateUploadUrl,
       (google::cloud::functions::v1::GenerateUploadUrlRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::functions::v1::GenerateDownloadUrlResponse>,
+      (StatusOr<google::cloud::functions::v1::GenerateDownloadUrlResponse>),
       GenerateDownloadUrl,
       (google::cloud::functions::v1::GenerateDownloadUrlRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), SetIamPolicy,
               (google::iam::v1::SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), GetIamPolicy,
               (google::iam::v1::GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD((StatusOr<google::iam::v1::TestIamPermissionsResponse>),
               TestIamPermissions,
               (google::iam::v1::TestIamPermissionsRequest const& request),
               (override));

--- a/google/cloud/functions/v2/mocks/mock_function_connection.h
+++ b/google/cloud/functions/v2/mocks/mock_function_connection.h
@@ -47,7 +47,7 @@ class MockFunctionServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::functions::v2::Function>, GetFunction,
+  MOCK_METHOD((StatusOr<google::cloud::functions::v2::Function>), GetFunction,
               (google::cloud::functions::v2::GetFunctionRequest const& request),
               (override));
 
@@ -57,35 +57,37 @@ class MockFunctionServiceConnection
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::functions::v2::Function>>, CreateFunction,
+      (future<StatusOr<google::cloud::functions::v2::Function>>),
+      CreateFunction,
       (google::cloud::functions::v2::CreateFunctionRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::functions::v2::Function>>, UpdateFunction,
+      (future<StatusOr<google::cloud::functions::v2::Function>>),
+      UpdateFunction,
       (google::cloud::functions::v2::UpdateFunctionRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::functions::v2::OperationMetadata>>,
+      (future<StatusOr<google::cloud::functions::v2::OperationMetadata>>),
       DeleteFunction,
       (google::cloud::functions::v2::DeleteFunctionRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::functions::v2::GenerateUploadUrlResponse>,
+      (StatusOr<google::cloud::functions::v2::GenerateUploadUrlResponse>),
       GenerateUploadUrl,
       (google::cloud::functions::v2::GenerateUploadUrlRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::functions::v2::GenerateDownloadUrlResponse>,
+      (StatusOr<google::cloud::functions::v2::GenerateDownloadUrlResponse>),
       GenerateDownloadUrl,
       (google::cloud::functions::v2::GenerateDownloadUrlRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::functions::v2::ListRuntimesResponse>,
+      (StatusOr<google::cloud::functions::v2::ListRuntimesResponse>),
       ListRuntimes,
       (google::cloud::functions::v2::ListRuntimesRequest const& request),
       (override));

--- a/google/cloud/gkebackup/v1/mocks/mock_backup_for_gke_connection.h
+++ b/google/cloud/gkebackup/v1/mocks/mock_backup_for_gke_connection.h
@@ -47,7 +47,7 @@ class MockBackupForGKEConnection : public gkebackup_v1::BackupForGKEConnection {
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::gkebackup::v1::BackupPlan>>,
+      (future<StatusOr<google::cloud::gkebackup::v1::BackupPlan>>),
       CreateBackupPlan,
       (google::cloud::gkebackup::v1::CreateBackupPlanRequest const& request),
       (override));
@@ -58,24 +58,24 @@ class MockBackupForGKEConnection : public gkebackup_v1::BackupForGKEConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::gkebackup::v1::BackupPlan>, GetBackupPlan,
+      (StatusOr<google::cloud::gkebackup::v1::BackupPlan>), GetBackupPlan,
       (google::cloud::gkebackup::v1::GetBackupPlanRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::gkebackup::v1::BackupPlan>>,
+      (future<StatusOr<google::cloud::gkebackup::v1::BackupPlan>>),
       UpdateBackupPlan,
       (google::cloud::gkebackup::v1::UpdateBackupPlanRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::gkebackup::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::gkebackup::v1::OperationMetadata>>),
       DeleteBackupPlan,
       (google::cloud::gkebackup::v1::DeleteBackupPlanRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::gkebackup::v1::Backup>>, CreateBackup,
+      (future<StatusOr<google::cloud::gkebackup::v1::Backup>>), CreateBackup,
       (google::cloud::gkebackup::v1::CreateBackupRequest const& request),
       (override));
 
@@ -83,17 +83,17 @@ class MockBackupForGKEConnection : public gkebackup_v1::BackupForGKEConnection {
               (google::cloud::gkebackup::v1::ListBackupsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::gkebackup::v1::Backup>, GetBackup,
+  MOCK_METHOD((StatusOr<google::cloud::gkebackup::v1::Backup>), GetBackup,
               (google::cloud::gkebackup::v1::GetBackupRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::gkebackup::v1::Backup>>, UpdateBackup,
+      (future<StatusOr<google::cloud::gkebackup::v1::Backup>>), UpdateBackup,
       (google::cloud::gkebackup::v1::UpdateBackupRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::gkebackup::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::gkebackup::v1::OperationMetadata>>),
       DeleteBackup,
       (google::cloud::gkebackup::v1::DeleteBackupRequest const& request),
       (override));
@@ -104,12 +104,12 @@ class MockBackupForGKEConnection : public gkebackup_v1::BackupForGKEConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::gkebackup::v1::VolumeBackup>, GetVolumeBackup,
+      (StatusOr<google::cloud::gkebackup::v1::VolumeBackup>), GetVolumeBackup,
       (google::cloud::gkebackup::v1::GetVolumeBackupRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::gkebackup::v1::RestorePlan>>,
+      (future<StatusOr<google::cloud::gkebackup::v1::RestorePlan>>),
       CreateRestorePlan,
       (google::cloud::gkebackup::v1::CreateRestorePlanRequest const& request),
       (override));
@@ -120,24 +120,24 @@ class MockBackupForGKEConnection : public gkebackup_v1::BackupForGKEConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::gkebackup::v1::RestorePlan>, GetRestorePlan,
+      (StatusOr<google::cloud::gkebackup::v1::RestorePlan>), GetRestorePlan,
       (google::cloud::gkebackup::v1::GetRestorePlanRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::gkebackup::v1::RestorePlan>>,
+      (future<StatusOr<google::cloud::gkebackup::v1::RestorePlan>>),
       UpdateRestorePlan,
       (google::cloud::gkebackup::v1::UpdateRestorePlanRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::gkebackup::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::gkebackup::v1::OperationMetadata>>),
       DeleteRestorePlan,
       (google::cloud::gkebackup::v1::DeleteRestorePlanRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::gkebackup::v1::Restore>>, CreateRestore,
+      (future<StatusOr<google::cloud::gkebackup::v1::Restore>>), CreateRestore,
       (google::cloud::gkebackup::v1::CreateRestoreRequest const& request),
       (override));
 
@@ -146,17 +146,17 @@ class MockBackupForGKEConnection : public gkebackup_v1::BackupForGKEConnection {
               (google::cloud::gkebackup::v1::ListRestoresRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::gkebackup::v1::Restore>, GetRestore,
+  MOCK_METHOD((StatusOr<google::cloud::gkebackup::v1::Restore>), GetRestore,
               (google::cloud::gkebackup::v1::GetRestoreRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::gkebackup::v1::Restore>>, UpdateRestore,
+      (future<StatusOr<google::cloud::gkebackup::v1::Restore>>), UpdateRestore,
       (google::cloud::gkebackup::v1::UpdateRestoreRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::gkebackup::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::gkebackup::v1::OperationMetadata>>),
       DeleteRestore,
       (google::cloud::gkebackup::v1::DeleteRestoreRequest const& request),
       (override));
@@ -167,12 +167,13 @@ class MockBackupForGKEConnection : public gkebackup_v1::BackupForGKEConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::gkebackup::v1::VolumeRestore>, GetVolumeRestore,
+      (StatusOr<google::cloud::gkebackup::v1::VolumeRestore>), GetVolumeRestore,
       (google::cloud::gkebackup::v1::GetVolumeRestoreRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::gkebackup::v1::GetBackupIndexDownloadUrlResponse>,
+      (StatusOr<
+          google::cloud::gkebackup::v1::GetBackupIndexDownloadUrlResponse>),
       GetBackupIndexDownloadUrl,
       (google::cloud::gkebackup::v1::GetBackupIndexDownloadUrlRequest const&
            request),

--- a/google/cloud/gkehub/v1/mocks/mock_gke_hub_connection.h
+++ b/google/cloud/gkehub/v1/mocks/mock_gke_hub_connection.h
@@ -55,47 +55,49 @@ class MockGkeHubConnection : public gkehub_v1::GkeHubConnection {
               (google::cloud::gkehub::v1::ListFeaturesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::gkehub::v1::Membership>, GetMembership,
+  MOCK_METHOD((StatusOr<google::cloud::gkehub::v1::Membership>), GetMembership,
               (google::cloud::gkehub::v1::GetMembershipRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::gkehub::v1::Feature>, GetFeature,
+  MOCK_METHOD((StatusOr<google::cloud::gkehub::v1::Feature>), GetFeature,
               (google::cloud::gkehub::v1::GetFeatureRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::gkehub::v1::Membership>>, CreateMembership,
+      (future<StatusOr<google::cloud::gkehub::v1::Membership>>),
+      CreateMembership,
       (google::cloud::gkehub::v1::CreateMembershipRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::gkehub::v1::Feature>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::gkehub::v1::Feature>>),
               CreateFeature,
               (google::cloud::gkehub::v1::CreateFeatureRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::gkehub::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::gkehub::v1::OperationMetadata>>),
       DeleteMembership,
       (google::cloud::gkehub::v1::DeleteMembershipRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::gkehub::v1::OperationMetadata>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::gkehub::v1::OperationMetadata>>),
               DeleteFeature,
               (google::cloud::gkehub::v1::DeleteFeatureRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::gkehub::v1::Membership>>, UpdateMembership,
+      (future<StatusOr<google::cloud::gkehub::v1::Membership>>),
+      UpdateMembership,
       (google::cloud::gkehub::v1::UpdateMembershipRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::gkehub::v1::Feature>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::gkehub::v1::Feature>>),
               UpdateFeature,
               (google::cloud::gkehub::v1::UpdateFeatureRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::gkehub::v1::GenerateConnectManifestResponse>,
+      (StatusOr<google::cloud::gkehub::v1::GenerateConnectManifestResponse>),
       GenerateConnectManifest,
       (google::cloud::gkehub::v1::GenerateConnectManifestRequest const&
            request),

--- a/google/cloud/gkemulticloud/v1/mocks/mock_attached_clusters_connection.h
+++ b/google/cloud/gkemulticloud/v1/mocks/mock_attached_clusters_connection.h
@@ -48,28 +48,28 @@ class MockAttachedClustersConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::gkemulticloud::v1::AttachedCluster>>,
+      (future<StatusOr<google::cloud::gkemulticloud::v1::AttachedCluster>>),
       CreateAttachedCluster,
       (google::cloud::gkemulticloud::v1::CreateAttachedClusterRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::gkemulticloud::v1::AttachedCluster>>,
+      (future<StatusOr<google::cloud::gkemulticloud::v1::AttachedCluster>>),
       UpdateAttachedCluster,
       (google::cloud::gkemulticloud::v1::UpdateAttachedClusterRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::gkemulticloud::v1::AttachedCluster>>,
+      (future<StatusOr<google::cloud::gkemulticloud::v1::AttachedCluster>>),
       ImportAttachedCluster,
       (google::cloud::gkemulticloud::v1::ImportAttachedClusterRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::gkemulticloud::v1::AttachedCluster>,
+      (StatusOr<google::cloud::gkemulticloud::v1::AttachedCluster>),
       GetAttachedCluster,
       (google::cloud::gkemulticloud::v1::GetAttachedClusterRequest const&
            request),
@@ -82,29 +82,29 @@ class MockAttachedClustersConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::gkemulticloud::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::gkemulticloud::v1::OperationMetadata>>),
       DeleteAttachedCluster,
       (google::cloud::gkemulticloud::v1::DeleteAttachedClusterRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::gkemulticloud::v1::AttachedServerConfig>,
+      (StatusOr<google::cloud::gkemulticloud::v1::AttachedServerConfig>),
       GetAttachedServerConfig,
       (google::cloud::gkemulticloud::v1::GetAttachedServerConfigRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::gkemulticloud::v1::
-                   GenerateAttachedClusterInstallManifestResponse>,
+      (StatusOr<google::cloud::gkemulticloud::v1::
+                    GenerateAttachedClusterInstallManifestResponse>),
       GenerateAttachedClusterInstallManifest,
       (google::cloud::gkemulticloud::v1::
            GenerateAttachedClusterInstallManifestRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::gkemulticloud::v1::
-                           GenerateAttachedClusterAgentTokenResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::gkemulticloud::v1::
+                            GenerateAttachedClusterAgentTokenResponse>),
               GenerateAttachedClusterAgentToken,
               (google::cloud::gkemulticloud::v1::
                    GenerateAttachedClusterAgentTokenRequest const& request),

--- a/google/cloud/gkemulticloud/v1/mocks/mock_aws_clusters_connection.h
+++ b/google/cloud/gkemulticloud/v1/mocks/mock_aws_clusters_connection.h
@@ -47,20 +47,20 @@ class MockAwsClustersConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::gkemulticloud::v1::AwsCluster>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::gkemulticloud::v1::AwsCluster>>),
               CreateAwsCluster,
               (google::cloud::gkemulticloud::v1::CreateAwsClusterRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::gkemulticloud::v1::AwsCluster>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::gkemulticloud::v1::AwsCluster>>),
               UpdateAwsCluster,
               (google::cloud::gkemulticloud::v1::UpdateAwsClusterRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::gkemulticloud::v1::AwsCluster>, GetAwsCluster,
+      (StatusOr<google::cloud::gkemulticloud::v1::AwsCluster>), GetAwsCluster,
       (google::cloud::gkemulticloud::v1::GetAwsClusterRequest const& request),
       (override));
 
@@ -71,48 +71,48 @@ class MockAwsClustersConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::gkemulticloud::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::gkemulticloud::v1::OperationMetadata>>),
       DeleteAwsCluster,
       (google::cloud::gkemulticloud::v1::DeleteAwsClusterRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::gkemulticloud::v1::
-                           GenerateAwsClusterAgentTokenResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::gkemulticloud::v1::
+                            GenerateAwsClusterAgentTokenResponse>),
               GenerateAwsClusterAgentToken,
               (google::cloud::gkemulticloud::v1::
                    GenerateAwsClusterAgentTokenRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::gkemulticloud::v1::GenerateAwsAccessTokenResponse>,
+      (StatusOr<
+          google::cloud::gkemulticloud::v1::GenerateAwsAccessTokenResponse>),
       GenerateAwsAccessToken,
       (google::cloud::gkemulticloud::v1::GenerateAwsAccessTokenRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::gkemulticloud::v1::AwsNodePool>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::gkemulticloud::v1::AwsNodePool>>),
               CreateAwsNodePool,
               (google::cloud::gkemulticloud::v1::CreateAwsNodePoolRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::gkemulticloud::v1::AwsNodePool>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::gkemulticloud::v1::AwsNodePool>>),
               UpdateAwsNodePool,
               (google::cloud::gkemulticloud::v1::UpdateAwsNodePoolRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::gkemulticloud::v1::AwsNodePool>>,
+      (future<StatusOr<google::cloud::gkemulticloud::v1::AwsNodePool>>),
       RollbackAwsNodePoolUpdate,
       (google::cloud::gkemulticloud::v1::RollbackAwsNodePoolUpdateRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::gkemulticloud::v1::AwsNodePool>, GetAwsNodePool,
+      (StatusOr<google::cloud::gkemulticloud::v1::AwsNodePool>), GetAwsNodePool,
       (google::cloud::gkemulticloud::v1::GetAwsNodePoolRequest const& request),
       (override));
 
@@ -123,27 +123,27 @@ class MockAwsClustersConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::gkemulticloud::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::gkemulticloud::v1::OperationMetadata>>),
       DeleteAwsNodePool,
       (google::cloud::gkemulticloud::v1::DeleteAwsNodePoolRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::gkemulticloud::v1::AwsOpenIdConfig>,
+      (StatusOr<google::cloud::gkemulticloud::v1::AwsOpenIdConfig>),
       GetAwsOpenIdConfig,
       (google::cloud::gkemulticloud::v1::GetAwsOpenIdConfigRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::gkemulticloud::v1::AwsJsonWebKeys>,
+  MOCK_METHOD((StatusOr<google::cloud::gkemulticloud::v1::AwsJsonWebKeys>),
               GetAwsJsonWebKeys,
               (google::cloud::gkemulticloud::v1::GetAwsJsonWebKeysRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::gkemulticloud::v1::AwsServerConfig>,
+      (StatusOr<google::cloud::gkemulticloud::v1::AwsServerConfig>),
       GetAwsServerConfig,
       (google::cloud::gkemulticloud::v1::GetAwsServerConfigRequest const&
            request),

--- a/google/cloud/gkemulticloud/v1/mocks/mock_azure_clusters_connection.h
+++ b/google/cloud/gkemulticloud/v1/mocks/mock_azure_clusters_connection.h
@@ -47,14 +47,14 @@ class MockAzureClustersConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::gkemulticloud::v1::AzureClient>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::gkemulticloud::v1::AzureClient>>),
               CreateAzureClient,
               (google::cloud::gkemulticloud::v1::CreateAzureClientRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::gkemulticloud::v1::AzureClient>, GetAzureClient,
+      (StatusOr<google::cloud::gkemulticloud::v1::AzureClient>), GetAzureClient,
       (google::cloud::gkemulticloud::v1::GetAzureClientRequest const& request),
       (override));
 
@@ -65,28 +65,29 @@ class MockAzureClustersConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::gkemulticloud::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::gkemulticloud::v1::OperationMetadata>>),
       DeleteAzureClient,
       (google::cloud::gkemulticloud::v1::DeleteAzureClientRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::gkemulticloud::v1::AzureCluster>>,
+      (future<StatusOr<google::cloud::gkemulticloud::v1::AzureCluster>>),
       CreateAzureCluster,
       (google::cloud::gkemulticloud::v1::CreateAzureClusterRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::gkemulticloud::v1::AzureCluster>>,
+      (future<StatusOr<google::cloud::gkemulticloud::v1::AzureCluster>>),
       UpdateAzureCluster,
       (google::cloud::gkemulticloud::v1::UpdateAzureClusterRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::gkemulticloud::v1::AzureCluster>, GetAzureCluster,
+      (StatusOr<google::cloud::gkemulticloud::v1::AzureCluster>),
+      GetAzureCluster,
       (google::cloud::gkemulticloud::v1::GetAzureClusterRequest const& request),
       (override));
 
@@ -97,42 +98,42 @@ class MockAzureClustersConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::gkemulticloud::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::gkemulticloud::v1::OperationMetadata>>),
       DeleteAzureCluster,
       (google::cloud::gkemulticloud::v1::DeleteAzureClusterRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::gkemulticloud::v1::
-                           GenerateAzureClusterAgentTokenResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::gkemulticloud::v1::
+                            GenerateAzureClusterAgentTokenResponse>),
               GenerateAzureClusterAgentToken,
               (google::cloud::gkemulticloud::v1::
                    GenerateAzureClusterAgentTokenRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::gkemulticloud::v1::GenerateAzureAccessTokenResponse>,
+      (StatusOr<
+          google::cloud::gkemulticloud::v1::GenerateAzureAccessTokenResponse>),
       GenerateAzureAccessToken,
       (google::cloud::gkemulticloud::v1::GenerateAzureAccessTokenRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::gkemulticloud::v1::AzureNodePool>>,
+      (future<StatusOr<google::cloud::gkemulticloud::v1::AzureNodePool>>),
       CreateAzureNodePool,
       (google::cloud::gkemulticloud::v1::CreateAzureNodePoolRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::gkemulticloud::v1::AzureNodePool>>,
+      (future<StatusOr<google::cloud::gkemulticloud::v1::AzureNodePool>>),
       UpdateAzureNodePool,
       (google::cloud::gkemulticloud::v1::UpdateAzureNodePoolRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::gkemulticloud::v1::AzureNodePool>,
+  MOCK_METHOD((StatusOr<google::cloud::gkemulticloud::v1::AzureNodePool>),
               GetAzureNodePool,
               (google::cloud::gkemulticloud::v1::GetAzureNodePoolRequest const&
                    request),
@@ -145,28 +146,28 @@ class MockAzureClustersConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::gkemulticloud::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::gkemulticloud::v1::OperationMetadata>>),
       DeleteAzureNodePool,
       (google::cloud::gkemulticloud::v1::DeleteAzureNodePoolRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::gkemulticloud::v1::AzureOpenIdConfig>,
+      (StatusOr<google::cloud::gkemulticloud::v1::AzureOpenIdConfig>),
       GetAzureOpenIdConfig,
       (google::cloud::gkemulticloud::v1::GetAzureOpenIdConfigRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::gkemulticloud::v1::AzureJsonWebKeys>,
+      (StatusOr<google::cloud::gkemulticloud::v1::AzureJsonWebKeys>),
       GetAzureJsonWebKeys,
       (google::cloud::gkemulticloud::v1::GetAzureJsonWebKeysRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::gkemulticloud::v1::AzureServerConfig>,
+      (StatusOr<google::cloud::gkemulticloud::v1::AzureServerConfig>),
       GetAzureServerConfig,
       (google::cloud::gkemulticloud::v1::GetAzureServerConfigRequest const&
            request),

--- a/google/cloud/iam/admin/v1/mocks/mock_iam_connection.h
+++ b/google/cloud/iam/admin/v1/mocks/mock_iam_connection.h
@@ -51,18 +51,18 @@ class MockIAMConnection : public iam_admin_v1::IAMConnection {
               (google::iam::admin::v1::ListServiceAccountsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::admin::v1::ServiceAccount>,
+  MOCK_METHOD((StatusOr<google::iam::admin::v1::ServiceAccount>),
               GetServiceAccount,
               (google::iam::admin::v1::GetServiceAccountRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::iam::admin::v1::ServiceAccount>, CreateServiceAccount,
+      (StatusOr<google::iam::admin::v1::ServiceAccount>), CreateServiceAccount,
       (google::iam::admin::v1::CreateServiceAccountRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::iam::admin::v1::ServiceAccount>, PatchServiceAccount,
+      (StatusOr<google::iam::admin::v1::ServiceAccount>), PatchServiceAccount,
       (google::iam::admin::v1::PatchServiceAccountRequest const& request),
       (override));
 
@@ -72,7 +72,7 @@ class MockIAMConnection : public iam_admin_v1::IAMConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::iam::admin::v1::UndeleteServiceAccountResponse>,
+      (StatusOr<google::iam::admin::v1::UndeleteServiceAccountResponse>),
       UndeleteServiceAccount,
       (google::iam::admin::v1::UndeleteServiceAccountRequest const& request),
       (override));
@@ -88,24 +88,25 @@ class MockIAMConnection : public iam_admin_v1::IAMConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>,
+      (StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>),
       ListServiceAccountKeys,
       (google::iam::admin::v1::ListServiceAccountKeysRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::iam::admin::v1::ServiceAccountKey>, GetServiceAccountKey,
+      (StatusOr<google::iam::admin::v1::ServiceAccountKey>),
+      GetServiceAccountKey,
       (google::iam::admin::v1::GetServiceAccountKeyRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::iam::admin::v1::ServiceAccountKey>,
+      (StatusOr<google::iam::admin::v1::ServiceAccountKey>),
       CreateServiceAccountKey,
       (google::iam::admin::v1::CreateServiceAccountKeyRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::iam::admin::v1::ServiceAccountKey>,
+      (StatusOr<google::iam::admin::v1::ServiceAccountKey>),
       UploadServiceAccountKey,
       (google::iam::admin::v1::UploadServiceAccountKeyRequest const& request),
       (override));
@@ -125,15 +126,15 @@ class MockIAMConnection : public iam_admin_v1::IAMConnection {
       (google::iam::admin::v1::EnableServiceAccountKeyRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), GetIamPolicy,
               (google::iam::v1::GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), SetIamPolicy,
               (google::iam::v1::SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD((StatusOr<google::iam::v1::TestIamPermissionsResponse>),
               TestIamPermissions,
               (google::iam::v1::TestIamPermissionsRequest const& request),
               (override));
@@ -145,23 +146,23 @@ class MockIAMConnection : public iam_admin_v1::IAMConnection {
   MOCK_METHOD((StreamRange<google::iam::admin::v1::Role>), ListRoles,
               (google::iam::admin::v1::ListRolesRequest request), (override));
 
-  MOCK_METHOD(StatusOr<google::iam::admin::v1::Role>, GetRole,
+  MOCK_METHOD((StatusOr<google::iam::admin::v1::Role>), GetRole,
               (google::iam::admin::v1::GetRoleRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::admin::v1::Role>, CreateRole,
+  MOCK_METHOD((StatusOr<google::iam::admin::v1::Role>), CreateRole,
               (google::iam::admin::v1::CreateRoleRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::admin::v1::Role>, UpdateRole,
+  MOCK_METHOD((StatusOr<google::iam::admin::v1::Role>), UpdateRole,
               (google::iam::admin::v1::UpdateRoleRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::admin::v1::Role>, DeleteRole,
+  MOCK_METHOD((StatusOr<google::iam::admin::v1::Role>), DeleteRole,
               (google::iam::admin::v1::DeleteRoleRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::admin::v1::Role>, UndeleteRole,
+  MOCK_METHOD((StatusOr<google::iam::admin::v1::Role>), UndeleteRole,
               (google::iam::admin::v1::UndeleteRoleRequest const& request),
               (override));
 
@@ -171,12 +172,13 @@ class MockIAMConnection : public iam_admin_v1::IAMConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::iam::admin::v1::QueryAuditableServicesResponse>,
+      (StatusOr<google::iam::admin::v1::QueryAuditableServicesResponse>),
       QueryAuditableServices,
       (google::iam::admin::v1::QueryAuditableServicesRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::iam::admin::v1::LintPolicyResponse>, LintPolicy,
+  MOCK_METHOD((StatusOr<google::iam::admin::v1::LintPolicyResponse>),
+              LintPolicy,
               (google::iam::admin::v1::LintPolicyRequest const& request),
               (override));
 };

--- a/google/cloud/iam/credentials/v1/mocks/mock_iam_credentials_connection.h
+++ b/google/cloud/iam/credentials/v1/mocks/mock_iam_credentials_connection.h
@@ -48,23 +48,24 @@ class MockIAMCredentialsConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>,
+      (StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>),
       GenerateAccessToken,
       (google::iam::credentials::v1::GenerateAccessTokenRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>,
+      (StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>),
       GenerateIdToken,
       (google::iam::credentials::v1::GenerateIdTokenRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::iam::credentials::v1::SignBlobResponse>,
+  MOCK_METHOD((StatusOr<google::iam::credentials::v1::SignBlobResponse>),
               SignBlob,
               (google::iam::credentials::v1::SignBlobRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::credentials::v1::SignJwtResponse>, SignJwt,
+  MOCK_METHOD((StatusOr<google::iam::credentials::v1::SignJwtResponse>),
+              SignJwt,
               (google::iam::credentials::v1::SignJwtRequest const& request),
               (override));
 };

--- a/google/cloud/iam/v1/mocks/mock_iam_policy_connection.h
+++ b/google/cloud/iam/v1/mocks/mock_iam_policy_connection.h
@@ -46,15 +46,15 @@ class MockIAMPolicyConnection : public iam_v1::IAMPolicyConnection {
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), SetIamPolicy,
               (google::iam::v1::SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), GetIamPolicy,
               (google::iam::v1::GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD((StatusOr<google::iam::v1::TestIamPermissionsResponse>),
               TestIamPermissions,
               (google::iam::v1::TestIamPermissionsRequest const& request),
               (override));

--- a/google/cloud/iam/v2/mocks/mock_policies_connection.h
+++ b/google/cloud/iam/v2/mocks/mock_policies_connection.h
@@ -49,18 +49,18 @@ class MockPoliciesConnection : public iam_v2::PoliciesConnection {
   MOCK_METHOD((StreamRange<google::iam::v2::Policy>), ListPolicies,
               (google::iam::v2::ListPoliciesRequest request), (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v2::Policy>, GetPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v2::Policy>), GetPolicy,
               (google::iam::v2::GetPolicyRequest const& request), (override));
 
-  MOCK_METHOD(future<StatusOr<google::iam::v2::Policy>>, CreatePolicy,
+  MOCK_METHOD((future<StatusOr<google::iam::v2::Policy>>), CreatePolicy,
               (google::iam::v2::CreatePolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::iam::v2::Policy>>, UpdatePolicy,
+  MOCK_METHOD((future<StatusOr<google::iam::v2::Policy>>), UpdatePolicy,
               (google::iam::v2::UpdatePolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::iam::v2::Policy>>, DeletePolicy,
+  MOCK_METHOD((future<StatusOr<google::iam::v2::Policy>>), DeletePolicy,
               (google::iam::v2::DeletePolicyRequest const& request),
               (override));
 };

--- a/google/cloud/iap/v1/mocks/mock_identity_aware_proxy_admin_connection.h
+++ b/google/cloud/iap/v1/mocks/mock_identity_aware_proxy_admin_connection.h
@@ -47,24 +47,25 @@ class MockIdentityAwareProxyAdminServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), SetIamPolicy,
               (google::iam::v1::SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), GetIamPolicy,
               (google::iam::v1::GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD((StatusOr<google::iam::v1::TestIamPermissionsResponse>),
               TestIamPermissions,
               (google::iam::v1::TestIamPermissionsRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::iap::v1::IapSettings>, GetIapSettings,
+  MOCK_METHOD((StatusOr<google::cloud::iap::v1::IapSettings>), GetIapSettings,
               (google::cloud::iap::v1::GetIapSettingsRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::iap::v1::IapSettings>, UpdateIapSettings,
+  MOCK_METHOD((StatusOr<google::cloud::iap::v1::IapSettings>),
+              UpdateIapSettings,
               (google::cloud::iap::v1::UpdateIapSettingsRequest const& request),
               (override));
 
@@ -74,12 +75,13 @@ class MockIdentityAwareProxyAdminServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::iap::v1::TunnelDestGroup>, CreateTunnelDestGroup,
+      (StatusOr<google::cloud::iap::v1::TunnelDestGroup>),
+      CreateTunnelDestGroup,
       (google::cloud::iap::v1::CreateTunnelDestGroupRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::iap::v1::TunnelDestGroup>, GetTunnelDestGroup,
+      (StatusOr<google::cloud::iap::v1::TunnelDestGroup>), GetTunnelDestGroup,
       (google::cloud::iap::v1::GetTunnelDestGroupRequest const& request),
       (override));
 
@@ -89,7 +91,8 @@ class MockIdentityAwareProxyAdminServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::iap::v1::TunnelDestGroup>, UpdateTunnelDestGroup,
+      (StatusOr<google::cloud::iap::v1::TunnelDestGroup>),
+      UpdateTunnelDestGroup,
       (google::cloud::iap::v1::UpdateTunnelDestGroupRequest const& request),
       (override));
 };

--- a/google/cloud/iap/v1/mocks/mock_identity_aware_proxy_o_auth_connection.h
+++ b/google/cloud/iap/v1/mocks/mock_identity_aware_proxy_o_auth_connection.h
@@ -47,20 +47,21 @@ class MockIdentityAwareProxyOAuthServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::iap::v1::ListBrandsResponse>, ListBrands,
+  MOCK_METHOD((StatusOr<google::cloud::iap::v1::ListBrandsResponse>),
+              ListBrands,
               (google::cloud::iap::v1::ListBrandsRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::iap::v1::Brand>, CreateBrand,
+  MOCK_METHOD((StatusOr<google::cloud::iap::v1::Brand>), CreateBrand,
               (google::cloud::iap::v1::CreateBrandRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::iap::v1::Brand>, GetBrand,
+  MOCK_METHOD((StatusOr<google::cloud::iap::v1::Brand>), GetBrand,
               (google::cloud::iap::v1::GetBrandRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::iap::v1::IdentityAwareProxyClient>,
+      (StatusOr<google::cloud::iap::v1::IdentityAwareProxyClient>),
       CreateIdentityAwareProxyClient,
       (google::cloud::iap::v1::CreateIdentityAwareProxyClientRequest const&
            request),
@@ -72,14 +73,14 @@ class MockIdentityAwareProxyOAuthServiceConnection
       (google::cloud::iap::v1::ListIdentityAwareProxyClientsRequest request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::iap::v1::IdentityAwareProxyClient>,
+  MOCK_METHOD((StatusOr<google::cloud::iap::v1::IdentityAwareProxyClient>),
               GetIdentityAwareProxyClient,
               (google::cloud::iap::v1::GetIdentityAwareProxyClientRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::iap::v1::IdentityAwareProxyClient>,
+      (StatusOr<google::cloud::iap::v1::IdentityAwareProxyClient>),
       ResetIdentityAwareProxyClientSecret,
       (google::cloud::iap::v1::ResetIdentityAwareProxyClientSecretRequest const&
            request),

--- a/google/cloud/ids/v1/mocks/mock_ids_connection.h
+++ b/google/cloud/ids/v1/mocks/mock_ids_connection.h
@@ -50,16 +50,16 @@ class MockIDSConnection : public ids_v1::IDSConnection {
               (google::cloud::ids::v1::ListEndpointsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::ids::v1::Endpoint>, GetEndpoint,
+  MOCK_METHOD((StatusOr<google::cloud::ids::v1::Endpoint>), GetEndpoint,
               (google::cloud::ids::v1::GetEndpointRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::ids::v1::Endpoint>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::ids::v1::Endpoint>>),
               CreateEndpoint,
               (google::cloud::ids::v1::CreateEndpointRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::ids::v1::OperationMetadata>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::ids::v1::OperationMetadata>>),
               DeleteEndpoint,
               (google::cloud::ids::v1::DeleteEndpointRequest const& request),
               (override));

--- a/google/cloud/kms/inventory/v1/mocks/mock_key_tracking_connection.h
+++ b/google/cloud/kms/inventory/v1/mocks/mock_key_tracking_connection.h
@@ -48,7 +48,7 @@ class MockKeyTrackingServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::kms::inventory::v1::ProtectedResourcesSummary>,
+      (StatusOr<google::cloud::kms::inventory::v1::ProtectedResourcesSummary>),
       GetProtectedResourcesSummary,
       (google::cloud::kms::inventory::v1::
            GetProtectedResourcesSummaryRequest const& request),

--- a/google/cloud/kms/v1/mocks/mock_ekm_connection.h
+++ b/google/cloud/kms/v1/mocks/mock_ekm_connection.h
@@ -51,30 +51,31 @@ class MockEkmServiceConnection : public kms_v1::EkmServiceConnection {
               (google::cloud::kms::v1::ListEkmConnectionsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::kms::v1::EkmConnection>, GetEkmConnection,
+  MOCK_METHOD((StatusOr<google::cloud::kms::v1::EkmConnection>),
+              GetEkmConnection,
               (google::cloud::kms::v1::GetEkmConnectionRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::kms::v1::EkmConnection>, CreateEkmConnection,
+      (StatusOr<google::cloud::kms::v1::EkmConnection>), CreateEkmConnection,
       (google::cloud::kms::v1::CreateEkmConnectionRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::kms::v1::EkmConnection>, UpdateEkmConnection,
+      (StatusOr<google::cloud::kms::v1::EkmConnection>), UpdateEkmConnection,
       (google::cloud::kms::v1::UpdateEkmConnectionRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::kms::v1::EkmConfig>, GetEkmConfig,
+  MOCK_METHOD((StatusOr<google::cloud::kms::v1::EkmConfig>), GetEkmConfig,
               (google::cloud::kms::v1::GetEkmConfigRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::kms::v1::EkmConfig>, UpdateEkmConfig,
+  MOCK_METHOD((StatusOr<google::cloud::kms::v1::EkmConfig>), UpdateEkmConfig,
               (google::cloud::kms::v1::UpdateEkmConfigRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::kms::v1::VerifyConnectivityResponse>,
+      (StatusOr<google::cloud::kms::v1::VerifyConnectivityResponse>),
       VerifyConnectivity,
       (google::cloud::kms::v1::VerifyConnectivityRequest const& request),
       (override));

--- a/google/cloud/kms/v1/mocks/mock_key_management_connection.h
+++ b/google/cloud/kms/v1/mocks/mock_key_management_connection.h
@@ -64,116 +64,118 @@ class MockKeyManagementServiceConnection
               (google::cloud::kms::v1::ListImportJobsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::kms::v1::KeyRing>, GetKeyRing,
+  MOCK_METHOD((StatusOr<google::cloud::kms::v1::KeyRing>), GetKeyRing,
               (google::cloud::kms::v1::GetKeyRingRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::kms::v1::CryptoKey>, GetCryptoKey,
+  MOCK_METHOD((StatusOr<google::cloud::kms::v1::CryptoKey>), GetCryptoKey,
               (google::cloud::kms::v1::GetCryptoKeyRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::kms::v1::CryptoKeyVersion>, GetCryptoKeyVersion,
+      (StatusOr<google::cloud::kms::v1::CryptoKeyVersion>), GetCryptoKeyVersion,
       (google::cloud::kms::v1::GetCryptoKeyVersionRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::kms::v1::PublicKey>, GetPublicKey,
+  MOCK_METHOD((StatusOr<google::cloud::kms::v1::PublicKey>), GetPublicKey,
               (google::cloud::kms::v1::GetPublicKeyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::kms::v1::ImportJob>, GetImportJob,
+  MOCK_METHOD((StatusOr<google::cloud::kms::v1::ImportJob>), GetImportJob,
               (google::cloud::kms::v1::GetImportJobRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::kms::v1::KeyRing>, CreateKeyRing,
+  MOCK_METHOD((StatusOr<google::cloud::kms::v1::KeyRing>), CreateKeyRing,
               (google::cloud::kms::v1::CreateKeyRingRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::kms::v1::CryptoKey>, CreateCryptoKey,
+  MOCK_METHOD((StatusOr<google::cloud::kms::v1::CryptoKey>), CreateCryptoKey,
               (google::cloud::kms::v1::CreateCryptoKeyRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::kms::v1::CryptoKeyVersion>,
+      (StatusOr<google::cloud::kms::v1::CryptoKeyVersion>),
       CreateCryptoKeyVersion,
       (google::cloud::kms::v1::CreateCryptoKeyVersionRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::kms::v1::CryptoKeyVersion>,
+      (StatusOr<google::cloud::kms::v1::CryptoKeyVersion>),
       ImportCryptoKeyVersion,
       (google::cloud::kms::v1::ImportCryptoKeyVersionRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::kms::v1::ImportJob>, CreateImportJob,
+  MOCK_METHOD((StatusOr<google::cloud::kms::v1::ImportJob>), CreateImportJob,
               (google::cloud::kms::v1::CreateImportJobRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::kms::v1::CryptoKey>, UpdateCryptoKey,
+  MOCK_METHOD((StatusOr<google::cloud::kms::v1::CryptoKey>), UpdateCryptoKey,
               (google::cloud::kms::v1::UpdateCryptoKeyRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::kms::v1::CryptoKeyVersion>,
+      (StatusOr<google::cloud::kms::v1::CryptoKeyVersion>),
       UpdateCryptoKeyVersion,
       (google::cloud::kms::v1::UpdateCryptoKeyVersionRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::kms::v1::CryptoKey>,
+      (StatusOr<google::cloud::kms::v1::CryptoKey>),
       UpdateCryptoKeyPrimaryVersion,
       (google::cloud::kms::v1::UpdateCryptoKeyPrimaryVersionRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::kms::v1::CryptoKeyVersion>,
+      (StatusOr<google::cloud::kms::v1::CryptoKeyVersion>),
       DestroyCryptoKeyVersion,
       (google::cloud::kms::v1::DestroyCryptoKeyVersionRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::kms::v1::CryptoKeyVersion>,
+      (StatusOr<google::cloud::kms::v1::CryptoKeyVersion>),
       RestoreCryptoKeyVersion,
       (google::cloud::kms::v1::RestoreCryptoKeyVersionRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::kms::v1::EncryptResponse>, Encrypt,
+  MOCK_METHOD((StatusOr<google::cloud::kms::v1::EncryptResponse>), Encrypt,
               (google::cloud::kms::v1::EncryptRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::kms::v1::DecryptResponse>, Decrypt,
+  MOCK_METHOD((StatusOr<google::cloud::kms::v1::DecryptResponse>), Decrypt,
               (google::cloud::kms::v1::DecryptRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::kms::v1::RawEncryptResponse>, RawEncrypt,
+  MOCK_METHOD((StatusOr<google::cloud::kms::v1::RawEncryptResponse>),
+              RawEncrypt,
               (google::cloud::kms::v1::RawEncryptRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::kms::v1::RawDecryptResponse>, RawDecrypt,
+  MOCK_METHOD((StatusOr<google::cloud::kms::v1::RawDecryptResponse>),
+              RawDecrypt,
               (google::cloud::kms::v1::RawDecryptRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::kms::v1::AsymmetricSignResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::kms::v1::AsymmetricSignResponse>),
               AsymmetricSign,
               (google::cloud::kms::v1::AsymmetricSignRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::kms::v1::AsymmetricDecryptResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::kms::v1::AsymmetricDecryptResponse>),
               AsymmetricDecrypt,
               (google::cloud::kms::v1::AsymmetricDecryptRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::kms::v1::MacSignResponse>, MacSign,
+  MOCK_METHOD((StatusOr<google::cloud::kms::v1::MacSignResponse>), MacSign,
               (google::cloud::kms::v1::MacSignRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::kms::v1::MacVerifyResponse>, MacVerify,
+  MOCK_METHOD((StatusOr<google::cloud::kms::v1::MacVerifyResponse>), MacVerify,
               (google::cloud::kms::v1::MacVerifyRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::kms::v1::GenerateRandomBytesResponse>,
+      (StatusOr<google::cloud::kms::v1::GenerateRandomBytesResponse>),
       GenerateRandomBytes,
       (google::cloud::kms::v1::GenerateRandomBytesRequest const& request),
       (override));

--- a/google/cloud/language/v1/mocks/mock_language_connection.h
+++ b/google/cloud/language/v1/mocks/mock_language_connection.h
@@ -48,41 +48,41 @@ class MockLanguageServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::language::v1::AnalyzeSentimentResponse>,
+      (StatusOr<google::cloud::language::v1::AnalyzeSentimentResponse>),
       AnalyzeSentiment,
       (google::cloud::language::v1::AnalyzeSentimentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::language::v1::AnalyzeEntitiesResponse>,
+      (StatusOr<google::cloud::language::v1::AnalyzeEntitiesResponse>),
       AnalyzeEntities,
       (google::cloud::language::v1::AnalyzeEntitiesRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::language::v1::AnalyzeEntitySentimentResponse>,
+      (StatusOr<google::cloud::language::v1::AnalyzeEntitySentimentResponse>),
       AnalyzeEntitySentiment,
       (google::cloud::language::v1::AnalyzeEntitySentimentRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::language::v1::AnalyzeSyntaxResponse>,
+      (StatusOr<google::cloud::language::v1::AnalyzeSyntaxResponse>),
       AnalyzeSyntax,
       (google::cloud::language::v1::AnalyzeSyntaxRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::language::v1::ClassifyTextResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::language::v1::ClassifyTextResponse>),
               ClassifyText,
               (google::cloud::language::v1::ClassifyTextRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::language::v1::ModerateTextResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::language::v1::ModerateTextResponse>),
               ModerateText,
               (google::cloud::language::v1::ModerateTextRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::language::v1::AnnotateTextResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::language::v1::AnnotateTextResponse>),
               AnnotateText,
               (google::cloud::language::v1::AnnotateTextRequest const& request),
               (override));

--- a/google/cloud/language/v2/mocks/mock_language_connection.h
+++ b/google/cloud/language/v2/mocks/mock_language_connection.h
@@ -48,28 +48,28 @@ class MockLanguageServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::language::v2::AnalyzeSentimentResponse>,
+      (StatusOr<google::cloud::language::v2::AnalyzeSentimentResponse>),
       AnalyzeSentiment,
       (google::cloud::language::v2::AnalyzeSentimentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::language::v2::AnalyzeEntitiesResponse>,
+      (StatusOr<google::cloud::language::v2::AnalyzeEntitiesResponse>),
       AnalyzeEntities,
       (google::cloud::language::v2::AnalyzeEntitiesRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::language::v2::ClassifyTextResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::language::v2::ClassifyTextResponse>),
               ClassifyText,
               (google::cloud::language::v2::ClassifyTextRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::language::v2::ModerateTextResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::language::v2::ModerateTextResponse>),
               ModerateText,
               (google::cloud::language::v2::ModerateTextRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::language::v2::AnnotateTextResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::language::v2::AnnotateTextResponse>),
               AnnotateText,
               (google::cloud::language::v2::AnnotateTextRequest const& request),
               (override));

--- a/google/cloud/logging/v2/mocks/mock_config_service_v2_connection.h
+++ b/google/cloud/logging/v2/mocks/mock_config_service_v2_connection.h
@@ -50,25 +50,25 @@ class MockConfigServiceV2Connection
   MOCK_METHOD((StreamRange<google::logging::v2::LogBucket>), ListBuckets,
               (google::logging::v2::ListBucketsRequest request), (override));
 
-  MOCK_METHOD(StatusOr<google::logging::v2::LogBucket>, GetBucket,
+  MOCK_METHOD((StatusOr<google::logging::v2::LogBucket>), GetBucket,
               (google::logging::v2::GetBucketRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::logging::v2::LogBucket>>,
+  MOCK_METHOD((future<StatusOr<google::logging::v2::LogBucket>>),
               CreateBucketAsync,
               (google::logging::v2::CreateBucketRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::logging::v2::LogBucket>>,
+  MOCK_METHOD((future<StatusOr<google::logging::v2::LogBucket>>),
               UpdateBucketAsync,
               (google::logging::v2::UpdateBucketRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::logging::v2::LogBucket>, CreateBucket,
+  MOCK_METHOD((StatusOr<google::logging::v2::LogBucket>), CreateBucket,
               (google::logging::v2::CreateBucketRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::logging::v2::LogBucket>, UpdateBucket,
+  MOCK_METHOD((StatusOr<google::logging::v2::LogBucket>), UpdateBucket,
               (google::logging::v2::UpdateBucketRequest const& request),
               (override));
 
@@ -83,14 +83,14 @@ class MockConfigServiceV2Connection
   MOCK_METHOD((StreamRange<google::logging::v2::LogView>), ListViews,
               (google::logging::v2::ListViewsRequest request), (override));
 
-  MOCK_METHOD(StatusOr<google::logging::v2::LogView>, GetView,
+  MOCK_METHOD((StatusOr<google::logging::v2::LogView>), GetView,
               (google::logging::v2::GetViewRequest const& request), (override));
 
-  MOCK_METHOD(StatusOr<google::logging::v2::LogView>, CreateView,
+  MOCK_METHOD((StatusOr<google::logging::v2::LogView>), CreateView,
               (google::logging::v2::CreateViewRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::logging::v2::LogView>, UpdateView,
+  MOCK_METHOD((StatusOr<google::logging::v2::LogView>), UpdateView,
               (google::logging::v2::UpdateViewRequest const& request),
               (override));
 
@@ -101,14 +101,14 @@ class MockConfigServiceV2Connection
   MOCK_METHOD((StreamRange<google::logging::v2::LogSink>), ListSinks,
               (google::logging::v2::ListSinksRequest request), (override));
 
-  MOCK_METHOD(StatusOr<google::logging::v2::LogSink>, GetSink,
+  MOCK_METHOD((StatusOr<google::logging::v2::LogSink>), GetSink,
               (google::logging::v2::GetSinkRequest const& request), (override));
 
-  MOCK_METHOD(StatusOr<google::logging::v2::LogSink>, CreateSink,
+  MOCK_METHOD((StatusOr<google::logging::v2::LogSink>), CreateSink,
               (google::logging::v2::CreateSinkRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::logging::v2::LogSink>, UpdateSink,
+  MOCK_METHOD((StatusOr<google::logging::v2::LogSink>), UpdateSink,
               (google::logging::v2::UpdateSinkRequest const& request),
               (override));
 
@@ -116,32 +116,32 @@ class MockConfigServiceV2Connection
               (google::logging::v2::DeleteSinkRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::logging::v2::Link>>, CreateLink,
+  MOCK_METHOD((future<StatusOr<google::logging::v2::Link>>), CreateLink,
               (google::logging::v2::CreateLinkRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::logging::v2::LinkMetadata>>, DeleteLink,
+  MOCK_METHOD((future<StatusOr<google::logging::v2::LinkMetadata>>), DeleteLink,
               (google::logging::v2::DeleteLinkRequest const& request),
               (override));
 
   MOCK_METHOD((StreamRange<google::logging::v2::Link>), ListLinks,
               (google::logging::v2::ListLinksRequest request), (override));
 
-  MOCK_METHOD(StatusOr<google::logging::v2::Link>, GetLink,
+  MOCK_METHOD((StatusOr<google::logging::v2::Link>), GetLink,
               (google::logging::v2::GetLinkRequest const& request), (override));
 
   MOCK_METHOD((StreamRange<google::logging::v2::LogExclusion>), ListExclusions,
               (google::logging::v2::ListExclusionsRequest request), (override));
 
-  MOCK_METHOD(StatusOr<google::logging::v2::LogExclusion>, GetExclusion,
+  MOCK_METHOD((StatusOr<google::logging::v2::LogExclusion>), GetExclusion,
               (google::logging::v2::GetExclusionRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::logging::v2::LogExclusion>, CreateExclusion,
+  MOCK_METHOD((StatusOr<google::logging::v2::LogExclusion>), CreateExclusion,
               (google::logging::v2::CreateExclusionRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::logging::v2::LogExclusion>, UpdateExclusion,
+  MOCK_METHOD((StatusOr<google::logging::v2::LogExclusion>), UpdateExclusion,
               (google::logging::v2::UpdateExclusionRequest const& request),
               (override));
 
@@ -149,23 +149,23 @@ class MockConfigServiceV2Connection
               (google::logging::v2::DeleteExclusionRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::logging::v2::CmekSettings>, GetCmekSettings,
+  MOCK_METHOD((StatusOr<google::logging::v2::CmekSettings>), GetCmekSettings,
               (google::logging::v2::GetCmekSettingsRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::logging::v2::CmekSettings>, UpdateCmekSettings,
+  MOCK_METHOD((StatusOr<google::logging::v2::CmekSettings>), UpdateCmekSettings,
               (google::logging::v2::UpdateCmekSettingsRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::logging::v2::Settings>, GetSettings,
+  MOCK_METHOD((StatusOr<google::logging::v2::Settings>), GetSettings,
               (google::logging::v2::GetSettingsRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::logging::v2::Settings>, UpdateSettings,
+  MOCK_METHOD((StatusOr<google::logging::v2::Settings>), UpdateSettings,
               (google::logging::v2::UpdateSettingsRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::logging::v2::CopyLogEntriesResponse>>,
+  MOCK_METHOD((future<StatusOr<google::logging::v2::CopyLogEntriesResponse>>),
               CopyLogEntries,
               (google::logging::v2::CopyLogEntriesRequest const& request),
               (override));

--- a/google/cloud/logging/v2/mocks/mock_logging_service_v2_connection.h
+++ b/google/cloud/logging/v2/mocks/mock_logging_service_v2_connection.h
@@ -51,7 +51,7 @@ class MockLoggingServiceV2Connection
               (google::logging::v2::DeleteLogRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::logging::v2::WriteLogEntriesResponse>,
+  MOCK_METHOD((StatusOr<google::logging::v2::WriteLogEntriesResponse>),
               WriteLogEntries,
               (google::logging::v2::WriteLogEntriesRequest const& request),
               (override));
@@ -73,7 +73,7 @@ class MockLoggingServiceV2Connection
                    google::logging::v2::TailLogEntriesResponse>>),
               AsyncTailLogEntries, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::logging::v2::WriteLogEntriesResponse>>,
+  MOCK_METHOD((future<StatusOr<google::logging::v2::WriteLogEntriesResponse>>),
               AsyncWriteLogEntries,
               (google::logging::v2::WriteLogEntriesRequest const& request),
               (override));

--- a/google/cloud/logging/v2/mocks/mock_metrics_service_v2_connection.h
+++ b/google/cloud/logging/v2/mocks/mock_metrics_service_v2_connection.h
@@ -50,15 +50,15 @@ class MockMetricsServiceV2Connection
   MOCK_METHOD((StreamRange<google::logging::v2::LogMetric>), ListLogMetrics,
               (google::logging::v2::ListLogMetricsRequest request), (override));
 
-  MOCK_METHOD(StatusOr<google::logging::v2::LogMetric>, GetLogMetric,
+  MOCK_METHOD((StatusOr<google::logging::v2::LogMetric>), GetLogMetric,
               (google::logging::v2::GetLogMetricRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::logging::v2::LogMetric>, CreateLogMetric,
+  MOCK_METHOD((StatusOr<google::logging::v2::LogMetric>), CreateLogMetric,
               (google::logging::v2::CreateLogMetricRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::logging::v2::LogMetric>, UpdateLogMetric,
+  MOCK_METHOD((StatusOr<google::logging::v2::LogMetric>), UpdateLogMetric,
               (google::logging::v2::UpdateLogMetricRequest const& request),
               (override));
 

--- a/google/cloud/managedidentities/v1/mocks/mock_managed_identities_connection.h
+++ b/google/cloud/managedidentities/v1/mocks/mock_managed_identities_connection.h
@@ -47,15 +47,15 @@ class MockManagedIdentitiesServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::managedidentities::v1::Domain>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::managedidentities::v1::Domain>>),
               CreateMicrosoftAdDomain,
               (google::cloud::managedidentities::v1::
                    CreateMicrosoftAdDomainRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::managedidentities::v1::ResetAdminPasswordResponse>,
+      (StatusOr<
+          google::cloud::managedidentities::v1::ResetAdminPasswordResponse>),
       ResetAdminPassword,
       (google::cloud::managedidentities::v1::ResetAdminPasswordRequest const&
            request),
@@ -67,43 +67,43 @@ class MockManagedIdentitiesServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::managedidentities::v1::Domain>, GetDomain,
+      (StatusOr<google::cloud::managedidentities::v1::Domain>), GetDomain,
       (google::cloud::managedidentities::v1::GetDomainRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::managedidentities::v1::Domain>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::managedidentities::v1::Domain>>),
               UpdateDomain,
               (google::cloud::managedidentities::v1::UpdateDomainRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::managedidentities::v1::OpMetadata>>,
+      (future<StatusOr<google::cloud::managedidentities::v1::OpMetadata>>),
       DeleteDomain,
       (google::cloud::managedidentities::v1::DeleteDomainRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::managedidentities::v1::Domain>>,
+      (future<StatusOr<google::cloud::managedidentities::v1::Domain>>),
       AttachTrust,
       (google::cloud::managedidentities::v1::AttachTrustRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::managedidentities::v1::Domain>>,
+      (future<StatusOr<google::cloud::managedidentities::v1::Domain>>),
       ReconfigureTrust,
       (google::cloud::managedidentities::v1::ReconfigureTrustRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::managedidentities::v1::Domain>>,
+      (future<StatusOr<google::cloud::managedidentities::v1::Domain>>),
       DetachTrust,
       (google::cloud::managedidentities::v1::DetachTrustRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::managedidentities::v1::Domain>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::managedidentities::v1::Domain>>),
               ValidateTrust,
               (google::cloud::managedidentities::v1::ValidateTrustRequest const&
                    request),

--- a/google/cloud/memcache/v1/mocks/mock_cloud_memcache_connection.h
+++ b/google/cloud/memcache/v1/mocks/mock_cloud_memcache_connection.h
@@ -52,37 +52,39 @@ class MockCloudMemcacheConnection
               (google::cloud::memcache::v1::ListInstancesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::memcache::v1::Instance>, GetInstance,
+  MOCK_METHOD((StatusOr<google::cloud::memcache::v1::Instance>), GetInstance,
               (google::cloud::memcache::v1::GetInstanceRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::memcache::v1::Instance>>, CreateInstance,
+      (future<StatusOr<google::cloud::memcache::v1::Instance>>), CreateInstance,
       (google::cloud::memcache::v1::CreateInstanceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::memcache::v1::Instance>>, UpdateInstance,
+      (future<StatusOr<google::cloud::memcache::v1::Instance>>), UpdateInstance,
       (google::cloud::memcache::v1::UpdateInstanceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::memcache::v1::Instance>>, UpdateParameters,
+      (future<StatusOr<google::cloud::memcache::v1::Instance>>),
+      UpdateParameters,
       (google::cloud::memcache::v1::UpdateParametersRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::memcache::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::memcache::v1::OperationMetadata>>),
       DeleteInstance,
       (google::cloud::memcache::v1::DeleteInstanceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::memcache::v1::Instance>>, ApplyParameters,
+      (future<StatusOr<google::cloud::memcache::v1::Instance>>),
+      ApplyParameters,
       (google::cloud::memcache::v1::ApplyParametersRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::memcache::v1::Instance>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::memcache::v1::Instance>>),
               RescheduleMaintenance,
               (google::cloud::memcache::v1::RescheduleMaintenanceRequest const&
                    request),

--- a/google/cloud/metastore/v1/mocks/mock_dataproc_metastore_connection.h
+++ b/google/cloud/metastore/v1/mocks/mock_dataproc_metastore_connection.h
@@ -52,22 +52,22 @@ class MockDataprocMetastoreConnection
               (google::cloud::metastore::v1::ListServicesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::metastore::v1::Service>, GetService,
+  MOCK_METHOD((StatusOr<google::cloud::metastore::v1::Service>), GetService,
               (google::cloud::metastore::v1::GetServiceRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::metastore::v1::Service>>, CreateService,
+      (future<StatusOr<google::cloud::metastore::v1::Service>>), CreateService,
       (google::cloud::metastore::v1::CreateServiceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::metastore::v1::Service>>, UpdateService,
+      (future<StatusOr<google::cloud::metastore::v1::Service>>), UpdateService,
       (google::cloud::metastore::v1::UpdateServiceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::metastore::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::metastore::v1::OperationMetadata>>),
       DeleteService,
       (google::cloud::metastore::v1::DeleteServiceRequest const& request),
       (override));
@@ -79,30 +79,31 @@ class MockDataprocMetastoreConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::metastore::v1::MetadataImport>, GetMetadataImport,
+      (StatusOr<google::cloud::metastore::v1::MetadataImport>),
+      GetMetadataImport,
       (google::cloud::metastore::v1::GetMetadataImportRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::metastore::v1::MetadataImport>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::metastore::v1::MetadataImport>>),
               CreateMetadataImport,
               (google::cloud::metastore::v1::CreateMetadataImportRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::metastore::v1::MetadataImport>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::metastore::v1::MetadataImport>>),
               UpdateMetadataImport,
               (google::cloud::metastore::v1::UpdateMetadataImportRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::metastore::v1::MetadataExport>>,
+      (future<StatusOr<google::cloud::metastore::v1::MetadataExport>>),
       ExportMetadata,
       (google::cloud::metastore::v1::ExportMetadataRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::metastore::v1::Restore>>, RestoreService,
+      (future<StatusOr<google::cloud::metastore::v1::Restore>>), RestoreService,
       (google::cloud::metastore::v1::RestoreServiceRequest const& request),
       (override));
 
@@ -110,37 +111,37 @@ class MockDataprocMetastoreConnection
               (google::cloud::metastore::v1::ListBackupsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::metastore::v1::Backup>, GetBackup,
+  MOCK_METHOD((StatusOr<google::cloud::metastore::v1::Backup>), GetBackup,
               (google::cloud::metastore::v1::GetBackupRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::metastore::v1::Backup>>, CreateBackup,
+      (future<StatusOr<google::cloud::metastore::v1::Backup>>), CreateBackup,
       (google::cloud::metastore::v1::CreateBackupRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::metastore::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::metastore::v1::OperationMetadata>>),
       DeleteBackup,
       (google::cloud::metastore::v1::DeleteBackupRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::metastore::v1::QueryMetadataResponse>>,
+      (future<StatusOr<google::cloud::metastore::v1::QueryMetadataResponse>>),
       QueryMetadata,
       (google::cloud::metastore::v1::QueryMetadataRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::metastore::v1::MoveTableToDatabaseResponse>>,
+      (future<
+          StatusOr<google::cloud::metastore::v1::MoveTableToDatabaseResponse>>),
       MoveTableToDatabase,
       (google::cloud::metastore::v1::MoveTableToDatabaseRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::metastore::v1::AlterMetadataResourceLocationResponse>>,
+      (future<StatusOr<google::cloud::metastore::v1::
+                           AlterMetadataResourceLocationResponse>>),
       AlterMetadataResourceLocation,
       (google::cloud::metastore::v1::AlterMetadataResourceLocationRequest const&
            request),

--- a/google/cloud/metastore/v1/mocks/mock_dataproc_metastore_federation_connection.h
+++ b/google/cloud/metastore/v1/mocks/mock_dataproc_metastore_federation_connection.h
@@ -53,24 +53,24 @@ class MockDataprocMetastoreFederationConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::metastore::v1::Federation>, GetFederation,
+      (StatusOr<google::cloud::metastore::v1::Federation>), GetFederation,
       (google::cloud::metastore::v1::GetFederationRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::metastore::v1::Federation>>,
+      (future<StatusOr<google::cloud::metastore::v1::Federation>>),
       CreateFederation,
       (google::cloud::metastore::v1::CreateFederationRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::metastore::v1::Federation>>,
+      (future<StatusOr<google::cloud::metastore::v1::Federation>>),
       UpdateFederation,
       (google::cloud::metastore::v1::UpdateFederationRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::metastore::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::metastore::v1::OperationMetadata>>),
       DeleteFederation,
       (google::cloud::metastore::v1::DeleteFederationRequest const& request),
       (override));

--- a/google/cloud/migrationcenter/v1/mocks/mock_migration_center_connection.h
+++ b/google/cloud/migrationcenter/v1/mocks/mock_migration_center_connection.h
@@ -53,17 +53,17 @@ class MockMigrationCenterConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::migrationcenter::v1::Asset>, GetAsset,
+      (StatusOr<google::cloud::migrationcenter::v1::Asset>), GetAsset,
       (google::cloud::migrationcenter::v1::GetAssetRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::migrationcenter::v1::Asset>, UpdateAsset,
+      (StatusOr<google::cloud::migrationcenter::v1::Asset>), UpdateAsset,
       (google::cloud::migrationcenter::v1::UpdateAssetRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::migrationcenter::v1::BatchUpdateAssetsResponse>,
+      (StatusOr<google::cloud::migrationcenter::v1::BatchUpdateAssetsResponse>),
       BatchUpdateAssets,
       (google::cloud::migrationcenter::v1::BatchUpdateAssetsRequest const&
            request),
@@ -81,21 +81,21 @@ class MockMigrationCenterConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::migrationcenter::v1::ReportAssetFramesResponse>,
+      (StatusOr<google::cloud::migrationcenter::v1::ReportAssetFramesResponse>),
       ReportAssetFrames,
       (google::cloud::migrationcenter::v1::ReportAssetFramesRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::migrationcenter::v1::AggregateAssetsValuesResponse>,
+      (StatusOr<
+          google::cloud::migrationcenter::v1::AggregateAssetsValuesResponse>),
       AggregateAssetsValues,
       (google::cloud::migrationcenter::v1::AggregateAssetsValuesRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::migrationcenter::v1::ImportJob>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::migrationcenter::v1::ImportJob>>),
               CreateImportJob,
               (google::cloud::migrationcenter::v1::CreateImportJobRequest const&
                    request),
@@ -108,38 +108,38 @@ class MockMigrationCenterConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::migrationcenter::v1::ImportJob>, GetImportJob,
+      (StatusOr<google::cloud::migrationcenter::v1::ImportJob>), GetImportJob,
       (google::cloud::migrationcenter::v1::GetImportJobRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::migrationcenter::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::migrationcenter::v1::OperationMetadata>>),
       DeleteImportJob,
       (google::cloud::migrationcenter::v1::DeleteImportJobRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::migrationcenter::v1::ImportJob>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::migrationcenter::v1::ImportJob>>),
               UpdateImportJob,
               (google::cloud::migrationcenter::v1::UpdateImportJobRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::migrationcenter::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::migrationcenter::v1::OperationMetadata>>),
       ValidateImportJob,
       (google::cloud::migrationcenter::v1::ValidateImportJobRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::migrationcenter::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::migrationcenter::v1::OperationMetadata>>),
       RunImportJob,
       (google::cloud::migrationcenter::v1::RunImportJobRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::migrationcenter::v1::ImportDataFile>,
+      (StatusOr<google::cloud::migrationcenter::v1::ImportDataFile>),
       GetImportDataFile,
       (google::cloud::migrationcenter::v1::GetImportDataFileRequest const&
            request),
@@ -152,14 +152,14 @@ class MockMigrationCenterConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::migrationcenter::v1::ImportDataFile>>,
+      (future<StatusOr<google::cloud::migrationcenter::v1::ImportDataFile>>),
       CreateImportDataFile,
       (google::cloud::migrationcenter::v1::CreateImportDataFileRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::migrationcenter::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::migrationcenter::v1::OperationMetadata>>),
       DeleteImportDataFile,
       (google::cloud::migrationcenter::v1::DeleteImportDataFileRequest const&
            request),
@@ -171,35 +171,37 @@ class MockMigrationCenterConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::migrationcenter::v1::Group>, GetGroup,
+      (StatusOr<google::cloud::migrationcenter::v1::Group>), GetGroup,
       (google::cloud::migrationcenter::v1::GetGroupRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::migrationcenter::v1::Group>>, CreateGroup,
+      (future<StatusOr<google::cloud::migrationcenter::v1::Group>>),
+      CreateGroup,
       (google::cloud::migrationcenter::v1::CreateGroupRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::migrationcenter::v1::Group>>, UpdateGroup,
+      (future<StatusOr<google::cloud::migrationcenter::v1::Group>>),
+      UpdateGroup,
       (google::cloud::migrationcenter::v1::UpdateGroupRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::migrationcenter::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::migrationcenter::v1::OperationMetadata>>),
       DeleteGroup,
       (google::cloud::migrationcenter::v1::DeleteGroupRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::migrationcenter::v1::Group>>,
+      (future<StatusOr<google::cloud::migrationcenter::v1::Group>>),
       AddAssetsToGroup,
       (google::cloud::migrationcenter::v1::AddAssetsToGroupRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::migrationcenter::v1::Group>>,
+      (future<StatusOr<google::cloud::migrationcenter::v1::Group>>),
       RemoveAssetsFromGroup,
       (google::cloud::migrationcenter::v1::RemoveAssetsFromGroupRequest const&
            request),
@@ -212,7 +214,7 @@ class MockMigrationCenterConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::migrationcenter::v1::ErrorFrame>, GetErrorFrame,
+      (StatusOr<google::cloud::migrationcenter::v1::ErrorFrame>), GetErrorFrame,
       (google::cloud::migrationcenter::v1::GetErrorFrameRequest const& request),
       (override));
 
@@ -222,24 +224,24 @@ class MockMigrationCenterConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::migrationcenter::v1::Source>, GetSource,
+      (StatusOr<google::cloud::migrationcenter::v1::Source>), GetSource,
       (google::cloud::migrationcenter::v1::GetSourceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::migrationcenter::v1::Source>>,
+      (future<StatusOr<google::cloud::migrationcenter::v1::Source>>),
       CreateSource,
       (google::cloud::migrationcenter::v1::CreateSourceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::migrationcenter::v1::Source>>,
+      (future<StatusOr<google::cloud::migrationcenter::v1::Source>>),
       UpdateSource,
       (google::cloud::migrationcenter::v1::UpdateSourceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::migrationcenter::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::migrationcenter::v1::OperationMetadata>>),
       DeleteSource,
       (google::cloud::migrationcenter::v1::DeleteSourceRequest const& request),
       (override));
@@ -251,52 +253,52 @@ class MockMigrationCenterConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::migrationcenter::v1::PreferenceSet>,
+      (StatusOr<google::cloud::migrationcenter::v1::PreferenceSet>),
       GetPreferenceSet,
       (google::cloud::migrationcenter::v1::GetPreferenceSetRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::migrationcenter::v1::PreferenceSet>>,
+      (future<StatusOr<google::cloud::migrationcenter::v1::PreferenceSet>>),
       CreatePreferenceSet,
       (google::cloud::migrationcenter::v1::CreatePreferenceSetRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::migrationcenter::v1::PreferenceSet>>,
+      (future<StatusOr<google::cloud::migrationcenter::v1::PreferenceSet>>),
       UpdatePreferenceSet,
       (google::cloud::migrationcenter::v1::UpdatePreferenceSetRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::migrationcenter::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::migrationcenter::v1::OperationMetadata>>),
       DeletePreferenceSet,
       (google::cloud::migrationcenter::v1::DeletePreferenceSetRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::migrationcenter::v1::Settings>, GetSettings,
+      (StatusOr<google::cloud::migrationcenter::v1::Settings>), GetSettings,
       (google::cloud::migrationcenter::v1::GetSettingsRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::migrationcenter::v1::Settings>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::migrationcenter::v1::Settings>>),
               UpdateSettings,
               (google::cloud::migrationcenter::v1::UpdateSettingsRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::migrationcenter::v1::ReportConfig>>,
+      (future<StatusOr<google::cloud::migrationcenter::v1::ReportConfig>>),
       CreateReportConfig,
       (google::cloud::migrationcenter::v1::CreateReportConfigRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::migrationcenter::v1::ReportConfig>,
+  MOCK_METHOD((StatusOr<google::cloud::migrationcenter::v1::ReportConfig>),
               GetReportConfig,
               (google::cloud::migrationcenter::v1::GetReportConfigRequest const&
                    request),
@@ -309,20 +311,20 @@ class MockMigrationCenterConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::migrationcenter::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::migrationcenter::v1::OperationMetadata>>),
       DeleteReportConfig,
       (google::cloud::migrationcenter::v1::DeleteReportConfigRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::migrationcenter::v1::Report>>,
+      (future<StatusOr<google::cloud::migrationcenter::v1::Report>>),
       CreateReport,
       (google::cloud::migrationcenter::v1::CreateReportRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::migrationcenter::v1::Report>, GetReport,
+      (StatusOr<google::cloud::migrationcenter::v1::Report>), GetReport,
       (google::cloud::migrationcenter::v1::GetReportRequest const& request),
       (override));
 
@@ -332,7 +334,7 @@ class MockMigrationCenterConnection
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::migrationcenter::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::migrationcenter::v1::OperationMetadata>>),
       DeleteReport,
       (google::cloud::migrationcenter::v1::DeleteReportRequest const& request),
       (override));

--- a/google/cloud/monitoring/dashboard/v1/mocks/mock_dashboards_connection.h
+++ b/google/cloud/monitoring/dashboard/v1/mocks/mock_dashboards_connection.h
@@ -47,7 +47,7 @@ class MockDashboardsServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::monitoring::dashboard::v1::Dashboard>,
+  MOCK_METHOD((StatusOr<google::monitoring::dashboard::v1::Dashboard>),
               CreateDashboard,
               (google::monitoring::dashboard::v1::CreateDashboardRequest const&
                    request),
@@ -60,7 +60,7 @@ class MockDashboardsServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::monitoring::dashboard::v1::Dashboard>, GetDashboard,
+      (StatusOr<google::monitoring::dashboard::v1::Dashboard>), GetDashboard,
       (google::monitoring::dashboard::v1::GetDashboardRequest const& request),
       (override));
 
@@ -69,7 +69,7 @@ class MockDashboardsServiceConnection
                    request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::monitoring::dashboard::v1::Dashboard>,
+  MOCK_METHOD((StatusOr<google::monitoring::dashboard::v1::Dashboard>),
               UpdateDashboard,
               (google::monitoring::dashboard::v1::UpdateDashboardRequest const&
                    request),

--- a/google/cloud/monitoring/metricsscope/v1/mocks/mock_metrics_scopes_connection.h
+++ b/google/cloud/monitoring/metricsscope/v1/mocks/mock_metrics_scopes_connection.h
@@ -48,28 +48,30 @@ class MockMetricsScopesConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::monitoring::metricsscope::v1::MetricsScope>,
+      (StatusOr<google::monitoring::metricsscope::v1::MetricsScope>),
       GetMetricsScope,
       (google::monitoring::metricsscope::v1::GetMetricsScopeRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::monitoring::metricsscope::v1::
-                           ListMetricsScopesByMonitoredProjectResponse>,
+  MOCK_METHOD((StatusOr<google::monitoring::metricsscope::v1::
+                            ListMetricsScopesByMonitoredProjectResponse>),
               ListMetricsScopesByMonitoredProject,
               (google::monitoring::metricsscope::v1::
                    ListMetricsScopesByMonitoredProjectRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::monitoring::metricsscope::v1::MonitoredProject>>,
+      (future<
+          StatusOr<google::monitoring::metricsscope::v1::MonitoredProject>>),
       CreateMonitoredProject,
       (google::monitoring::metricsscope::v1::
            CreateMonitoredProjectRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::monitoring::metricsscope::v1::OperationMetadata>>,
+      (future<
+          StatusOr<google::monitoring::metricsscope::v1::OperationMetadata>>),
       DeleteMonitoredProject,
       (google::monitoring::metricsscope::v1::
            DeleteMonitoredProjectRequest const& request),

--- a/google/cloud/monitoring/v3/mocks/mock_alert_policy_connection.h
+++ b/google/cloud/monitoring/v3/mocks/mock_alert_policy_connection.h
@@ -52,11 +52,12 @@ class MockAlertPolicyServiceConnection
               (google::monitoring::v3::ListAlertPoliciesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::monitoring::v3::AlertPolicy>, GetAlertPolicy,
+  MOCK_METHOD((StatusOr<google::monitoring::v3::AlertPolicy>), GetAlertPolicy,
               (google::monitoring::v3::GetAlertPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::monitoring::v3::AlertPolicy>, CreateAlertPolicy,
+  MOCK_METHOD((StatusOr<google::monitoring::v3::AlertPolicy>),
+              CreateAlertPolicy,
               (google::monitoring::v3::CreateAlertPolicyRequest const& request),
               (override));
 
@@ -64,7 +65,8 @@ class MockAlertPolicyServiceConnection
               (google::monitoring::v3::DeleteAlertPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::monitoring::v3::AlertPolicy>, UpdateAlertPolicy,
+  MOCK_METHOD((StatusOr<google::monitoring::v3::AlertPolicy>),
+              UpdateAlertPolicy,
               (google::monitoring::v3::UpdateAlertPolicyRequest const& request),
               (override));
 };

--- a/google/cloud/monitoring/v3/mocks/mock_group_connection.h
+++ b/google/cloud/monitoring/v3/mocks/mock_group_connection.h
@@ -50,15 +50,15 @@ class MockGroupServiceConnection
   MOCK_METHOD((StreamRange<google::monitoring::v3::Group>), ListGroups,
               (google::monitoring::v3::ListGroupsRequest request), (override));
 
-  MOCK_METHOD(StatusOr<google::monitoring::v3::Group>, GetGroup,
+  MOCK_METHOD((StatusOr<google::monitoring::v3::Group>), GetGroup,
               (google::monitoring::v3::GetGroupRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::monitoring::v3::Group>, CreateGroup,
+  MOCK_METHOD((StatusOr<google::monitoring::v3::Group>), CreateGroup,
               (google::monitoring::v3::CreateGroupRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::monitoring::v3::Group>, UpdateGroup,
+  MOCK_METHOD((StatusOr<google::monitoring::v3::Group>), UpdateGroup,
               (google::monitoring::v3::UpdateGroupRequest const& request),
               (override));
 

--- a/google/cloud/monitoring/v3/mocks/mock_metric_connection.h
+++ b/google/cloud/monitoring/v3/mocks/mock_metric_connection.h
@@ -54,7 +54,7 @@ class MockMetricServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::api::MonitoredResourceDescriptor>,
+      (StatusOr<google::api::MonitoredResourceDescriptor>),
       GetMonitoredResourceDescriptor,
       (google::monitoring::v3::GetMonitoredResourceDescriptorRequest const&
            request),
@@ -66,12 +66,12 @@ class MockMetricServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::api::MetricDescriptor>, GetMetricDescriptor,
+      (StatusOr<google::api::MetricDescriptor>), GetMetricDescriptor,
       (google::monitoring::v3::GetMetricDescriptorRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::api::MetricDescriptor>, CreateMetricDescriptor,
+      (StatusOr<google::api::MetricDescriptor>), CreateMetricDescriptor,
       (google::monitoring::v3::CreateMetricDescriptorRequest const& request),
       (override));
 

--- a/google/cloud/monitoring/v3/mocks/mock_notification_channel_connection.h
+++ b/google/cloud/monitoring/v3/mocks/mock_notification_channel_connection.h
@@ -55,7 +55,7 @@ class MockNotificationChannelServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::monitoring::v3::NotificationChannelDescriptor>,
+      (StatusOr<google::monitoring::v3::NotificationChannelDescriptor>),
       GetNotificationChannelDescriptor,
       (google::monitoring::v3::GetNotificationChannelDescriptorRequest const&
            request),
@@ -67,19 +67,19 @@ class MockNotificationChannelServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::monitoring::v3::NotificationChannel>,
+      (StatusOr<google::monitoring::v3::NotificationChannel>),
       GetNotificationChannel,
       (google::monitoring::v3::GetNotificationChannelRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::monitoring::v3::NotificationChannel>,
+      (StatusOr<google::monitoring::v3::NotificationChannel>),
       CreateNotificationChannel,
       (google::monitoring::v3::CreateNotificationChannelRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::monitoring::v3::NotificationChannel>,
+      (StatusOr<google::monitoring::v3::NotificationChannel>),
       UpdateNotificationChannel,
       (google::monitoring::v3::UpdateNotificationChannelRequest const& request),
       (override));
@@ -96,15 +96,15 @@ class MockNotificationChannelServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::monitoring::v3::
-                   GetNotificationChannelVerificationCodeResponse>,
+      (StatusOr<google::monitoring::v3::
+                    GetNotificationChannelVerificationCodeResponse>),
       GetNotificationChannelVerificationCode,
       (google::monitoring::v3::
            GetNotificationChannelVerificationCodeRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::monitoring::v3::NotificationChannel>,
+      (StatusOr<google::monitoring::v3::NotificationChannel>),
       VerifyNotificationChannel,
       (google::monitoring::v3::VerifyNotificationChannelRequest const& request),
       (override));

--- a/google/cloud/monitoring/v3/mocks/mock_service_monitoring_connection.h
+++ b/google/cloud/monitoring/v3/mocks/mock_service_monitoring_connection.h
@@ -47,11 +47,11 @@ class MockServiceMonitoringServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::monitoring::v3::Service>, CreateService,
+  MOCK_METHOD((StatusOr<google::monitoring::v3::Service>), CreateService,
               (google::monitoring::v3::CreateServiceRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::monitoring::v3::Service>, GetService,
+  MOCK_METHOD((StatusOr<google::monitoring::v3::Service>), GetService,
               (google::monitoring::v3::GetServiceRequest const& request),
               (override));
 
@@ -59,7 +59,7 @@ class MockServiceMonitoringServiceConnection
               (google::monitoring::v3::ListServicesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::monitoring::v3::Service>, UpdateService,
+  MOCK_METHOD((StatusOr<google::monitoring::v3::Service>), UpdateService,
               (google::monitoring::v3::UpdateServiceRequest const& request),
               (override));
 
@@ -67,14 +67,14 @@ class MockServiceMonitoringServiceConnection
               (google::monitoring::v3::DeleteServiceRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::monitoring::v3::ServiceLevelObjective>,
+  MOCK_METHOD((StatusOr<google::monitoring::v3::ServiceLevelObjective>),
               CreateServiceLevelObjective,
               (google::monitoring::v3::CreateServiceLevelObjectiveRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::monitoring::v3::ServiceLevelObjective>,
+      (StatusOr<google::monitoring::v3::ServiceLevelObjective>),
       GetServiceLevelObjective,
       (google::monitoring::v3::GetServiceLevelObjectiveRequest const& request),
       (override));
@@ -85,7 +85,7 @@ class MockServiceMonitoringServiceConnection
       (google::monitoring::v3::ListServiceLevelObjectivesRequest request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::monitoring::v3::ServiceLevelObjective>,
+  MOCK_METHOD((StatusOr<google::monitoring::v3::ServiceLevelObjective>),
               UpdateServiceLevelObjective,
               (google::monitoring::v3::UpdateServiceLevelObjectiveRequest const&
                    request),

--- a/google/cloud/monitoring/v3/mocks/mock_snooze_connection.h
+++ b/google/cloud/monitoring/v3/mocks/mock_snooze_connection.h
@@ -47,18 +47,18 @@ class MockSnoozeServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::monitoring::v3::Snooze>, CreateSnooze,
+  MOCK_METHOD((StatusOr<google::monitoring::v3::Snooze>), CreateSnooze,
               (google::monitoring::v3::CreateSnoozeRequest const& request),
               (override));
 
   MOCK_METHOD((StreamRange<google::monitoring::v3::Snooze>), ListSnoozes,
               (google::monitoring::v3::ListSnoozesRequest request), (override));
 
-  MOCK_METHOD(StatusOr<google::monitoring::v3::Snooze>, GetSnooze,
+  MOCK_METHOD((StatusOr<google::monitoring::v3::Snooze>), GetSnooze,
               (google::monitoring::v3::GetSnoozeRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::monitoring::v3::Snooze>, UpdateSnooze,
+  MOCK_METHOD((StatusOr<google::monitoring::v3::Snooze>), UpdateSnooze,
               (google::monitoring::v3::UpdateSnoozeRequest const& request),
               (override));
 };

--- a/google/cloud/monitoring/v3/mocks/mock_uptime_check_connection.h
+++ b/google/cloud/monitoring/v3/mocks/mock_uptime_check_connection.h
@@ -53,18 +53,19 @@ class MockUptimeCheckServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::monitoring::v3::UptimeCheckConfig>, GetUptimeCheckConfig,
+      (StatusOr<google::monitoring::v3::UptimeCheckConfig>),
+      GetUptimeCheckConfig,
       (google::monitoring::v3::GetUptimeCheckConfigRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::monitoring::v3::UptimeCheckConfig>,
+      (StatusOr<google::monitoring::v3::UptimeCheckConfig>),
       CreateUptimeCheckConfig,
       (google::monitoring::v3::CreateUptimeCheckConfigRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::monitoring::v3::UptimeCheckConfig>,
+      (StatusOr<google::monitoring::v3::UptimeCheckConfig>),
       UpdateUptimeCheckConfig,
       (google::monitoring::v3::UpdateUptimeCheckConfigRequest const& request),
       (override));

--- a/google/cloud/netapp/v1/mocks/mock_net_app_connection.h
+++ b/google/cloud/netapp/v1/mocks/mock_net_app_connection.h
@@ -52,23 +52,24 @@ class MockNetAppConnection : public netapp_v1::NetAppConnection {
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::netapp::v1::StoragePool>>,
+      (future<StatusOr<google::cloud::netapp::v1::StoragePool>>),
       CreateStoragePool,
       (google::cloud::netapp::v1::CreateStoragePoolRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::netapp::v1::StoragePool>, GetStoragePool,
+  MOCK_METHOD((StatusOr<google::cloud::netapp::v1::StoragePool>),
+              GetStoragePool,
               (google::cloud::netapp::v1::GetStoragePoolRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::netapp::v1::StoragePool>>,
+      (future<StatusOr<google::cloud::netapp::v1::StoragePool>>),
       UpdateStoragePool,
       (google::cloud::netapp::v1::UpdateStoragePoolRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::netapp::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::netapp::v1::OperationMetadata>>),
       DeleteStoragePool,
       (google::cloud::netapp::v1::DeleteStoragePoolRequest const& request),
       (override));
@@ -77,24 +78,27 @@ class MockNetAppConnection : public netapp_v1::NetAppConnection {
               (google::cloud::netapp::v1::ListVolumesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::netapp::v1::Volume>, GetVolume,
+  MOCK_METHOD((StatusOr<google::cloud::netapp::v1::Volume>), GetVolume,
               (google::cloud::netapp::v1::GetVolumeRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::netapp::v1::Volume>>, CreateVolume,
+  MOCK_METHOD((future<StatusOr<google::cloud::netapp::v1::Volume>>),
+              CreateVolume,
               (google::cloud::netapp::v1::CreateVolumeRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::netapp::v1::Volume>>, UpdateVolume,
+  MOCK_METHOD((future<StatusOr<google::cloud::netapp::v1::Volume>>),
+              UpdateVolume,
               (google::cloud::netapp::v1::UpdateVolumeRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::netapp::v1::OperationMetadata>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::netapp::v1::OperationMetadata>>),
               DeleteVolume,
               (google::cloud::netapp::v1::DeleteVolumeRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::netapp::v1::Volume>>, RevertVolume,
+  MOCK_METHOD((future<StatusOr<google::cloud::netapp::v1::Volume>>),
+              RevertVolume,
               (google::cloud::netapp::v1::RevertVolumeRequest const& request),
               (override));
 
@@ -102,21 +106,21 @@ class MockNetAppConnection : public netapp_v1::NetAppConnection {
               (google::cloud::netapp::v1::ListSnapshotsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::netapp::v1::Snapshot>, GetSnapshot,
+  MOCK_METHOD((StatusOr<google::cloud::netapp::v1::Snapshot>), GetSnapshot,
               (google::cloud::netapp::v1::GetSnapshotRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::netapp::v1::Snapshot>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::netapp::v1::Snapshot>>),
               CreateSnapshot,
               (google::cloud::netapp::v1::CreateSnapshotRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::netapp::v1::OperationMetadata>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::netapp::v1::OperationMetadata>>),
               DeleteSnapshot,
               (google::cloud::netapp::v1::DeleteSnapshotRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::netapp::v1::Snapshot>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::netapp::v1::Snapshot>>),
               UpdateSnapshot,
               (google::cloud::netapp::v1::UpdateSnapshotRequest const& request),
               (override));
@@ -127,24 +131,25 @@ class MockNetAppConnection : public netapp_v1::NetAppConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::netapp::v1::ActiveDirectory>, GetActiveDirectory,
+      (StatusOr<google::cloud::netapp::v1::ActiveDirectory>),
+      GetActiveDirectory,
       (google::cloud::netapp::v1::GetActiveDirectoryRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::netapp::v1::ActiveDirectory>>,
+      (future<StatusOr<google::cloud::netapp::v1::ActiveDirectory>>),
       CreateActiveDirectory,
       (google::cloud::netapp::v1::CreateActiveDirectoryRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::netapp::v1::ActiveDirectory>>,
+      (future<StatusOr<google::cloud::netapp::v1::ActiveDirectory>>),
       UpdateActiveDirectory,
       (google::cloud::netapp::v1::UpdateActiveDirectoryRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::netapp::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::netapp::v1::OperationMetadata>>),
       DeleteActiveDirectory,
       (google::cloud::netapp::v1::DeleteActiveDirectoryRequest const& request),
       (override));
@@ -155,32 +160,32 @@ class MockNetAppConnection : public netapp_v1::NetAppConnection {
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::netapp::v1::KmsConfig>>, CreateKmsConfig,
+      (future<StatusOr<google::cloud::netapp::v1::KmsConfig>>), CreateKmsConfig,
       (google::cloud::netapp::v1::CreateKmsConfigRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::netapp::v1::KmsConfig>, GetKmsConfig,
+  MOCK_METHOD((StatusOr<google::cloud::netapp::v1::KmsConfig>), GetKmsConfig,
               (google::cloud::netapp::v1::GetKmsConfigRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::netapp::v1::KmsConfig>>, UpdateKmsConfig,
+      (future<StatusOr<google::cloud::netapp::v1::KmsConfig>>), UpdateKmsConfig,
       (google::cloud::netapp::v1::UpdateKmsConfigRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::netapp::v1::KmsConfig>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::netapp::v1::KmsConfig>>),
               EncryptVolumes,
               (google::cloud::netapp::v1::EncryptVolumesRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::netapp::v1::VerifyKmsConfigResponse>,
+      (StatusOr<google::cloud::netapp::v1::VerifyKmsConfigResponse>),
       VerifyKmsConfig,
       (google::cloud::netapp::v1::VerifyKmsConfigRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::netapp::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::netapp::v1::OperationMetadata>>),
       DeleteKmsConfig,
       (google::cloud::netapp::v1::DeleteKmsConfigRequest const& request),
       (override));
@@ -190,53 +195,56 @@ class MockNetAppConnection : public netapp_v1::NetAppConnection {
               (google::cloud::netapp::v1::ListReplicationsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::netapp::v1::Replication>, GetReplication,
+  MOCK_METHOD((StatusOr<google::cloud::netapp::v1::Replication>),
+              GetReplication,
               (google::cloud::netapp::v1::GetReplicationRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::netapp::v1::Replication>>,
+      (future<StatusOr<google::cloud::netapp::v1::Replication>>),
       CreateReplication,
       (google::cloud::netapp::v1::CreateReplicationRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::netapp::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::netapp::v1::OperationMetadata>>),
       DeleteReplication,
       (google::cloud::netapp::v1::DeleteReplicationRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::netapp::v1::Replication>>,
+      (future<StatusOr<google::cloud::netapp::v1::Replication>>),
       UpdateReplication,
       (google::cloud::netapp::v1::UpdateReplicationRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::netapp::v1::Replication>>, StopReplication,
+      (future<StatusOr<google::cloud::netapp::v1::Replication>>),
+      StopReplication,
       (google::cloud::netapp::v1::StopReplicationRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::netapp::v1::Replication>>,
+      (future<StatusOr<google::cloud::netapp::v1::Replication>>),
       ResumeReplication,
       (google::cloud::netapp::v1::ResumeReplicationRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::netapp::v1::Replication>>,
+      (future<StatusOr<google::cloud::netapp::v1::Replication>>),
       ReverseReplicationDirection,
       (google::cloud::netapp::v1::ReverseReplicationDirectionRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::netapp::v1::BackupVault>>,
+      (future<StatusOr<google::cloud::netapp::v1::BackupVault>>),
       CreateBackupVault,
       (google::cloud::netapp::v1::CreateBackupVaultRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::netapp::v1::BackupVault>, GetBackupVault,
+  MOCK_METHOD((StatusOr<google::cloud::netapp::v1::BackupVault>),
+              GetBackupVault,
               (google::cloud::netapp::v1::GetBackupVaultRequest const& request),
               (override));
 
@@ -246,22 +254,23 @@ class MockNetAppConnection : public netapp_v1::NetAppConnection {
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::netapp::v1::BackupVault>>,
+      (future<StatusOr<google::cloud::netapp::v1::BackupVault>>),
       UpdateBackupVault,
       (google::cloud::netapp::v1::UpdateBackupVaultRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::netapp::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::netapp::v1::OperationMetadata>>),
       DeleteBackupVault,
       (google::cloud::netapp::v1::DeleteBackupVaultRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::netapp::v1::Backup>>, CreateBackup,
+  MOCK_METHOD((future<StatusOr<google::cloud::netapp::v1::Backup>>),
+              CreateBackup,
               (google::cloud::netapp::v1::CreateBackupRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::netapp::v1::Backup>, GetBackup,
+  MOCK_METHOD((StatusOr<google::cloud::netapp::v1::Backup>), GetBackup,
               (google::cloud::netapp::v1::GetBackupRequest const& request),
               (override));
 
@@ -269,23 +278,24 @@ class MockNetAppConnection : public netapp_v1::NetAppConnection {
               (google::cloud::netapp::v1::ListBackupsRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::netapp::v1::OperationMetadata>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::netapp::v1::OperationMetadata>>),
               DeleteBackup,
               (google::cloud::netapp::v1::DeleteBackupRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::netapp::v1::Backup>>, UpdateBackup,
+  MOCK_METHOD((future<StatusOr<google::cloud::netapp::v1::Backup>>),
+              UpdateBackup,
               (google::cloud::netapp::v1::UpdateBackupRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::netapp::v1::BackupPolicy>>,
+      (future<StatusOr<google::cloud::netapp::v1::BackupPolicy>>),
       CreateBackupPolicy,
       (google::cloud::netapp::v1::CreateBackupPolicyRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::netapp::v1::BackupPolicy>, GetBackupPolicy,
+      (StatusOr<google::cloud::netapp::v1::BackupPolicy>), GetBackupPolicy,
       (google::cloud::netapp::v1::GetBackupPolicyRequest const& request),
       (override));
 
@@ -295,13 +305,13 @@ class MockNetAppConnection : public netapp_v1::NetAppConnection {
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::netapp::v1::BackupPolicy>>,
+      (future<StatusOr<google::cloud::netapp::v1::BackupPolicy>>),
       UpdateBackupPolicy,
       (google::cloud::netapp::v1::UpdateBackupPolicyRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::netapp::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::netapp::v1::OperationMetadata>>),
       DeleteBackupPolicy,
       (google::cloud::netapp::v1::DeleteBackupPolicyRequest const& request),
       (override));

--- a/google/cloud/networkconnectivity/v1/mocks/mock_hub_connection.h
+++ b/google/cloud/networkconnectivity/v1/mocks/mock_hub_connection.h
@@ -53,23 +53,25 @@ class MockHubServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::networkconnectivity::v1::Hub>, GetHub,
+      (StatusOr<google::cloud::networkconnectivity::v1::Hub>), GetHub,
       (google::cloud::networkconnectivity::v1::GetHubRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networkconnectivity::v1::Hub>>, CreateHub,
+      (future<StatusOr<google::cloud::networkconnectivity::v1::Hub>>),
+      CreateHub,
       (google::cloud::networkconnectivity::v1::CreateHubRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networkconnectivity::v1::Hub>>, UpdateHub,
+      (future<StatusOr<google::cloud::networkconnectivity::v1::Hub>>),
+      UpdateHub,
       (google::cloud::networkconnectivity::v1::UpdateHubRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::networkconnectivity::v1::OperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::networkconnectivity::v1::OperationMetadata>>),
       DeleteHub,
       (google::cloud::networkconnectivity::v1::DeleteHubRequest const& request),
       (override));
@@ -86,55 +88,55 @@ class MockHubServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::networkconnectivity::v1::Spoke>, GetSpoke,
+      (StatusOr<google::cloud::networkconnectivity::v1::Spoke>), GetSpoke,
       (google::cloud::networkconnectivity::v1::GetSpokeRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::networkconnectivity::v1::Spoke>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::networkconnectivity::v1::Spoke>>),
               CreateSpoke,
               (google::cloud::networkconnectivity::v1::CreateSpokeRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::networkconnectivity::v1::Spoke>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::networkconnectivity::v1::Spoke>>),
               UpdateSpoke,
               (google::cloud::networkconnectivity::v1::UpdateSpokeRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::networkconnectivity::v1::RejectHubSpokeResponse>>,
+      (future<StatusOr<
+           google::cloud::networkconnectivity::v1::RejectHubSpokeResponse>>),
       RejectHubSpoke,
       (google::cloud::networkconnectivity::v1::RejectHubSpokeRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::networkconnectivity::v1::AcceptHubSpokeResponse>>,
+      (future<StatusOr<
+           google::cloud::networkconnectivity::v1::AcceptHubSpokeResponse>>),
       AcceptHubSpoke,
       (google::cloud::networkconnectivity::v1::AcceptHubSpokeRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::networkconnectivity::v1::OperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::networkconnectivity::v1::OperationMetadata>>),
       DeleteSpoke,
       (google::cloud::networkconnectivity::v1::DeleteSpokeRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::networkconnectivity::v1::RouteTable>,
+      (StatusOr<google::cloud::networkconnectivity::v1::RouteTable>),
       GetRouteTable,
       (google::cloud::networkconnectivity::v1::GetRouteTableRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::networkconnectivity::v1::Route>, GetRoute,
+      (StatusOr<google::cloud::networkconnectivity::v1::Route>), GetRoute,
       (google::cloud::networkconnectivity::v1::GetRouteRequest const& request),
       (override));
 
@@ -150,7 +152,7 @@ class MockHubServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::networkconnectivity::v1::Group>, GetGroup,
+      (StatusOr<google::cloud::networkconnectivity::v1::Group>), GetGroup,
       (google::cloud::networkconnectivity::v1::GetGroupRequest const& request),
       (override));
 

--- a/google/cloud/networkmanagement/v1/mocks/mock_reachability_connection.h
+++ b/google/cloud/networkmanagement/v1/mocks/mock_reachability_connection.h
@@ -55,35 +55,39 @@ class MockReachabilityServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::networkmanagement::v1::ConnectivityTest>,
+      (StatusOr<google::cloud::networkmanagement::v1::ConnectivityTest>),
       GetConnectivityTest,
       (google::cloud::networkmanagement::v1::GetConnectivityTestRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networkmanagement::v1::ConnectivityTest>>,
+      (future<
+          StatusOr<google::cloud::networkmanagement::v1::ConnectivityTest>>),
       CreateConnectivityTest,
       (google::cloud::networkmanagement::v1::
            CreateConnectivityTestRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networkmanagement::v1::ConnectivityTest>>,
+      (future<
+          StatusOr<google::cloud::networkmanagement::v1::ConnectivityTest>>),
       UpdateConnectivityTest,
       (google::cloud::networkmanagement::v1::
            UpdateConnectivityTestRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networkmanagement::v1::ConnectivityTest>>,
+      (future<
+          StatusOr<google::cloud::networkmanagement::v1::ConnectivityTest>>),
       RerunConnectivityTest,
       (google::cloud::networkmanagement::v1::RerunConnectivityTestRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networkmanagement::v1::OperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::networkmanagement::v1::OperationMetadata>>),
       DeleteConnectivityTest,
       (google::cloud::networkmanagement::v1::
            DeleteConnectivityTestRequest const& request),

--- a/google/cloud/networksecurity/v1/mocks/mock_network_security_connection.h
+++ b/google/cloud/networksecurity/v1/mocks/mock_network_security_connection.h
@@ -55,28 +55,30 @@ class MockNetworkSecurityConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::networksecurity::v1::AuthorizationPolicy>,
+      (StatusOr<google::cloud::networksecurity::v1::AuthorizationPolicy>),
       GetAuthorizationPolicy,
       (google::cloud::networksecurity::v1::GetAuthorizationPolicyRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networksecurity::v1::AuthorizationPolicy>>,
+      (future<
+          StatusOr<google::cloud::networksecurity::v1::AuthorizationPolicy>>),
       CreateAuthorizationPolicy,
       (google::cloud::networksecurity::v1::
            CreateAuthorizationPolicyRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networksecurity::v1::AuthorizationPolicy>>,
+      (future<
+          StatusOr<google::cloud::networksecurity::v1::AuthorizationPolicy>>),
       UpdateAuthorizationPolicy,
       (google::cloud::networksecurity::v1::
            UpdateAuthorizationPolicyRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networksecurity::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::networksecurity::v1::OperationMetadata>>),
       DeleteAuthorizationPolicy,
       (google::cloud::networksecurity::v1::
            DeleteAuthorizationPolicyRequest const& request),
@@ -90,28 +92,28 @@ class MockNetworkSecurityConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::networksecurity::v1::ServerTlsPolicy>,
+      (StatusOr<google::cloud::networksecurity::v1::ServerTlsPolicy>),
       GetServerTlsPolicy,
       (google::cloud::networksecurity::v1::GetServerTlsPolicyRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networksecurity::v1::ServerTlsPolicy>>,
+      (future<StatusOr<google::cloud::networksecurity::v1::ServerTlsPolicy>>),
       CreateServerTlsPolicy,
       (google::cloud::networksecurity::v1::CreateServerTlsPolicyRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networksecurity::v1::ServerTlsPolicy>>,
+      (future<StatusOr<google::cloud::networksecurity::v1::ServerTlsPolicy>>),
       UpdateServerTlsPolicy,
       (google::cloud::networksecurity::v1::UpdateServerTlsPolicyRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networksecurity::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::networksecurity::v1::OperationMetadata>>),
       DeleteServerTlsPolicy,
       (google::cloud::networksecurity::v1::DeleteServerTlsPolicyRequest const&
            request),
@@ -125,28 +127,28 @@ class MockNetworkSecurityConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::networksecurity::v1::ClientTlsPolicy>,
+      (StatusOr<google::cloud::networksecurity::v1::ClientTlsPolicy>),
       GetClientTlsPolicy,
       (google::cloud::networksecurity::v1::GetClientTlsPolicyRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networksecurity::v1::ClientTlsPolicy>>,
+      (future<StatusOr<google::cloud::networksecurity::v1::ClientTlsPolicy>>),
       CreateClientTlsPolicy,
       (google::cloud::networksecurity::v1::CreateClientTlsPolicyRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networksecurity::v1::ClientTlsPolicy>>,
+      (future<StatusOr<google::cloud::networksecurity::v1::ClientTlsPolicy>>),
       UpdateClientTlsPolicy,
       (google::cloud::networksecurity::v1::UpdateClientTlsPolicyRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networksecurity::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::networksecurity::v1::OperationMetadata>>),
       DeleteClientTlsPolicy,
       (google::cloud::networksecurity::v1::DeleteClientTlsPolicyRequest const&
            request),

--- a/google/cloud/networkservices/v1/mocks/mock_dep_connection.h
+++ b/google/cloud/networkservices/v1/mocks/mock_dep_connection.h
@@ -55,28 +55,30 @@ class MockDepServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::networkservices::v1::LbTrafficExtension>,
+      (StatusOr<google::cloud::networkservices::v1::LbTrafficExtension>),
       GetLbTrafficExtension,
       (google::cloud::networkservices::v1::GetLbTrafficExtensionRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networkservices::v1::LbTrafficExtension>>,
+      (future<
+          StatusOr<google::cloud::networkservices::v1::LbTrafficExtension>>),
       CreateLbTrafficExtension,
       (google::cloud::networkservices::v1::
            CreateLbTrafficExtensionRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networkservices::v1::LbTrafficExtension>>,
+      (future<
+          StatusOr<google::cloud::networkservices::v1::LbTrafficExtension>>),
       UpdateLbTrafficExtension,
       (google::cloud::networkservices::v1::
            UpdateLbTrafficExtensionRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networkservices::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::networkservices::v1::OperationMetadata>>),
       DeleteLbTrafficExtension,
       (google::cloud::networkservices::v1::
            DeleteLbTrafficExtensionRequest const& request),
@@ -90,28 +92,28 @@ class MockDepServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::networkservices::v1::LbRouteExtension>,
+      (StatusOr<google::cloud::networkservices::v1::LbRouteExtension>),
       GetLbRouteExtension,
       (google::cloud::networkservices::v1::GetLbRouteExtensionRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networkservices::v1::LbRouteExtension>>,
+      (future<StatusOr<google::cloud::networkservices::v1::LbRouteExtension>>),
       CreateLbRouteExtension,
       (google::cloud::networkservices::v1::CreateLbRouteExtensionRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networkservices::v1::LbRouteExtension>>,
+      (future<StatusOr<google::cloud::networkservices::v1::LbRouteExtension>>),
       UpdateLbRouteExtension,
       (google::cloud::networkservices::v1::UpdateLbRouteExtensionRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networkservices::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::networkservices::v1::OperationMetadata>>),
       DeleteLbRouteExtension,
       (google::cloud::networkservices::v1::DeleteLbRouteExtensionRequest const&
            request),

--- a/google/cloud/networkservices/v1/mocks/mock_network_services_connection.h
+++ b/google/cloud/networkservices/v1/mocks/mock_network_services_connection.h
@@ -54,28 +54,28 @@ class MockNetworkServicesConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::networkservices::v1::EndpointPolicy>,
+      (StatusOr<google::cloud::networkservices::v1::EndpointPolicy>),
       GetEndpointPolicy,
       (google::cloud::networkservices::v1::GetEndpointPolicyRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networkservices::v1::EndpointPolicy>>,
+      (future<StatusOr<google::cloud::networkservices::v1::EndpointPolicy>>),
       CreateEndpointPolicy,
       (google::cloud::networkservices::v1::CreateEndpointPolicyRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networkservices::v1::EndpointPolicy>>,
+      (future<StatusOr<google::cloud::networkservices::v1::EndpointPolicy>>),
       UpdateEndpointPolicy,
       (google::cloud::networkservices::v1::UpdateEndpointPolicyRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networkservices::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::networkservices::v1::OperationMetadata>>),
       DeleteEndpointPolicy,
       (google::cloud::networkservices::v1::DeleteEndpointPolicyRequest const&
            request),
@@ -87,24 +87,24 @@ class MockNetworkServicesConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::networkservices::v1::Gateway>, GetGateway,
+      (StatusOr<google::cloud::networkservices::v1::Gateway>), GetGateway,
       (google::cloud::networkservices::v1::GetGatewayRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networkservices::v1::Gateway>>,
+      (future<StatusOr<google::cloud::networkservices::v1::Gateway>>),
       CreateGateway,
       (google::cloud::networkservices::v1::CreateGatewayRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networkservices::v1::Gateway>>,
+      (future<StatusOr<google::cloud::networkservices::v1::Gateway>>),
       UpdateGateway,
       (google::cloud::networkservices::v1::UpdateGatewayRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networkservices::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::networkservices::v1::OperationMetadata>>),
       DeleteGateway,
       (google::cloud::networkservices::v1::DeleteGatewayRequest const& request),
       (override));
@@ -116,24 +116,24 @@ class MockNetworkServicesConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::networkservices::v1::GrpcRoute>, GetGrpcRoute,
+      (StatusOr<google::cloud::networkservices::v1::GrpcRoute>), GetGrpcRoute,
       (google::cloud::networkservices::v1::GetGrpcRouteRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::networkservices::v1::GrpcRoute>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::networkservices::v1::GrpcRoute>>),
               CreateGrpcRoute,
               (google::cloud::networkservices::v1::CreateGrpcRouteRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::networkservices::v1::GrpcRoute>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::networkservices::v1::GrpcRoute>>),
               UpdateGrpcRoute,
               (google::cloud::networkservices::v1::UpdateGrpcRouteRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networkservices::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::networkservices::v1::OperationMetadata>>),
       DeleteGrpcRoute,
       (google::cloud::networkservices::v1::DeleteGrpcRouteRequest const&
            request),
@@ -146,24 +146,24 @@ class MockNetworkServicesConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::networkservices::v1::HttpRoute>, GetHttpRoute,
+      (StatusOr<google::cloud::networkservices::v1::HttpRoute>), GetHttpRoute,
       (google::cloud::networkservices::v1::GetHttpRouteRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::networkservices::v1::HttpRoute>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::networkservices::v1::HttpRoute>>),
               CreateHttpRoute,
               (google::cloud::networkservices::v1::CreateHttpRouteRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::networkservices::v1::HttpRoute>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::networkservices::v1::HttpRoute>>),
               UpdateHttpRoute,
               (google::cloud::networkservices::v1::UpdateHttpRouteRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networkservices::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::networkservices::v1::OperationMetadata>>),
       DeleteHttpRoute,
       (google::cloud::networkservices::v1::DeleteHttpRouteRequest const&
            request),
@@ -176,24 +176,24 @@ class MockNetworkServicesConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::networkservices::v1::TcpRoute>, GetTcpRoute,
+      (StatusOr<google::cloud::networkservices::v1::TcpRoute>), GetTcpRoute,
       (google::cloud::networkservices::v1::GetTcpRouteRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::networkservices::v1::TcpRoute>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::networkservices::v1::TcpRoute>>),
               CreateTcpRoute,
               (google::cloud::networkservices::v1::CreateTcpRouteRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::networkservices::v1::TcpRoute>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::networkservices::v1::TcpRoute>>),
               UpdateTcpRoute,
               (google::cloud::networkservices::v1::UpdateTcpRouteRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networkservices::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::networkservices::v1::OperationMetadata>>),
       DeleteTcpRoute,
       (google::cloud::networkservices::v1::DeleteTcpRouteRequest const&
            request),
@@ -206,24 +206,24 @@ class MockNetworkServicesConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::networkservices::v1::TlsRoute>, GetTlsRoute,
+      (StatusOr<google::cloud::networkservices::v1::TlsRoute>), GetTlsRoute,
       (google::cloud::networkservices::v1::GetTlsRouteRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::networkservices::v1::TlsRoute>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::networkservices::v1::TlsRoute>>),
               CreateTlsRoute,
               (google::cloud::networkservices::v1::CreateTlsRouteRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::networkservices::v1::TlsRoute>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::networkservices::v1::TlsRoute>>),
               UpdateTlsRoute,
               (google::cloud::networkservices::v1::UpdateTlsRouteRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networkservices::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::networkservices::v1::OperationMetadata>>),
       DeleteTlsRoute,
       (google::cloud::networkservices::v1::DeleteTlsRouteRequest const&
            request),
@@ -236,21 +236,21 @@ class MockNetworkServicesConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::networkservices::v1::ServiceBinding>,
+      (StatusOr<google::cloud::networkservices::v1::ServiceBinding>),
       GetServiceBinding,
       (google::cloud::networkservices::v1::GetServiceBindingRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networkservices::v1::ServiceBinding>>,
+      (future<StatusOr<google::cloud::networkservices::v1::ServiceBinding>>),
       CreateServiceBinding,
       (google::cloud::networkservices::v1::CreateServiceBindingRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networkservices::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::networkservices::v1::OperationMetadata>>),
       DeleteServiceBinding,
       (google::cloud::networkservices::v1::DeleteServiceBindingRequest const&
            request),
@@ -262,22 +262,22 @@ class MockNetworkServicesConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::networkservices::v1::Mesh>, GetMesh,
+      (StatusOr<google::cloud::networkservices::v1::Mesh>), GetMesh,
       (google::cloud::networkservices::v1::GetMeshRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networkservices::v1::Mesh>>, CreateMesh,
+      (future<StatusOr<google::cloud::networkservices::v1::Mesh>>), CreateMesh,
       (google::cloud::networkservices::v1::CreateMeshRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networkservices::v1::Mesh>>, UpdateMesh,
+      (future<StatusOr<google::cloud::networkservices::v1::Mesh>>), UpdateMesh,
       (google::cloud::networkservices::v1::UpdateMeshRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::networkservices::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::networkservices::v1::OperationMetadata>>),
       DeleteMesh,
       (google::cloud::networkservices::v1::DeleteMeshRequest const& request),
       (override));

--- a/google/cloud/notebooks/v1/mocks/mock_managed_notebook_connection.h
+++ b/google/cloud/notebooks/v1/mocks/mock_managed_notebook_connection.h
@@ -52,67 +52,68 @@ class MockManagedNotebookServiceConnection
               (google::cloud::notebooks::v1::ListRuntimesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::notebooks::v1::Runtime>, GetRuntime,
+  MOCK_METHOD((StatusOr<google::cloud::notebooks::v1::Runtime>), GetRuntime,
               (google::cloud::notebooks::v1::GetRuntimeRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v1::Runtime>>, CreateRuntime,
+      (future<StatusOr<google::cloud::notebooks::v1::Runtime>>), CreateRuntime,
       (google::cloud::notebooks::v1::CreateRuntimeRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v1::Runtime>>, UpdateRuntime,
+      (future<StatusOr<google::cloud::notebooks::v1::Runtime>>), UpdateRuntime,
       (google::cloud::notebooks::v1::UpdateRuntimeRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>),
       DeleteRuntime,
       (google::cloud::notebooks::v1::DeleteRuntimeRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v1::Runtime>>, StartRuntime,
+      (future<StatusOr<google::cloud::notebooks::v1::Runtime>>), StartRuntime,
       (google::cloud::notebooks::v1::StartRuntimeRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::notebooks::v1::Runtime>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::notebooks::v1::Runtime>>),
               StopRuntime,
               (google::cloud::notebooks::v1::StopRuntimeRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v1::Runtime>>, SwitchRuntime,
+      (future<StatusOr<google::cloud::notebooks::v1::Runtime>>), SwitchRuntime,
       (google::cloud::notebooks::v1::SwitchRuntimeRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v1::Runtime>>, ResetRuntime,
+      (future<StatusOr<google::cloud::notebooks::v1::Runtime>>), ResetRuntime,
       (google::cloud::notebooks::v1::ResetRuntimeRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v1::Runtime>>, UpgradeRuntime,
+      (future<StatusOr<google::cloud::notebooks::v1::Runtime>>), UpgradeRuntime,
       (google::cloud::notebooks::v1::UpgradeRuntimeRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v1::Runtime>>,
+      (future<StatusOr<google::cloud::notebooks::v1::Runtime>>),
       ReportRuntimeEvent,
       (google::cloud::notebooks::v1::ReportRuntimeEventRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::notebooks::v1::RefreshRuntimeTokenInternalResponse>,
+      (StatusOr<
+          google::cloud::notebooks::v1::RefreshRuntimeTokenInternalResponse>),
       RefreshRuntimeTokenInternal,
       (google::cloud::notebooks::v1::RefreshRuntimeTokenInternalRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v1::Runtime>>, DiagnoseRuntime,
+      (future<StatusOr<google::cloud::notebooks::v1::Runtime>>),
+      DiagnoseRuntime,
       (google::cloud::notebooks::v1::DiagnoseRuntimeRequest const& request),
       (override));
 };

--- a/google/cloud/notebooks/v1/mocks/mock_notebook_connection.h
+++ b/google/cloud/notebooks/v1/mocks/mock_notebook_connection.h
@@ -52,121 +52,123 @@ class MockNotebookServiceConnection
               (google::cloud::notebooks::v1::ListInstancesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::notebooks::v1::Instance>, GetInstance,
+  MOCK_METHOD((StatusOr<google::cloud::notebooks::v1::Instance>), GetInstance,
               (google::cloud::notebooks::v1::GetInstanceRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v1::Instance>>, CreateInstance,
+      (future<StatusOr<google::cloud::notebooks::v1::Instance>>),
+      CreateInstance,
       (google::cloud::notebooks::v1::CreateInstanceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v1::Instance>>,
+      (future<StatusOr<google::cloud::notebooks::v1::Instance>>),
       RegisterInstance,
       (google::cloud::notebooks::v1::RegisterInstanceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v1::Instance>>,
+      (future<StatusOr<google::cloud::notebooks::v1::Instance>>),
       SetInstanceAccelerator,
       (google::cloud::notebooks::v1::SetInstanceAcceleratorRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v1::Instance>>,
+      (future<StatusOr<google::cloud::notebooks::v1::Instance>>),
       SetInstanceMachineType,
       (google::cloud::notebooks::v1::SetInstanceMachineTypeRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::notebooks::v1::Instance>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::notebooks::v1::Instance>>),
               UpdateInstanceConfig,
               (google::cloud::notebooks::v1::UpdateInstanceConfigRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v1::Instance>>,
+      (future<StatusOr<google::cloud::notebooks::v1::Instance>>),
       UpdateShieldedInstanceConfig,
       (google::cloud::notebooks::v1::UpdateShieldedInstanceConfigRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v1::Instance>>,
+      (future<StatusOr<google::cloud::notebooks::v1::Instance>>),
       SetInstanceLabels,
       (google::cloud::notebooks::v1::SetInstanceLabelsRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::notebooks::v1::UpdateInstanceMetadataItemsResponse>,
+      (StatusOr<
+          google::cloud::notebooks::v1::UpdateInstanceMetadataItemsResponse>),
       UpdateInstanceMetadataItems,
       (google::cloud::notebooks::v1::UpdateInstanceMetadataItemsRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>),
       DeleteInstance,
       (google::cloud::notebooks::v1::DeleteInstanceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v1::Instance>>, StartInstance,
+      (future<StatusOr<google::cloud::notebooks::v1::Instance>>), StartInstance,
       (google::cloud::notebooks::v1::StartInstanceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v1::Instance>>, StopInstance,
+      (future<StatusOr<google::cloud::notebooks::v1::Instance>>), StopInstance,
       (google::cloud::notebooks::v1::StopInstanceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v1::Instance>>, ResetInstance,
+      (future<StatusOr<google::cloud::notebooks::v1::Instance>>), ResetInstance,
       (google::cloud::notebooks::v1::ResetInstanceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v1::Instance>>,
+      (future<StatusOr<google::cloud::notebooks::v1::Instance>>),
       ReportInstanceInfo,
       (google::cloud::notebooks::v1::ReportInstanceInfoRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::notebooks::v1::IsInstanceUpgradeableResponse>,
+      (StatusOr<google::cloud::notebooks::v1::IsInstanceUpgradeableResponse>),
       IsInstanceUpgradeable,
       (google::cloud::notebooks::v1::IsInstanceUpgradeableRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::notebooks::v1::GetInstanceHealthResponse>,
+      (StatusOr<google::cloud::notebooks::v1::GetInstanceHealthResponse>),
       GetInstanceHealth,
       (google::cloud::notebooks::v1::GetInstanceHealthRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v1::Instance>>, UpgradeInstance,
+      (future<StatusOr<google::cloud::notebooks::v1::Instance>>),
+      UpgradeInstance,
       (google::cloud::notebooks::v1::UpgradeInstanceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v1::Instance>>,
+      (future<StatusOr<google::cloud::notebooks::v1::Instance>>),
       RollbackInstance,
       (google::cloud::notebooks::v1::RollbackInstanceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v1::Instance>>,
+      (future<StatusOr<google::cloud::notebooks::v1::Instance>>),
       DiagnoseInstance,
       (google::cloud::notebooks::v1::DiagnoseInstanceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v1::Instance>>,
+      (future<StatusOr<google::cloud::notebooks::v1::Instance>>),
       UpgradeInstanceInternal,
       (google::cloud::notebooks::v1::UpgradeInstanceInternalRequest const&
            request),
@@ -178,18 +180,18 @@ class MockNotebookServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::notebooks::v1::Environment>, GetEnvironment,
+      (StatusOr<google::cloud::notebooks::v1::Environment>), GetEnvironment,
       (google::cloud::notebooks::v1::GetEnvironmentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v1::Environment>>,
+      (future<StatusOr<google::cloud::notebooks::v1::Environment>>),
       CreateEnvironment,
       (google::cloud::notebooks::v1::CreateEnvironmentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>),
       DeleteEnvironment,
       (google::cloud::notebooks::v1::DeleteEnvironmentRequest const& request),
       (override));
@@ -199,23 +201,25 @@ class MockNotebookServiceConnection
               (google::cloud::notebooks::v1::ListSchedulesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::notebooks::v1::Schedule>, GetSchedule,
+  MOCK_METHOD((StatusOr<google::cloud::notebooks::v1::Schedule>), GetSchedule,
               (google::cloud::notebooks::v1::GetScheduleRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>),
       DeleteSchedule,
       (google::cloud::notebooks::v1::DeleteScheduleRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v1::Schedule>>, CreateSchedule,
+      (future<StatusOr<google::cloud::notebooks::v1::Schedule>>),
+      CreateSchedule,
       (google::cloud::notebooks::v1::CreateScheduleRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v1::Schedule>>, TriggerSchedule,
+      (future<StatusOr<google::cloud::notebooks::v1::Schedule>>),
+      TriggerSchedule,
       (google::cloud::notebooks::v1::TriggerScheduleRequest const& request),
       (override));
 
@@ -225,18 +229,18 @@ class MockNotebookServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::notebooks::v1::Execution>, GetExecution,
+      (StatusOr<google::cloud::notebooks::v1::Execution>), GetExecution,
       (google::cloud::notebooks::v1::GetExecutionRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>),
       DeleteExecution,
       (google::cloud::notebooks::v1::DeleteExecutionRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v1::Execution>>,
+      (future<StatusOr<google::cloud::notebooks::v1::Execution>>),
       CreateExecution,
       (google::cloud::notebooks::v1::CreateExecutionRequest const& request),
       (override));

--- a/google/cloud/notebooks/v2/mocks/mock_notebook_connection.h
+++ b/google/cloud/notebooks/v2/mocks/mock_notebook_connection.h
@@ -52,62 +52,65 @@ class MockNotebookServiceConnection
               (google::cloud::notebooks::v2::ListInstancesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::notebooks::v2::Instance>, GetInstance,
+  MOCK_METHOD((StatusOr<google::cloud::notebooks::v2::Instance>), GetInstance,
               (google::cloud::notebooks::v2::GetInstanceRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v2::Instance>>, CreateInstance,
+      (future<StatusOr<google::cloud::notebooks::v2::Instance>>),
+      CreateInstance,
       (google::cloud::notebooks::v2::CreateInstanceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v2::Instance>>, UpdateInstance,
+      (future<StatusOr<google::cloud::notebooks::v2::Instance>>),
+      UpdateInstance,
       (google::cloud::notebooks::v2::UpdateInstanceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v2::OperationMetadata>>,
+      (future<StatusOr<google::cloud::notebooks::v2::OperationMetadata>>),
       DeleteInstance,
       (google::cloud::notebooks::v2::DeleteInstanceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v2::Instance>>, StartInstance,
+      (future<StatusOr<google::cloud::notebooks::v2::Instance>>), StartInstance,
       (google::cloud::notebooks::v2::StartInstanceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v2::Instance>>, StopInstance,
+      (future<StatusOr<google::cloud::notebooks::v2::Instance>>), StopInstance,
       (google::cloud::notebooks::v2::StopInstanceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v2::Instance>>, ResetInstance,
+      (future<StatusOr<google::cloud::notebooks::v2::Instance>>), ResetInstance,
       (google::cloud::notebooks::v2::ResetInstanceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::notebooks::v2::CheckInstanceUpgradabilityResponse>,
+      (StatusOr<
+          google::cloud::notebooks::v2::CheckInstanceUpgradabilityResponse>),
       CheckInstanceUpgradability,
       (google::cloud::notebooks::v2::CheckInstanceUpgradabilityRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v2::Instance>>, UpgradeInstance,
+      (future<StatusOr<google::cloud::notebooks::v2::Instance>>),
+      UpgradeInstance,
       (google::cloud::notebooks::v2::UpgradeInstanceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v2::Instance>>,
+      (future<StatusOr<google::cloud::notebooks::v2::Instance>>),
       RollbackInstance,
       (google::cloud::notebooks::v2::RollbackInstanceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::notebooks::v2::Instance>>,
+      (future<StatusOr<google::cloud::notebooks::v2::Instance>>),
       DiagnoseInstance,
       (google::cloud::notebooks::v2::DiagnoseInstanceRequest const& request),
       (override));

--- a/google/cloud/optimization/v1/mocks/mock_fleet_routing_connection.h
+++ b/google/cloud/optimization/v1/mocks/mock_fleet_routing_connection.h
@@ -48,17 +48,18 @@ class MockFleetRoutingConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::optimization::v1::OptimizeToursResponse>,
+      (StatusOr<google::cloud::optimization::v1::OptimizeToursResponse>),
       OptimizeTours,
       (google::cloud::optimization::v1::OptimizeToursRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<
-                  google::cloud::optimization::v1::BatchOptimizeToursResponse>>,
-              BatchOptimizeTours,
-              (google::cloud::optimization::v1::BatchOptimizeToursRequest const&
-                   request),
-              (override));
+  MOCK_METHOD(
+      (future<StatusOr<
+           google::cloud::optimization::v1::BatchOptimizeToursResponse>>),
+      BatchOptimizeTours,
+      (google::cloud::optimization::v1::BatchOptimizeToursRequest const&
+           request),
+      (override));
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/orgpolicy/v2/mocks/mock_org_policy_connection.h
+++ b/google/cloud/orgpolicy/v2/mocks/mock_org_policy_connection.h
@@ -55,22 +55,22 @@ class MockOrgPolicyConnection : public orgpolicy_v2::OrgPolicyConnection {
               (google::cloud::orgpolicy::v2::ListPoliciesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::orgpolicy::v2::Policy>, GetPolicy,
+  MOCK_METHOD((StatusOr<google::cloud::orgpolicy::v2::Policy>), GetPolicy,
               (google::cloud::orgpolicy::v2::GetPolicyRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::orgpolicy::v2::Policy>, GetEffectivePolicy,
+      (StatusOr<google::cloud::orgpolicy::v2::Policy>), GetEffectivePolicy,
       (google::cloud::orgpolicy::v2::GetEffectivePolicyRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::orgpolicy::v2::Policy>, CreatePolicy,
+      (StatusOr<google::cloud::orgpolicy::v2::Policy>), CreatePolicy,
       (google::cloud::orgpolicy::v2::CreatePolicyRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::orgpolicy::v2::Policy>, UpdatePolicy,
+      (StatusOr<google::cloud::orgpolicy::v2::Policy>), UpdatePolicy,
       (google::cloud::orgpolicy::v2::UpdatePolicyRequest const& request),
       (override));
 
@@ -80,21 +80,21 @@ class MockOrgPolicyConnection : public orgpolicy_v2::OrgPolicyConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::orgpolicy::v2::CustomConstraint>,
+      (StatusOr<google::cloud::orgpolicy::v2::CustomConstraint>),
       CreateCustomConstraint,
       (google::cloud::orgpolicy::v2::CreateCustomConstraintRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::orgpolicy::v2::CustomConstraint>,
+      (StatusOr<google::cloud::orgpolicy::v2::CustomConstraint>),
       UpdateCustomConstraint,
       (google::cloud::orgpolicy::v2::UpdateCustomConstraintRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::orgpolicy::v2::CustomConstraint>,
+      (StatusOr<google::cloud::orgpolicy::v2::CustomConstraint>),
       GetCustomConstraint,
       (google::cloud::orgpolicy::v2::GetCustomConstraintRequest const& request),
       (override));

--- a/google/cloud/osconfig/agentendpoint/v1/mocks/mock_agent_endpoint_connection.h
+++ b/google/cloud/osconfig/agentendpoint/v1/mocks/mock_agent_endpoint_connection.h
@@ -47,46 +47,46 @@ class MockAgentEndpointServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StreamRange<google::cloud::osconfig::agentendpoint::v1::
-                              ReceiveTaskNotificationResponse>,
+  MOCK_METHOD((StreamRange<google::cloud::osconfig::agentendpoint::v1::
+                               ReceiveTaskNotificationResponse>),
               ReceiveTaskNotification,
               (google::cloud::osconfig::agentendpoint::v1::
                    ReceiveTaskNotificationRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::osconfig::agentendpoint::v1::StartNextTaskResponse>,
+      (StatusOr<
+          google::cloud::osconfig::agentendpoint::v1::StartNextTaskResponse>),
       StartNextTask,
       (google::cloud::osconfig::agentendpoint::v1::StartNextTaskRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::osconfig::agentendpoint::v1::
-                           ReportTaskProgressResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::osconfig::agentendpoint::v1::
+                            ReportTaskProgressResponse>),
               ReportTaskProgress,
               (google::cloud::osconfig::agentendpoint::v1::
                    ReportTaskProgressRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::osconfig::agentendpoint::v1::
-                           ReportTaskCompleteResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::osconfig::agentendpoint::v1::
+                            ReportTaskCompleteResponse>),
               ReportTaskComplete,
               (google::cloud::osconfig::agentendpoint::v1::
                    ReportTaskCompleteRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::osconfig::agentendpoint::v1::RegisterAgentResponse>,
+      (StatusOr<
+          google::cloud::osconfig::agentendpoint::v1::RegisterAgentResponse>),
       RegisterAgent,
       (google::cloud::osconfig::agentendpoint::v1::RegisterAgentRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::osconfig::agentendpoint::v1::ReportInventoryResponse>,
+      (StatusOr<
+          google::cloud::osconfig::agentendpoint::v1::ReportInventoryResponse>),
       ReportInventory,
       (google::cloud::osconfig::agentendpoint::v1::ReportInventoryRequest const&
            request),

--- a/google/cloud/osconfig/v1/mocks/mock_os_config_connection.h
+++ b/google/cloud/osconfig/v1/mocks/mock_os_config_connection.h
@@ -48,16 +48,16 @@ class MockOsConfigServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::osconfig::v1::PatchJob>, ExecutePatchJob,
+      (StatusOr<google::cloud::osconfig::v1::PatchJob>), ExecutePatchJob,
       (google::cloud::osconfig::v1::ExecutePatchJobRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::osconfig::v1::PatchJob>, GetPatchJob,
+  MOCK_METHOD((StatusOr<google::cloud::osconfig::v1::PatchJob>), GetPatchJob,
               (google::cloud::osconfig::v1::GetPatchJobRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::osconfig::v1::PatchJob>, CancelPatchJob,
+      (StatusOr<google::cloud::osconfig::v1::PatchJob>), CancelPatchJob,
       (google::cloud::osconfig::v1::CancelPatchJobRequest const& request),
       (override));
 
@@ -72,14 +72,14 @@ class MockOsConfigServiceConnection
       (google::cloud::osconfig::v1::ListPatchJobInstanceDetailsRequest request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::osconfig::v1::PatchDeployment>,
+  MOCK_METHOD((StatusOr<google::cloud::osconfig::v1::PatchDeployment>),
               CreatePatchDeployment,
               (google::cloud::osconfig::v1::CreatePatchDeploymentRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::osconfig::v1::PatchDeployment>,
+      (StatusOr<google::cloud::osconfig::v1::PatchDeployment>),
       GetPatchDeployment,
       (google::cloud::osconfig::v1::GetPatchDeploymentRequest const& request),
       (override));
@@ -95,19 +95,19 @@ class MockOsConfigServiceConnection
                    request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::osconfig::v1::PatchDeployment>,
+  MOCK_METHOD((StatusOr<google::cloud::osconfig::v1::PatchDeployment>),
               UpdatePatchDeployment,
               (google::cloud::osconfig::v1::UpdatePatchDeploymentRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::osconfig::v1::PatchDeployment>,
+      (StatusOr<google::cloud::osconfig::v1::PatchDeployment>),
       PausePatchDeployment,
       (google::cloud::osconfig::v1::PausePatchDeploymentRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::osconfig::v1::PatchDeployment>,
+  MOCK_METHOD((StatusOr<google::cloud::osconfig::v1::PatchDeployment>),
               ResumePatchDeployment,
               (google::cloud::osconfig::v1::ResumePatchDeploymentRequest const&
                    request),

--- a/google/cloud/osconfig/v1/mocks/mock_os_config_zonal_connection.h
+++ b/google/cloud/osconfig/v1/mocks/mock_os_config_zonal_connection.h
@@ -48,20 +48,20 @@ class MockOsConfigZonalServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::osconfig::v1::OSPolicyAssignment>>,
+      (future<StatusOr<google::cloud::osconfig::v1::OSPolicyAssignment>>),
       CreateOSPolicyAssignment,
       (google::cloud::osconfig::v1::CreateOSPolicyAssignmentRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::osconfig::v1::OSPolicyAssignment>>,
+      (future<StatusOr<google::cloud::osconfig::v1::OSPolicyAssignment>>),
       UpdateOSPolicyAssignment,
       (google::cloud::osconfig::v1::UpdateOSPolicyAssignmentRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::osconfig::v1::OSPolicyAssignment>,
+  MOCK_METHOD((StatusOr<google::cloud::osconfig::v1::OSPolicyAssignment>),
               GetOSPolicyAssignment,
               (google::cloud::osconfig::v1::GetOSPolicyAssignmentRequest const&
                    request),
@@ -81,15 +81,15 @@ class MockOsConfigZonalServiceConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::osconfig::v1::OSPolicyAssignmentOperationMetadata>>,
+      (future<StatusOr<
+           google::cloud::osconfig::v1::OSPolicyAssignmentOperationMetadata>>),
       DeleteOSPolicyAssignment,
       (google::cloud::osconfig::v1::DeleteOSPolicyAssignmentRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::osconfig::v1::OSPolicyAssignmentReport>,
+      (StatusOr<google::cloud::osconfig::v1::OSPolicyAssignmentReport>),
       GetOSPolicyAssignmentReport,
       (google::cloud::osconfig::v1::GetOSPolicyAssignmentReportRequest const&
            request),
@@ -102,7 +102,7 @@ class MockOsConfigZonalServiceConnection
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::osconfig::v1::Inventory>, GetInventory,
+  MOCK_METHOD((StatusOr<google::cloud::osconfig::v1::Inventory>), GetInventory,
               (google::cloud::osconfig::v1::GetInventoryRequest const& request),
               (override));
 
@@ -111,7 +111,7 @@ class MockOsConfigZonalServiceConnection
               (google::cloud::osconfig::v1::ListInventoriesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::osconfig::v1::VulnerabilityReport>,
+  MOCK_METHOD((StatusOr<google::cloud::osconfig::v1::VulnerabilityReport>),
               GetVulnerabilityReport,
               (google::cloud::osconfig::v1::GetVulnerabilityReportRequest const&
                    request),

--- a/google/cloud/oslogin/v1/mocks/mock_os_login_connection.h
+++ b/google/cloud/oslogin/v1/mocks/mock_os_login_connection.h
@@ -48,7 +48,7 @@ class MockOsLoginServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::oslogin::common::SshPublicKey>,
+      (StatusOr<google::cloud::oslogin::common::SshPublicKey>),
       CreateSshPublicKey,
       (google::cloud::oslogin::v1::CreateSshPublicKeyRequest const& request),
       (override));
@@ -64,23 +64,23 @@ class MockOsLoginServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::oslogin::v1::LoginProfile>, GetLoginProfile,
+      (StatusOr<google::cloud::oslogin::v1::LoginProfile>), GetLoginProfile,
       (google::cloud::oslogin::v1::GetLoginProfileRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::oslogin::common::SshPublicKey>, GetSshPublicKey,
+      (StatusOr<google::cloud::oslogin::common::SshPublicKey>), GetSshPublicKey,
       (google::cloud::oslogin::v1::GetSshPublicKeyRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::oslogin::v1::ImportSshPublicKeyResponse>,
+      (StatusOr<google::cloud::oslogin::v1::ImportSshPublicKeyResponse>),
       ImportSshPublicKey,
       (google::cloud::oslogin::v1::ImportSshPublicKeyRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::oslogin::common::SshPublicKey>,
+      (StatusOr<google::cloud::oslogin::common::SshPublicKey>),
       UpdateSshPublicKey,
       (google::cloud::oslogin::v1::UpdateSshPublicKeyRequest const& request),
       (override));

--- a/google/cloud/policysimulator/v1/mocks/mock_simulator_connection.h
+++ b/google/cloud/policysimulator/v1/mocks/mock_simulator_connection.h
@@ -47,12 +47,12 @@ class MockSimulatorConnection : public policysimulator_v1::SimulatorConnection {
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::policysimulator::v1::Replay>, GetReplay,
+      (StatusOr<google::cloud::policysimulator::v1::Replay>), GetReplay,
       (google::cloud::policysimulator::v1::GetReplayRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::policysimulator::v1::Replay>>,
+      (future<StatusOr<google::cloud::policysimulator::v1::Replay>>),
       CreateReplay,
       (google::cloud::policysimulator::v1::CreateReplayRequest const& request),
       (override));

--- a/google/cloud/policytroubleshooter/iam/v3/mocks/mock_policy_troubleshooter_connection.h
+++ b/google/cloud/policytroubleshooter/iam/v3/mocks/mock_policy_troubleshooter_connection.h
@@ -47,8 +47,8 @@ class MockPolicyTroubleshooterConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::policytroubleshooter::iam::v3::
-                           TroubleshootIamPolicyResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::policytroubleshooter::iam::v3::
+                            TroubleshootIamPolicyResponse>),
               TroubleshootIamPolicy,
               (google::cloud::policytroubleshooter::iam::v3::
                    TroubleshootIamPolicyRequest const& request),

--- a/google/cloud/policytroubleshooter/v1/mocks/mock_iam_checker_connection.h
+++ b/google/cloud/policytroubleshooter/v1/mocks/mock_iam_checker_connection.h
@@ -47,8 +47,8 @@ class MockIamCheckerConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::policytroubleshooter::v1::
-                           TroubleshootIamPolicyResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::policytroubleshooter::v1::
+                            TroubleshootIamPolicyResponse>),
               TroubleshootIamPolicy,
               (google::cloud::policytroubleshooter::v1::
                    TroubleshootIamPolicyRequest const& request),

--- a/google/cloud/privateca/v1/mocks/mock_certificate_authority_connection.h
+++ b/google/cloud/privateca/v1/mocks/mock_certificate_authority_connection.h
@@ -48,14 +48,14 @@ class MockCertificateAuthorityServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::security::privateca::v1::Certificate>,
+      (StatusOr<google::cloud::security::privateca::v1::Certificate>),
       CreateCertificate,
       (google::cloud::security::privateca::v1::CreateCertificateRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::security::privateca::v1::Certificate>,
+      (StatusOr<google::cloud::security::privateca::v1::Certificate>),
       GetCertificate,
       (google::cloud::security::privateca::v1::GetCertificateRequest const&
            request),
@@ -68,60 +68,60 @@ class MockCertificateAuthorityServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::security::privateca::v1::Certificate>,
+      (StatusOr<google::cloud::security::privateca::v1::Certificate>),
       RevokeCertificate,
       (google::cloud::security::privateca::v1::RevokeCertificateRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::security::privateca::v1::Certificate>,
+      (StatusOr<google::cloud::security::privateca::v1::Certificate>),
       UpdateCertificate,
       (google::cloud::security::privateca::v1::UpdateCertificateRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::security::privateca::v1::CertificateAuthority>>,
+      (future<StatusOr<
+           google::cloud::security::privateca::v1::CertificateAuthority>>),
       ActivateCertificateAuthority,
       (google::cloud::security::privateca::v1::
            ActivateCertificateAuthorityRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::security::privateca::v1::CertificateAuthority>>,
+      (future<StatusOr<
+           google::cloud::security::privateca::v1::CertificateAuthority>>),
       CreateCertificateAuthority,
       (google::cloud::security::privateca::v1::
            CreateCertificateAuthorityRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::security::privateca::v1::CertificateAuthority>>,
+      (future<StatusOr<
+           google::cloud::security::privateca::v1::CertificateAuthority>>),
       DisableCertificateAuthority,
       (google::cloud::security::privateca::v1::
            DisableCertificateAuthorityRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::security::privateca::v1::CertificateAuthority>>,
+      (future<StatusOr<
+           google::cloud::security::privateca::v1::CertificateAuthority>>),
       EnableCertificateAuthority,
       (google::cloud::security::privateca::v1::
            EnableCertificateAuthorityRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::security::privateca::v1::
-                           FetchCertificateAuthorityCsrResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::security::privateca::v1::
+                            FetchCertificateAuthorityCsrResponse>),
               FetchCertificateAuthorityCsr,
               (google::cloud::security::privateca::v1::
                    FetchCertificateAuthorityCsrRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::security::privateca::v1::CertificateAuthority>,
+      (StatusOr<google::cloud::security::privateca::v1::CertificateAuthority>),
       GetCertificateAuthority,
       (google::cloud::security::privateca::v1::
            GetCertificateAuthorityRequest const& request),
@@ -136,45 +136,45 @@ class MockCertificateAuthorityServiceConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::security::privateca::v1::CertificateAuthority>>,
+      (future<StatusOr<
+           google::cloud::security::privateca::v1::CertificateAuthority>>),
       UndeleteCertificateAuthority,
       (google::cloud::security::privateca::v1::
            UndeleteCertificateAuthorityRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::security::privateca::v1::CertificateAuthority>>,
+      (future<StatusOr<
+           google::cloud::security::privateca::v1::CertificateAuthority>>),
       DeleteCertificateAuthority,
       (google::cloud::security::privateca::v1::
            DeleteCertificateAuthorityRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::security::privateca::v1::CertificateAuthority>>,
+      (future<StatusOr<
+           google::cloud::security::privateca::v1::CertificateAuthority>>),
       UpdateCertificateAuthority,
       (google::cloud::security::privateca::v1::
            UpdateCertificateAuthorityRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::security::privateca::v1::CaPool>>,
+      (future<StatusOr<google::cloud::security::privateca::v1::CaPool>>),
       CreateCaPool,
       (google::cloud::security::privateca::v1::CreateCaPoolRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::security::privateca::v1::CaPool>>,
+      (future<StatusOr<google::cloud::security::privateca::v1::CaPool>>),
       UpdateCaPool,
       (google::cloud::security::privateca::v1::UpdateCaPoolRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::security::privateca::v1::CaPool>, GetCaPool,
+      (StatusOr<google::cloud::security::privateca::v1::CaPool>), GetCaPool,
       (google::cloud::security::privateca::v1::GetCaPoolRequest const& request),
       (override));
 
@@ -185,23 +185,23 @@ class MockCertificateAuthorityServiceConnection
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::security::privateca::v1::OperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::security::privateca::v1::OperationMetadata>>),
       DeleteCaPool,
       (google::cloud::security::privateca::v1::DeleteCaPoolRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::security::privateca::v1::FetchCaCertsResponse>,
+      (StatusOr<google::cloud::security::privateca::v1::FetchCaCertsResponse>),
       FetchCaCerts,
       (google::cloud::security::privateca::v1::FetchCaCertsRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::security::privateca::v1::CertificateRevocationList>,
+      (StatusOr<
+          google::cloud::security::privateca::v1::CertificateRevocationList>),
       GetCertificateRevocationList,
       (google::cloud::security::privateca::v1::
            GetCertificateRevocationListRequest const& request),
@@ -216,30 +216,31 @@ class MockCertificateAuthorityServiceConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::security::privateca::v1::CertificateRevocationList>>,
+      (future<StatusOr<
+           google::cloud::security::privateca::v1::CertificateRevocationList>>),
       UpdateCertificateRevocationList,
       (google::cloud::security::privateca::v1::
            UpdateCertificateRevocationListRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<
-                  google::cloud::security::privateca::v1::CertificateTemplate>>,
-              CreateCertificateTemplate,
-              (google::cloud::security::privateca::v1::
-                   CreateCertificateTemplateRequest const& request),
-              (override));
+  MOCK_METHOD(
+      (future<StatusOr<
+           google::cloud::security::privateca::v1::CertificateTemplate>>),
+      CreateCertificateTemplate,
+      (google::cloud::security::privateca::v1::
+           CreateCertificateTemplateRequest const& request),
+      (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::security::privateca::v1::OperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::security::privateca::v1::OperationMetadata>>),
       DeleteCertificateTemplate,
       (google::cloud::security::privateca::v1::
            DeleteCertificateTemplateRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::security::privateca::v1::CertificateTemplate>,
+      (StatusOr<google::cloud::security::privateca::v1::CertificateTemplate>),
       GetCertificateTemplate,
       (google::cloud::security::privateca::v1::
            GetCertificateTemplateRequest const& request),
@@ -253,12 +254,13 @@ class MockCertificateAuthorityServiceConnection
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<
-                  google::cloud::security::privateca::v1::CertificateTemplate>>,
-              UpdateCertificateTemplate,
-              (google::cloud::security::privateca::v1::
-                   UpdateCertificateTemplateRequest const& request),
-              (override));
+  MOCK_METHOD(
+      (future<StatusOr<
+           google::cloud::security::privateca::v1::CertificateTemplate>>),
+      UpdateCertificateTemplate,
+      (google::cloud::security::privateca::v1::
+           UpdateCertificateTemplateRequest const& request),
+      (override));
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/profiler/v2/mocks/mock_profiler_connection.h
+++ b/google/cloud/profiler/v2/mocks/mock_profiler_connection.h
@@ -47,20 +47,20 @@ class MockProfilerServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::devtools::cloudprofiler::v2::Profile>,
+  MOCK_METHOD((StatusOr<google::devtools::cloudprofiler::v2::Profile>),
               CreateProfile,
               (google::devtools::cloudprofiler::v2::CreateProfileRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::devtools::cloudprofiler::v2::Profile>,
+      (StatusOr<google::devtools::cloudprofiler::v2::Profile>),
       CreateOfflineProfile,
       (google::devtools::cloudprofiler::v2::CreateOfflineProfileRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::devtools::cloudprofiler::v2::Profile>,
+  MOCK_METHOD((StatusOr<google::devtools::cloudprofiler::v2::Profile>),
               UpdateProfile,
               (google::devtools::cloudprofiler::v2::UpdateProfileRequest const&
                    request),

--- a/google/cloud/pubsub/admin/mocks/mock_subscription_admin_connection.h
+++ b/google/cloud/pubsub/admin/mocks/mock_subscription_admin_connection.h
@@ -47,14 +47,14 @@ class MockSubscriptionAdminConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::pubsub::v1::Subscription>, CreateSubscription,
+  MOCK_METHOD((StatusOr<google::pubsub::v1::Subscription>), CreateSubscription,
               (google::pubsub::v1::Subscription const& request), (override));
 
-  MOCK_METHOD(StatusOr<google::pubsub::v1::Subscription>, GetSubscription,
+  MOCK_METHOD((StatusOr<google::pubsub::v1::Subscription>), GetSubscription,
               (google::pubsub::v1::GetSubscriptionRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::pubsub::v1::Subscription>, UpdateSubscription,
+  MOCK_METHOD((StatusOr<google::pubsub::v1::Subscription>), UpdateSubscription,
               (google::pubsub::v1::UpdateSubscriptionRequest const& request),
               (override));
 
@@ -71,18 +71,18 @@ class MockSubscriptionAdminConnection
               (google::pubsub::v1::ModifyPushConfigRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::pubsub::v1::Snapshot>, GetSnapshot,
+  MOCK_METHOD((StatusOr<google::pubsub::v1::Snapshot>), GetSnapshot,
               (google::pubsub::v1::GetSnapshotRequest const& request),
               (override));
 
   MOCK_METHOD((StreamRange<google::pubsub::v1::Snapshot>), ListSnapshots,
               (google::pubsub::v1::ListSnapshotsRequest request), (override));
 
-  MOCK_METHOD(StatusOr<google::pubsub::v1::Snapshot>, CreateSnapshot,
+  MOCK_METHOD((StatusOr<google::pubsub::v1::Snapshot>), CreateSnapshot,
               (google::pubsub::v1::CreateSnapshotRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::pubsub::v1::Snapshot>, UpdateSnapshot,
+  MOCK_METHOD((StatusOr<google::pubsub::v1::Snapshot>), UpdateSnapshot,
               (google::pubsub::v1::UpdateSnapshotRequest const& request),
               (override));
 
@@ -90,7 +90,7 @@ class MockSubscriptionAdminConnection
               (google::pubsub::v1::DeleteSnapshotRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::pubsub::v1::SeekResponse>, Seek,
+  MOCK_METHOD((StatusOr<google::pubsub::v1::SeekResponse>), Seek,
               (google::pubsub::v1::SeekRequest const& request), (override));
 };
 

--- a/google/cloud/pubsub/admin/mocks/mock_topic_admin_connection.h
+++ b/google/cloud/pubsub/admin/mocks/mock_topic_admin_connection.h
@@ -46,14 +46,14 @@ class MockTopicAdminConnection : public pubsub_admin::TopicAdminConnection {
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::pubsub::v1::Topic>, CreateTopic,
+  MOCK_METHOD((StatusOr<google::pubsub::v1::Topic>), CreateTopic,
               (google::pubsub::v1::Topic const& request), (override));
 
-  MOCK_METHOD(StatusOr<google::pubsub::v1::Topic>, UpdateTopic,
+  MOCK_METHOD((StatusOr<google::pubsub::v1::Topic>), UpdateTopic,
               (google::pubsub::v1::UpdateTopicRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::pubsub::v1::Topic>, GetTopic,
+  MOCK_METHOD((StatusOr<google::pubsub::v1::Topic>), GetTopic,
               (google::pubsub::v1::GetTopicRequest const& request), (override));
 
   MOCK_METHOD((StreamRange<google::pubsub::v1::Topic>), ListTopics,
@@ -71,7 +71,7 @@ class MockTopicAdminConnection : public pubsub_admin::TopicAdminConnection {
               (google::pubsub::v1::DeleteTopicRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::pubsub::v1::DetachSubscriptionResponse>,
+  MOCK_METHOD((StatusOr<google::pubsub::v1::DetachSubscriptionResponse>),
               DetachSubscription,
               (google::pubsub::v1::DetachSubscriptionRequest const& request),
               (override));

--- a/google/cloud/pubsub/mocks/mock_schema_connection.h
+++ b/google/cloud/pubsub/mocks/mock_schema_connection.h
@@ -46,11 +46,11 @@ class MockSchemaServiceConnection : public pubsub::SchemaServiceConnection {
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::pubsub::v1::Schema>, CreateSchema,
+  MOCK_METHOD((StatusOr<google::pubsub::v1::Schema>), CreateSchema,
               (google::pubsub::v1::CreateSchemaRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::pubsub::v1::Schema>, GetSchema,
+  MOCK_METHOD((StatusOr<google::pubsub::v1::Schema>), GetSchema,
               (google::pubsub::v1::GetSchemaRequest const& request),
               (override));
 
@@ -61,15 +61,15 @@ class MockSchemaServiceConnection : public pubsub::SchemaServiceConnection {
               (google::pubsub::v1::ListSchemaRevisionsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::pubsub::v1::Schema>, CommitSchema,
+  MOCK_METHOD((StatusOr<google::pubsub::v1::Schema>), CommitSchema,
               (google::pubsub::v1::CommitSchemaRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::pubsub::v1::Schema>, RollbackSchema,
+  MOCK_METHOD((StatusOr<google::pubsub::v1::Schema>), RollbackSchema,
               (google::pubsub::v1::RollbackSchemaRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::pubsub::v1::Schema>, DeleteSchemaRevision,
+  MOCK_METHOD((StatusOr<google::pubsub::v1::Schema>), DeleteSchemaRevision,
               (google::pubsub::v1::DeleteSchemaRevisionRequest const& request),
               (override));
 
@@ -77,12 +77,12 @@ class MockSchemaServiceConnection : public pubsub::SchemaServiceConnection {
               (google::pubsub::v1::DeleteSchemaRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::pubsub::v1::ValidateSchemaResponse>,
+  MOCK_METHOD((StatusOr<google::pubsub::v1::ValidateSchemaResponse>),
               ValidateSchema,
               (google::pubsub::v1::ValidateSchemaRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::pubsub::v1::ValidateMessageResponse>,
+  MOCK_METHOD((StatusOr<google::pubsub::v1::ValidateMessageResponse>),
               ValidateMessage,
               (google::pubsub::v1::ValidateMessageRequest const& request),
               (override));

--- a/google/cloud/pubsublite/mocks/mock_admin_connection.h
+++ b/google/cloud/pubsublite/mocks/mock_admin_connection.h
@@ -47,16 +47,16 @@ class MockAdminServiceConnection : public pubsublite::AdminServiceConnection {
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::pubsublite::v1::Topic>, CreateTopic,
+      (StatusOr<google::cloud::pubsublite::v1::Topic>), CreateTopic,
       (google::cloud::pubsublite::v1::CreateTopicRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::pubsublite::v1::Topic>, GetTopic,
+  MOCK_METHOD((StatusOr<google::cloud::pubsublite::v1::Topic>), GetTopic,
               (google::cloud::pubsublite::v1::GetTopicRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::pubsublite::v1::TopicPartitions>,
+      (StatusOr<google::cloud::pubsublite::v1::TopicPartitions>),
       GetTopicPartitions,
       (google::cloud::pubsublite::v1::GetTopicPartitionsRequest const& request),
       (override));
@@ -66,7 +66,7 @@ class MockAdminServiceConnection : public pubsublite::AdminServiceConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::pubsublite::v1::Topic>, UpdateTopic,
+      (StatusOr<google::cloud::pubsublite::v1::Topic>), UpdateTopic,
       (google::cloud::pubsublite::v1::UpdateTopicRequest const& request),
       (override));
 
@@ -81,12 +81,13 @@ class MockAdminServiceConnection : public pubsublite::AdminServiceConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::pubsublite::v1::Subscription>, CreateSubscription,
+      (StatusOr<google::cloud::pubsublite::v1::Subscription>),
+      CreateSubscription,
       (google::cloud::pubsublite::v1::CreateSubscriptionRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::pubsublite::v1::Subscription>, GetSubscription,
+      (StatusOr<google::cloud::pubsublite::v1::Subscription>), GetSubscription,
       (google::cloud::pubsublite::v1::GetSubscriptionRequest const& request),
       (override));
 
@@ -96,7 +97,8 @@ class MockAdminServiceConnection : public pubsublite::AdminServiceConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::pubsublite::v1::Subscription>, UpdateSubscription,
+      (StatusOr<google::cloud::pubsublite::v1::Subscription>),
+      UpdateSubscription,
       (google::cloud::pubsublite::v1::UpdateSubscriptionRequest const& request),
       (override));
 
@@ -106,18 +108,19 @@ class MockAdminServiceConnection : public pubsublite::AdminServiceConnection {
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::pubsublite::v1::SeekSubscriptionResponse>>,
+      (future<
+          StatusOr<google::cloud::pubsublite::v1::SeekSubscriptionResponse>>),
       SeekSubscription,
       (google::cloud::pubsublite::v1::SeekSubscriptionRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::pubsublite::v1::Reservation>, CreateReservation,
+      (StatusOr<google::cloud::pubsublite::v1::Reservation>), CreateReservation,
       (google::cloud::pubsublite::v1::CreateReservationRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::pubsublite::v1::Reservation>, GetReservation,
+      (StatusOr<google::cloud::pubsublite::v1::Reservation>), GetReservation,
       (google::cloud::pubsublite::v1::GetReservationRequest const& request),
       (override));
 
@@ -127,7 +130,7 @@ class MockAdminServiceConnection : public pubsublite::AdminServiceConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::pubsublite::v1::Reservation>, UpdateReservation,
+      (StatusOr<google::cloud::pubsublite::v1::Reservation>), UpdateReservation,
       (google::cloud::pubsublite::v1::UpdateReservationRequest const& request),
       (override));
 
@@ -142,7 +145,7 @@ class MockAdminServiceConnection : public pubsublite::AdminServiceConnection {
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::pubsublite::v1::TopicPartitions>>,
+      (future<StatusOr<google::cloud::pubsublite::v1::TopicPartitions>>),
       AsyncGetTopicPartitions,
       (google::cloud::pubsublite::v1::GetTopicPartitionsRequest const& request),
       (override));

--- a/google/cloud/pubsublite/mocks/mock_topic_stats_connection.h
+++ b/google/cloud/pubsublite/mocks/mock_topic_stats_connection.h
@@ -48,20 +48,20 @@ class MockTopicStatsServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::pubsublite::v1::ComputeMessageStatsResponse>,
+      (StatusOr<google::cloud::pubsublite::v1::ComputeMessageStatsResponse>),
       ComputeMessageStats,
       (google::cloud::pubsublite::v1::ComputeMessageStatsRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::pubsublite::v1::ComputeHeadCursorResponse>,
+      (StatusOr<google::cloud::pubsublite::v1::ComputeHeadCursorResponse>),
       ComputeHeadCursor,
       (google::cloud::pubsublite::v1::ComputeHeadCursorRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::pubsublite::v1::ComputeTimeCursorResponse>,
+      (StatusOr<google::cloud::pubsublite::v1::ComputeTimeCursorResponse>),
       ComputeTimeCursor,
       (google::cloud::pubsublite::v1::ComputeTimeCursorRequest const& request),
       (override));

--- a/google/cloud/rapidmigrationassessment/v1/mocks/mock_rapid_migration_assessment_connection.h
+++ b/google/cloud/rapidmigrationassessment/v1/mocks/mock_rapid_migration_assessment_connection.h
@@ -49,21 +49,23 @@ class MockRapidMigrationAssessmentConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::rapidmigrationassessment::v1::Collector>>,
+      (future<
+          StatusOr<google::cloud::rapidmigrationassessment::v1::Collector>>),
       CreateCollector,
       (google::cloud::rapidmigrationassessment::v1::
            CreateCollectorRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::rapidmigrationassessment::v1::Annotation>>,
+      (future<
+          StatusOr<google::cloud::rapidmigrationassessment::v1::Annotation>>),
       CreateAnnotation,
       (google::cloud::rapidmigrationassessment::v1::
            CreateAnnotationRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::rapidmigrationassessment::v1::Annotation>,
+      (StatusOr<google::cloud::rapidmigrationassessment::v1::Annotation>),
       GetAnnotation,
       (google::cloud::rapidmigrationassessment::v1::GetAnnotationRequest const&
            request),
@@ -77,42 +79,47 @@ class MockRapidMigrationAssessmentConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::rapidmigrationassessment::v1::Collector>,
+      (StatusOr<google::cloud::rapidmigrationassessment::v1::Collector>),
       GetCollector,
       (google::cloud::rapidmigrationassessment::v1::GetCollectorRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::rapidmigrationassessment::v1::Collector>>,
+      (future<
+          StatusOr<google::cloud::rapidmigrationassessment::v1::Collector>>),
       UpdateCollector,
       (google::cloud::rapidmigrationassessment::v1::
            UpdateCollectorRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::rapidmigrationassessment::v1::Collector>>,
+      (future<
+          StatusOr<google::cloud::rapidmigrationassessment::v1::Collector>>),
       DeleteCollector,
       (google::cloud::rapidmigrationassessment::v1::
            DeleteCollectorRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::rapidmigrationassessment::v1::Collector>>,
+      (future<
+          StatusOr<google::cloud::rapidmigrationassessment::v1::Collector>>),
       ResumeCollector,
       (google::cloud::rapidmigrationassessment::v1::
            ResumeCollectorRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::rapidmigrationassessment::v1::Collector>>,
+      (future<
+          StatusOr<google::cloud::rapidmigrationassessment::v1::Collector>>),
       RegisterCollector,
       (google::cloud::rapidmigrationassessment::v1::
            RegisterCollectorRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::rapidmigrationassessment::v1::Collector>>,
+      (future<
+          StatusOr<google::cloud::rapidmigrationassessment::v1::Collector>>),
       PauseCollector,
       (google::cloud::rapidmigrationassessment::v1::PauseCollectorRequest const&
            request),

--- a/google/cloud/recaptchaenterprise/v1/mocks/mock_recaptcha_enterprise_connection.h
+++ b/google/cloud/recaptchaenterprise/v1/mocks/mock_recaptcha_enterprise_connection.h
@@ -48,22 +48,22 @@ class MockRecaptchaEnterpriseServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::recaptchaenterprise::v1::Assessment>,
+      (StatusOr<google::cloud::recaptchaenterprise::v1::Assessment>),
       CreateAssessment,
       (google::cloud::recaptchaenterprise::v1::CreateAssessmentRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::recaptchaenterprise::v1::AnnotateAssessmentResponse>,
+      (StatusOr<
+          google::cloud::recaptchaenterprise::v1::AnnotateAssessmentResponse>),
       AnnotateAssessment,
       (google::cloud::recaptchaenterprise::v1::AnnotateAssessmentRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::recaptchaenterprise::v1::Key>, CreateKey,
+      (StatusOr<google::cloud::recaptchaenterprise::v1::Key>), CreateKey,
       (google::cloud::recaptchaenterprise::v1::CreateKeyRequest const& request),
       (override));
 
@@ -72,20 +72,20 @@ class MockRecaptchaEnterpriseServiceConnection
               (google::cloud::recaptchaenterprise::v1::ListKeysRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::recaptchaenterprise::v1::
-                           RetrieveLegacySecretKeyResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::recaptchaenterprise::v1::
+                            RetrieveLegacySecretKeyResponse>),
               RetrieveLegacySecretKey,
               (google::cloud::recaptchaenterprise::v1::
                    RetrieveLegacySecretKeyRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::recaptchaenterprise::v1::Key>, GetKey,
+      (StatusOr<google::cloud::recaptchaenterprise::v1::Key>), GetKey,
       (google::cloud::recaptchaenterprise::v1::GetKeyRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::recaptchaenterprise::v1::Key>, UpdateKey,
+      (StatusOr<google::cloud::recaptchaenterprise::v1::Key>), UpdateKey,
       (google::cloud::recaptchaenterprise::v1::UpdateKeyRequest const& request),
       (override));
 
@@ -94,22 +94,24 @@ class MockRecaptchaEnterpriseServiceConnection
       (google::cloud::recaptchaenterprise::v1::DeleteKeyRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::recaptchaenterprise::v1::Key>, MigrateKey,
+  MOCK_METHOD((StatusOr<google::cloud::recaptchaenterprise::v1::Key>),
+              MigrateKey,
               (google::cloud::recaptchaenterprise::v1::MigrateKeyRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::recaptchaenterprise::v1::Metrics>,
+  MOCK_METHOD((StatusOr<google::cloud::recaptchaenterprise::v1::Metrics>),
               GetMetrics,
               (google::cloud::recaptchaenterprise::v1::GetMetricsRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::recaptchaenterprise::v1::FirewallPolicy>,
-              CreateFirewallPolicy,
-              (google::cloud::recaptchaenterprise::v1::
-                   CreateFirewallPolicyRequest const& request),
-              (override));
+  MOCK_METHOD(
+      (StatusOr<google::cloud::recaptchaenterprise::v1::FirewallPolicy>),
+      CreateFirewallPolicy,
+      (google::cloud::recaptchaenterprise::v1::
+           CreateFirewallPolicyRequest const& request),
+      (override));
 
   MOCK_METHOD(
       (StreamRange<google::cloud::recaptchaenterprise::v1::FirewallPolicy>),
@@ -119,25 +121,26 @@ class MockRecaptchaEnterpriseServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::recaptchaenterprise::v1::FirewallPolicy>,
+      (StatusOr<google::cloud::recaptchaenterprise::v1::FirewallPolicy>),
       GetFirewallPolicy,
       (google::cloud::recaptchaenterprise::v1::GetFirewallPolicyRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::recaptchaenterprise::v1::FirewallPolicy>,
-              UpdateFirewallPolicy,
-              (google::cloud::recaptchaenterprise::v1::
-                   UpdateFirewallPolicyRequest const& request),
-              (override));
+  MOCK_METHOD(
+      (StatusOr<google::cloud::recaptchaenterprise::v1::FirewallPolicy>),
+      UpdateFirewallPolicy,
+      (google::cloud::recaptchaenterprise::v1::
+           UpdateFirewallPolicyRequest const& request),
+      (override));
 
   MOCK_METHOD(Status, DeleteFirewallPolicy,
               (google::cloud::recaptchaenterprise::v1::
                    DeleteFirewallPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::recaptchaenterprise::v1::
-                           ReorderFirewallPoliciesResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::recaptchaenterprise::v1::
+                            ReorderFirewallPoliciesResponse>),
               ReorderFirewallPolicies,
               (google::cloud::recaptchaenterprise::v1::
                    ReorderFirewallPoliciesRequest const& request),

--- a/google/cloud/recommender/v1/mocks/mock_recommender_connection.h
+++ b/google/cloud/recommender/v1/mocks/mock_recommender_connection.h
@@ -52,11 +52,11 @@ class MockRecommenderConnection : public recommender_v1::RecommenderConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::recommender::v1::Insight>, GetInsight,
+      (StatusOr<google::cloud::recommender::v1::Insight>), GetInsight,
       (google::cloud::recommender::v1::GetInsightRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::recommender::v1::Insight>,
+  MOCK_METHOD((StatusOr<google::cloud::recommender::v1::Insight>),
               MarkInsightAccepted,
               (google::cloud::recommender::v1::MarkInsightAcceptedRequest const&
                    request),
@@ -69,62 +69,62 @@ class MockRecommenderConnection : public recommender_v1::RecommenderConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::recommender::v1::Recommendation>,
+      (StatusOr<google::cloud::recommender::v1::Recommendation>),
       GetRecommendation,
       (google::cloud::recommender::v1::GetRecommendationRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::recommender::v1::Recommendation>,
+      (StatusOr<google::cloud::recommender::v1::Recommendation>),
       MarkRecommendationDismissed,
       (google::cloud::recommender::v1::MarkRecommendationDismissedRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::recommender::v1::Recommendation>,
+      (StatusOr<google::cloud::recommender::v1::Recommendation>),
       MarkRecommendationClaimed,
       (google::cloud::recommender::v1::MarkRecommendationClaimedRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::recommender::v1::Recommendation>,
+      (StatusOr<google::cloud::recommender::v1::Recommendation>),
       MarkRecommendationSucceeded,
       (google::cloud::recommender::v1::MarkRecommendationSucceededRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::recommender::v1::Recommendation>,
+      (StatusOr<google::cloud::recommender::v1::Recommendation>),
       MarkRecommendationFailed,
       (google::cloud::recommender::v1::MarkRecommendationFailedRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::recommender::v1::RecommenderConfig>,
+      (StatusOr<google::cloud::recommender::v1::RecommenderConfig>),
       GetRecommenderConfig,
       (google::cloud::recommender::v1::GetRecommenderConfigRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::recommender::v1::RecommenderConfig>,
+      (StatusOr<google::cloud::recommender::v1::RecommenderConfig>),
       UpdateRecommenderConfig,
       (google::cloud::recommender::v1::UpdateRecommenderConfigRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::recommender::v1::InsightTypeConfig>,
+      (StatusOr<google::cloud::recommender::v1::InsightTypeConfig>),
       GetInsightTypeConfig,
       (google::cloud::recommender::v1::GetInsightTypeConfigRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::recommender::v1::InsightTypeConfig>,
+      (StatusOr<google::cloud::recommender::v1::InsightTypeConfig>),
       UpdateInsightTypeConfig,
       (google::cloud::recommender::v1::UpdateInsightTypeConfigRequest const&
            request),

--- a/google/cloud/redis/cluster/v1/mocks/mock_cloud_redis_cluster_connection.h
+++ b/google/cloud/redis/cluster/v1/mocks/mock_cloud_redis_cluster_connection.h
@@ -53,23 +53,23 @@ class MockCloudRedisClusterConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::redis::cluster::v1::Cluster>, GetCluster,
+      (StatusOr<google::cloud::redis::cluster::v1::Cluster>), GetCluster,
       (google::cloud::redis::cluster::v1::GetClusterRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::redis::cluster::v1::Cluster>>,
+      (future<StatusOr<google::cloud::redis::cluster::v1::Cluster>>),
       UpdateCluster,
       (google::cloud::redis::cluster::v1::UpdateClusterRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::protobuf::Any>>, DeleteCluster,
+      (future<StatusOr<google::protobuf::Any>>), DeleteCluster,
       (google::cloud::redis::cluster::v1::DeleteClusterRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::redis::cluster::v1::Cluster>>,
+      (future<StatusOr<google::cloud::redis::cluster::v1::Cluster>>),
       CreateCluster,
       (google::cloud::redis::cluster::v1::CreateClusterRequest const& request),
       (override));

--- a/google/cloud/redis/v1/mocks/mock_cloud_redis_connection.h
+++ b/google/cloud/redis/v1/mocks/mock_cloud_redis_connection.h
@@ -50,53 +50,53 @@ class MockCloudRedisConnection : public redis_v1::CloudRedisConnection {
               (google::cloud::redis::v1::ListInstancesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::redis::v1::Instance>, GetInstance,
+  MOCK_METHOD((StatusOr<google::cloud::redis::v1::Instance>), GetInstance,
               (google::cloud::redis::v1::GetInstanceRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::redis::v1::InstanceAuthString>,
+      (StatusOr<google::cloud::redis::v1::InstanceAuthString>),
       GetInstanceAuthString,
       (google::cloud::redis::v1::GetInstanceAuthStringRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::redis::v1::Instance>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::redis::v1::Instance>>),
               CreateInstance,
               (google::cloud::redis::v1::CreateInstanceRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::redis::v1::Instance>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::redis::v1::Instance>>),
               UpdateInstance,
               (google::cloud::redis::v1::UpdateInstanceRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::redis::v1::Instance>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::redis::v1::Instance>>),
               UpgradeInstance,
               (google::cloud::redis::v1::UpgradeInstanceRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::redis::v1::Instance>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::redis::v1::Instance>>),
               ImportInstance,
               (google::cloud::redis::v1::ImportInstanceRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::redis::v1::Instance>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::redis::v1::Instance>>),
               ExportInstance,
               (google::cloud::redis::v1::ExportInstanceRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::redis::v1::Instance>>, FailoverInstance,
+      (future<StatusOr<google::cloud::redis::v1::Instance>>), FailoverInstance,
       (google::cloud::redis::v1::FailoverInstanceRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::redis::v1::OperationMetadata>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::redis::v1::OperationMetadata>>),
               DeleteInstance,
               (google::cloud::redis::v1::DeleteInstanceRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::redis::v1::Instance>>,
+      (future<StatusOr<google::cloud::redis::v1::Instance>>),
       RescheduleMaintenance,
       (google::cloud::redis::v1::RescheduleMaintenanceRequest const& request),
       (override));

--- a/google/cloud/resourcemanager/v3/mocks/mock_folders_connection.h
+++ b/google/cloud/resourcemanager/v3/mocks/mock_folders_connection.h
@@ -47,7 +47,7 @@ class MockFoldersConnection : public resourcemanager_v3::FoldersConnection {
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::resourcemanager::v3::Folder>, GetFolder,
+      (StatusOr<google::cloud::resourcemanager::v3::Folder>), GetFolder,
       (google::cloud::resourcemanager::v3::GetFolderRequest const& request),
       (override));
 
@@ -62,43 +62,44 @@ class MockFoldersConnection : public resourcemanager_v3::FoldersConnection {
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::resourcemanager::v3::Folder>>,
+      (future<StatusOr<google::cloud::resourcemanager::v3::Folder>>),
       CreateFolder,
       (google::cloud::resourcemanager::v3::CreateFolderRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::resourcemanager::v3::Folder>>,
+      (future<StatusOr<google::cloud::resourcemanager::v3::Folder>>),
       UpdateFolder,
       (google::cloud::resourcemanager::v3::UpdateFolderRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::resourcemanager::v3::Folder>>, MoveFolder,
+      (future<StatusOr<google::cloud::resourcemanager::v3::Folder>>),
+      MoveFolder,
       (google::cloud::resourcemanager::v3::MoveFolderRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::resourcemanager::v3::Folder>>,
+      (future<StatusOr<google::cloud::resourcemanager::v3::Folder>>),
       DeleteFolder,
       (google::cloud::resourcemanager::v3::DeleteFolderRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::resourcemanager::v3::Folder>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::resourcemanager::v3::Folder>>),
               UndeleteFolder,
               (google::cloud::resourcemanager::v3::UndeleteFolderRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), GetIamPolicy,
               (google::iam::v1::GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), SetIamPolicy,
               (google::iam::v1::SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD((StatusOr<google::iam::v1::TestIamPermissionsResponse>),
               TestIamPermissions,
               (google::iam::v1::TestIamPermissionsRequest const& request),
               (override));

--- a/google/cloud/resourcemanager/v3/mocks/mock_organizations_connection.h
+++ b/google/cloud/resourcemanager/v3/mocks/mock_organizations_connection.h
@@ -47,7 +47,7 @@ class MockOrganizationsConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::resourcemanager::v3::Organization>,
+  MOCK_METHOD((StatusOr<google::cloud::resourcemanager::v3::Organization>),
               GetOrganization,
               (google::cloud::resourcemanager::v3::GetOrganizationRequest const&
                    request),
@@ -59,15 +59,15 @@ class MockOrganizationsConnection
       (google::cloud::resourcemanager::v3::SearchOrganizationsRequest request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), GetIamPolicy,
               (google::iam::v1::GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), SetIamPolicy,
               (google::iam::v1::SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD((StatusOr<google::iam::v1::TestIamPermissionsResponse>),
               TestIamPermissions,
               (google::iam::v1::TestIamPermissionsRequest const& request),
               (override));

--- a/google/cloud/resourcemanager/v3/mocks/mock_projects_connection.h
+++ b/google/cloud/resourcemanager/v3/mocks/mock_projects_connection.h
@@ -47,7 +47,7 @@ class MockProjectsConnection : public resourcemanager_v3::ProjectsConnection {
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::resourcemanager::v3::Project>, GetProject,
+      (StatusOr<google::cloud::resourcemanager::v3::Project>), GetProject,
       (google::cloud::resourcemanager::v3::GetProjectRequest const& request),
       (override));
 
@@ -63,44 +63,44 @@ class MockProjectsConnection : public resourcemanager_v3::ProjectsConnection {
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::resourcemanager::v3::Project>>,
+      (future<StatusOr<google::cloud::resourcemanager::v3::Project>>),
       CreateProject,
       (google::cloud::resourcemanager::v3::CreateProjectRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::resourcemanager::v3::Project>>,
+      (future<StatusOr<google::cloud::resourcemanager::v3::Project>>),
       UpdateProject,
       (google::cloud::resourcemanager::v3::UpdateProjectRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::resourcemanager::v3::Project>>,
+      (future<StatusOr<google::cloud::resourcemanager::v3::Project>>),
       MoveProject,
       (google::cloud::resourcemanager::v3::MoveProjectRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::resourcemanager::v3::Project>>,
+      (future<StatusOr<google::cloud::resourcemanager::v3::Project>>),
       DeleteProject,
       (google::cloud::resourcemanager::v3::DeleteProjectRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::resourcemanager::v3::Project>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::resourcemanager::v3::Project>>),
               UndeleteProject,
               (google::cloud::resourcemanager::v3::UndeleteProjectRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), GetIamPolicy,
               (google::iam::v1::GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), SetIamPolicy,
               (google::iam::v1::SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD((StatusOr<google::iam::v1::TestIamPermissionsResponse>),
               TestIamPermissions,
               (google::iam::v1::TestIamPermissionsRequest const& request),
               (override));

--- a/google/cloud/resourcemanager/v3/mocks/mock_tag_bindings_connection.h
+++ b/google/cloud/resourcemanager/v3/mocks/mock_tag_bindings_connection.h
@@ -54,15 +54,15 @@ class MockTagBindingsConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::resourcemanager::v3::TagBinding>>,
+      (future<StatusOr<google::cloud::resourcemanager::v3::TagBinding>>),
       CreateTagBinding,
       (google::cloud::resourcemanager::v3::CreateTagBindingRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::resourcemanager::v3::DeleteTagBindingMetadata>>,
+      (future<StatusOr<
+           google::cloud::resourcemanager::v3::DeleteTagBindingMetadata>>),
       DeleteTagBinding,
       (google::cloud::resourcemanager::v3::DeleteTagBindingRequest const&
            request),

--- a/google/cloud/resourcemanager/v3/mocks/mock_tag_holds_connection.h
+++ b/google/cloud/resourcemanager/v3/mocks/mock_tag_holds_connection.h
@@ -47,14 +47,14 @@ class MockTagHoldsConnection : public resourcemanager_v3::TagHoldsConnection {
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::resourcemanager::v3::TagHold>>,
+      (future<StatusOr<google::cloud::resourcemanager::v3::TagHold>>),
       CreateTagHold,
       (google::cloud::resourcemanager::v3::CreateTagHoldRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::resourcemanager::v3::DeleteTagHoldMetadata>>,
+      (future<
+          StatusOr<google::cloud::resourcemanager::v3::DeleteTagHoldMetadata>>),
       DeleteTagHold,
       (google::cloud::resourcemanager::v3::DeleteTagHoldRequest const& request),
       (override));

--- a/google/cloud/resourcemanager/v3/mocks/mock_tag_keys_connection.h
+++ b/google/cloud/resourcemanager/v3/mocks/mock_tag_keys_connection.h
@@ -52,43 +52,44 @@ class MockTagKeysConnection : public resourcemanager_v3::TagKeysConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::resourcemanager::v3::TagKey>, GetTagKey,
+      (StatusOr<google::cloud::resourcemanager::v3::TagKey>), GetTagKey,
       (google::cloud::resourcemanager::v3::GetTagKeyRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::resourcemanager::v3::TagKey>, GetNamespacedTagKey,
+      (StatusOr<google::cloud::resourcemanager::v3::TagKey>),
+      GetNamespacedTagKey,
       (google::cloud::resourcemanager::v3::GetNamespacedTagKeyRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::resourcemanager::v3::TagKey>>,
+      (future<StatusOr<google::cloud::resourcemanager::v3::TagKey>>),
       CreateTagKey,
       (google::cloud::resourcemanager::v3::CreateTagKeyRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::resourcemanager::v3::TagKey>>,
+      (future<StatusOr<google::cloud::resourcemanager::v3::TagKey>>),
       UpdateTagKey,
       (google::cloud::resourcemanager::v3::UpdateTagKeyRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::resourcemanager::v3::TagKey>>,
+      (future<StatusOr<google::cloud::resourcemanager::v3::TagKey>>),
       DeleteTagKey,
       (google::cloud::resourcemanager::v3::DeleteTagKeyRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), GetIamPolicy,
               (google::iam::v1::GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), SetIamPolicy,
               (google::iam::v1::SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD((StatusOr<google::iam::v1::TestIamPermissionsResponse>),
               TestIamPermissions,
               (google::iam::v1::TestIamPermissionsRequest const& request),
               (override));

--- a/google/cloud/resourcemanager/v3/mocks/mock_tag_values_connection.h
+++ b/google/cloud/resourcemanager/v3/mocks/mock_tag_values_connection.h
@@ -53,44 +53,44 @@ class MockTagValuesConnection : public resourcemanager_v3::TagValuesConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::resourcemanager::v3::TagValue>, GetTagValue,
+      (StatusOr<google::cloud::resourcemanager::v3::TagValue>), GetTagValue,
       (google::cloud::resourcemanager::v3::GetTagValueRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::resourcemanager::v3::TagValue>,
+      (StatusOr<google::cloud::resourcemanager::v3::TagValue>),
       GetNamespacedTagValue,
       (google::cloud::resourcemanager::v3::GetNamespacedTagValueRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::resourcemanager::v3::TagValue>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::resourcemanager::v3::TagValue>>),
               CreateTagValue,
               (google::cloud::resourcemanager::v3::CreateTagValueRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::resourcemanager::v3::TagValue>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::resourcemanager::v3::TagValue>>),
               UpdateTagValue,
               (google::cloud::resourcemanager::v3::UpdateTagValueRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::resourcemanager::v3::TagValue>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::resourcemanager::v3::TagValue>>),
               DeleteTagValue,
               (google::cloud::resourcemanager::v3::DeleteTagValueRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), GetIamPolicy,
               (google::iam::v1::GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), SetIamPolicy,
               (google::iam::v1::SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD((StatusOr<google::iam::v1::TestIamPermissionsResponse>),
               TestIamPermissions,
               (google::iam::v1::TestIamPermissionsRequest const& request),
               (override));

--- a/google/cloud/resourcesettings/v1/mocks/mock_resource_settings_connection.h
+++ b/google/cloud/resourcesettings/v1/mocks/mock_resource_settings_connection.h
@@ -53,11 +53,11 @@ class MockResourceSettingsServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::resourcesettings::v1::Setting>, GetSetting,
+      (StatusOr<google::cloud::resourcesettings::v1::Setting>), GetSetting,
       (google::cloud::resourcesettings::v1::GetSettingRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::resourcesettings::v1::Setting>,
+  MOCK_METHOD((StatusOr<google::cloud::resourcesettings::v1::Setting>),
               UpdateSetting,
               (google::cloud::resourcesettings::v1::UpdateSettingRequest const&
                    request),

--- a/google/cloud/retail/v2/mocks/mock_catalog_connection.h
+++ b/google/cloud/retail/v2/mocks/mock_catalog_connection.h
@@ -51,7 +51,7 @@ class MockCatalogServiceConnection
               (google::cloud::retail::v2::ListCatalogsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::retail::v2::Catalog>, UpdateCatalog,
+  MOCK_METHOD((StatusOr<google::cloud::retail::v2::Catalog>), UpdateCatalog,
               (google::cloud::retail::v2::UpdateCatalogRequest const& request),
               (override));
 
@@ -61,48 +61,48 @@ class MockCatalogServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::retail::v2::GetDefaultBranchResponse>,
+      (StatusOr<google::cloud::retail::v2::GetDefaultBranchResponse>),
       GetDefaultBranch,
       (google::cloud::retail::v2::GetDefaultBranchRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::retail::v2::CompletionConfig>,
+      (StatusOr<google::cloud::retail::v2::CompletionConfig>),
       GetCompletionConfig,
       (google::cloud::retail::v2::GetCompletionConfigRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::retail::v2::CompletionConfig>,
+      (StatusOr<google::cloud::retail::v2::CompletionConfig>),
       UpdateCompletionConfig,
       (google::cloud::retail::v2::UpdateCompletionConfigRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::retail::v2::AttributesConfig>,
+      (StatusOr<google::cloud::retail::v2::AttributesConfig>),
       GetAttributesConfig,
       (google::cloud::retail::v2::GetAttributesConfigRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::retail::v2::AttributesConfig>,
+      (StatusOr<google::cloud::retail::v2::AttributesConfig>),
       UpdateAttributesConfig,
       (google::cloud::retail::v2::UpdateAttributesConfigRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::retail::v2::AttributesConfig>,
+      (StatusOr<google::cloud::retail::v2::AttributesConfig>),
       AddCatalogAttribute,
       (google::cloud::retail::v2::AddCatalogAttributeRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::retail::v2::AttributesConfig>,
+      (StatusOr<google::cloud::retail::v2::AttributesConfig>),
       RemoveCatalogAttribute,
       (google::cloud::retail::v2::RemoveCatalogAttributeRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::retail::v2::AttributesConfig>,
+  MOCK_METHOD((StatusOr<google::cloud::retail::v2::AttributesConfig>),
               ReplaceCatalogAttribute,
               (google::cloud::retail::v2::ReplaceCatalogAttributeRequest const&
                    request),

--- a/google/cloud/retail/v2/mocks/mock_completion_connection.h
+++ b/google/cloud/retail/v2/mocks/mock_completion_connection.h
@@ -47,13 +47,14 @@ class MockCompletionServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::retail::v2::CompleteQueryResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::retail::v2::CompleteQueryResponse>),
               CompleteQuery,
               (google::cloud::retail::v2::CompleteQueryRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::retail::v2::ImportCompletionDataResponse>>,
+      (future<
+          StatusOr<google::cloud::retail::v2::ImportCompletionDataResponse>>),
       ImportCompletionData,
       (google::cloud::retail::v2::ImportCompletionDataRequest const& request),
       (override));

--- a/google/cloud/retail/v2/mocks/mock_control_connection.h
+++ b/google/cloud/retail/v2/mocks/mock_control_connection.h
@@ -47,7 +47,7 @@ class MockControlServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::retail::v2::Control>, CreateControl,
+  MOCK_METHOD((StatusOr<google::cloud::retail::v2::Control>), CreateControl,
               (google::cloud::retail::v2::CreateControlRequest const& request),
               (override));
 
@@ -55,11 +55,11 @@ class MockControlServiceConnection
               (google::cloud::retail::v2::DeleteControlRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::retail::v2::Control>, UpdateControl,
+  MOCK_METHOD((StatusOr<google::cloud::retail::v2::Control>), UpdateControl,
               (google::cloud::retail::v2::UpdateControlRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::retail::v2::Control>, GetControl,
+  MOCK_METHOD((StatusOr<google::cloud::retail::v2::Control>), GetControl,
               (google::cloud::retail::v2::GetControlRequest const& request),
               (override));
 

--- a/google/cloud/retail/v2/mocks/mock_model_connection.h
+++ b/google/cloud/retail/v2/mocks/mock_model_connection.h
@@ -46,19 +46,19 @@ class MockModelServiceConnection : public retail_v2::ModelServiceConnection {
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::retail::v2::Model>>, CreateModel,
+  MOCK_METHOD((future<StatusOr<google::cloud::retail::v2::Model>>), CreateModel,
               (google::cloud::retail::v2::CreateModelRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::retail::v2::Model>, GetModel,
+  MOCK_METHOD((StatusOr<google::cloud::retail::v2::Model>), GetModel,
               (google::cloud::retail::v2::GetModelRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::retail::v2::Model>, PauseModel,
+  MOCK_METHOD((StatusOr<google::cloud::retail::v2::Model>), PauseModel,
               (google::cloud::retail::v2::PauseModelRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::retail::v2::Model>, ResumeModel,
+  MOCK_METHOD((StatusOr<google::cloud::retail::v2::Model>), ResumeModel,
               (google::cloud::retail::v2::ResumeModelRequest const& request),
               (override));
 
@@ -70,11 +70,11 @@ class MockModelServiceConnection : public retail_v2::ModelServiceConnection {
               (google::cloud::retail::v2::ListModelsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::retail::v2::Model>, UpdateModel,
+  MOCK_METHOD((StatusOr<google::cloud::retail::v2::Model>), UpdateModel,
               (google::cloud::retail::v2::UpdateModelRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::retail::v2::TuneModelResponse>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::retail::v2::TuneModelResponse>>),
               TuneModel,
               (google::cloud::retail::v2::TuneModelRequest const& request),
               (override));

--- a/google/cloud/retail/v2/mocks/mock_prediction_connection.h
+++ b/google/cloud/retail/v2/mocks/mock_prediction_connection.h
@@ -47,7 +47,7 @@ class MockPredictionServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::retail::v2::PredictResponse>, Predict,
+  MOCK_METHOD((StatusOr<google::cloud::retail::v2::PredictResponse>), Predict,
               (google::cloud::retail::v2::PredictRequest const& request),
               (override));
 };

--- a/google/cloud/retail/v2/mocks/mock_product_connection.h
+++ b/google/cloud/retail/v2/mocks/mock_product_connection.h
@@ -47,11 +47,11 @@ class MockProductServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::retail::v2::Product>, CreateProduct,
+  MOCK_METHOD((StatusOr<google::cloud::retail::v2::Product>), CreateProduct,
               (google::cloud::retail::v2::CreateProductRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::retail::v2::Product>, GetProduct,
+  MOCK_METHOD((StatusOr<google::cloud::retail::v2::Product>), GetProduct,
               (google::cloud::retail::v2::GetProductRequest const& request),
               (override));
 
@@ -59,7 +59,7 @@ class MockProductServiceConnection
               (google::cloud::retail::v2::ListProductsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::retail::v2::Product>, UpdateProduct,
+  MOCK_METHOD((StatusOr<google::cloud::retail::v2::Product>), UpdateProduct,
               (google::cloud::retail::v2::UpdateProductRequest const& request),
               (override));
 
@@ -68,39 +68,42 @@ class MockProductServiceConnection
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::retail::v2::ImportProductsResponse>>,
+      (future<StatusOr<google::cloud::retail::v2::ImportProductsResponse>>),
       ImportProducts,
       (google::cloud::retail::v2::ImportProductsRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::retail::v2::SetInventoryResponse>>,
-              SetInventory,
-              (google::cloud::retail::v2::SetInventoryRequest const& request),
-              (override));
+  MOCK_METHOD(
+      (future<StatusOr<google::cloud::retail::v2::SetInventoryResponse>>),
+      SetInventory,
+      (google::cloud::retail::v2::SetInventoryRequest const& request),
+      (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::retail::v2::AddFulfillmentPlacesResponse>>,
+      (future<
+          StatusOr<google::cloud::retail::v2::AddFulfillmentPlacesResponse>>),
       AddFulfillmentPlaces,
       (google::cloud::retail::v2::AddFulfillmentPlacesRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::retail::v2::RemoveFulfillmentPlacesResponse>>,
+      (future<StatusOr<
+           google::cloud::retail::v2::RemoveFulfillmentPlacesResponse>>),
       RemoveFulfillmentPlaces,
       (google::cloud::retail::v2::RemoveFulfillmentPlacesRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::retail::v2::AddLocalInventoriesResponse>>,
+      (future<
+          StatusOr<google::cloud::retail::v2::AddLocalInventoriesResponse>>),
       AddLocalInventories,
       (google::cloud::retail::v2::AddLocalInventoriesRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::retail::v2::RemoveLocalInventoriesResponse>>,
+      (future<
+          StatusOr<google::cloud::retail::v2::RemoveLocalInventoriesResponse>>),
       RemoveLocalInventories,
       (google::cloud::retail::v2::RemoveLocalInventoriesRequest const& request),
       (override));

--- a/google/cloud/retail/v2/mocks/mock_serving_config_connection.h
+++ b/google/cloud/retail/v2/mocks/mock_serving_config_connection.h
@@ -48,7 +48,7 @@ class MockServingConfigServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::retail::v2::ServingConfig>, CreateServingConfig,
+      (StatusOr<google::cloud::retail::v2::ServingConfig>), CreateServingConfig,
       (google::cloud::retail::v2::CreateServingConfigRequest const& request),
       (override));
 
@@ -58,12 +58,12 @@ class MockServingConfigServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::retail::v2::ServingConfig>, UpdateServingConfig,
+      (StatusOr<google::cloud::retail::v2::ServingConfig>), UpdateServingConfig,
       (google::cloud::retail::v2::UpdateServingConfigRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::retail::v2::ServingConfig>, GetServingConfig,
+      (StatusOr<google::cloud::retail::v2::ServingConfig>), GetServingConfig,
       (google::cloud::retail::v2::GetServingConfigRequest const& request),
       (override));
 
@@ -72,11 +72,12 @@ class MockServingConfigServiceConnection
               (google::cloud::retail::v2::ListServingConfigsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::retail::v2::ServingConfig>, AddControl,
+  MOCK_METHOD((StatusOr<google::cloud::retail::v2::ServingConfig>), AddControl,
               (google::cloud::retail::v2::AddControlRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::retail::v2::ServingConfig>, RemoveControl,
+  MOCK_METHOD((StatusOr<google::cloud::retail::v2::ServingConfig>),
+              RemoveControl,
               (google::cloud::retail::v2::RemoveControlRequest const& request),
               (override));
 };

--- a/google/cloud/retail/v2/mocks/mock_user_event_connection.h
+++ b/google/cloud/retail/v2/mocks/mock_user_event_connection.h
@@ -47,29 +47,29 @@ class MockUserEventServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::retail::v2::UserEvent>, WriteUserEvent,
+  MOCK_METHOD((StatusOr<google::cloud::retail::v2::UserEvent>), WriteUserEvent,
               (google::cloud::retail::v2::WriteUserEventRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::api::HttpBody>, CollectUserEvent,
+      (StatusOr<google::api::HttpBody>), CollectUserEvent,
       (google::cloud::retail::v2::CollectUserEventRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::retail::v2::PurgeUserEventsResponse>>,
+      (future<StatusOr<google::cloud::retail::v2::PurgeUserEventsResponse>>),
       PurgeUserEvents,
       (google::cloud::retail::v2::PurgeUserEventsRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::retail::v2::ImportUserEventsResponse>>,
+      (future<StatusOr<google::cloud::retail::v2::ImportUserEventsResponse>>),
       ImportUserEvents,
       (google::cloud::retail::v2::ImportUserEventsRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::retail::v2::RejoinUserEventsResponse>>,
+      (future<StatusOr<google::cloud::retail::v2::RejoinUserEventsResponse>>),
       RejoinUserEvents,
       (google::cloud::retail::v2::RejoinUserEventsRequest const& request),
       (override));

--- a/google/cloud/run/v2/mocks/mock_executions_connection.h
+++ b/google/cloud/run/v2/mocks/mock_executions_connection.h
@@ -46,7 +46,7 @@ class MockExecutionsConnection : public run_v2::ExecutionsConnection {
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::run::v2::Execution>, GetExecution,
+  MOCK_METHOD((StatusOr<google::cloud::run::v2::Execution>), GetExecution,
               (google::cloud::run::v2::GetExecutionRequest const& request),
               (override));
 
@@ -54,12 +54,12 @@ class MockExecutionsConnection : public run_v2::ExecutionsConnection {
               (google::cloud::run::v2::ListExecutionsRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::run::v2::Execution>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::run::v2::Execution>>),
               DeleteExecution,
               (google::cloud::run::v2::DeleteExecutionRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::run::v2::Execution>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::run::v2::Execution>>),
               CancelExecution,
               (google::cloud::run::v2::CancelExecutionRequest const& request),
               (override));

--- a/google/cloud/run/v2/mocks/mock_jobs_connection.h
+++ b/google/cloud/run/v2/mocks/mock_jobs_connection.h
@@ -46,38 +46,38 @@ class MockJobsConnection : public run_v2::JobsConnection {
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::run::v2::Job>>, CreateJob,
+  MOCK_METHOD((future<StatusOr<google::cloud::run::v2::Job>>), CreateJob,
               (google::cloud::run::v2::CreateJobRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::run::v2::Job>, GetJob,
+  MOCK_METHOD((StatusOr<google::cloud::run::v2::Job>), GetJob,
               (google::cloud::run::v2::GetJobRequest const& request),
               (override));
 
   MOCK_METHOD((StreamRange<google::cloud::run::v2::Job>), ListJobs,
               (google::cloud::run::v2::ListJobsRequest request), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::run::v2::Job>>, UpdateJob,
+  MOCK_METHOD((future<StatusOr<google::cloud::run::v2::Job>>), UpdateJob,
               (google::cloud::run::v2::UpdateJobRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::run::v2::Job>>, DeleteJob,
+  MOCK_METHOD((future<StatusOr<google::cloud::run::v2::Job>>), DeleteJob,
               (google::cloud::run::v2::DeleteJobRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::run::v2::Execution>>, RunJob,
+  MOCK_METHOD((future<StatusOr<google::cloud::run::v2::Execution>>), RunJob,
               (google::cloud::run::v2::RunJobRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), GetIamPolicy,
               (google::iam::v1::GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), SetIamPolicy,
               (google::iam::v1::SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD((StatusOr<google::iam::v1::TestIamPermissionsResponse>),
               TestIamPermissions,
               (google::iam::v1::TestIamPermissionsRequest const& request),
               (override));

--- a/google/cloud/run/v2/mocks/mock_revisions_connection.h
+++ b/google/cloud/run/v2/mocks/mock_revisions_connection.h
@@ -46,7 +46,7 @@ class MockRevisionsConnection : public run_v2::RevisionsConnection {
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::run::v2::Revision>, GetRevision,
+  MOCK_METHOD((StatusOr<google::cloud::run::v2::Revision>), GetRevision,
               (google::cloud::run::v2::GetRevisionRequest const& request),
               (override));
 
@@ -54,7 +54,7 @@ class MockRevisionsConnection : public run_v2::RevisionsConnection {
               (google::cloud::run::v2::ListRevisionsRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::run::v2::Revision>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::run::v2::Revision>>),
               DeleteRevision,
               (google::cloud::run::v2::DeleteRevisionRequest const& request),
               (override));

--- a/google/cloud/run/v2/mocks/mock_services_connection.h
+++ b/google/cloud/run/v2/mocks/mock_services_connection.h
@@ -46,11 +46,12 @@ class MockServicesConnection : public run_v2::ServicesConnection {
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::run::v2::Service>>, CreateService,
+  MOCK_METHOD((future<StatusOr<google::cloud::run::v2::Service>>),
+              CreateService,
               (google::cloud::run::v2::CreateServiceRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::run::v2::Service>, GetService,
+  MOCK_METHOD((StatusOr<google::cloud::run::v2::Service>), GetService,
               (google::cloud::run::v2::GetServiceRequest const& request),
               (override));
 
@@ -58,23 +59,25 @@ class MockServicesConnection : public run_v2::ServicesConnection {
               (google::cloud::run::v2::ListServicesRequest request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::run::v2::Service>>, UpdateService,
+  MOCK_METHOD((future<StatusOr<google::cloud::run::v2::Service>>),
+              UpdateService,
               (google::cloud::run::v2::UpdateServiceRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::run::v2::Service>>, DeleteService,
+  MOCK_METHOD((future<StatusOr<google::cloud::run::v2::Service>>),
+              DeleteService,
               (google::cloud::run::v2::DeleteServiceRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), GetIamPolicy,
               (google::iam::v1::GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), SetIamPolicy,
               (google::iam::v1::SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD((StatusOr<google::iam::v1::TestIamPermissionsResponse>),
               TestIamPermissions,
               (google::iam::v1::TestIamPermissionsRequest const& request),
               (override));

--- a/google/cloud/run/v2/mocks/mock_tasks_connection.h
+++ b/google/cloud/run/v2/mocks/mock_tasks_connection.h
@@ -46,7 +46,7 @@ class MockTasksConnection : public run_v2::TasksConnection {
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::run::v2::Task>, GetTask,
+  MOCK_METHOD((StatusOr<google::cloud::run::v2::Task>), GetTask,
               (google::cloud::run::v2::GetTaskRequest const& request),
               (override));
 

--- a/google/cloud/scheduler/v1/mocks/mock_cloud_scheduler_connection.h
+++ b/google/cloud/scheduler/v1/mocks/mock_cloud_scheduler_connection.h
@@ -51,15 +51,15 @@ class MockCloudSchedulerConnection
               (google::cloud::scheduler::v1::ListJobsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::scheduler::v1::Job>, GetJob,
+  MOCK_METHOD((StatusOr<google::cloud::scheduler::v1::Job>), GetJob,
               (google::cloud::scheduler::v1::GetJobRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::scheduler::v1::Job>, CreateJob,
+  MOCK_METHOD((StatusOr<google::cloud::scheduler::v1::Job>), CreateJob,
               (google::cloud::scheduler::v1::CreateJobRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::scheduler::v1::Job>, UpdateJob,
+  MOCK_METHOD((StatusOr<google::cloud::scheduler::v1::Job>), UpdateJob,
               (google::cloud::scheduler::v1::UpdateJobRequest const& request),
               (override));
 
@@ -67,15 +67,15 @@ class MockCloudSchedulerConnection
               (google::cloud::scheduler::v1::DeleteJobRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::scheduler::v1::Job>, PauseJob,
+  MOCK_METHOD((StatusOr<google::cloud::scheduler::v1::Job>), PauseJob,
               (google::cloud::scheduler::v1::PauseJobRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::scheduler::v1::Job>, ResumeJob,
+  MOCK_METHOD((StatusOr<google::cloud::scheduler::v1::Job>), ResumeJob,
               (google::cloud::scheduler::v1::ResumeJobRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::scheduler::v1::Job>, RunJob,
+  MOCK_METHOD((StatusOr<google::cloud::scheduler::v1::Job>), RunJob,
               (google::cloud::scheduler::v1::RunJobRequest const& request),
               (override));
 };

--- a/google/cloud/secretmanager/v1/mocks/mock_secret_manager_connection.h
+++ b/google/cloud/secretmanager/v1/mocks/mock_secret_manager_connection.h
@@ -53,23 +53,23 @@ class MockSecretManagerServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::secretmanager::v1::Secret>, CreateSecret,
+      (StatusOr<google::cloud::secretmanager::v1::Secret>), CreateSecret,
       (google::cloud::secretmanager::v1::CreateSecretRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::secretmanager::v1::SecretVersion>,
+  MOCK_METHOD((StatusOr<google::cloud::secretmanager::v1::SecretVersion>),
               AddSecretVersion,
               (google::cloud::secretmanager::v1::AddSecretVersionRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::secretmanager::v1::Secret>, GetSecret,
+      (StatusOr<google::cloud::secretmanager::v1::Secret>), GetSecret,
       (google::cloud::secretmanager::v1::GetSecretRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::secretmanager::v1::Secret>, UpdateSecret,
+      (StatusOr<google::cloud::secretmanager::v1::Secret>), UpdateSecret,
       (google::cloud::secretmanager::v1::UpdateSecretRequest const& request),
       (override));
 
@@ -84,49 +84,49 @@ class MockSecretManagerServiceConnection
       (google::cloud::secretmanager::v1::ListSecretVersionsRequest request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::secretmanager::v1::SecretVersion>,
+  MOCK_METHOD((StatusOr<google::cloud::secretmanager::v1::SecretVersion>),
               GetSecretVersion,
               (google::cloud::secretmanager::v1::GetSecretVersionRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::secretmanager::v1::AccessSecretVersionResponse>,
+      (StatusOr<google::cloud::secretmanager::v1::AccessSecretVersionResponse>),
       AccessSecretVersion,
       (google::cloud::secretmanager::v1::AccessSecretVersionRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::secretmanager::v1::SecretVersion>,
+      (StatusOr<google::cloud::secretmanager::v1::SecretVersion>),
       DisableSecretVersion,
       (google::cloud::secretmanager::v1::DisableSecretVersionRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::secretmanager::v1::SecretVersion>,
+      (StatusOr<google::cloud::secretmanager::v1::SecretVersion>),
       EnableSecretVersion,
       (google::cloud::secretmanager::v1::EnableSecretVersionRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::secretmanager::v1::SecretVersion>,
+      (StatusOr<google::cloud::secretmanager::v1::SecretVersion>),
       DestroySecretVersion,
       (google::cloud::secretmanager::v1::DestroySecretVersionRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), SetIamPolicy,
               (google::iam::v1::SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), GetIamPolicy,
               (google::iam::v1::GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD((StatusOr<google::iam::v1::TestIamPermissionsResponse>),
               TestIamPermissions,
               (google::iam::v1::TestIamPermissionsRequest const& request),
               (override));

--- a/google/cloud/securesourcemanager/v1/mocks/mock_secure_source_manager_connection.h
+++ b/google/cloud/securesourcemanager/v1/mocks/mock_secure_source_manager_connection.h
@@ -53,22 +53,22 @@ class MockSecureSourceManagerConnection
       (google::cloud::securesourcemanager::v1::ListInstancesRequest request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::securesourcemanager::v1::Instance>,
+  MOCK_METHOD((StatusOr<google::cloud::securesourcemanager::v1::Instance>),
               GetInstance,
               (google::cloud::securesourcemanager::v1::GetInstanceRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::securesourcemanager::v1::Instance>>,
+      (future<StatusOr<google::cloud::securesourcemanager::v1::Instance>>),
       CreateInstance,
       (google::cloud::securesourcemanager::v1::CreateInstanceRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::securesourcemanager::v1::OperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::securesourcemanager::v1::OperationMetadata>>),
       DeleteInstance,
       (google::cloud::securesourcemanager::v1::DeleteInstanceRequest const&
            request),
@@ -81,36 +81,36 @@ class MockSecureSourceManagerConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securesourcemanager::v1::Repository>,
+      (StatusOr<google::cloud::securesourcemanager::v1::Repository>),
       GetRepository,
       (google::cloud::securesourcemanager::v1::GetRepositoryRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::securesourcemanager::v1::Repository>>,
+      (future<StatusOr<google::cloud::securesourcemanager::v1::Repository>>),
       CreateRepository,
       (google::cloud::securesourcemanager::v1::CreateRepositoryRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::securesourcemanager::v1::OperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::securesourcemanager::v1::OperationMetadata>>),
       DeleteRepository,
       (google::cloud::securesourcemanager::v1::DeleteRepositoryRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetIamPolicyRepo,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), GetIamPolicyRepo,
               (google::iam::v1::GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetIamPolicyRepo,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), SetIamPolicyRepo,
               (google::iam::v1::SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD((StatusOr<google::iam::v1::TestIamPermissionsResponse>),
               TestIamPermissionsRepo,
               (google::iam::v1::TestIamPermissionsRequest const& request),
               (override));

--- a/google/cloud/securitycenter/v1/mocks/mock_security_center_connection.h
+++ b/google/cloud/securitycenter/v1/mocks/mock_security_center_connection.h
@@ -47,39 +47,40 @@ class MockSecurityCenterConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<
-                  google::cloud::securitycenter::v1::BulkMuteFindingsResponse>>,
-              BulkMuteFindings,
-              (google::cloud::securitycenter::v1::BulkMuteFindingsRequest const&
-                   request),
-              (override));
+  MOCK_METHOD(
+      (future<StatusOr<
+           google::cloud::securitycenter::v1::BulkMuteFindingsResponse>>),
+      BulkMuteFindings,
+      (google::cloud::securitycenter::v1::BulkMuteFindingsRequest const&
+           request),
+      (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v1::
-                   SecurityHealthAnalyticsCustomModule>,
+      (StatusOr<google::cloud::securitycenter::v1::
+                    SecurityHealthAnalyticsCustomModule>),
       CreateSecurityHealthAnalyticsCustomModule,
       (google::cloud::securitycenter::v1::
            CreateSecurityHealthAnalyticsCustomModuleRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v1::Source>, CreateSource,
+      (StatusOr<google::cloud::securitycenter::v1::Source>), CreateSource,
       (google::cloud::securitycenter::v1::CreateSourceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v1::Finding>, CreateFinding,
+      (StatusOr<google::cloud::securitycenter::v1::Finding>), CreateFinding,
       (google::cloud::securitycenter::v1::CreateFindingRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::securitycenter::v1::MuteConfig>,
+  MOCK_METHOD((StatusOr<google::cloud::securitycenter::v1::MuteConfig>),
               CreateMuteConfig,
               (google::cloud::securitycenter::v1::CreateMuteConfigRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v1::NotificationConfig>,
+      (StatusOr<google::cloud::securitycenter::v1::NotificationConfig>),
       CreateNotificationConfig,
       (google::cloud::securitycenter::v1::CreateNotificationConfigRequest const&
            request),
@@ -103,37 +104,37 @@ class MockSecurityCenterConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v1::BigQueryExport>,
+      (StatusOr<google::cloud::securitycenter::v1::BigQueryExport>),
       GetBigQueryExport,
       (google::cloud::securitycenter::v1::GetBigQueryExportRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), GetIamPolicy,
               (google::iam::v1::GetIamPolicyRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v1::MuteConfig>, GetMuteConfig,
+      (StatusOr<google::cloud::securitycenter::v1::MuteConfig>), GetMuteConfig,
       (google::cloud::securitycenter::v1::GetMuteConfigRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v1::NotificationConfig>,
+      (StatusOr<google::cloud::securitycenter::v1::NotificationConfig>),
       GetNotificationConfig,
       (google::cloud::securitycenter::v1::GetNotificationConfigRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v1::OrganizationSettings>,
+      (StatusOr<google::cloud::securitycenter::v1::OrganizationSettings>),
       GetOrganizationSettings,
       (google::cloud::securitycenter::v1::GetOrganizationSettingsRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::securitycenter::v1::
-                           EffectiveSecurityHealthAnalyticsCustomModule>,
+  MOCK_METHOD((StatusOr<google::cloud::securitycenter::v1::
+                            EffectiveSecurityHealthAnalyticsCustomModule>),
               GetEffectiveSecurityHealthAnalyticsCustomModule,
               (google::cloud::securitycenter::v1::
                    GetEffectiveSecurityHealthAnalyticsCustomModuleRequest const&
@@ -141,15 +142,15 @@ class MockSecurityCenterConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v1::
-                   SecurityHealthAnalyticsCustomModule>,
+      (StatusOr<google::cloud::securitycenter::v1::
+                    SecurityHealthAnalyticsCustomModule>),
       GetSecurityHealthAnalyticsCustomModule,
       (google::cloud::securitycenter::v1::
            GetSecurityHealthAnalyticsCustomModuleRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v1::Source>, GetSource,
+      (StatusOr<google::cloud::securitycenter::v1::Source>), GetSource,
       (google::cloud::securitycenter::v1::GetSourceRequest const& request),
       (override));
 
@@ -217,94 +218,95 @@ class MockSecurityCenterConnection
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::securitycenter::v1::RunAssetDiscoveryResponse>>,
+      (future<StatusOr<
+           google::cloud::securitycenter::v1::RunAssetDiscoveryResponse>>),
       RunAssetDiscovery,
       (google::cloud::securitycenter::v1::RunAssetDiscoveryRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::securitycenter::v1::Finding>,
+  MOCK_METHOD((StatusOr<google::cloud::securitycenter::v1::Finding>),
               SetFindingState,
               (google::cloud::securitycenter::v1::SetFindingStateRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v1::Finding>, SetMute,
+      (StatusOr<google::cloud::securitycenter::v1::Finding>), SetMute,
       (google::cloud::securitycenter::v1::SetMuteRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), SetIamPolicy,
               (google::iam::v1::SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD((StatusOr<google::iam::v1::TestIamPermissionsResponse>),
               TestIamPermissions,
               (google::iam::v1::TestIamPermissionsRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v1::
-                   SimulateSecurityHealthAnalyticsCustomModuleResponse>,
+      (StatusOr<google::cloud::securitycenter::v1::
+                    SimulateSecurityHealthAnalyticsCustomModuleResponse>),
       SimulateSecurityHealthAnalyticsCustomModule,
       (google::cloud::securitycenter::v1::
            SimulateSecurityHealthAnalyticsCustomModuleRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v1::ExternalSystem>,
+      (StatusOr<google::cloud::securitycenter::v1::ExternalSystem>),
       UpdateExternalSystem,
       (google::cloud::securitycenter::v1::UpdateExternalSystemRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v1::Finding>, UpdateFinding,
+      (StatusOr<google::cloud::securitycenter::v1::Finding>), UpdateFinding,
       (google::cloud::securitycenter::v1::UpdateFindingRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::securitycenter::v1::MuteConfig>,
+  MOCK_METHOD((StatusOr<google::cloud::securitycenter::v1::MuteConfig>),
               UpdateMuteConfig,
               (google::cloud::securitycenter::v1::UpdateMuteConfigRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v1::NotificationConfig>,
+      (StatusOr<google::cloud::securitycenter::v1::NotificationConfig>),
       UpdateNotificationConfig,
       (google::cloud::securitycenter::v1::UpdateNotificationConfigRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::securitycenter::v1::OrganizationSettings>,
-              UpdateOrganizationSettings,
-              (google::cloud::securitycenter::v1::
-                   UpdateOrganizationSettingsRequest const& request),
-              (override));
+  MOCK_METHOD(
+      (StatusOr<google::cloud::securitycenter::v1::OrganizationSettings>),
+      UpdateOrganizationSettings,
+      (google::cloud::securitycenter::v1::
+           UpdateOrganizationSettingsRequest const& request),
+      (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v1::
-                   SecurityHealthAnalyticsCustomModule>,
+      (StatusOr<google::cloud::securitycenter::v1::
+                    SecurityHealthAnalyticsCustomModule>),
       UpdateSecurityHealthAnalyticsCustomModule,
       (google::cloud::securitycenter::v1::
            UpdateSecurityHealthAnalyticsCustomModuleRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v1::Source>, UpdateSource,
+      (StatusOr<google::cloud::securitycenter::v1::Source>), UpdateSource,
       (google::cloud::securitycenter::v1::UpdateSourceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v1::SecurityMarks>,
+      (StatusOr<google::cloud::securitycenter::v1::SecurityMarks>),
       UpdateSecurityMarks,
       (google::cloud::securitycenter::v1::UpdateSecurityMarksRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v1::BigQueryExport>,
+      (StatusOr<google::cloud::securitycenter::v1::BigQueryExport>),
       CreateBigQueryExport,
       (google::cloud::securitycenter::v1::CreateBigQueryExportRequest const&
            request),
@@ -317,7 +319,7 @@ class MockSecurityCenterConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v1::BigQueryExport>,
+      (StatusOr<google::cloud::securitycenter::v1::BigQueryExport>),
       UpdateBigQueryExport,
       (google::cloud::securitycenter::v1::UpdateBigQueryExportRequest const&
            request),

--- a/google/cloud/securitycenter/v2/mocks/mock_security_center_connection.h
+++ b/google/cloud/securitycenter/v2/mocks/mock_security_center_connection.h
@@ -47,47 +47,48 @@ class MockSecurityCenterConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::securitycenter::v2::
-                           BatchCreateResourceValueConfigsResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::securitycenter::v2::
+                            BatchCreateResourceValueConfigsResponse>),
               BatchCreateResourceValueConfigs,
               (google::cloud::securitycenter::v2::
                    BatchCreateResourceValueConfigsRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<
-                  google::cloud::securitycenter::v2::BulkMuteFindingsResponse>>,
-              BulkMuteFindings,
-              (google::cloud::securitycenter::v2::BulkMuteFindingsRequest const&
-                   request),
-              (override));
+  MOCK_METHOD(
+      (future<StatusOr<
+           google::cloud::securitycenter::v2::BulkMuteFindingsResponse>>),
+      BulkMuteFindings,
+      (google::cloud::securitycenter::v2::BulkMuteFindingsRequest const&
+           request),
+      (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v2::BigQueryExport>,
+      (StatusOr<google::cloud::securitycenter::v2::BigQueryExport>),
       CreateBigQueryExport,
       (google::cloud::securitycenter::v2::CreateBigQueryExportRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v2::Finding>, CreateFinding,
+      (StatusOr<google::cloud::securitycenter::v2::Finding>), CreateFinding,
       (google::cloud::securitycenter::v2::CreateFindingRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::securitycenter::v2::MuteConfig>,
+  MOCK_METHOD((StatusOr<google::cloud::securitycenter::v2::MuteConfig>),
               CreateMuteConfig,
               (google::cloud::securitycenter::v2::CreateMuteConfigRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v2::NotificationConfig>,
+      (StatusOr<google::cloud::securitycenter::v2::NotificationConfig>),
       CreateNotificationConfig,
       (google::cloud::securitycenter::v2::CreateNotificationConfigRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v2::Source>, CreateSource,
+      (StatusOr<google::cloud::securitycenter::v2::Source>), CreateSource,
       (google::cloud::securitycenter::v2::CreateSourceRequest const& request),
       (override));
 
@@ -114,49 +115,49 @@ class MockSecurityCenterConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v2::BigQueryExport>,
+      (StatusOr<google::cloud::securitycenter::v2::BigQueryExport>),
       GetBigQueryExport,
       (google::cloud::securitycenter::v2::GetBigQueryExportRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v2::Simulation>, GetSimulation,
+      (StatusOr<google::cloud::securitycenter::v2::Simulation>), GetSimulation,
       (google::cloud::securitycenter::v2::GetSimulationRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v2::ValuedResource>,
+      (StatusOr<google::cloud::securitycenter::v2::ValuedResource>),
       GetValuedResource,
       (google::cloud::securitycenter::v2::GetValuedResourceRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), GetIamPolicy,
               (google::iam::v1::GetIamPolicyRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v2::MuteConfig>, GetMuteConfig,
+      (StatusOr<google::cloud::securitycenter::v2::MuteConfig>), GetMuteConfig,
       (google::cloud::securitycenter::v2::GetMuteConfigRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v2::NotificationConfig>,
+      (StatusOr<google::cloud::securitycenter::v2::NotificationConfig>),
       GetNotificationConfig,
       (google::cloud::securitycenter::v2::GetNotificationConfigRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v2::ResourceValueConfig>,
+      (StatusOr<google::cloud::securitycenter::v2::ResourceValueConfig>),
       GetResourceValueConfig,
       (google::cloud::securitycenter::v2::GetResourceValueConfigRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v2::Source>, GetSource,
+      (StatusOr<google::cloud::securitycenter::v2::Source>), GetSource,
       (google::cloud::securitycenter::v2::GetSourceRequest const& request),
       (override));
 
@@ -214,73 +215,74 @@ class MockSecurityCenterConnection
       (google::cloud::securitycenter::v2::ListValuedResourcesRequest request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::securitycenter::v2::Finding>,
+  MOCK_METHOD((StatusOr<google::cloud::securitycenter::v2::Finding>),
               SetFindingState,
               (google::cloud::securitycenter::v2::SetFindingStateRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), SetIamPolicy,
               (google::iam::v1::SetIamPolicyRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v2::Finding>, SetMute,
+      (StatusOr<google::cloud::securitycenter::v2::Finding>), SetMute,
       (google::cloud::securitycenter::v2::SetMuteRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD((StatusOr<google::iam::v1::TestIamPermissionsResponse>),
               TestIamPermissions,
               (google::iam::v1::TestIamPermissionsRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v2::BigQueryExport>,
+      (StatusOr<google::cloud::securitycenter::v2::BigQueryExport>),
       UpdateBigQueryExport,
       (google::cloud::securitycenter::v2::UpdateBigQueryExportRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v2::ExternalSystem>,
+      (StatusOr<google::cloud::securitycenter::v2::ExternalSystem>),
       UpdateExternalSystem,
       (google::cloud::securitycenter::v2::UpdateExternalSystemRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v2::Finding>, UpdateFinding,
+      (StatusOr<google::cloud::securitycenter::v2::Finding>), UpdateFinding,
       (google::cloud::securitycenter::v2::UpdateFindingRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::securitycenter::v2::MuteConfig>,
+  MOCK_METHOD((StatusOr<google::cloud::securitycenter::v2::MuteConfig>),
               UpdateMuteConfig,
               (google::cloud::securitycenter::v2::UpdateMuteConfigRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v2::NotificationConfig>,
+      (StatusOr<google::cloud::securitycenter::v2::NotificationConfig>),
       UpdateNotificationConfig,
       (google::cloud::securitycenter::v2::UpdateNotificationConfigRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::securitycenter::v2::ResourceValueConfig>,
-              UpdateResourceValueConfig,
-              (google::cloud::securitycenter::v2::
-                   UpdateResourceValueConfigRequest const& request),
-              (override));
+  MOCK_METHOD(
+      (StatusOr<google::cloud::securitycenter::v2::ResourceValueConfig>),
+      UpdateResourceValueConfig,
+      (google::cloud::securitycenter::v2::
+           UpdateResourceValueConfigRequest const& request),
+      (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v2::SecurityMarks>,
+      (StatusOr<google::cloud::securitycenter::v2::SecurityMarks>),
       UpdateSecurityMarks,
       (google::cloud::securitycenter::v2::UpdateSecurityMarksRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycenter::v2::Source>, UpdateSource,
+      (StatusOr<google::cloud::securitycenter::v2::Source>), UpdateSource,
       (google::cloud::securitycenter::v2::UpdateSourceRequest const& request),
       (override));
 };

--- a/google/cloud/securitycentermanagement/v1/mocks/mock_security_center_management_connection.h
+++ b/google/cloud/securitycentermanagement/v1/mocks/mock_security_center_management_connection.h
@@ -56,8 +56,8 @@ class MockSecurityCenterManagementConnection
            ListEffectiveSecurityHealthAnalyticsCustomModulesRequest request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::securitycentermanagement::v1::
-                           EffectiveSecurityHealthAnalyticsCustomModule>,
+  MOCK_METHOD((StatusOr<google::cloud::securitycentermanagement::v1::
+                            EffectiveSecurityHealthAnalyticsCustomModule>),
               GetEffectiveSecurityHealthAnalyticsCustomModule,
               (google::cloud::securitycentermanagement::v1::
                    GetEffectiveSecurityHealthAnalyticsCustomModuleRequest const&
@@ -80,24 +80,24 @@ class MockSecurityCenterManagementConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycentermanagement::v1::
-                   SecurityHealthAnalyticsCustomModule>,
+      (StatusOr<google::cloud::securitycentermanagement::v1::
+                    SecurityHealthAnalyticsCustomModule>),
       GetSecurityHealthAnalyticsCustomModule,
       (google::cloud::securitycentermanagement::v1::
            GetSecurityHealthAnalyticsCustomModuleRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycentermanagement::v1::
-                   SecurityHealthAnalyticsCustomModule>,
+      (StatusOr<google::cloud::securitycentermanagement::v1::
+                    SecurityHealthAnalyticsCustomModule>),
       CreateSecurityHealthAnalyticsCustomModule,
       (google::cloud::securitycentermanagement::v1::
            CreateSecurityHealthAnalyticsCustomModuleRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycentermanagement::v1::
-                   SecurityHealthAnalyticsCustomModule>,
+      (StatusOr<google::cloud::securitycentermanagement::v1::
+                    SecurityHealthAnalyticsCustomModule>),
       UpdateSecurityHealthAnalyticsCustomModule,
       (google::cloud::securitycentermanagement::v1::
            UpdateSecurityHealthAnalyticsCustomModuleRequest const& request),
@@ -110,8 +110,8 @@ class MockSecurityCenterManagementConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycentermanagement::v1::
-                   SimulateSecurityHealthAnalyticsCustomModuleResponse>,
+      (StatusOr<google::cloud::securitycentermanagement::v1::
+                    SimulateSecurityHealthAnalyticsCustomModuleResponse>),
       SimulateSecurityHealthAnalyticsCustomModule,
       (google::cloud::securitycentermanagement::v1::
            SimulateSecurityHealthAnalyticsCustomModuleRequest const& request),
@@ -126,8 +126,8 @@ class MockSecurityCenterManagementConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycentermanagement::v1::
-                   EffectiveEventThreatDetectionCustomModule>,
+      (StatusOr<google::cloud::securitycentermanagement::v1::
+                    EffectiveEventThreatDetectionCustomModule>),
       GetEffectiveEventThreatDetectionCustomModule,
       (google::cloud::securitycentermanagement::v1::
            GetEffectiveEventThreatDetectionCustomModuleRequest const& request),
@@ -148,24 +148,24 @@ class MockSecurityCenterManagementConnection
            ListDescendantEventThreatDetectionCustomModulesRequest request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::securitycentermanagement::v1::
-                           EventThreatDetectionCustomModule>,
+  MOCK_METHOD((StatusOr<google::cloud::securitycentermanagement::v1::
+                            EventThreatDetectionCustomModule>),
               GetEventThreatDetectionCustomModule,
               (google::cloud::securitycentermanagement::v1::
                    GetEventThreatDetectionCustomModuleRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycentermanagement::v1::
-                   EventThreatDetectionCustomModule>,
+      (StatusOr<google::cloud::securitycentermanagement::v1::
+                    EventThreatDetectionCustomModule>),
       CreateEventThreatDetectionCustomModule,
       (google::cloud::securitycentermanagement::v1::
            CreateEventThreatDetectionCustomModuleRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycentermanagement::v1::
-                   EventThreatDetectionCustomModule>,
+      (StatusOr<google::cloud::securitycentermanagement::v1::
+                    EventThreatDetectionCustomModule>),
       UpdateEventThreatDetectionCustomModule,
       (google::cloud::securitycentermanagement::v1::
            UpdateEventThreatDetectionCustomModuleRequest const& request),
@@ -178,8 +178,8 @@ class MockSecurityCenterManagementConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::securitycentermanagement::v1::
-                   ValidateEventThreatDetectionCustomModuleResponse>,
+      (StatusOr<google::cloud::securitycentermanagement::v1::
+                    ValidateEventThreatDetectionCustomModuleResponse>),
       ValidateEventThreatDetectionCustomModule,
       (google::cloud::securitycentermanagement::v1::
            ValidateEventThreatDetectionCustomModuleRequest const& request),

--- a/google/cloud/servicecontrol/v1/mocks/mock_quota_controller_connection.h
+++ b/google/cloud/servicecontrol/v1/mocks/mock_quota_controller_connection.h
@@ -48,7 +48,7 @@ class MockQuotaControllerConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::api::servicecontrol::v1::AllocateQuotaResponse>,
+      (StatusOr<google::api::servicecontrol::v1::AllocateQuotaResponse>),
       AllocateQuota,
       (google::api::servicecontrol::v1::AllocateQuotaRequest const& request),
       (override));

--- a/google/cloud/servicecontrol/v1/mocks/mock_service_controller_connection.h
+++ b/google/cloud/servicecontrol/v1/mocks/mock_service_controller_connection.h
@@ -47,11 +47,12 @@ class MockServiceControllerConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::api::servicecontrol::v1::CheckResponse>, Check,
+  MOCK_METHOD((StatusOr<google::api::servicecontrol::v1::CheckResponse>), Check,
               (google::api::servicecontrol::v1::CheckRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::api::servicecontrol::v1::ReportResponse>, Report,
+  MOCK_METHOD((StatusOr<google::api::servicecontrol::v1::ReportResponse>),
+              Report,
               (google::api::servicecontrol::v1::ReportRequest const& request),
               (override));
 };

--- a/google/cloud/servicecontrol/v2/mocks/mock_service_controller_connection.h
+++ b/google/cloud/servicecontrol/v2/mocks/mock_service_controller_connection.h
@@ -47,11 +47,12 @@ class MockServiceControllerConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::api::servicecontrol::v2::CheckResponse>, Check,
+  MOCK_METHOD((StatusOr<google::api::servicecontrol::v2::CheckResponse>), Check,
               (google::api::servicecontrol::v2::CheckRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::api::servicecontrol::v2::ReportResponse>, Report,
+  MOCK_METHOD((StatusOr<google::api::servicecontrol::v2::ReportResponse>),
+              Report,
               (google::api::servicecontrol::v2::ReportRequest const& request),
               (override));
 };

--- a/google/cloud/servicedirectory/v1/mocks/mock_lookup_connection.h
+++ b/google/cloud/servicedirectory/v1/mocks/mock_lookup_connection.h
@@ -48,7 +48,7 @@ class MockLookupServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::servicedirectory::v1::ResolveServiceResponse>,
+      (StatusOr<google::cloud::servicedirectory::v1::ResolveServiceResponse>),
       ResolveService,
       (google::cloud::servicedirectory::v1::ResolveServiceRequest const&
            request),

--- a/google/cloud/servicedirectory/v1/mocks/mock_registration_connection.h
+++ b/google/cloud/servicedirectory/v1/mocks/mock_registration_connection.h
@@ -48,7 +48,8 @@ class MockRegistrationServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::servicedirectory::v1::Namespace>, CreateNamespace,
+      (StatusOr<google::cloud::servicedirectory::v1::Namespace>),
+      CreateNamespace,
       (google::cloud::servicedirectory::v1::CreateNamespaceRequest const&
            request),
       (override));
@@ -60,12 +61,13 @@ class MockRegistrationServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::servicedirectory::v1::Namespace>, GetNamespace,
+      (StatusOr<google::cloud::servicedirectory::v1::Namespace>), GetNamespace,
       (google::cloud::servicedirectory::v1::GetNamespaceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::servicedirectory::v1::Namespace>, UpdateNamespace,
+      (StatusOr<google::cloud::servicedirectory::v1::Namespace>),
+      UpdateNamespace,
       (google::cloud::servicedirectory::v1::UpdateNamespaceRequest const&
            request),
       (override));
@@ -76,7 +78,7 @@ class MockRegistrationServiceConnection
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::servicedirectory::v1::Service>,
+  MOCK_METHOD((StatusOr<google::cloud::servicedirectory::v1::Service>),
               CreateService,
               (google::cloud::servicedirectory::v1::CreateServiceRequest const&
                    request),
@@ -88,11 +90,11 @@ class MockRegistrationServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::servicedirectory::v1::Service>, GetService,
+      (StatusOr<google::cloud::servicedirectory::v1::Service>), GetService,
       (google::cloud::servicedirectory::v1::GetServiceRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::servicedirectory::v1::Service>,
+  MOCK_METHOD((StatusOr<google::cloud::servicedirectory::v1::Service>),
               UpdateService,
               (google::cloud::servicedirectory::v1::UpdateServiceRequest const&
                    request),
@@ -103,7 +105,7 @@ class MockRegistrationServiceConnection
                    request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::servicedirectory::v1::Endpoint>,
+  MOCK_METHOD((StatusOr<google::cloud::servicedirectory::v1::Endpoint>),
               CreateEndpoint,
               (google::cloud::servicedirectory::v1::CreateEndpointRequest const&
                    request),
@@ -116,11 +118,11 @@ class MockRegistrationServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::servicedirectory::v1::Endpoint>, GetEndpoint,
+      (StatusOr<google::cloud::servicedirectory::v1::Endpoint>), GetEndpoint,
       (google::cloud::servicedirectory::v1::GetEndpointRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::servicedirectory::v1::Endpoint>,
+  MOCK_METHOD((StatusOr<google::cloud::servicedirectory::v1::Endpoint>),
               UpdateEndpoint,
               (google::cloud::servicedirectory::v1::UpdateEndpointRequest const&
                    request),
@@ -131,15 +133,15 @@ class MockRegistrationServiceConnection
                    request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), GetIamPolicy,
               (google::iam::v1::GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), SetIamPolicy,
               (google::iam::v1::SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD((StatusOr<google::iam::v1::TestIamPermissionsResponse>),
               TestIamPermissions,
               (google::iam::v1::TestIamPermissionsRequest const& request),
               (override));

--- a/google/cloud/servicehealth/v1/mocks/mock_service_health_connection.h
+++ b/google/cloud/servicehealth/v1/mocks/mock_service_health_connection.h
@@ -53,7 +53,7 @@ class MockServiceHealthConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::servicehealth::v1::Event>, GetEvent,
+      (StatusOr<google::cloud::servicehealth::v1::Event>), GetEvent,
       (google::cloud::servicehealth::v1::GetEventRequest const& request),
       (override));
 
@@ -64,7 +64,7 @@ class MockServiceHealthConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::servicehealth::v1::OrganizationEvent>,
+      (StatusOr<google::cloud::servicehealth::v1::OrganizationEvent>),
       GetOrganizationEvent,
       (google::cloud::servicehealth::v1::GetOrganizationEventRequest const&
            request),
@@ -78,7 +78,7 @@ class MockServiceHealthConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::servicehealth::v1::OrganizationImpact>,
+      (StatusOr<google::cloud::servicehealth::v1::OrganizationImpact>),
       GetOrganizationImpact,
       (google::cloud::servicehealth::v1::GetOrganizationImpactRequest const&
            request),

--- a/google/cloud/servicemanagement/v1/mocks/mock_service_manager_connection.h
+++ b/google/cloud/servicemanagement/v1/mocks/mock_service_manager_connection.h
@@ -53,28 +53,30 @@ class MockServiceManagerConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::api::servicemanagement::v1::ManagedService>, GetService,
+      (StatusOr<google::api::servicemanagement::v1::ManagedService>),
+      GetService,
       (google::api::servicemanagement::v1::GetServiceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::api::servicemanagement::v1::ManagedService>>,
+      (future<StatusOr<google::api::servicemanagement::v1::ManagedService>>),
       CreateService,
       (google::api::servicemanagement::v1::CreateServiceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::api::servicemanagement::v1::OperationMetadata>>,
+      (future<StatusOr<google::api::servicemanagement::v1::OperationMetadata>>),
       DeleteService,
       (google::api::servicemanagement::v1::DeleteServiceRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<
-                  google::api::servicemanagement::v1::UndeleteServiceResponse>>,
-              UndeleteService,
-              (google::api::servicemanagement::v1::UndeleteServiceRequest const&
-                   request),
-              (override));
+  MOCK_METHOD(
+      (future<StatusOr<
+           google::api::servicemanagement::v1::UndeleteServiceResponse>>),
+      UndeleteService,
+      (google::api::servicemanagement::v1::UndeleteServiceRequest const&
+           request),
+      (override));
 
   MOCK_METHOD(
       (StreamRange<google::api::Service>), ListServiceConfigs,
@@ -82,20 +84,20 @@ class MockServiceManagerConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::api::Service>, GetServiceConfig,
+      (StatusOr<google::api::Service>), GetServiceConfig,
       (google::api::servicemanagement::v1::GetServiceConfigRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::api::Service>, CreateServiceConfig,
+      (StatusOr<google::api::Service>), CreateServiceConfig,
       (google::api::servicemanagement::v1::CreateServiceConfigRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::api::servicemanagement::v1::SubmitConfigSourceResponse>>,
+      (future<StatusOr<
+           google::api::servicemanagement::v1::SubmitConfigSourceResponse>>),
       SubmitConfigSource,
       (google::api::servicemanagement::v1::SubmitConfigSourceRequest const&
            request),
@@ -108,21 +110,22 @@ class MockServiceManagerConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::api::servicemanagement::v1::Rollout>, GetServiceRollout,
+      (StatusOr<google::api::servicemanagement::v1::Rollout>),
+      GetServiceRollout,
       (google::api::servicemanagement::v1::GetServiceRolloutRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::api::servicemanagement::v1::Rollout>>,
+      (future<StatusOr<google::api::servicemanagement::v1::Rollout>>),
       CreateServiceRollout,
       (google::api::servicemanagement::v1::CreateServiceRolloutRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::api::servicemanagement::v1::GenerateConfigReportResponse>,
+      (StatusOr<
+          google::api::servicemanagement::v1::GenerateConfigReportResponse>),
       GenerateConfigReport,
       (google::api::servicemanagement::v1::GenerateConfigReportRequest const&
            request),

--- a/google/cloud/serviceusage/v1/mocks/mock_service_usage_connection.h
+++ b/google/cloud/serviceusage/v1/mocks/mock_service_usage_connection.h
@@ -48,18 +48,18 @@ class MockServiceUsageConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::api::serviceusage::v1::EnableServiceResponse>>,
+      (future<StatusOr<google::api::serviceusage::v1::EnableServiceResponse>>),
       EnableService,
       (google::api::serviceusage::v1::EnableServiceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::api::serviceusage::v1::DisableServiceResponse>>,
+      (future<StatusOr<google::api::serviceusage::v1::DisableServiceResponse>>),
       DisableService,
       (google::api::serviceusage::v1::DisableServiceRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::api::serviceusage::v1::Service>, GetService,
+  MOCK_METHOD((StatusOr<google::api::serviceusage::v1::Service>), GetService,
               (google::api::serviceusage::v1::GetServiceRequest const& request),
               (override));
 
@@ -69,15 +69,15 @@ class MockServiceUsageConnection
               (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::api::serviceusage::v1::BatchEnableServicesResponse>>,
+      (future<StatusOr<
+           google::api::serviceusage::v1::BatchEnableServicesResponse>>),
       BatchEnableServices,
       (google::api::serviceusage::v1::BatchEnableServicesRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::api::serviceusage::v1::BatchGetServicesResponse>,
+      (StatusOr<google::api::serviceusage::v1::BatchGetServicesResponse>),
       BatchGetServices,
       (google::api::serviceusage::v1::BatchGetServicesRequest const& request),
       (override));

--- a/google/cloud/shell/v1/mocks/mock_cloud_shell_connection.h
+++ b/google/cloud/shell/v1/mocks/mock_cloud_shell_connection.h
@@ -47,29 +47,31 @@ class MockCloudShellServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::shell::v1::Environment>, GetEnvironment,
+  MOCK_METHOD((StatusOr<google::cloud::shell::v1::Environment>), GetEnvironment,
               (google::cloud::shell::v1::GetEnvironmentRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::shell::v1::StartEnvironmentResponse>>,
+      (future<StatusOr<google::cloud::shell::v1::StartEnvironmentResponse>>),
       StartEnvironment,
       (google::cloud::shell::v1::StartEnvironmentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::shell::v1::AuthorizeEnvironmentResponse>>,
+      (future<
+          StatusOr<google::cloud::shell::v1::AuthorizeEnvironmentResponse>>),
       AuthorizeEnvironment,
       (google::cloud::shell::v1::AuthorizeEnvironmentRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::shell::v1::AddPublicKeyResponse>>,
-              AddPublicKey,
-              (google::cloud::shell::v1::AddPublicKeyRequest const& request),
-              (override));
+  MOCK_METHOD(
+      (future<StatusOr<google::cloud::shell::v1::AddPublicKeyResponse>>),
+      AddPublicKey,
+      (google::cloud::shell::v1::AddPublicKeyRequest const& request),
+      (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::shell::v1::RemovePublicKeyResponse>>,
+      (future<StatusOr<google::cloud::shell::v1::RemovePublicKeyResponse>>),
       RemovePublicKey,
       (google::cloud::shell::v1::RemovePublicKeyRequest const& request),
       (override));

--- a/google/cloud/spanner/admin/mocks/mock_database_admin_connection.h
+++ b/google/cloud/spanner/admin/mocks/mock_database_admin_connection.h
@@ -54,27 +54,27 @@ class MockDatabaseAdminConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::spanner::admin::database::v1::Database>>,
+      (future<StatusOr<google::spanner::admin::database::v1::Database>>),
       CreateDatabase,
       (google::spanner::admin::database::v1::CreateDatabaseRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::spanner::admin::database::v1::Database>, GetDatabase,
+      (StatusOr<google::spanner::admin::database::v1::Database>), GetDatabase,
       (google::spanner::admin::database::v1::GetDatabaseRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::spanner::admin::database::v1::Database>>,
+      (future<StatusOr<google::spanner::admin::database::v1::Database>>),
       UpdateDatabase,
       (google::spanner::admin::database::v1::UpdateDatabaseRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata>>,
+      (future<StatusOr<
+           google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata>>),
       UpdateDatabaseDdl,
       (google::spanner::admin::database::v1::UpdateDatabaseDdlRequest const&
            request),
@@ -86,43 +86,43 @@ class MockDatabaseAdminConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::spanner::admin::database::v1::GetDatabaseDdlResponse>,
+      (StatusOr<google::spanner::admin::database::v1::GetDatabaseDdlResponse>),
       GetDatabaseDdl,
       (google::spanner::admin::database::v1::GetDatabaseDdlRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), SetIamPolicy,
               (google::iam::v1::SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), GetIamPolicy,
               (google::iam::v1::GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD((StatusOr<google::iam::v1::TestIamPermissionsResponse>),
               TestIamPermissions,
               (google::iam::v1::TestIamPermissionsRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::spanner::admin::database::v1::Backup>>,
+  MOCK_METHOD((future<StatusOr<google::spanner::admin::database::v1::Backup>>),
               CreateBackup,
               (google::spanner::admin::database::v1::CreateBackupRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::spanner::admin::database::v1::Backup>>,
+      (future<StatusOr<google::spanner::admin::database::v1::Backup>>),
       CopyBackup,
       (google::spanner::admin::database::v1::CopyBackupRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::spanner::admin::database::v1::Backup>, GetBackup,
+      (StatusOr<google::spanner::admin::database::v1::Backup>), GetBackup,
       (google::spanner::admin::database::v1::GetBackupRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::spanner::admin::database::v1::Backup>,
+  MOCK_METHOD((StatusOr<google::spanner::admin::database::v1::Backup>),
               UpdateBackup,
               (google::spanner::admin::database::v1::UpdateBackupRequest const&
                    request),
@@ -139,7 +139,7 @@ class MockDatabaseAdminConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::spanner::admin::database::v1::Database>>,
+      (future<StatusOr<google::spanner::admin::database::v1::Database>>),
       RestoreDatabase,
       (google::spanner::admin::database::v1::RestoreDatabaseRequest const&
            request),

--- a/google/cloud/spanner/admin/mocks/mock_instance_admin_connection.h
+++ b/google/cloud/spanner/admin/mocks/mock_instance_admin_connection.h
@@ -55,21 +55,21 @@ class MockInstanceAdminConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::spanner::admin::instance::v1::InstanceConfig>,
+      (StatusOr<google::spanner::admin::instance::v1::InstanceConfig>),
       GetInstanceConfig,
       (google::spanner::admin::instance::v1::GetInstanceConfigRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::spanner::admin::instance::v1::InstanceConfig>>,
+      (future<StatusOr<google::spanner::admin::instance::v1::InstanceConfig>>),
       CreateInstanceConfig,
       (google::spanner::admin::instance::v1::CreateInstanceConfigRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::spanner::admin::instance::v1::InstanceConfig>>,
+      (future<StatusOr<google::spanner::admin::instance::v1::InstanceConfig>>),
       UpdateInstanceConfig,
       (google::spanner::admin::instance::v1::UpdateInstanceConfigRequest const&
            request),
@@ -102,19 +102,19 @@ class MockInstanceAdminConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::spanner::admin::instance::v1::Instance>, GetInstance,
+      (StatusOr<google::spanner::admin::instance::v1::Instance>), GetInstance,
       (google::spanner::admin::instance::v1::GetInstanceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::spanner::admin::instance::v1::Instance>>,
+      (future<StatusOr<google::spanner::admin::instance::v1::Instance>>),
       CreateInstance,
       (google::spanner::admin::instance::v1::CreateInstanceRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::spanner::admin::instance::v1::Instance>>,
+      (future<StatusOr<google::spanner::admin::instance::v1::Instance>>),
       UpdateInstance,
       (google::spanner::admin::instance::v1::UpdateInstanceRequest const&
            request),
@@ -126,28 +126,29 @@ class MockInstanceAdminConnection
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), SetIamPolicy,
               (google::iam::v1::SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), GetIamPolicy,
               (google::iam::v1::GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD((StatusOr<google::iam::v1::TestIamPermissionsResponse>),
               TestIamPermissions,
               (google::iam::v1::TestIamPermissionsRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::spanner::admin::instance::v1::InstancePartition>,
+      (StatusOr<google::spanner::admin::instance::v1::InstancePartition>),
       GetInstancePartition,
       (google::spanner::admin::instance::v1::GetInstancePartitionRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::spanner::admin::instance::v1::InstancePartition>>,
+      (future<
+          StatusOr<google::spanner::admin::instance::v1::InstancePartition>>),
       CreateInstancePartition,
       (google::spanner::admin::instance::v1::
            CreateInstancePartitionRequest const& request),
@@ -159,7 +160,8 @@ class MockInstanceAdminConnection
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::spanner::admin::instance::v1::InstancePartition>>,
+      (future<
+          StatusOr<google::spanner::admin::instance::v1::InstancePartition>>),
       UpdateInstancePartition,
       (google::spanner::admin::instance::v1::
            UpdateInstancePartitionRequest const& request),

--- a/google/cloud/speech/v1/mocks/mock_adaptation_connection.h
+++ b/google/cloud/speech/v1/mocks/mock_adaptation_connection.h
@@ -47,11 +47,11 @@ class MockAdaptationConnection : public speech_v1::AdaptationConnection {
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::speech::v1::PhraseSet>, CreatePhraseSet,
+      (StatusOr<google::cloud::speech::v1::PhraseSet>), CreatePhraseSet,
       (google::cloud::speech::v1::CreatePhraseSetRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::speech::v1::PhraseSet>, GetPhraseSet,
+  MOCK_METHOD((StatusOr<google::cloud::speech::v1::PhraseSet>), GetPhraseSet,
               (google::cloud::speech::v1::GetPhraseSetRequest const& request),
               (override));
 
@@ -61,7 +61,7 @@ class MockAdaptationConnection : public speech_v1::AdaptationConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::speech::v1::PhraseSet>, UpdatePhraseSet,
+      (StatusOr<google::cloud::speech::v1::PhraseSet>), UpdatePhraseSet,
       (google::cloud::speech::v1::UpdatePhraseSetRequest const& request),
       (override));
 
@@ -71,11 +71,12 @@ class MockAdaptationConnection : public speech_v1::AdaptationConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::speech::v1::CustomClass>, CreateCustomClass,
+      (StatusOr<google::cloud::speech::v1::CustomClass>), CreateCustomClass,
       (google::cloud::speech::v1::CreateCustomClassRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::speech::v1::CustomClass>, GetCustomClass,
+  MOCK_METHOD((StatusOr<google::cloud::speech::v1::CustomClass>),
+              GetCustomClass,
               (google::cloud::speech::v1::GetCustomClassRequest const& request),
               (override));
 
@@ -85,7 +86,7 @@ class MockAdaptationConnection : public speech_v1::AdaptationConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::speech::v1::CustomClass>, UpdateCustomClass,
+      (StatusOr<google::cloud::speech::v1::CustomClass>), UpdateCustomClass,
       (google::cloud::speech::v1::UpdateCustomClassRequest const& request),
       (override));
 

--- a/google/cloud/speech/v1/mocks/mock_speech_connection.h
+++ b/google/cloud/speech/v1/mocks/mock_speech_connection.h
@@ -46,12 +46,14 @@ class MockSpeechConnection : public speech_v1::SpeechConnection {
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::speech::v1::RecognizeResponse>, Recognize,
+  MOCK_METHOD((StatusOr<google::cloud::speech::v1::RecognizeResponse>),
+              Recognize,
               (google::cloud::speech::v1::RecognizeRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::speech::v1::LongRunningRecognizeResponse>>,
+      (future<
+          StatusOr<google::cloud::speech::v1::LongRunningRecognizeResponse>>),
       LongRunningRecognize,
       (google::cloud::speech::v1::LongRunningRecognizeRequest const& request),
       (override));

--- a/google/cloud/speech/v2/mocks/mock_speech_connection.h
+++ b/google/cloud/speech/v2/mocks/mock_speech_connection.h
@@ -47,7 +47,8 @@ class MockSpeechConnection : public speech_v2::SpeechConnection {
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::speech::v2::Recognizer>>, CreateRecognizer,
+      (future<StatusOr<google::cloud::speech::v2::Recognizer>>),
+      CreateRecognizer,
       (google::cloud::speech::v2::CreateRecognizerRequest const& request),
       (override));
 
@@ -56,27 +57,30 @@ class MockSpeechConnection : public speech_v2::SpeechConnection {
               (google::cloud::speech::v2::ListRecognizersRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::speech::v2::Recognizer>, GetRecognizer,
+  MOCK_METHOD((StatusOr<google::cloud::speech::v2::Recognizer>), GetRecognizer,
               (google::cloud::speech::v2::GetRecognizerRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::speech::v2::Recognizer>>, UpdateRecognizer,
+      (future<StatusOr<google::cloud::speech::v2::Recognizer>>),
+      UpdateRecognizer,
       (google::cloud::speech::v2::UpdateRecognizerRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::speech::v2::Recognizer>>, DeleteRecognizer,
+      (future<StatusOr<google::cloud::speech::v2::Recognizer>>),
+      DeleteRecognizer,
       (google::cloud::speech::v2::DeleteRecognizerRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::speech::v2::Recognizer>>,
+      (future<StatusOr<google::cloud::speech::v2::Recognizer>>),
       UndeleteRecognizer,
       (google::cloud::speech::v2::UndeleteRecognizerRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::speech::v2::RecognizeResponse>, Recognize,
+  MOCK_METHOD((StatusOr<google::cloud::speech::v2::RecognizeResponse>),
+              Recognize,
               (google::cloud::speech::v2::RecognizeRequest const& request),
               (override));
 
@@ -86,21 +90,21 @@ class MockSpeechConnection : public speech_v2::SpeechConnection {
               AsyncStreamingRecognize, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::speech::v2::BatchRecognizeResponse>>,
+      (future<StatusOr<google::cloud::speech::v2::BatchRecognizeResponse>>),
       BatchRecognize,
       (google::cloud::speech::v2::BatchRecognizeRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::speech::v2::Config>, GetConfig,
+  MOCK_METHOD((StatusOr<google::cloud::speech::v2::Config>), GetConfig,
               (google::cloud::speech::v2::GetConfigRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::speech::v2::Config>, UpdateConfig,
+  MOCK_METHOD((StatusOr<google::cloud::speech::v2::Config>), UpdateConfig,
               (google::cloud::speech::v2::UpdateConfigRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::speech::v2::CustomClass>>,
+      (future<StatusOr<google::cloud::speech::v2::CustomClass>>),
       CreateCustomClass,
       (google::cloud::speech::v2::CreateCustomClassRequest const& request),
       (override));
@@ -110,30 +114,31 @@ class MockSpeechConnection : public speech_v2::SpeechConnection {
               (google::cloud::speech::v2::ListCustomClassesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::speech::v2::CustomClass>, GetCustomClass,
+  MOCK_METHOD((StatusOr<google::cloud::speech::v2::CustomClass>),
+              GetCustomClass,
               (google::cloud::speech::v2::GetCustomClassRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::speech::v2::CustomClass>>,
+      (future<StatusOr<google::cloud::speech::v2::CustomClass>>),
       UpdateCustomClass,
       (google::cloud::speech::v2::UpdateCustomClassRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::speech::v2::CustomClass>>,
+      (future<StatusOr<google::cloud::speech::v2::CustomClass>>),
       DeleteCustomClass,
       (google::cloud::speech::v2::DeleteCustomClassRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::speech::v2::CustomClass>>,
+      (future<StatusOr<google::cloud::speech::v2::CustomClass>>),
       UndeleteCustomClass,
       (google::cloud::speech::v2::UndeleteCustomClassRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::speech::v2::PhraseSet>>, CreatePhraseSet,
+      (future<StatusOr<google::cloud::speech::v2::PhraseSet>>), CreatePhraseSet,
       (google::cloud::speech::v2::CreatePhraseSetRequest const& request),
       (override));
 
@@ -142,22 +147,23 @@ class MockSpeechConnection : public speech_v2::SpeechConnection {
               (google::cloud::speech::v2::ListPhraseSetsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::speech::v2::PhraseSet>, GetPhraseSet,
+  MOCK_METHOD((StatusOr<google::cloud::speech::v2::PhraseSet>), GetPhraseSet,
               (google::cloud::speech::v2::GetPhraseSetRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::speech::v2::PhraseSet>>, UpdatePhraseSet,
+      (future<StatusOr<google::cloud::speech::v2::PhraseSet>>), UpdatePhraseSet,
       (google::cloud::speech::v2::UpdatePhraseSetRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::speech::v2::PhraseSet>>, DeletePhraseSet,
+      (future<StatusOr<google::cloud::speech::v2::PhraseSet>>), DeletePhraseSet,
       (google::cloud::speech::v2::DeletePhraseSetRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::speech::v2::PhraseSet>>, UndeletePhraseSet,
+      (future<StatusOr<google::cloud::speech::v2::PhraseSet>>),
+      UndeletePhraseSet,
       (google::cloud::speech::v2::UndeletePhraseSetRequest const& request),
       (override));
 };

--- a/google/cloud/sql/v1/mocks/mock_sql_backup_runs_connection.h
+++ b/google/cloud/sql/v1/mocks/mock_sql_backup_runs_connection.h
@@ -48,20 +48,20 @@ class MockSqlBackupRunsServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::sql::v1::Operation>, Delete,
+      (StatusOr<google::cloud::sql::v1::Operation>), Delete,
       (google::cloud::sql::v1::SqlBackupRunsDeleteRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::sql::v1::BackupRun>, Get,
+  MOCK_METHOD((StatusOr<google::cloud::sql::v1::BackupRun>), Get,
               (google::cloud::sql::v1::SqlBackupRunsGetRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::sql::v1::Operation>, Insert,
+      (StatusOr<google::cloud::sql::v1::Operation>), Insert,
       (google::cloud::sql::v1::SqlBackupRunsInsertRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::sql::v1::BackupRunsListResponse>, List,
+  MOCK_METHOD((StatusOr<google::cloud::sql::v1::BackupRunsListResponse>), List,
               (google::cloud::sql::v1::SqlBackupRunsListRequest const& request),
               (override));
 };

--- a/google/cloud/sql/v1/mocks/mock_sql_connect_connection.h
+++ b/google/cloud/sql/v1/mocks/mock_sql_connect_connection.h
@@ -48,12 +48,12 @@ class MockSqlConnectServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::sql::v1::ConnectSettings>, GetConnectSettings,
+      (StatusOr<google::cloud::sql::v1::ConnectSettings>), GetConnectSettings,
       (google::cloud::sql::v1::GetConnectSettingsRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::sql::v1::GenerateEphemeralCertResponse>,
+      (StatusOr<google::cloud::sql::v1::GenerateEphemeralCertResponse>),
       GenerateEphemeralCert,
       (google::cloud::sql::v1::GenerateEphemeralCertRequest const& request),
       (override));

--- a/google/cloud/sql/v1/mocks/mock_sql_databases_connection.h
+++ b/google/cloud/sql/v1/mocks/mock_sql_databases_connection.h
@@ -48,30 +48,30 @@ class MockSqlDatabasesServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::sql::v1::Operation>, Delete,
+      (StatusOr<google::cloud::sql::v1::Operation>), Delete,
       (google::cloud::sql::v1::SqlDatabasesDeleteRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::sql::v1::Database>, Get,
+  MOCK_METHOD((StatusOr<google::cloud::sql::v1::Database>), Get,
               (google::cloud::sql::v1::SqlDatabasesGetRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::sql::v1::Operation>, Insert,
+      (StatusOr<google::cloud::sql::v1::Operation>), Insert,
       (google::cloud::sql::v1::SqlDatabasesInsertRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::sql::v1::DatabasesListResponse>, List,
+  MOCK_METHOD((StatusOr<google::cloud::sql::v1::DatabasesListResponse>), List,
               (google::cloud::sql::v1::SqlDatabasesListRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::sql::v1::Operation>, Patch,
+      (StatusOr<google::cloud::sql::v1::Operation>), Patch,
       (google::cloud::sql::v1::SqlDatabasesUpdateRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::sql::v1::Operation>, Update,
+      (StatusOr<google::cloud::sql::v1::Operation>), Update,
       (google::cloud::sql::v1::SqlDatabasesUpdateRequest const& request),
       (override));
 };

--- a/google/cloud/sql/v1/mocks/mock_sql_flags_connection.h
+++ b/google/cloud/sql/v1/mocks/mock_sql_flags_connection.h
@@ -46,7 +46,7 @@ class MockSqlFlagsServiceConnection : public sql_v1::SqlFlagsServiceConnection {
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::sql::v1::FlagsListResponse>, List,
+  MOCK_METHOD((StatusOr<google::cloud::sql::v1::FlagsListResponse>), List,
               (google::cloud::sql::v1::SqlFlagsListRequest const& request),
               (override));
 };

--- a/google/cloud/sql/v1/mocks/mock_sql_instances_connection.h
+++ b/google/cloud/sql/v1/mocks/mock_sql_instances_connection.h
@@ -48,55 +48,55 @@ class MockSqlInstancesServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::sql::v1::Operation>, AddServerCa,
+      (StatusOr<google::cloud::sql::v1::Operation>), AddServerCa,
       (google::cloud::sql::v1::SqlInstancesAddServerCaRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::sql::v1::Operation>, Clone,
+  MOCK_METHOD((StatusOr<google::cloud::sql::v1::Operation>), Clone,
               (google::cloud::sql::v1::SqlInstancesCloneRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::sql::v1::Operation>, Delete,
+      (StatusOr<google::cloud::sql::v1::Operation>), Delete,
       (google::cloud::sql::v1::SqlInstancesDeleteRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::sql::v1::Operation>, DemoteMaster,
+      (StatusOr<google::cloud::sql::v1::Operation>), DemoteMaster,
       (google::cloud::sql::v1::SqlInstancesDemoteMasterRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::sql::v1::Operation>, Demote,
+      (StatusOr<google::cloud::sql::v1::Operation>), Demote,
       (google::cloud::sql::v1::SqlInstancesDemoteRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::sql::v1::Operation>, Export,
+      (StatusOr<google::cloud::sql::v1::Operation>), Export,
       (google::cloud::sql::v1::SqlInstancesExportRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::sql::v1::Operation>, Failover,
+      (StatusOr<google::cloud::sql::v1::Operation>), Failover,
       (google::cloud::sql::v1::SqlInstancesFailoverRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::sql::v1::Operation>, Reencrypt,
+      (StatusOr<google::cloud::sql::v1::Operation>), Reencrypt,
       (google::cloud::sql::v1::SqlInstancesReencryptRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::sql::v1::DatabaseInstance>, Get,
+  MOCK_METHOD((StatusOr<google::cloud::sql::v1::DatabaseInstance>), Get,
               (google::cloud::sql::v1::SqlInstancesGetRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::sql::v1::Operation>, Import,
+      (StatusOr<google::cloud::sql::v1::Operation>), Import,
       (google::cloud::sql::v1::SqlInstancesImportRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::sql::v1::Operation>, Insert,
+      (StatusOr<google::cloud::sql::v1::Operation>), Insert,
       (google::cloud::sql::v1::SqlInstancesInsertRequest const& request),
       (override));
 
@@ -105,113 +105,114 @@ class MockSqlInstancesServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::sql::v1::InstancesListServerCasResponse>,
+      (StatusOr<google::cloud::sql::v1::InstancesListServerCasResponse>),
       ListServerCas,
       (google::cloud::sql::v1::SqlInstancesListServerCasRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::sql::v1::Operation>, Patch,
+  MOCK_METHOD((StatusOr<google::cloud::sql::v1::Operation>), Patch,
               (google::cloud::sql::v1::SqlInstancesPatchRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::sql::v1::Operation>, PromoteReplica,
+  MOCK_METHOD((StatusOr<google::cloud::sql::v1::Operation>), PromoteReplica,
               (google::cloud::sql::v1::SqlInstancesPromoteReplicaRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::sql::v1::Operation>, Switchover,
+      (StatusOr<google::cloud::sql::v1::Operation>), Switchover,
       (google::cloud::sql::v1::SqlInstancesSwitchoverRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::sql::v1::Operation>, ResetSslConfig,
+  MOCK_METHOD((StatusOr<google::cloud::sql::v1::Operation>), ResetSslConfig,
               (google::cloud::sql::v1::SqlInstancesResetSslConfigRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::sql::v1::Operation>, Restart,
+      (StatusOr<google::cloud::sql::v1::Operation>), Restart,
       (google::cloud::sql::v1::SqlInstancesRestartRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::sql::v1::Operation>, RestoreBackup,
+      (StatusOr<google::cloud::sql::v1::Operation>), RestoreBackup,
       (google::cloud::sql::v1::SqlInstancesRestoreBackupRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::sql::v1::Operation>, RotateServerCa,
+  MOCK_METHOD((StatusOr<google::cloud::sql::v1::Operation>), RotateServerCa,
               (google::cloud::sql::v1::SqlInstancesRotateServerCaRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::sql::v1::Operation>, StartReplica,
+      (StatusOr<google::cloud::sql::v1::Operation>), StartReplica,
       (google::cloud::sql::v1::SqlInstancesStartReplicaRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::sql::v1::Operation>, StopReplica,
+      (StatusOr<google::cloud::sql::v1::Operation>), StopReplica,
       (google::cloud::sql::v1::SqlInstancesStopReplicaRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::sql::v1::Operation>, TruncateLog,
+      (StatusOr<google::cloud::sql::v1::Operation>), TruncateLog,
       (google::cloud::sql::v1::SqlInstancesTruncateLogRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::sql::v1::Operation>, Update,
+      (StatusOr<google::cloud::sql::v1::Operation>), Update,
       (google::cloud::sql::v1::SqlInstancesUpdateRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::sql::v1::SslCert>, CreateEphemeral,
+      (StatusOr<google::cloud::sql::v1::SslCert>), CreateEphemeral,
       (google::cloud::sql::v1::SqlInstancesCreateEphemeralCertRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::sql::v1::Operation>, RescheduleMaintenance,
+      (StatusOr<google::cloud::sql::v1::Operation>), RescheduleMaintenance,
       (google::cloud::sql::v1::SqlInstancesRescheduleMaintenanceRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::sql::v1::
-                   SqlInstancesVerifyExternalSyncSettingsResponse>,
+      (StatusOr<google::cloud::sql::v1::
+                    SqlInstancesVerifyExternalSyncSettingsResponse>),
       VerifyExternalSyncSettings,
       (google::cloud::sql::v1::
            SqlInstancesVerifyExternalSyncSettingsRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::sql::v1::Operation>, StartExternalSync,
+      (StatusOr<google::cloud::sql::v1::Operation>), StartExternalSync,
       (google::cloud::sql::v1::SqlInstancesStartExternalSyncRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::sql::v1::Operation>, PerformDiskShrink,
+      (StatusOr<google::cloud::sql::v1::Operation>), PerformDiskShrink,
       (google::cloud::sql::v1::SqlInstancesPerformDiskShrinkRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::sql::v1::SqlInstancesGetDiskShrinkConfigResponse>,
+      (StatusOr<
+          google::cloud::sql::v1::SqlInstancesGetDiskShrinkConfigResponse>),
       GetDiskShrinkConfig,
       (google::cloud::sql::v1::SqlInstancesGetDiskShrinkConfigRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::sql::v1::Operation>, ResetReplicaSize,
+      (StatusOr<google::cloud::sql::v1::Operation>), ResetReplicaSize,
       (google::cloud::sql::v1::SqlInstancesResetReplicaSizeRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::sql::v1::SqlInstancesGetLatestRecoveryTimeResponse>,
+      (StatusOr<
+          google::cloud::sql::v1::SqlInstancesGetLatestRecoveryTimeResponse>),
       GetLatestRecoveryTime,
       (google::cloud::sql::v1::SqlInstancesGetLatestRecoveryTimeRequest const&
            request),

--- a/google/cloud/sql/v1/mocks/mock_sql_operations_connection.h
+++ b/google/cloud/sql/v1/mocks/mock_sql_operations_connection.h
@@ -47,7 +47,7 @@ class MockSqlOperationsServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::sql::v1::Operation>, Get,
+  MOCK_METHOD((StatusOr<google::cloud::sql::v1::Operation>), Get,
               (google::cloud::sql::v1::SqlOperationsGetRequest const& request),
               (override));
 

--- a/google/cloud/sql/v1/mocks/mock_sql_ssl_certs_connection.h
+++ b/google/cloud/sql/v1/mocks/mock_sql_ssl_certs_connection.h
@@ -47,19 +47,20 @@ class MockSqlSslCertsServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::sql::v1::Operation>, Delete,
+  MOCK_METHOD((StatusOr<google::cloud::sql::v1::Operation>), Delete,
               (google::cloud::sql::v1::SqlSslCertsDeleteRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::sql::v1::SslCert>, Get,
+  MOCK_METHOD((StatusOr<google::cloud::sql::v1::SslCert>), Get,
               (google::cloud::sql::v1::SqlSslCertsGetRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::sql::v1::SslCertsInsertResponse>, Insert,
+  MOCK_METHOD((StatusOr<google::cloud::sql::v1::SslCertsInsertResponse>),
+              Insert,
               (google::cloud::sql::v1::SqlSslCertsInsertRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::sql::v1::SslCertsListResponse>, List,
+  MOCK_METHOD((StatusOr<google::cloud::sql::v1::SslCertsListResponse>), List,
               (google::cloud::sql::v1::SqlSslCertsListRequest const& request),
               (override));
 };

--- a/google/cloud/sql/v1/mocks/mock_sql_tiers_connection.h
+++ b/google/cloud/sql/v1/mocks/mock_sql_tiers_connection.h
@@ -46,7 +46,7 @@ class MockSqlTiersServiceConnection : public sql_v1::SqlTiersServiceConnection {
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::sql::v1::TiersListResponse>, List,
+  MOCK_METHOD((StatusOr<google::cloud::sql::v1::TiersListResponse>), List,
               (google::cloud::sql::v1::SqlTiersListRequest const& request),
               (override));
 };

--- a/google/cloud/sql/v1/mocks/mock_sql_users_connection.h
+++ b/google/cloud/sql/v1/mocks/mock_sql_users_connection.h
@@ -46,23 +46,23 @@ class MockSqlUsersServiceConnection : public sql_v1::SqlUsersServiceConnection {
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::sql::v1::Operation>, Delete,
+  MOCK_METHOD((StatusOr<google::cloud::sql::v1::Operation>), Delete,
               (google::cloud::sql::v1::SqlUsersDeleteRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::sql::v1::User>, Get,
+  MOCK_METHOD((StatusOr<google::cloud::sql::v1::User>), Get,
               (google::cloud::sql::v1::SqlUsersGetRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::sql::v1::Operation>, Insert,
+  MOCK_METHOD((StatusOr<google::cloud::sql::v1::Operation>), Insert,
               (google::cloud::sql::v1::SqlUsersInsertRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::sql::v1::UsersListResponse>, List,
+  MOCK_METHOD((StatusOr<google::cloud::sql::v1::UsersListResponse>), List,
               (google::cloud::sql::v1::SqlUsersListRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::sql::v1::Operation>, Update,
+  MOCK_METHOD((StatusOr<google::cloud::sql::v1::Operation>), Update,
               (google::cloud::sql::v1::SqlUsersUpdateRequest const& request),
               (override));
 };

--- a/google/cloud/storagecontrol/v2/mocks/mock_storage_control_connection.h
+++ b/google/cloud/storagecontrol/v2/mocks/mock_storage_control_connection.h
@@ -48,7 +48,7 @@ class MockStorageControlConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::storage::control::v2::Folder>, CreateFolder,
+      (StatusOr<google::storage::control::v2::Folder>), CreateFolder,
       (google::storage::control::v2::CreateFolderRequest const& request),
       (override));
 
@@ -57,7 +57,7 @@ class MockStorageControlConnection
       (google::storage::control::v2::DeleteFolderRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::storage::control::v2::Folder>, GetFolder,
+  MOCK_METHOD((StatusOr<google::storage::control::v2::Folder>), GetFolder,
               (google::storage::control::v2::GetFolderRequest const& request),
               (override));
 
@@ -66,17 +66,17 @@ class MockStorageControlConnection
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::storage::control::v2::Folder>>, RenameFolder,
+      (future<StatusOr<google::storage::control::v2::Folder>>), RenameFolder,
       (google::storage::control::v2::RenameFolderRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::storage::control::v2::StorageLayout>, GetStorageLayout,
+      (StatusOr<google::storage::control::v2::StorageLayout>), GetStorageLayout,
       (google::storage::control::v2::GetStorageLayoutRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::storage::control::v2::ManagedFolder>,
+      (StatusOr<google::storage::control::v2::ManagedFolder>),
       CreateManagedFolder,
       (google::storage::control::v2::CreateManagedFolderRequest const& request),
       (override));
@@ -87,7 +87,7 @@ class MockStorageControlConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::storage::control::v2::ManagedFolder>, GetManagedFolder,
+      (StatusOr<google::storage::control::v2::ManagedFolder>), GetManagedFolder,
       (google::storage::control::v2::GetManagedFolderRequest const& request),
       (override));
 

--- a/google/cloud/storageinsights/v1/mocks/mock_storage_insights_connection.h
+++ b/google/cloud/storageinsights/v1/mocks/mock_storage_insights_connection.h
@@ -53,21 +53,21 @@ class MockStorageInsightsConnection
       (google::cloud::storageinsights::v1::ListReportConfigsRequest request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::storageinsights::v1::ReportConfig>,
+  MOCK_METHOD((StatusOr<google::cloud::storageinsights::v1::ReportConfig>),
               GetReportConfig,
               (google::cloud::storageinsights::v1::GetReportConfigRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::storageinsights::v1::ReportConfig>,
+      (StatusOr<google::cloud::storageinsights::v1::ReportConfig>),
       CreateReportConfig,
       (google::cloud::storageinsights::v1::CreateReportConfigRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::storageinsights::v1::ReportConfig>,
+      (StatusOr<google::cloud::storageinsights::v1::ReportConfig>),
       UpdateReportConfig,
       (google::cloud::storageinsights::v1::UpdateReportConfigRequest const&
            request),
@@ -85,7 +85,7 @@ class MockStorageInsightsConnection
       (google::cloud::storageinsights::v1::ListReportDetailsRequest request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::storageinsights::v1::ReportDetail>,
+  MOCK_METHOD((StatusOr<google::cloud::storageinsights::v1::ReportDetail>),
               GetReportDetail,
               (google::cloud::storageinsights::v1::GetReportDetailRequest const&
                    request),

--- a/google/cloud/storagetransfer/v1/mocks/mock_storage_transfer_connection.h
+++ b/google/cloud/storagetransfer/v1/mocks/mock_storage_transfer_connection.h
@@ -48,24 +48,24 @@ class MockStorageTransferServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::storagetransfer::v1::GoogleServiceAccount>,
+      (StatusOr<google::storagetransfer::v1::GoogleServiceAccount>),
       GetGoogleServiceAccount,
       (google::storagetransfer::v1::GetGoogleServiceAccountRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::storagetransfer::v1::TransferJob>, CreateTransferJob,
+      (StatusOr<google::storagetransfer::v1::TransferJob>), CreateTransferJob,
       (google::storagetransfer::v1::CreateTransferJobRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::storagetransfer::v1::TransferJob>, UpdateTransferJob,
+      (StatusOr<google::storagetransfer::v1::TransferJob>), UpdateTransferJob,
       (google::storagetransfer::v1::UpdateTransferJobRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::storagetransfer::v1::TransferJob>, GetTransferJob,
+      (StatusOr<google::storagetransfer::v1::TransferJob>), GetTransferJob,
       (google::storagetransfer::v1::GetTransferJobRequest const& request),
       (override));
 
@@ -86,7 +86,7 @@ class MockStorageTransferServiceConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::storagetransfer::v1::TransferOperation>>,
+      (future<StatusOr<google::storagetransfer::v1::TransferOperation>>),
       RunTransferJob,
       (google::storagetransfer::v1::RunTransferJobRequest const& request),
       (override));
@@ -97,16 +97,16 @@ class MockStorageTransferServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::storagetransfer::v1::AgentPool>, CreateAgentPool,
+      (StatusOr<google::storagetransfer::v1::AgentPool>), CreateAgentPool,
       (google::storagetransfer::v1::CreateAgentPoolRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::storagetransfer::v1::AgentPool>, UpdateAgentPool,
+      (StatusOr<google::storagetransfer::v1::AgentPool>), UpdateAgentPool,
       (google::storagetransfer::v1::UpdateAgentPoolRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::storagetransfer::v1::AgentPool>, GetAgentPool,
+  MOCK_METHOD((StatusOr<google::storagetransfer::v1::AgentPool>), GetAgentPool,
               (google::storagetransfer::v1::GetAgentPoolRequest const& request),
               (override));
 

--- a/google/cloud/support/v2/mocks/mock_case_connection.h
+++ b/google/cloud/support/v2/mocks/mock_case_connection.h
@@ -46,7 +46,7 @@ class MockCaseServiceConnection : public support_v2::CaseServiceConnection {
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::support::v2::Case>, GetCase,
+  MOCK_METHOD((StatusOr<google::cloud::support::v2::Case>), GetCase,
               (google::cloud::support::v2::GetCaseRequest const& request),
               (override));
 
@@ -58,19 +58,19 @@ class MockCaseServiceConnection : public support_v2::CaseServiceConnection {
               (google::cloud::support::v2::SearchCasesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::support::v2::Case>, CreateCase,
+  MOCK_METHOD((StatusOr<google::cloud::support::v2::Case>), CreateCase,
               (google::cloud::support::v2::CreateCaseRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::support::v2::Case>, UpdateCase,
+  MOCK_METHOD((StatusOr<google::cloud::support::v2::Case>), UpdateCase,
               (google::cloud::support::v2::UpdateCaseRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::support::v2::Case>, EscalateCase,
+  MOCK_METHOD((StatusOr<google::cloud::support::v2::Case>), EscalateCase,
               (google::cloud::support::v2::EscalateCaseRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::support::v2::Case>, CloseCase,
+  MOCK_METHOD((StatusOr<google::cloud::support::v2::Case>), CloseCase,
               (google::cloud::support::v2::CloseCaseRequest const& request),
               (override));
 

--- a/google/cloud/support/v2/mocks/mock_comment_connection.h
+++ b/google/cloud/support/v2/mocks/mock_comment_connection.h
@@ -51,7 +51,7 @@ class MockCommentServiceConnection
               (google::cloud::support::v2::ListCommentsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::support::v2::Comment>, CreateComment,
+  MOCK_METHOD((StatusOr<google::cloud::support::v2::Comment>), CreateComment,
               (google::cloud::support::v2::CreateCommentRequest const& request),
               (override));
 };

--- a/google/cloud/talent/v4/mocks/mock_company_connection.h
+++ b/google/cloud/talent/v4/mocks/mock_company_connection.h
@@ -47,15 +47,15 @@ class MockCompanyServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::talent::v4::Company>, CreateCompany,
+  MOCK_METHOD((StatusOr<google::cloud::talent::v4::Company>), CreateCompany,
               (google::cloud::talent::v4::CreateCompanyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::talent::v4::Company>, GetCompany,
+  MOCK_METHOD((StatusOr<google::cloud::talent::v4::Company>), GetCompany,
               (google::cloud::talent::v4::GetCompanyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::talent::v4::Company>, UpdateCompany,
+  MOCK_METHOD((StatusOr<google::cloud::talent::v4::Company>), UpdateCompany,
               (google::cloud::talent::v4::UpdateCompanyRequest const& request),
               (override));
 

--- a/google/cloud/talent/v4/mocks/mock_completion_connection.h
+++ b/google/cloud/talent/v4/mocks/mock_completion_connection.h
@@ -46,7 +46,7 @@ class MockCompletionConnection : public talent_v4::CompletionConnection {
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::talent::v4::CompleteQueryResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::talent::v4::CompleteQueryResponse>),
               CompleteQuery,
               (google::cloud::talent::v4::CompleteQueryRequest const& request),
               (override));

--- a/google/cloud/talent/v4/mocks/mock_event_connection.h
+++ b/google/cloud/talent/v4/mocks/mock_event_connection.h
@@ -47,7 +47,7 @@ class MockEventServiceConnection : public talent_v4::EventServiceConnection {
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::talent::v4::ClientEvent>, CreateClientEvent,
+      (StatusOr<google::cloud::talent::v4::ClientEvent>), CreateClientEvent,
       (google::cloud::talent::v4::CreateClientEventRequest const& request),
       (override));
 };

--- a/google/cloud/talent/v4/mocks/mock_job_connection.h
+++ b/google/cloud/talent/v4/mocks/mock_job_connection.h
@@ -46,26 +46,26 @@ class MockJobServiceConnection : public talent_v4::JobServiceConnection {
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::talent::v4::Job>, CreateJob,
+  MOCK_METHOD((StatusOr<google::cloud::talent::v4::Job>), CreateJob,
               (google::cloud::talent::v4::CreateJobRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::talent::v4::BatchCreateJobsResponse>>,
+      (future<StatusOr<google::cloud::talent::v4::BatchCreateJobsResponse>>),
       BatchCreateJobs,
       (google::cloud::talent::v4::BatchCreateJobsRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::talent::v4::Job>, GetJob,
+  MOCK_METHOD((StatusOr<google::cloud::talent::v4::Job>), GetJob,
               (google::cloud::talent::v4::GetJobRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::talent::v4::Job>, UpdateJob,
+  MOCK_METHOD((StatusOr<google::cloud::talent::v4::Job>), UpdateJob,
               (google::cloud::talent::v4::UpdateJobRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::talent::v4::BatchUpdateJobsResponse>>,
+      (future<StatusOr<google::cloud::talent::v4::BatchUpdateJobsResponse>>),
       BatchUpdateJobs,
       (google::cloud::talent::v4::BatchUpdateJobsRequest const& request),
       (override));
@@ -75,7 +75,7 @@ class MockJobServiceConnection : public talent_v4::JobServiceConnection {
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::talent::v4::BatchDeleteJobsResponse>>,
+      (future<StatusOr<google::cloud::talent::v4::BatchDeleteJobsResponse>>),
       BatchDeleteJobs,
       (google::cloud::talent::v4::BatchDeleteJobsRequest const& request),
       (override));
@@ -83,12 +83,12 @@ class MockJobServiceConnection : public talent_v4::JobServiceConnection {
   MOCK_METHOD((StreamRange<google::cloud::talent::v4::Job>), ListJobs,
               (google::cloud::talent::v4::ListJobsRequest request), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::talent::v4::SearchJobsResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::talent::v4::SearchJobsResponse>),
               SearchJobs,
               (google::cloud::talent::v4::SearchJobsRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::talent::v4::SearchJobsResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::talent::v4::SearchJobsResponse>),
               SearchJobsForAlert,
               (google::cloud::talent::v4::SearchJobsRequest const& request),
               (override));

--- a/google/cloud/talent/v4/mocks/mock_tenant_connection.h
+++ b/google/cloud/talent/v4/mocks/mock_tenant_connection.h
@@ -46,15 +46,15 @@ class MockTenantServiceConnection : public talent_v4::TenantServiceConnection {
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::talent::v4::Tenant>, CreateTenant,
+  MOCK_METHOD((StatusOr<google::cloud::talent::v4::Tenant>), CreateTenant,
               (google::cloud::talent::v4::CreateTenantRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::talent::v4::Tenant>, GetTenant,
+  MOCK_METHOD((StatusOr<google::cloud::talent::v4::Tenant>), GetTenant,
               (google::cloud::talent::v4::GetTenantRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::talent::v4::Tenant>, UpdateTenant,
+  MOCK_METHOD((StatusOr<google::cloud::talent::v4::Tenant>), UpdateTenant,
               (google::cloud::talent::v4::UpdateTenantRequest const& request),
               (override));
 

--- a/google/cloud/tasks/v2/mocks/mock_cloud_tasks_connection.h
+++ b/google/cloud/tasks/v2/mocks/mock_cloud_tasks_connection.h
@@ -50,15 +50,15 @@ class MockCloudTasksConnection : public tasks_v2::CloudTasksConnection {
               (google::cloud::tasks::v2::ListQueuesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::tasks::v2::Queue>, GetQueue,
+  MOCK_METHOD((StatusOr<google::cloud::tasks::v2::Queue>), GetQueue,
               (google::cloud::tasks::v2::GetQueueRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::tasks::v2::Queue>, CreateQueue,
+  MOCK_METHOD((StatusOr<google::cloud::tasks::v2::Queue>), CreateQueue,
               (google::cloud::tasks::v2::CreateQueueRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::tasks::v2::Queue>, UpdateQueue,
+  MOCK_METHOD((StatusOr<google::cloud::tasks::v2::Queue>), UpdateQueue,
               (google::cloud::tasks::v2::UpdateQueueRequest const& request),
               (override));
 
@@ -66,27 +66,27 @@ class MockCloudTasksConnection : public tasks_v2::CloudTasksConnection {
               (google::cloud::tasks::v2::DeleteQueueRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::tasks::v2::Queue>, PurgeQueue,
+  MOCK_METHOD((StatusOr<google::cloud::tasks::v2::Queue>), PurgeQueue,
               (google::cloud::tasks::v2::PurgeQueueRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::tasks::v2::Queue>, PauseQueue,
+  MOCK_METHOD((StatusOr<google::cloud::tasks::v2::Queue>), PauseQueue,
               (google::cloud::tasks::v2::PauseQueueRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::tasks::v2::Queue>, ResumeQueue,
+  MOCK_METHOD((StatusOr<google::cloud::tasks::v2::Queue>), ResumeQueue,
               (google::cloud::tasks::v2::ResumeQueueRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), GetIamPolicy,
               (google::iam::v1::GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetIamPolicy,
+  MOCK_METHOD((StatusOr<google::iam::v1::Policy>), SetIamPolicy,
               (google::iam::v1::SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD((StatusOr<google::iam::v1::TestIamPermissionsResponse>),
               TestIamPermissions,
               (google::iam::v1::TestIamPermissionsRequest const& request),
               (override));
@@ -94,11 +94,11 @@ class MockCloudTasksConnection : public tasks_v2::CloudTasksConnection {
   MOCK_METHOD((StreamRange<google::cloud::tasks::v2::Task>), ListTasks,
               (google::cloud::tasks::v2::ListTasksRequest request), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::tasks::v2::Task>, GetTask,
+  MOCK_METHOD((StatusOr<google::cloud::tasks::v2::Task>), GetTask,
               (google::cloud::tasks::v2::GetTaskRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::tasks::v2::Task>, CreateTask,
+  MOCK_METHOD((StatusOr<google::cloud::tasks::v2::Task>), CreateTask,
               (google::cloud::tasks::v2::CreateTaskRequest const& request),
               (override));
 
@@ -106,7 +106,7 @@ class MockCloudTasksConnection : public tasks_v2::CloudTasksConnection {
               (google::cloud::tasks::v2::DeleteTaskRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::tasks::v2::Task>, RunTask,
+  MOCK_METHOD((StatusOr<google::cloud::tasks::v2::Task>), RunTask,
               (google::cloud::tasks::v2::RunTaskRequest const& request),
               (override));
 };

--- a/google/cloud/telcoautomation/v1/mocks/mock_telco_automation_connection.h
+++ b/google/cloud/telcoautomation/v1/mocks/mock_telco_automation_connection.h
@@ -55,22 +55,22 @@ class MockTelcoAutomationConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::telcoautomation::v1::OrchestrationCluster>,
+      (StatusOr<google::cloud::telcoautomation::v1::OrchestrationCluster>),
       GetOrchestrationCluster,
       (google::cloud::telcoautomation::v1::GetOrchestrationClusterRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::telcoautomation::v1::OrchestrationCluster>>,
+      (future<
+          StatusOr<google::cloud::telcoautomation::v1::OrchestrationCluster>>),
       CreateOrchestrationCluster,
       (google::cloud::telcoautomation::v1::
            CreateOrchestrationClusterRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::telcoautomation::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::telcoautomation::v1::OperationMetadata>>),
       DeleteOrchestrationCluster,
       (google::cloud::telcoautomation::v1::
            DeleteOrchestrationClusterRequest const& request),
@@ -82,36 +82,36 @@ class MockTelcoAutomationConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::telcoautomation::v1::EdgeSlm>, GetEdgeSlm,
+      (StatusOr<google::cloud::telcoautomation::v1::EdgeSlm>), GetEdgeSlm,
       (google::cloud::telcoautomation::v1::GetEdgeSlmRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::telcoautomation::v1::EdgeSlm>>,
+      (future<StatusOr<google::cloud::telcoautomation::v1::EdgeSlm>>),
       CreateEdgeSlm,
       (google::cloud::telcoautomation::v1::CreateEdgeSlmRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::telcoautomation::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::telcoautomation::v1::OperationMetadata>>),
       DeleteEdgeSlm,
       (google::cloud::telcoautomation::v1::DeleteEdgeSlmRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::telcoautomation::v1::Blueprint>,
+  MOCK_METHOD((StatusOr<google::cloud::telcoautomation::v1::Blueprint>),
               CreateBlueprint,
               (google::cloud::telcoautomation::v1::CreateBlueprintRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::telcoautomation::v1::Blueprint>,
+  MOCK_METHOD((StatusOr<google::cloud::telcoautomation::v1::Blueprint>),
               UpdateBlueprint,
               (google::cloud::telcoautomation::v1::UpdateBlueprintRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::telcoautomation::v1::Blueprint>, GetBlueprint,
+      (StatusOr<google::cloud::telcoautomation::v1::Blueprint>), GetBlueprint,
       (google::cloud::telcoautomation::v1::GetBlueprintRequest const& request),
       (override));
 
@@ -127,18 +127,20 @@ class MockTelcoAutomationConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::telcoautomation::v1::Blueprint>, ApproveBlueprint,
+      (StatusOr<google::cloud::telcoautomation::v1::Blueprint>),
+      ApproveBlueprint,
       (google::cloud::telcoautomation::v1::ApproveBlueprintRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::telcoautomation::v1::Blueprint>, ProposeBlueprint,
+      (StatusOr<google::cloud::telcoautomation::v1::Blueprint>),
+      ProposeBlueprint,
       (google::cloud::telcoautomation::v1::ProposeBlueprintRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::telcoautomation::v1::Blueprint>,
+  MOCK_METHOD((StatusOr<google::cloud::telcoautomation::v1::Blueprint>),
               RejectBlueprint,
               (google::cloud::telcoautomation::v1::RejectBlueprintRequest const&
                    request),
@@ -165,8 +167,8 @@ class MockTelcoAutomationConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::telcoautomation::v1::DiscardBlueprintChangesResponse>,
+      (StatusOr<
+          google::cloud::telcoautomation::v1::DiscardBlueprintChangesResponse>),
       DiscardBlueprintChanges,
       (google::cloud::telcoautomation::v1::DiscardBlueprintChangesRequest const&
            request),
@@ -179,28 +181,28 @@ class MockTelcoAutomationConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::telcoautomation::v1::PublicBlueprint>,
+      (StatusOr<google::cloud::telcoautomation::v1::PublicBlueprint>),
       GetPublicBlueprint,
       (google::cloud::telcoautomation::v1::GetPublicBlueprintRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::telcoautomation::v1::Deployment>,
+      (StatusOr<google::cloud::telcoautomation::v1::Deployment>),
       CreateDeployment,
       (google::cloud::telcoautomation::v1::CreateDeploymentRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::telcoautomation::v1::Deployment>,
+      (StatusOr<google::cloud::telcoautomation::v1::Deployment>),
       UpdateDeployment,
       (google::cloud::telcoautomation::v1::UpdateDeploymentRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::telcoautomation::v1::Deployment>, GetDeployment,
+      (StatusOr<google::cloud::telcoautomation::v1::Deployment>), GetDeployment,
       (google::cloud::telcoautomation::v1::GetDeploymentRequest const& request),
       (override));
 
@@ -223,37 +225,36 @@ class MockTelcoAutomationConnection
            request),
       (override));
 
-  MOCK_METHOD(
-      StatusOr<
-          google::cloud::telcoautomation::v1::DiscardDeploymentChangesResponse>,
-      DiscardDeploymentChanges,
-      (google::cloud::telcoautomation::v1::
-           DiscardDeploymentChangesRequest const& request),
-      (override));
+  MOCK_METHOD((StatusOr<google::cloud::telcoautomation::v1::
+                            DiscardDeploymentChangesResponse>),
+              DiscardDeploymentChanges,
+              (google::cloud::telcoautomation::v1::
+                   DiscardDeploymentChangesRequest const& request),
+              (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::telcoautomation::v1::Deployment>,
+  MOCK_METHOD((StatusOr<google::cloud::telcoautomation::v1::Deployment>),
               ApplyDeployment,
               (google::cloud::telcoautomation::v1::ApplyDeploymentRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::telcoautomation::v1::ComputeDeploymentStatusResponse>,
+      (StatusOr<
+          google::cloud::telcoautomation::v1::ComputeDeploymentStatusResponse>),
       ComputeDeploymentStatus,
       (google::cloud::telcoautomation::v1::ComputeDeploymentStatusRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::telcoautomation::v1::Deployment>,
+      (StatusOr<google::cloud::telcoautomation::v1::Deployment>),
       RollbackDeployment,
       (google::cloud::telcoautomation::v1::RollbackDeploymentRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::telcoautomation::v1::HydratedDeployment>,
+      (StatusOr<google::cloud::telcoautomation::v1::HydratedDeployment>),
       GetHydratedDeployment,
       (google::cloud::telcoautomation::v1::GetHydratedDeploymentRequest const&
            request),
@@ -266,14 +267,15 @@ class MockTelcoAutomationConnection
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::telcoautomation::v1::HydratedDeployment>,
-              UpdateHydratedDeployment,
-              (google::cloud::telcoautomation::v1::
-                   UpdateHydratedDeploymentRequest const& request),
-              (override));
+  MOCK_METHOD(
+      (StatusOr<google::cloud::telcoautomation::v1::HydratedDeployment>),
+      UpdateHydratedDeployment,
+      (google::cloud::telcoautomation::v1::
+           UpdateHydratedDeploymentRequest const& request),
+      (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::telcoautomation::v1::HydratedDeployment>,
+      (StatusOr<google::cloud::telcoautomation::v1::HydratedDeployment>),
       ApplyHydratedDeployment,
       (google::cloud::telcoautomation::v1::ApplyHydratedDeploymentRequest const&
            request),

--- a/google/cloud/texttospeech/v1/mocks/mock_text_to_speech_connection.h
+++ b/google/cloud/texttospeech/v1/mocks/mock_text_to_speech_connection.h
@@ -48,12 +48,13 @@ class MockTextToSpeechConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::texttospeech::v1::ListVoicesResponse>, ListVoices,
+      (StatusOr<google::cloud::texttospeech::v1::ListVoicesResponse>),
+      ListVoices,
       (google::cloud::texttospeech::v1::ListVoicesRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::texttospeech::v1::SynthesizeSpeechResponse>,
+      (StatusOr<google::cloud::texttospeech::v1::SynthesizeSpeechResponse>),
       SynthesizeSpeech,
       (google::cloud::texttospeech::v1::SynthesizeSpeechRequest const& request),
       (override));

--- a/google/cloud/timeseriesinsights/v1/mocks/mock_timeseries_insights_controller_connection.h
+++ b/google/cloud/timeseriesinsights/v1/mocks/mock_timeseries_insights_controller_connection.h
@@ -54,7 +54,7 @@ class MockTimeseriesInsightsControllerConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::timeseriesinsights::v1::DataSet>, CreateDataSet,
+      (StatusOr<google::cloud::timeseriesinsights::v1::DataSet>), CreateDataSet,
       (google::cloud::timeseriesinsights::v1::CreateDataSetRequest const&
            request),
       (override));
@@ -66,28 +66,28 @@ class MockTimeseriesInsightsControllerConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::timeseriesinsights::v1::AppendEventsResponse>,
+      (StatusOr<google::cloud::timeseriesinsights::v1::AppendEventsResponse>),
       AppendEvents,
       (google::cloud::timeseriesinsights::v1::AppendEventsRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::timeseriesinsights::v1::QueryDataSetResponse>,
+      (StatusOr<google::cloud::timeseriesinsights::v1::QueryDataSetResponse>),
       QueryDataSet,
       (google::cloud::timeseriesinsights::v1::QueryDataSetRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::timeseriesinsights::v1::EvaluatedSlice>,
+      (StatusOr<google::cloud::timeseriesinsights::v1::EvaluatedSlice>),
       EvaluateSlice,
       (google::cloud::timeseriesinsights::v1::EvaluateSliceRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::timeseriesinsights::v1::EvaluatedSlice>,
+      (StatusOr<google::cloud::timeseriesinsights::v1::EvaluatedSlice>),
       EvaluateTimeseries,
       (google::cloud::timeseriesinsights::v1::EvaluateTimeseriesRequest const&
            request),

--- a/google/cloud/tpu/v1/mocks/mock_tpu_connection.h
+++ b/google/cloud/tpu/v1/mocks/mock_tpu_connection.h
@@ -49,27 +49,27 @@ class MockTpuConnection : public tpu_v1::TpuConnection {
   MOCK_METHOD((StreamRange<google::cloud::tpu::v1::Node>), ListNodes,
               (google::cloud::tpu::v1::ListNodesRequest request), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::tpu::v1::Node>, GetNode,
+  MOCK_METHOD((StatusOr<google::cloud::tpu::v1::Node>), GetNode,
               (google::cloud::tpu::v1::GetNodeRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::tpu::v1::Node>>, CreateNode,
+  MOCK_METHOD((future<StatusOr<google::cloud::tpu::v1::Node>>), CreateNode,
               (google::cloud::tpu::v1::CreateNodeRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::tpu::v1::Node>>, DeleteNode,
+  MOCK_METHOD((future<StatusOr<google::cloud::tpu::v1::Node>>), DeleteNode,
               (google::cloud::tpu::v1::DeleteNodeRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::tpu::v1::Node>>, ReimageNode,
+  MOCK_METHOD((future<StatusOr<google::cloud::tpu::v1::Node>>), ReimageNode,
               (google::cloud::tpu::v1::ReimageNodeRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::tpu::v1::Node>>, StopNode,
+  MOCK_METHOD((future<StatusOr<google::cloud::tpu::v1::Node>>), StopNode,
               (google::cloud::tpu::v1::StopNodeRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::tpu::v1::Node>>, StartNode,
+  MOCK_METHOD((future<StatusOr<google::cloud::tpu::v1::Node>>), StartNode,
               (google::cloud::tpu::v1::StartNodeRequest const& request),
               (override));
 
@@ -79,7 +79,8 @@ class MockTpuConnection : public tpu_v1::TpuConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::tpu::v1::TensorFlowVersion>, GetTensorFlowVersion,
+      (StatusOr<google::cloud::tpu::v1::TensorFlowVersion>),
+      GetTensorFlowVersion,
       (google::cloud::tpu::v1::GetTensorFlowVersionRequest const& request),
       (override));
 
@@ -89,7 +90,7 @@ class MockTpuConnection : public tpu_v1::TpuConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::tpu::v1::AcceleratorType>, GetAcceleratorType,
+      (StatusOr<google::cloud::tpu::v1::AcceleratorType>), GetAcceleratorType,
       (google::cloud::tpu::v1::GetAcceleratorTypeRequest const& request),
       (override));
 };

--- a/google/cloud/tpu/v2/mocks/mock_tpu_connection.h
+++ b/google/cloud/tpu/v2/mocks/mock_tpu_connection.h
@@ -49,33 +49,33 @@ class MockTpuConnection : public tpu_v2::TpuConnection {
   MOCK_METHOD((StreamRange<google::cloud::tpu::v2::Node>), ListNodes,
               (google::cloud::tpu::v2::ListNodesRequest request), (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::tpu::v2::Node>, GetNode,
+  MOCK_METHOD((StatusOr<google::cloud::tpu::v2::Node>), GetNode,
               (google::cloud::tpu::v2::GetNodeRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::tpu::v2::Node>>, CreateNode,
+  MOCK_METHOD((future<StatusOr<google::cloud::tpu::v2::Node>>), CreateNode,
               (google::cloud::tpu::v2::CreateNodeRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::tpu::v2::OperationMetadata>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::tpu::v2::OperationMetadata>>),
               DeleteNode,
               (google::cloud::tpu::v2::DeleteNodeRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::tpu::v2::Node>>, StopNode,
+  MOCK_METHOD((future<StatusOr<google::cloud::tpu::v2::Node>>), StopNode,
               (google::cloud::tpu::v2::StopNodeRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::tpu::v2::Node>>, StartNode,
+  MOCK_METHOD((future<StatusOr<google::cloud::tpu::v2::Node>>), StartNode,
               (google::cloud::tpu::v2::StartNodeRequest const& request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::tpu::v2::Node>>, UpdateNode,
+  MOCK_METHOD((future<StatusOr<google::cloud::tpu::v2::Node>>), UpdateNode,
               (google::cloud::tpu::v2::UpdateNodeRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::tpu::v2::GenerateServiceIdentityResponse>,
+      (StatusOr<google::cloud::tpu::v2::GenerateServiceIdentityResponse>),
       GenerateServiceIdentity,
       (google::cloud::tpu::v2::GenerateServiceIdentityRequest const& request),
       (override));
@@ -86,7 +86,7 @@ class MockTpuConnection : public tpu_v2::TpuConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::tpu::v2::AcceleratorType>, GetAcceleratorType,
+      (StatusOr<google::cloud::tpu::v2::AcceleratorType>), GetAcceleratorType,
       (google::cloud::tpu::v2::GetAcceleratorTypeRequest const& request),
       (override));
 
@@ -95,13 +95,13 @@ class MockTpuConnection : public tpu_v2::TpuConnection {
               (google::cloud::tpu::v2::ListRuntimeVersionsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::tpu::v2::RuntimeVersion>,
+  MOCK_METHOD((StatusOr<google::cloud::tpu::v2::RuntimeVersion>),
               GetRuntimeVersion,
               (google::cloud::tpu::v2::GetRuntimeVersionRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::tpu::v2::GetGuestAttributesResponse>,
+      (StatusOr<google::cloud::tpu::v2::GetGuestAttributesResponse>),
       GetGuestAttributes,
       (google::cloud::tpu::v2::GetGuestAttributesRequest const& request),
       (override));

--- a/google/cloud/trace/v1/mocks/mock_trace_connection.h
+++ b/google/cloud/trace/v1/mocks/mock_trace_connection.h
@@ -52,7 +52,7 @@ class MockTraceServiceConnection : public trace_v1::TraceServiceConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::devtools::cloudtrace::v1::Trace>, GetTrace,
+      (StatusOr<google::devtools::cloudtrace::v1::Trace>), GetTrace,
       (google::devtools::cloudtrace::v1::GetTraceRequest const& request),
       (override));
 

--- a/google/cloud/trace/v2/mocks/mock_trace_connection.h
+++ b/google/cloud/trace/v2/mocks/mock_trace_connection.h
@@ -51,7 +51,7 @@ class MockTraceServiceConnection : public trace_v2::TraceServiceConnection {
       (google::devtools::cloudtrace::v2::BatchWriteSpansRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::devtools::cloudtrace::v2::Span>, CreateSpan,
+  MOCK_METHOD((StatusOr<google::devtools::cloudtrace::v2::Span>), CreateSpan,
               (google::devtools::cloudtrace::v2::Span const& request),
               (override));
 };

--- a/google/cloud/translate/v3/mocks/mock_translation_connection.h
+++ b/google/cloud/translate/v3/mocks/mock_translation_connection.h
@@ -48,47 +48,48 @@ class MockTranslationServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::translation::v3::TranslateTextResponse>,
+      (StatusOr<google::cloud::translation::v3::TranslateTextResponse>),
       TranslateText,
       (google::cloud::translation::v3::TranslateTextRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::translation::v3::DetectLanguageResponse>,
+      (StatusOr<google::cloud::translation::v3::DetectLanguageResponse>),
       DetectLanguage,
       (google::cloud::translation::v3::DetectLanguageRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::translation::v3::SupportedLanguages>,
+      (StatusOr<google::cloud::translation::v3::SupportedLanguages>),
       GetSupportedLanguages,
       (google::cloud::translation::v3::GetSupportedLanguagesRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::translation::v3::TranslateDocumentResponse>,
+      (StatusOr<google::cloud::translation::v3::TranslateDocumentResponse>),
       TranslateDocument,
       (google::cloud::translation::v3::TranslateDocumentRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::translation::v3::BatchTranslateResponse>>,
+      (future<
+          StatusOr<google::cloud::translation::v3::BatchTranslateResponse>>),
       BatchTranslateText,
       (google::cloud::translation::v3::BatchTranslateTextRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::translation::v3::BatchTranslateDocumentResponse>>,
+      (future<StatusOr<
+           google::cloud::translation::v3::BatchTranslateDocumentResponse>>),
       BatchTranslateDocument,
       (google::cloud::translation::v3::BatchTranslateDocumentRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::translation::v3::Glossary>>,
+      (future<StatusOr<google::cloud::translation::v3::Glossary>>),
       CreateGlossary,
       (google::cloud::translation::v3::CreateGlossaryRequest const& request),
       (override));
@@ -99,18 +100,19 @@ class MockTranslationServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::translation::v3::Glossary>, GetGlossary,
+      (StatusOr<google::cloud::translation::v3::Glossary>), GetGlossary,
       (google::cloud::translation::v3::GetGlossaryRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::translation::v3::DeleteGlossaryResponse>>,
+      (future<
+          StatusOr<google::cloud::translation::v3::DeleteGlossaryResponse>>),
       DeleteGlossary,
       (google::cloud::translation::v3::DeleteGlossaryRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::translation::v3::AdaptiveMtDataset>,
+      (StatusOr<google::cloud::translation::v3::AdaptiveMtDataset>),
       CreateAdaptiveMtDataset,
       (google::cloud::translation::v3::CreateAdaptiveMtDatasetRequest const&
            request),
@@ -123,7 +125,7 @@ class MockTranslationServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::translation::v3::AdaptiveMtDataset>,
+      (StatusOr<google::cloud::translation::v3::AdaptiveMtDataset>),
       GetAdaptiveMtDataset,
       (google::cloud::translation::v3::GetAdaptiveMtDatasetRequest const&
            request),
@@ -136,14 +138,14 @@ class MockTranslationServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::translation::v3::AdaptiveMtTranslateResponse>,
+      (StatusOr<google::cloud::translation::v3::AdaptiveMtTranslateResponse>),
       AdaptiveMtTranslate,
       (google::cloud::translation::v3::AdaptiveMtTranslateRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::translation::v3::AdaptiveMtFile>,
+      (StatusOr<google::cloud::translation::v3::AdaptiveMtFile>),
       GetAdaptiveMtFile,
       (google::cloud::translation::v3::GetAdaptiveMtFileRequest const& request),
       (override));
@@ -155,7 +157,7 @@ class MockTranslationServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::translation::v3::ImportAdaptiveMtFileResponse>,
+      (StatusOr<google::cloud::translation::v3::ImportAdaptiveMtFileResponse>),
       ImportAdaptiveMtFile,
       (google::cloud::translation::v3::ImportAdaptiveMtFileRequest const&
            request),

--- a/google/cloud/video/livestream/v1/mocks/mock_livestream_connection.h
+++ b/google/cloud/video/livestream/v1/mocks/mock_livestream_connection.h
@@ -47,7 +47,7 @@ class MockLivestreamServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::video::livestream::v1::Channel>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::video::livestream::v1::Channel>>),
               CreateChannel,
               (google::cloud::video::livestream::v1::CreateChannelRequest const&
                    request),
@@ -60,40 +60,41 @@ class MockLivestreamServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::video::livestream::v1::Channel>, GetChannel,
+      (StatusOr<google::cloud::video::livestream::v1::Channel>), GetChannel,
       (google::cloud::video::livestream::v1::GetChannelRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::video::livestream::v1::OperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::video::livestream::v1::OperationMetadata>>),
       DeleteChannel,
       (google::cloud::video::livestream::v1::DeleteChannelRequest const&
            request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::video::livestream::v1::Channel>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::video::livestream::v1::Channel>>),
               UpdateChannel,
               (google::cloud::video::livestream::v1::UpdateChannelRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::video::livestream::v1::ChannelOperationResponse>>,
+      (future<StatusOr<
+           google::cloud::video::livestream::v1::ChannelOperationResponse>>),
       StartChannel,
       (google::cloud::video::livestream::v1::StartChannelRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::video::livestream::v1::ChannelOperationResponse>>,
+      (future<StatusOr<
+           google::cloud::video::livestream::v1::ChannelOperationResponse>>),
       StopChannel,
       (google::cloud::video::livestream::v1::StopChannelRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::video::livestream::v1::Input>>,
+      (future<StatusOr<google::cloud::video::livestream::v1::Input>>),
       CreateInput,
       (google::cloud::video::livestream::v1::CreateInputRequest const& request),
       (override));
@@ -104,24 +105,25 @@ class MockLivestreamServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::video::livestream::v1::Input>, GetInput,
+      (StatusOr<google::cloud::video::livestream::v1::Input>), GetInput,
       (google::cloud::video::livestream::v1::GetInputRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::video::livestream::v1::OperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::video::livestream::v1::OperationMetadata>>),
       DeleteInput,
       (google::cloud::video::livestream::v1::DeleteInputRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::video::livestream::v1::Input>>,
+      (future<StatusOr<google::cloud::video::livestream::v1::Input>>),
       UpdateInput,
       (google::cloud::video::livestream::v1::UpdateInputRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::video::livestream::v1::Event>, CreateEvent,
+      (StatusOr<google::cloud::video::livestream::v1::Event>), CreateEvent,
       (google::cloud::video::livestream::v1::CreateEventRequest const& request),
       (override));
 
@@ -131,7 +133,7 @@ class MockLivestreamServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::video::livestream::v1::Event>, GetEvent,
+      (StatusOr<google::cloud::video::livestream::v1::Event>), GetEvent,
       (google::cloud::video::livestream::v1::GetEventRequest const& request),
       (override));
 
@@ -141,19 +143,20 @@ class MockLivestreamServiceConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::video::livestream::v1::Asset>>,
+      (future<StatusOr<google::cloud::video::livestream::v1::Asset>>),
       CreateAsset,
       (google::cloud::video::livestream::v1::CreateAssetRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::video::livestream::v1::OperationMetadata>>,
+      (future<
+          StatusOr<google::cloud::video::livestream::v1::OperationMetadata>>),
       DeleteAsset,
       (google::cloud::video::livestream::v1::DeleteAssetRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::video::livestream::v1::Asset>, GetAsset,
+      (StatusOr<google::cloud::video::livestream::v1::Asset>), GetAsset,
       (google::cloud::video::livestream::v1::GetAssetRequest const& request),
       (override));
 
@@ -163,12 +166,13 @@ class MockLivestreamServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::video::livestream::v1::Pool>, GetPool,
+      (StatusOr<google::cloud::video::livestream::v1::Pool>), GetPool,
       (google::cloud::video::livestream::v1::GetPoolRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::video::livestream::v1::Pool>>, UpdatePool,
+      (future<StatusOr<google::cloud::video::livestream::v1::Pool>>),
+      UpdatePool,
       (google::cloud::video::livestream::v1::UpdatePoolRequest const& request),
       (override));
 };

--- a/google/cloud/video/stitcher/v1/mocks/mock_video_stitcher_connection.h
+++ b/google/cloud/video/stitcher/v1/mocks/mock_video_stitcher_connection.h
@@ -48,7 +48,7 @@ class MockVideoStitcherServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::video::stitcher::v1::CdnKey>>,
+      (future<StatusOr<google::cloud::video::stitcher::v1::CdnKey>>),
       CreateCdnKey,
       (google::cloud::video::stitcher::v1::CreateCdnKeyRequest const& request),
       (override));
@@ -59,31 +59,31 @@ class MockVideoStitcherServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::video::stitcher::v1::CdnKey>, GetCdnKey,
+      (StatusOr<google::cloud::video::stitcher::v1::CdnKey>), GetCdnKey,
       (google::cloud::video::stitcher::v1::GetCdnKeyRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::video::stitcher::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::video::stitcher::v1::OperationMetadata>>),
       DeleteCdnKey,
       (google::cloud::video::stitcher::v1::DeleteCdnKeyRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::video::stitcher::v1::CdnKey>>,
+      (future<StatusOr<google::cloud::video::stitcher::v1::CdnKey>>),
       UpdateCdnKey,
       (google::cloud::video::stitcher::v1::UpdateCdnKeyRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::video::stitcher::v1::VodSession>,
+      (StatusOr<google::cloud::video::stitcher::v1::VodSession>),
       CreateVodSession,
       (google::cloud::video::stitcher::v1::CreateVodSessionRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::video::stitcher::v1::VodSession>, GetVodSession,
+      (StatusOr<google::cloud::video::stitcher::v1::VodSession>), GetVodSession,
       (google::cloud::video::stitcher::v1::GetVodSessionRequest const& request),
       (override));
 
@@ -94,7 +94,7 @@ class MockVideoStitcherServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::video::stitcher::v1::VodStitchDetail>,
+      (StatusOr<google::cloud::video::stitcher::v1::VodStitchDetail>),
       GetVodStitchDetail,
       (google::cloud::video::stitcher::v1::GetVodStitchDetailRequest const&
            request),
@@ -107,7 +107,7 @@ class MockVideoStitcherServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::video::stitcher::v1::VodAdTagDetail>,
+      (StatusOr<google::cloud::video::stitcher::v1::VodAdTagDetail>),
       GetVodAdTagDetail,
       (google::cloud::video::stitcher::v1::GetVodAdTagDetailRequest const&
            request),
@@ -120,14 +120,15 @@ class MockVideoStitcherServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::video::stitcher::v1::LiveAdTagDetail>,
+      (StatusOr<google::cloud::video::stitcher::v1::LiveAdTagDetail>),
       GetLiveAdTagDetail,
       (google::cloud::video::stitcher::v1::GetLiveAdTagDetailRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::video::stitcher::v1::Slate>>, CreateSlate,
+      (future<StatusOr<google::cloud::video::stitcher::v1::Slate>>),
+      CreateSlate,
       (google::cloud::video::stitcher::v1::CreateSlateRequest const& request),
       (override));
 
@@ -137,36 +138,37 @@ class MockVideoStitcherServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::video::stitcher::v1::Slate>, GetSlate,
+      (StatusOr<google::cloud::video::stitcher::v1::Slate>), GetSlate,
       (google::cloud::video::stitcher::v1::GetSlateRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::video::stitcher::v1::Slate>>, UpdateSlate,
+      (future<StatusOr<google::cloud::video::stitcher::v1::Slate>>),
+      UpdateSlate,
       (google::cloud::video::stitcher::v1::UpdateSlateRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::video::stitcher::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::video::stitcher::v1::OperationMetadata>>),
       DeleteSlate,
       (google::cloud::video::stitcher::v1::DeleteSlateRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::video::stitcher::v1::LiveSession>,
+      (StatusOr<google::cloud::video::stitcher::v1::LiveSession>),
       CreateLiveSession,
       (google::cloud::video::stitcher::v1::CreateLiveSessionRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::video::stitcher::v1::LiveSession>,
+  MOCK_METHOD((StatusOr<google::cloud::video::stitcher::v1::LiveSession>),
               GetLiveSession,
               (google::cloud::video::stitcher::v1::GetLiveSessionRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::video::stitcher::v1::LiveConfig>>,
+      (future<StatusOr<google::cloud::video::stitcher::v1::LiveConfig>>),
       CreateLiveConfig,
       (google::cloud::video::stitcher::v1::CreateLiveConfigRequest const&
            request),
@@ -179,12 +181,12 @@ class MockVideoStitcherServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::video::stitcher::v1::LiveConfig>, GetLiveConfig,
+      (StatusOr<google::cloud::video::stitcher::v1::LiveConfig>), GetLiveConfig,
       (google::cloud::video::stitcher::v1::GetLiveConfigRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::video::stitcher::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::video::stitcher::v1::OperationMetadata>>),
       DeleteLiveConfig,
       (google::cloud::video::stitcher::v1::DeleteLiveConfigRequest const&
            request),

--- a/google/cloud/video/transcoder/v1/mocks/mock_transcoder_connection.h
+++ b/google/cloud/video/transcoder/v1/mocks/mock_transcoder_connection.h
@@ -48,7 +48,7 @@ class MockTranscoderServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::video::transcoder::v1::Job>, CreateJob,
+      (StatusOr<google::cloud::video::transcoder::v1::Job>), CreateJob,
       (google::cloud::video::transcoder::v1::CreateJobRequest const& request),
       (override));
 
@@ -58,7 +58,7 @@ class MockTranscoderServiceConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::video::transcoder::v1::Job>, GetJob,
+      (StatusOr<google::cloud::video::transcoder::v1::Job>), GetJob,
       (google::cloud::video::transcoder::v1::GetJobRequest const& request),
       (override));
 
@@ -68,7 +68,7 @@ class MockTranscoderServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::video::transcoder::v1::JobTemplate>,
+      (StatusOr<google::cloud::video::transcoder::v1::JobTemplate>),
       CreateJobTemplate,
       (google::cloud::video::transcoder::v1::CreateJobTemplateRequest const&
            request),
@@ -81,7 +81,7 @@ class MockTranscoderServiceConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::video::transcoder::v1::JobTemplate>,
+      (StatusOr<google::cloud::video::transcoder::v1::JobTemplate>),
       GetJobTemplate,
       (google::cloud::video::transcoder::v1::GetJobTemplateRequest const&
            request),

--- a/google/cloud/videointelligence/v1/mocks/mock_video_intelligence_connection.h
+++ b/google/cloud/videointelligence/v1/mocks/mock_video_intelligence_connection.h
@@ -47,12 +47,13 @@ class MockVideoIntelligenceServiceConnection
  public:
   MOCK_METHOD(Options, options, (), (override));
 
-  MOCK_METHOD(future<StatusOr<
-                  google::cloud::videointelligence::v1::AnnotateVideoResponse>>,
-              AnnotateVideo,
-              (google::cloud::videointelligence::v1::AnnotateVideoRequest const&
-                   request),
-              (override));
+  MOCK_METHOD(
+      (future<StatusOr<
+           google::cloud::videointelligence::v1::AnnotateVideoResponse>>),
+      AnnotateVideo,
+      (google::cloud::videointelligence::v1::AnnotateVideoRequest const&
+           request),
+      (override));
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/vision/v1/mocks/mock_image_annotator_connection.h
+++ b/google/cloud/vision/v1/mocks/mock_image_annotator_connection.h
@@ -48,27 +48,28 @@ class MockImageAnnotatorConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::vision::v1::BatchAnnotateImagesResponse>,
+      (StatusOr<google::cloud::vision::v1::BatchAnnotateImagesResponse>),
       BatchAnnotateImages,
       (google::cloud::vision::v1::BatchAnnotateImagesRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::vision::v1::BatchAnnotateFilesResponse>,
+      (StatusOr<google::cloud::vision::v1::BatchAnnotateFilesResponse>),
       BatchAnnotateFiles,
       (google::cloud::vision::v1::BatchAnnotateFilesRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<
-                  google::cloud::vision::v1::AsyncBatchAnnotateImagesResponse>>,
-              AsyncBatchAnnotateImages,
-              (google::cloud::vision::v1::AsyncBatchAnnotateImagesRequest const&
-                   request),
-              (override));
+  MOCK_METHOD(
+      (future<StatusOr<
+           google::cloud::vision::v1::AsyncBatchAnnotateImagesResponse>>),
+      AsyncBatchAnnotateImages,
+      (google::cloud::vision::v1::AsyncBatchAnnotateImagesRequest const&
+           request),
+      (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::vision::v1::AsyncBatchAnnotateFilesResponse>>,
+      (future<StatusOr<
+           google::cloud::vision::v1::AsyncBatchAnnotateFilesResponse>>),
       AsyncBatchAnnotateFiles,
       (google::cloud::vision::v1::AsyncBatchAnnotateFilesRequest const&
            request),

--- a/google/cloud/vision/v1/mocks/mock_product_search_connection.h
+++ b/google/cloud/vision/v1/mocks/mock_product_search_connection.h
@@ -47,7 +47,7 @@ class MockProductSearchConnection : public vision_v1::ProductSearchConnection {
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::vision::v1::ProductSet>, CreateProductSet,
+      (StatusOr<google::cloud::vision::v1::ProductSet>), CreateProductSet,
       (google::cloud::vision::v1::CreateProductSetRequest const& request),
       (override));
 
@@ -56,12 +56,12 @@ class MockProductSearchConnection : public vision_v1::ProductSearchConnection {
               (google::cloud::vision::v1::ListProductSetsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::vision::v1::ProductSet>, GetProductSet,
+  MOCK_METHOD((StatusOr<google::cloud::vision::v1::ProductSet>), GetProductSet,
               (google::cloud::vision::v1::GetProductSetRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::vision::v1::ProductSet>, UpdateProductSet,
+      (StatusOr<google::cloud::vision::v1::ProductSet>), UpdateProductSet,
       (google::cloud::vision::v1::UpdateProductSetRequest const& request),
       (override));
 
@@ -70,7 +70,7 @@ class MockProductSearchConnection : public vision_v1::ProductSearchConnection {
       (google::cloud::vision::v1::DeleteProductSetRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::vision::v1::Product>, CreateProduct,
+  MOCK_METHOD((StatusOr<google::cloud::vision::v1::Product>), CreateProduct,
               (google::cloud::vision::v1::CreateProductRequest const& request),
               (override));
 
@@ -78,11 +78,11 @@ class MockProductSearchConnection : public vision_v1::ProductSearchConnection {
               (google::cloud::vision::v1::ListProductsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::vision::v1::Product>, GetProduct,
+  MOCK_METHOD((StatusOr<google::cloud::vision::v1::Product>), GetProduct,
               (google::cloud::vision::v1::GetProductRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::vision::v1::Product>, UpdateProduct,
+  MOCK_METHOD((StatusOr<google::cloud::vision::v1::Product>), UpdateProduct,
               (google::cloud::vision::v1::UpdateProductRequest const& request),
               (override));
 
@@ -91,7 +91,8 @@ class MockProductSearchConnection : public vision_v1::ProductSearchConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::vision::v1::ReferenceImage>, CreateReferenceImage,
+      (StatusOr<google::cloud::vision::v1::ReferenceImage>),
+      CreateReferenceImage,
       (google::cloud::vision::v1::CreateReferenceImageRequest const& request),
       (override));
 
@@ -106,7 +107,7 @@ class MockProductSearchConnection : public vision_v1::ProductSearchConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::vision::v1::ReferenceImage>, GetReferenceImage,
+      (StatusOr<google::cloud::vision::v1::ReferenceImage>), GetReferenceImage,
       (google::cloud::vision::v1::GetReferenceImageRequest const& request),
       (override));
 
@@ -128,13 +129,13 @@ class MockProductSearchConnection : public vision_v1::ProductSearchConnection {
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vision::v1::ImportProductSetsResponse>>,
+      (future<StatusOr<google::cloud::vision::v1::ImportProductSetsResponse>>),
       ImportProductSets,
       (google::cloud::vision::v1::ImportProductSetsRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vision::v1::BatchOperationMetadata>>,
+      (future<StatusOr<google::cloud::vision::v1::BatchOperationMetadata>>),
       PurgeProducts,
       (google::cloud::vision::v1::PurgeProductsRequest const& request),
       (override));

--- a/google/cloud/vmmigration/v1/mocks/mock_vm_migration_connection.h
+++ b/google/cloud/vmmigration/v1/mocks/mock_vm_migration_connection.h
@@ -51,28 +51,28 @@ class MockVmMigrationConnection : public vmmigration_v1::VmMigrationConnection {
               (google::cloud::vmmigration::v1::ListSourcesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::vmmigration::v1::Source>, GetSource,
+  MOCK_METHOD((StatusOr<google::cloud::vmmigration::v1::Source>), GetSource,
               (google::cloud::vmmigration::v1::GetSourceRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmmigration::v1::Source>>, CreateSource,
+      (future<StatusOr<google::cloud::vmmigration::v1::Source>>), CreateSource,
       (google::cloud::vmmigration::v1::CreateSourceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmmigration::v1::Source>>, UpdateSource,
+      (future<StatusOr<google::cloud::vmmigration::v1::Source>>), UpdateSource,
       (google::cloud::vmmigration::v1::UpdateSourceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>),
       DeleteSource,
       (google::cloud::vmmigration::v1::DeleteSourceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::vmmigration::v1::FetchInventoryResponse>,
+      (StatusOr<google::cloud::vmmigration::v1::FetchInventoryResponse>),
       FetchInventory,
       (google::cloud::vmmigration::v1::FetchInventoryRequest const& request),
       (override));
@@ -84,21 +84,21 @@ class MockVmMigrationConnection : public vmmigration_v1::VmMigrationConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::vmmigration::v1::UtilizationReport>,
+      (StatusOr<google::cloud::vmmigration::v1::UtilizationReport>),
       GetUtilizationReport,
       (google::cloud::vmmigration::v1::GetUtilizationReportRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmmigration::v1::UtilizationReport>>,
+      (future<StatusOr<google::cloud::vmmigration::v1::UtilizationReport>>),
       CreateUtilizationReport,
       (google::cloud::vmmigration::v1::CreateUtilizationReportRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>),
       DeleteUtilizationReport,
       (google::cloud::vmmigration::v1::DeleteUtilizationReportRequest const&
            request),
@@ -111,35 +111,35 @@ class MockVmMigrationConnection : public vmmigration_v1::VmMigrationConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::vmmigration::v1::DatacenterConnector>,
+      (StatusOr<google::cloud::vmmigration::v1::DatacenterConnector>),
       GetDatacenterConnector,
       (google::cloud::vmmigration::v1::GetDatacenterConnectorRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmmigration::v1::DatacenterConnector>>,
+      (future<StatusOr<google::cloud::vmmigration::v1::DatacenterConnector>>),
       CreateDatacenterConnector,
       (google::cloud::vmmigration::v1::CreateDatacenterConnectorRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>),
       DeleteDatacenterConnector,
       (google::cloud::vmmigration::v1::DeleteDatacenterConnectorRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::vmmigration::v1::UpgradeApplianceResponse>>,
+      (future<
+          StatusOr<google::cloud::vmmigration::v1::UpgradeApplianceResponse>>),
       UpgradeAppliance,
       (google::cloud::vmmigration::v1::UpgradeApplianceRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmmigration::v1::MigratingVm>>,
+      (future<StatusOr<google::cloud::vmmigration::v1::MigratingVm>>),
       CreateMigratingVm,
       (google::cloud::vmmigration::v1::CreateMigratingVmRequest const& request),
       (override));
@@ -150,55 +150,59 @@ class MockVmMigrationConnection : public vmmigration_v1::VmMigrationConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::vmmigration::v1::MigratingVm>, GetMigratingVm,
+      (StatusOr<google::cloud::vmmigration::v1::MigratingVm>), GetMigratingVm,
       (google::cloud::vmmigration::v1::GetMigratingVmRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmmigration::v1::MigratingVm>>,
+      (future<StatusOr<google::cloud::vmmigration::v1::MigratingVm>>),
       UpdateMigratingVm,
       (google::cloud::vmmigration::v1::UpdateMigratingVmRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>),
       DeleteMigratingVm,
       (google::cloud::vmmigration::v1::DeleteMigratingVmRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmmigration::v1::StartMigrationResponse>>,
+      (future<
+          StatusOr<google::cloud::vmmigration::v1::StartMigrationResponse>>),
       StartMigration,
       (google::cloud::vmmigration::v1::StartMigrationRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmmigration::v1::ResumeMigrationResponse>>,
+      (future<
+          StatusOr<google::cloud::vmmigration::v1::ResumeMigrationResponse>>),
       ResumeMigration,
       (google::cloud::vmmigration::v1::ResumeMigrationRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmmigration::v1::PauseMigrationResponse>>,
+      (future<
+          StatusOr<google::cloud::vmmigration::v1::PauseMigrationResponse>>),
       PauseMigration,
       (google::cloud::vmmigration::v1::PauseMigrationRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::vmmigration::v1::FinalizeMigrationResponse>>,
+      (future<
+          StatusOr<google::cloud::vmmigration::v1::FinalizeMigrationResponse>>),
       FinalizeMigration,
       (google::cloud::vmmigration::v1::FinalizeMigrationRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmmigration::v1::CloneJob>>,
+      (future<StatusOr<google::cloud::vmmigration::v1::CloneJob>>),
       CreateCloneJob,
       (google::cloud::vmmigration::v1::CreateCloneJobRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmmigration::v1::CancelCloneJobResponse>>,
+      (future<
+          StatusOr<google::cloud::vmmigration::v1::CancelCloneJobResponse>>),
       CancelCloneJob,
       (google::cloud::vmmigration::v1::CancelCloneJobRequest const& request),
       (override));
@@ -209,19 +213,19 @@ class MockVmMigrationConnection : public vmmigration_v1::VmMigrationConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::vmmigration::v1::CloneJob>, GetCloneJob,
+      (StatusOr<google::cloud::vmmigration::v1::CloneJob>), GetCloneJob,
       (google::cloud::vmmigration::v1::GetCloneJobRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmmigration::v1::CutoverJob>>,
+      (future<StatusOr<google::cloud::vmmigration::v1::CutoverJob>>),
       CreateCutoverJob,
       (google::cloud::vmmigration::v1::CreateCutoverJobRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::vmmigration::v1::CancelCutoverJobResponse>>,
+      (future<
+          StatusOr<google::cloud::vmmigration::v1::CancelCutoverJobResponse>>),
       CancelCutoverJob,
       (google::cloud::vmmigration::v1::CancelCutoverJobRequest const& request),
       (override));
@@ -232,7 +236,7 @@ class MockVmMigrationConnection : public vmmigration_v1::VmMigrationConnection {
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::vmmigration::v1::CutoverJob>, GetCutoverJob,
+      (StatusOr<google::cloud::vmmigration::v1::CutoverJob>), GetCutoverJob,
       (google::cloud::vmmigration::v1::GetCutoverJobRequest const& request),
       (override));
 
@@ -240,36 +244,36 @@ class MockVmMigrationConnection : public vmmigration_v1::VmMigrationConnection {
               (google::cloud::vmmigration::v1::ListGroupsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::vmmigration::v1::Group>, GetGroup,
+  MOCK_METHOD((StatusOr<google::cloud::vmmigration::v1::Group>), GetGroup,
               (google::cloud::vmmigration::v1::GetGroupRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmmigration::v1::Group>>, CreateGroup,
+      (future<StatusOr<google::cloud::vmmigration::v1::Group>>), CreateGroup,
       (google::cloud::vmmigration::v1::CreateGroupRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmmigration::v1::Group>>, UpdateGroup,
+      (future<StatusOr<google::cloud::vmmigration::v1::Group>>), UpdateGroup,
       (google::cloud::vmmigration::v1::UpdateGroupRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>),
       DeleteGroup,
       (google::cloud::vmmigration::v1::DeleteGroupRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::vmmigration::v1::AddGroupMigrationResponse>>,
+      (future<
+          StatusOr<google::cloud::vmmigration::v1::AddGroupMigrationResponse>>),
       AddGroupMigration,
       (google::cloud::vmmigration::v1::AddGroupMigrationRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<
-          google::cloud::vmmigration::v1::RemoveGroupMigrationResponse>>,
+      (future<StatusOr<
+           google::cloud::vmmigration::v1::RemoveGroupMigrationResponse>>),
       RemoveGroupMigration,
       (google::cloud::vmmigration::v1::RemoveGroupMigrationRequest const&
            request),
@@ -282,24 +286,25 @@ class MockVmMigrationConnection : public vmmigration_v1::VmMigrationConnection {
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::vmmigration::v1::TargetProject>, GetTargetProject,
+      (StatusOr<google::cloud::vmmigration::v1::TargetProject>),
+      GetTargetProject,
       (google::cloud::vmmigration::v1::GetTargetProjectRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::vmmigration::v1::TargetProject>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::vmmigration::v1::TargetProject>>),
               CreateTargetProject,
               (google::cloud::vmmigration::v1::CreateTargetProjectRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::vmmigration::v1::TargetProject>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::vmmigration::v1::TargetProject>>),
               UpdateTargetProject,
               (google::cloud::vmmigration::v1::UpdateTargetProjectRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>),
       DeleteTargetProject,
       (google::cloud::vmmigration::v1::DeleteTargetProjectRequest const&
            request),
@@ -311,7 +316,7 @@ class MockVmMigrationConnection : public vmmigration_v1::VmMigrationConnection {
       (google::cloud::vmmigration::v1::ListReplicationCyclesRequest request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::vmmigration::v1::ReplicationCycle>,
+  MOCK_METHOD((StatusOr<google::cloud::vmmigration::v1::ReplicationCycle>),
               GetReplicationCycle,
               (google::cloud::vmmigration::v1::GetReplicationCycleRequest const&
                    request),

--- a/google/cloud/vmwareengine/v1/mocks/mock_vmware_engine_connection.h
+++ b/google/cloud/vmwareengine/v1/mocks/mock_vmware_engine_connection.h
@@ -54,30 +54,31 @@ class MockVmwareEngineConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::vmwareengine::v1::PrivateCloud>, GetPrivateCloud,
+      (StatusOr<google::cloud::vmwareengine::v1::PrivateCloud>),
+      GetPrivateCloud,
       (google::cloud::vmwareengine::v1::GetPrivateCloudRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::vmwareengine::v1::PrivateCloud>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::vmwareengine::v1::PrivateCloud>>),
               CreatePrivateCloud,
               (google::cloud::vmwareengine::v1::CreatePrivateCloudRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::vmwareengine::v1::PrivateCloud>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::vmwareengine::v1::PrivateCloud>>),
               UpdatePrivateCloud,
               (google::cloud::vmwareengine::v1::UpdatePrivateCloudRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::vmwareengine::v1::PrivateCloud>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::vmwareengine::v1::PrivateCloud>>),
               DeletePrivateCloud,
               (google::cloud::vmwareengine::v1::DeletePrivateCloudRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::PrivateCloud>>,
+      (future<StatusOr<google::cloud::vmwareengine::v1::PrivateCloud>>),
       UndeletePrivateCloud,
       (google::cloud::vmwareengine::v1::UndeletePrivateCloudRequest const&
            request),
@@ -89,22 +90,24 @@ class MockVmwareEngineConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::vmwareengine::v1::Cluster>, GetCluster,
+      (StatusOr<google::cloud::vmwareengine::v1::Cluster>), GetCluster,
       (google::cloud::vmwareengine::v1::GetClusterRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::Cluster>>, CreateCluster,
+      (future<StatusOr<google::cloud::vmwareengine::v1::Cluster>>),
+      CreateCluster,
       (google::cloud::vmwareengine::v1::CreateClusterRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::Cluster>>, UpdateCluster,
+      (future<StatusOr<google::cloud::vmwareengine::v1::Cluster>>),
+      UpdateCluster,
       (google::cloud::vmwareengine::v1::UpdateClusterRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::vmwareengine::v1::OperationMetadata>>),
       DeleteCluster,
       (google::cloud::vmwareengine::v1::DeleteClusterRequest const& request),
       (override));
@@ -113,7 +116,7 @@ class MockVmwareEngineConnection
               (google::cloud::vmwareengine::v1::ListNodesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::vmwareengine::v1::Node>, GetNode,
+  MOCK_METHOD((StatusOr<google::cloud::vmwareengine::v1::Node>), GetNode,
               (google::cloud::vmwareengine::v1::GetNodeRequest const& request),
               (override));
 
@@ -129,28 +132,28 @@ class MockVmwareEngineConnection
                    FetchNetworkPolicyExternalAddressesRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::vmwareengine::v1::ExternalAddress>,
+  MOCK_METHOD((StatusOr<google::cloud::vmwareengine::v1::ExternalAddress>),
               GetExternalAddress,
               (google::cloud::vmwareengine::v1::GetExternalAddressRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::ExternalAddress>>,
+      (future<StatusOr<google::cloud::vmwareengine::v1::ExternalAddress>>),
       CreateExternalAddress,
       (google::cloud::vmwareengine::v1::CreateExternalAddressRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::ExternalAddress>>,
+      (future<StatusOr<google::cloud::vmwareengine::v1::ExternalAddress>>),
       UpdateExternalAddress,
       (google::cloud::vmwareengine::v1::UpdateExternalAddressRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::vmwareengine::v1::OperationMetadata>>),
       DeleteExternalAddress,
       (google::cloud::vmwareengine::v1::DeleteExternalAddressRequest const&
            request),
@@ -162,12 +165,12 @@ class MockVmwareEngineConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::vmwareengine::v1::Subnet>, GetSubnet,
+      (StatusOr<google::cloud::vmwareengine::v1::Subnet>), GetSubnet,
       (google::cloud::vmwareengine::v1::GetSubnetRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::Subnet>>, UpdateSubnet,
+      (future<StatusOr<google::cloud::vmwareengine::v1::Subnet>>), UpdateSubnet,
       (google::cloud::vmwareengine::v1::UpdateSubnetRequest const& request),
       (override));
 
@@ -178,28 +181,28 @@ class MockVmwareEngineConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::vmwareengine::v1::ExternalAccessRule>,
+      (StatusOr<google::cloud::vmwareengine::v1::ExternalAccessRule>),
       GetExternalAccessRule,
       (google::cloud::vmwareengine::v1::GetExternalAccessRuleRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::ExternalAccessRule>>,
+      (future<StatusOr<google::cloud::vmwareengine::v1::ExternalAccessRule>>),
       CreateExternalAccessRule,
       (google::cloud::vmwareengine::v1::CreateExternalAccessRuleRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::ExternalAccessRule>>,
+      (future<StatusOr<google::cloud::vmwareengine::v1::ExternalAccessRule>>),
       UpdateExternalAccessRule,
       (google::cloud::vmwareengine::v1::UpdateExternalAccessRuleRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::vmwareengine::v1::OperationMetadata>>),
       DeleteExternalAccessRule,
       (google::cloud::vmwareengine::v1::DeleteExternalAccessRuleRequest const&
            request),
@@ -212,27 +215,27 @@ class MockVmwareEngineConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::vmwareengine::v1::LoggingServer>,
+      (StatusOr<google::cloud::vmwareengine::v1::LoggingServer>),
       GetLoggingServer,
       (google::cloud::vmwareengine::v1::GetLoggingServerRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::LoggingServer>>,
+      (future<StatusOr<google::cloud::vmwareengine::v1::LoggingServer>>),
       CreateLoggingServer,
       (google::cloud::vmwareengine::v1::CreateLoggingServerRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::LoggingServer>>,
+      (future<StatusOr<google::cloud::vmwareengine::v1::LoggingServer>>),
       UpdateLoggingServer,
       (google::cloud::vmwareengine::v1::UpdateLoggingServerRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::vmwareengine::v1::OperationMetadata>>),
       DeleteLoggingServer,
       (google::cloud::vmwareengine::v1::DeleteLoggingServerRequest const&
            request),
@@ -244,51 +247,51 @@ class MockVmwareEngineConnection
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::vmwareengine::v1::NodeType>, GetNodeType,
+      (StatusOr<google::cloud::vmwareengine::v1::NodeType>), GetNodeType,
       (google::cloud::vmwareengine::v1::GetNodeTypeRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::vmwareengine::v1::Credentials>,
+  MOCK_METHOD((StatusOr<google::cloud::vmwareengine::v1::Credentials>),
               ShowNsxCredentials,
               (google::cloud::vmwareengine::v1::ShowNsxCredentialsRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::vmwareengine::v1::Credentials>,
+      (StatusOr<google::cloud::vmwareengine::v1::Credentials>),
       ShowVcenterCredentials,
       (google::cloud::vmwareengine::v1::ShowVcenterCredentialsRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::PrivateCloud>>,
+      (future<StatusOr<google::cloud::vmwareengine::v1::PrivateCloud>>),
       ResetNsxCredentials,
       (google::cloud::vmwareengine::v1::ResetNsxCredentialsRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::PrivateCloud>>,
+      (future<StatusOr<google::cloud::vmwareengine::v1::PrivateCloud>>),
       ResetVcenterCredentials,
       (google::cloud::vmwareengine::v1::ResetVcenterCredentialsRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::vmwareengine::v1::DnsForwarding>,
+      (StatusOr<google::cloud::vmwareengine::v1::DnsForwarding>),
       GetDnsForwarding,
       (google::cloud::vmwareengine::v1::GetDnsForwardingRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::DnsForwarding>>,
+      (future<StatusOr<google::cloud::vmwareengine::v1::DnsForwarding>>),
       UpdateDnsForwarding,
       (google::cloud::vmwareengine::v1::UpdateDnsForwardingRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::vmwareengine::v1::NetworkPeering>,
+  MOCK_METHOD((StatusOr<google::cloud::vmwareengine::v1::NetworkPeering>),
               GetNetworkPeering,
               (google::cloud::vmwareengine::v1::GetNetworkPeeringRequest const&
                    request),
@@ -301,21 +304,21 @@ class MockVmwareEngineConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::NetworkPeering>>,
+      (future<StatusOr<google::cloud::vmwareengine::v1::NetworkPeering>>),
       CreateNetworkPeering,
       (google::cloud::vmwareengine::v1::CreateNetworkPeeringRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::vmwareengine::v1::OperationMetadata>>),
       DeleteNetworkPeering,
       (google::cloud::vmwareengine::v1::DeleteNetworkPeeringRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::NetworkPeering>>,
+      (future<StatusOr<google::cloud::vmwareengine::v1::NetworkPeering>>),
       UpdateNetworkPeering,
       (google::cloud::vmwareengine::v1::UpdateNetworkPeeringRequest const&
            request),
@@ -328,7 +331,7 @@ class MockVmwareEngineConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::HcxActivationKey>>,
+      (future<StatusOr<google::cloud::vmwareengine::v1::HcxActivationKey>>),
       CreateHcxActivationKey,
       (google::cloud::vmwareengine::v1::CreateHcxActivationKeyRequest const&
            request),
@@ -341,14 +344,14 @@ class MockVmwareEngineConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::vmwareengine::v1::HcxActivationKey>,
+      (StatusOr<google::cloud::vmwareengine::v1::HcxActivationKey>),
       GetHcxActivationKey,
       (google::cloud::vmwareengine::v1::GetHcxActivationKeyRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::vmwareengine::v1::NetworkPolicy>,
+      (StatusOr<google::cloud::vmwareengine::v1::NetworkPolicy>),
       GetNetworkPolicy,
       (google::cloud::vmwareengine::v1::GetNetworkPolicyRequest const& request),
       (override));
@@ -360,21 +363,21 @@ class MockVmwareEngineConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::NetworkPolicy>>,
+      (future<StatusOr<google::cloud::vmwareengine::v1::NetworkPolicy>>),
       CreateNetworkPolicy,
       (google::cloud::vmwareengine::v1::CreateNetworkPolicyRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::NetworkPolicy>>,
+      (future<StatusOr<google::cloud::vmwareengine::v1::NetworkPolicy>>),
       UpdateNetworkPolicy,
       (google::cloud::vmwareengine::v1::UpdateNetworkPolicyRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::vmwareengine::v1::OperationMetadata>>),
       DeleteNetworkPolicy,
       (google::cloud::vmwareengine::v1::DeleteNetworkPolicyRequest const&
            request),
@@ -388,66 +391,66 @@ class MockVmwareEngineConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::vmwareengine::v1::ManagementDnsZoneBinding>,
+      (StatusOr<google::cloud::vmwareengine::v1::ManagementDnsZoneBinding>),
       GetManagementDnsZoneBinding,
       (google::cloud::vmwareengine::v1::
            GetManagementDnsZoneBindingRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::vmwareengine::v1::ManagementDnsZoneBinding>>,
+      (future<
+          StatusOr<google::cloud::vmwareengine::v1::ManagementDnsZoneBinding>>),
       CreateManagementDnsZoneBinding,
       (google::cloud::vmwareengine::v1::
            CreateManagementDnsZoneBindingRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::vmwareengine::v1::ManagementDnsZoneBinding>>,
+      (future<
+          StatusOr<google::cloud::vmwareengine::v1::ManagementDnsZoneBinding>>),
       UpdateManagementDnsZoneBinding,
       (google::cloud::vmwareengine::v1::
            UpdateManagementDnsZoneBindingRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::vmwareengine::v1::OperationMetadata>>),
       DeleteManagementDnsZoneBinding,
       (google::cloud::vmwareengine::v1::
            DeleteManagementDnsZoneBindingRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<
-          StatusOr<google::cloud::vmwareengine::v1::ManagementDnsZoneBinding>>,
+      (future<
+          StatusOr<google::cloud::vmwareengine::v1::ManagementDnsZoneBinding>>),
       RepairManagementDnsZoneBinding,
       (google::cloud::vmwareengine::v1::
            RepairManagementDnsZoneBindingRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::VmwareEngineNetwork>>,
+      (future<StatusOr<google::cloud::vmwareengine::v1::VmwareEngineNetwork>>),
       CreateVmwareEngineNetwork,
       (google::cloud::vmwareengine::v1::CreateVmwareEngineNetworkRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::VmwareEngineNetwork>>,
+      (future<StatusOr<google::cloud::vmwareengine::v1::VmwareEngineNetwork>>),
       UpdateVmwareEngineNetwork,
       (google::cloud::vmwareengine::v1::UpdateVmwareEngineNetworkRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::vmwareengine::v1::OperationMetadata>>),
       DeleteVmwareEngineNetwork,
       (google::cloud::vmwareengine::v1::DeleteVmwareEngineNetworkRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::vmwareengine::v1::VmwareEngineNetwork>,
+      (StatusOr<google::cloud::vmwareengine::v1::VmwareEngineNetwork>),
       GetVmwareEngineNetwork,
       (google::cloud::vmwareengine::v1::GetVmwareEngineNetworkRequest const&
            request),
@@ -461,14 +464,14 @@ class MockVmwareEngineConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::PrivateConnection>>,
+      (future<StatusOr<google::cloud::vmwareengine::v1::PrivateConnection>>),
       CreatePrivateConnection,
       (google::cloud::vmwareengine::v1::CreatePrivateConnectionRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::vmwareengine::v1::PrivateConnection>,
+      (StatusOr<google::cloud::vmwareengine::v1::PrivateConnection>),
       GetPrivateConnection,
       (google::cloud::vmwareengine::v1::GetPrivateConnectionRequest const&
            request),
@@ -481,14 +484,14 @@ class MockVmwareEngineConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::PrivateConnection>>,
+      (future<StatusOr<google::cloud::vmwareengine::v1::PrivateConnection>>),
       UpdatePrivateConnection,
       (google::cloud::vmwareengine::v1::UpdatePrivateConnectionRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::vmwareengine::v1::OperationMetadata>>),
       DeletePrivateConnection,
       (google::cloud::vmwareengine::v1::DeletePrivateConnectionRequest const&
            request),
@@ -501,21 +504,21 @@ class MockVmwareEngineConnection
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::DnsBindPermission>>,
+      (future<StatusOr<google::cloud::vmwareengine::v1::DnsBindPermission>>),
       GrantDnsBindPermission,
       (google::cloud::vmwareengine::v1::GrantDnsBindPermissionRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::vmwareengine::v1::DnsBindPermission>,
+      (StatusOr<google::cloud::vmwareengine::v1::DnsBindPermission>),
       GetDnsBindPermission,
       (google::cloud::vmwareengine::v1::GetDnsBindPermissionRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vmwareengine::v1::DnsBindPermission>>,
+      (future<StatusOr<google::cloud::vmwareengine::v1::DnsBindPermission>>),
       RevokeDnsBindPermission,
       (google::cloud::vmwareengine::v1::RevokeDnsBindPermissionRequest const&
            request),

--- a/google/cloud/vpcaccess/v1/mocks/mock_vpc_access_connection.h
+++ b/google/cloud/vpcaccess/v1/mocks/mock_vpc_access_connection.h
@@ -48,13 +48,13 @@ class MockVpcAccessServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vpcaccess::v1::Connector>>,
+      (future<StatusOr<google::cloud::vpcaccess::v1::Connector>>),
       CreateConnector,
       (google::cloud::vpcaccess::v1::CreateConnectorRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::vpcaccess::v1::Connector>, GetConnector,
+      (StatusOr<google::cloud::vpcaccess::v1::Connector>), GetConnector,
       (google::cloud::vpcaccess::v1::GetConnectorRequest const& request),
       (override));
 
@@ -64,7 +64,7 @@ class MockVpcAccessServiceConnection
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::vpcaccess::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::vpcaccess::v1::OperationMetadata>>),
       DeleteConnector,
       (google::cloud::vpcaccess::v1::DeleteConnectorRequest const& request),
       (override));

--- a/google/cloud/webrisk/v1/mocks/mock_web_risk_connection.h
+++ b/google/cloud/webrisk/v1/mocks/mock_web_risk_connection.h
@@ -48,27 +48,27 @@ class MockWebRiskServiceConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::webrisk::v1::ComputeThreatListDiffResponse>,
+      (StatusOr<google::cloud::webrisk::v1::ComputeThreatListDiffResponse>),
       ComputeThreatListDiff,
       (google::cloud::webrisk::v1::ComputeThreatListDiffRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::webrisk::v1::SearchUrisResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::webrisk::v1::SearchUrisResponse>),
               SearchUris,
               (google::cloud::webrisk::v1::SearchUrisRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::webrisk::v1::SearchHashesResponse>,
+  MOCK_METHOD((StatusOr<google::cloud::webrisk::v1::SearchHashesResponse>),
               SearchHashes,
               (google::cloud::webrisk::v1::SearchHashesRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::webrisk::v1::Submission>, CreateSubmission,
+      (StatusOr<google::cloud::webrisk::v1::Submission>), CreateSubmission,
       (google::cloud::webrisk::v1::CreateSubmissionRequest const& request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::webrisk::v1::Submission>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::webrisk::v1::Submission>>),
               SubmitUri,
               (google::cloud::webrisk::v1::SubmitUriRequest const& request),
               (override));

--- a/google/cloud/websecurityscanner/v1/mocks/mock_web_security_scanner_connection.h
+++ b/google/cloud/websecurityscanner/v1/mocks/mock_web_security_scanner_connection.h
@@ -48,7 +48,7 @@ class MockWebSecurityScannerConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::websecurityscanner::v1::ScanConfig>,
+      (StatusOr<google::cloud::websecurityscanner::v1::ScanConfig>),
       CreateScanConfig,
       (google::cloud::websecurityscanner::v1::CreateScanConfigRequest const&
            request),
@@ -61,7 +61,7 @@ class MockWebSecurityScannerConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::websecurityscanner::v1::ScanConfig>,
+      (StatusOr<google::cloud::websecurityscanner::v1::ScanConfig>),
       GetScanConfig,
       (google::cloud::websecurityscanner::v1::GetScanConfigRequest const&
            request),
@@ -74,20 +74,20 @@ class MockWebSecurityScannerConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::websecurityscanner::v1::ScanConfig>,
+      (StatusOr<google::cloud::websecurityscanner::v1::ScanConfig>),
       UpdateScanConfig,
       (google::cloud::websecurityscanner::v1::UpdateScanConfigRequest const&
            request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::websecurityscanner::v1::ScanRun>,
+  MOCK_METHOD((StatusOr<google::cloud::websecurityscanner::v1::ScanRun>),
               StartScanRun,
               (google::cloud::websecurityscanner::v1::StartScanRunRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::websecurityscanner::v1::ScanRun>, GetScanRun,
+      (StatusOr<google::cloud::websecurityscanner::v1::ScanRun>), GetScanRun,
       (google::cloud::websecurityscanner::v1::GetScanRunRequest const& request),
       (override));
 
@@ -97,7 +97,7 @@ class MockWebSecurityScannerConnection
       (google::cloud::websecurityscanner::v1::ListScanRunsRequest request),
       (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::websecurityscanner::v1::ScanRun>,
+  MOCK_METHOD((StatusOr<google::cloud::websecurityscanner::v1::ScanRun>),
               StopScanRun,
               (google::cloud::websecurityscanner::v1::StopScanRunRequest const&
                    request),
@@ -110,7 +110,7 @@ class MockWebSecurityScannerConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::websecurityscanner::v1::Finding>, GetFinding,
+      (StatusOr<google::cloud::websecurityscanner::v1::Finding>), GetFinding,
       (google::cloud::websecurityscanner::v1::GetFindingRequest const& request),
       (override));
 
@@ -121,8 +121,8 @@ class MockWebSecurityScannerConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<
-          google::cloud::websecurityscanner::v1::ListFindingTypeStatsResponse>,
+      (StatusOr<
+          google::cloud::websecurityscanner::v1::ListFindingTypeStatsResponse>),
       ListFindingTypeStats,
       (google::cloud::websecurityscanner::v1::ListFindingTypeStatsRequest const&
            request),

--- a/google/cloud/workflows/executions/v1/mocks/mock_executions_connection.h
+++ b/google/cloud/workflows/executions/v1/mocks/mock_executions_connection.h
@@ -54,21 +54,21 @@ class MockExecutionsConnection
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::workflows::executions::v1::Execution>,
+      (StatusOr<google::cloud::workflows::executions::v1::Execution>),
       CreateExecution,
       (google::cloud::workflows::executions::v1::CreateExecutionRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::workflows::executions::v1::Execution>,
+      (StatusOr<google::cloud::workflows::executions::v1::Execution>),
       GetExecution,
       (google::cloud::workflows::executions::v1::GetExecutionRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::workflows::executions::v1::Execution>,
+      (StatusOr<google::cloud::workflows::executions::v1::Execution>),
       CancelExecution,
       (google::cloud::workflows::executions::v1::CancelExecutionRequest const&
            request),

--- a/google/cloud/workflows/v1/mocks/mock_workflows_connection.h
+++ b/google/cloud/workflows/v1/mocks/mock_workflows_connection.h
@@ -51,23 +51,25 @@ class MockWorkflowsConnection : public workflows_v1::WorkflowsConnection {
               (google::cloud::workflows::v1::ListWorkflowsRequest request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::cloud::workflows::v1::Workflow>, GetWorkflow,
+  MOCK_METHOD((StatusOr<google::cloud::workflows::v1::Workflow>), GetWorkflow,
               (google::cloud::workflows::v1::GetWorkflowRequest const& request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::workflows::v1::Workflow>>, CreateWorkflow,
+      (future<StatusOr<google::cloud::workflows::v1::Workflow>>),
+      CreateWorkflow,
       (google::cloud::workflows::v1::CreateWorkflowRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::workflows::v1::OperationMetadata>>,
+      (future<StatusOr<google::cloud::workflows::v1::OperationMetadata>>),
       DeleteWorkflow,
       (google::cloud::workflows::v1::DeleteWorkflowRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::workflows::v1::Workflow>>, UpdateWorkflow,
+      (future<StatusOr<google::cloud::workflows::v1::Workflow>>),
+      UpdateWorkflow,
       (google::cloud::workflows::v1::UpdateWorkflowRequest const& request),
       (override));
 };

--- a/google/cloud/workstations/v1/mocks/mock_workstations_connection.h
+++ b/google/cloud/workstations/v1/mocks/mock_workstations_connection.h
@@ -48,7 +48,7 @@ class MockWorkstationsConnection
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::workstations::v1::WorkstationCluster>,
+      (StatusOr<google::cloud::workstations::v1::WorkstationCluster>),
       GetWorkstationCluster,
       (google::cloud::workstations::v1::GetWorkstationClusterRequest const&
            request),
@@ -61,28 +61,28 @@ class MockWorkstationsConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::workstations::v1::WorkstationCluster>>,
+      (future<StatusOr<google::cloud::workstations::v1::WorkstationCluster>>),
       CreateWorkstationCluster,
       (google::cloud::workstations::v1::CreateWorkstationClusterRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::workstations::v1::WorkstationCluster>>,
+      (future<StatusOr<google::cloud::workstations::v1::WorkstationCluster>>),
       UpdateWorkstationCluster,
       (google::cloud::workstations::v1::UpdateWorkstationClusterRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::workstations::v1::WorkstationCluster>>,
+      (future<StatusOr<google::cloud::workstations::v1::WorkstationCluster>>),
       DeleteWorkstationCluster,
       (google::cloud::workstations::v1::DeleteWorkstationClusterRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::workstations::v1::WorkstationConfig>,
+      (StatusOr<google::cloud::workstations::v1::WorkstationConfig>),
       GetWorkstationConfig,
       (google::cloud::workstations::v1::GetWorkstationConfigRequest const&
            request),
@@ -102,28 +102,28 @@ class MockWorkstationsConnection
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::workstations::v1::WorkstationConfig>>,
+      (future<StatusOr<google::cloud::workstations::v1::WorkstationConfig>>),
       CreateWorkstationConfig,
       (google::cloud::workstations::v1::CreateWorkstationConfigRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::workstations::v1::WorkstationConfig>>,
+      (future<StatusOr<google::cloud::workstations::v1::WorkstationConfig>>),
       UpdateWorkstationConfig,
       (google::cloud::workstations::v1::UpdateWorkstationConfigRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::workstations::v1::WorkstationConfig>>,
+      (future<StatusOr<google::cloud::workstations::v1::WorkstationConfig>>),
       DeleteWorkstationConfig,
       (google::cloud::workstations::v1::DeleteWorkstationConfigRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::workstations::v1::Workstation>, GetWorkstation,
+      (StatusOr<google::cloud::workstations::v1::Workstation>), GetWorkstation,
       (google::cloud::workstations::v1::GetWorkstationRequest const& request),
       (override));
 
@@ -139,38 +139,38 @@ class MockWorkstationsConnection
       (google::cloud::workstations::v1::ListUsableWorkstationsRequest request),
       (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::workstations::v1::Workstation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::workstations::v1::Workstation>>),
               CreateWorkstation,
               (google::cloud::workstations::v1::CreateWorkstationRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::workstations::v1::Workstation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::workstations::v1::Workstation>>),
               UpdateWorkstation,
               (google::cloud::workstations::v1::UpdateWorkstationRequest const&
                    request),
               (override));
 
-  MOCK_METHOD(future<StatusOr<google::cloud::workstations::v1::Workstation>>,
+  MOCK_METHOD((future<StatusOr<google::cloud::workstations::v1::Workstation>>),
               DeleteWorkstation,
               (google::cloud::workstations::v1::DeleteWorkstationRequest const&
                    request),
               (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::workstations::v1::Workstation>>,
+      (future<StatusOr<google::cloud::workstations::v1::Workstation>>),
       StartWorkstation,
       (google::cloud::workstations::v1::StartWorkstationRequest const& request),
       (override));
 
   MOCK_METHOD(
-      future<StatusOr<google::cloud::workstations::v1::Workstation>>,
+      (future<StatusOr<google::cloud::workstations::v1::Workstation>>),
       StopWorkstation,
       (google::cloud::workstations::v1::StopWorkstationRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::cloud::workstations::v1::GenerateAccessTokenResponse>,
+      (StatusOr<google::cloud::workstations::v1::GenerateAccessTokenResponse>),
       GenerateAccessToken,
       (google::cloud::workstations::v1::GenerateAccessTokenRequest const&
            request),


### PR DESCRIPTION
fixes #12693 

Add parens around any return type where a substitution is performed by the generator just in case in introduces a `,` which breaks the preprocessor.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13939)
<!-- Reviewable:end -->
