### PR TITLE
impl(GCS+gRPC): full proto request for uploads

### DIFF
--- a/google/cloud/storage/internal/async/connection_impl.h
+++ b/google/cloud/storage/internal/async/connection_impl.h
@@ -121,7 +121,7 @@ class AsyncConnectionImpl
   UnbufferedUploadImpl(
       internal::ImmutableOptions current,
       std::function<void(grpc::ClientContext&)> configure_context,
-      std::string upload_id,
+      google::storage::v2::BidiWriteObjectRequest request,
       std::shared_ptr<storage::internal::HashFunction> hash_function,
       std::int64_t persisted_size);
 

--- a/google/cloud/storage/internal/async/writer_connection_impl.h
+++ b/google/cloud/storage/internal/async/writer_connection_impl.h
@@ -39,12 +39,14 @@ class AsyncWriterConnectionImpl
 
   explicit AsyncWriterConnectionImpl(
       google::cloud::internal::ImmutableOptions options,
-      std::unique_ptr<StreamingRpc> impl, std::string upload_id,
+      google::storage::v2::BidiWriteObjectRequest request,
+      std::unique_ptr<StreamingRpc> impl,
       std::shared_ptr<storage::internal::HashFunction> hash_function,
       std::int64_t persisted_size);
   explicit AsyncWriterConnectionImpl(
       google::cloud::internal::ImmutableOptions options,
-      std::unique_ptr<StreamingRpc> impl, std::string upload_id,
+      google::storage::v2::BidiWriteObjectRequest request,
+      std::unique_ptr<StreamingRpc> impl,
       std::shared_ptr<storage::internal::HashFunction> hash_function,
       storage::ObjectMetadata metadata);
   ~AsyncWriterConnectionImpl() override;
@@ -63,6 +65,15 @@ class AsyncWriterConnectionImpl
   RpcMetadata GetRequestMetadata() override;
 
  private:
+  using PersistedStateType =
+      absl::variant<std::int64_t, storage::ObjectMetadata>;
+  AsyncWriterConnectionImpl(
+      google::cloud::internal::ImmutableOptions options,
+      google::storage::v2::BidiWriteObjectRequest request,
+      std::unique_ptr<StreamingRpc> impl,
+      std::shared_ptr<storage::internal::HashFunction> hash_function,
+      PersistedStateType persisted_state, std::int64_t offset);
+
   google::storage::v2::BidiWriteObjectRequest MakeRequest();
 
   future<Status> OnPartialUpload(std::size_t upload_size,
@@ -75,9 +86,9 @@ class AsyncWriterConnectionImpl
 
   google::cloud::internal::ImmutableOptions options_;
   std::shared_ptr<StreamingRpc> impl_;
-  std::string upload_id_;
+  google::storage::v2::BidiWriteObjectRequest request_;
   std::shared_ptr<storage::internal::HashFunction> hash_function_;
-  absl::variant<std::int64_t, storage::ObjectMetadata> persisted_state_;
+  PersistedStateType persisted_state_;
   std::int64_t offset_ = 0;
   bool first_request_ = true;
 


### PR DESCRIPTION
Change the `AsyncWriterConnectionImpl` to receive a full `BidiWriterObjectRequest`. Should we ever need more information from that message it is now ready. It also gives us some type safety / decoration on function and constructor parameters.

Part of the work for #13910

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14003)
<!-- Reviewable:end -->
