### PR TITLE
impl: add client origin metadata for a failed streaming read

### DIFF
--- a/google/cloud/completion_queue_test.cc
+++ b/google/cloud/completion_queue_test.cc
@@ -46,6 +46,7 @@ using ::google::cloud::testing_util::IsOk;
 using ::testing::Contains;
 using ::testing::HasSubstr;
 using ::testing::Not;
+using ::testing::Pair;
 using ::testing::StrictMock;
 
 using Request = google::protobuf::Duration;
@@ -421,6 +422,8 @@ TEST(CompletionQueueTest, MakeRpcsAfterShutdown) {
       },
       [](Status const& status) {
         EXPECT_EQ(StatusCode::kCancelled, status.code());
+        auto const& metadata = status.error_info().metadata();
+        EXPECT_THAT(metadata, Contains(Pair("gl-cpp.error.origin", "client")));
       });
 
   mock_cq->SimulateCompletion(true);

--- a/google/cloud/internal/async_read_stream_impl.h
+++ b/google/cloud/internal/async_read_stream_impl.h
@@ -18,6 +18,7 @@
 #include "google/cloud/grpc_error_delegate.h"
 #include "google/cloud/internal/call_context.h"
 #include "google/cloud/internal/completion_queue_impl.h"
+#include "google/cloud/internal/make_status.h"
 #include "google/cloud/version.h"
 #include <grpcpp/support/async_stream.h>
 #include <memory>
@@ -264,8 +265,11 @@ class AsyncReadStreamImpl
 
   /// Handle the result of a Finish() request.
   void OnFinish(bool ok, Status status) {
-    on_finish_(ok ? std::move(status)
-                  : Status(StatusCode::kCancelled, "call cancelled"));
+    on_finish_(
+        ok ? std::move(status)
+           : internal::CancelledError("call cancelled",
+                                      GCP_ERROR_INFO().WithMetadata(
+                                          "gl-cpp.error.origin", "client")));
   }
 
   /**


### PR DESCRIPTION
https://github.com/googleapis/google-cloud-cpp/issues/13724
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14103)
<!-- Reviewable:end -->
