### PR TITLE
impl(otel): add IsInitialMetadataReady

### DIFF
--- a/google/cloud/internal/grpc_opentelemetry.cc
+++ b/google/cloud/internal/grpc_opentelemetry.cc
@@ -145,6 +145,13 @@ void ExtractAttributes(grpc::ClientContext& context,
   }
 }
 
+bool IsInitialMetadataReady(StatusCode code) {
+  // We assume that if the status code is one of the following
+  // the initial metadata *might* not be ready.
+  // See go/cloud-cxx:grpc-workaround for details.
+  return (code != StatusCode::kCancelled);
+}
+
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 
 }  // namespace internal

--- a/google/cloud/internal/grpc_opentelemetry.h
+++ b/google/cloud/internal/grpc_opentelemetry.h
@@ -18,6 +18,7 @@
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/options.h"
+#include "google/cloud/status.h"
 #include "google/cloud/version.h"
 #include <grpcpp/grpcpp.h>
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
@@ -69,6 +70,11 @@ void InjectTraceContext(
  */
 void ExtractAttributes(grpc::ClientContext& context,
                        opentelemetry::trace::Span& span);
+
+/**
+ * Returns true if the status `code` suggests the initial metadata is available.
+ */
+bool IsInitialMetadataReady(StatusCode code);
 
 /**
  * Extracts information from the `grpc::ClientContext`, and adds it to a span.


### PR DESCRIPTION
https://github.com/googleapis/google-cloud-cpp/issues/13724

This is a helper to check for the status codes we want to omit. Currently, it only includes cancelled, but depending on what gRPC says we can change the status codes to check for.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14066)
<!-- Reviewable:end -->
