### PR TITLE
cleanup(GCS+gRPC): use protos for `ReadObject*()`

### DIFF
--- a/google/cloud/storage/async/client.cc
+++ b/google/cloud/storage/async/client.cc
@@ -38,6 +38,53 @@ AsyncClient::AsyncClient(Options options) {
 AsyncClient::AsyncClient(std::shared_ptr<AsyncConnection> connection)
     : connection_(std::move(connection)) {}
 
+future<StatusOr<std::pair<AsyncReader, AsyncToken>>> AsyncClient::ReadObject(
+    BucketName const& bucket_name, std::string object_name, Options opts) {
+  auto request = google::storage::v2::ReadObjectRequest{};
+  request.set_bucket(bucket_name.FullName());
+  request.set_object(std::move(object_name));
+  return ReadObject(std::move(request), std::move(opts));
+}
+
+future<StatusOr<std::pair<AsyncReader, AsyncToken>>> AsyncClient::ReadObject(
+    google::storage::v2::ReadObjectRequest request, Options opts) {
+  return connection_
+      ->ReadObject(
+          {std::move(request),
+           internal::MergeOptions(std::move(opts), connection_->options())})
+      .then([](auto f) -> StatusOr<std::pair<AsyncReader, AsyncToken>> {
+        auto impl = f.get();
+        if (!impl) return std::move(impl).status();
+        auto t = storage_internal::MakeAsyncToken(impl->get());
+        return std::make_pair(AsyncReader(*std::move(impl)), std::move(t));
+      });
+}
+
+future<StatusOr<ReadPayload>> AsyncClient::ReadObjectRange(
+    BucketName const& bucket_name, std::string object_name, std::int64_t offset,
+    std::int64_t limit, Options opts) {
+  auto request = google::storage::v2::ReadObjectRequest{};
+  request.set_bucket(bucket_name.FullName());
+  request.set_object(std::move(object_name));
+  request.set_read_offset(offset);
+  request.set_read_limit(limit);
+
+  return connection_->ReadObjectRange(
+      {std::move(request),
+       internal::MergeOptions(std::move(opts), connection_->options())});
+}
+
+future<StatusOr<ReadPayload>> AsyncClient::ReadObjectRange(
+    google::storage::v2::ReadObjectRequest request, std::int64_t offset,
+    std::int64_t limit, Options opts) {
+  request.set_read_offset(offset);
+  request.set_read_limit(limit);
+
+  return connection_->ReadObjectRange(
+      {std::move(request),
+       internal::MergeOptions(std::move(opts), connection_->options())});
+}
+
 future<StatusOr<std::pair<AsyncWriter, AsyncToken>>>
 AsyncClient::StartBufferedUpload(BucketName const& bucket_name,
                                  std::string object_name, Options opts) {

--- a/google/cloud/storage/async/client.cc
+++ b/google/cloud/storage/async/client.cc
@@ -66,12 +66,8 @@ future<StatusOr<ReadPayload>> AsyncClient::ReadObjectRange(
   auto request = google::storage::v2::ReadObjectRequest{};
   request.set_bucket(bucket_name.FullName());
   request.set_object(std::move(object_name));
-  request.set_read_offset(offset);
-  request.set_read_limit(limit);
 
-  return connection_->ReadObjectRange(
-      {std::move(request),
-       internal::MergeOptions(std::move(opts), connection_->options())});
+  return ReadObjectRange(std::move(request), offset, limit, std::move(opts));
 }
 
 future<StatusOr<ReadPayload>> AsyncClient::ReadObjectRange(

--- a/google/cloud/storage/async/client_test.cc
+++ b/google/cloud/storage/async/client_test.cc
@@ -92,20 +92,24 @@ TEST(AsyncClient, InsertObject) {
   EXPECT_THAT(response, IsOkAndHolds(TestObject()));
 }
 
-TEST(AsyncClient, ReadObject) {
+TEST(AsyncClient, ReadObject1) {
+  auto constexpr kExpectedRequest = R"pb(
+    bucket: "projects/_/buckets/test-bucket"
+    object: "test-object"
+  )pb";
   auto mock = std::make_shared<MockAsyncConnection>();
   EXPECT_CALL(*mock, options)
       .WillRepeatedly(
           Return(Options{}.set<TestOption<0>>("O0").set<TestOption<1>>("O1")));
 
   EXPECT_CALL(*mock, ReadObject)
-      .WillOnce([](AsyncConnection::ReadObjectParams const& p) {
+      .WillOnce([&](AsyncConnection::ReadObjectParams const& p) {
         EXPECT_THAT(p.options.get<TestOption<0>>(), "O0");
         EXPECT_THAT(p.options.get<TestOption<1>>(), "O1-function");
         EXPECT_THAT(p.options.get<TestOption<2>>(), "O2-function");
-        EXPECT_EQ(p.request.bucket_name(), "test-bucket");
-        EXPECT_EQ(p.request.object_name(), "test-object");
-        EXPECT_EQ(p.request.GetOption<storage::Generation>().value_or(0), 42);
+        auto expected = google::storage::v2::ReadObjectRequest{};
+        EXPECT_TRUE(TextFormat::ParseFromString(kExpectedRequest, &expected));
+        EXPECT_THAT(p.request, IsProtoEqual(expected));
         auto reader = std::make_unique<MockAsyncReaderConnection>();
         EXPECT_CALL(*reader, Read).WillOnce([] {
           return make_ready_future(
@@ -116,13 +120,63 @@ TEST(AsyncClient, ReadObject) {
       });
 
   auto client = AsyncClient(mock);
-  auto rt =
-      client
-          .ReadObject("test-bucket", "test-object", storage::Generation(42),
-                      Options{}
-                          .set<TestOption<1>>("O1-function")
-                          .set<TestOption<2>>("O2-function"))
-          .get();
+  auto rt = client
+                .ReadObject(BucketName("test-bucket"), "test-object",
+                            Options{}
+                                .set<TestOption<1>>("O1-function")
+                                .set<TestOption<2>>("O2-function"))
+                .get();
+  ASSERT_STATUS_OK(rt);
+  AsyncReader r;
+  AsyncToken t;
+  std::tie(r, t) = *std::move(rt);
+  EXPECT_TRUE(t.valid());
+
+  auto pt = r.Read(std::move(t)).get();
+  AsyncReaderConnection::ReadResponse p;
+  AsyncToken t2;
+  ASSERT_STATUS_OK(pt);
+  std::tie(p, t2) = *std::move(pt);
+  EXPECT_FALSE(t2.valid());
+  EXPECT_THAT(
+      p, VariantWith<ReadPayload>(ResultOf(
+             "empty response", [](auto const& p) { return p.size(); }, 0)));
+}
+
+TEST(AsyncClient, ReadObject2) {
+  auto constexpr kExpectedRequest =
+      R"pb(bucket: "test-only-invalid" object: "test-object" generation: 42)pb";
+  auto mock = std::make_shared<MockAsyncConnection>();
+  EXPECT_CALL(*mock, options)
+      .WillRepeatedly(
+          Return(Options{}.set<TestOption<0>>("O0").set<TestOption<1>>("O1")));
+
+  EXPECT_CALL(*mock, ReadObject)
+      .WillOnce([&](AsyncConnection::ReadObjectParams const& p) {
+        EXPECT_THAT(p.options.get<TestOption<0>>(), "O0");
+        EXPECT_THAT(p.options.get<TestOption<1>>(), "O1-function");
+        EXPECT_THAT(p.options.get<TestOption<2>>(), "O2-function");
+        auto expected = google::storage::v2::ReadObjectRequest{};
+        EXPECT_TRUE(TextFormat::ParseFromString(kExpectedRequest, &expected));
+        EXPECT_THAT(p.request, IsProtoEqual(expected));
+        auto reader = std::make_unique<MockAsyncReaderConnection>();
+        EXPECT_CALL(*reader, Read).WillOnce([] {
+          return make_ready_future(
+              AsyncReaderConnection::ReadResponse{Status{}});
+        });
+        return make_ready_future(make_status_or(
+            std::unique_ptr<AsyncReaderConnection>(std::move(reader))));
+      });
+
+  auto client = AsyncClient(mock);
+  auto request = google::storage::v2::ReadObjectRequest{};
+  EXPECT_TRUE(TextFormat::ParseFromString(kExpectedRequest, &request));
+  auto rt = client
+                .ReadObject(std::move(request),
+                            Options{}
+                                .set<TestOption<1>>("O1-function")
+                                .set<TestOption<2>>("O2-function"))
+                .get();
   ASSERT_STATUS_OK(rt);
   AsyncReader r;
   AsyncToken t;
@@ -340,7 +394,13 @@ TEST(AsyncClient, ResumeBufferedUploadResumeFinalized) {
                                       IsProtoEqual(TestProtoObject())));
 }
 
-TEST(AsyncClient, ReadObjectRange) {
+TEST(AsyncClient, ReadObjectRange1) {
+  auto constexpr kExpectedRequest = R"pb(
+    bucket: "projects/_/buckets/test-bucket"
+    object: "test-object"
+    read_offset: 100
+    read_limit: 42
+  )pb";
   auto mock = std::make_shared<MockAsyncConnection>();
   EXPECT_CALL(*mock, options)
       .WillRepeatedly(
@@ -351,21 +411,56 @@ TEST(AsyncClient, ReadObjectRange) {
         EXPECT_THAT(p.options.get<TestOption<0>>(), "O0");
         EXPECT_THAT(p.options.get<TestOption<1>>(), "O1-function");
         EXPECT_THAT(p.options.get<TestOption<2>>(), "O2-function");
-        EXPECT_EQ(p.request.bucket_name(), "test-bucket");
-        EXPECT_EQ(p.request.object_name(), "test-object");
-        EXPECT_EQ(p.request.GetOption<storage::Generation>().value_or(0), 42);
-        auto const range = p.request.GetOption<storage::ReadRange>().value_or(
-            storage::ReadRangeData{0, 0});
-        EXPECT_EQ(range.begin, 100);
-        EXPECT_EQ(range.end, 142);
+        auto expected = google::storage::v2::ReadObjectRequest{};
+        EXPECT_TRUE(TextFormat::ParseFromString(kExpectedRequest, &expected));
+        EXPECT_THAT(p.request, IsProtoEqual(expected));
         return make_ready_future(
             make_status_or(ReadPayload{}.set_metadata(TestObject())));
       });
 
   auto client = AsyncClient(mock);
+  auto payload =
+      client
+          .ReadObjectRange(BucketName("test-bucket"), "test-object", 100, 42,
+                           Options{}
+                               .set<TestOption<1>>("O1-function")
+                               .set<TestOption<2>>("O2-function"))
+          .get();
+  ASSERT_STATUS_OK(payload);
+  EXPECT_THAT(payload->metadata(), Optional(Eq(TestObject())));
+}
+
+TEST(AsyncClient, ReadObjectRange2) {
+  auto constexpr kExpectedRequest = R"pb(
+    bucket: "test-only-invalid"
+    object: "test-object"
+    read_offset: 100
+    read_limit: 42
+  )pb";
+  auto mock = std::make_shared<MockAsyncConnection>();
+  EXPECT_CALL(*mock, options)
+      .WillRepeatedly(
+          Return(Options{}.set<TestOption<0>>("O0").set<TestOption<1>>("O1")));
+
+  EXPECT_CALL(*mock, ReadObjectRange)
+      .WillOnce([&](AsyncConnection::ReadObjectParams const& p) {
+        EXPECT_THAT(p.options.get<TestOption<0>>(), "O0");
+        EXPECT_THAT(p.options.get<TestOption<1>>(), "O1-function");
+        EXPECT_THAT(p.options.get<TestOption<2>>(), "O2-function");
+        auto expected = google::storage::v2::ReadObjectRequest{};
+        EXPECT_TRUE(TextFormat::ParseFromString(kExpectedRequest, &expected));
+        EXPECT_THAT(p.request, IsProtoEqual(expected));
+        return make_ready_future(
+            make_status_or(ReadPayload{}.set_metadata(TestObject())));
+      });
+
+  auto client = AsyncClient(mock);
+  auto request = google::storage::v2::ReadObjectRequest{};
+  EXPECT_TRUE(TextFormat::ParseFromString(kExpectedRequest, &request));
+  // Set the offset to verify the client library overrides it.
+  request.set_read_offset(23456);
   auto payload = client
-                     .ReadObjectRange("test-bucket", "test-object", 100, 42,
-                                      storage::Generation(42),
+                     .ReadObjectRange(std::move(request), 100, 42,
                                       Options{}
                                           .set<TestOption<1>>("O1-function")
                                           .set<TestOption<2>>("O2-function"))

--- a/google/cloud/storage/async/client_test.cc
+++ b/google/cloud/storage/async/client_test.cc
@@ -407,7 +407,7 @@ TEST(AsyncClient, ReadObjectRange1) {
           Return(Options{}.set<TestOption<0>>("O0").set<TestOption<1>>("O1")));
 
   EXPECT_CALL(*mock, ReadObjectRange)
-      .WillOnce([](AsyncConnection::ReadObjectParams const& p) {
+      .WillOnce([&](AsyncConnection::ReadObjectParams const& p) {
         EXPECT_THAT(p.options.get<TestOption<0>>(), "O0");
         EXPECT_THAT(p.options.get<TestOption<1>>(), "O1-function");
         EXPECT_THAT(p.options.get<TestOption<2>>(), "O2-function");

--- a/google/cloud/storage/async/connection.h
+++ b/google/cloud/storage/async/connection.h
@@ -85,7 +85,7 @@ class AsyncConnection {
     /// The name of the bucket and object to read. Includes optional parameters,
     /// such as pre-conditions on the read operation, or the range within the
     /// object to read.
-    ReadObjectRequest request;
+    google::storage::v2::ReadObjectRequest request;
     /// Any options modifying the RPC behavior, including per-client and
     /// per-connection options.
     Options options;

--- a/google/cloud/storage/async/object_requests.h
+++ b/google/cloud/storage/async/object_requests.h
@@ -131,48 +131,6 @@ class InsertObjectRequest {
   Impl impl_;
 };
 
-/**
- * A request to read an object.
- *
- * This class can hold all the mandatory and optional parameters to read an
- * object.
- *
- * This class is in the public API for the library because it is required for
- * mocking.
- */
-class ReadObjectRequest {
- public:
-  ReadObjectRequest() = default;
-  ReadObjectRequest(std::string bucket_name, std::string object_name)
-      : impl_(std::move(bucket_name), std::move(object_name)) {}
-
-  std::string const& bucket_name() const { return impl_.bucket_name(); }
-  std::string const& object_name() const { return impl_.object_name(); }
-
-  template <typename... T>
-  ReadObjectRequest& set_multiple_options(T&&... o) & {
-    impl_.set_multiple_options(std::forward<T>(o)...);
-    return *this;
-  }
-  template <typename... T>
-  ReadObjectRequest&& set_multiple_options(T&&... o) && {
-    return std::move(set_multiple_options(std::forward<T>(o)...));
-  }
-
-  template <typename T>
-  bool HasOption() const {
-    return impl_.HasOption<T>();
-  }
-  template <typename T>
-  T GetOption() const {
-    return impl_.GetOption<T>();
-  }
-
- protected:
-  friend class storage_internal::AsyncConnectionImpl;
-  storage::internal::ReadObjectRangeRequest impl_;
-};
-
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage_experimental
 }  // namespace cloud

--- a/google/cloud/storage/benchmarks/async_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/async_throughput_benchmark.cc
@@ -490,7 +490,8 @@ g::future<Result> DownloadOne(Configuration const& cfg,
   auto const transfer_start = std::chrono::system_clock::now();
   auto const start = std::chrono::steady_clock::now();
   auto [reader, token] =
-      (co_await client.ReadObject(cfg.bucket, object_name)).value();
+      (co_await client.ReadObject(gcs_ex::BucketName(cfg.bucket), object_name))
+          .value();
 
   std::int64_t generation = 0;
   std::uint64_t size = 0;

--- a/google/cloud/storage/examples/storage_async_mock_samples.cc
+++ b/google/cloud/storage/examples/storage_async_mock_samples.cc
@@ -81,7 +81,9 @@ TEST(StorageAsyncMockingSamples, MockReadObject) {
   gcs_ex::AsyncReader reader;
   gcs_ex::AsyncToken token;
   std::tie(reader, token) =
-      client.ReadObject("test-bucket", "test-object").get().value();
+      client.ReadObject(gcs_ex::BucketName("test-bucket"), "test-object")
+          .get()
+          .value();
 
   gcs_ex::ReadPayload payload;
   gcs_ex::AsyncToken t;  // Avoid use-after-move warnings from clang-tidy.

--- a/google/cloud/storage/examples/storage_async_samples.cc
+++ b/google/cloud/storage/examples/storage_async_samples.cc
@@ -152,9 +152,10 @@ void ReadObject(google::cloud::storage_experimental::AsyncClient& client,
   auto coro =
       [](gcs_ex::AsyncClient& client, std::string bucket_name,
          std::string object_name) -> google::cloud::future<std::uint64_t> {
-    auto [reader, token] = (co_await client.ReadObject(std::move(bucket_name),
-                                                       std::move(object_name)))
-                               .value();
+    auto [reader, token] =
+        (co_await client.ReadObject(gcs_ex::BucketName(std::move(bucket_name)),
+                                    std::move(object_name)))
+            .value();
     std::uint64_t count = 0;
     while (token.valid()) {
       auto [payload, t] = (co_await reader.Read(std::move(token))).value();
@@ -182,10 +183,12 @@ void ReadObjectWithOptions(
       [](gcs_ex::AsyncClient& client, std::string bucket_name,
          std::string object_name,
          std::int64_t generation) -> google::cloud::future<std::uint64_t> {
-    auto [reader, token] = (co_await client.ReadObject(
-                                std::move(bucket_name), std::move(object_name),
-                                gcs::Generation(generation)))
-                               .value();
+    auto request = google::storage::v2::ReadObjectRequest{};
+    request.set_bucket(gcs_ex::BucketName(std::move(bucket_name)).FullName());
+    request.set_object(std::move(object_name));
+    request.set_generation(generation);
+    auto [reader, token] =
+        (co_await client.ReadObject(std::move(request))).value();
     std::uint64_t count = 0;
     while (token.valid()) {
       auto [payload, t] = (co_await reader.Read(std::move(token))).value();
@@ -202,6 +205,32 @@ void ReadObjectWithOptions(
   auto const count =
       coro(client, argv.at(0), argv.at(1), std::stoll(argv.at(2))).get();
   std::cout << "The object contains " << count << " lines\n";
+}
+
+void ReadObjectRange(google::cloud::storage_experimental::AsyncClient& client,
+                     std::vector<std::string> const& argv) {
+  //! [read-object-range]
+  namespace gcs_ex = google::cloud::storage_experimental;
+  auto coro =
+      [](gcs_ex::AsyncClient& client, std::string bucket_name,
+         std::string object_name) -> google::cloud::future<std::uint64_t> {
+    // Read the first 8 bytes of the object.
+    auto payload = (co_await client.ReadObjectRange(
+                        gcs_ex::BucketName(std::move(bucket_name)),
+                        std::move(object_name), /*offset=*/0, /*limit=*/8))
+                       .value();
+    auto contents = payload.contents();
+    std::uint64_t count = 0;
+    for (auto buffer : contents) {
+      count += std::count(buffer.begin(), buffer.end(), '\n');
+    }
+    co_return count;
+  };
+  //! [read-object-range]
+  // The example is easier to test and run if we call the coroutine and block
+  // until it completes.
+  auto const count = coro(client, argv.at(0), argv.at(1)).get();
+  std::cout << "The object range contains " << count << " lines\n";
 }
 
 void StartBufferedUpload(
@@ -522,6 +551,11 @@ void ReadObject(google::cloud::storage_experimental::AsyncClient&,
   std::cerr << "AsyncClient::ReadObject() example requires coroutines\n";
 }
 
+void ReadObjectRange(google::cloud::storage_experimental::AsyncClient&,
+                     std::vector<std::string> const&) {
+  std::cerr << "AsyncClient::ReadObjectRange() example requires coroutines\n";
+}
+
 void ReadObjectWithOptions(google::cloud::storage_experimental::AsyncClient&,
                            std::vector<std::string> const&) {
   std::cerr << "AsyncClient::ReadObject() example requires coroutines\n";
@@ -745,9 +779,16 @@ void AutoRun(std::vector<std::string> const& argv) {
   std::cout << "Running the ReadObject() example" << std::endl;
   ReadObject(client, {bucket_name, composed_name});
 
+  std::cout << "Running the ReadObjectRange() example" << std::endl;
+  ReadObjectRange(client, {bucket_name, composed_name});
+
   std::cout << "Retrieving object metadata" << std::endl;
   auto response =
-      client.ReadObjectRange(bucket_name, composed_name, 0, 1).get();
+      client
+          .ReadObjectRange(
+              google::cloud::storage_experimental::BucketName(bucket_name),
+              composed_name, 0, 1)
+          .get();
   if (!response.ok()) throw std::move(response).status();
 
   auto const metadata = response->metadata();
@@ -891,13 +932,14 @@ int main(int argc, char* argv[]) try {
       make_entry("insert-object-vector-strings", {}, InsertObjectVectorStrings),
       make_entry("insert-object-vector-vectors", {}, InsertObjectVectorVectors),
       make_entry("read-object", {}, ReadObject),
+      make_entry("read-object-range", {}, ReadObjectRange),
       make_entry("read-object-with-options", {"<generation>"},
                  ReadObjectWithOptions),
       make_entry("compose-object", {"<o1> <o2>"}, ComposeObject),
       make_entry("compose-object-request", {"<o1> <o2>"}, ComposeObjectRequest),
       make_entry("delete-object", {}, AsyncDeleteObject),
 
-      make_entry("buffered-upload", {}, StartBufferedUpload),
+      make_entry("start-buffered-upload", {}, StartBufferedUpload),
       make_entry("suspend-buffered-upload", {}, SuspendBufferedUpload),
       make_resume_entry("resume-buffered-upload", {}, ResumeBufferedUpload),
 

--- a/google/cloud/storage/examples/storage_otel_samples.cc
+++ b/google/cloud/storage/examples/storage_otel_samples.cc
@@ -58,8 +58,9 @@ void InstrumentedClient(std::vector<std::string> const& argv) {
       if (!metadata) throw std::move(metadata).status();
 
       std::int64_t count = 0;
-      auto [reader, token] =
-          (co_await client.ReadObject(bucket_name, object_name)).value();
+      auto [reader, token] = (co_await client.ReadObject(
+                                  gcs_ex::BucketName(bucket_name), object_name))
+                                 .value();
       while (token.valid()) {
         auto [payload, t] = (co_await reader.Read(std::move(token))).value();
         token = std::move(t);

--- a/google/cloud/storage/internal/async/connection_impl.h
+++ b/google/cloud/storage/internal/async/connection_impl.h
@@ -89,8 +89,7 @@ class AsyncConnectionImpl
   // new `AsyncReaderConnection` instances at different offsets.
   AsyncReaderConnectionFactory MakeReaderConnectionFactory(
       google::cloud::internal::ImmutableOptions current,
-      google::cloud::storage_experimental::ReadObjectRequest request,
-      google::storage::v2::ReadObjectRequest proto_request,
+      google::storage::v2::ReadObjectRequest request,
       std::shared_ptr<storage::internal::HashFunction> hash_function);
 
  private:

--- a/google/cloud/storage/quickstart/quickstart_async.cc
+++ b/google/cloud/storage/quickstart/quickstart_async.cc
@@ -41,7 +41,10 @@ int main(int argc, char* argv[]) {
           });
   done.get();
 
-  done = client.ReadObjectRange(bucket_name, kObjectName, 0, 1000)
+  done = client
+             .ReadObjectRange(
+                 google::cloud::storage_experimental::BucketName(bucket_name),
+                 kObjectName, 0, 1000)
              .then([](auto f) {
                auto payload = f.get();
                if (!payload) {

--- a/google/cloud/storage/tests/async_client_integration_test.cc
+++ b/google/cloud/storage/tests/async_client_integration_test.cc
@@ -78,10 +78,10 @@ TEST_F(AsyncClientIntegrationTest, ObjectCRUD) {
   ASSERT_STATUS_OK(insert);
   ScheduleForDelete(*insert);
 
-  auto pending0 =
-      async.ReadObjectRange(bucket_name(), object_name, 0, LoremIpsum().size());
-  auto pending1 =
-      async.ReadObjectRange(bucket_name(), object_name, 0, LoremIpsum().size());
+  auto pending0 = async.ReadObjectRange(BucketName(bucket_name()), object_name,
+                                        0, LoremIpsum().size());
+  auto pending1 = async.ReadObjectRange(BucketName(bucket_name()), object_name,
+                                        0, LoremIpsum().size());
 
   for (auto* p : {&pending1, &pending0}) {
     auto response = p->get();
@@ -138,7 +138,7 @@ TEST_F(AsyncClientIntegrationTest, ComposeObject) {
   ScheduleForDelete(*composed);
 
   auto read = async
-                  .ReadObjectRange(bucket_name(), destination, 0,
+                  .ReadObjectRange(BucketName(bucket_name()), destination, 0,
                                    2 * LoremIpsum().size())
                   .get();
   ASSERT_STATUS_OK(read);
@@ -178,7 +178,7 @@ TEST_F(AsyncClientIntegrationTest, StreamingRead) {
 
   ASSERT_EQ(insert->size(), expected_size);
 
-  auto r = async.ReadObject(bucket_name(), object_name).get();
+  auto r = async.ReadObject(BucketName(bucket_name()), object_name).get();
   ASSERT_STATUS_OK(r);
   AsyncReader reader;
   AsyncToken token;

--- a/google/cloud/storage/tests/smoke_test_async.cc
+++ b/google/cloud/storage/tests/smoke_test_async.cc
@@ -37,7 +37,7 @@ TEST(SmokeTest, Grpc) {
       GetEnv("GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME").value_or("");
   if (bucket_name.empty()) GTEST_SKIP();
 
-  auto client = google::cloud::storage_experimental::AsyncClient();
+  auto client = AsyncClient();
   auto gen = google::cloud::internal::MakeDefaultPRNG();
   auto object_name = google::cloud::storage::testing::MakeRandomObjectName(gen);
 
@@ -48,11 +48,11 @@ TEST(SmokeTest, Grpc) {
   ASSERT_STATUS_OK(insert);
   auto metadata = *insert;
 
-  auto payload =
-      client
-          .ReadObjectRange(bucket_name, metadata.name(), 0, 1024,
-                           storage::Generation(metadata.generation()))
-          .get();
+  auto request = google::storage::v2::ReadObjectRequest{};
+  request.set_bucket(BucketName(bucket_name).FullName());
+  request.set_object(metadata.name());
+  request.set_generation(metadata.generation());
+  auto payload = client.ReadObjectRange(std::move(request), 0, 1024).get();
   ASSERT_STATUS_OK(payload);
   std::string contents;
   for (auto v : payload->contents()) contents += std::string(v);


### PR DESCRIPTION
Part of the work for #13910

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14032)
<!-- Reviewable:end -->
