### PR TITLE
ci: upgrade `m32` build to fedora 40

### DIFF
--- a/ci/cloudbuild/dockerfiles/fedora-m32.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-m32.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM fedora:39
+FROM fedora:40
 ARG NCPU=4
 
 # Install the minimal development tools:
@@ -20,7 +20,7 @@ RUN dnf makecache && \
     dnf install -y cmake curl diffutils findutils gcc-c++ git make \
         ninja-build patch tar unzip wget which zip
 
-# Fedora 39 includes packages, with recent enough versions, for most of the
+# Fedora 40 includes packages, with recent enough versions, for most of the
 # direct dependencies of `google-cloud-cpp`. We will install those.
 
 # First install the "host" (64-bit) version of the protobuf compiler and gRPC
@@ -44,7 +44,7 @@ RUN dnf makecache && \
         openssl-devel.i686 \
         protobuf-devel.i686 \
         re2-devel.i686 \
-        zlib-devel.i686
+        zlib-ng-compat-devel.i686
 
 # Install the Python modules needed to run the storage emulator
 RUN dnf makecache && dnf install -y python3-devel


### PR DESCRIPTION
https://github.com/googleapis/google-cloud-cpp/pull/14079

Initially I tried to change `zlib` to `zlib-ng`, but got

```
ninja: error: '/usr/lib/libz.so', needed by 'google/cloud/completion_queue_test', missing and no known rule to make it
```

So I found https://discussion.fedoraproject.org/t/zlib-installed-but-not-installed-bug/112414/6, and it said to try `zlib-ng-compat`, and that worked