### PR TITLE
fix(spanner): correct use of Interval offset in Timestamp addition

### DIFF
--- a/google/cloud/spanner/interval.cc
+++ b/google/cloud/spanner/interval.cc
@@ -404,13 +404,12 @@ StatusOr<Timestamp> Add(Timestamp const& ts, Interval const& intvl,
   auto tz = LoadTimeZone(time_zone);
   if (!tz) return tz.status();
   auto ci = tz->At(*ts.get<absl::Time>());
-  auto offset = absl::FromChrono(intvl.offset_);
-  auto seconds = absl::IDivDuration(offset, absl::Seconds(1), &offset);
   auto cs = absl::CivilSecond(  // add the civil-time parts
       ci.cs.year(), ci.cs.month() + intvl.months_, ci.cs.day() + intvl.days_,
-      ci.cs.hour(), ci.cs.minute(), ci.cs.second() + seconds);
+      ci.cs.hour(), ci.cs.minute(), ci.cs.second());
   return *MakeTimestamp(internal::ToProtoTimestamp(  // overflow saturates
-      absl::FromCivil(cs, *tz) + ci.subsecond + offset));
+      absl::FromCivil(cs, *tz) + ci.subsecond +
+      absl::FromChrono(intvl.offset_)));
 }
 
 StatusOr<Interval> Diff(Timestamp const& ts1, Timestamp const& ts2,


### PR DESCRIPTION
When adding an `Interval` to a `Timestamp`+time-zone, the offset should be interpreted as an absolute value rather than a civil one.  (This is a poor choice in my opinion, but so be it.)

Update the test case, which now has to use a "1 day" interval to show the difference between `Add(ts, "1 day", tz)` and `Add(ts, "24 hours", tz)` over a civil-time discontinuity.

Add a new test based upon the postgresql.org examples, one of which would have demonstrated the original problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14121)
<!-- Reviewable:end -->
