### PR TITLE
impl(generator): use documentation link from yaml in README

### DIFF
--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -64,7 +64,7 @@ std::string FormatCloudServiceDocsLink(
     std::map<std::string, std::string> const& vars) {
   return absl::StrCat("[cloud-service-docs]: ",
                       vars.find("documentation_uri") == vars.end()
-                          ? "https://cloud.google.com/$site_root$ [VERIFY HERE]"
+                          ? "https://cloud.google.com/$site_root$ [EDIT HERE]"
                           : "$documentation_uri$",
                       "\n");
 }

--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -60,6 +60,15 @@ ProductPath ParseProductPath(std::string const& product_path) {
   return make_result(std::prev(v.end()));
 }
 
+std::string FormatCloudServiceDocsLink(
+    std::map<std::string, std::string> const& vars) {
+  return absl::StrCat("[cloud-service-docs]: ",
+                      vars.find("documentation_uri") == vars.end()
+                          ? "https://cloud.google.com/$site_root$ [VERIFY HERE]"
+                          : "$documentation_uri$",
+                      "\n");
+}
+
 }  // namespace
 
 auto constexpr kApiIndexFilename = "api-index-v1.json";
@@ -335,7 +344,7 @@ void GenerateScaffold(
 
 void GenerateReadme(std::ostream& os,
                     std::map<std::string, std::string> const& variables) {
-  auto constexpr kText = R"""(# $title$ C++ Client Library
+  auto constexpr kText1 = R"""(# $title$ C++ Client Library
 $construction$
 This directory contains an idiomatic C++ client library for the
 [$title$][cloud-service-docs], a service to $description$
@@ -359,14 +368,18 @@ this library.
 * [Reference doxygen documentation][doxygen-link] for each release of this
   client library
 * Detailed header comments in our [public `.h`][source-link] files
+)""";
 
-[cloud-service-docs]: https://cloud.google.com/$site_root$
-[doxygen-link]: https://cloud.google.com/cpp/docs/reference/$library$/latest/
+  auto constexpr kText2 =
+      R"""([doxygen-link]: https://cloud.google.com/cpp/docs/reference/$library$/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/$library$
 )""";
   google::protobuf::io::OstreamOutputStream output(&os);
   google::protobuf::io::Printer printer(&output, '$');
-  printer.Print(variables, kText);
+  printer.Print(
+      variables,
+      absl::StrCat(kText1, FormatCloudServiceDocsLink(variables), kText2)
+          .c_str());
 }
 
 void GenerateBuild(std::ostream& os,
@@ -497,7 +510,7 @@ endif ()
 
 void GenerateDoxygenMainPage(
     std::ostream& os, std::map<std::string, std::string> const& variables) {
-  auto constexpr kText = R"""(/*!
+  auto constexpr kText1 = R"""(/*!
 
 @mainpage $title$ C++ Client Library
 
@@ -533,14 +546,17 @@ which should give you a taste of the $title$ C++ client library API.
   policies.
 - @ref $library$-env - describes environment variables that can configure the
   behavior of the library.
+)""";
 
-[cloud-service-docs]: https://cloud.google.com/$site_root$
-
+  auto constexpr kText2 = R"""(
 */
 )""";
   google::protobuf::io::OstreamOutputStream output(&os);
   google::protobuf::io::Printer printer(&output, '$');
-  printer.Print(variables, kText);
+  printer.Print(
+      variables,
+      absl::StrCat(kText1, FormatCloudServiceDocsLink(variables), kText2)
+          .c_str());
 }
 
 void GenerateDoxygenEnvironmentPage(

--- a/generator/internal/scaffold_generator_test.cc
+++ b/generator/internal/scaffold_generator_test.cc
@@ -49,6 +49,10 @@ char const* const kHierarchy[] = {
     "/external/googleapis/",
     "/external/googleapis/protolists/",
     "/external/googleapis/protodeps/",
+    "/google/",
+    "/google/cloud/",
+    "/google/cloud/test/",
+    "/google/cloud/test/v1/",
 };
 
 TEST(ScaffoldGeneratorTest, LibraryName) {
@@ -102,6 +106,7 @@ nlohmann::json MockIndex() {
       {"hostName", "test.googleapis.com"},
       {"title", "Test Only API"},
       {"description", "Provides a placeholder to write this test."},
+      {"configFile", "test_v1.yaml"},
   };
   return nlohmann::json{{"apis", std::vector<nlohmann::json>{api}}};
 }
@@ -112,6 +117,7 @@ class ScaffoldGenerator : public ::testing::Test {
     std::remove((path_ + "/api-index-v1.json").c_str());
     std::remove((path_ + "/external/googleapis/protolists/test.list").c_str());
     std::remove((path_ + "/external/googleapis/protodeps/test.deps").c_str());
+    std::remove((path_ + "/google/cloud/test/v1/test_v1.yaml").c_str());
     // Remove in reverse order, `std::rbegin()` is a C++14 feature.
     auto const size = sizeof(kHierarchy) / sizeof(kHierarchy[0]);
     for (std::size_t i = 0; i != size; ++i) {
@@ -144,6 +150,18 @@ class ScaffoldGenerator : public ::testing::Test {
 @com_google_googleapis//google/api:client_proto
 @com_google_googleapis//google/api:annotations_proto
 @com_google_googleapis//google/api:http_proto
+)""";
+
+    std::ofstream(path_ + "/google/cloud/test/v1/test_v1.yaml")
+        << R"""(type: google.api.Service
+config_version: 1
+name: test.googleapis.com
+title: Test API
+
+publishing:
+  new_issue_uri: https://issuetracker.google.com/issues/new?component=8675309
+  documentation_uri: https://cloud.google.com/test/docs
+  api_short_name: test
 )""";
 
     google::cloud::cpp::generator::ServiceConfiguration service;
@@ -201,7 +219,55 @@ TEST_F(ScaffoldGenerator, Readme) {
   GenerateReadme(os, vars);
   auto const actual = std::move(os).str();
   EXPECT_THAT(actual, HasSubstr(R"""(
-[cloud-service-docs]: https://cloud.google.com/test
+[cloud-service-docs]: https://cloud.google.com/test/docs
+[doxygen-link]: https://cloud.google.com/cpp/docs/reference/test/latest/
+[source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/test
+)"""));
+  EXPECT_THAT(actual, Not(HasSubstr("$construction$")));
+  EXPECT_THAT(actual, HasSubstr("**GA**"));
+  EXPECT_THAT(actual, Not(HasSubstr("$status$")));
+}
+
+TEST_F(ScaffoldGenerator, ReadmeNoPublishingDocumentationUri) {
+  std::ofstream(path() + "/google/cloud/test/v1/test_v1.yaml")
+      << R"""(type: google.api.Service
+config_version: 1
+name: test.googleapis.com
+title: Test API
+
+publishing:
+  new_issue_uri: https://issuetracker.google.com/issues/new?component=8675309
+  api_short_name: test
+)""";
+
+  auto const vars = ScaffoldVars(path(), MockIndex(), service(), false);
+  std::ostringstream os;
+  GenerateReadme(os, vars);
+  auto const actual = std::move(os).str();
+  EXPECT_THAT(actual, HasSubstr(R"""(
+[cloud-service-docs]: https://cloud.google.com/test [VERIFY HERE]
+[doxygen-link]: https://cloud.google.com/cpp/docs/reference/test/latest/
+[source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/test
+)"""));
+  EXPECT_THAT(actual, Not(HasSubstr("$construction$")));
+  EXPECT_THAT(actual, HasSubstr("**GA**"));
+  EXPECT_THAT(actual, Not(HasSubstr("$status$")));
+}
+
+TEST_F(ScaffoldGenerator, ReadmeNoPublishing) {
+  std::ofstream(path() + "/google/cloud/test/v1/test_v1.yaml")
+      << R"""(type: google.api.Service
+config_version: 1
+name: test.googleapis.com
+title: Test API
+)""";
+
+  auto const vars = ScaffoldVars(path(), MockIndex(), service(), false);
+  std::ostringstream os;
+  GenerateReadme(os, vars);
+  auto const actual = std::move(os).str();
+  EXPECT_THAT(actual, HasSubstr(R"""(
+[cloud-service-docs]: https://cloud.google.com/test [VERIFY HERE]
 [doxygen-link]: https://cloud.google.com/cpp/docs/reference/test/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/test
 )"""));
@@ -253,7 +319,7 @@ An idiomatic C++ client library for the [Test Only API][cloud-service-docs], a s
 to Provides a placeholder to write this test.
 )"""));
   EXPECT_THAT(actual, HasSubstr(R"""(
-[cloud-service-docs]: https://cloud.google.com/test
+[cloud-service-docs]: https://cloud.google.com/test/docs
 )"""));
   EXPECT_THAT(actual, Not(HasSubstr("$status$")));
   EXPECT_THAT(actual, HasSubstr("**GA**"));

--- a/generator/internal/scaffold_generator_test.cc
+++ b/generator/internal/scaffold_generator_test.cc
@@ -245,7 +245,7 @@ publishing:
   GenerateReadme(os, vars);
   auto const actual = std::move(os).str();
   EXPECT_THAT(actual, HasSubstr(R"""(
-[cloud-service-docs]: https://cloud.google.com/test [VERIFY HERE]
+[cloud-service-docs]: https://cloud.google.com/test [EDIT HERE]
 [doxygen-link]: https://cloud.google.com/cpp/docs/reference/test/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/test
 )"""));
@@ -267,7 +267,7 @@ title: Test API
   GenerateReadme(os, vars);
   auto const actual = std::move(os).str();
   EXPECT_THAT(actual, HasSubstr(R"""(
-[cloud-service-docs]: https://cloud.google.com/test [VERIFY HERE]
+[cloud-service-docs]: https://cloud.google.com/test [EDIT HERE]
 [doxygen-link]: https://cloud.google.com/cpp/docs/reference/test/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/test
 )"""));


### PR DESCRIPTION
fixes #12630

As a side benefit, the test fixture now supports a service yaml file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14136)
<!-- Reviewable:end -->
