### PR TITLE
refactor(otel): set unit once

### DIFF
--- a/google/cloud/opentelemetry/internal/time_series.cc
+++ b/google/cloud/opentelemetry/internal/time_series.cc
@@ -115,7 +115,6 @@ google::monitoring::v3::TimeSeries ToTimeSeries(
     opentelemetry::sdk::metrics::MetricData const& metric_data,
     opentelemetry::sdk::metrics::SumPointData const& sum_data) {
   google::monitoring::v3::TimeSeries ts;
-  ts.set_unit(metric_data.instrument_descriptor.unit_);
   ts.set_metric_kind(google::api::MetricDescriptor::CUMULATIVE);
   ts.set_value_type(ToValueType(metric_data.instrument_descriptor.value_type_));
 
@@ -129,7 +128,6 @@ google::monitoring::v3::TimeSeries ToTimeSeries(
     opentelemetry::sdk::metrics::MetricData const& metric_data,
     opentelemetry::sdk::metrics::LastValuePointData const& gauge_data) {
   google::monitoring::v3::TimeSeries ts;
-  ts.set_unit(metric_data.instrument_descriptor.unit_);
   ts.set_metric_kind(google::api::MetricDescriptor::GAUGE);
   ts.set_value_type(ToValueType(metric_data.instrument_descriptor.value_type_));
 
@@ -145,7 +143,6 @@ google::monitoring::v3::TimeSeries ToTimeSeries(
     opentelemetry::sdk::metrics::MetricData const& metric_data,
     opentelemetry::sdk::metrics::HistogramPointData const& histogram_data) {
   google::monitoring::v3::TimeSeries ts;
-  ts.set_unit(metric_data.instrument_descriptor.unit_);
   ts.set_metric_kind(google::api::MetricDescriptor::CUMULATIVE);
   ts.set_value_type(google::api::MetricDescriptor::DISTRIBUTION);
 
@@ -206,6 +203,7 @@ google::monitoring::v3::CreateTimeSeriesRequest ToRequest(
         };
         auto ts = absl::visit(Visitor{metric_data}, pda.point_data);
         if (!ts) continue;
+        ts->set_unit(metric_data.instrument_descriptor.unit_);
         *ts->mutable_resource() = resource;
         *ts->mutable_metric() = ToMetric(metric_data, pda.attributes);
         *request.add_time_series() = *std::move(ts);

--- a/google/cloud/opentelemetry/internal/time_series_test.cc
+++ b/google/cloud/opentelemetry/internal/time_series_test.cc
@@ -267,7 +267,6 @@ TEST(SumPointData, Simple) {
   auto const end = start + std::chrono::seconds(5);
 
   opentelemetry::sdk::metrics::MetricData md;
-  md.instrument_descriptor.unit_ = "unit";
   md.instrument_descriptor.value_type_ =
       opentelemetry::sdk::metrics::InstrumentValueType::kInt;
   md.start_ts = start;
@@ -277,7 +276,6 @@ TEST(SumPointData, Simple) {
   point.value_ = std::int64_t{42};
 
   auto ts = ToTimeSeries(md, point);
-  EXPECT_EQ(ts.unit(), "unit");
   EXPECT_EQ(ts.metric_kind(), google::api::MetricDescriptor::CUMULATIVE);
   EXPECT_THAT(ts.points(),
               ElementsAre(AllOf(Int64TypedValue(42), Interval(start, end))));
@@ -342,7 +340,6 @@ TEST(LastValuePointData, Simple) {
   auto const now = std::chrono::system_clock::now();
 
   opentelemetry::sdk::metrics::MetricData md;
-  md.instrument_descriptor.unit_ = "unit";
   md.instrument_descriptor.value_type_ =
       opentelemetry::sdk::metrics::InstrumentValueType::kInt;
   md.start_ts = now;
@@ -368,7 +365,6 @@ TEST(LastValuePointData, Simple) {
   };
 
   auto ts = ToTimeSeries(md, point);
-  EXPECT_EQ(ts.unit(), "unit");
   EXPECT_EQ(ts.metric_kind(), google::api::MetricDescriptor::GAUGE);
   EXPECT_THAT(ts.points(),
               ElementsAre(AllOf(Int64TypedValue(42), interval(now))));
@@ -415,7 +411,6 @@ TEST(HistogramPointData, SimpleWithInt64Sum) {
   auto const end = start + std::chrono::seconds(5);
 
   opentelemetry::sdk::metrics::MetricData md;
-  md.instrument_descriptor.unit_ = "unit";
   md.instrument_descriptor.value_type_ =
       opentelemetry::sdk::metrics::InstrumentValueType::kInt;
   md.start_ts = start;
@@ -428,7 +423,6 @@ TEST(HistogramPointData, SimpleWithInt64Sum) {
   point.count_ = 16;
 
   auto ts = ToTimeSeries(md, point);
-  EXPECT_EQ(ts.unit(), "unit");
   EXPECT_EQ(ts.metric_kind(), google::api::MetricDescriptor::CUMULATIVE);
   EXPECT_THAT(
       ts.points(),


### PR DESCRIPTION
Instead of setting the `unit` in each TimeSeries helper, set it once in `ToRequest()`.

Note that we still verify the unit in the `ToRequest()` unit tests, e.g.: https://github.com/googleapis/google-cloud-cpp/blob/788a072a705816e43f6b7229f4c688c547b8d972/google/cloud/opentelemetry/internal/time_series_test.cc#L514

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13974)
<!-- Reviewable:end -->
