### PR TITLE
cleanup(generator): add a DebugString() method for a DiscoveryResource

### DIFF
--- a/generator/internal/discovery_resource.cc
+++ b/generator/internal/discovery_resource.cc
@@ -320,6 +320,11 @@ StatusOr<std::string> DiscoveryResource::JsonToProtobufService(
       "\n}\n");
 }
 
+std::string DiscoveryResource::DebugString() const {
+  return absl::StrCat("name: ", name_, "; package_name: ", package_name_,
+                      "; json_: ", json_.dump());
+}
+
 }  // namespace generator_internal
 }  // namespace cloud
 }  // namespace google

--- a/generator/internal/discovery_resource.h
+++ b/generator/internal/discovery_resource.h
@@ -88,6 +88,8 @@ class DiscoveryResource {
   StatusOr<std::string> JsonToProtobufService(
       DiscoveryDocumentProperties const& document_properties) const;
 
+  std::string DebugString() const;
+
  private:
   std::string name_;
   std::string package_name_;


### PR DESCRIPTION
https://github.com/googleapis/google-cloud-cpp/issues/13892

I found this helpful while working on https://github.com/googleapis/google-cloud-cpp/pull/13955, so adding it. It is only meant for debugging, so I didn't add any tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13956)
<!-- Reviewable:end -->
