### PR TITLE
impl(otel): support `CreateServiceTimeSeries` rpc

### DIFF
--- a/google/cloud/opentelemetry/monitoring_exporter.h
+++ b/google/cloud/opentelemetry/monitoring_exporter.h
@@ -51,6 +51,17 @@ struct MetricPrefixOption {
   using Type = std::string;
 };
 
+/**
+ * Export Google-defined metrics.
+ *
+ * Set to true if exporting Google-defined metrics. This option is only relevant
+ * to Google applications and libraries. It can be ignored by external
+ * developers.
+ */
+struct ServiceTimeSeriesOption {
+  using Type = bool;
+};
+
 std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter>
 MakeMonitoringExporter(
     Project project,


### PR DESCRIPTION
Part of the work for #14074 

Note that this is not usable in practice until we can also override the `MonitoredResource`. That is why we have not added an integration test for it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14118)
<!-- Reviewable:end -->
