### PR TITLE
impl(ci): omit bigquery files from typos

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -6,7 +6,9 @@ extend-exclude = [
     # fields. These typos can be propagated to the generated .h files.
     # TODO(#11736): Try and get typos fixed upstream.
     "generator/discovery/compute_public_google_rest_v1.json",
+    "generator/discovery/bigquery_public_google_rest_v2.json",
     "protos/google/cloud/compute/*/*/*.proto",
+    "protos/google/cloud/bigquery/*/*/*.proto",
     "google/cloud/compute/*/*/*.h",
     # Truncates strings, which might not form valid words.
     "google/cloud/internal/debug_string_protobuf_test.cc",


### PR DESCRIPTION
https://github.com/googleapis/google-cloud-cpp/issues/13892

We do the same for compute. Omit the discovery document and the generated protos (which contains everything from the discovery document)
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14015)
<!-- Reviewable:end -->
