### PR TITLE
cleanup(beyondcorp): remove unused bazel deps

### DIFF
--- a/google/cloud/beyondcorp/BUILD.bazel
+++ b/google/cloud/beyondcorp/BUILD.bazel
@@ -58,8 +58,6 @@ cc_library(
         "@com_google_googleapis//google/cloud/beyondcorp/appconnections/v1:appconnections_cc_grpc",
         "@com_google_googleapis//google/cloud/beyondcorp/appconnectors/v1:appconnectors_cc_grpc",
         "@com_google_googleapis//google/cloud/beyondcorp/appgateways/v1:appgateways_cc_grpc",
-        "@com_google_googleapis//google/cloud/beyondcorp/clientconnectorservices/v1:clientconnectorservices_cc_grpc",
-        "@com_google_googleapis//google/cloud/beyondcorp/clientgateways/v1:clientgateways_cc_grpc",
     ],
 )
 


### PR DESCRIPTION
A minor thing we missed in https://github.com/googleapis/google-cloud-cpp/pull/12498

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14041)
<!-- Reviewable:end -->
