### PR TITLE
impl(generator): support apiVersion in discovery documents

### DIFF
--- a/generator/internal/discovery_file_test.cc
+++ b/generator/internal/discovery_file_test.cc
@@ -24,6 +24,7 @@ namespace cloud {
 namespace generator_internal {
 namespace {
 
+using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::Eq;
 using ::testing::HasSubstr;
@@ -245,7 +246,7 @@ message GetMyResourceRequest {
   DiscoveryTypeVertex get_response("MyResource", "other.package", {}, &pool());
   r.AddResponseType("Operation", &operation_type);
   r.AddResponseType("MyResource", &get_response);
-  ASSERT_STATUS_OK(r.SetServiceApiVersion());
+  EXPECT_THAT(r.SetServiceApiVersion(), IsOk());
   DiscoveryFile f(&r, "my_path", "my_relative_proto_path", "my.package.name",
                   r.GetRequestTypesList());
   f.AddImportPath("path/to/import.proto");
@@ -367,7 +368,7 @@ message GetMyResourceRequest {
   DiscoveryTypeVertex get_response("MyResource", "other.package", {}, &pool());
   r.AddResponseType("Operation", &operation_type);
   r.AddResponseType("MyResource", &get_response);
-  ASSERT_STATUS_OK(r.SetServiceApiVersion());
+  EXPECT_THAT(r.SetServiceApiVersion(), IsOk());
   DiscoveryFile f(&r, "my_path", "my_relative_proto_path", "my.package.name",
                   r.GetRequestTypesList());
   std::map<std::string, DiscoveryTypeVertex> types;
@@ -522,7 +523,7 @@ service MyResources {
   auto resource_json = nlohmann::json::parse(kResourceJson, nullptr, false);
   ASSERT_TRUE(resource_json.is_object());
   DiscoveryResource r("myResources", "", resource_json);
-  ASSERT_STATUS_OK(r.SetServiceApiVersion());
+  EXPECT_THAT(r.SetServiceApiVersion(), IsOk());
   DiscoveryFile f(&r, "my_path", "my_relative_proto_path", "my.package.name",
                   r.GetRequestTypesList());
   std::map<std::string, DiscoveryTypeVertex> types;
@@ -587,7 +588,7 @@ TEST_F(DiscoveryFileTest, FormatFileResourceScopeError) {
                                        get_request_type_json, &pool());
   r.AddRequestType("DoFooRequest", &do_foo_request_type);
   r.AddRequestType("GetMyResourceRequest", &get_request_type);
-  ASSERT_STATUS_OK(r.SetServiceApiVersion());
+  EXPECT_THAT(r.SetServiceApiVersion(), IsOk());
   DiscoveryFile f(&r, "my_path", "my_relative_proto_path", "my.package.name",
                   r.GetRequestTypesList());
   f.AddImportPath("path/to/import.proto");
@@ -647,7 +648,7 @@ TEST_F(DiscoveryFileTest, FormatFileTypeMissingError) {
   DiscoveryTypeVertex get_response("MyResource", "other.package", {}, &pool());
   r.AddResponseType("Operation", &operation_type);
   r.AddResponseType("MyResource", &get_response);
-  ASSERT_STATUS_OK(r.SetServiceApiVersion());
+  EXPECT_THAT(r.SetServiceApiVersion(), IsOk());
   DiscoveryFile f(&r, "my_path", "my_relative_proto_path", "my.package.name",
                   r.GetRequestTypesList());
   f.AddImportPath("path/to/import.proto");

--- a/generator/internal/discovery_file_test.cc
+++ b/generator/internal/discovery_file_test.cc
@@ -245,6 +245,7 @@ message GetMyResourceRequest {
   DiscoveryTypeVertex get_response("MyResource", "other.package", {}, &pool());
   r.AddResponseType("Operation", &operation_type);
   r.AddResponseType("MyResource", &get_response);
+  ASSERT_STATUS_OK(r.SetServiceApiVersion());
   DiscoveryFile f(&r, "my_path", "my_relative_proto_path", "my.package.name",
                   r.GetRequestTypesList());
   f.AddImportPath("path/to/import.proto");
@@ -366,6 +367,7 @@ message GetMyResourceRequest {
   DiscoveryTypeVertex get_response("MyResource", "other.package", {}, &pool());
   r.AddResponseType("Operation", &operation_type);
   r.AddResponseType("MyResource", &get_response);
+  ASSERT_STATUS_OK(r.SetServiceApiVersion());
   DiscoveryFile f(&r, "my_path", "my_relative_proto_path", "my.package.name",
                   r.GetRequestTypesList());
   std::map<std::string, DiscoveryTypeVertex> types;
@@ -520,6 +522,7 @@ service MyResources {
   auto resource_json = nlohmann::json::parse(kResourceJson, nullptr, false);
   ASSERT_TRUE(resource_json.is_object());
   DiscoveryResource r("myResources", "", resource_json);
+  ASSERT_STATUS_OK(r.SetServiceApiVersion());
   DiscoveryFile f(&r, "my_path", "my_relative_proto_path", "my.package.name",
                   r.GetRequestTypesList());
   std::map<std::string, DiscoveryTypeVertex> types;
@@ -584,6 +587,7 @@ TEST_F(DiscoveryFileTest, FormatFileResourceScopeError) {
                                        get_request_type_json, &pool());
   r.AddRequestType("DoFooRequest", &do_foo_request_type);
   r.AddRequestType("GetMyResourceRequest", &get_request_type);
+  ASSERT_STATUS_OK(r.SetServiceApiVersion());
   DiscoveryFile f(&r, "my_path", "my_relative_proto_path", "my.package.name",
                   r.GetRequestTypesList());
   f.AddImportPath("path/to/import.proto");
@@ -643,6 +647,7 @@ TEST_F(DiscoveryFileTest, FormatFileTypeMissingError) {
   DiscoveryTypeVertex get_response("MyResource", "other.package", {}, &pool());
   r.AddResponseType("Operation", &operation_type);
   r.AddResponseType("MyResource", &get_response);
+  ASSERT_STATUS_OK(r.SetServiceApiVersion());
   DiscoveryFile f(&r, "my_path", "my_relative_proto_path", "my.package.name",
                   r.GetRequestTypesList());
   f.AddImportPath("path/to/import.proto");

--- a/generator/internal/discovery_resource.cc
+++ b/generator/internal/discovery_resource.cc
@@ -62,8 +62,6 @@ absl::optional<std::string> DetermineLongRunningOperationService(
 
 DiscoveryResource::DiscoveryResource() : json_("") {}
 
-// TODO(#11377): remove default_host and base_path as member variables and pass
-// DiscoveryDocumentProperties as an argument to JsonToProtobufService.
 DiscoveryResource::DiscoveryResource(std::string name, std::string package_name,
                                      nlohmann::json json)
     : name_(std::move(name)),
@@ -90,6 +88,36 @@ std::vector<DiscoveryTypeVertex*> DiscoveryResource::GetRequestTypesList()
                    return p.second;
                  });
   return v;
+}
+
+StatusOr<std::string> DiscoveryResource::GetServiceApiVersion() const {
+  if (service_api_version_.has_value()) return *service_api_version_;
+
+  if (!json_.contains("methods")) {
+    service_api_version_ = internal::InvalidArgumentError(
+        "resource contains no methods",
+        GCP_ERROR_INFO().WithMetadata("json", json_.dump()));
+    return *service_api_version_;
+  }
+
+  std::string service_api_version;
+  for (auto const& m : *json_.find("methods")) {
+    std::string method_api_version = m.value("apiVersion", "");
+    // We expect well formed JSON and anticipate this is the usual case.
+    if (service_api_version == method_api_version) {
+      continue;
+    }
+    if (service_api_version.empty()) {
+      service_api_version = method_api_version;
+    } else {
+      service_api_version_ = internal::InvalidArgumentError(
+          "resource contains methods with different apiVersion values",
+          GCP_ERROR_INFO().WithMetadata("json", json_.dump()));
+      return *service_api_version_;
+    }
+  }
+  service_api_version_ = service_api_version;
+  return *service_api_version_;
 }
 
 std::string DiscoveryResource::FormatUrlPath(std::string const& path) {
@@ -251,6 +279,11 @@ StatusOr<std::string> DiscoveryResource::JsonToProtobufService(
   service_text.push_back(
       absl::StrFormat("  option (google.api.default_host) = \"%s\";",
                       document_properties.default_hostname));
+  auto service_api_version = GetServiceApiVersion();
+  if (service_api_version.ok() && !service_api_version->empty()) {
+    service_text.push_back(absl::StrFormat(
+        "  option (google.api.api_version) = \"%s\";", *service_api_version));
+  }
   auto scopes = FormatOAuthScopes();
   if (!scopes) return std::move(scopes).status();
   service_text.push_back(

--- a/generator/internal/discovery_resource.h
+++ b/generator/internal/discovery_resource.h
@@ -53,6 +53,11 @@ class DiscoveryResource {
 
   std::vector<DiscoveryTypeVertex*> GetRequestTypesList() const;
 
+  // "apiVersion" is an optional field that can be specified per method in a
+  // Discovery Document. These must all be equal to qualify a resource for proto
+  // generation.
+  StatusOr<std::string> GetServiceApiVersion() const;
+
   // Examines the provided path and converts any parameter names in curly braces
   // to snake case, e.g. "projects/{projectId}/zone/{zone}" yields
   // "projects/{project_id}/zone/{zone}".
@@ -97,6 +102,7 @@ class DiscoveryResource {
   nlohmann::json json_;
   std::map<std::string, DiscoveryTypeVertex*> request_types_;
   std::map<std::string, DiscoveryTypeVertex*> response_types_;
+  mutable absl::optional<StatusOr<std::string>> service_api_version_;
 };
 
 }  // namespace generator_internal

--- a/generator/internal/discovery_resource.h
+++ b/generator/internal/discovery_resource.h
@@ -57,6 +57,7 @@ class DiscoveryResource {
   // Discovery Document. These must all be equal to qualify a resource for proto
   // generation.
   StatusOr<std::string> GetServiceApiVersion() const;
+  Status SetServiceApiVersion();
 
   // Examines the provided path and converts any parameter names in curly braces
   // to snake case, e.g. "projects/{projectId}/zone/{zone}" yields
@@ -102,7 +103,7 @@ class DiscoveryResource {
   nlohmann::json json_;
   std::map<std::string, DiscoveryTypeVertex*> request_types_;
   std::map<std::string, DiscoveryTypeVertex*> response_types_;
-  mutable absl::optional<StatusOr<std::string>> service_api_version_;
+  absl::optional<StatusOr<std::string>> service_api_version_;
 };
 
 }  // namespace generator_internal

--- a/generator/internal/discovery_resource_test.cc
+++ b/generator/internal/discovery_resource_test.cc
@@ -22,6 +22,7 @@ namespace cloud {
 namespace generator_internal {
 namespace {
 
+using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::IsOkAndHolds;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::Eq;
@@ -72,7 +73,7 @@ TEST_F(DiscoveryResourceTest, GetServiceApiVersionEmpty) {
   auto resource_json = nlohmann::json::parse(kResourceJson, nullptr, false);
   ASSERT_TRUE(resource_json.is_object());
   DiscoveryResource r("myTests", "", resource_json);
-  ASSERT_STATUS_OK(r.SetServiceApiVersion());
+  EXPECT_THAT(r.SetServiceApiVersion(), IsOk());
   EXPECT_THAT(r.GetServiceApiVersion(), IsOkAndHolds(IsEmpty()));
 }
 
@@ -90,7 +91,7 @@ TEST_F(DiscoveryResourceTest, GetServiceApiVersionSameVersion) {
   auto resource_json = nlohmann::json::parse(kResourceJson, nullptr, false);
   ASSERT_TRUE(resource_json.is_object());
   DiscoveryResource r("myTests", "", resource_json);
-  ASSERT_STATUS_OK(r.SetServiceApiVersion());
+  EXPECT_THAT(r.SetServiceApiVersion(), IsOk());
   EXPECT_THAT(r.GetServiceApiVersion(), IsOkAndHolds("test-api-version"));
 }
 
@@ -746,7 +747,7 @@ service MyResources {
   r.AddResponseType("Operation", &t3);
   DiscoveryDocumentProperties document_properties{
       "base/path", "https://my.endpoint.com", "", "", "", "", {}, "2023"};
-  ASSERT_STATUS_OK(r.SetServiceApiVersion());
+  EXPECT_THAT(r.SetServiceApiVersion(), IsOk());
   auto emitted_proto = r.JsonToProtobufService(document_properties);
   EXPECT_THAT(emitted_proto, IsOkAndHolds(kExpectedProto));
 }
@@ -855,7 +856,7 @@ service MyResources {
   r.AddResponseType("Operation", &t3);
   DiscoveryDocumentProperties document_properties{
       "base/path", "https://my.endpoint.com", "", "", "", "", {}, "2023"};
-  ASSERT_STATUS_OK(r.SetServiceApiVersion());
+  EXPECT_THAT(r.SetServiceApiVersion(), IsOk());
   auto emitted_proto = r.JsonToProtobufService(document_properties);
   ASSERT_STATUS_OK(emitted_proto);
   EXPECT_THAT(*emitted_proto, Eq(kExpectedProto));
@@ -887,7 +888,7 @@ TEST_F(DiscoveryResourceTest, JsonToProtobufServiceMissingOAuthScopes) {
   r.AddRequestType("GetMyResourcesRequest", &t);
   DiscoveryDocumentProperties document_properties{
       "base/path", "https://my.endpoint.com", "", "", "", "", {}, "2023"};
-  ASSERT_STATUS_OK(r.SetServiceApiVersion());
+  EXPECT_THAT(r.SetServiceApiVersion(), IsOk());
   auto emitted_proto = r.JsonToProtobufService(document_properties);
   EXPECT_THAT(
       emitted_proto,
@@ -925,7 +926,7 @@ TEST_F(DiscoveryResourceTest, JsonToProtobufServiceMissingRequestType) {
   DiscoveryResource r("myResources", "this.package", resource_json);
   DiscoveryDocumentProperties document_properties{
       "base/path", "https://my.endpoint.com", "", "", "", "", {}, "2023"};
-  ASSERT_STATUS_OK(r.SetServiceApiVersion());
+  EXPECT_THAT(r.SetServiceApiVersion(), IsOk());
   auto emitted_proto = r.JsonToProtobufService(document_properties);
   EXPECT_THAT(
       emitted_proto,
@@ -967,7 +968,7 @@ service MyResources {
   DiscoveryResource r("myResources", "this.package", resource_json);
   DiscoveryDocumentProperties document_properties{
       "base/path", "https://my.endpoint.com", "", "", "", "", {}, "2023"};
-  ASSERT_STATUS_OK(r.SetServiceApiVersion());
+  EXPECT_THAT(r.SetServiceApiVersion(), IsOk());
   auto emitted_proto = r.JsonToProtobufService(document_properties);
   ASSERT_STATUS_OK(emitted_proto);
   EXPECT_THAT(*emitted_proto, Eq(kExpectedProto));
@@ -1001,7 +1002,7 @@ TEST_F(DiscoveryResourceTest, JsonToProtobufServiceErrorFormattingRpcOptions) {
   r.AddRequestType("GetMyResourcesRequest", &t);
   DiscoveryDocumentProperties document_properties{
       "base/path", "https://my.endpoint.com", "", "", "", "", {}, "2023"};
-  ASSERT_STATUS_OK(r.SetServiceApiVersion());
+  EXPECT_THAT(r.SetServiceApiVersion(), IsOk());
   auto emitted_proto = r.JsonToProtobufService(document_properties);
   EXPECT_THAT(
       emitted_proto,

--- a/generator/internal/discovery_to_proto.cc
+++ b/generator/internal/discovery_to_proto.cc
@@ -172,15 +172,19 @@ StatusOr<std::map<std::string, DiscoveryTypeVertex>> ExtractTypesFromSchema(
   return types;
 }
 
-std::map<std::string, DiscoveryResource> ExtractResources(
+StatusOr<std::map<std::string, DiscoveryResource>> ExtractResources(
     DiscoveryDocumentProperties const& document_properties,
     nlohmann::json const& discovery_doc) {
-  if (!discovery_doc.contains("resources")) return {};
+  if (!discovery_doc.contains("resources") ||
+      discovery_doc.find("resources")->empty()) {
+    return internal::InvalidArgumentError(
+        "No resources found in Discovery Document.");
+  }
   std::map<std::string, DiscoveryResource> resources;
   auto const& resources_json = discovery_doc.find("resources");
   for (auto r = resources_json->begin(); r != resources_json->end(); ++r) {
     std::string resource_name = r.key();
-    resources.emplace(
+    auto iter = resources.emplace(
         resource_name,
         DiscoveryResource{resource_name,
                           absl::StrFormat(kResourcePackageNameFormat,
@@ -189,7 +193,12 @@ std::map<std::string, DiscoveryResource> ExtractResources(
                                           CamelCaseToSnakeCase(resource_name),
                                           document_properties.version),
                           r.value()});
+    auto verify_service_api_version = iter.first->second.GetServiceApiVersion();
+    if (!verify_service_api_version.ok()) {
+      return std::move(verify_service_api_version).status();
+    }
   }
+
   return resources;
 }
 
@@ -623,19 +632,16 @@ Status GenerateProtosFromDiscoveryDoc(
   if (!types) return std::move(types).status();
 
   auto resources = ExtractResources(document_properties, discovery_doc);
-  if (resources.empty()) {
-    return internal::InvalidArgumentError(
-        "No resources found in Discovery Document.");
-  }
+  if (!resources.ok()) return std::move(resources).status();
 
   auto method_status =
-      ProcessMethodRequestsAndResponses(resources, *types, &descriptor_pool);
+      ProcessMethodRequestsAndResponses(*resources, *types, &descriptor_pool);
   if (!method_status.ok()) return method_status;
 
   EstablishTypeDependencies(*types);
-  ApplyResourceLabelsToTypes(resources);
+  ApplyResourceLabelsToTypes(*resources);
   auto files = AssignResourcesAndTypesToFiles(
-      resources, *types, document_properties, output_path, export_output_path);
+      *resources, *types, document_properties, output_path, export_output_path);
   if (!files) return std::move(files).status();
 
   // google::protobuf::DescriptorPool lazily initializes itself. Searching for

--- a/generator/internal/discovery_to_proto.cc
+++ b/generator/internal/discovery_to_proto.cc
@@ -193,9 +193,9 @@ StatusOr<std::map<std::string, DiscoveryResource>> ExtractResources(
                                           CamelCaseToSnakeCase(resource_name),
                                           document_properties.version),
                           r.value()});
-    auto verify_service_api_version = iter.first->second.GetServiceApiVersion();
+    auto verify_service_api_version = iter.first->second.SetServiceApiVersion();
     if (!verify_service_api_version.ok()) {
-      return std::move(verify_service_api_version).status();
+      return verify_service_api_version;
     }
   }
 

--- a/generator/internal/discovery_to_proto.h
+++ b/generator/internal/discovery_to_proto.h
@@ -38,7 +38,7 @@ StatusOr<std::map<std::string, DiscoveryTypeVertex>> ExtractTypesFromSchema(
 
 // Creates a DiscoveryResource for every resource defined in the Discovery
 // Document.
-std::map<std::string, DiscoveryResource> ExtractResources(
+StatusOr<std::map<std::string, DiscoveryResource>> ExtractResources(
     DiscoveryDocumentProperties const& document_properties,
     nlohmann::json const& discovery_doc);
 

--- a/generator/internal/discovery_to_proto_test.cc
+++ b/generator/internal/discovery_to_proto_test.cc
@@ -311,6 +311,57 @@ TEST(ExtractResourcesTest, SomeApiVersionsSpecified) {
           StatusCode::kInvalidArgument,
           HasSubstr(
               "resource contains methods with different apiVersion values")));
+
+  auto constexpr kMethodOrderReversedResourceJson = R"""({
+  "resources": {
+    "resource1": {
+      "methods": {
+        "emptyResponseMethod2": {
+        },
+        "emptyResponseMethod1": {
+          "apiVersion": "test-api-version"
+        }
+      }
+    }
+  }
+})""";
+  resource_json =
+      nlohmann::json::parse(kMethodOrderReversedResourceJson, nullptr, false);
+  ASSERT_TRUE(resource_json.is_object());
+  resources = ExtractResources({}, resource_json);
+  EXPECT_THAT(
+      resources,
+      StatusIs(
+          StatusCode::kInvalidArgument,
+          HasSubstr(
+              "resource contains methods with different apiVersion values")));
+}
+
+TEST(ExtractResourcesTest, OnlyLastMethodApiVersionsSpecified) {
+  auto constexpr kResourceJson = R"""({
+  "resources": {
+    "resource1": {
+      "methods": {
+        "emptyResponseMethod1": {
+        },
+        "emptyResponseMethod2": {
+        },
+        "emptyResponseMethod3": {
+          "apiVersion": "test-api-version"
+        }
+      }
+    }
+  }
+})""";
+  auto resource_json = nlohmann::json::parse(kResourceJson, nullptr, false);
+  ASSERT_TRUE(resource_json.is_object());
+  auto resources = ExtractResources({}, resource_json);
+  EXPECT_THAT(
+      resources,
+      StatusIs(
+          StatusCode::kInvalidArgument,
+          HasSubstr(
+              "resource contains methods with different apiVersion values")));
 }
 
 class DetermineAndVerifyResponseTypeNameTest

--- a/generator/internal/discovery_to_proto_test.cc
+++ b/generator/internal/discovery_to_proto_test.cc
@@ -211,23 +211,106 @@ TEST_F(ExtractTypesFromSchemaTest, SchemaAnyType) {
 
 TEST(ExtractResourcesTest, EmptyResources) {
   auto resources = ExtractResources({}, {});
-  EXPECT_THAT(resources, IsEmpty());
+  EXPECT_THAT(resources,
+              StatusIs(StatusCode::kInvalidArgument,
+                       HasSubstr("No resources found in Discovery Document.")));
 }
 
 TEST(ExtractResourcesTest, NonEmptyResources) {
   auto constexpr kResourceJson = R"""({
   "resources": {
     "resource1": {
+      "methods": {
+        "method0": {
+        }
+      }
     },
     "resource2": {
+      "methods": {
+        "method0": {
+        }
+      }
     }
   }
 })""";
   auto resource_json = nlohmann::json::parse(kResourceJson, nullptr, false);
   ASSERT_TRUE(resource_json.is_object());
   auto resources = ExtractResources({}, resource_json);
-  EXPECT_THAT(resources,
+  ASSERT_STATUS_OK(resources);
+  EXPECT_THAT(*resources,
               UnorderedElementsAre(Key("resource1"), Key("resource2")));
+}
+
+TEST(ExtractResourcesTest, SameApiVersionsSpecified) {
+  auto constexpr kResourceJson = R"""({
+  "resources": {
+    "resource1": {
+      "methods": {
+        "emptyResponseMethod1": {
+          "apiVersion": "test-api-version"
+        },
+        "emptyResponseMethod2": {
+          "apiVersion": "test-api-version"
+        }
+      }
+    }
+  }
+})""";
+  auto resource_json = nlohmann::json::parse(kResourceJson, nullptr, false);
+  ASSERT_TRUE(resource_json.is_object());
+  auto resources = ExtractResources({}, resource_json);
+  EXPECT_THAT(resources, IsOk());
+}
+
+TEST(ExtractResourcesTest, DifferentApiVersionsSpecified) {
+  auto constexpr kResourceJson = R"""({
+  "resources": {
+    "resource1": {
+      "methods": {
+        "emptyResponseMethod1": {
+          "apiVersion": "test-api-version"
+        },
+        "emptyResponseMethod2": {
+          "apiVersion": "other-test-api-version"
+        }
+      }
+    }
+  }
+})""";
+  auto resource_json = nlohmann::json::parse(kResourceJson, nullptr, false);
+  ASSERT_TRUE(resource_json.is_object());
+  auto resources = ExtractResources({}, resource_json);
+  EXPECT_THAT(
+      resources,
+      StatusIs(
+          StatusCode::kInvalidArgument,
+          HasSubstr(
+              "resource contains methods with different apiVersion values")));
+}
+
+TEST(ExtractResourcesTest, SomeApiVersionsSpecified) {
+  auto constexpr kResourceJson = R"""({
+  "resources": {
+    "resource1": {
+      "methods": {
+        "emptyResponseMethod1": {
+          "apiVersion": "test-api-version"
+        },
+        "emptyResponseMethod2": {
+        }
+      }
+    }
+  }
+})""";
+  auto resource_json = nlohmann::json::parse(kResourceJson, nullptr, false);
+  ASSERT_TRUE(resource_json.is_object());
+  auto resources = ExtractResources({}, resource_json);
+  EXPECT_THAT(
+      resources,
+      StatusIs(
+          StatusCode::kInvalidArgument,
+          HasSubstr(
+              "resource contains methods with different apiVersion values")));
 }
 
 class DetermineAndVerifyResponseTypeNameTest
@@ -2452,14 +2535,14 @@ TEST_F(AssignResourcesAndTypesToFilesTest, ResourceAndCommonFilesWithImports) {
       ExtractTypesFromSchema(document_properties, discovery_json, &pool());
   ASSERT_STATUS_OK(types);
   auto resources = ExtractResources(document_properties, discovery_json);
-  ASSERT_THAT(resources, Not(IsEmpty()));
+  ASSERT_STATUS_OK(resources);
   auto method_status =
-      ProcessMethodRequestsAndResponses(resources, *types, &pool());
+      ProcessMethodRequestsAndResponses(*resources, *types, &pool());
   ASSERT_STATUS_OK(method_status);
   EstablishTypeDependencies(*types);
-  ApplyResourceLabelsToTypes(resources);
+  ApplyResourceLabelsToTypes(*resources);
   auto files =
-      AssignResourcesAndTypesToFiles(resources, *types, document_properties,
+      AssignResourcesAndTypesToFiles(*resources, *types, document_properties,
                                      "output_path", "export_output_path");
   ASSERT_STATUS_OK(files);
 


### PR DESCRIPTION
While the Discovery Document schema allows for per-method apiVersion specification, Discovery Documents intended for proto generation are expected to have methods that all have the same value (or lack of value) for `apiVersion`. It is considered an error if that is not the case.

The generator checks early on to make sure the resource definition is well-formed, and the later uses the apiVersion (if present) when formatting the proto file. As verifying the apiVersion requires iterating through all the methods, we want to save that value for later to avoid repeating that processing.

fixes #13981

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13982)
<!-- Reviewable:end -->
