### PR TITLE
cleanup(bigtable): `RowKeyType` again

### DIFF
--- a/google/cloud/bigtable/internal/traced_row_reader_test.cc
+++ b/google/cloud/bigtable/internal/traced_row_reader_test.cc
@@ -57,7 +57,7 @@ TEST(TracedStreamRange, Success) {
   auto reader = bigtable_mocks::MakeRowReader(Rows({"r1", "r2", "r3"}));
   auto traced = MakeTestRowReader(std::move(reader));
 
-  std::vector<std::string> actual;
+  std::vector<bigtable::RowKeyType> actual;
   for (auto& v : traced) {
     ASSERT_STATUS_OK(v);
     actual.push_back(std::move(v->row_key()));


### PR DESCRIPTION
This code isn't currently built in oogle3gay, so we didn't catch it earlier.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13992)
<!-- Reviewable:end -->
