### PR TITLE
impl(oauth2): service account parses project_id

### DIFF
--- a/google/cloud/internal/oauth2_service_account_credentials.cc
+++ b/google/cloud/internal/oauth2_service_account_credentials.cc
@@ -21,8 +21,8 @@
 #include "google/cloud/internal/oauth2_universe_domain.h"
 #include "google/cloud/internal/rest_response.h"
 #include "google/cloud/internal/sign_using_sha256.h"
-#include "absl/functional/function_ref.h"
 #include <nlohmann/json.hpp>
+#include <functional>
 
 namespace google {
 namespace cloud {
@@ -41,10 +41,10 @@ StatusOr<ServiceAccountCredentialsInfo> ParseServiceAccountCredentials(
                      "data loaded from ", source));
   }
 
-  using Validator = absl::FunctionRef<Status(absl::string_view name,
-                                             nlohmann::json::iterator)>;
-  using Store = absl::FunctionRef<void(ServiceAccountCredentialsInfo&,
-                                       nlohmann::json::iterator const&)>;
+  using Validator =
+      std::function<Status(absl::string_view name, nlohmann::json::iterator)>;
+  using Store = std::function<void(ServiceAccountCredentialsInfo&,
+                                   nlohmann::json::iterator const&)>;
 
   auto optional_field = [](absl::string_view, nlohmann::json::iterator const&) {
     return Status{};

--- a/google/cloud/internal/oauth2_service_account_credentials.h
+++ b/google/cloud/internal/oauth2_service_account_credentials.h
@@ -53,6 +53,7 @@ struct ServiceAccountCredentialsInfo {
   absl::optional<std::string> subject;
   bool enable_self_signed_jwt;
   absl::optional<std::string> universe_domain;
+  absl::optional<std::string> project_id;
 };
 
 /// Indicates whether or not to use a self-signed JWT or issue a request to
@@ -231,6 +232,9 @@ class ServiceAccountCredentials : public oauth2_internal::Credentials {
 
   StatusOr<std::string> universe_domain() const override;
   StatusOr<std::string> universe_domain(Options const&) const override;
+
+  StatusOr<std::string> project_id() const;
+  StatusOr<std::string> project_id(Options const&) const;
 
  private:
   bool UseOAuth();

--- a/google/cloud/internal/openssl/parse_service_account_p12_file.cc
+++ b/google/cloud/internal/openssl/parse_service_account_p12_file.cc
@@ -128,7 +128,8 @@ StatusOr<ServiceAccountCredentialsInfo> ParseServiceAccountP12File(
                                        /*scopes=*/{},
                                        /*subject=*/{},
                                        /*enable_self_signed_jwt=*/false,
-                                       /*universe_domain=*/{}};
+                                       /*universe_domain=*/absl::nullopt,
+                                       /*project_id=*/absl::nullopt};
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/oauth2/service_account_credentials.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials.cc
@@ -146,7 +146,8 @@ oauth2_internal::ServiceAccountCredentialsInfo MapServiceAccountCredentialsInfo(
   return {std::move(info.client_email), std::move(info.private_key_id),
           std::move(info.private_key),  std::move(info.token_uri),
           std::move(info.scopes),       std::move(info.subject),
-          enable_self_signed_jwt,       {}};
+          enable_self_signed_jwt,       /*.universe_domain=*/absl::nullopt,
+          /*.project_id=*/absl::nullopt};
 }
 
 }  // namespace internal


### PR DESCRIPTION
A service account key file may include a `project_id` field. So far we
had not needed this field and we did not parse it, but that is about to
change.

Part of the work for #14112

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14124)
<!-- Reviewable:end -->
