### PR TITLE
fix(pubsub): correctly trace modacks in the unary pull

### DIFF
--- a/google/cloud/pubsub/internal/default_pull_lease_manager.h
+++ b/google/cloud/pubsub/internal/default_pull_lease_manager.h
@@ -33,6 +33,20 @@ namespace cloud {
 namespace pubsub_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+class DefaultPullLeaseManagerImpl : public PullLeaseManagerImpl {
+ public:
+  DefaultPullLeaseManagerImpl() = default;
+
+  future<Status> AsyncModifyAckDeadline(
+      std::shared_ptr<SubscriberStub> stub, google::cloud::CompletionQueue& cq,
+      std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
+      google::pubsub::v1::ModifyAckDeadlineRequest const& request) override {
+    return stub->AsyncModifyAckDeadline(cq, std::move(context),
+                                        std::move(options), request);
+  }
+};
+
 /**
  * Maintains the lease for a single message.
  */
@@ -45,6 +59,7 @@ class DefaultPullLeaseManager
   DefaultPullLeaseManager(
       CompletionQueue cq, std::weak_ptr<SubscriberStub> w, Options options,
       pubsub::Subscription subscription, std::string ack_id,
+      std::shared_ptr<PullLeaseManagerImpl> impl,
       std::shared_ptr<Clock> clock = std::make_shared<Clock>());
   ~DefaultPullLeaseManager() override;
 
@@ -76,6 +91,7 @@ class DefaultPullLeaseManager
   google::cloud::internal::ImmutableOptions options_;
   pubsub::Subscription subscription_;
   std::string ack_id_;
+  std::shared_ptr<PullLeaseManagerImpl> impl_;
   std::shared_ptr<Clock> clock_;
   // The absolute deadline to complete processing the message.
   // The application can configure this value using

--- a/google/cloud/pubsub/internal/pull_lease_manager.h
+++ b/google/cloud/pubsub/internal/pull_lease_manager.h
@@ -53,6 +53,19 @@ class PullLeaseManager {
   }
 };
 
+/**
+ * Interface to make a modify ack deadline rpc request.
+ */
+class PullLeaseManagerImpl {
+ public:
+  virtual ~PullLeaseManagerImpl() = default;
+  virtual future<Status> AsyncModifyAckDeadline(
+      std::shared_ptr<SubscriberStub> stub, google::cloud::CompletionQueue& cq,
+      std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
+      google::pubsub::v1::ModifyAckDeadlineRequest const& request) = 0;
+};
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace pubsub_internal
 }  // namespace cloud

--- a/google/cloud/pubsub/internal/pull_lease_manager_factory.cc
+++ b/google/cloud/pubsub/internal/pull_lease_manager_factory.cc
@@ -38,9 +38,6 @@ std::shared_ptr<PullLeaseManager> MakePullLeaseManager(
       std::make_shared<pubsub_internal::DefaultPullLeaseManager>(
           std::move(cq), std::move(stub), options, std::move(subscription),
           std::move(ack_id), std::move(manager_impl), std::move(clock));
-  if (internal::TracingEnabled(options)) {
-    manager = MakeTracingPullLeaseManager(std::move(manager));
-  }
   return manager;
 }
 

--- a/google/cloud/pubsub/internal/pull_lease_manager_factory.cc
+++ b/google/cloud/pubsub/internal/pull_lease_manager_factory.cc
@@ -28,10 +28,16 @@ std::shared_ptr<PullLeaseManager> MakePullLeaseManager(
     CompletionQueue cq, std::weak_ptr<SubscriberStub> stub,
     pubsub::Subscription subscription, std::string ack_id,
     Options const& options, std::shared_ptr<Clock> clock) {
+  std::shared_ptr<PullLeaseManagerImpl> manager_impl =
+      std::make_shared<pubsub_internal::DefaultPullLeaseManagerImpl>();
+  if (internal::TracingEnabled(options)) {
+    manager_impl = MakeTracingPullLeaseManagerImpl(std::move(manager_impl),
+                                                   ack_id, subscription);
+  }
   std::shared_ptr<PullLeaseManager> manager =
       std::make_shared<pubsub_internal::DefaultPullLeaseManager>(
           std::move(cq), std::move(stub), options, std::move(subscription),
-          std::move(ack_id), std::move(clock));
+          std::move(ack_id), std::move(manager_impl), std::move(clock));
   if (internal::TracingEnabled(options)) {
     manager = MakeTracingPullLeaseManager(std::move(manager));
   }

--- a/google/cloud/pubsub/internal/tracing_pull_lease_manager.h
+++ b/google/cloud/pubsub/internal/tracing_pull_lease_manager.h
@@ -27,9 +27,6 @@ std::shared_ptr<PullLeaseManagerImpl> MakeTracingPullLeaseManagerImpl(
     std::shared_ptr<PullLeaseManagerImpl> manager, std::string ack_id,
     pubsub::Subscription subscription);
 
-std::shared_ptr<PullLeaseManager> MakeTracingPullLeaseManager(
-    std::shared_ptr<PullLeaseManager> manager);
-
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace pubsub_internal
 }  // namespace cloud

--- a/google/cloud/pubsub/internal/tracing_pull_lease_manager.h
+++ b/google/cloud/pubsub/internal/tracing_pull_lease_manager.h
@@ -23,6 +23,10 @@ namespace cloud {
 namespace pubsub_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+std::shared_ptr<PullLeaseManagerImpl> MakeTracingPullLeaseManagerImpl(
+    std::shared_ptr<PullLeaseManagerImpl> manager, std::string ack_id,
+    pubsub::Subscription subscription);
+
 std::shared_ptr<PullLeaseManager> MakeTracingPullLeaseManager(
     std::shared_ptr<PullLeaseManager> manager);
 

--- a/google/cloud/pubsub/internal/tracing_pull_lease_manager_test.cc
+++ b/google/cloud/pubsub/internal/tracing_pull_lease_manager_test.cc
@@ -47,7 +47,6 @@ using ::testing::_;
 using ::testing::AllOf;
 using ::testing::ByMove;
 using ::testing::Contains;
-using ::testing::IsEmpty;
 using ::testing::Return;
 
 pubsub::Subscription const kTestSubscription =

--- a/google/cloud/pubsub/internal/tracing_pull_lease_manager_test.cc
+++ b/google/cloud/pubsub/internal/tracing_pull_lease_manager_test.cc
@@ -18,8 +18,10 @@
 #include "google/cloud/pubsub/subscription.h"
 #include "google/cloud/pubsub/testing/mock_pull_lease_manager.h"
 #include "google/cloud/pubsub/testing/mock_subscriber_stub.h"
+#include "google/cloud/pubsub/testing/test_retry_policies.h"
 #include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
+#include "google/cloud/testing_util/mock_completion_queue_impl.h"
 #include "google/cloud/testing_util/opentelemetry_matchers.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
@@ -31,7 +33,7 @@ namespace pubsub_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-using ::google::cloud::pubsub_testing::MockPullLeaseManager;
+using ::google::cloud::pubsub_testing::MockPullLeaseManagerImpl;
 using ::google::cloud::pubsub_testing::MockSubscriberStub;
 using ::google::cloud::testing_util::InstallSpanCatcher;
 using ::google::cloud::testing_util::OTelAttribute;
@@ -54,23 +56,25 @@ auto constexpr kTestAckId = "test-ack-id";
 auto constexpr kLeaseExtension = std::chrono::seconds(10);
 auto const kCurrentTime = std::chrono::system_clock::now();
 
-std::shared_ptr<PullLeaseManager> MakeTestPullLeaseManager(
-    std::shared_ptr<MockPullLeaseManager> mock) {
-  EXPECT_CALL(*mock, ack_id()).WillRepeatedly(Return(kTestAckId));
-  EXPECT_CALL(*mock, subscription()).WillRepeatedly(Return(kTestSubscription));
-
-  return MakeTracingPullLeaseManager(std::move(mock));
-}
-
-TEST(TracingPullLeaseManagerTest, ExtendSuccess) {
+TEST(TracingPullLeaseManagerImplTest, AsyncModifyAckDeadlineSuccess) {
   auto span_catcher = InstallSpanCatcher();
-  auto mock = std::make_unique<MockPullLeaseManager>();
-  EXPECT_CALL(*mock, ExtendLease(_, _, _))
+  auto mock = std::make_shared<MockPullLeaseManagerImpl>();
+  EXPECT_CALL(*mock, AsyncModifyAckDeadline(_, _, _, _, _))
       .WillOnce(Return(ByMove(make_ready_future(Status{}))));
-  auto manager = MakeTestPullLeaseManager(std::move(mock));
+  auto manager = MakeTracingPullLeaseManagerImpl(std::move(mock), kTestAckId,
+                                                 kTestSubscription);
   auto stub = std::make_shared<MockSubscriberStub>();
+  auto impl = std::make_shared<testing_util::MockCompletionQueueImpl>();
+  CompletionQueue cq = CompletionQueue(std::move(impl));
+  std::shared_ptr<grpc::ClientContext> context;
+  auto options = google::cloud::internal::MakeImmutableOptions(
+      google::cloud::pubsub_testing::MakeTestOptions());
+  google::pubsub::v1::ModifyAckDeadlineRequest request;
+  request.set_ack_deadline_seconds(
+      static_cast<std::int32_t>(kLeaseExtension.count()));
 
-  auto status = manager->ExtendLease(stub, kCurrentTime, kLeaseExtension);
+  auto status =
+      manager->AsyncModifyAckDeadline(stub, cq, context, options, request);
   EXPECT_STATUS_OK(status.get());
 
   auto spans = span_catcher->GetSpans();
@@ -80,16 +84,26 @@ TEST(TracingPullLeaseManagerTest, ExtendSuccess) {
                          SpanNamed("test-subscription modack"))));
 }
 
-TEST(TracingPullLeaseManagerTest, ExtendError) {
+TEST(TracingPullLeaseManagerImplTest, AsyncModifyAckDeadlineError) {
   auto span_catcher = InstallSpanCatcher();
-  auto mock = std::make_unique<MockPullLeaseManager>();
-  EXPECT_CALL(*mock, ExtendLease(_, _, _))
+  auto mock = std::make_shared<MockPullLeaseManagerImpl>();
+  EXPECT_CALL(*mock, AsyncModifyAckDeadline(_, _, _, _, _))
       .WillOnce(Return(ByMove(
           make_ready_future(Status{StatusCode::kPermissionDenied, "uh-oh"}))));
-  auto manager = MakeTestPullLeaseManager(std::move(mock));
+  auto manager = MakeTracingPullLeaseManagerImpl(std::move(mock), kTestAckId,
+                                                 kTestSubscription);
   auto stub = std::make_shared<MockSubscriberStub>();
+  auto impl = std::make_shared<testing_util::MockCompletionQueueImpl>();
+  CompletionQueue cq = CompletionQueue(std::move(impl));
+  std::shared_ptr<grpc::ClientContext> context;
+  auto options = google::cloud::internal::MakeImmutableOptions(
+      google::cloud::pubsub_testing::MakeTestOptions());
+  google::pubsub::v1::ModifyAckDeadlineRequest request;
+  request.set_ack_deadline_seconds(
+      static_cast<std::int32_t>(kLeaseExtension.count()));
 
-  auto status = manager->ExtendLease(stub, kCurrentTime, kLeaseExtension);
+  auto status =
+      manager->AsyncModifyAckDeadline(stub, cq, context, options, request);
   EXPECT_THAT(status.get(), StatusIs(StatusCode::kPermissionDenied, "uh-oh"));
 
   auto spans = span_catcher->GetSpans();
@@ -99,16 +113,26 @@ TEST(TracingPullLeaseManagerTest, ExtendError) {
                      SpanNamed("test-subscription modack"))));
 }
 
-TEST(TracingPullLeaseManagerTest, ExtendAttributes) {
+TEST(TracingPullLeaseManagerImplTest, AsyncModifyAckDeadlineAttributes) {
   namespace sc = ::opentelemetry::trace::SemanticConventions;
   auto span_catcher = InstallSpanCatcher();
-  auto mock = std::make_unique<MockPullLeaseManager>();
-  EXPECT_CALL(*mock, ExtendLease(_, _, _))
+  auto mock = std::make_shared<MockPullLeaseManagerImpl>();
+  EXPECT_CALL(*mock, AsyncModifyAckDeadline(_, _, _, _, _))
       .WillOnce(Return(ByMove(make_ready_future(Status{}))));
-  auto manager = MakeTestPullLeaseManager(std::move(mock));
+  auto manager = MakeTracingPullLeaseManagerImpl(std::move(mock), kTestAckId,
+                                                 kTestSubscription);
   auto stub = std::make_shared<MockSubscriberStub>();
+  auto impl = std::make_shared<testing_util::MockCompletionQueueImpl>();
+  CompletionQueue cq = CompletionQueue(std::move(impl));
+  std::shared_ptr<grpc::ClientContext> context;
+  auto options = google::cloud::internal::MakeImmutableOptions(
+      google::cloud::pubsub_testing::MakeTestOptions());
+  google::pubsub::v1::ModifyAckDeadlineRequest request;
+  request.set_ack_deadline_seconds(
+      static_cast<std::int32_t>(kLeaseExtension.count()));
 
-  auto status = manager->ExtendLease(stub, kCurrentTime, kLeaseExtension);
+  auto status =
+      manager->AsyncModifyAckDeadline(stub, cq, context, options, request);
   EXPECT_STATUS_OK(status.get());
 
   auto spans = span_catcher->GetSpans();
@@ -151,18 +175,28 @@ TEST(TracingPullLeaseManagerTest, ExtendAttributes) {
 
 using ::google::cloud::testing_util::SpanLinksSizeIs;
 
-TEST(TracingPullLeaseManagerTest, ExtendAddsLink) {
+TEST(TracingPullLeaseManagerImplTest, AsyncModifyAckDeadlineAddsLink) {
   auto span_catcher = InstallSpanCatcher();
   auto consumer_span = internal::MakeSpan("receive");
   auto scope = internal::OTelScope(consumer_span);
-  auto mock = std::make_unique<MockPullLeaseManager>();
-  EXPECT_CALL(*mock, ExtendLease(_, _, _))
+  auto mock = std::make_shared<MockPullLeaseManagerImpl>();
+  EXPECT_CALL(*mock, AsyncModifyAckDeadline(_, _, _, _, _))
       .WillOnce(Return(ByMove(make_ready_future(Status{}))));
-  auto manager = MakeTestPullLeaseManager(std::move(mock));
+  auto manager = MakeTracingPullLeaseManagerImpl(std::move(mock), kTestAckId,
+                                                 kTestSubscription);
   auto stub = std::make_shared<MockSubscriberStub>();
+  auto impl = std::make_shared<testing_util::MockCompletionQueueImpl>();
+  CompletionQueue cq = CompletionQueue(std::move(impl));
+  std::shared_ptr<grpc::ClientContext> context;
+  auto options = google::cloud::internal::MakeImmutableOptions(
+      google::cloud::pubsub_testing::MakeTestOptions());
+  google::pubsub::v1::ModifyAckDeadlineRequest request;
+  request.set_ack_deadline_seconds(
+      static_cast<std::int32_t>(kLeaseExtension.count()));
   consumer_span->End();
 
-  auto status = manager->ExtendLease(stub, kCurrentTime, kLeaseExtension);
+  auto status =
+      manager->AsyncModifyAckDeadline(stub, cq, context, options, request);
   EXPECT_STATUS_OK(status.get());
 
   auto spans = span_catcher->GetSpans();
@@ -172,18 +206,28 @@ TEST(TracingPullLeaseManagerTest, ExtendAddsLink) {
 
 #else
 
-TEST(TracingPullLeaseManagerTest, ExtendAddsSpanIdAndTraceIdAttribute) {
+TEST(TracingPullLeaseManagerImplTest, ExtendAddsSpanIdAndTraceIdAttribute) {
   auto span_catcher = InstallSpanCatcher();
   auto consumer_span = internal::MakeSpan("receive");
   auto scope = internal::OTelScope(consumer_span);
-  auto mock = std::make_unique<MockPullLeaseManager>();
-  EXPECT_CALL(*mock, ExtendLease(_, _, _))
+  auto mock = std::make_shared<MockPullLeaseManagerImpl>();
+  EXPECT_CALL(*mock, AsyncModifyAckDeadline(_, _, _, _, _))
       .WillOnce(Return(ByMove(make_ready_future(Status{}))));
-  auto manager = MakeTestPullLeaseManager(std::move(mock));
+  auto manager = MakeTracingPullLeaseManagerImpl(std::move(mock), kTestAckId,
+                                                 kTestSubscription);
   auto stub = std::make_shared<MockSubscriberStub>();
+  auto impl = std::make_shared<testing_util::MockCompletionQueueImpl>();
+  CompletionQueue cq = CompletionQueue(std::move(impl));
+  std::shared_ptr<grpc::ClientContext> context;
+  auto options = google::cloud::internal::MakeImmutableOptions(
+      google::cloud::pubsub_testing::MakeTestOptions());
+  google::pubsub::v1::ModifyAckDeadlineRequest request;
+  request.set_ack_deadline_seconds(
+      static_cast<std::int32_t>(kLeaseExtension.count()));
   consumer_span->End();
 
-  auto status = manager->ExtendLease(stub, kCurrentTime, kLeaseExtension);
+  auto status =
+      manager->AsyncModifyAckDeadline(stub, cq, context, options, request);
   EXPECT_STATUS_OK(status.get());
 
   auto spans = span_catcher->GetSpans();
@@ -197,28 +241,6 @@ TEST(TracingPullLeaseManagerTest, ExtendAddsSpanIdAndTraceIdAttribute) {
 }
 
 #endif
-
-TEST(TracingPullLeaseManagerTest, AckIdNoSpans) {
-  auto span_catcher = InstallSpanCatcher();
-  auto mock = std::make_unique<MockPullLeaseManager>();
-  auto manager = MakeTestPullLeaseManager(std::move(mock));
-
-  EXPECT_EQ(kTestAckId, manager->ack_id());
-
-  auto spans = span_catcher->GetSpans();
-  EXPECT_THAT(spans, IsEmpty());
-}
-
-TEST(TracingPullLeaseManagerTest, SubscriptionNoSpans) {
-  auto span_catcher = InstallSpanCatcher();
-  auto mock = std::make_unique<MockPullLeaseManager>();
-  auto manager = MakeTestPullLeaseManager(std::move(mock));
-
-  EXPECT_EQ(kTestSubscription, manager->subscription());
-
-  auto spans = span_catcher->GetSpans();
-  EXPECT_THAT(spans, IsEmpty());
-}
 
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsub/testing/mock_pull_lease_manager.h
+++ b/google/cloud/pubsub/testing/mock_pull_lease_manager.h
@@ -43,6 +43,17 @@ class MockPullLeaseManager : public pubsub_internal::PullLeaseManager {
   MOCK_METHOD(pubsub::Subscription, subscription, (), (const, override));
 };
 
+class MockPullLeaseManagerImpl : public pubsub_internal::PullLeaseManagerImpl {
+ public:
+  MOCK_METHOD(future<Status>, AsyncModifyAckDeadline,
+              (std::shared_ptr<pubsub_internal::SubscriberStub> stub,
+               google::cloud::CompletionQueue& cq,
+               std::shared_ptr<grpc::ClientContext> context,
+               google::cloud::internal::ImmutableOptions options,
+               google::pubsub::v1::ModifyAckDeadlineRequest const& request),
+              (override));
+};
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace pubsub_testing
 }  // namespace cloud


### PR DESCRIPTION
- refactor(pubsub): create pull manager impl to wrap the modack rpc
- test(pubsub): use the mock pull lease manager impl in the tracing unittest
- refactor(pubsub): remove tracing lease manager class
- test(pubsub): add a test for the default pull lease manager impl

I split up the commits for easier reading, if reviewers prefer I can merge them lmk. 

Fixes https://github.com/googleapis/google-cloud-cpp/issues/14020

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14049)
<!-- Reviewable:end -->
