### PR TITLE
impl(otel): GCM export

### DIFF
--- a/google/cloud/opentelemetry/monitoring_exporter.cc
+++ b/google/cloud/opentelemetry/monitoring_exporter.cc
@@ -14,6 +14,8 @@
 
 #include "google/cloud/opentelemetry/monitoring_exporter.h"
 #include "google/cloud/monitoring/v3/metric_client.h"
+#include "google/cloud/opentelemetry/internal/time_series.h"
+#include "google/cloud/log.h"
 #include "google/cloud/project.h"
 #include <memory>
 
@@ -21,16 +23,61 @@ namespace google {
 namespace cloud {
 namespace otel_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+class MonitoringExporter final
+    : public opentelemetry::sdk::metrics::PushMetricExporter {
+ public:
+  explicit MonitoringExporter(
+      Project project,
+      std::shared_ptr<monitoring_v3::MetricServiceConnection> conn)
+      : project_(std::move(project)), client_(std::move(conn)) {}
+
+  opentelemetry::sdk::metrics::AggregationTemporality GetAggregationTemporality(
+      opentelemetry::sdk::metrics::InstrumentType) const noexcept override {
+    return opentelemetry::sdk::metrics::AggregationTemporality::kCumulative;
+  }
+
+  opentelemetry::sdk::common::ExportResult Export(
+      opentelemetry::sdk::metrics::ResourceMetrics const& data) noexcept
+      override {
+    // TODO(#13869) - Respect `noexcept` qualifier
+    auto request = ToRequest(data);
+    request.set_name(project_.FullName());
+    if (request.time_series().empty()) {
+      GCP_LOG(WARNING) << "Cloud Monitoring Export skipped. No TimeSeries "
+                          "added to request.";
+      return opentelemetry::sdk::common::ExportResult::kSuccess;
+    }
+
+    // TODO(#13869) - Exporters of Google-defined metrics will need to use
+    // `CreateServiceTimeSeries` instead of `CreateTimeSeries`. We will add that
+    // complexity later.
+    auto status = client_.CreateTimeSeries(request);
+    if (status.ok()) return opentelemetry::sdk::common::ExportResult::kSuccess;
+    GCP_LOG(WARNING) << "Cloud Monitoring Export failed with status=" << status;
+    if (status.code() == StatusCode::kInvalidArgument) {
+      return opentelemetry::sdk::common::ExportResult::kFailureInvalidArgument;
+    }
+    return opentelemetry::sdk::common::ExportResult::kFailure;
+  }
+
+  bool ForceFlush(std::chrono::microseconds) noexcept override { return false; }
+
+  bool Shutdown(std::chrono::microseconds) noexcept override { return true; }
+
+ private:
+  Project project_;
+  monitoring_v3::MetricServiceClient client_;
+};
+}  // namespace
 
 std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter>
 MakeMonitoringExporter(
-    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     Project project,
-    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     std::shared_ptr<monitoring_v3::MetricServiceConnection> conn) {
-  (void)project;
-  (void)conn;
-  return nullptr;
+  return std::make_unique<MonitoringExporter>(std::move(project),
+                                              std::move(conn));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/opentelemetry/monitoring_exporter_test.cc
+++ b/google/cloud/opentelemetry/monitoring_exporter_test.cc
@@ -54,6 +54,7 @@ opentelemetry::sdk::metrics::ResourceMetrics MakeResourceMetrics(
   }
 
   opentelemetry::sdk::metrics::ResourceMetrics rm;
+  rm.resource_ = nullptr;
   rm.scope_metric_data_.push_back(std::move(sm));
 
   return rm;

--- a/google/cloud/opentelemetry/monitoring_exporter_test.cc
+++ b/google/cloud/opentelemetry/monitoring_exporter_test.cc
@@ -14,8 +14,12 @@
 
 #include "google/cloud/opentelemetry/monitoring_exporter.h"
 #include "google/cloud/monitoring/v3/mocks/mock_metric_connection.h"
+#include "google/cloud/internal/make_status.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/version.h"
 #include <gmock/gmock.h>
+#include <opentelemetry/sdk/metrics/export/metric_producer.h>
+#include <opentelemetry/sdk/resource/resource.h>
 
 namespace google {
 namespace cloud {
@@ -23,11 +27,123 @@ namespace otel {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-TEST(MonitoringExporter, Placeholder) {
+using ::testing::AllOf;
+using ::testing::HasSubstr;
+using ::testing::SizeIs;
+
+/**
+ * Returns a `ResourceMetrics` composed of N TimeSeries.
+ *
+ * Note that `ToRequest(...)` is tested extensively in time_series_test.cc. The
+ * type of TimeSeries used here doesn't matter. The count should give us
+ * sufficient confidence that we are calling `ToRequest(...)`
+ */
+opentelemetry::sdk::metrics::ResourceMetrics MakeResourceMetrics(
+    int expected_time_series_count) {
+  opentelemetry::sdk::metrics::PointDataAttributes pda;
+  pda.point_data = opentelemetry::sdk::metrics::SumPointData{};
+
+  opentelemetry::sdk::metrics::MetricData md;
+  md.point_data_attr_.push_back(pda);
+  md.instrument_descriptor.type_ = {};
+  md.instrument_descriptor.value_type_ = {};
+
+  opentelemetry::sdk::metrics::ScopeMetrics sm;
+  for (auto i = 0; i != expected_time_series_count; ++i) {
+    sm.metric_data_.push_back(md);
+  }
+
+  opentelemetry::sdk::metrics::ResourceMetrics rm;
+  rm.scope_metric_data_.push_back(std::move(sm));
+
+  return rm;
+}
+
+TEST(MonitoringExporter, ExportSuccess) {
   auto mock =
       std::make_shared<monitoring_v3_mocks::MockMetricServiceConnection>();
+  EXPECT_CALL(*mock, CreateTimeSeries)
+      .WillOnce(
+          [](google::monitoring::v3::CreateTimeSeriesRequest const& request) {
+            EXPECT_THAT(request.name(), "projects/test-project");
+            EXPECT_THAT(request.time_series(), SizeIs(2));
+            return Status();
+          });
+
   auto exporter = otel_internal::MakeMonitoringExporter(Project("test-project"),
                                                         std::move(mock));
+  auto data = MakeResourceMetrics(/*expected_time_series_count=*/2);
+  auto result = exporter->Export(data);
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess);
+}
+
+TEST(MonitoringExporter, ExportSkippedIfNoTimeSeries) {
+  testing_util::ScopedLog log;
+
+  auto mock =
+      std::make_shared<monitoring_v3_mocks::MockMetricServiceConnection>();
+  EXPECT_CALL(*mock, CreateTimeSeries).Times(0);
+
+  auto exporter = otel_internal::MakeMonitoringExporter(Project("test-project"),
+                                                        std::move(mock));
+  auto data = MakeResourceMetrics(/*expected_time_series_count=*/0);
+  auto result = exporter->Export(data);
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess);
+
+  EXPECT_THAT(log.ExtractLines(),
+              Contains(AllOf(HasSubstr("Cloud Monitoring Export skipped"),
+                             HasSubstr("No TimeSeries"))));
+}
+
+TEST(MonitoringExporter, ExportFailure) {
+  testing_util::ScopedLog log;
+
+  auto mock =
+      std::make_shared<monitoring_v3_mocks::MockMetricServiceConnection>();
+  EXPECT_CALL(*mock, CreateTimeSeries)
+      .WillOnce(
+          [](google::monitoring::v3::CreateTimeSeriesRequest const& request) {
+            EXPECT_THAT(request.name(), "projects/test-project");
+            EXPECT_THAT(request.time_series(), SizeIs(2));
+            return internal::PermissionDeniedError("nope");
+          });
+
+  auto exporter = otel_internal::MakeMonitoringExporter(Project("test-project"),
+                                                        std::move(mock));
+  auto data = MakeResourceMetrics(/*expected_time_series_count=*/2);
+  auto result = exporter->Export(data);
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kFailure);
+
+  EXPECT_THAT(
+      log.ExtractLines(),
+      Contains(AllOf(HasSubstr("Cloud Monitoring Export failed"),
+                     HasSubstr("PERMISSION_DENIED"), HasSubstr("nope"))));
+}
+
+TEST(MonitoringExporter, ExportFailureWithInvalidArgument) {
+  testing_util::ScopedLog log;
+
+  auto mock =
+      std::make_shared<monitoring_v3_mocks::MockMetricServiceConnection>();
+  EXPECT_CALL(*mock, CreateTimeSeries)
+      .WillOnce(
+          [](google::monitoring::v3::CreateTimeSeriesRequest const& request) {
+            EXPECT_THAT(request.name(), "projects/test-project");
+            EXPECT_THAT(request.time_series(), SizeIs(2));
+            return internal::InvalidArgumentError("nope");
+          });
+
+  auto exporter = otel_internal::MakeMonitoringExporter(Project("test-project"),
+                                                        std::move(mock));
+  auto data = MakeResourceMetrics(/*expected_time_series_count=*/2);
+  auto result = exporter->Export(data);
+  EXPECT_EQ(result,
+            opentelemetry::sdk::common::ExportResult::kFailureInvalidArgument);
+
+  EXPECT_THAT(
+      log.ExtractLines(),
+      Contains(AllOf(HasSubstr("Cloud Monitoring Export failed"),
+                     HasSubstr("PERMISSION_DENIED"), HasSubstr("nope"))));
 }
 
 }  // namespace

--- a/google/cloud/opentelemetry/monitoring_exporter_test.cc
+++ b/google/cloud/opentelemetry/monitoring_exporter_test.cc
@@ -143,7 +143,7 @@ TEST(MonitoringExporter, ExportFailureWithInvalidArgument) {
   EXPECT_THAT(
       log.ExtractLines(),
       Contains(AllOf(HasSubstr("Cloud Monitoring Export failed"),
-                     HasSubstr("PERMISSION_DENIED"), HasSubstr("nope"))));
+                     HasSubstr("INVALID_ARGUMENT"), HasSubstr("nope"))));
 }
 
 }  // namespace


### PR DESCRIPTION
Part of the work for #13869 

Implement the exporter, especially the `Export()` function.

Note that there are still more line items to clean up in the linked issue (e.g. respecting `noexcept` qualifiers). We also will need to generalize the exporter to handle things like:
- support for Google-defined metrics
- options to set the metric type prefix (currently `"workload.googleapis.com/"`)

But as is, this should be a working exporter.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13970)
<!-- Reviewable:end -->
