### PR TITLE
cleanup(storage): remove logging noise

### DIFF
--- a/google/cloud/storage/internal/grpc/bucket_request_parser.cc
+++ b/google/cloud/storage/internal/grpc/bucket_request_parser.cc
@@ -22,7 +22,6 @@
 #include "google/cloud/storage/internal/object_access_control_parser.h"
 #include "google/cloud/storage/internal/patch_builder_details.h"
 #include "google/cloud/internal/time_utils.h"
-#include "google/cloud/log.h"
 #include <algorithm>
 
 namespace google {

--- a/google/cloud/storage/internal/grpc/object_request_parser.cc
+++ b/google/cloud/storage/internal/grpc/object_request_parser.cc
@@ -22,7 +22,6 @@
 #include "google/cloud/internal/invoke_result.h"
 #include "google/cloud/internal/make_status.h"
 #include "google/cloud/internal/time_utils.h"
-#include "google/cloud/log.h"
 #include <iterator>
 
 namespace google {

--- a/google/cloud/storage/internal/grpc/stub.cc
+++ b/google/cloud/storage/internal/grpc/stub.cc
@@ -40,7 +40,6 @@
 #include "google/cloud/internal/invoke_result.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/service_endpoint.h"
-#include "google/cloud/log.h"
 #include "absl/strings/match.h"
 #include "absl/time/time.h"
 #include <grpcpp/grpcpp.h>

--- a/google/cloud/storage/internal/tracing_connection_test.cc
+++ b/google/cloud/storage/internal/tracing_connection_test.cc
@@ -17,7 +17,6 @@
 #include "google/cloud/storage/internal/tracing_connection.h"
 #include "google/cloud/storage/testing/canonical_errors.h"
 #include "google/cloud/storage/testing/mock_client.h"
-#include "google/cloud/log.h"
 #include "google/cloud/testing_util/opentelemetry_matchers.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>


### PR DESCRIPTION
We should only log from the logging decorators. These were debugging remnants that are no longer relevant. I took the opportunity to remove unused `"google/cloud/log.h"` includes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13975)
<!-- Reviewable:end -->
