### PR TITLE
refactor: prepare for squashed sources

### DIFF
--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.cc
@@ -33,10 +33,6 @@ namespace cloud {
 namespace golden_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-namespace {
-  auto constexpr kServiceApiVersion = "test-api-version";
-}  // namespace
-
 GoldenKitchenSinkMetadata::GoldenKitchenSinkMetadata(
     std::shared_ptr<GoldenKitchenSinkStub> child,
     std::multimap<std::string, std::string> fixed_metadata,
@@ -250,7 +246,7 @@ void GoldenKitchenSinkMetadata::SetMetadata(grpc::ClientContext& context,
 
 void GoldenKitchenSinkMetadata::SetMetadata(grpc::ClientContext& context,
                                         Options const& options) {
-  context.AddMetadata("x-goog-api-version", kServiceApiVersion);
+  context.AddMetadata("x-goog-api-version", "test-api-version");
   google::cloud::internal::SetMetadata(
       context, options, fixed_metadata_, api_client_header_);
 }

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_metadata_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_metadata_decorator.cc
@@ -31,10 +31,6 @@ namespace cloud {
 namespace golden_v1_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-namespace {
-  auto constexpr kServiceApiVersion = "test-api-version";
-}  // namespace
-
 GoldenKitchenSinkRestMetadata::GoldenKitchenSinkRestMetadata(
     std::shared_ptr<GoldenKitchenSinkRestStub> child,
     std::string api_client_header)
@@ -165,7 +161,7 @@ GoldenKitchenSinkRestMetadata::ExplicitRouting2(
 void GoldenKitchenSinkRestMetadata::SetMetadata(
       rest_internal::RestContext& rest_context,
       Options const& options, std::vector<std::string> const& params) {
-  rest_context.AddHeader("x-goog-api-version", kServiceApiVersion);
+  rest_context.AddHeader("x-goog-api-version", "test-api-version");
   google::cloud::rest_internal::SetMetadata(
       rest_context, options, params, api_client_header_);
 }

--- a/generator/internal/metadata_decorator_generator.cc
+++ b/generator/internal/metadata_decorator_generator.cc
@@ -193,13 +193,6 @@ Status MetadataDecoratorGenerator::GenerateCc() {
   auto result = CcOpenNamespaces(NamespaceType::kInternal);
   if (!result.ok()) return result;
 
-  if (HasApiVersion()) {
-    CcPrint(R"""(
-namespace {
-  auto constexpr kServiceApiVersion = "$api_version$";
-}  // namespace
-)""");
-  }
   // constructor
   CcPrint(R"""(
 $metadata_class_name$::$metadata_class_name$(
@@ -406,7 +399,7 @@ void $metadata_class_name$::SetMetadata(grpc::ClientContext& context,
 )""");
   if (HasApiVersion()) {
     CcPrint(
-        R"""(  context.AddMetadata("x-goog-api-version", kServiceApiVersion);
+        R"""(  context.AddMetadata("x-goog-api-version", "$api_version$");
 )""");
   }
   CcPrint(R"""(  google::cloud::internal::SetMetadata(

--- a/generator/internal/metadata_decorator_rest_generator.cc
+++ b/generator/internal/metadata_decorator_rest_generator.cc
@@ -242,13 +242,7 @@ Status MetadataDecoratorRestGenerator::GenerateCc() {
 
   auto result = CcOpenNamespaces(NamespaceType::kInternal);
   if (!result.ok()) return result;
-  if (HasApiVersion()) {
-    CcPrint(R"""(
-namespace {
-  auto constexpr kServiceApiVersion = "$api_version$";
-}  // namespace
-)""");
-  }
+
   // constructor
   CcPrint(R"""(
 $metadata_rest_class_name$::$metadata_rest_class_name$(
@@ -389,7 +383,7 @@ void $metadata_rest_class_name$::SetMetadata(
 )""");
   if (HasApiVersion()) {
     CcPrint(
-        R"""(  rest_context.AddHeader("x-goog-api-version", kServiceApiVersion);
+        R"""(  rest_context.AddHeader("x-goog-api-version", "$api_version$");
 )""");
   }
   CcPrint(R"""(  google::cloud::rest_internal::SetMetadata(


### PR DESCRIPTION
Part of the work for #14108 

These definitions conflict if we squash all of the source files for a given service.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14155)
<!-- Reviewable:end -->
