### PR TITLE
fix(common): support libc++ >= 18.1

### DIFF
--- a/google/cloud/internal/future_impl.cc
+++ b/google/cloud/internal/future_impl.cc
@@ -19,9 +19,9 @@
 
 // This function is only needed if exceptions are enabled.
 #ifdef GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-// The constructor for `future_error` from `std::future_errc` is not
-// guaranteed to exist until C++17, but stdlibc++, MSVC are forgiving, and
-// libc++ is forgiving until version 18.1
+// The `std::future_error::future_error(std::future_errc)` constructor is not
+// guaranteed to exist until C++17. Fortunately, stdlibc++, MSVC are forgiving,
+// and libc++ is forgiving until version 18.1.
 #if GOOGLE_CLOUD_CPP_CPP_VERSION >= 201703L || _LIBCPP_VERSION < 180100
 
 namespace {
@@ -31,7 +31,8 @@ std::future_error MakeFutureErrorImpl(std::future_errc ec) {
 }  // namespace
 
 #else
-
+// We can probably tolerate this terrible hack (which depends on UB) until we
+// require C++17.
 namespace {
 struct OhTheHorrors {};
 }  // namespace
@@ -47,7 +48,6 @@ class promise<OhTheHorrors> {
 }  // namespace std
 
 namespace {
-// This function is only needed if exceptions are enabled.
 std::future_error MakeFutureErrorImpl(std::future_errc ec) {
   return std::promise<OhTheHorrors>::MakeFutureError(ec);
 }

--- a/google/cloud/internal/future_impl.cc
+++ b/google/cloud/internal/future_impl.cc
@@ -19,6 +19,7 @@
 
 // This function is only needed if exceptions are enabled.
 #ifdef GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+// TODO(#14152): Remove libC++ hack
 // The `std::future_error::future_error(std::future_errc)` constructor is not
 // guaranteed to exist until C++17. Fortunately, stdlibc++, MSVC are forgiving,
 // and libc++ is forgiving until version 18.1.

--- a/google/cloud/internal/future_impl.cc
+++ b/google/cloud/internal/future_impl.cc
@@ -13,8 +13,48 @@
 // limitations under the License.
 
 #include "google/cloud/internal/future_impl.h"
+#include "google/cloud/internal/port_platform.h"
 #include "google/cloud/terminate_handler.h"
 #include <stdexcept>
+
+// This function is only needed if exceptions are enabled.
+#ifdef GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+// The constructor for `future_error` from `std::future_errc` is not
+// guaranteed to exist until C++17, but stdlibc++, MSVC are forgiving, and
+// libc++ is forgiving until version 18.1
+#if GOOGLE_CLOUD_CPP_CPP_VERSION >= 201703L || _LIBCPP_VERSION < 180100
+
+namespace {
+std::future_error MakeFutureErrorImpl(std::future_errc ec) {
+  return std::future_error(ec);
+}
+}  // namespace
+
+#else
+
+namespace {
+struct OhTheHorrors {};
+}  // namespace
+
+namespace std {
+template <>
+class promise<OhTheHorrors> {
+ public:
+  static auto MakeFutureError(std::future_errc ec) {
+    return std::future_error(std::make_error_code(ec));
+  }
+};
+}  // namespace std
+
+namespace {
+// This function is only needed if exceptions are enabled.
+std::future_error MakeFutureErrorImpl(std::future_errc ec) {
+  return std::promise<OhTheHorrors>::MakeFutureError(ec);
+}
+}  // namespace
+
+#endif
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 
 namespace google {
 namespace cloud {
@@ -24,7 +64,7 @@ namespace internal {
 [[noreturn]] void ThrowFutureError(std::future_errc ec, char const* msg) {
 #ifdef GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   (void)msg;  // disable unused argument warning.
-  throw std::future_error(ec);
+  throw MakeFutureErrorImpl(ec);
 #else
   std::string full_msg = "future_error[";
   full_msg += std::make_error_code(ec).message();
@@ -46,7 +86,7 @@ namespace internal {
 
 std::exception_ptr MakeFutureError(std::future_errc ec) {
 #ifdef GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  return std::make_exception_ptr(std::future_error(ec));
+  return std::make_exception_ptr(MakeFutureErrorImpl(ec));
 #else
   (void)ec;
   // We cannot create a valid `std::exception_ptr` in this case. It does not


### PR DESCRIPTION
Starting with libc++ 18.1 the `std::future_error(future_errc)`
constructor only appears if compiling with C++17.

Part of the work for #14076

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14151)
<!-- Reviewable:end -->
