### PR TITLE
impl(GCS+gRPC): proto-based  idempotency policy

### DIFF
--- a/google/cloud/storage/async/idempotency_policy.cc
+++ b/google/cloud/storage/async/idempotency_policy.cc
@@ -1,0 +1,132 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/async/idempotency_policy.h"
+
+namespace google {
+namespace cloud {
+namespace storage_experimental {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+class StrictIdempotencyPolicy : public IdempotencyPolicy {
+ public:
+  ~StrictIdempotencyPolicy() override = default;
+};
+
+class AlwaysRetryIdempotencyPolicy : public IdempotencyPolicy {
+ public:
+  ~AlwaysRetryIdempotencyPolicy() override = default;
+
+  google::cloud::Idempotency ReadObject(
+      google::storage::v2::ReadObjectRequest const&) override {
+    return Idempotency::kIdempotent;
+  }
+
+  google::cloud::Idempotency InsertObject(
+      google::storage::v2::WriteObjectRequest const&) override {
+    return Idempotency::kIdempotent;
+  }
+
+  google::cloud::Idempotency WriteObject(
+      google::storage::v2::WriteObjectRequest const&) override {
+    return Idempotency::kIdempotent;
+  }
+
+  google::cloud::Idempotency ComposeObject(
+      google::storage::v2::ComposeObjectRequest const&) override {
+    return Idempotency::kIdempotent;
+  }
+
+  google::cloud::Idempotency DeleteObject(
+      google::storage::v2::DeleteObjectRequest const&) override {
+    return Idempotency::kIdempotent;
+  }
+
+  google::cloud::Idempotency RewriteObject(
+      google::storage::v2::RewriteObjectRequest const&) override {
+    return Idempotency::kIdempotent;
+  }
+};
+
+}  // namespace
+
+IdempotencyPolicy::~IdempotencyPolicy() = default;
+
+google::cloud::Idempotency IdempotencyPolicy::ReadObject(
+    google::storage::v2::ReadObjectRequest const&) {
+  // Read operations are always idempotent.
+  return Idempotency::kIdempotent;
+}
+
+google::cloud::Idempotency IdempotencyPolicy::InsertObject(
+    google::storage::v2::WriteObjectRequest const& request) {
+  auto const& spec = request.write_object_spec();
+  if (spec.has_if_generation_match() || spec.has_if_metageneration_match()) {
+    return Idempotency::kIdempotent;
+  }
+  return Idempotency::kNonIdempotent;
+}
+
+google::cloud::Idempotency IdempotencyPolicy::WriteObject(
+    google::storage::v2::WriteObjectRequest const&) {
+  // Write requests for resumable uploads are (each part) always idempotent.
+  // The initial StartResumableWrite() request has no visible side-effects. It
+  // creates an upload id, but this cannot be queried if the response is lost.
+  // The upload ids are also automatically garbage collected, and have no costs.
+  //
+  // Once the resumable upload id is created, the upload can succeed only once.
+  return Idempotency::kIdempotent;
+}
+
+google::cloud::Idempotency IdempotencyPolicy::ComposeObject(
+    google::storage::v2::ComposeObjectRequest const& request) {
+  // Either of these pre-conditions will fail once the operation succeeds. Their
+  // presence makes the operation idempotent.
+  if (request.has_if_generation_match() ||
+      request.has_if_metageneration_match()) {
+    return Idempotency::kIdempotent;
+  }
+  return Idempotency::kNonIdempotent;
+}
+
+google::cloud::Idempotency IdempotencyPolicy::DeleteObject(
+    google::storage::v2::DeleteObjectRequest const& request) {
+  if (request.generation() != 0 || request.has_if_generation_match() ||
+      request.has_if_metageneration_match()) {
+    return Idempotency::kIdempotent;
+  }
+  return Idempotency::kNonIdempotent;
+}
+
+google::cloud::Idempotency IdempotencyPolicy::RewriteObject(
+    google::storage::v2::RewriteObjectRequest const&) {
+  // Rewrite requests are idempotent because they can only succeed once.
+  return Idempotency::kIdempotent;
+}
+
+/// Creates an idempotency policy where only safe operations are retried.
+std::unique_ptr<IdempotencyPolicy> MakeStrictIdempotencyPolicy() {
+  return std::make_unique<StrictIdempotencyPolicy>();
+}
+
+/// Creates an idempotency policy that retries all operations.
+std::unique_ptr<IdempotencyPolicy> MakeAlwaysRetryIdempotencyPolicy() {
+  return std::make_unique<AlwaysRetryIdempotencyPolicy>();
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace storage_experimental
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/async/idempotency_policy.h
+++ b/google/cloud/storage/async/idempotency_policy.h
@@ -39,7 +39,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * Even operations that "add" data can result in data loss. Consider, as another
  * example, inserting a new object. If called without pre-conditions retrying
  * this operation will insert multiple new versions. If the bucket is configured
- * to only keep the las N versions of each object. Then the retry would have
+ * to only keep the last N versions of each object, then the retry would have
  * deleted more data than desired.
  *
  * Some applications are designed to handle duplicate requests without data

--- a/google/cloud/storage/async/idempotency_policy.h
+++ b/google/cloud/storage/async/idempotency_policy.h
@@ -1,0 +1,105 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_ASYNC_IDEMPOTENCY_POLICY_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_ASYNC_IDEMPOTENCY_POLICY_H
+
+#include "google/cloud/idempotency.h"
+#include "google/cloud/version.h"
+#include <google/storage/v2/storage.pb.h>
+#include <functional>
+#include <memory>
+
+namespace google {
+namespace cloud {
+namespace storage_experimental {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+/**
+ * Define the interface for the `AsyncClient`'s idempotency policy.
+ *
+ * The idempotency policy controls which requests are treated as idempotent and
+ * therefore safe to retry on a transient failure. Retrying non-idempotent
+ * operations can result in data loss.
+ *
+ * Consider, for example, `DeleteObject()`. If this operation is called without
+ * pre-conditions retrying it may delete more than one version of an object.
+ *
+ * Even operations that "add" data can result in data loss. Consider, as another
+ * example, inserting a new object. If called without pre-conditions retrying
+ * this operation will insert multiple new versions. If the bucket is configured
+ * to only keep the las N versions of each object. Then the retry would have
+ * deleted more data than desired.
+ *
+ * Some applications are designed to handle duplicate requests without data
+ * loss, or the library may be used in an environment where the risk of data
+ * loss due to duplicate requests is negligible or zero.
+ *
+ * This policy allows application developers to control the behavior of the
+ * library with respect to retrying non-idempotent operations. Application
+ * developers can configure the library to only retry operations that are known
+ * to be idempotent (that is, they will succeed only once). Application may also
+ * configure the library to retry all operations, regardless of whether the
+ * operations are idempotent or not.
+ */
+class IdempotencyPolicy {
+ public:
+  virtual ~IdempotencyPolicy() = 0;
+
+  /// Determine if a google.storage.v2.ReadObjectRequest is idempotent.
+  virtual google::cloud::Idempotency ReadObject(
+      google::storage::v2::ReadObjectRequest const&);
+
+  /// Determine if a google.storage.v2.WriteObjectRequest for a one-shot upload
+  /// is idempotent.
+  virtual google::cloud::Idempotency InsertObject(
+      google::storage::v2::WriteObjectRequest const&);
+
+  /// Determine if a google.storage.v2.WriteObjectRequest for a resumable upload
+  /// is idempotent.
+  virtual google::cloud::Idempotency WriteObject(
+      google::storage::v2::WriteObjectRequest const&);
+
+  /// Determine if a google.storage.v2.ComposeObjectRequest is idempotent.
+  virtual google::cloud::Idempotency ComposeObject(
+      google::storage::v2::ComposeObjectRequest const&);
+
+  /// Determine if a google.storage.v2.DeleteObjectRequest is idempotent.
+  virtual google::cloud::Idempotency DeleteObject(
+      google::storage::v2::DeleteObjectRequest const&);
+
+  /// Determine if a google.storage.v2.RewriteObjectRequest is idempotent.
+  virtual google::cloud::Idempotency RewriteObject(
+      google::storage::v2::RewriteObjectRequest const&);
+};
+
+/// Creates an idempotency policy where only safe operations are retried.
+std::unique_ptr<IdempotencyPolicy> MakeStrictIdempotencyPolicy();
+
+/// Creates an idempotency policy that retries all operations.
+std::unique_ptr<IdempotencyPolicy> MakeAlwaysRetryIdempotencyPolicy();
+
+/**
+ * An option (see `google::cloud::Options`) to set the idempotency policy.
+ */
+struct IdempotencyPolicyOption {
+  using Type = std::function<std::unique_ptr<IdempotencyPolicy>()>;
+};
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace storage_experimental
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_ASYNC_IDEMPOTENCY_POLICY_H

--- a/google/cloud/storage/async/idempotency_policy_test.cc
+++ b/google/cloud/storage/async/idempotency_policy_test.cc
@@ -1,0 +1,109 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/async/idempotency_policy.h"
+#include <google/protobuf/text_format.h>
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage_experimental {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+using ::google::protobuf::TextFormat;
+using ::testing::NotNull;
+
+template <typename M>
+auto TestMessage(char const* text, M m) {
+  EXPECT_TRUE(TextFormat::ParseFromString(text, &m));
+  return m;
+}
+
+TEST(IdempotencyPolicy, Strict) {
+  auto policy = MakeStrictIdempotencyPolicy();
+  ASSERT_THAT(policy, NotNull());
+
+  EXPECT_EQ(policy->ReadObject(google::storage::v2::ReadObjectRequest{}),
+            Idempotency::kIdempotent);
+
+  EXPECT_EQ(policy->InsertObject(google::storage::v2::WriteObjectRequest{}),
+            Idempotency::kNonIdempotent);
+
+  EXPECT_EQ(policy->InsertObject(TestMessage(
+                R"pb(write_object_spec { if_generation_match: 42 })pb",
+                google::storage::v2::WriteObjectRequest{})),
+            Idempotency::kIdempotent);
+  EXPECT_EQ(policy->InsertObject(TestMessage(
+                R"pb(write_object_spec { if_metageneration_match: 42 })pb",
+                google::storage::v2::WriteObjectRequest{})),
+            Idempotency::kIdempotent);
+  EXPECT_EQ(policy->InsertObject(google::storage::v2::WriteObjectRequest{}),
+            Idempotency::kNonIdempotent);
+
+  EXPECT_EQ(policy->WriteObject(google::storage::v2::WriteObjectRequest{}),
+            Idempotency::kIdempotent);
+
+  EXPECT_EQ(policy->ComposeObject(google::storage::v2::ComposeObjectRequest{}),
+            Idempotency::kNonIdempotent);
+  EXPECT_EQ(policy->ComposeObject(
+                TestMessage(R"pb(if_generation_match: 42)pb",
+                            google::storage::v2::ComposeObjectRequest{})),
+            Idempotency::kIdempotent);
+  EXPECT_EQ(policy->ComposeObject(
+                TestMessage(R"pb(if_metageneration_match: 42)pb",
+                            google::storage::v2::ComposeObjectRequest{})),
+            Idempotency::kIdempotent);
+
+  EXPECT_EQ(policy->DeleteObject(google::storage::v2::DeleteObjectRequest{}),
+            Idempotency::kNonIdempotent);
+  EXPECT_EQ(
+      policy->DeleteObject(TestMessage(
+          R"pb(generation: 42)pb", google::storage::v2::DeleteObjectRequest{})),
+      Idempotency::kIdempotent);
+  EXPECT_EQ(policy->DeleteObject(
+                TestMessage(R"pb(if_generation_match: 42)pb",
+                            google::storage::v2::DeleteObjectRequest{})),
+            Idempotency::kIdempotent);
+  EXPECT_EQ(policy->DeleteObject(
+                TestMessage(R"pb(if_metageneration_match: 42)pb",
+                            google::storage::v2::DeleteObjectRequest{})),
+            Idempotency::kIdempotent);
+
+  EXPECT_EQ(policy->RewriteObject(google::storage::v2::RewriteObjectRequest{}),
+            Idempotency::kIdempotent);
+}
+
+TEST(IdempotencyPolicy, AlwaysRetry) {
+  auto policy = MakeAlwaysRetryIdempotencyPolicy();
+  ASSERT_THAT(policy, NotNull());
+  EXPECT_EQ(policy->ReadObject(google::storage::v2::ReadObjectRequest{}),
+            Idempotency::kIdempotent);
+  EXPECT_EQ(policy->InsertObject(google::storage::v2::WriteObjectRequest{}),
+            Idempotency::kIdempotent);
+  EXPECT_EQ(policy->WriteObject(google::storage::v2::WriteObjectRequest{}),
+            Idempotency::kIdempotent);
+  EXPECT_EQ(policy->ComposeObject(google::storage::v2::ComposeObjectRequest{}),
+            Idempotency::kIdempotent);
+  EXPECT_EQ(policy->DeleteObject(google::storage::v2::DeleteObjectRequest{}),
+            Idempotency::kIdempotent);
+  EXPECT_EQ(policy->RewriteObject(google::storage::v2::RewriteObjectRequest{}),
+            Idempotency::kIdempotent);
+}
+
+}  // namespace
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace storage_experimental
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.bzl
+++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.bzl
@@ -19,6 +19,7 @@
 google_cloud_cpp_storage_grpc_hdrs = [
     "async/client.h",
     "async/connection.h",
+    "async/idempotency_policy.h",
     "async/object_requests.h",
     "async/object_responses.h",
     "async/reader.h",
@@ -87,6 +88,7 @@ google_cloud_cpp_storage_grpc_hdrs = [
 
 google_cloud_cpp_storage_grpc_srcs = [
     "async/client.cc",
+    "async/idempotency_policy.cc",
     "async/object_responses.cc",
     "async/reader.cc",
     "async/resume_policy.cc",

--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
@@ -72,6 +72,8 @@ else ()
         async/client.cc
         async/client.h
         async/connection.h
+        async/idempotency_policy.cc
+        async/idempotency_policy.h
         async/object_requests.h
         async/object_responses.cc
         async/object_responses.h
@@ -352,6 +354,7 @@ if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
     set(storage_client_grpc_unit_tests
         # cmake-format: sort
         async/client_test.cc
+        async/idempotency_policy_test.cc
         async/reader_test.cc
         async/resume_policy_test.cc
         async/rewriter_test.cc

--- a/google/cloud/storage/internal/async/connection_impl.cc
+++ b/google/cloud/storage/internal/async/connection_impl.cc
@@ -60,7 +60,7 @@ inline std::unique_ptr<BackoffPolicy> backoff_policy(Options const& options) {
   return options.get<storage::BackoffPolicyOption>()->clone();
 }
 
-inline std::unique_ptr<storage::IdempotencyPolicy> idempotency_policy(
+inline std::unique_ptr<storage::IdempotencyPolicy> legacy_idempotency_policy(
     Options const& options) {
   return options.get<storage::IdempotencyPolicyOption>()->clone();
 }
@@ -243,7 +243,7 @@ future<StatusOr<storage::ObjectMetadata>> AsyncConnectionImpl::ComposeObject(
         StatusOr<storage::ObjectMetadata>(std::move(proto).status()));
   }
   auto const idempotency =
-      idempotency_policy(*current)->IsIdempotent(p.request.impl_)
+      legacy_idempotency_policy(*current)->IsIdempotent(p.request.impl_)
           ? Idempotency::kIdempotent
           : Idempotency::kNonIdempotent;
   auto call = [stub = stub_, request = std::move(p.request)](
@@ -271,7 +271,7 @@ future<Status> AsyncConnectionImpl::DeleteObject(DeleteObjectParams p) {
   auto current = internal::MakeImmutableOptions(std::move(p.options));
   auto proto = ToProto(p.request.impl_);
   auto const idempotency =
-      idempotency_policy(*current)->IsIdempotent(p.request.impl_)
+      legacy_idempotency_policy(*current)->IsIdempotent(p.request.impl_)
           ? Idempotency::kIdempotent
           : Idempotency::kNonIdempotent;
   auto retry = retry_policy(*current);

--- a/google/cloud/storage/internal/async/default_options.cc
+++ b/google/cloud/storage/internal/async/default_options.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/async/default_options.h"
+#include "google/cloud/storage/async/idempotency_policy.h"
 #include "google/cloud/storage/async/resume_policy.h"
 #include "google/cloud/storage/async/writer_connection.h"
 #include "google/cloud/storage/internal/grpc/stub.h"
@@ -61,8 +62,11 @@ auto Adjust(Options opts) {
 Options DefaultOptionsAsync(Options opts) {
   opts = internal::MergeOptions(
       std::move(opts),
-      Options{}.set<storage_experimental::ResumePolicyOption>(
-          storage_experimental::UnlimitedErrorCountResumePolicy()));
+      Options{}
+          .set<storage_experimental::ResumePolicyOption>(
+              storage_experimental::UnlimitedErrorCountResumePolicy())
+          .set<storage_experimental::IdempotencyPolicyOption>(
+              storage_experimental::MakeStrictIdempotencyPolicy));
   return Adjust(DefaultOptionsGrpc(std::move(opts)));
 }
 

--- a/google/cloud/storage/storage_client_grpc_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_grpc_unit_tests.bzl
@@ -18,6 +18,7 @@
 
 storage_client_grpc_unit_tests = [
     "async/client_test.cc",
+    "async/idempotency_policy_test.cc",
     "async/reader_test.cc",
     "async/resume_policy_test.cc",
     "async/rewriter_test.cc",


### PR DESCRIPTION
We need a way to determine of a proto-request is idempotent.

Part of the work for #13910

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13968)
<!-- Reviewable:end -->
