### PR TITLE
impl(GCS+gRPC): fix `GrpcMetrics*Option` names

### DIFF
--- a/google/cloud/storage/grpc_plugin.h
+++ b/google/cloud/storage/grpc_plugin.h
@@ -81,7 +81,7 @@ google::cloud::storage::Client DefaultGrpcClient(Options opts = {});
  * https://github.com/grpc/proposal/blob/master/A78-grpc-metrics-wrr-pf-xds.md
  * [Google Cloud Monitoring]: https://cloud.google.com/monitoring/docs
  */
-struct EnableGrpcMetrics {
+struct EnableGrpcMetricsOption {
   using Type = bool;
 };
 
@@ -90,11 +90,11 @@ struct EnableGrpcMetrics {
  *
  * When `EnableGrpcMetrics` is enabled, this option controls the frequency at
  * which metrics are exported to [Google Cloud Monitoring]. The default is 60
- * seconds. Values below 60 seconds are ignored.
+ * seconds. Values below 5 seconds are ignored.
  *
  * [Google Cloud Monitoring]: https://cloud.google.com/monitoring/docs
  */
-struct GrpcMetricsPeriod {
+struct GrpcMetricsPeriodOption {
   using Type = std::chrono::seconds;
 };
 

--- a/google/cloud/storage/internal/grpc/default_options.cc
+++ b/google/cloud/storage/internal/grpc/default_options.cc
@@ -88,10 +88,12 @@ Options DefaultOptionsGrpc(Options options) {
           .set<EndpointOption>(ep)
           .set<AuthorityOption>(ep)
           .set<storage_experimental::EnableGrpcMetrics>(true)
-          .set<storage_experimental::GrpcMetricsPeriodOption>(kDefaultMetricsPeriod));
+          .set<storage_experimental::GrpcMetricsPeriodOption>(
+              kDefaultMetricsPeriod));
   if (options.get<storage_experimental::GrpcMetricsPeriodOption>() <
       kMinMetricsPeriod) {
-    options.set<storage_experimental::GrpcMetricsPeriodOption>(kMinMetricsPeriod);
+    options.set<storage_experimental::GrpcMetricsPeriodOption>(
+        kMinMetricsPeriod);
   }
   // We can only compute this once the endpoint is known, so take an additional
   // step.

--- a/google/cloud/storage/internal/grpc/default_options.cc
+++ b/google/cloud/storage/internal/grpc/default_options.cc
@@ -87,7 +87,7 @@ Options DefaultOptionsGrpc(Options options) {
       Options{}
           .set<EndpointOption>(ep)
           .set<AuthorityOption>(ep)
-          .set<storage_experimental::EnableGrpcMetrics>(true)
+          .set<storage_experimental::EnableGrpcMetricsOption>(true)
           .set<storage_experimental::GrpcMetricsPeriodOption>(
               kDefaultMetricsPeriod));
   if (options.get<storage_experimental::GrpcMetricsPeriodOption>() <

--- a/google/cloud/storage/internal/grpc/default_options.cc
+++ b/google/cloud/storage/internal/grpc/default_options.cc
@@ -88,10 +88,10 @@ Options DefaultOptionsGrpc(Options options) {
           .set<EndpointOption>(ep)
           .set<AuthorityOption>(ep)
           .set<storage_experimental::EnableGrpcMetrics>(true)
-          .set<storage_experimental::GrpcMetricsPeriod>(kDefaultMetricsPeriod));
-  if (options.get<storage_experimental::GrpcMetricsPeriod>() <
+          .set<storage_experimental::GrpcMetricsPeriodOption>(kDefaultMetricsPeriod));
+  if (options.get<storage_experimental::GrpcMetricsPeriodOption>() <
       kMinMetricsPeriod) {
-    options.set<storage_experimental::GrpcMetricsPeriod>(kMinMetricsPeriod);
+    options.set<storage_experimental::GrpcMetricsPeriodOption>(kMinMetricsPeriod);
   }
   // We can only compute this once the endpoint is known, so take an additional
   // step.

--- a/google/cloud/storage/internal/grpc/default_options_test.cc
+++ b/google/cloud/storage/internal/grpc/default_options_test.cc
@@ -132,14 +132,14 @@ TEST(DefaultOptionsGrpc, MetricsPeriod) {
 }
 
 TEST(DefaultOptionsGrpc, MinMetricsPeriod) {
-  auto const o0 =
-      DefaultOptionsGrpc(Options{}.set<storage_experimental::GrpcMetricsPeriodOption>(
+  auto const o0 = DefaultOptionsGrpc(
+      Options{}.set<storage_experimental::GrpcMetricsPeriodOption>(
           std::chrono::seconds(0)));
   EXPECT_GT(o0.get<storage_experimental::GrpcMetricsPeriodOption>(),
             std::chrono::seconds(0));
 
-  auto const m5 =
-      DefaultOptionsGrpc(Options{}.set<storage_experimental::GrpcMetricsPeriodOption>(
+  auto const m5 = DefaultOptionsGrpc(
+      Options{}.set<storage_experimental::GrpcMetricsPeriodOption>(
           std::chrono::seconds(-5)));
   EXPECT_GT(m5.get<storage_experimental::GrpcMetricsPeriodOption>(),
             std::chrono::seconds(0));

--- a/google/cloud/storage/internal/grpc/default_options_test.cc
+++ b/google/cloud/storage/internal/grpc/default_options_test.cc
@@ -127,21 +127,21 @@ TEST(DefaultOptionsGrpc, MetricsEnabled) {
 
 TEST(DefaultOptionsGrpc, MetricsPeriod) {
   auto const options = DefaultOptionsGrpc(Options{});
-  EXPECT_GE(options.get<storage_experimental::GrpcMetricsPeriod>(),
+  EXPECT_GE(options.get<storage_experimental::GrpcMetricsPeriodOption>(),
             std::chrono::seconds(60));
 }
 
 TEST(DefaultOptionsGrpc, MinMetricsPeriod) {
   auto const o0 =
-      DefaultOptionsGrpc(Options{}.set<storage_experimental::GrpcMetricsPeriod>(
+      DefaultOptionsGrpc(Options{}.set<storage_experimental::GrpcMetricsPeriodOption>(
           std::chrono::seconds(0)));
-  EXPECT_GT(o0.get<storage_experimental::GrpcMetricsPeriod>(),
+  EXPECT_GT(o0.get<storage_experimental::GrpcMetricsPeriodOption>(),
             std::chrono::seconds(0));
 
   auto const m5 =
-      DefaultOptionsGrpc(Options{}.set<storage_experimental::GrpcMetricsPeriod>(
+      DefaultOptionsGrpc(Options{}.set<storage_experimental::GrpcMetricsPeriodOption>(
           std::chrono::seconds(-5)));
-  EXPECT_GT(m5.get<storage_experimental::GrpcMetricsPeriod>(),
+  EXPECT_GT(m5.get<storage_experimental::GrpcMetricsPeriodOption>(),
             std::chrono::seconds(0));
 }
 

--- a/google/cloud/storage/internal/grpc/default_options_test.cc
+++ b/google/cloud/storage/internal/grpc/default_options_test.cc
@@ -122,7 +122,7 @@ TEST(DefaultOptionsGrpc, DefaultOptionsUploadBuffer) {
 
 TEST(DefaultOptionsGrpc, MetricsEnabled) {
   auto const options = DefaultOptionsGrpc(Options{});
-  EXPECT_TRUE(options.get<storage_experimental::EnableGrpcMetrics>());
+  EXPECT_TRUE(options.get<storage_experimental::EnableGrpcMetricsOption>());
 }
 
 TEST(DefaultOptionsGrpc, MetricsPeriod) {


### PR DESCRIPTION
Part of the work for #13998

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14116)
<!-- Reviewable:end -->
