### PR TITLE
cleanup(otel): explicit span ctor

### DIFF
--- a/google/cloud/internal/trace_propagator.cc
+++ b/google/cloud/internal/trace_propagator.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "absl/strings/numbers.h"
 #include <opentelemetry/context/propagation/composite_propagator.h>
+#include <opentelemetry/nostd/span.h>
 #include <opentelemetry/trace/context.h>
 #include <opentelemetry/trace/propagation/http_trace_context.h>
 #include <cstdlib>
@@ -65,7 +66,9 @@ class CloudTraceContext
     // the oldest version of Abseil we support. So we use `std::strtoull`, which
     // requires the input to be null-terminated.
     std::array<char, 2 * SpanId::kSize + 1> span_id;
-    span_context.span_id().ToLowerBase16({span_id.data(), span_id.size() - 1});
+    span_context.span_id().ToLowerBase16(
+        opentelemetry::nostd::span<char, 2 * SpanId::kSize>{
+            span_id.data(), span_id.size() - 1});
     span_id[2 * SpanId::kSize] = '\0';
     char* end = nullptr;
     std::uint64_t span_id_dec = std::strtoull(span_id.data(), &end, 16);


### PR DESCRIPTION
https://en.cppreference.com/w/cpp/container/span/span

The constructor I am trying to use is explicit in C++20 land.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/13994)
<!-- Reviewable:end -->
