### PR TITLE
cleanup(generator): remove obsolete method comment substitution

### DIFF
--- a/ci/cloudbuild/builds/generate-libraries.sh
+++ b/ci/cloudbuild/builds/generate-libraries.sh
@@ -43,7 +43,7 @@ if [ -z "${GENERATE_GOLDEN_ONLY}" ]; then
     --discovery_proto_path="${PWD}/protos" \
     --output_path="${PROJECT_ROOT}/protos" \
     --export_output_path="${PROJECT_ROOT}" \
-    --check_parameter_comment_substitutions=true \
+    --check_comment_substitutions=true \
     --generate_discovery_protos=true \
     --config_file="${PROJECT_ROOT}/generator/generator_config.textproto"
 
@@ -75,7 +75,7 @@ if [ -z "${GENERATE_GOLDEN_ONLY}" ]; then
     --googleapis_proto_path="${bazel_output_base}"/external/com_google_googleapis \
     --discovery_proto_path="${PWD}/protos" \
     --output_path="${PROJECT_ROOT}" \
-    --check_parameter_comment_substitutions=true \
+    --check_comment_substitutions=true \
     --config_file="${PROJECT_ROOT}/generator/generator_config.textproto"
 
   if [ -n "${UPDATED_DISCOVERY_DOCUMENT}" ]; then

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -750,7 +750,7 @@ auto constexpr kServiceProto =
     "}\n"
     "// Leading comments about service Service.\n"
     "service Service {\n"
-    "  // Leading comments about rpc Method0$.\n"
+    "  // Leading comments about rpc Method0.\n"
     "  rpc Method0(Bar) returns (google.protobuf.Empty) {\n"
     "  }\n"
     "  // Leading comments about rpc Method1.\n"
@@ -799,7 +799,7 @@ auto constexpr kServiceProto =
     "    option (google.api.method_signature) = \"name,swallow_types\";\n"
     "    option (google.api.method_signature) = \"\";\n"
     "  }\n"
-    "  // Leading comments about rpc $Method6.\n"
+    "  // Leading comments about rpc Method6.\n"
     "  rpc Method6(Foo) returns (google.protobuf.Empty) {\n"
     "    option (google.api.http) = {\n"
     "       get: \"/v1/{name=projects/*/instances/*/databases/*}\"\n"
@@ -1011,7 +1011,7 @@ TEST_F(CreateMethodVarsTest, FormatMethodCommentsProtobufRequest) {
       *service_file_descriptor->service(0)->method(0), false);
   EXPECT_EQ(actual, R"""(  // clang-format off
   ///
-  /// Leading comments about rpc Method0$$.
+  /// Leading comments about rpc Method0.
   ///
   /// @param request Unary RPCs, such as the one wrapped by this
   ///     function, receive a single `request` proto message which includes all
@@ -1130,7 +1130,7 @@ TEST_F(CreateMethodVarsTest, FormatMethodCommentsMethodSignature) {
       *service_file_descriptor->service(0)->method(6), "labels", false);
   EXPECT_EQ(actual, R"""(  // clang-format off
   ///
-  /// Leading comments about rpc $$Method6.
+  /// Leading comments about rpc Method6.
   ///
   /// @param labels  labels $$field comment.
   /// @param opts Optional. Override the class-level options, such as retry and

--- a/generator/internal/format_method_comments.h
+++ b/generator/internal/format_method_comments.h
@@ -31,6 +31,12 @@ std::string FormatMethodComments(
     std::string const& variable_parameter_comments,
     bool is_discovery_document_proto);
 
+/**
+ * If there were any method comment substitutions that went unused, log
+ * errors about them and return false. Otherwise do nothing and return true.
+ */
+bool CheckMethodCommentSubstitutions();
+
 }  // namespace generator_internal
 }  // namespace cloud
 }  // namespace google


### PR DESCRIPTION
Remove the unnecessary `s/\$/$$/` method comment substitution.

How do we know it's unnecessary?  By making it a fatal error for a substitution to fail to match.  This will make it easy for us to remove dead cruft.

Fixes #12190.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14127)
<!-- Reviewable:end -->
