### PR TITLE
impl: add client origin metadata for a failed async unary rpc

### DIFF
--- a/google/cloud/completion_queue_test.cc
+++ b/google/cloud/completion_queue_test.cc
@@ -43,6 +43,7 @@ namespace {
 
 using ::google::cloud::testing_util::FakeCompletionQueueImpl;
 using ::google::cloud::testing_util::IsOk;
+using ::google::cloud::testing_util::StatusIs;
 using ::testing::Contains;
 using ::testing::HasSubstr;
 using ::testing::Not;
@@ -406,7 +407,7 @@ TEST(CompletionQueueTest, MakeRpcsAfterShutdown) {
           r1, std::make_unique<grpc::ClientContext>())
           .then([](future<StatusOr<Response>> f) {
             auto status = f.get().status();
-            EXPECT_EQ(StatusCode::kCancelled, status.code());
+            EXPECT_THAT(status, StatusIs(StatusCode::kCancelled));
             auto const& metadata = status.error_info().metadata();
             EXPECT_THAT(metadata,
                         Contains(Pair("gl-cpp.error.origin", "client")));

--- a/google/cloud/completion_queue_test.cc
+++ b/google/cloud/completion_queue_test.cc
@@ -46,6 +46,7 @@ using ::google::cloud::testing_util::IsOk;
 using ::testing::Contains;
 using ::testing::HasSubstr;
 using ::testing::Not;
+using ::testing::Pair;
 using ::testing::StrictMock;
 
 using Request = google::protobuf::Duration;
@@ -404,7 +405,11 @@ TEST(CompletionQueueTest, MakeRpcsAfterShutdown) {
           },
           r1, std::make_unique<grpc::ClientContext>())
           .then([](future<StatusOr<Response>> f) {
-            EXPECT_EQ(StatusCode::kCancelled, f.get().status().code());
+            auto status = f.get().status();
+            EXPECT_EQ(StatusCode::kCancelled, status.code());
+            auto const& metadata = status.error_info().metadata();
+            EXPECT_THAT(metadata,
+                        Contains(Pair("gl-cpp.error.origin", "client")));
           });
 
   Request r2;

--- a/google/cloud/internal/async_rpc_details.h
+++ b/google/cloud/internal/async_rpc_details.h
@@ -73,11 +73,8 @@ class AsyncUnaryRpcFuture : public AsyncGrpcOperation {
     ScopedCallContext scope(call_context_);
     if (!ok) {
       // `Finish()` always returns `true` for unary RPCs, so the only time we
-      // get `!ok` is after `Shutdown()` was called; create a client-origin
-      // "cancelled". By marking the status, we can use that to determine
-      // whether it *might* not be safe to make a GetServerInitialMetadata call
-      // on the client context. This omits the grpc server initial metadata
-      // tracing information from the span attributes.
+      // get `!ok` is after `Shutdown()` was called; create a "cancelled"
+      // originating from the client.
       promise_.set_value(internal::CancelledError(
           "call cancelled",
           GCP_ERROR_INFO().WithMetadata("gl-cpp.error.origin", "client")));

--- a/google/cloud/internal/async_rpc_details.h
+++ b/google/cloud/internal/async_rpc_details.h
@@ -19,6 +19,7 @@
 #include "google/cloud/future.h"
 #include "google/cloud/grpc_error_delegate.h"
 #include "google/cloud/internal/call_context.h"
+#include "google/cloud/internal/make_status.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include "absl/functional/function_ref.h"
@@ -73,7 +74,8 @@ class AsyncUnaryRpcFuture : public AsyncGrpcOperation {
     if (!ok) {
       // `Finish()` always returns `true` for unary RPCs, so the only time we
       // get `!ok` is after `Shutdown()` was called; treat that as "cancelled".
-      promise_.set_value(Status(StatusCode::kCancelled, "call cancelled"));
+      promise_.set_value(internal::CancelledError("gRPC async unary RPC failed",
+                                                  GCP_ERROR_INFO()));
       return true;
     }
     if (!status_.ok()) {

--- a/google/cloud/internal/async_rpc_details.h
+++ b/google/cloud/internal/async_rpc_details.h
@@ -73,9 +73,14 @@ class AsyncUnaryRpcFuture : public AsyncGrpcOperation {
     ScopedCallContext scope(call_context_);
     if (!ok) {
       // `Finish()` always returns `true` for unary RPCs, so the only time we
-      // get `!ok` is after `Shutdown()` was called; treat that as "cancelled".
-      promise_.set_value(internal::CancelledError("gRPC async unary RPC failed",
-                                                  GCP_ERROR_INFO()));
+      // get `!ok` is after `Shutdown()` was called; create a client-origin
+      // "cancelled". By marking the status, we can use that to determine
+      // whether it *might* not be safe to make a GetServerInitialMetadata call
+      // on the client context. This omits the grpc server initial metadata
+      // tracing information from the span attributes.
+      promise_.set_value(internal::CancelledError(
+          "call cancelled",
+          GCP_ERROR_INFO().WithMetadata("gl-cpp.error.origin", "client")));
       return true;
     }
     if (!status_.ok()) {


### PR DESCRIPTION
https://github.com/googleapis/google-cloud-cpp/issues/13724

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14088)
<!-- Reviewable:end -->
