### PR TITLE
ci(gcb): reduce overhead of builds

### DIFF
--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -158,26 +158,6 @@ steps:
         xargs -r printf "gcr.io/${PROJECT_ID}/${_IMAGE}@%s\n" | \
         xargs -r -P 4 -L 32 gcloud container images delete -q --force-delete-tags
 
-  # Cancels *this* specific build if one is already queued up for a newer
-  # commit. This frees up resources to run the build for the newer commit.
-- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-  allowFailure: true
-  waitFor: [ '-' ]
-  entrypoint: 'bash'
-  args:
-    - '-c'
-    - |
-      set -xe
-      test -z "${_PR_NUMBER}" && exit 0
-      ctime="$(gcloud builds describe --region '${_POOL_REGION}' --format 'value(create_time)' '${BUILD_ID}')"
-      query="tags=pr"
-      query+=" AND tags=${_PR_NUMBER}"
-      query+=" AND tags=${_BUILD_NAME}"
-      query+=" AND substitutions.COMMIT_SHA != ${COMMIT_SHA}"
-      query+=" AND create_time > ${ctime}"
-      gcloud builds list --region '${_POOL_REGION}' --limit 1 --format='value(id)' --filter "${query}" | \
-        grep . && gcloud builds cancel --region '${_POOL_REGION}' '${BUILD_ID}'
-
   # Cancels in-progress builds for previous commits in the current PR so we can
   # free up resources to start running the builds for the new commit.
 - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'


### PR DESCRIPTION
To handle (what I think are rare) overload conditions we cancel a build
if a newer build for the same PR is pending. We only do this at the
beginning of the build, so it only helps if the queue is pretty deep
already. I think a better way to deal with that problem is to get more
quota.

Motivated by #14075

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14086)
<!-- Reviewable:end -->
