### PR TITLE
ci: upgrade `publish-docs` to Fedora:40

### DIFF
--- a/ci/cloudbuild/dockerfiles/fedora-latest-publish-docs.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-latest-publish-docs.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM fedora:39
+FROM fedora:40
 ARG NCPU=4
 ARG ARCH=amd64
 


### PR DESCRIPTION
https://github.com/googleapis/google-cloud-cpp/issues/14076

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14149)
<!-- Reviewable:end -->
