### PR TITLE
cleanup(docs): fix declare GA docs

### DIFF
--- a/doc/contributor/howto-guide-declare-a-library-ga.md
+++ b/doc/contributor/howto-guide-declare-a-library-ga.md
@@ -85,10 +85,11 @@ for lib in "${ga[@]}"; do sed -i 's/^Please note that the Google Cloud C/While t
 
 ### `google/cloud/${library}/CMakeLists.txt`:
 
-Update the CMake library targets.
+Update the CMake library targets and the quickstart runner.
 
 ```shell
 for lib in "${ga[@]}"; do sed -i 's/EXPERIMENTAL/TRANSITION/' google/cloud/${lib}/CMakeLists.txt; done
+for lib in "${ga[@]}"; do sed -i 's/experimental-//' google/cloud/${lib}/CMakeLists.txt; done
 ```
 
 ## Reference the GA targets in the quickstarts


### PR DESCRIPTION
At some point I "simplified" the declare GA instructions by removing this critical step. :monkey:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13989)
<!-- Reviewable:end -->
