### PR TITLE
cleanup(GCS+gRPC): return protos on uploads

### DIFF
--- a/google/cloud/storage/async/client.cc
+++ b/google/cloud/storage/async/client.cc
@@ -58,7 +58,7 @@ AsyncClient::StartBufferedUpload(
       .then([](auto f) -> StatusOr<std::pair<AsyncWriter, AsyncToken>> {
         auto w = f.get();
         if (!w) return std::move(w).status();
-        auto t = absl::holds_alternative<storage::ObjectMetadata>(
+        auto t = absl::holds_alternative<google::storage::v2::Object>(
                      (*w)->PersistedState())
                      ? AsyncToken()
                      : storage_internal::MakeAsyncToken(w->get());
@@ -83,7 +83,7 @@ AsyncClient::ResumeBufferedUpload(
       .then([](auto f) -> StatusOr<std::pair<AsyncWriter, AsyncToken>> {
         auto w = f.get();
         if (!w) return std::move(w).status();
-        auto t = absl::holds_alternative<storage::ObjectMetadata>(
+        auto t = absl::holds_alternative<google::storage::v2::Object>(
                      (*w)->PersistedState())
                      ? AsyncToken()
                      : storage_internal::MakeAsyncToken(w->get());
@@ -111,7 +111,7 @@ AsyncClient::StartUnbufferedUpload(
       .then([](auto f) -> StatusOr<std::pair<AsyncWriter, AsyncToken>> {
         auto w = f.get();
         if (!w) return std::move(w).status();
-        auto t = absl::holds_alternative<storage::ObjectMetadata>(
+        auto t = absl::holds_alternative<google::storage::v2::Object>(
                      (*w)->PersistedState())
                      ? AsyncToken()
                      : storage_internal::MakeAsyncToken(w->get());
@@ -136,7 +136,7 @@ AsyncClient::ResumeUnbufferedUpload(
       .then([](auto f) -> StatusOr<std::pair<AsyncWriter, AsyncToken>> {
         auto w = f.get();
         if (!w) return std::move(w).status();
-        auto t = absl::holds_alternative<storage::ObjectMetadata>(
+        auto t = absl::holds_alternative<google::storage::v2::Object>(
                      (*w)->PersistedState())
                      ? AsyncToken()
                      : storage_internal::MakeAsyncToken(w->get());

--- a/google/cloud/storage/async/client_test.cc
+++ b/google/cloud/storage/async/client_test.cc
@@ -162,7 +162,7 @@ TEST(AsyncClient, StartBufferedUpload1) {
         auto writer = std::make_unique<MockAsyncWriterConnection>();
         EXPECT_CALL(*writer, PersistedState).WillOnce(Return(0));
         EXPECT_CALL(*writer, Finalize).WillRepeatedly([] {
-          return make_ready_future(make_status_or(TestObject()));
+          return make_ready_future(make_status_or(TestProtoObject()));
         });
         return make_ready_future(make_status_or(
             std::unique_ptr<AsyncWriterConnection>(std::move(writer))));
@@ -181,7 +181,7 @@ TEST(AsyncClient, StartBufferedUpload1) {
   std::tie(w, t) = *std::move(wt);
   EXPECT_TRUE(t.valid());
   auto object = w.Finalize(std::move(t)).get();
-  EXPECT_THAT(object, IsOkAndHolds(TestObject()));
+  EXPECT_THAT(object, IsOkAndHolds(IsProtoEqual(TestProtoObject())));
 }
 
 TEST(AsyncClient, StartBufferedUpload2) {
@@ -207,7 +207,7 @@ TEST(AsyncClient, StartBufferedUpload2) {
         auto writer = std::make_unique<MockAsyncWriterConnection>();
         EXPECT_CALL(*writer, PersistedState).WillOnce(Return(0));
         EXPECT_CALL(*writer, Finalize).WillRepeatedly([] {
-          return make_ready_future(make_status_or(TestObject()));
+          return make_ready_future(make_status_or(TestProtoObject()));
         });
         return make_ready_future(make_status_or(
             std::unique_ptr<AsyncWriterConnection>(std::move(writer))));
@@ -228,7 +228,7 @@ TEST(AsyncClient, StartBufferedUpload2) {
   std::tie(w, t) = *std::move(wt);
   EXPECT_TRUE(t.valid());
   auto object = w.Finalize(std::move(t)).get();
-  EXPECT_THAT(object, IsOkAndHolds(TestObject()));
+  EXPECT_THAT(object, IsOkAndHolds(IsProtoEqual(TestProtoObject())));
 }
 
 TEST(AsyncClient, ResumeBufferedUpload1) {
@@ -250,7 +250,7 @@ TEST(AsyncClient, ResumeBufferedUpload1) {
         EXPECT_THAT(p.request, IsProtoEqual(expected));
         auto writer = std::make_unique<MockAsyncWriterConnection>();
         EXPECT_CALL(*writer, PersistedState)
-            .WillRepeatedly(Return(TestObject()));
+            .WillRepeatedly(Return(TestProtoObject()));
 
         return make_ready_future(make_status_or(
             std::unique_ptr<AsyncWriterConnection>(std::move(writer))));
@@ -268,8 +268,8 @@ TEST(AsyncClient, ResumeBufferedUpload1) {
   AsyncToken t;
   std::tie(w, t) = *std::move(wt);
   EXPECT_FALSE(t.valid());
-  EXPECT_THAT(w.PersistedState(),
-              VariantWith<storage::ObjectMetadata>(TestObject()));
+  EXPECT_THAT(w.PersistedState(), VariantWith<google::storage::v2::Object>(
+                                      IsProtoEqual(TestProtoObject())));
 }
 
 TEST(AsyncClient, ResumeBufferedUpload2) {
@@ -293,7 +293,7 @@ TEST(AsyncClient, ResumeBufferedUpload2) {
         EXPECT_THAT(p.request, IsProtoEqual(expected));
         auto writer = std::make_unique<MockAsyncWriterConnection>();
         EXPECT_CALL(*writer, PersistedState)
-            .WillRepeatedly(Return(TestObject()));
+            .WillRepeatedly(Return(TestProtoObject()));
 
         return make_ready_future(make_status_or(
             std::unique_ptr<AsyncWriterConnection>(std::move(writer))));
@@ -313,8 +313,8 @@ TEST(AsyncClient, ResumeBufferedUpload2) {
   AsyncToken t;
   std::tie(w, t) = *std::move(wt);
   EXPECT_FALSE(t.valid());
-  EXPECT_THAT(w.PersistedState(),
-              VariantWith<storage::ObjectMetadata>(TestObject()));
+  EXPECT_THAT(w.PersistedState(), VariantWith<google::storage::v2::Object>(
+                                      IsProtoEqual(TestProtoObject())));
 }
 
 TEST(AsyncClient, ResumeBufferedUploadResumeFinalized) {
@@ -322,7 +322,8 @@ TEST(AsyncClient, ResumeBufferedUploadResumeFinalized) {
   EXPECT_CALL(*mock, options).WillRepeatedly(Return(Options{}));
   EXPECT_CALL(*mock, ResumeBufferedUpload).WillOnce([] {
     auto writer = std::make_unique<MockAsyncWriterConnection>();
-    EXPECT_CALL(*writer, PersistedState).WillRepeatedly(Return(TestObject()));
+    EXPECT_CALL(*writer, PersistedState)
+        .WillRepeatedly(Return(TestProtoObject()));
 
     return make_ready_future(make_status_or(
         std::unique_ptr<AsyncWriterConnection>(std::move(writer))));
@@ -335,8 +336,8 @@ TEST(AsyncClient, ResumeBufferedUploadResumeFinalized) {
   AsyncToken t;
   std::tie(w, t) = *std::move(wt);
   EXPECT_FALSE(t.valid());
-  EXPECT_THAT(w.PersistedState(),
-              VariantWith<storage::ObjectMetadata>(TestObject()));
+  EXPECT_THAT(w.PersistedState(), VariantWith<google::storage::v2::Object>(
+                                      IsProtoEqual(TestProtoObject())));
 }
 
 TEST(AsyncClient, ReadObjectRange) {
@@ -395,7 +396,7 @@ TEST(AsyncClient, StartUnbufferedUpload1) {
         auto writer = std::make_unique<MockAsyncWriterConnection>();
         EXPECT_CALL(*writer, PersistedState).WillOnce(Return(0));
         EXPECT_CALL(*writer, Finalize).WillRepeatedly([] {
-          return make_ready_future(make_status_or(TestObject()));
+          return make_ready_future(make_status_or(TestProtoObject()));
         });
         return make_ready_future(make_status_or(
             std::unique_ptr<AsyncWriterConnection>(std::move(writer))));
@@ -416,7 +417,7 @@ TEST(AsyncClient, StartUnbufferedUpload1) {
   std::tie(w, t) = *std::move(wt);
   EXPECT_TRUE(t.valid());
   auto object = w.Finalize(std::move(t)).get();
-  EXPECT_THAT(object, IsOkAndHolds(TestObject()));
+  EXPECT_THAT(object, IsOkAndHolds(IsProtoEqual(TestProtoObject())));
 }
 
 TEST(AsyncClient, StartUnbufferedUpload2) {
@@ -442,7 +443,7 @@ TEST(AsyncClient, StartUnbufferedUpload2) {
         auto writer = std::make_unique<MockAsyncWriterConnection>();
         EXPECT_CALL(*writer, PersistedState).WillOnce(Return(0));
         EXPECT_CALL(*writer, Finalize).WillRepeatedly([] {
-          return make_ready_future(make_status_or(TestObject()));
+          return make_ready_future(make_status_or(TestProtoObject()));
         });
         return make_ready_future(make_status_or(
             std::unique_ptr<AsyncWriterConnection>(std::move(writer))));
@@ -463,7 +464,7 @@ TEST(AsyncClient, StartUnbufferedUpload2) {
   std::tie(w, t) = *std::move(wt);
   EXPECT_TRUE(t.valid());
   auto object = w.Finalize(std::move(t)).get();
-  EXPECT_THAT(object, IsOkAndHolds(TestObject()));
+  EXPECT_THAT(object, IsOkAndHolds(IsProtoEqual(TestProtoObject())));
 }
 
 TEST(AsyncClient, ResumeUnbufferedUpload1) {
@@ -484,7 +485,7 @@ TEST(AsyncClient, ResumeUnbufferedUpload1) {
         EXPECT_THAT(p.request, IsProtoEqual(expected));
         auto writer = std::make_unique<MockAsyncWriterConnection>();
         EXPECT_CALL(*writer, PersistedState)
-            .WillRepeatedly(Return(TestObject()));
+            .WillRepeatedly(Return(TestProtoObject()));
 
         return make_ready_future(make_status_or(
             std::unique_ptr<AsyncWriterConnection>(std::move(writer))));
@@ -502,8 +503,8 @@ TEST(AsyncClient, ResumeUnbufferedUpload1) {
   AsyncToken t;
   std::tie(w, t) = *std::move(wt);
   EXPECT_FALSE(t.valid());
-  EXPECT_THAT(w.PersistedState(),
-              VariantWith<storage::ObjectMetadata>(TestObject()));
+  EXPECT_THAT(w.PersistedState(), VariantWith<google::storage::v2::Object>(
+                                      IsProtoEqual(TestProtoObject())));
 }
 
 TEST(AsyncClient, ResumeUnbufferedUpload2) {
@@ -527,7 +528,7 @@ TEST(AsyncClient, ResumeUnbufferedUpload2) {
         EXPECT_THAT(p.request, IsProtoEqual(expected));
         auto writer = std::make_unique<MockAsyncWriterConnection>();
         EXPECT_CALL(*writer, PersistedState)
-            .WillRepeatedly(Return(TestObject()));
+            .WillRepeatedly(Return(TestProtoObject()));
 
         return make_ready_future(make_status_or(
             std::unique_ptr<AsyncWriterConnection>(std::move(writer))));
@@ -547,8 +548,8 @@ TEST(AsyncClient, ResumeUnbufferedUpload2) {
   AsyncToken t;
   std::tie(w, t) = *std::move(wt);
   EXPECT_FALSE(t.valid());
-  EXPECT_THAT(w.PersistedState(),
-              VariantWith<storage::ObjectMetadata>(TestObject()));
+  EXPECT_THAT(w.PersistedState(), VariantWith<google::storage::v2::Object>(
+                                      IsProtoEqual(TestProtoObject())));
 }
 
 TEST(AsyncClient, ResumeUnbufferedUploadResumeFinalized) {
@@ -556,7 +557,8 @@ TEST(AsyncClient, ResumeUnbufferedUploadResumeFinalized) {
   EXPECT_CALL(*mock, options).WillRepeatedly(Return(Options{}));
   EXPECT_CALL(*mock, ResumeUnbufferedUpload).WillOnce([] {
     auto writer = std::make_unique<MockAsyncWriterConnection>();
-    EXPECT_CALL(*writer, PersistedState).WillRepeatedly(Return(TestObject()));
+    EXPECT_CALL(*writer, PersistedState)
+        .WillRepeatedly(Return(TestProtoObject()));
 
     return make_ready_future(make_status_or(
         std::unique_ptr<AsyncWriterConnection>(std::move(writer))));
@@ -569,8 +571,8 @@ TEST(AsyncClient, ResumeUnbufferedUploadResumeFinalized) {
   AsyncToken t;
   std::tie(w, t) = *std::move(wt);
   EXPECT_FALSE(t.valid());
-  EXPECT_THAT(w.PersistedState(),
-              VariantWith<storage::ObjectMetadata>(TestObject()));
+  EXPECT_THAT(w.PersistedState(), VariantWith<google::storage::v2::Object>(
+                                      IsProtoEqual(TestProtoObject())));
 }
 
 TEST(AsyncClient, ComposeObject1) {

--- a/google/cloud/storage/async/object_requests.h
+++ b/google/cloud/storage/async/object_requests.h
@@ -132,51 +132,6 @@ class InsertObjectRequest {
 };
 
 /**
- * A request to start or resume a resumable upload.
- *
- * This class can hold all the mandatory and optional parameters to start or
- * resume a resumable upload. Resumable uploads can be used to stream large
- * objects as they can recover when the upload is interrupted. This request
- * does not contain any of the payload for the object; that is provided via a
- * `storage_experimental::AsyncWriter`.
- *
- * This class is in the public API for the library because it is required for
- * mocking.
- */
-class ResumableUploadRequest {
- public:
-  ResumableUploadRequest() = default;
-  ResumableUploadRequest(std::string bucket_name, std::string object_name)
-      : impl_(std::move(bucket_name), std::move(object_name)) {}
-
-  std::string const& bucket_name() const { return impl_.bucket_name(); }
-  std::string const& object_name() const { return impl_.object_name(); }
-
-  template <typename... T>
-  ResumableUploadRequest& set_multiple_options(T&&... o) & {
-    impl_.set_multiple_options(std::forward<T>(o)...);
-    return *this;
-  }
-  template <typename... T>
-  ResumableUploadRequest&& set_multiple_options(T&&... o) && {
-    return std::move(set_multiple_options(std::forward<T>(o)...));
-  }
-
-  template <typename T>
-  bool HasOption() const {
-    return impl_.HasOption<T>();
-  }
-  template <typename T>
-  T GetOption() const {
-    return impl_.GetOption<T>();
-  }
-
- protected:
-  friend class storage_internal::AsyncConnectionImpl;
-  storage::internal::ResumableUploadRequest impl_;
-};
-
-/**
  * A request to read an object.
  *
  * This class can hold all the mandatory and optional parameters to read an

--- a/google/cloud/storage/async/writer.cc
+++ b/google/cloud/storage/async/writer.cc
@@ -69,8 +69,9 @@ future<StatusOr<google::storage::v2::Object>> AsyncWriter::Finalize(
     AsyncToken token, WritePayload payload) {
   if (!impl_) return StreamError<google::storage::v2::Object>(GCP_ERROR_INFO());
   auto t = storage_internal::MakeAsyncToken(impl_.get());
-  if (token != t)
+  if (token != t) {
     return TokenError<google::storage::v2::Object>(GCP_ERROR_INFO());
+  }
 
   return impl_->Finalize(std::move(payload)).then([impl = impl_](auto f) {
     return f.get();

--- a/google/cloud/storage/async/writer.cc
+++ b/google/cloud/storage/async/writer.cc
@@ -45,7 +45,7 @@ std::string AsyncWriter::UploadId() const {
   return {};
 }
 
-absl::variant<std::int64_t, storage::ObjectMetadata>
+absl::variant<std::int64_t, google::storage::v2::Object>
 AsyncWriter::PersistedState() const {
   if (impl_) return impl_->PersistedState();
   return -1;
@@ -65,18 +65,19 @@ future<StatusOr<AsyncToken>> AsyncWriter::Write(AsyncToken token,
       });
 }
 
-future<StatusOr<storage::ObjectMetadata>> AsyncWriter::Finalize(
+future<StatusOr<google::storage::v2::Object>> AsyncWriter::Finalize(
     AsyncToken token, WritePayload payload) {
-  if (!impl_) return StreamError<storage::ObjectMetadata>(GCP_ERROR_INFO());
+  if (!impl_) return StreamError<google::storage::v2::Object>(GCP_ERROR_INFO());
   auto t = storage_internal::MakeAsyncToken(impl_.get());
-  if (token != t) return TokenError<storage::ObjectMetadata>(GCP_ERROR_INFO());
+  if (token != t)
+    return TokenError<google::storage::v2::Object>(GCP_ERROR_INFO());
 
   return impl_->Finalize(std::move(payload)).then([impl = impl_](auto f) {
     return f.get();
   });
 }
 
-future<StatusOr<storage::ObjectMetadata>> AsyncWriter::Finalize(
+future<StatusOr<google::storage::v2::Object>> AsyncWriter::Finalize(
     AsyncToken token) {
   return Finalize(std::move(token), WritePayload{});
 }

--- a/google/cloud/storage/async/writer.h
+++ b/google/cloud/storage/async/writer.h
@@ -22,6 +22,7 @@
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include "absl/types/variant.h"
+#include <google/storage/v2/storage.pb.h>
 #include <memory>
 #include <utility>
 
@@ -82,7 +83,7 @@ class AsyncWriter {
    * and `Finalize()`.
    *
    * Applications may finalize an upload, and then try to resume the upload. In
-   * this case this function returns `storage::ObjectMetadata`.
+   * this case this function returns `google::storage::v2::Object`.
    *
    * During an upload the service will periodically persist the uploaded data.
    * Applications should not assume that all data "sent" is persisted. The
@@ -93,7 +94,7 @@ class AsyncWriter {
    * that new data starts at the correct offset.
    *
    * If an upload is resumed after it is finalized, the library will return a
-   * variant holding `storage::ObjectMetadata` value.
+   * variant holding `google::storage::v2::Object` value.
    *
    * Otherwise the variant returns the size of the persisted data. The
    * application should send the remaining data to upload, starting from this
@@ -103,19 +104,20 @@ class AsyncWriter {
    * Calling this function on a default-constructed or moved-from `AsyncWriter`
    * results in undefined behavior.
    */
-  absl::variant<std::int64_t, storage::ObjectMetadata> PersistedState() const;
+  absl::variant<std::int64_t, google::storage::v2::Object> PersistedState()
+      const;
 
   /// Upload @p payload returning a new token to continue the upload.
   future<StatusOr<AsyncToken>> Write(AsyncToken token, WritePayload payload);
 
   /// Finalize the upload with the existing data.
-  future<StatusOr<storage::ObjectMetadata>> Finalize(AsyncToken token);
+  future<StatusOr<google::storage::v2::Object>> Finalize(AsyncToken token);
 
   /**
    * Upload @p payload and then finalize the upload.
    */
-  future<StatusOr<storage::ObjectMetadata>> Finalize(AsyncToken token,
-                                                     WritePayload payload);
+  future<StatusOr<google::storage::v2::Object>> Finalize(AsyncToken token,
+                                                         WritePayload payload);
 
   /**
    * The headers (if any) returned by the service. For debugging only.

--- a/google/cloud/storage/async/writer_connection.h
+++ b/google/cloud/storage/async/writer_connection.h
@@ -23,6 +23,7 @@
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include "absl/types/variant.h"
+#include <google/storage/v2/storage.pb.h>
 #include <cstdint>
 #include <string>
 
@@ -102,14 +103,15 @@ class AsyncWriterConnection {
 
   /// Returns the last known state of the upload. Updated during initialization
   /// and by successful `Query()` or `Finalize()` requests.
-  virtual absl::variant<std::int64_t, storage::ObjectMetadata> PersistedState()
-      const = 0;
+  virtual absl::variant<std::int64_t, google::storage::v2::Object>
+  PersistedState() const = 0;
 
   /// Uploads some data to the service.
   virtual future<Status> Write(WritePayload payload) = 0;
 
   /// Finalizes an upload.
-  virtual future<StatusOr<storage::ObjectMetadata>> Finalize(WritePayload) = 0;
+  virtual future<StatusOr<google::storage::v2::Object>> Finalize(
+      WritePayload) = 0;
 
   /// Uploads some data to the service and flushes the value.
   virtual future<Status> Flush(WritePayload payload) = 0;

--- a/google/cloud/storage/async/writer_test.cc
+++ b/google/cloud/storage/async/writer_test.cc
@@ -55,7 +55,7 @@ TEST(AsyncWriterTest, Basic) {
       .WillOnce([] { return make_ready_future(Status{}); });
   EXPECT_CALL(*mock, Finalize(WritePayloadContents(ElementsAre("ccc"))))
       .WillOnce([] {
-        return make_ready_future(make_status_or(storage::ObjectMetadata()));
+        return make_ready_future(make_status_or(google::storage::v2::Object{}));
       });
   EXPECT_CALL(*mock, GetRequestMetadata)
       .WillOnce(Return(RpcMetadata{{{"hk0", "v0"}, {"hk1", "v1"}},
@@ -90,7 +90,7 @@ TEST(AsyncWriterTest, FinalizeEmpty) {
   EXPECT_CALL(*mock, Write(WritePayloadContents(ElementsAre("bbb"))))
       .WillOnce([] { return make_ready_future(Status{}); });
   EXPECT_CALL(*mock, Finalize(WritePayloadContents(IsEmpty()))).WillOnce([] {
-    return make_ready_future(make_status_or(storage::ObjectMetadata()));
+    return make_ready_future(make_status_or(google::storage::v2::Object{}));
   });
 
   auto token = storage_internal::MakeAsyncToken(mock.get());
@@ -121,7 +121,7 @@ TEST(AsyncWriterTest, ErrorOnFinalize) {
   auto mock = std::make_unique<MockAsyncWriterConnection>();
   EXPECT_CALL(*mock, Finalize).WillOnce([] {
     return make_ready_future(
-        StatusOr<storage::ObjectMetadata>(PermanentError()));
+        StatusOr<google::storage::v2::Object>(PermanentError()));
   });
 
   auto token = storage_internal::MakeAsyncToken(mock.get());

--- a/google/cloud/storage/examples/storage_async_samples.cc
+++ b/google/cloud/storage/examples/storage_async_samples.cc
@@ -212,7 +212,7 @@ void StartBufferedUpload(
   namespace gcs_ex = google::cloud::storage_experimental;
   auto coro = [](gcs_ex::AsyncClient& client, std::string bucket_name,
                  std::string object_name)
-      -> google::cloud::future<gcs::ObjectMetadata> {
+      -> google::cloud::future<google::storage::v2::Object> {
     auto [writer, token] = (co_await client.StartBufferedUpload(
                                 gcs_ex::BucketName(std::move(bucket_name)),
                                 std::move(object_name)))
@@ -228,8 +228,8 @@ void StartBufferedUpload(
   //! [start-buffered-upload]
   // The example is easier to test and run if we call the coroutine and block
   // until it completes.
-  auto const metadata = coro(client, argv.at(0), argv.at(1)).get();
-  std::cout << "Object successfully uploaded " << metadata << "\n";
+  auto const object = coro(client, argv.at(0), argv.at(1)).get();
+  std::cout << "Object successfully uploaded " << object.DebugString() << "\n";
 }
 
 std::string SuspendBufferedUpload(
@@ -273,16 +273,15 @@ void ResumeBufferedUpload(
   //! [resume-buffered-upload]
   namespace gcs = google::cloud::storage;
   namespace gcs_ex = google::cloud::storage_experimental;
-  auto coro =
-      [](gcs_ex::AsyncClient& client,
-         std::string upload_id) -> google::cloud::future<gcs::ObjectMetadata> {
+  auto coro = [](gcs_ex::AsyncClient& client, std::string upload_id)
+      -> google::cloud::future<google::storage::v2::Object> {
     auto [writer, token] =
         (co_await client.ResumeBufferedUpload(std::move(upload_id))).value();
     auto state = writer.PersistedState();
-    if (std::holds_alternative<gcs::ObjectMetadata>(state)) {
+    if (std::holds_alternative<google::storage::v2::Object>(state)) {
       std::cout << "The upload " << writer.UploadId()
                 << " was already finalized\n";
-      co_return std::get<gcs::ObjectMetadata>(std::move(state));
+      co_return std::get<google::storage::v2::Object>(std::move(state));
     }
     auto persisted_bytes = std::get<std::int64_t>(state);
     if (persisted_bytes != 0) {
@@ -302,8 +301,8 @@ void ResumeBufferedUpload(
   //! [resume-buffered-upload]
   // The example is easier to test and run if we call the coroutine and block
   // until it completes.
-  auto const metadata = coro(client, argv.at(0)).get();
-  std::cout << "Object successfully uploaded " << metadata << "\n";
+  auto const object = coro(client, argv.at(0)).get();
+  std::cout << "Object successfully uploaded " << object.DebugString() << "\n";
 }
 
 void StartUnbufferedUpload(
@@ -314,7 +313,7 @@ void StartUnbufferedUpload(
   namespace gcs_ex = google::cloud::storage_experimental;
   auto coro = [](gcs_ex::AsyncClient& client, std::string bucket_name,
                  std::string object_name, std::string const& filename)
-      -> google::cloud::future<gcs::ObjectMetadata> {
+      -> google::cloud::future<google::storage::v2::Object> {
     std::ifstream is(filename);
     if (is.bad()) throw std::runtime_error("Cannot read " + filename);
 
@@ -336,8 +335,8 @@ void StartUnbufferedUpload(
   //! [start-unbuffered-upload]
   // The example is easier to test and run if we call the coroutine and block
   // until it completes..
-  auto const metadata = coro(client, argv.at(0), argv.at(1), argv.at(2)).get();
-  std::cout << "File successfully uploaded " << metadata << "\n";
+  auto const object = coro(client, argv.at(0), argv.at(1), argv.at(2)).get();
+  std::cout << "File successfully uploaded " << object.DebugString() << "\n";
 }
 
 std::string SuspendUnbufferedUpload(
@@ -395,19 +394,19 @@ void ResumeUnbufferedUpload(
   //! [resume-unbuffered-upload]
   namespace gcs = google::cloud::storage;
   namespace gcs_ex = google::cloud::storage_experimental;
-  auto coro =
-      [](gcs_ex::AsyncClient& client, std::string upload_id,
-         std::string filename) -> google::cloud::future<gcs::ObjectMetadata> {
+  auto coro = [](gcs_ex::AsyncClient& client, std::string upload_id,
+                 std::string filename)
+      -> google::cloud::future<google::storage::v2::Object> {
     std::ifstream is(filename);
     if (is.bad()) throw std::runtime_error("Cannot read " + filename);
     auto [writer, token] =
         (co_await client.ResumeUnbufferedUpload(std::move(upload_id))).value();
 
     auto state = writer.PersistedState();
-    if (std::holds_alternative<gcs::ObjectMetadata>(state)) {
+    if (std::holds_alternative<google::storage::v2::Object>(state)) {
       std::cout << "The upload " << writer.UploadId()
                 << " was already finalized\n";
-      co_return std::get<gcs::ObjectMetadata>(std::move(state));
+      co_return std::get<google::storage::v2::Object>(std::move(state));
     }
 
     auto persisted_bytes = std::get<std::int64_t>(state);
@@ -425,8 +424,8 @@ void ResumeUnbufferedUpload(
   //! [resume-unbuffered-upload]
   // The example is easier to test and run if we call the coroutine and block
   // until it completes.
-  auto const metadata = coro(client, argv.at(0), argv.at(1)).get();
-  std::cout << "Object successfully uploaded " << metadata << "\n";
+  auto const object = coro(client, argv.at(0), argv.at(1)).get();
+  std::cout << "Object successfully uploaded " << object.DebugString() << "\n";
 }
 
 void RewriteObject(google::cloud::storage_experimental::AsyncClient& client,

--- a/google/cloud/storage/internal/async/connection_impl.cc
+++ b/google/cloud/storage/internal/async/connection_impl.cc
@@ -508,11 +508,11 @@ AsyncConnectionImpl::ResumeUnbufferedUploadImpl(
             std::move(response).status()));
   }
   if (response->has_resource()) {
-    auto metadata = FromProto(response->resource(), *current);
     return make_ready_future(
         StatusOr<std::unique_ptr<storage_experimental::AsyncWriterConnection>>(
             std::make_unique<AsyncWriterConnectionFinalized>(
-                std::move(*query.mutable_upload_id()), std::move(metadata))));
+                std::move(*query.mutable_upload_id()),
+                std::move(*response->mutable_resource()))));
   }
 
   // In most cases computing a hash for a resumed upload is not feasible. We

--- a/google/cloud/storage/internal/async/connection_impl_upload_hash_test.cc
+++ b/google/cloud/storage/internal/async/connection_impl_upload_hash_test.cc
@@ -221,7 +221,7 @@ TEST_P(AsyncConnectionImplUploadHashTest, StartUnbuffered) {
 
   auto response = w2.get();
   ASSERT_STATUS_OK(response);
-  EXPECT_EQ(response->bucket(), "test-bucket");
+  EXPECT_EQ(response->bucket(), "projects/_/buckets/test-bucket");
   EXPECT_EQ(response->name(), "test-object");
   EXPECT_EQ(response->generation(), 123456);
 
@@ -321,7 +321,7 @@ TEST_P(AsyncConnectionImplUploadHashTest,
 
   auto response = w2.get();
   ASSERT_STATUS_OK(response);
-  EXPECT_EQ(response->bucket(), "test-bucket");
+  EXPECT_EQ(response->bucket(), "projects/_/buckets/test-bucket");
   EXPECT_EQ(response->name(), "test-object");
   EXPECT_EQ(response->generation(), 123456);
 
@@ -419,7 +419,7 @@ TEST_P(AsyncConnectionImplUploadHashTest, ResumeUnbufferedWithPersistedData) {
 
   auto response = w2.get();
   ASSERT_STATUS_OK(response);
-  EXPECT_EQ(response->bucket(), "test-bucket");
+  EXPECT_EQ(response->bucket(), "projects/_/buckets/test-bucket");
   EXPECT_EQ(response->name(), "test-object");
   EXPECT_EQ(response->generation(), 123456);
 
@@ -516,7 +516,7 @@ TEST_P(AsyncConnectionImplUploadHashTest, StartBuffered) {
 
   auto response = w2.get();
   ASSERT_STATUS_OK(response);
-  EXPECT_EQ(response->bucket(), "test-bucket");
+  EXPECT_EQ(response->bucket(), "projects/_/buckets/test-bucket");
   EXPECT_EQ(response->name(), "test-object");
   EXPECT_EQ(response->generation(), 123456);
 
@@ -615,7 +615,7 @@ TEST_P(AsyncConnectionImplUploadHashTest, ResumeBufferedWithoutPersistedData) {
 
   auto response = w2.get();
   ASSERT_STATUS_OK(response);
-  EXPECT_EQ(response->bucket(), "test-bucket");
+  EXPECT_EQ(response->bucket(), "projects/_/buckets/test-bucket");
   EXPECT_EQ(response->name(), "test-object");
   EXPECT_EQ(response->generation(), 123456);
 
@@ -713,7 +713,7 @@ TEST_P(AsyncConnectionImplUploadHashTest, ResumeBufferedWithPersistedData) {
 
   auto response = w2.get();
   ASSERT_STATUS_OK(response);
-  EXPECT_EQ(response->bucket(), "test-bucket");
+  EXPECT_EQ(response->bucket(), "projects/_/buckets/test-bucket");
   EXPECT_EQ(response->name(), "test-object");
   EXPECT_EQ(response->generation(), 123456);
 

--- a/google/cloud/storage/internal/async/connection_tracing_test.cc
+++ b/google/cloud/storage/internal/async/connection_tracing_test.cc
@@ -237,7 +237,7 @@ TEST(ConnectionTracing, StartUnbufferedUploadSuccess) {
   auto mock_reader = std::make_unique<MockAsyncWriterConnection>();
   EXPECT_CALL(*mock_reader, Finalize)
       .WillOnce(Return(ByMove(
-          make_ready_future(make_status_or(storage::ObjectMetadata{})))));
+          make_ready_future(make_status_or(google::storage::v2::Object{})))));
   p.set_value(
       StatusOr<std::unique_ptr<storage_experimental::AsyncWriterConnection>>(
           std::move(mock_reader)));
@@ -299,7 +299,7 @@ TEST(ConnectionTracing, StartBufferedUploadSuccess) {
   auto mock_reader = std::make_unique<MockAsyncWriterConnection>();
   EXPECT_CALL(*mock_reader, Finalize)
       .WillOnce(Return(ByMove(
-          make_ready_future(make_status_or(storage::ObjectMetadata{})))));
+          make_ready_future(make_status_or(google::storage::v2::Object{})))));
   p.set_value(
       StatusOr<std::unique_ptr<storage_experimental::AsyncWriterConnection>>(
           std::move(mock_reader)));
@@ -362,7 +362,7 @@ TEST(ConnectionTracing, ResumeUnbufferedUploadSuccess) {
   auto mock_reader = std::make_unique<MockAsyncWriterConnection>();
   EXPECT_CALL(*mock_reader, Finalize)
       .WillOnce(Return(ByMove(
-          make_ready_future(make_status_or(storage::ObjectMetadata{})))));
+          make_ready_future(make_status_or(google::storage::v2::Object{})))));
   p.set_value(
       StatusOr<std::unique_ptr<storage_experimental::AsyncWriterConnection>>(
           std::move(mock_reader)));
@@ -425,7 +425,7 @@ TEST(ConnectionTracing, ResumeBufferedUploadSuccess) {
   auto mock_reader = std::make_unique<MockAsyncWriterConnection>();
   EXPECT_CALL(*mock_reader, Finalize)
       .WillOnce(Return(ByMove(
-          make_ready_future(make_status_or(storage::ObjectMetadata{})))));
+          make_ready_future(make_status_or(google::storage::v2::Object{})))));
   p.set_value(
       StatusOr<std::unique_ptr<storage_experimental::AsyncWriterConnection>>(
           std::move(mock_reader)));

--- a/google/cloud/storage/internal/async/writer_connection_finalized.cc
+++ b/google/cloud/storage/internal/async/writer_connection_finalized.cc
@@ -29,8 +29,8 @@ Status MakeError(google::cloud::internal::ErrorInfoBuilder eib) {
 }  // namespace
 
 AsyncWriterConnectionFinalized::AsyncWriterConnectionFinalized(
-    std::string upload_id, storage::ObjectMetadata metadata)
-    : upload_id_(std::move(upload_id)), metadata_(std::move(metadata)) {}
+    std::string upload_id, google::storage::v2::Object object)
+    : upload_id_(std::move(upload_id)), object_(std::move(object)) {}
 
 AsyncWriterConnectionFinalized::~AsyncWriterConnectionFinalized() = default;
 
@@ -40,9 +40,9 @@ std::string AsyncWriterConnectionFinalized::UploadId() const {
   return upload_id_;
 }
 
-absl::variant<std::int64_t, storage::ObjectMetadata>
+absl::variant<std::int64_t, google::storage::v2::Object>
 AsyncWriterConnectionFinalized::PersistedState() const {
-  return metadata_;
+  return object_;
 }
 
 future<Status> AsyncWriterConnectionFinalized::Write(
@@ -50,10 +50,10 @@ future<Status> AsyncWriterConnectionFinalized::Write(
   return make_ready_future(MakeError(GCP_ERROR_INFO()));
 }
 
-future<StatusOr<storage::ObjectMetadata>>
+future<StatusOr<google::storage::v2::Object>>
 AsyncWriterConnectionFinalized::Finalize(storage_experimental::WritePayload) {
   return make_ready_future(
-      StatusOr<storage::ObjectMetadata>(MakeError(GCP_ERROR_INFO())));
+      StatusOr<google::storage::v2::Object>(MakeError(GCP_ERROR_INFO())));
 }
 
 future<Status> AsyncWriterConnectionFinalized::Flush(

--- a/google/cloud/storage/internal/async/writer_connection_finalized.h
+++ b/google/cloud/storage/internal/async/writer_connection_finalized.h
@@ -46,17 +46,17 @@ class AsyncWriterConnectionFinalized
     : public storage_experimental::AsyncWriterConnection {
  public:
   explicit AsyncWriterConnectionFinalized(std::string upload_id,
-                                          storage::ObjectMetadata metadata);
+                                          google::storage::v2::Object object);
   ~AsyncWriterConnectionFinalized() override;
 
   void Cancel() override;
 
   std::string UploadId() const override;
-  absl::variant<std::int64_t, storage::ObjectMetadata> PersistedState()
+  absl::variant<std::int64_t, google::storage::v2::Object> PersistedState()
       const override;
 
   future<Status> Write(storage_experimental::WritePayload payload) override;
-  future<StatusOr<storage::ObjectMetadata>> Finalize(
+  future<StatusOr<google::storage::v2::Object>> Finalize(
       storage_experimental::WritePayload) override;
   future<Status> Flush(storage_experimental::WritePayload payload) override;
   future<StatusOr<std::int64_t>> Query() override;
@@ -64,7 +64,7 @@ class AsyncWriterConnectionFinalized
 
  private:
   std::string upload_id_;
-  storage::ObjectMetadata metadata_;
+  google::storage::v2::Object object_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/async/writer_connection_impl.h
+++ b/google/cloud/storage/internal/async/writer_connection_impl.h
@@ -48,17 +48,17 @@ class AsyncWriterConnectionImpl
       google::storage::v2::BidiWriteObjectRequest request,
       std::unique_ptr<StreamingRpc> impl,
       std::shared_ptr<storage::internal::HashFunction> hash_function,
-      storage::ObjectMetadata metadata);
+      google::storage::v2::Object metadata);
   ~AsyncWriterConnectionImpl() override;
 
   void Cancel() override { return impl_->Cancel(); }
 
   std::string UploadId() const override;
-  absl::variant<std::int64_t, storage::ObjectMetadata> PersistedState()
+  absl::variant<std::int64_t, google::storage::v2::Object> PersistedState()
       const override;
 
   future<Status> Write(storage_experimental::WritePayload payload) override;
-  future<StatusOr<storage::ObjectMetadata>> Finalize(
+  future<StatusOr<google::storage::v2::Object>> Finalize(
       storage_experimental::WritePayload) override;
   future<Status> Flush(storage_experimental::WritePayload payload) override;
   future<StatusOr<std::int64_t>> Query() override;
@@ -66,7 +66,7 @@ class AsyncWriterConnectionImpl
 
  private:
   using PersistedStateType =
-      absl::variant<std::int64_t, storage::ObjectMetadata>;
+      absl::variant<std::int64_t, google::storage::v2::Object>;
   AsyncWriterConnectionImpl(
       google::cloud::internal::ImmutableOptions options,
       google::storage::v2::BidiWriteObjectRequest request,
@@ -78,7 +78,7 @@ class AsyncWriterConnectionImpl
 
   future<Status> OnPartialUpload(std::size_t upload_size,
                                  StatusOr<bool> success);
-  future<StatusOr<storage::ObjectMetadata>> OnFinalUpload(
+  future<StatusOr<google::storage::v2::Object>> OnFinalUpload(
       std::size_t upload_size, StatusOr<bool> success);
   future<StatusOr<std::int64_t>> OnQuery(
       absl::optional<google::storage::v2::BidiWriteObjectResponse> response);

--- a/google/cloud/storage/internal/async/writer_connection_tracing.cc
+++ b/google/cloud/storage/internal/async/writer_connection_tracing.cc
@@ -50,7 +50,7 @@ class AsyncWriterConnectionTracing
     return impl_->UploadId();
   }
 
-  absl::variant<std::int64_t, storage::ObjectMetadata> PersistedState()
+  absl::variant<std::int64_t, google::storage::v2::Object> PersistedState()
       const override {
     // No tracing, this is a local call without any significant work.
     return impl_->PersistedState();
@@ -74,7 +74,7 @@ class AsyncWriterConnectionTracing
         });
   }
 
-  future<StatusOr<storage::ObjectMetadata>> Finalize(
+  future<StatusOr<google::storage::v2::Object>> Finalize(
       storage_experimental::WritePayload p) override {
     internal::OTelScope scope(span_);
     auto size = static_cast<std::uint64_t>(p.size());

--- a/google/cloud/storage/internal/async/writer_connection_tracing_test.cc
+++ b/google/cloud/storage/internal/async/writer_connection_tracing_test.cc
@@ -94,7 +94,7 @@ TEST(WriterConnectionTracing, FullCycle) {
     return make_ready_future(StatusOr<std::int64_t>(1024));
   });
   EXPECT_CALL(*mock, Finalize).WillOnce([] {
-    return make_ready_future(make_status_or(storage::ObjectMetadata{}));
+    return make_ready_future(make_status_or(google::storage::v2::Object{}));
   });
   EXPECT_CALL(*mock, GetRequestMetadata)
       .WillOnce(Return(RpcMetadata{{{"hk0", "v0"}, {"hk1", "v1"}},
@@ -136,7 +136,7 @@ TEST(WriterConnectionTracing, FinalizeError) {
   auto mock = std::make_unique<MockAsyncWriterConnection>();
   EXPECT_CALL(*mock, Finalize).WillOnce([] {
     return make_ready_future(
-        StatusOr<storage::ObjectMetadata>(PermanentError()));
+        StatusOr<google::storage::v2::Object>(PermanentError()));
   });
   auto actual = MakeTracingWriterConnection(
       internal::MakeSpan("test-span-name"), std::move(mock));
@@ -227,7 +227,7 @@ TEST(WriterConnectionTracing, Cancel) {
   auto mock = std::make_unique<MockAsyncWriterConnection>();
   EXPECT_CALL(*mock, Cancel).Times(1);
   EXPECT_CALL(*mock, Finalize).WillOnce([] {
-    return make_ready_future(make_status_or(storage::ObjectMetadata{}));
+    return make_ready_future(make_status_or(google::storage::v2::Object{}));
   });
   auto actual = MakeTracingWriterConnection(
       internal::MakeSpan("test-span-name"), std::move(mock));

--- a/google/cloud/storage/mocks/mock_async_writer_connection.h
+++ b/google/cloud/storage/mocks/mock_async_writer_connection.h
@@ -29,11 +29,11 @@ class MockAsyncWriterConnection
  public:
   MOCK_METHOD(void, Cancel, (), (override));
   MOCK_METHOD(std::string, UploadId, (), (const, override));
-  MOCK_METHOD((absl::variant<std::int64_t, storage::ObjectMetadata>),
+  MOCK_METHOD((absl::variant<std::int64_t, google::storage::v2::Object>),
               PersistedState, (), (const, override));
   MOCK_METHOD(future<Status>, Write, (storage_experimental::WritePayload),
               (override));
-  MOCK_METHOD(future<StatusOr<storage::ObjectMetadata>>, Finalize,
+  MOCK_METHOD(future<StatusOr<google::storage::v2::Object>>, Finalize,
               (storage_experimental::WritePayload), (override));
   MOCK_METHOD(future<Status>, Flush, (storage_experimental::WritePayload),
               (override));

--- a/google/cloud/storage/tests/BUILD.bazel
+++ b/google/cloud/storage/tests/BUILD.bazel
@@ -60,6 +60,7 @@ VARIATIONS = {
         "//:common",
         "//:storage",
         "//google/cloud/storage:storage_client_testing",
+        "//google/cloud/testing_util:google_cloud_cpp_testing_grpc_private",
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -110,8 +110,9 @@ foreach (fname IN LISTS storage_client_integration_tests)
                 nlohmann_json)
     if (GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
         target_link_libraries(
-            ${target} PRIVATE google-cloud-cpp::storage
-                              google_cloud_cpp_storage_tests_conformance_protos)
+            ${target}
+            PRIVATE google-cloud-cpp::storage google_cloud_cpp_testing_grpc
+                    google_cloud_cpp_storage_tests_conformance_protos)
     endif ()
 
     add_test(NAME ${target} COMMAND ${target})

--- a/google/cloud/storage/tests/async_client_integration_test.cc
+++ b/google/cloud/storage/tests/async_client_integration_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/async/client.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
 #include "google/cloud/internal/getenv.h"
+#include "google/cloud/testing_util/is_proto_equal.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <algorithm>
@@ -31,6 +32,7 @@ namespace {
 
 namespace gcs = ::google::cloud::storage;
 using ::google::cloud::internal::GetEnv;
+using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::IsEmpty;
 using ::testing::Le;
@@ -215,7 +217,7 @@ TEST_F(AsyncClientIntegrationTest, StartUnbufferedUploadEmpty) {
   ASSERT_STATUS_OK(metadata);
   ScheduleForDelete(*metadata);
 
-  EXPECT_EQ(metadata->bucket(), bucket_name());
+  EXPECT_EQ(metadata->bucket(), BucketName(bucket_name()).FullName());
   EXPECT_EQ(metadata->name(), object_name);
   EXPECT_EQ(metadata->size(), 0);
 }
@@ -244,7 +246,7 @@ TEST_F(AsyncClientIntegrationTest, StartUnbufferedUploadMultiple) {
   ASSERT_STATUS_OK(metadata);
   ScheduleForDelete(*metadata);
 
-  EXPECT_EQ(metadata->bucket(), bucket_name());
+  EXPECT_EQ(metadata->bucket(), BucketName(bucket_name()).FullName());
   EXPECT_EQ(metadata->name(), object_name);
   EXPECT_EQ(metadata->size(), kBlockCount * kBlockSize);
 }
@@ -306,7 +308,7 @@ TEST_F(AsyncClientIntegrationTest, StartUnbufferedUploadResume) {
   ASSERT_STATUS_OK(metadata);
   ScheduleForDelete(*metadata);
 
-  EXPECT_EQ(metadata->bucket(), bucket_name());
+  EXPECT_EQ(metadata->bucket(), BucketName(bucket_name()).FullName());
   EXPECT_EQ(metadata->name(), object_name);
   EXPECT_EQ(metadata->size(), kDesiredSize);
 }
@@ -330,7 +332,7 @@ TEST_F(AsyncClientIntegrationTest, StartUnbufferedUploadResumeFinalized) {
   ASSERT_STATUS_OK(metadata);
   ScheduleForDelete(*metadata);
 
-  EXPECT_EQ(metadata->bucket(), bucket_name());
+  EXPECT_EQ(metadata->bucket(), BucketName(bucket_name()).FullName());
   EXPECT_EQ(metadata->name(), object_name);
   EXPECT_EQ(metadata->size(), kBlockSize);
 
@@ -338,10 +340,8 @@ TEST_F(AsyncClientIntegrationTest, StartUnbufferedUploadResumeFinalized) {
   ASSERT_STATUS_OK(w);
   std::tie(writer, token) = *std::move(w);
   EXPECT_FALSE(token.valid());
-  ASSERT_TRUE(absl::holds_alternative<storage::ObjectMetadata>(
-      writer.PersistedState()));
-  auto finalized = absl::get<storage::ObjectMetadata>(writer.PersistedState());
-  EXPECT_EQ(*metadata, finalized);
+  EXPECT_THAT(writer.PersistedState(), VariantWith<google::storage::v2::Object>(
+                                           IsProtoEqual(*metadata)));
 }
 
 TEST_F(AsyncClientIntegrationTest, StartBufferedUploadEmpty) {
@@ -359,7 +359,7 @@ TEST_F(AsyncClientIntegrationTest, StartBufferedUploadEmpty) {
   ASSERT_STATUS_OK(metadata);
   ScheduleForDelete(*metadata);
 
-  EXPECT_EQ(metadata->bucket(), bucket_name());
+  EXPECT_EQ(metadata->bucket(), BucketName(bucket_name()).FullName());
   EXPECT_EQ(metadata->name(), object_name);
   EXPECT_EQ(metadata->size(), 0);
 }
@@ -388,7 +388,7 @@ TEST_F(AsyncClientIntegrationTest, StartBufferedUploadMultiple) {
   ASSERT_STATUS_OK(metadata);
   ScheduleForDelete(*metadata);
 
-  EXPECT_EQ(metadata->bucket(), bucket_name());
+  EXPECT_EQ(metadata->bucket(), BucketName(bucket_name()).FullName());
   EXPECT_EQ(metadata->name(), object_name);
   EXPECT_EQ(metadata->size(), kBlockCount * kBlockSize);
 }


### PR DESCRIPTION
Now that all resumable upload operations consume protos, it is time to start returning protos when these operations complete.

Part of the work for #13910

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14029)
<!-- Reviewable:end -->
