### PR TITLE
refactor(otel): prepare to batch requests

### DIFF
--- a/google/cloud/opentelemetry/internal/time_series.h
+++ b/google/cloud/opentelemetry/internal/time_series.h
@@ -44,6 +44,10 @@ google::monitoring::v3::TimeSeries ToTimeSeries(
     opentelemetry::sdk::metrics::MetricData const& metric_data,
     opentelemetry::sdk::metrics::HistogramPointData const& histogram_data);
 
+google::api::MonitoredResource ToMonitoredResource(
+    opentelemetry::sdk::metrics::ResourceMetrics const& data,
+    absl::optional<google::api::MonitoredResource> const& mr_proto);
+
 /**
  * We need to convert from the C++ OpenTelemetry metrics implementation to
  * Cloud Monitoring protos.
@@ -62,10 +66,16 @@ google::monitoring::v3::TimeSeries ToTimeSeries(
  * https://github.com/open-telemetry/opentelemetry-cpp/blob/fabd8cc2bc318cb47d5db7322ea9c8cd3f4b847a/exporters/otlp/src/otlp_metric_utils.cc
  * [OTLP]: https://opentelemetry.io/docs/specs/otel/protocol/
  */
-google::monitoring::v3::CreateTimeSeriesRequest ToRequest(
+std::vector<google::monitoring::v3::TimeSeries> ToTimeSeries(
     opentelemetry::sdk::metrics::ResourceMetrics const& data,
-    std::string const& prefix,
-    absl::optional<google::api::MonitoredResource> const& mr_proto);
+    std::string const& prefix);
+
+/**
+ * Convert from OpenTelemetry metrics to Cloud Monitoring protos.
+ */
+google::monitoring::v3::CreateTimeSeriesRequest ToRequest(
+    std::string const& project, google::api::MonitoredResource const& mr_proto,
+    std::vector<google::monitoring::v3::TimeSeries> tss);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace otel_internal

--- a/google/cloud/opentelemetry/monitoring_exporter_test.cc
+++ b/google/cloud/opentelemetry/monitoring_exporter_test.cc
@@ -117,7 +117,7 @@ TEST(MonitoringExporter, ExportSkippedIfNoTimeSeries) {
 
   EXPECT_THAT(log.ExtractLines(),
               Contains(AllOf(HasSubstr("Cloud Monitoring Export skipped"),
-                             HasSubstr("No TimeSeries"))));
+                             HasSubstr("No data"))));
 }
 
 TEST(MonitoringExporter, ExportFailure) {


### PR DESCRIPTION
Part of the work for #14128 

1. Factor out the code that creates a `google::api::MonitoredResource`
2. Have `Export()` create the `google::api::MonitoredResource` (instead of `ToRequest()`)
3. Factor out creation of the `google::monitoring::v3::TimeSeries`es. I considered calling the method `ToTimeSerieses`, but that would be too goofy.
4. Have `ToRequest()` accept this `MonitoredResource` and list of `TimeSeries` as parameters. While we're at it, have it accept the project as well.

Note that there are no changes to `monitoring_exporter_test.cc` (outside of rewriting an error message).

---

A follow up PR will introduce batching.

```cc
google::monitoring::v3::CreateTimeSeriesRequest ToRequest(...);
```

becomes....

```cc
std::vector<google::monitoring::v3::CreateTimeSeriesRequest> ToRequests(...);
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14129)
<!-- Reviewable:end -->
