### PR TITLE
fix(storage): missing include

### DIFF
--- a/google/cloud/storage/internal/retry_object_read_source.cc
+++ b/google/cloud/storage/internal/retry_object_read_source.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/internal/retry_object_read_source.h"
 #include <algorithm>
+#include <sstream>
 #include <string>
 #include <thread>
 
@@ -99,7 +100,7 @@ StatusOr<ReadSourceResult> RetryObjectReadSource::Read(char* buf,
   if (HandleResult(result)) return result;
   // We have exhausted the retry policy, return the error.
   auto status = std::move(result).status();
-  std::stringstream os;
+  std::ostringstream os;
   if (internal::StatusTraits::IsPermanentFailure(status)) {
     os << "Permanent error in Read(): " << status.message();
   } else {


### PR DESCRIPTION
We probably lost a transient include from `google/cloud/log.h` in #13975 

https://c3i.jfrog.io/c3i/misc/logs/pr/23695/4-linux-clang/google-cloud-cpp/2.23.0//e846e5adce243ac53f5c2319b7d1d0638f84c96a-build.txt

```
/home/conan/workspace/prod-v1/bsr/31134/fbecd/.conan/data/google-cloud-cpp/2.23.0/_/_/build/e846e5adce243ac53f5c2319b7d1d0638f84c96a/src/google/cloud/storage/internal/retry_object_read_source.cc:102:21: error: implicit instantiation of undefined template 'std::basic_stringstream<char>'
  std::stringstream os;
                    ^
/usr/local/bin/../include/c++/v1/iosfwd:142:32: note: template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_stringstream;
                               ^
1 error generated.
make[2]: *** [google/cloud/storage/CMakeFiles/google_cloud_cpp_storage.dir/internal/retry_object_read_source.cc.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [google/cloud/storage/CMakeFiles/google_cloud_cpp_storage.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
make: *** [all] Error 2
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14052)
<!-- Reviewable:end -->
