### PR TITLE
cleanup(otel): full namespace for protobuf

### DIFF
--- a/google/cloud/opentelemetry/internal/recordable_test.cc
+++ b/google/cloud/opentelemetry/internal/recordable_test.cc
@@ -117,8 +117,8 @@ Matcher<v2::AttributeValue const&> AttributeValue(
 }
 
 Matcher<v2::Span::Attributes const&> Attributes(
-    Matcher<protobuf::Map<std::string, v2::AttributeValue> const&> const&
-        attribute_map_matcher,
+    Matcher<google::protobuf::Map<
+        std::string, v2::AttributeValue> const&> const& attribute_map_matcher,
     int dropped_attributes_count = 0) {
   return AllOf(
       ResultOf(


### PR DESCRIPTION
We do string substitutions on `google::protobuf::*`, so we need to qualify the namespace.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13983)
<!-- Reviewable:end -->
