### PR TITLE
fix(bigquery): use `absl::optional` for fields in job related structs

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/job.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job.cc
@@ -25,25 +25,25 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 std::string JobReference::DebugString(absl::string_view name,
                                       TracingOptions const& options,
                                       int indent) const {
-  return internal::DebugFormatter(name, options, indent)
-      .StringField("project_id", project_id)
-      .StringField("job_id", job_id)
-      .StringField("location", location)
-      .Build();
+  auto f = internal::DebugFormatter(name, options, indent);
+  if (project_id) f.StringField("project_id", *project_id);
+  if (job_id) f.StringField("job_id", *job_id);
+  if (location) f.StringField("location", *location);
+  return f.Build();
 }
 
 std::string Job::DebugString(absl::string_view name,
                              TracingOptions const& options, int indent) const {
-  return internal::DebugFormatter(name, options, indent)
-      .StringField("etag", etag)
-      .StringField("kind", kind)
-      .StringField("self_link", self_link)
-      .StringField("id", id)
-      .SubMessage("configuration", configuration)
-      .SubMessage("reference", job_reference)
-      .SubMessage("status", status)
-      .SubMessage("statistics", statistics)
-      .Build();
+  auto f = internal::DebugFormatter(name, options, indent);
+  if (kind) f.StringField("kind", *kind);
+  if (etag) f.StringField("etag", *etag);
+  if (self_link) f.StringField("self_link", *self_link);
+  if (id) f.StringField("id", *id);
+  if (configuration) f.SubMessage("configuration", *configuration);
+  if (job_reference) f.SubMessage("reference", *job_reference);
+  if (status) f.SubMessage("status", *status);
+  if (statistics) f.SubMessage("statistics", *statistics);
+  return f.Build();
 }
 
 std::string ListFormatJob::DebugString(absl::string_view name,
@@ -83,9 +83,9 @@ void from_json(nlohmann::json const& j, JobStatus& jb) {
 }
 
 void to_json(nlohmann::json& j, JobReference const& jb) {
-  j = nlohmann::json{{"projectId", jb.project_id},
-                     {"jobId", jb.job_id},
-                     {"location", jb.location}};
+  if (jb.project_id) j["projectId"] = *jb.project_id;
+  if (jb.job_id) j["jobId"] = *jb.job_id;
+  if (jb.location) j["location"] = *jb.location;
 }
 void from_json(nlohmann::json const& j, JobReference& jb) {
   SafeGetTo(jb.project_id, j, "projectId");
@@ -94,15 +94,15 @@ void from_json(nlohmann::json const& j, JobReference& jb) {
 }
 
 void to_json(nlohmann::json& j, Job const& jb) {
-  j = nlohmann::json{{"kind", jb.kind},
-                     {"etag", jb.etag},
-                     {"id", jb.id},
-                     {"selfLink", jb.self_link},
-                     {"user_email", jb.user_email},
-                     {"status", jb.status},
-                     {"jobReference", jb.job_reference},
-                     {"configuration", jb.configuration},
-                     {"statistics", jb.statistics}};
+  if (jb.kind) j["kind"] = *jb.kind;
+  if (jb.etag) j["etag"] = *jb.etag;
+  if (jb.id) j["id"] = *jb.id;
+  if (jb.self_link) j["selfLink"] = *jb.self_link;
+  if (jb.user_email) j["user_email"] = *jb.user_email;
+  if (jb.status) j["status"] = *jb.status;
+  if (jb.job_reference) j["jobReference"] = *jb.job_reference;
+  if (jb.configuration) j["configuration"] = *jb.configuration;
+  if (jb.statistics) j["statistics"] = *jb.statistics;
 }
 void from_json(nlohmann::json const& j, Job& jb) {
   SafeGetTo(jb.kind, j, "kind");

--- a/google/cloud/bigquery/v2/minimal/internal/job.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job.h
@@ -42,9 +42,9 @@ void to_json(nlohmann::json& j, JobStatus const& jb);
 void from_json(nlohmann::json const& j, JobStatus& jb);
 
 struct JobReference {
-  std::string project_id;
-  std::string job_id;
-  std::string location;
+  absl::optional<std::string> project_id;
+  absl::optional<std::string> job_id;
+  absl::optional<std::string> location;
 
   std::string DebugString(absl::string_view name,
                           TracingOptions const& options = {},
@@ -54,16 +54,16 @@ void to_json(nlohmann::json& j, JobReference const& jb);
 void from_json(nlohmann::json const& j, JobReference& jb);
 
 struct Job {
-  std::string kind;
-  std::string etag;
-  std::string id;
-  std::string self_link;
-  std::string user_email;
+  absl::optional<std::string> kind;
+  absl::optional<std::string> etag;
+  absl::optional<std::string> id;
+  absl::optional<std::string> self_link;
+  absl::optional<std::string> user_email;
 
-  JobStatus status;
-  JobReference job_reference;
-  JobConfiguration configuration;
-  JobStatistics statistics;
+  absl::optional<JobStatus> status;
+  absl::optional<JobReference> job_reference;
+  absl::optional<JobConfiguration> configuration;
+  absl::optional<JobStatistics> statistics;
 
   std::string DebugString(absl::string_view name,
                           TracingOptions const& options = {},

--- a/google/cloud/bigquery/v2/minimal/internal/job_configuration.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_configuration.cc
@@ -25,22 +25,22 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 std::string JobConfiguration::DebugString(absl::string_view name,
                                           TracingOptions const& options,
                                           int indent) const {
-  return internal::DebugFormatter(name, options, indent)
-      .StringField("job_type", job_type)
-      .Field("dry_run", dry_run)
-      .Field("job_timeout", job_timeout)
-      .Field("labels", labels)
-      .SubMessage("query_config", query)
-      .Build();
+  
+  auto f = internal::DebugFormatter(name, options, indent);
+  if (job_type) f.StringField("job_type", *job_type);
+  if (dry_run) f.Field("dry_run", *dry_run);
+  if (job_timeout) f.Field("job_timeout", *job_timeout);
+  if (labels) f.Field("labels", *labels);
+  if (query) f.SubMessage("query_config", *query);
+  return f.Build();
 }
 
 void to_json(nlohmann::json& j, JobConfiguration const& c) {
-  j = nlohmann::json{{"jobType", c.job_type},
-                     {"query", c.query},
-                     {"dryRun", c.dry_run},
-                     {"labels", c.labels}};
-
-  ToJson(c.job_timeout, j, "jobTimeoutMs");
+  if (c.job_type) j["jobType"] = *c.job_type;
+  if (c.query) j["query"] = *c.query;
+  if (c.dry_run) j["dryRun"] = *c.dry_run;
+  if (c.labels) j["labels"] = *c.labels;
+  if (c.job_timeout) ToJson(c.job_timeout.value(), j, "jobTimeoutMs");
 }
 void from_json(nlohmann::json const& j, JobConfiguration& c) {
   SafeGetTo(c.job_type, j, "jobType");

--- a/google/cloud/bigquery/v2/minimal/internal/job_configuration.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_configuration.h
@@ -20,6 +20,7 @@
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
 #include "absl/strings/string_view.h"
+#include "absl/types/optional.h"
 #include <nlohmann/json.hpp>
 #include <chrono>
 #include <string>
@@ -30,12 +31,12 @@ namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 struct JobConfiguration {
-  std::string job_type;
-  bool dry_run = false;
-  std::chrono::milliseconds job_timeout = std::chrono::milliseconds(0);
-  std::map<std::string, std::string> labels;
+  absl::optional<std::string> job_type;
+  absl::optional<bool> dry_run;
+  absl::optional<std::chrono::milliseconds> job_timeout;
+  absl::optional<std::map<std::string, std::string>> labels;
 
-  JobConfigurationQuery query;
+  absl::optional<JobConfigurationQuery> query;
 
   std::string DebugString(absl::string_view name,
                           TracingOptions const& options = {},

--- a/google/cloud/bigquery/v2/minimal/internal/job_configuration_query.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_configuration_query.cc
@@ -25,60 +25,58 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 std::string JobConfigurationQuery::DebugString(absl::string_view name,
                                                TracingOptions const& options,
                                                int indent) const {
-  return internal::DebugFormatter(name, options, indent)
-      .StringField("query", query)
-      .StringField("create_disposition", create_disposition)
-      .StringField("write_disposition", write_disposition)
-      .StringField("priority", priority)
-      .StringField("parameter_mode", parameter_mode)
-      .Field("preserve_nulls", preserve_nulls)
-      .Field("allow_large_results", allow_large_results)
-      .Field("use_query_cache", use_query_cache)
-      .Field("flatten_results", flatten_results)
-      .Field("use_legacy_sql", use_legacy_sql)
-      .Field("create_session", create_session)
-      .Field("maximum_bytes_billed", maximum_bytes_billed)
-      .Field("schema_update_options", schema_update_options)
-      .Field("connection_properties", connection_properties)
-      .Field("query_parameters", query_parameters)
-      .SubMessage("default_dataset", default_dataset)
-      .SubMessage("destination_table", destination_table)
-      .SubMessage("time_partitioning", time_partitioning)
-      .SubMessage("range_partitioning", range_partitioning)
-      .SubMessage("clustering", clustering)
-      .SubMessage("destination_encryption_configuration",
-                  destination_encryption_configuration)
-      .SubMessage("script_options", script_options)
-      .SubMessage("system_variables", system_variables)
-      .Build();
+  auto f = internal::DebugFormatter(name, options, indent);
+  if (query) f.StringField("query", *query);
+  if (create_disposition) f.StringField("create_disposition", *create_disposition);
+  if (write_disposition) f.StringField("write_disposition", *write_disposition);
+  if (priority) f.StringField("priority", *priority);
+  if (parameter_mode) f.StringField("parameter_mode", *parameter_mode);
+  if (preserve_nulls) f.Field("preserve_nulls", *preserve_nulls);
+  if (allow_large_results) f.Field("allow_large_results", *allow_large_results);
+  if (use_query_cache) f.Field("use_query_cache", *use_query_cache);
+  if (flatten_results) f.Field("flatten_results", *flatten_results);
+  if (use_legacy_sql) f.Field("use_legacy_sql", *use_legacy_sql);
+  if (create_session) f.Field("create_session", *create_session);
+  if (maximum_bytes_billed) f.Field("maximum_bytes_billed", *maximum_bytes_billed);
+  if (schema_update_options) f.Field("schema_update_options", *schema_update_options);
+  if (connection_properties) f.Field("connection_properties", *connection_properties);
+  if (query_parameters) f.Field("query_parameters", *query_parameters);
+  if (default_dataset) f.SubMessage("default_dataset", *default_dataset);
+  if (destination_table) f.SubMessage("destination_table", *destination_table);
+  if (time_partitioning) f.SubMessage("time_partitioning", *time_partitioning);
+  if (range_partitioning) f.SubMessage("range_partitioning", *range_partitioning);
+  if (clustering) f.SubMessage("clustering", *clustering);
+  if (destination_encryption_configuration) f.SubMessage("destination_encryption_configuration",
+                                                        *destination_encryption_configuration);
+  if (script_options) f.SubMessage("script_options", *script_options);
+  if (system_variables) f.SubMessage("system_variables", *system_variables);
+  return f.Build();
 }
 
 void to_json(nlohmann::json& j, JobConfigurationQuery const& c) {
-  j = nlohmann::json{
-      {"query", c.query},
-      {"createDisposition", c.create_disposition},
-      {"writeDisposition", c.write_disposition},
-      {"priority", c.priority},
-      {"parameterMode", c.parameter_mode},
-      {"preserveNulls", c.preserve_nulls},
-      {"allowLargeResults", c.allow_large_results},
-      {"useQueryCache", c.use_query_cache},
-      {"flattenResults", c.flatten_results},
-      {"useLegacySql", c.use_legacy_sql},
-      {"createSession", c.create_session},
-      {"maximumBytesBilled", std::to_string(c.maximum_bytes_billed)},
-      {"queryParameters", c.query_parameters},
-      {"schemaUpdateOptions", c.schema_update_options},
-      {"connectionProperties", c.connection_properties},
-      {"defaultDataset", c.default_dataset},
-      {"destinationTable", c.destination_table},
-      {"timePartitioning", c.time_partitioning},
-      {"rangePartitioning", c.range_partitioning},
-      {"clustering", c.clustering},
-      {"destinationEncryptionConfiguration",
-       c.destination_encryption_configuration},
-      {"scriptOptions", c.script_options},
-      {"systemVariables", c.system_variables}};
+  if (c.query) j["query"] = *c.query;
+  if (c.create_disposition) j["createDisposition"] = *c.create_disposition;
+  if (c.write_disposition) j["writeDisposition"] = *c.write_disposition;
+  if (c.priority) j["priority"] = *c.priority;
+  if (c.parameter_mode) j["parameterMode"] = *c.parameter_mode;
+  if (c.preserve_nulls) j["preserveNulls"] = *c.preserve_nulls;
+  if (c.allow_large_results) j["allowLargeResults"] = *c.allow_large_results;
+  if (c.use_query_cache) j["useQueryCache"] = *c.use_query_cache;
+  if (c.flatten_results) j["flattenResults"] = *c.flatten_results;
+  if (c.use_legacy_sql) j["useLegacySql"] = *c.use_legacy_sql;
+  if (c.create_session) j["createSession"] = *c.create_session;
+  if (c.maximum_bytes_billed) j["maximumBytesBilled"] = std::to_string(*c.maximum_bytes_billed);
+  if (c.query_parameters) j["queryParameters"] = *c.query_parameters;
+  if (c.schema_update_options) j["schemaUpdateOptions"] = *c.schema_update_options;
+  if (c.connection_properties) j["connectionProperties"] = *c.connection_properties;
+  if (c.default_dataset) j["defaultDataset"] = *c.default_dataset;
+  if (c.destination_table) j["destinationTable"] = *c.destination_table;
+  if (c.time_partitioning) j["timePartitioning"] = *c.time_partitioning;
+  if (c.range_partitioning) j["rangePartitioning"] = *c.range_partitioning;
+  if (c.clustering) j["clustering"] = *c.clustering;
+  if (c.destination_encryption_configuration) j["destinationEncryptionConfiguration"] = *c.destination_encryption_configuration;
+  if (c.script_options) j["scriptOptions"] = *c.script_options;
+  if (c.system_variables) j["systemVariables"] = *c.system_variables;
 }
 void from_json(nlohmann::json const& j, JobConfigurationQuery& c) {
   SafeGetTo(c.query, j, "query");

--- a/google/cloud/bigquery/v2/minimal/internal/job_configuration_query.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_configuration_query.h
@@ -20,6 +20,7 @@
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
 #include "absl/strings/string_view.h"
+#include "absl/types/optional.h"
 #include <nlohmann/json.hpp>
 #include <string>
 
@@ -29,31 +30,31 @@ namespace bigquery_v2_minimal_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 struct JobConfigurationQuery {
-  std::string query;
-  std::string create_disposition;
-  std::string write_disposition;
-  std::string priority;
-  std::string parameter_mode;
-  bool preserve_nulls = false;
-  bool allow_large_results = false;
-  bool use_query_cache = false;
-  bool flatten_results = false;
-  bool use_legacy_sql = false;
-  bool create_session = false;
-  std::int64_t maximum_bytes_billed = 0;
+  absl::optional<std::string> query;
+  absl::optional<std::string> create_disposition;
+  absl::optional<std::string> write_disposition;
+  absl::optional<std::string> priority;
+  absl::optional<std::string> parameter_mode;
+  absl::optional<bool> preserve_nulls;
+  absl::optional<bool> allow_large_results;
+  absl::optional<bool> use_query_cache;
+  absl::optional<bool> flatten_results;
+  absl::optional<bool> use_legacy_sql;
+  absl::optional<bool> create_session;
+  absl::optional<std::int64_t> maximum_bytes_billed;
 
-  std::vector<QueryParameter> query_parameters;
-  std::vector<std::string> schema_update_options;
-  std::vector<ConnectionProperty> connection_properties;
+  absl::optional<std::vector<QueryParameter>> query_parameters;
+  absl::optional<std::vector<std::string>> schema_update_options;
+  absl::optional<std::vector<ConnectionProperty>> connection_properties;
 
-  DatasetReference default_dataset;
-  TableReference destination_table;
-  TimePartitioning time_partitioning;
-  RangePartitioning range_partitioning;
-  Clustering clustering;
-  EncryptionConfiguration destination_encryption_configuration;
-  ScriptOptions script_options;
-  SystemVariables system_variables;
+  absl::optional<DatasetReference> default_dataset;
+  absl::optional<TableReference> destination_table;
+  absl::optional<TimePartitioning> time_partitioning;
+  absl::optional<RangePartitioning> range_partitioning;
+  absl::optional<Clustering> clustering;
+  absl::optional<EncryptionConfiguration> destination_encryption_configuration;
+  absl::optional<ScriptOptions> script_options;
+  absl::optional<SystemVariables> system_variables;
 
   std::string DebugString(absl::string_view name,
                           TracingOptions const& options = {},

--- a/google/cloud/bigquery/v2/minimal/internal/json_utils.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/json_utils.cc
@@ -58,6 +58,28 @@ void ToIntJson(std::chrono::milliseconds const& field, nlohmann::json& j,
   j[name] = m;
 }
 
+void FromJson(absl::optional<std::chrono::milliseconds>& field, nlohmann::json const& j,
+              char const* name) {
+  auto const m = GetNumberFromJson(j, name);
+  if (m >= 0) {
+    field = std::chrono::milliseconds(m);
+  }
+}
+
+void ToJson(absl::optional<std::chrono::milliseconds> const& field, nlohmann::json& j,
+            char const* name) {
+  if (field) {
+    ToJson(*field, j, name);
+  }
+}
+
+void ToIntJson(absl::optional<std::chrono::milliseconds> const& field, nlohmann::json& j,
+               char const* name) {
+  if (field) {
+    ToIntJson(*field, j, name);
+  }
+}
+
 void FromJson(std::chrono::hours& field, nlohmann::json const& j,
               char const* name) {
   auto const m = GetNumberFromJson(j, name);
@@ -72,6 +94,21 @@ void ToJson(std::chrono::hours const& field, nlohmann::json& j,
       std::chrono::duration_cast<std::chrono::hours>(field).count());
 
   j[name] = std::to_string(m);
+}
+
+void FromJson(absl::optional<std::chrono::hours>& field, nlohmann::json const& j,
+              char const* name) {
+  auto const m = GetNumberFromJson(j, name);
+  if (m >= 0) {
+    field = std::chrono::hours(m);
+  }
+}
+
+void ToJson(absl::optional<std::chrono::hours> const& field, nlohmann::json& j,
+            char const* name) {
+  if (field) {
+    ToJson(*field, j, name);
+  }
 }
 
 void FromJson(std::chrono::system_clock::time_point& field,
@@ -91,6 +128,22 @@ void ToJson(std::chrono::system_clock::time_point const& field,
           .count());
 
   j[name] = std::to_string(m);
+}
+
+void FromJson(absl::optional<std::chrono::system_clock::time_point>& field, nlohmann::json const& j,
+              char const* name) {
+  auto const m = GetNumberFromJson(j, name);
+  if (m >= 0) {
+    field = std::chrono::system_clock::from_time_t(0) +
+            std::chrono::milliseconds(m);
+  }
+}
+
+void ToJson(absl::optional<std::chrono::system_clock::time_point> const& field, nlohmann::json& j,
+            char const* name) {
+  if (field) {
+    ToJson(*field, j, name);
+  }
 }
 
 nlohmann::json RemoveJsonKeysAndEmptyFields(

--- a/google/cloud/bigquery/v2/minimal/internal/json_utils.h
+++ b/google/cloud/bigquery/v2/minimal/internal/json_utils.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_V2_MINIMAL_INTERNAL_JSON_UTILS_H
 
 #include "google/cloud/version.h"
+#include "absl/types/optional.h"
 #include <nlohmann/json.hpp>
 #include <chrono>
 
@@ -34,16 +35,36 @@ void ToJson(std::chrono::milliseconds const& field, nlohmann::json& j,
 void ToIntJson(std::chrono::milliseconds const& field, nlohmann::json& j,
                char const* name);
 
+void FromJson(absl::optional<std::chrono::milliseconds>& field, nlohmann::json const& j,
+              char const* name);
+
+void ToJson(absl::optional<std::chrono::milliseconds> const& field, nlohmann::json& j,
+            char const* name);
+void ToIntJson(absl::optional<std::chrono::milliseconds> const& field, nlohmann::json& j,
+               char const* name);
+
 void FromJson(std::chrono::system_clock::time_point& field,
               nlohmann::json const& j, char const* name);
 
 void ToJson(std::chrono::system_clock::time_point const& field,
             nlohmann::json& j, char const* name);
 
+void FromJson(absl::optional<std::chrono::system_clock::time_point>& field,
+              nlohmann::json const& j, char const* name);
+
+void ToJson(absl::optional<std::chrono::system_clock::time_point> const& field,
+            nlohmann::json& j, char const* name);
+
 void FromJson(std::chrono::hours& field, nlohmann::json const& j,
               char const* name);
 
 void ToJson(std::chrono::hours const& field, nlohmann::json& j,
+            char const* name);
+
+void FromJson(absl::optional<std::chrono::hours>& field, nlohmann::json const& j,
+              char const* name);
+
+void ToJson(absl::optional<std::chrono::hours> const& field, nlohmann::json& j,
             char const* name);
 
 // Removes not needed keys and empty arrays and objects from the json
@@ -72,6 +93,18 @@ bool SafeGetTo(std::shared_ptr<T>& value, nlohmann::json const& j,
   if (i == j.end()) return false;
   if (value == nullptr) {
     value = std::make_shared<T>();
+  }
+  i->get_to(*value);
+  return true;
+}
+
+template <typename T>
+bool SafeGetTo(absl::optional<T>& value, nlohmann::json const& j,
+               std::string const& key) {
+  auto i = j.find(key);
+  if (i == j.end()) return false;
+  if (value == absl::nullopt) {
+    value = absl::optional<T>(T{});
   }
   i->get_to(*value);
   return true;


### PR DESCRIPTION
Current  implementation of BigQuery's REST API by default sends all fields, which causes problems because the default values like `""` are different from ` ` (literally nothing).

Take the `InsertJobRequest` message as an example, if we only set the `configuration.query.query` and `configuration.query.writeDisposition` field, it's expected that following JSON will be sent:

```json
{
  "configuration": {
    "query": {
      "query": "SELECT * FROM dataset_id.table_id LIMIT 5",
      "writeDisposition": "WRITE_TRUNCATE"
    }
  }
}
```

However, current implementation will serialise all fields with their initial values by default:

<details>
<summary>Full JSON string</summary>

```json
{
  "configuration": {
    "dryRun": false,
    "jobTimeoutMs": "0",
    "jobType": "",
    "query": {
      "allowLargeResults": true,
      "clustering": {
        "fields": []
      },
      "connectionProperties": [],
      "createDisposition": "",
      "createSession": false,
      "defaultDataset": {
        "datasetId": "",
        "projectId": ""
      },
      "destinationEncryptionConfiguration": {
        "kmsKeyName": ""
      },
      "destinationTable": {
        "datasetId": "",
        "projectId": "",
        "tableId": ""
      },
      "flattenResults": false,
      "maximumBytesBilled": "0",
      "parameterMode": "",
      "preserveNulls": false,
      "priority": "",
      "query": "SELECT * FROM dataset_id.table_id LIMIT 5",
      "queryParameters": [],
      "rangePartitioning": {
        "field": "",
        "range": {
          "end": "",
          "interval": "",
          "start": ""
        }
      },
      "schemaUpdateOptions": [],
      "scriptOptions": {
        "keyResultStatement": "",
        "statementByteBudget": "0",
        "statementTimeoutMs": "0"
      },
      "timePartitioning": {
        "expirationTime": "0",
        "field": "",
        "type": ""
      },
      "useLegacySql": false,
      "useQueryCache": false,
      "writeDisposition": "WRITE_TRUNCATE"
    }
  },
  "etag": "",
  "id": "",
  "jobReference": {
    "jobId": "",
    "location": "",
    "projectId": ""
  },
  "kind": "",
  "selfLink": "",
  "statistics": {
    "completionRatio": 0,
    "creationTime": "0",
    "dataMaskingStatistics": {
      "dataMaskingApplied": false
    },
    "endTime": "0",
    "finalExecutionDurationMs": "0",
    "numChildJobs": "0",
    "parentJobId": "",
    "query": {
      "billingTier": 0,
      "cacheHit": false,
      "dclTargetDataset": {
        "datasetId": "",
        "projectId": ""
      },
      "dclTargetTable": {
        "datasetId": "",
        "projectId": "",
        "tableId": ""
      },
      "dclTargetView": {
        "datasetId": "",
        "projectId": "",
        "tableId": ""
      },
      "ddlAffectedRowAccessPolicyCount": "0",
      "ddlOperationPerformed": "",
      "ddlTargetDataset": {
        "datasetId": "",
        "projectId": ""
      },
      "ddlTargetRoutine": {
        "datasetId": "",
        "projectId": "",
        "routineId": ""
      },
      "ddlTargetRowAccessPolicy": {
        "datasetId": "",
        "policyId": "",
        "projectId": "",
        "tableId": ""
      },
      "ddlTargetTable": {
        "datasetId": "",
        "projectId": "",
        "tableId": ""
      },
      "dmlStats": {
        "deletedRowCount": "0",
        "insertedRowCount": "0",
        "updatedRowCount": "0"
      },
      "estimatedBytesProcessed": "0",
      "materializedViewStatistics": {
        "materializedView": []
      },
      "metadataCacheStatistics": {
        "tableMetadataCacheUsage": []
      },
      "numDmlAffectedRows": "0",
      "performanceInsights": {
        "avgPreviousExecutionMs": "0",
        "stagePerformanceChangeInsights": {
          "inputDataChange": {
            "recordsReadDiffPercentage": 0
          },
          "stageId": "0"
        },
        "stagePerformanceStandaloneInsights": {
          "insufficientShuffleQuota": false,
          "slotContention": false,
          "stageId": "0"
        }
      },
      "queryPlan": [],
      "referencedRoutines": [],
      "referencedTables": [],
      "schema": {
        "fields": []
      },
      "searchStatistics": {
        "indexUnusedReasons": [],
        "indexUsageMode": ""
      },
      "statementType": "",
      "timeline": [],
      "totalBytesBilled": "0",
      "totalBytesProcessed": "0",
      "totalBytesProcessedAccuracy": "",
      "totalPartitionsProcessed": "0",
      "totalSlotMs": "0",
      "transferredBytes": "0",
      "undeclaredQueryParameters": []
    },
    "quotaDeferments": [],
    "reservation_id": "",
    "rowLevelSecurityStatistics": {
      "rowLevelSecurityApplied": false
    },
    "scriptStatistics": {
      "evaluationKind": "",
      "stackFrames": []
    },
    "sessionInfo": {
      "sessionId": ""
    },
    "startTime": "0",
    "totalBytesProcessed": "0",
    "totalSlotMs": "0",
    "transactionInfo": {
      "transactionId": ""
    }
  },
  "status": {
    "errorResult": {
      "location": "",
      "message": "",
      "reason": ""
    },
    "errors": [],
    "state": ""
  },
  "user_email": ""
}
```

</details>

Similar fix has been attempted in https://github.com/googleapis/google-cloud-cpp/pull/12988, but was later closed. I'll be happy to work on this further (including update these tests) if we all agree to use `absl::optional` as it's can achieve identical behaviour as in Golang implementation of BigQuery:

```go
type JobConfigurationQuery struct {
	// AllowLargeResults: Optional. If true and query uses legacy SQL
	// dialect, allows the query to produce arbitrarily large result tables
	// at a slight cost in performance. Requires destinationTable to be set.
	// For GoogleSQL queries, this flag is ignored and large results are
	// always allowed. However, you must still set destinationTable when
	// result size exceeds the allowed maximum response size.
	AllowLargeResults bool `json:"allowLargeResults,omitempty"`

	// ...
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14050)
<!-- Reviewable:end -->
