### PR TITLE
cleanup(GCS+gRPC): simplify ClientContext configuration

### DIFF
--- a/google/cloud/storage/internal/async/connection_impl.cc
+++ b/google/cloud/storage/internal/async/connection_impl.cc
@@ -385,7 +385,6 @@ AsyncConnectionImpl::StartResumableWrite(
           CompletionQueue& cq, std::shared_ptr<grpc::ClientContext> context,
           google::cloud::internal::ImmutableOptions options,
           google::storage::v2::StartResumableWriteRequest const& proto) {
-        internal::ConfigureContext(*context, *options);
         return stub->AsyncStartResumableWrite(cq, std::move(context),
                                               std::move(options), proto);
       },
@@ -494,11 +493,10 @@ AsyncConnectionImpl::ResumeUnbufferedUploadImpl(
                 request.GetOption<storage::MD5HashValue>(),
                 request.GetOption<storage::DisableMD5Hash>())
           : storage::internal::CreateNullHashFunction();
-  auto configure =
-      [current, upload_id = query.upload_id()](grpc::ClientContext& context) {
-        internal::ConfigureContext(context, *current);
-        ApplyResumableUploadRoutingHeader(context, upload_id);
-      };
+  auto configure = [upload_id =
+                        query.upload_id()](grpc::ClientContext& context) {
+    ApplyResumableUploadRoutingHeader(context, upload_id);
+  };
   auto proto = google::storage::v2::BidiWriteObjectRequest{};
   proto.set_upload_id(std::move(*query.mutable_upload_id()));
   *proto.mutable_common_object_request_params() =

--- a/google/cloud/storage/internal/grpc/configure_client_context.h
+++ b/google/cloud/storage/internal/grpc/configure_client_context.h
@@ -42,7 +42,7 @@ void AddIdempotencyToken(grpc::ClientContext& ctx,
  * @see https://cloud.google.com/apis/docs/system-parameters
  */
 template <typename Request>
-void ApplyQueryParameters(grpc::ClientContext& ctx, Options const& options,
+void ApplyQueryParameters(grpc::ClientContext& ctx, Options const& /*options*/,
                           Request const& request) {
   // The gRPC API has a single field for the `QuotaUser` parameter, while the
   // JSON API has two:
@@ -63,7 +63,6 @@ void ApplyQueryParameters(grpc::ClientContext& ctx, Options const& options,
     ctx.AddMetadata("x-goog-fieldmask",
                     request.template GetOption<storage::Fields>().value());
   }
-  internal::ConfigureContext(ctx, options);
 }
 
 /**

--- a/google/cloud/storage/internal/grpc/configure_client_context_test.cc
+++ b/google/cloud/storage/internal/grpc/configure_client_context_test.cc
@@ -30,7 +30,6 @@ using ::google::cloud::testing_util::ValidateMetadataFixture;
 using ::testing::_;
 using ::testing::Contains;
 using ::testing::IsEmpty;
-using ::testing::MockFunction;
 using ::testing::Not;
 using ::testing::Pair;
 
@@ -117,19 +116,6 @@ TEST_F(GrpcConfigureClientContext, ApplyQueryParametersQuotaUserAndUserIp) {
     auto metadata = GetMetadata(ctx);
     EXPECT_THAT(metadata, Contains(Pair("x-goog-quota-user", test.expected)));
   }
-}
-
-TEST_F(GrpcConfigureClientContext, ApplyQueryParametersGrpcOptions) {
-  MockFunction<void(grpc::ClientContext&)> mock;
-  EXPECT_CALL(mock, Call);
-
-  auto const options = Options{}.set<google::cloud::internal::GrpcSetupOption>(
-      mock.AsStdFunction());
-
-  grpc::ClientContext ctx;
-  ApplyQueryParameters(
-      ctx, options,
-      storage::internal::ReadObjectRangeRequest("test-bucket", "test-object"));
 }
 
 TEST_F(GrpcConfigureClientContext, ApplyRoutingHeadersInsertObjectMedia) {


### PR DESCRIPTION
Part of the work for #13910.

Some of these PRs are very small, sorry.  I was trying to logically break down the work and I think in this case I went overboard.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14006)
<!-- Reviewable:end -->
