### PR TITLE
impl(otel): `CreateTimeSeriesRequest` helper

### DIFF
--- a/google/cloud/opentelemetry/internal/time_series.cc
+++ b/google/cloud/opentelemetry/internal/time_series.cc
@@ -176,8 +176,8 @@ google::monitoring::v3::CreateTimeSeriesRequest ToRequest(
     auto mr = ToMonitoredResource(data.resource_->GetAttributes());
     resource.set_type(std::move(mr.type));
     for (auto& label : mr.labels) {
-      resource.mutable_labels()->emplace(std::move(label.first),
-                                         std::move(label.second));
+      (*resource.mutable_labels())[std::move(label.first)] =
+          std::move(label.second);
     }
   }
 

--- a/google/cloud/opentelemetry/internal/time_series.cc
+++ b/google/cloud/opentelemetry/internal/time_series.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/log.h"
 #include <opentelemetry/common/attribute_value.h>
 #include <opentelemetry/sdk/metrics/data/metric_data.h>
+#include <opentelemetry/sdk/metrics/export/metric_producer.h>
 #include <cctype>
 
 namespace google {
@@ -164,6 +165,54 @@ google::monitoring::v3::TimeSeries ToTimeSeries(
   counts.Reserve(static_cast<int>(histogram_data.counts_.size()));
   for (auto c : histogram_data.counts_) counts.Add(c);
   return ts;
+}
+
+google::monitoring::v3::CreateTimeSeriesRequest ToRequest(
+    opentelemetry::sdk::metrics::ResourceMetrics const& data) {
+  google::monitoring::v3::CreateTimeSeriesRequest request;
+
+  google::api::MonitoredResource resource;
+  if (data.resource_) {
+    auto mr = ToMonitoredResource(data.resource_->GetAttributes());
+    resource.set_type(std::move(mr.type));
+    for (auto& label : mr.labels) {
+      resource.mutable_labels()->emplace(std::move(label.first),
+                                         std::move(label.second));
+    }
+  }
+
+  for (auto const& scope_metric : data.scope_metric_data_) {
+    for (auto const& metric_data : scope_metric.metric_data_) {
+      for (auto const& pda : metric_data.point_data_attr_) {
+        struct Visitor {
+          opentelemetry::sdk::metrics::MetricData const& metric_data;
+
+          absl::optional<google::monitoring::v3::TimeSeries> operator()(
+              opentelemetry::sdk::metrics::SumPointData const& point) {
+            return ToTimeSeries(metric_data, point);
+          }
+          absl::optional<google::monitoring::v3::TimeSeries> operator()(
+              opentelemetry::sdk::metrics::LastValuePointData const& point) {
+            return ToTimeSeries(metric_data, point);
+          }
+          absl::optional<google::monitoring::v3::TimeSeries> operator()(
+              opentelemetry::sdk::metrics::HistogramPointData const& point) {
+            return ToTimeSeries(metric_data, point);
+          }
+          absl::optional<google::monitoring::v3::TimeSeries> operator()(
+              opentelemetry::sdk::metrics::DropPointData const&) {
+            return absl::nullopt;
+          }
+        };
+        auto ts = absl::visit(Visitor{metric_data}, pda.point_data);
+        if (!ts) continue;
+        *ts->mutable_resource() = resource;
+        *ts->mutable_metric() = ToMetric(metric_data, pda.attributes);
+        *request.add_time_series() = *std::move(ts);
+      }
+    }
+  }
+  return request;
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/opentelemetry/internal/time_series.h
+++ b/google/cloud/opentelemetry/internal/time_series.h
@@ -41,6 +41,27 @@ google::monitoring::v3::TimeSeries ToTimeSeries(
     opentelemetry::sdk::metrics::MetricData const& metric_data,
     opentelemetry::sdk::metrics::HistogramPointData const& histogram_data);
 
+/**
+ * We need to convert from the C++ OpenTelemetry metrics implementation to
+ * Cloud Monitoring protos.
+ *
+ * See go/otel-gcp-metric-exporter-spec for a somewhat outdated specification.
+ * Note that this document describes how to convert from [OTLP] -> protos.
+ *
+ * To add to the fun, in C++, the OpenTelemetry metrics implementation is not
+ * based on OTLP. We can look at the [C++ OTLP exporter implementation] to
+ * convert from the OpenTelemetry metrics implementation -> OTLP.
+ *
+ * There is also the golang implementation:
+ * https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/babed4870546b78cee69606726961cfd20cbea42/exporter/metric/metric.go#L514
+ *
+ * [C++ OTLP exporter implementation]:
+ * https://github.com/open-telemetry/opentelemetry-cpp/blob/fabd8cc2bc318cb47d5db7322ea9c8cd3f4b847a/exporters/otlp/src/otlp_metric_utils.cc
+ * [OTLP]: https://opentelemetry.io/docs/specs/otel/protocol/
+ */
+google::monitoring::v3::CreateTimeSeriesRequest ToRequest(
+    opentelemetry::sdk::metrics::ResourceMetrics const& data);
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace otel_internal
 }  // namespace cloud

--- a/google/cloud/opentelemetry/internal/time_series_test.cc
+++ b/google/cloud/opentelemetry/internal/time_series_test.cc
@@ -493,6 +493,8 @@ TEST(ToRequest, Sum) {
   md.point_data_attr_.push_back(std::move(pda));
   md.instrument_descriptor.name_ = "metric-name";
   md.instrument_descriptor.unit_ = "unit";
+  md.instrument_descriptor.type_ = {};
+  md.instrument_descriptor.value_type_ = {};
 
   opentelemetry::sdk::metrics::ScopeMetrics sm;
   sm.metric_data_.push_back(md);
@@ -520,6 +522,8 @@ TEST(ToRequest, Gauge) {
   md.point_data_attr_.push_back(std::move(pda));
   md.instrument_descriptor.name_ = "metric-name";
   md.instrument_descriptor.unit_ = "unit";
+  md.instrument_descriptor.type_ = {};
+  md.instrument_descriptor.value_type_ = {};
 
   opentelemetry::sdk::metrics::ScopeMetrics sm;
   sm.metric_data_.push_back(md);
@@ -547,6 +551,8 @@ TEST(ToRequest, Histogram) {
   md.point_data_attr_.push_back(std::move(pda));
   md.instrument_descriptor.name_ = "metric-name";
   md.instrument_descriptor.unit_ = "unit";
+  md.instrument_descriptor.type_ = {};
+  md.instrument_descriptor.value_type_ = {};
 
   opentelemetry::sdk::metrics::ScopeMetrics sm;
   sm.metric_data_.push_back(md);
@@ -574,6 +580,8 @@ TEST(ToRequest, DropIgnored) {
   md.point_data_attr_.push_back(std::move(pda));
   md.instrument_descriptor.name_ = "metric-name";
   md.instrument_descriptor.unit_ = "unit";
+  md.instrument_descriptor.type_ = {};
+  md.instrument_descriptor.value_type_ = {};
 
   opentelemetry::sdk::metrics::ScopeMetrics sm;
   sm.metric_data_.push_back(md);
@@ -605,6 +613,8 @@ TEST(ToRequest, Combined) {
   md.point_data_attr_.push_back(std::move(drop_pda));
   md.instrument_descriptor.name_ = "metric-name";
   md.instrument_descriptor.unit_ = "unit";
+  md.instrument_descriptor.type_ = {};
+  md.instrument_descriptor.value_type_ = {};
 
   opentelemetry::sdk::metrics::ScopeMetrics sm;
   sm.metric_data_.push_back(std::move(md));


### PR DESCRIPTION
Part of the work for #13869 

Helper function to convert from `opentelemetry::sdk::metrics::ResourceMetrics` to `google::monitoring::v3::CreateTimeSeriesRequest`.

For unit testing, we have more involved testing for conversions from `*PointData` -> `google::monitoring::v3::TimeSeries`. In these tests, we only need to verify that the `TimeSeries` helpers are used.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13951)
<!-- Reviewable:end -->
