### PR TITLE
impl(GCS+gRPC): separate functions to resume uploads

### DIFF
--- a/google/cloud/storage/async/connection.h
+++ b/google/cloud/storage/async/connection.h
@@ -124,6 +124,32 @@ class AsyncConnection {
   StartBufferedUpload(UploadParams p) = 0;
 
   /**
+   * A thin wrapper around the `QueryWriteStatus()` parameters.
+   *
+   * We use a single struct as the input parameter for this function to
+   * prevent breaking any mocks when additional parameters are needed.
+   */
+  struct ResumeUploadParams {
+    /// The upload id and any common object request parameters. Note that
+    /// bucket name, object name, and pre-conditions are saved as part of the
+    /// service internal information about the upload id.
+    google::storage::v2::QueryWriteStatusRequest request;
+    /// Any options modifying the RPC behavior, including per-client and
+    /// per-connection options.
+    Options options;
+  };
+
+  /// Resume an upload configured for persistent sources.
+  virtual future<
+      StatusOr<std::unique_ptr<storage_experimental::AsyncWriterConnection>>>
+  ResumeUnbufferedUpload(ResumeUploadParams p) = 0;
+
+  /// Resume an upload configured for streaming sources.
+  virtual future<
+      StatusOr<std::unique_ptr<storage_experimental::AsyncWriterConnection>>>
+  ResumeBufferedUpload(ResumeUploadParams p) = 0;
+
+  /**
    * A thin wrapper around the `ComposeObject()` parameters.
    *
    * We use a single struct as the input parameter for this function to

--- a/google/cloud/storage/internal/async/connection_impl.h
+++ b/google/cloud/storage/internal/async/connection_impl.h
@@ -71,6 +71,12 @@ class AsyncConnectionImpl
   future<StatusOr<std::unique_ptr<storage_experimental::AsyncWriterConnection>>>
   StartBufferedUpload(UploadParams p) override;
 
+  future<StatusOr<std::unique_ptr<storage_experimental::AsyncWriterConnection>>>
+  ResumeUnbufferedUpload(ResumeUploadParams p) override;
+
+  future<StatusOr<std::unique_ptr<storage_experimental::AsyncWriterConnection>>>
+  ResumeBufferedUpload(ResumeUploadParams p) override;
+
   future<StatusOr<google::storage::v2::Object>> ComposeObject(
       ComposeObjectParams p) override;
 

--- a/google/cloud/storage/internal/async/connection_impl_upload_hash_test.cc
+++ b/google/cloud/storage/internal/async/connection_impl_upload_hash_test.cc
@@ -293,13 +293,10 @@ TEST_P(AsyncConnectionImplUploadHashTest,
 
   auto connection = MakeAsyncConnection(CompletionQueue(mock_cq),
                                         std::move(mock), std::move(options));
-
-  auto pending = connection->StartUnbufferedUpload(
-      {storage_experimental::ResumableUploadRequest("test-bucket",
-                                                    "test-object")
-           .set_multiple_options(
-               storage::UseResumableUploadSession("resume-upload-id")),
-       connection->options()});
+  auto request = google::storage::v2::QueryWriteStatusRequest{};
+  request.set_upload_id("resume-upload-id");
+  auto pending = connection->ResumeUnbufferedUpload(
+      {std::move(request), connection->options()});
 
   auto next = sequencer.PopFrontWithName();
   EXPECT_EQ(next.second, "QueryWriteStatus(1)");
@@ -394,13 +391,10 @@ TEST_P(AsyncConnectionImplUploadHashTest, ResumeUnbufferedWithPersistedData) {
 
   auto connection = MakeAsyncConnection(CompletionQueue(mock_cq),
                                         std::move(mock), std::move(options));
-
-  auto pending = connection->StartUnbufferedUpload(
-      {storage_experimental::ResumableUploadRequest("test-bucket",
-                                                    "test-object")
-           .set_multiple_options(
-               storage::UseResumableUploadSession("resume-upload-id")),
-       connection->options()});
+  auto request = google::storage::v2::QueryWriteStatusRequest{};
+  request.set_upload_id("resume-upload-id");
+  auto pending = connection->ResumeUnbufferedUpload(
+      {std::move(request), connection->options()});
 
   auto next = sequencer.PopFrontWithName();
   EXPECT_EQ(next.second, "QueryWriteStatus(1)");
@@ -594,13 +588,10 @@ TEST_P(AsyncConnectionImplUploadHashTest, ResumeBufferedWithoutPersistedData) {
 
   auto connection = MakeAsyncConnection(CompletionQueue(mock_cq),
                                         std::move(mock), std::move(options));
-
-  auto pending = connection->StartBufferedUpload(
-      {storage_experimental::ResumableUploadRequest("test-bucket",
-                                                    "test-object")
-           .set_multiple_options(
-               storage::UseResumableUploadSession("resume-upload-id")),
-       connection->options()});
+  auto request = google::storage::v2::QueryWriteStatusRequest{};
+  request.set_upload_id("resume-upload-id");
+  auto pending = connection->ResumeUnbufferedUpload(
+      {std::move(request), connection->options()});
 
   auto next = sequencer.PopFrontWithName();
   EXPECT_EQ(next.second, "QueryWriteStatus(1)");
@@ -695,13 +686,10 @@ TEST_P(AsyncConnectionImplUploadHashTest, ResumeBufferedWithPersistedData) {
 
   auto connection = MakeAsyncConnection(CompletionQueue(mock_cq),
                                         std::move(mock), std::move(options));
-
-  auto pending = connection->StartBufferedUpload(
-      {storage_experimental::ResumableUploadRequest("test-bucket",
-                                                    "test-object")
-           .set_multiple_options(
-               storage::UseResumableUploadSession("resume-upload-id")),
-       connection->options()});
+  auto request = google::storage::v2::QueryWriteStatusRequest{};
+  request.set_upload_id("resume-upload-id");
+  auto pending = connection->ResumeUnbufferedUpload(
+      {std::move(request), connection->options()});
 
   auto next = sequencer.PopFrontWithName();
   EXPECT_EQ(next.second, "QueryWriteStatus(1)");

--- a/google/cloud/storage/internal/async/connection_impl_upload_test.cc
+++ b/google/cloud/storage/internal/async/connection_impl_upload_test.cc
@@ -1059,6 +1059,261 @@ TEST_F(AsyncConnectionImplTest, ResumeBufferedUploadNewUploadResume) {
   next.first.set_value(true);
 }
 
+TEST_F(AsyncConnectionImplTest, ResumeBufferedUpload) {
+  // The placeholder values in the `common_object_request_params` are just
+  // canaries to verify the full request is passed along.
+  auto constexpr kRequestText = R"pb(
+    upload_id: "test-upload-id"
+    common_object_request_params {
+      encryption_algorithm: "test-ea"
+      encryption_key_bytes: "test-ekb"
+      encryption_key_sha256_bytes: "test-eksb"
+    }
+  )pb";
+
+  AsyncSequencer<bool> sequencer;
+  auto mock = std::make_shared<storage::testing::MockStorageStub>();
+  EXPECT_CALL(*mock, AsyncQueryWriteStatus)
+      .WillOnce([&] {
+        return sequencer.PushBack("QueryWriteStatus(1)").then([](auto) {
+          return StatusOr<google::storage::v2::QueryWriteStatusResponse>(
+              TransientError());
+        });
+      })
+      .WillOnce(
+          [&](auto&, auto, auto,
+              google::storage::v2::QueryWriteStatusRequest const& request) {
+            auto expected = google::storage::v2::QueryWriteStatusRequest{};
+            EXPECT_TRUE(TextFormat::ParseFromString(kRequestText, &expected));
+            EXPECT_THAT(request, IsProtoEqual(expected));
+
+            return sequencer.PushBack("QueryWriteStatus(2)").then([](auto) {
+              auto response = google::storage::v2::QueryWriteStatusResponse{};
+              response.set_persisted_size(16384);
+              return make_status_or(response);
+            });
+          });
+  EXPECT_CALL(*mock, AsyncBidiWriteObject)
+      .WillOnce(
+          [&] { return MakeErrorBidiWriteStream(sequencer, TransientError()); })
+      .WillOnce([&]() {
+        auto stream = std::make_unique<MockAsyncBidiWriteObjectStream>();
+        EXPECT_CALL(*stream, Start).WillOnce([&] {
+          return sequencer.PushBack("Start");
+        });
+        EXPECT_CALL(*stream, Write)
+            .WillOnce(
+                [&](google::storage::v2::BidiWriteObjectRequest const& request,
+                    grpc::WriteOptions wopt) {
+                  EXPECT_TRUE(request.has_upload_id());
+                  EXPECT_EQ(request.upload_id(), "test-upload-id");
+                  EXPECT_FALSE(wopt.is_last_message());
+                  return sequencer.PushBack("Write");
+                })
+            .WillOnce(
+                [&](google::storage::v2::BidiWriteObjectRequest const& request,
+                    grpc::WriteOptions wopt) {
+                  EXPECT_FALSE(request.has_upload_id());
+                  EXPECT_TRUE(request.finish_write());
+                  EXPECT_TRUE(request.has_object_checksums());
+                  EXPECT_TRUE(wopt.is_last_message());
+                  return sequencer.PushBack("Write");
+                });
+        EXPECT_CALL(*stream, Read).WillOnce([&] {
+          return sequencer.PushBack("Read").then([](auto) {
+            auto response = google::storage::v2::BidiWriteObjectResponse{};
+            response.mutable_resource()->set_bucket(
+                "projects/_/buckets/test-bucket");
+            response.mutable_resource()->set_name("test-object");
+            response.mutable_resource()->set_generation(123456);
+            return absl::make_optional(std::move(response));
+          });
+        });
+        EXPECT_CALL(*stream, Cancel).Times(1);
+        EXPECT_CALL(*stream, Finish).WillOnce([&] {
+          return sequencer.PushBack("Finish").then(
+              [](auto) { return Status{}; });
+        });
+        return std::unique_ptr<AsyncBidiWriteObjectStream>(std::move(stream));
+      });
+
+  internal::AutomaticallyCreatedBackgroundThreads pool(1);
+  auto connection = MakeTestConnection(pool.cq(), mock);
+  auto request = google::storage::v2::QueryWriteStatusRequest{};
+  ASSERT_TRUE(TextFormat::ParseFromString(kRequestText, &request));
+  auto pending = connection->ResumeUnbufferedUpload(
+      {std::move(request), connection->options()});
+
+  auto next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "QueryWriteStatus(1)");
+  next.first.set_value(true);
+
+  next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "QueryWriteStatus(2)");
+  next.first.set_value(true);
+
+  next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "Start");
+  next.first.set_value(false);  // The first stream fails
+
+  next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "Finish");
+  next.first.set_value(false);
+
+  next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "Start");
+  next.first.set_value(true);
+
+  auto r = pending.get();
+  ASSERT_STATUS_OK(r);
+  auto writer = *std::move(r);
+  EXPECT_EQ(writer->UploadId(), "test-upload-id");
+  EXPECT_EQ(absl::get<std::int64_t>(writer->PersistedState()), 16384);
+
+  auto w1 = writer->Write({});
+  next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "Write");
+  next.first.set_value(true);
+  EXPECT_STATUS_OK(w1.get());
+
+  auto w2 = writer->Finalize({});
+  next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "Write");
+  next.first.set_value(true);
+  next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "Read");
+  next.first.set_value(true);
+
+  auto response = w2.get();
+  ASSERT_STATUS_OK(response);
+  EXPECT_EQ(response->bucket(), "test-bucket");
+  EXPECT_EQ(response->name(), "test-object");
+  EXPECT_EQ(response->generation(), 123456);
+
+  writer.reset();
+  next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "Finish");
+  next.first.set_value(true);
+}
+
+TEST_F(AsyncConnectionImplTest, ResumeBufferedUploadFinalized) {
+  auto constexpr kRequestText = R"pb(
+    upload_id: "test-upload-id"
+    common_object_request_params {
+      encryption_algorithm: "test-ea"
+      encryption_key_bytes: "test-ekb"
+      encryption_key_sha256_bytes: "test-eksb"
+    }
+  )pb";
+
+  AsyncSequencer<bool> sequencer;
+  auto mock = std::make_shared<storage::testing::MockStorageStub>();
+  EXPECT_CALL(*mock, AsyncQueryWriteStatus)
+      .WillOnce([&] {
+        return sequencer.PushBack("QueryWriteStatus(1)").then([](auto) {
+          return StatusOr<google::storage::v2::QueryWriteStatusResponse>(
+              TransientError());
+        });
+      })
+      .WillOnce(
+          [&](auto&, auto, auto,
+              google::storage::v2::QueryWriteStatusRequest const& request) {
+            auto expected = google::storage::v2::QueryWriteStatusRequest{};
+            EXPECT_TRUE(TextFormat::ParseFromString(kRequestText, &expected));
+            EXPECT_THAT(request, IsProtoEqual(expected));
+
+            return sequencer.PushBack("QueryWriteStatus(2)").then([](auto) {
+              auto response = google::storage::v2::QueryWriteStatusResponse{};
+              response.mutable_resource()->set_bucket(
+                  "projects/_/buckets/test-bucket");
+              response.mutable_resource()->set_name("test-object");
+              response.mutable_resource()->set_generation(123456);
+              return make_status_or(response);
+            });
+          });
+  EXPECT_CALL(*mock, AsyncBidiWriteObject).Times(0);
+
+  internal::AutomaticallyCreatedBackgroundThreads pool(1);
+  auto connection = MakeTestConnection(pool.cq(), mock);
+  auto request = google::storage::v2::QueryWriteStatusRequest{};
+  ASSERT_TRUE(TextFormat::ParseFromString(kRequestText, &request));
+  auto pending = connection->ResumeBufferedUpload(
+      {std::move(request), connection->options()});
+
+  auto next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "QueryWriteStatus(1)");
+  next.first.set_value(true);
+
+  next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "QueryWriteStatus(2)");
+  next.first.set_value(true);
+
+  auto r = pending.get();
+  ASSERT_STATUS_OK(r);
+  auto writer = *std::move(r);
+  EXPECT_EQ(writer->UploadId(), "test-upload-id");
+  ASSERT_TRUE(absl::holds_alternative<storage::ObjectMetadata>(
+      writer->PersistedState()));
+  auto metadata = absl::get<storage::ObjectMetadata>(writer->PersistedState());
+  EXPECT_EQ(metadata.bucket(), "test-bucket");
+  EXPECT_EQ(metadata.name(), "test-object");
+  EXPECT_EQ(metadata.generation(), 123456);
+
+  writer.reset();
+}
+
+TEST_F(AsyncConnectionImplTest, ResumeBufferedUploadTooManyTransients) {
+  AsyncSequencer<bool> sequencer;
+  auto mock = std::make_shared<storage::testing::MockStorageStub>();
+  EXPECT_CALL(*mock, AsyncQueryWriteStatus).Times(3).WillRepeatedly([&] {
+    return sequencer.PushBack("QueryWriteStatus").then([](auto) {
+      return StatusOr<google::storage::v2::QueryWriteStatusResponse>(
+          TransientError());
+    });
+  });
+
+  internal::AutomaticallyCreatedBackgroundThreads pool(1);
+  auto connection = MakeTestConnection(pool.cq(), mock);
+  auto request = google::storage::v2::QueryWriteStatusRequest{};
+  request.set_upload_id("resume-upload-id");
+  auto pending = connection->ResumeBufferedUpload(
+      {std::move(request), connection->options()});
+
+  for (int i = 0; i != 3; ++i) {
+    auto next = sequencer.PopFrontWithName();
+    EXPECT_EQ(next.second, "QueryWriteStatus");
+    next.first.set_value(false);
+  }
+
+  auto r = pending.get();
+  EXPECT_THAT(r, StatusIs(TransientError().code()));
+}
+
+TEST_F(AsyncConnectionImplTest, ResumeBufferedUploadPermanentError) {
+  AsyncSequencer<bool> sequencer;
+  auto mock = std::make_shared<storage::testing::MockStorageStub>();
+  EXPECT_CALL(*mock, AsyncQueryWriteStatus).WillOnce([&] {
+    return sequencer.PushBack("QueryWriteStatus").then([](auto) {
+      return StatusOr<google::storage::v2::QueryWriteStatusResponse>(
+          PermanentError());
+    });
+  });
+
+  internal::AutomaticallyCreatedBackgroundThreads pool(1);
+  auto connection = MakeTestConnection(pool.cq(), mock);
+  auto request = google::storage::v2::QueryWriteStatusRequest{};
+  request.set_upload_id("resume-upload-id");
+  auto pending = connection->ResumeBufferedUpload(
+      {std::move(request), connection->options()});
+
+  auto next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "QueryWriteStatus");
+  next.first.set_value(false);
+
+  auto r = pending.get();
+  EXPECT_THAT(r, StatusIs(PermanentError().code()));
+}
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage_internal

--- a/google/cloud/storage/mocks/mock_async_connection.h
+++ b/google/cloud/storage/mocks/mock_async_connection.h
@@ -48,6 +48,14 @@ class MockAsyncConnection : public storage_experimental::AsyncConnection {
       future<StatusOr<
           std::unique_ptr<storage_experimental::AsyncWriterConnection>>>,
       StartBufferedUpload, (UploadParams), (override));
+  MOCK_METHOD(
+      future<StatusOr<
+          std::unique_ptr<storage_experimental::AsyncWriterConnection>>>,
+      ResumeUnbufferedUpload, (ResumeUploadParams), (override));
+  MOCK_METHOD(
+      future<StatusOr<
+          std::unique_ptr<storage_experimental::AsyncWriterConnection>>>,
+      ResumeBufferedUpload, (ResumeUploadParams), (override));
   MOCK_METHOD(future<StatusOr<google::storage::v2::Object>>, ComposeObject,
               (ComposeObjectParams), (override));
   MOCK_METHOD(future<Status>, DeleteObject, (DeleteObjectParams), (override));


### PR DESCRIPTION
To use protos as the input parameters in `AsyncClient::*Upload` we will need to separate the functions to start vs. resume an upload. I think the end result is easier to explain too, so that is nice. This PR introduces the new functions in the `*Connection` layer.

Part of the work for #13910

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14013)
<!-- Reviewable:end -->
