### PR TITLE
ci: no formatting for all patch files

### DIFF
--- a/ci/cloudbuild/builds/checkers.sh
+++ b/ci/cloudbuild/builds/checkers.sh
@@ -134,7 +134,7 @@ time {
   expressions+=("-e" "':x;/^\n*$/{\$d;N;bx;}'")
   # Adds a trailing newline if one doesn't already exist
   expressions+=("-e" "'\$a\'")
-  git_files -z | grep -zv 'googleapis.patch$' |
+  git_files -z | grep -zv '\.patch$' |
     grep -zv '\.gz$' |
     grep -zv '\.pb$' |
     grep -zv '\.png$' |


### PR DESCRIPTION
Skip all `*.patch` files in the "trailing whitespace" format step.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14063)
<!-- Reviewable:end -->
