### PR TITLE
impl(generator): replace table row with a repeated struct

### DIFF
--- a/generator/internal/discovery_type_vertex.cc
+++ b/generator/internal/discovery_type_vertex.cc
@@ -173,6 +173,10 @@ DiscoveryTypeVertex::DetermineTypeAndSynthesis(nlohmann::json const& v,
     auto const& items = v["items"];
     if (items.contains("$ref")) {
       type = items["$ref"];
+      if (type == "TableRow") {
+        return TypeInfo{"google.protobuf.Struct", compare_package_name,
+                        properties_for_synthesis, false, false};
+      }
       compare_package_name = true;
       is_message = true;
     } else if (items.contains("type")) {

--- a/generator/internal/discovery_type_vertex_test.cc
+++ b/generator/internal/discovery_type_vertex_test.cc
@@ -225,6 +225,10 @@ INSTANTIATE_TEST_SUITE_P(
                               R"""({"type":"array","items":{"$ref":"Foo"}})""",
                               "Foo", true, false, true, true},
         DetermineTypesSuccess{
+            "array_table_row",
+            R"""({"type":"array","items":{"$ref":"TableRow"}})""",
+            "google.protobuf.Struct", true, false, false, false},
+        DetermineTypesSuccess{
             "array_string", R"""({"type":"array","items":{"type":"string"}})""",
             "string", true, false, false, false},
         DetermineTypesSuccess{

--- a/generator/internal/discovery_type_vertex_test.cc
+++ b/generator/internal/discovery_type_vertex_test.cc
@@ -573,6 +573,13 @@ TEST_F(DiscoveryTypeVertexDescriptorTest, JsonToProtobufArrayTypes) {
           }
         }
       }
+    },
+    "tableRowArray": {
+      "type": "array",
+      "description": "Description of tableRowArray.",
+      "items": {
+        "$ref": "TableRow"
+      }
     }
   }
 }
@@ -610,6 +617,9 @@ TEST_F(DiscoveryTypeVertexDescriptorTest, JsonToProtobufArrayTypes) {
 
   // Description of synthesizedArray.
   repeated SynthesizedArrayItem synthesized_array = 8 [json_name="synthesizedArray"];
+
+  // Description of tableRowArray.
+  repeated google.protobuf.Struct table_row_array = 9 [json_name="tableRowArray"];
 }
 )""";
 


### PR DESCRIPTION
https://github.com/googleapis/google-cloud-cpp/issues/13892

Convert TableRow to repeated struct based on [groups.google.com/a/google.com/g/cloud-cxx-team/c/5bTWceeo4_o/m/n3NuDkL9AQAJ?utm_medium=email&utm_source=footer](https://groups.google.com/a/google.com/g/cloud-cxx-team/c/5bTWceeo4_o/m/n3NuDkL9AQAJ?utm_medium=email&utm_source=footer)

This covers the following case:
2. TableCell
```
  "TableCell": {
      "id": "TableCell",
      "properties": {
        "v": {
          "type": "any"
        }
      },
      "type": "object"
    },
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14084)
<!-- Reviewable:end -->
