### PR TITLE
impl(otel): batch TimeSeries

### DIFF
--- a/google/cloud/opentelemetry/internal/time_series.cc
+++ b/google/cloud/opentelemetry/internal/time_series.cc
@@ -225,8 +225,8 @@ std::vector<google::monitoring::v3::CreateTimeSeriesRequest> ToRequests(
   for (auto& ts : tss) {
     if (requests.empty() ||
         requests.back().time_series().size() == kMaxTimeSeriesPerRequest) {
-      // If the current request is full (i.e. it has 200 TimeSeries), create a
-      // new request.
+      // If the current request has hit the maximum number of TimeSeries, create
+      // a new request.
       requests.emplace_back();
       requests.back().set_name(project);
     }

--- a/google/cloud/opentelemetry/internal/time_series.cc
+++ b/google/cloud/opentelemetry/internal/time_series.cc
@@ -218,16 +218,22 @@ std::vector<google::monitoring::v3::TimeSeries> ToTimeSeries(
   return tss;
 }
 
-google::monitoring::v3::CreateTimeSeriesRequest ToRequest(
+std::vector<google::monitoring::v3::CreateTimeSeriesRequest> ToRequests(
     std::string const& project, google::api::MonitoredResource const& mr_proto,
     std::vector<google::monitoring::v3::TimeSeries> tss) {
-  google::monitoring::v3::CreateTimeSeriesRequest request;
-  request.set_name(project);
+  std::vector<google::monitoring::v3::CreateTimeSeriesRequest> requests;
   for (auto& ts : tss) {
+    if (requests.empty() ||
+        requests.back().time_series().size() == kMaxTimeSeriesPerRequest) {
+      // If the current request is full (i.e. it has 200 TimeSeries), create a
+      // new request.
+      requests.emplace_back();
+      requests.back().set_name(project);
+    }
     *ts.mutable_resource() = mr_proto;
-    *request.add_time_series() = std::move(ts);
+    *requests.back().add_time_series() = std::move(ts);
   }
-  return request;
+  return requests;
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/opentelemetry/internal/time_series.h
+++ b/google/cloud/opentelemetry/internal/time_series.h
@@ -27,6 +27,11 @@ namespace cloud {
 namespace otel_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+// GCM enforces a limit of 200 TimeSeries per CreateTimeSeriesRequest.
+//
+// See: https://cloud.google.com/monitoring/quotas
+auto constexpr kMaxTimeSeriesPerRequest = 200;
+
 google::api::Metric ToMetric(
     opentelemetry::sdk::metrics::MetricData const& metric_data,
     opentelemetry::sdk::metrics::PointAttributes const& attributes,
@@ -72,8 +77,13 @@ std::vector<google::monitoring::v3::TimeSeries> ToTimeSeries(
 
 /**
  * Convert from OpenTelemetry metrics to Cloud Monitoring protos.
+ *
+ * We return a vector of requests, because Cloud Monitoring accepts at most 200
+ * TimeSeries per request.
+ *
+ * See: https://cloud.google.com/monitoring/quotas
  */
-google::monitoring::v3::CreateTimeSeriesRequest ToRequest(
+std::vector<google::monitoring::v3::CreateTimeSeriesRequest> ToRequests(
     std::string const& project, google::api::MonitoredResource const& mr_proto,
     std::vector<google::monitoring::v3::TimeSeries> tss);
 

--- a/google/cloud/opentelemetry/internal/time_series.h
+++ b/google/cloud/opentelemetry/internal/time_series.h
@@ -78,7 +78,7 @@ std::vector<google::monitoring::v3::TimeSeries> ToTimeSeries(
 /**
  * Convert from OpenTelemetry metrics to Cloud Monitoring protos.
  *
- * We return a vector of requests, because Cloud Monitoring accepts at most 200
+ * We return a vector of requests, because Cloud Monitoring limits the amount of
  * TimeSeries per request.
  *
  * See: https://cloud.google.com/monitoring/quotas


### PR DESCRIPTION
Fixes #14128 

Break up the export into multiple requests, each with no more than 200 TimeSeries in them. If we do not do this, we may drop all of our metrics on the floor if the cardinality is sufficiently high.

Generalize the existing tests to exercise the batching logic.

The error handling logic really is not important. I do not think anyone consumes the error. Arguably the tests are too strict.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14133)
<!-- Reviewable:end -->
