### PR TITLE
cleanup: prepare for clang-tidy 18

### DIFF
--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_retry_traits.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct GoldenKitchenSinkRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk && status.code() != StatusCode::kInternal && status.code() != StatusCode::kUnavailable;
   }
 };

--- a/generator/integration_tests/golden/v1/internal/golden_rest_only_retry_traits.h
+++ b/generator/integration_tests/golden/v1/internal/golden_rest_only_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct GoldenRestOnlyRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk && status.code() != StatusCode::kUnavailable;
   }
 };

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_retry_traits.h
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct GoldenThingAdminRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk && status.code() != StatusCode::kDeadlineExceeded && status.code() != StatusCode::kUnavailable;
   }
 };

--- a/generator/integration_tests/golden/v1/internal/request_id_retry_traits.h
+++ b/generator/integration_tests/golden/v1/internal/request_id_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RequestIdServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk && status.code() != StatusCode::kUnavailable;
   }
 };

--- a/generator/internal/retry_traits_generator.cc
+++ b/generator/internal/retry_traits_generator.cc
@@ -53,7 +53,7 @@ Status RetryTraitsGenerator::GenerateHeader() {
     "\n"
     "/// Define the gRPC status code semantics for retrying requests.\n"
     "struct $retry_traits_name$ {\n"
-    "  static inline bool IsPermanentFailure(google::cloud::Status const& status) {\n"
+    "  static bool IsPermanentFailure(google::cloud::Status const& status) {\n"
     "    return $retry_status_code_expression$;\n"
     "  }\n"
     "};\n"

--- a/google/cloud/accessapproval/v1/internal/access_approval_retry_traits.h
+++ b/google/cloud/accessapproval/v1/internal/access_approval_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct AccessApprovalRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/accesscontextmanager/v1/internal/access_context_manager_retry_traits.h
+++ b/google/cloud/accesscontextmanager/v1/internal/access_context_manager_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct AccessContextManagerRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/advisorynotifications/v1/internal/advisory_notifications_retry_traits.h
+++ b/google/cloud/advisorynotifications/v1/internal/advisory_notifications_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct AdvisoryNotificationsServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/aiplatform/v1/internal/dataset_retry_traits.h
+++ b/google/cloud/aiplatform/v1/internal/dataset_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct DatasetServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/aiplatform/v1/internal/deployment_resource_pool_retry_traits.h
+++ b/google/cloud/aiplatform/v1/internal/deployment_resource_pool_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct DeploymentResourcePoolServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/aiplatform/v1/internal/endpoint_retry_traits.h
+++ b/google/cloud/aiplatform/v1/internal/endpoint_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct EndpointServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/aiplatform/v1/internal/feature_online_store_admin_retry_traits.h
+++ b/google/cloud/aiplatform/v1/internal/feature_online_store_admin_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct FeatureOnlineStoreAdminServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/aiplatform/v1/internal/feature_online_store_retry_traits.h
+++ b/google/cloud/aiplatform/v1/internal/feature_online_store_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct FeatureOnlineStoreServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/aiplatform/v1/internal/feature_registry_retry_traits.h
+++ b/google/cloud/aiplatform/v1/internal/feature_registry_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct FeatureRegistryServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/aiplatform/v1/internal/featurestore_online_serving_retry_traits.h
+++ b/google/cloud/aiplatform/v1/internal/featurestore_online_serving_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct FeaturestoreOnlineServingServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/aiplatform/v1/internal/featurestore_retry_traits.h
+++ b/google/cloud/aiplatform/v1/internal/featurestore_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct FeaturestoreServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/aiplatform/v1/internal/gen_ai_tuning_retry_traits.h
+++ b/google/cloud/aiplatform/v1/internal/gen_ai_tuning_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct GenAiTuningServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/aiplatform/v1/internal/index_endpoint_retry_traits.h
+++ b/google/cloud/aiplatform/v1/internal/index_endpoint_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct IndexEndpointServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/aiplatform/v1/internal/index_retry_traits.h
+++ b/google/cloud/aiplatform/v1/internal/index_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct IndexServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/aiplatform/v1/internal/job_retry_traits.h
+++ b/google/cloud/aiplatform/v1/internal/job_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct JobServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/aiplatform/v1/internal/llm_utility_retry_traits.h
+++ b/google/cloud/aiplatform/v1/internal/llm_utility_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct LlmUtilityServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/aiplatform/v1/internal/match_retry_traits.h
+++ b/google/cloud/aiplatform/v1/internal/match_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct MatchServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/aiplatform/v1/internal/metadata_retry_traits.h
+++ b/google/cloud/aiplatform/v1/internal/metadata_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct MetadataServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/aiplatform/v1/internal/migration_retry_traits.h
+++ b/google/cloud/aiplatform/v1/internal/migration_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct MigrationServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/aiplatform/v1/internal/model_garden_retry_traits.h
+++ b/google/cloud/aiplatform/v1/internal/model_garden_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ModelGardenServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/aiplatform/v1/internal/model_retry_traits.h
+++ b/google/cloud/aiplatform/v1/internal/model_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ModelServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/aiplatform/v1/internal/notebook_retry_traits.h
+++ b/google/cloud/aiplatform/v1/internal/notebook_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct NotebookServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/aiplatform/v1/internal/persistent_resource_retry_traits.h
+++ b/google/cloud/aiplatform/v1/internal/persistent_resource_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct PersistentResourceServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/aiplatform/v1/internal/pipeline_retry_traits.h
+++ b/google/cloud/aiplatform/v1/internal/pipeline_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct PipelineServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/aiplatform/v1/internal/prediction_retry_traits.h
+++ b/google/cloud/aiplatform/v1/internal/prediction_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct PredictionServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/aiplatform/v1/internal/schedule_retry_traits.h
+++ b/google/cloud/aiplatform/v1/internal/schedule_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ScheduleServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/aiplatform/v1/internal/specialist_pool_retry_traits.h
+++ b/google/cloud/aiplatform/v1/internal/specialist_pool_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SpecialistPoolServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/aiplatform/v1/internal/tensorboard_retry_traits.h
+++ b/google/cloud/aiplatform/v1/internal/tensorboard_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct TensorboardServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/aiplatform/v1/internal/vizier_retry_traits.h
+++ b/google/cloud/aiplatform/v1/internal/vizier_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct VizierServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/alloydb/v1/internal/alloy_db_admin_retry_traits.h
+++ b/google/cloud/alloydb/v1/internal/alloy_db_admin_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct AlloyDBAdminRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/apigateway/v1/internal/api_gateway_retry_traits.h
+++ b/google/cloud/apigateway/v1/internal/api_gateway_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ApiGatewayServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable &&
            status.code() != StatusCode::kUnknown;

--- a/google/cloud/apigeeconnect/v1/internal/connection_retry_traits.h
+++ b/google/cloud/apigeeconnect/v1/internal/connection_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ConnectionServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable &&
            status.code() != StatusCode::kUnknown;

--- a/google/cloud/apikeys/v2/internal/api_keys_retry_traits.h
+++ b/google/cloud/apikeys/v2/internal/api_keys_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ApiKeysRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/appengine/v1/internal/applications_retry_traits.h
+++ b/google/cloud/appengine/v1/internal/applications_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ApplicationsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/appengine/v1/internal/authorized_certificates_retry_traits.h
+++ b/google/cloud/appengine/v1/internal/authorized_certificates_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct AuthorizedCertificatesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/appengine/v1/internal/authorized_domains_retry_traits.h
+++ b/google/cloud/appengine/v1/internal/authorized_domains_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct AuthorizedDomainsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/appengine/v1/internal/domain_mappings_retry_traits.h
+++ b/google/cloud/appengine/v1/internal/domain_mappings_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct DomainMappingsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/appengine/v1/internal/firewall_retry_traits.h
+++ b/google/cloud/appengine/v1/internal/firewall_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct FirewallRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/appengine/v1/internal/instances_retry_traits.h
+++ b/google/cloud/appengine/v1/internal/instances_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct InstancesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/appengine/v1/internal/services_retry_traits.h
+++ b/google/cloud/appengine/v1/internal/services_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ServicesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/appengine/v1/internal/versions_retry_traits.h
+++ b/google/cloud/appengine/v1/internal/versions_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct VersionsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/apphub/v1/internal/app_hub_retry_traits.h
+++ b/google/cloud/apphub/v1/internal/app_hub_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct AppHubRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/artifactregistry/v1/internal/artifact_registry_retry_traits.h
+++ b/google/cloud/artifactregistry/v1/internal/artifact_registry_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ArtifactRegistryRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/asset/v1/internal/asset_retry_traits.h
+++ b/google/cloud/asset/v1/internal/asset_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct AssetServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/assuredworkloads/v1/internal/assured_workloads_retry_traits.h
+++ b/google/cloud/assuredworkloads/v1/internal/assured_workloads_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct AssuredWorkloadsServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/automl/v1/internal/auto_ml_retry_traits.h
+++ b/google/cloud/automl/v1/internal/auto_ml_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct AutoMlRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/automl/v1/internal/prediction_retry_traits.h
+++ b/google/cloud/automl/v1/internal/prediction_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct PredictionServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/backupdr/v1/internal/backup_dr_retry_traits.h
+++ b/google/cloud/backupdr/v1/internal/backup_dr_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct BackupDRRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/baremetalsolution/v2/internal/bare_metal_solution_retry_traits.h
+++ b/google/cloud/baremetalsolution/v2/internal/bare_metal_solution_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct BareMetalSolutionRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/batch/v1/internal/batch_retry_traits.h
+++ b/google/cloud/batch/v1/internal/batch_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct BatchServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/beyondcorp/appconnections/v1/internal/app_connections_retry_traits.h
+++ b/google/cloud/beyondcorp/appconnections/v1/internal/app_connections_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct AppConnectionsServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/beyondcorp/appconnectors/v1/internal/app_connectors_retry_traits.h
+++ b/google/cloud/beyondcorp/appconnectors/v1/internal/app_connectors_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct AppConnectorsServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/beyondcorp/appgateways/v1/internal/app_gateways_retry_traits.h
+++ b/google/cloud/beyondcorp/appgateways/v1/internal/app_gateways_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct AppGatewaysServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/bigquery/analyticshub/v1/internal/analytics_hub_retry_traits.h
+++ b/google/cloud/bigquery/analyticshub/v1/internal/analytics_hub_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct AnalyticsHubServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/bigquery/biglake/v1/internal/metastore_retry_traits.h
+++ b/google/cloud/bigquery/biglake/v1/internal/metastore_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct MetastoreServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/bigquery/connection/v1/internal/connection_retry_traits.h
+++ b/google/cloud/bigquery/connection/v1/internal/connection_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ConnectionServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/bigquery/datapolicies/v1/internal/data_policy_retry_traits.h
+++ b/google/cloud/bigquery/datapolicies/v1/internal/data_policy_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct DataPolicyServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_retry_traits.h
+++ b/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct DataTransferServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/bigquery/migration/v2/internal/migration_retry_traits.h
+++ b/google/cloud/bigquery/migration/v2/internal/migration_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct MigrationServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/bigquery/reservation/v1/internal/reservation_retry_traits.h
+++ b/google/cloud/bigquery/reservation/v1/internal/reservation_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ReservationServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/bigquery/storage/v1/internal/bigquery_read_retry_traits.h
+++ b/google/cloud/bigquery/storage/v1/internal/bigquery_read_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct BigQueryReadRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/bigquery/storage/v1/internal/bigquery_write_retry_traits.h
+++ b/google/cloud/bigquery/storage/v1/internal/bigquery_write_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct BigQueryWriteRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/bigtable/admin/internal/bigtable_instance_admin_retry_traits.h
+++ b/google/cloud/bigtable/admin/internal/bigtable_instance_admin_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct BigtableInstanceAdminRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kAborted &&
            status.code() != StatusCode::kUnavailable;

--- a/google/cloud/bigtable/admin/internal/bigtable_table_admin_retry_traits.h
+++ b/google/cloud/bigtable/admin/internal/bigtable_table_admin_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct BigtableTableAdminRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kAborted &&
            status.code() != StatusCode::kUnavailable;

--- a/google/cloud/billing/budgets/v1/internal/budget_retry_traits.h
+++ b/google/cloud/billing/budgets/v1/internal/budget_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct BudgetServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/billing/v1/internal/cloud_billing_retry_traits.h
+++ b/google/cloud/billing/v1/internal/cloud_billing_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct CloudBillingRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/billing/v1/internal/cloud_catalog_retry_traits.h
+++ b/google/cloud/billing/v1/internal/cloud_catalog_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct CloudCatalogRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/binaryauthorization/v1/internal/binauthz_management_service_v1_retry_traits.h
+++ b/google/cloud/binaryauthorization/v1/internal/binauthz_management_service_v1_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct BinauthzManagementServiceV1RetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/binaryauthorization/v1/internal/system_policy_v1_retry_traits.h
+++ b/google/cloud/binaryauthorization/v1/internal/system_policy_v1_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SystemPolicyV1RetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/binaryauthorization/v1/internal/validation_helper_v1_retry_traits.h
+++ b/google/cloud/binaryauthorization/v1/internal/validation_helper_v1_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ValidationHelperV1RetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/certificatemanager/v1/internal/certificate_manager_retry_traits.h
+++ b/google/cloud/certificatemanager/v1/internal/certificate_manager_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct CertificateManagerRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/channel/v1/internal/cloud_channel_reports_retry_traits.h
+++ b/google/cloud/channel/v1/internal/cloud_channel_reports_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct CloudChannelReportsServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/channel/v1/internal/cloud_channel_retry_traits.h
+++ b/google/cloud/channel/v1/internal/cloud_channel_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct CloudChannelServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/cloudbuild/v1/internal/cloud_build_retry_traits.h
+++ b/google/cloud/cloudbuild/v1/internal/cloud_build_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct CloudBuildRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/cloudbuild/v2/internal/repository_manager_retry_traits.h
+++ b/google/cloud/cloudbuild/v2/internal/repository_manager_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RepositoryManagerRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_retry_traits.h
+++ b/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct CloudControlsPartnerCoreRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_monitoring_retry_traits.h
+++ b/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_monitoring_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct CloudControlsPartnerMonitoringRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/cloudquotas/v1/internal/cloud_quotas_retry_traits.h
+++ b/google/cloud/cloudquotas/v1/internal/cloud_quotas_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct CloudQuotasRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/commerce/consumer/procurement/v1/internal/consumer_procurement_retry_traits.h
+++ b/google/cloud/commerce/consumer/procurement/v1/internal/consumer_procurement_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ConsumerProcurementServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/composer/v1/internal/environments_retry_traits.h
+++ b/google/cloud/composer/v1/internal/environments_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct EnvironmentsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/composer/v1/internal/image_versions_retry_traits.h
+++ b/google/cloud/composer/v1/internal/image_versions_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ImageVersionsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/accelerator_types/v1/internal/accelerator_types_retry_traits.h
+++ b/google/cloud/compute/accelerator_types/v1/internal/accelerator_types_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct AcceleratorTypesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/addresses/v1/internal/addresses_retry_traits.h
+++ b/google/cloud/compute/addresses/v1/internal/addresses_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct AddressesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/autoscalers/v1/internal/autoscalers_retry_traits.h
+++ b/google/cloud/compute/autoscalers/v1/internal/autoscalers_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct AutoscalersRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/backend_buckets/v1/internal/backend_buckets_retry_traits.h
+++ b/google/cloud/compute/backend_buckets/v1/internal/backend_buckets_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct BackendBucketsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/backend_services/v1/internal/backend_services_retry_traits.h
+++ b/google/cloud/compute/backend_services/v1/internal/backend_services_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct BackendServicesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/disk_types/v1/internal/disk_types_retry_traits.h
+++ b/google/cloud/compute/disk_types/v1/internal/disk_types_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct DiskTypesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/disks/v1/internal/disks_retry_traits.h
+++ b/google/cloud/compute/disks/v1/internal/disks_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct DisksRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/external_vpn_gateways/v1/internal/external_vpn_gateways_retry_traits.h
+++ b/google/cloud/compute/external_vpn_gateways/v1/internal/external_vpn_gateways_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ExternalVpnGatewaysRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/firewall_policies/v1/internal/firewall_policies_retry_traits.h
+++ b/google/cloud/compute/firewall_policies/v1/internal/firewall_policies_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct FirewallPoliciesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/firewalls/v1/internal/firewalls_retry_traits.h
+++ b/google/cloud/compute/firewalls/v1/internal/firewalls_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct FirewallsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/forwarding_rules/v1/internal/forwarding_rules_retry_traits.h
+++ b/google/cloud/compute/forwarding_rules/v1/internal/forwarding_rules_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ForwardingRulesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/global_addresses/v1/internal/global_addresses_retry_traits.h
+++ b/google/cloud/compute/global_addresses/v1/internal/global_addresses_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct GlobalAddressesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/global_forwarding_rules/v1/internal/global_forwarding_rules_retry_traits.h
+++ b/google/cloud/compute/global_forwarding_rules/v1/internal/global_forwarding_rules_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct GlobalForwardingRulesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/global_network_endpoint_groups/v1/internal/global_network_endpoint_groups_retry_traits.h
+++ b/google/cloud/compute/global_network_endpoint_groups/v1/internal/global_network_endpoint_groups_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct GlobalNetworkEndpointGroupsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/global_operations/v1/internal/global_operations_retry_traits.h
+++ b/google/cloud/compute/global_operations/v1/internal/global_operations_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct GlobalOperationsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/global_organization_operations/v1/internal/global_organization_operations_retry_traits.h
+++ b/google/cloud/compute/global_organization_operations/v1/internal/global_organization_operations_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct GlobalOrganizationOperationsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/global_public_delegated_prefixes/v1/internal/global_public_delegated_prefixes_retry_traits.h
+++ b/google/cloud/compute/global_public_delegated_prefixes/v1/internal/global_public_delegated_prefixes_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct GlobalPublicDelegatedPrefixesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/health_checks/v1/internal/health_checks_retry_traits.h
+++ b/google/cloud/compute/health_checks/v1/internal/health_checks_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct HealthChecksRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/http_health_checks/v1/internal/http_health_checks_retry_traits.h
+++ b/google/cloud/compute/http_health_checks/v1/internal/http_health_checks_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct HttpHealthChecksRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/https_health_checks/v1/internal/https_health_checks_retry_traits.h
+++ b/google/cloud/compute/https_health_checks/v1/internal/https_health_checks_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct HttpsHealthChecksRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/image_family_views/v1/internal/image_family_views_retry_traits.h
+++ b/google/cloud/compute/image_family_views/v1/internal/image_family_views_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ImageFamilyViewsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/images/v1/internal/images_retry_traits.h
+++ b/google/cloud/compute/images/v1/internal/images_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ImagesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/instance_group_manager_resize_requests/v1/internal/instance_group_manager_resize_requests_retry_traits.h
+++ b/google/cloud/compute/instance_group_manager_resize_requests/v1/internal/instance_group_manager_resize_requests_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct InstanceGroupManagerResizeRequestsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/instance_group_managers/v1/internal/instance_group_managers_retry_traits.h
+++ b/google/cloud/compute/instance_group_managers/v1/internal/instance_group_managers_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct InstanceGroupManagersRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/instance_groups/v1/internal/instance_groups_retry_traits.h
+++ b/google/cloud/compute/instance_groups/v1/internal/instance_groups_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct InstanceGroupsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/instance_settings/v1/internal/instance_settings_retry_traits.h
+++ b/google/cloud/compute/instance_settings/v1/internal/instance_settings_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct InstanceSettingsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/instance_templates/v1/internal/instance_templates_retry_traits.h
+++ b/google/cloud/compute/instance_templates/v1/internal/instance_templates_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct InstanceTemplatesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/instances/v1/internal/instances_retry_traits.h
+++ b/google/cloud/compute/instances/v1/internal/instances_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct InstancesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/interconnect_attachments/v1/internal/interconnect_attachments_retry_traits.h
+++ b/google/cloud/compute/interconnect_attachments/v1/internal/interconnect_attachments_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct InterconnectAttachmentsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/interconnect_locations/v1/internal/interconnect_locations_retry_traits.h
+++ b/google/cloud/compute/interconnect_locations/v1/internal/interconnect_locations_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct InterconnectLocationsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/interconnect_remote_locations/v1/internal/interconnect_remote_locations_retry_traits.h
+++ b/google/cloud/compute/interconnect_remote_locations/v1/internal/interconnect_remote_locations_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct InterconnectRemoteLocationsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/interconnects/v1/internal/interconnects_retry_traits.h
+++ b/google/cloud/compute/interconnects/v1/internal/interconnects_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct InterconnectsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/license_codes/v1/internal/license_codes_retry_traits.h
+++ b/google/cloud/compute/license_codes/v1/internal/license_codes_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct LicenseCodesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/licenses/v1/internal/licenses_retry_traits.h
+++ b/google/cloud/compute/licenses/v1/internal/licenses_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct LicensesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/machine_images/v1/internal/machine_images_retry_traits.h
+++ b/google/cloud/compute/machine_images/v1/internal/machine_images_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct MachineImagesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/machine_types/v1/internal/machine_types_retry_traits.h
+++ b/google/cloud/compute/machine_types/v1/internal/machine_types_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct MachineTypesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/network_attachments/v1/internal/network_attachments_retry_traits.h
+++ b/google/cloud/compute/network_attachments/v1/internal/network_attachments_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct NetworkAttachmentsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/network_edge_security_services/v1/internal/network_edge_security_services_retry_traits.h
+++ b/google/cloud/compute/network_edge_security_services/v1/internal/network_edge_security_services_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct NetworkEdgeSecurityServicesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/network_endpoint_groups/v1/internal/network_endpoint_groups_retry_traits.h
+++ b/google/cloud/compute/network_endpoint_groups/v1/internal/network_endpoint_groups_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct NetworkEndpointGroupsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/network_firewall_policies/v1/internal/network_firewall_policies_retry_traits.h
+++ b/google/cloud/compute/network_firewall_policies/v1/internal/network_firewall_policies_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct NetworkFirewallPoliciesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/networks/v1/internal/networks_retry_traits.h
+++ b/google/cloud/compute/networks/v1/internal/networks_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct NetworksRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/node_groups/v1/internal/node_groups_retry_traits.h
+++ b/google/cloud/compute/node_groups/v1/internal/node_groups_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct NodeGroupsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/node_templates/v1/internal/node_templates_retry_traits.h
+++ b/google/cloud/compute/node_templates/v1/internal/node_templates_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct NodeTemplatesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/node_types/v1/internal/node_types_retry_traits.h
+++ b/google/cloud/compute/node_types/v1/internal/node_types_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct NodeTypesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/packet_mirrorings/v1/internal/packet_mirrorings_retry_traits.h
+++ b/google/cloud/compute/packet_mirrorings/v1/internal/packet_mirrorings_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct PacketMirroringsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/projects/v1/internal/projects_retry_traits.h
+++ b/google/cloud/compute/projects/v1/internal/projects_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ProjectsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/public_advertised_prefixes/v1/internal/public_advertised_prefixes_retry_traits.h
+++ b/google/cloud/compute/public_advertised_prefixes/v1/internal/public_advertised_prefixes_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct PublicAdvertisedPrefixesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/public_delegated_prefixes/v1/internal/public_delegated_prefixes_retry_traits.h
+++ b/google/cloud/compute/public_delegated_prefixes/v1/internal/public_delegated_prefixes_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct PublicDelegatedPrefixesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/region_autoscalers/v1/internal/region_autoscalers_retry_traits.h
+++ b/google/cloud/compute/region_autoscalers/v1/internal/region_autoscalers_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RegionAutoscalersRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/region_backend_services/v1/internal/region_backend_services_retry_traits.h
+++ b/google/cloud/compute/region_backend_services/v1/internal/region_backend_services_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RegionBackendServicesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/region_commitments/v1/internal/region_commitments_retry_traits.h
+++ b/google/cloud/compute/region_commitments/v1/internal/region_commitments_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RegionCommitmentsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/region_disk_types/v1/internal/region_disk_types_retry_traits.h
+++ b/google/cloud/compute/region_disk_types/v1/internal/region_disk_types_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RegionDiskTypesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/region_disks/v1/internal/region_disks_retry_traits.h
+++ b/google/cloud/compute/region_disks/v1/internal/region_disks_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RegionDisksRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/region_health_check_services/v1/internal/region_health_check_services_retry_traits.h
+++ b/google/cloud/compute/region_health_check_services/v1/internal/region_health_check_services_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RegionHealthCheckServicesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/region_health_checks/v1/internal/region_health_checks_retry_traits.h
+++ b/google/cloud/compute/region_health_checks/v1/internal/region_health_checks_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RegionHealthChecksRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/region_instance_group_managers/v1/internal/region_instance_group_managers_retry_traits.h
+++ b/google/cloud/compute/region_instance_group_managers/v1/internal/region_instance_group_managers_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RegionInstanceGroupManagersRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/region_instance_groups/v1/internal/region_instance_groups_retry_traits.h
+++ b/google/cloud/compute/region_instance_groups/v1/internal/region_instance_groups_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RegionInstanceGroupsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/region_instance_templates/v1/internal/region_instance_templates_retry_traits.h
+++ b/google/cloud/compute/region_instance_templates/v1/internal/region_instance_templates_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RegionInstanceTemplatesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/region_instances/v1/internal/region_instances_retry_traits.h
+++ b/google/cloud/compute/region_instances/v1/internal/region_instances_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RegionInstancesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/region_network_endpoint_groups/v1/internal/region_network_endpoint_groups_retry_traits.h
+++ b/google/cloud/compute/region_network_endpoint_groups/v1/internal/region_network_endpoint_groups_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RegionNetworkEndpointGroupsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/region_network_firewall_policies/v1/internal/region_network_firewall_policies_retry_traits.h
+++ b/google/cloud/compute/region_network_firewall_policies/v1/internal/region_network_firewall_policies_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RegionNetworkFirewallPoliciesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/region_notification_endpoints/v1/internal/region_notification_endpoints_retry_traits.h
+++ b/google/cloud/compute/region_notification_endpoints/v1/internal/region_notification_endpoints_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RegionNotificationEndpointsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/region_operations/v1/internal/region_operations_retry_traits.h
+++ b/google/cloud/compute/region_operations/v1/internal/region_operations_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RegionOperationsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/region_security_policies/v1/internal/region_security_policies_retry_traits.h
+++ b/google/cloud/compute/region_security_policies/v1/internal/region_security_policies_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RegionSecurityPoliciesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/region_ssl_certificates/v1/internal/region_ssl_certificates_retry_traits.h
+++ b/google/cloud/compute/region_ssl_certificates/v1/internal/region_ssl_certificates_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RegionSslCertificatesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/region_ssl_policies/v1/internal/region_ssl_policies_retry_traits.h
+++ b/google/cloud/compute/region_ssl_policies/v1/internal/region_ssl_policies_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RegionSslPoliciesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/region_target_http_proxies/v1/internal/region_target_http_proxies_retry_traits.h
+++ b/google/cloud/compute/region_target_http_proxies/v1/internal/region_target_http_proxies_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RegionTargetHttpProxiesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/region_target_https_proxies/v1/internal/region_target_https_proxies_retry_traits.h
+++ b/google/cloud/compute/region_target_https_proxies/v1/internal/region_target_https_proxies_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RegionTargetHttpsProxiesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/region_target_tcp_proxies/v1/internal/region_target_tcp_proxies_retry_traits.h
+++ b/google/cloud/compute/region_target_tcp_proxies/v1/internal/region_target_tcp_proxies_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RegionTargetTcpProxiesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/region_url_maps/v1/internal/region_url_maps_retry_traits.h
+++ b/google/cloud/compute/region_url_maps/v1/internal/region_url_maps_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RegionUrlMapsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/region_zones/v1/internal/region_zones_retry_traits.h
+++ b/google/cloud/compute/region_zones/v1/internal/region_zones_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RegionZonesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/regions/v1/internal/regions_retry_traits.h
+++ b/google/cloud/compute/regions/v1/internal/regions_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RegionsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/reservations/v1/internal/reservations_retry_traits.h
+++ b/google/cloud/compute/reservations/v1/internal/reservations_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ReservationsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/resource_policies/v1/internal/resource_policies_retry_traits.h
+++ b/google/cloud/compute/resource_policies/v1/internal/resource_policies_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ResourcePoliciesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/routers/v1/internal/routers_retry_traits.h
+++ b/google/cloud/compute/routers/v1/internal/routers_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RoutersRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/routes/v1/internal/routes_retry_traits.h
+++ b/google/cloud/compute/routes/v1/internal/routes_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RoutesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/security_policies/v1/internal/security_policies_retry_traits.h
+++ b/google/cloud/compute/security_policies/v1/internal/security_policies_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SecurityPoliciesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/service_attachments/v1/internal/service_attachments_retry_traits.h
+++ b/google/cloud/compute/service_attachments/v1/internal/service_attachments_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ServiceAttachmentsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/snapshot_settings/v1/internal/snapshot_settings_retry_traits.h
+++ b/google/cloud/compute/snapshot_settings/v1/internal/snapshot_settings_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SnapshotSettingsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/snapshots/v1/internal/snapshots_retry_traits.h
+++ b/google/cloud/compute/snapshots/v1/internal/snapshots_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SnapshotsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/ssl_certificates/v1/internal/ssl_certificates_retry_traits.h
+++ b/google/cloud/compute/ssl_certificates/v1/internal/ssl_certificates_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SslCertificatesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/ssl_policies/v1/internal/ssl_policies_retry_traits.h
+++ b/google/cloud/compute/ssl_policies/v1/internal/ssl_policies_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SslPoliciesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/storage_pool_types/v1/internal/storage_pool_types_retry_traits.h
+++ b/google/cloud/compute/storage_pool_types/v1/internal/storage_pool_types_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct StoragePoolTypesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/storage_pools/v1/internal/storage_pools_retry_traits.h
+++ b/google/cloud/compute/storage_pools/v1/internal/storage_pools_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct StoragePoolsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/subnetworks/v1/internal/subnetworks_retry_traits.h
+++ b/google/cloud/compute/subnetworks/v1/internal/subnetworks_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SubnetworksRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/target_grpc_proxies/v1/internal/target_grpc_proxies_retry_traits.h
+++ b/google/cloud/compute/target_grpc_proxies/v1/internal/target_grpc_proxies_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct TargetGrpcProxiesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/target_http_proxies/v1/internal/target_http_proxies_retry_traits.h
+++ b/google/cloud/compute/target_http_proxies/v1/internal/target_http_proxies_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct TargetHttpProxiesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/target_https_proxies/v1/internal/target_https_proxies_retry_traits.h
+++ b/google/cloud/compute/target_https_proxies/v1/internal/target_https_proxies_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct TargetHttpsProxiesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/target_instances/v1/internal/target_instances_retry_traits.h
+++ b/google/cloud/compute/target_instances/v1/internal/target_instances_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct TargetInstancesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/target_pools/v1/internal/target_pools_retry_traits.h
+++ b/google/cloud/compute/target_pools/v1/internal/target_pools_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct TargetPoolsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/target_ssl_proxies/v1/internal/target_ssl_proxies_retry_traits.h
+++ b/google/cloud/compute/target_ssl_proxies/v1/internal/target_ssl_proxies_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct TargetSslProxiesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/target_tcp_proxies/v1/internal/target_tcp_proxies_retry_traits.h
+++ b/google/cloud/compute/target_tcp_proxies/v1/internal/target_tcp_proxies_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct TargetTcpProxiesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/target_vpn_gateways/v1/internal/target_vpn_gateways_retry_traits.h
+++ b/google/cloud/compute/target_vpn_gateways/v1/internal/target_vpn_gateways_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct TargetVpnGatewaysRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/url_maps/v1/internal/url_maps_retry_traits.h
+++ b/google/cloud/compute/url_maps/v1/internal/url_maps_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct UrlMapsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/vpn_gateways/v1/internal/vpn_gateways_retry_traits.h
+++ b/google/cloud/compute/vpn_gateways/v1/internal/vpn_gateways_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct VpnGatewaysRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/vpn_tunnels/v1/internal/vpn_tunnels_retry_traits.h
+++ b/google/cloud/compute/vpn_tunnels/v1/internal/vpn_tunnels_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct VpnTunnelsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/zone_operations/v1/internal/zone_operations_retry_traits.h
+++ b/google/cloud/compute/zone_operations/v1/internal/zone_operations_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ZoneOperationsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/compute/zones/v1/internal/zones_retry_traits.h
+++ b/google/cloud/compute/zones/v1/internal/zones_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ZonesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/confidentialcomputing/v1/internal/confidential_computing_retry_traits.h
+++ b/google/cloud/confidentialcomputing/v1/internal/confidential_computing_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ConfidentialComputingRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/config/v1/internal/config_retry_traits.h
+++ b/google/cloud/config/v1/internal/config_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ConfigRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/connectors/v1/internal/connectors_retry_traits.h
+++ b/google/cloud/connectors/v1/internal/connectors_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ConnectorsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/contactcenterinsights/v1/internal/contact_center_insights_retry_traits.h
+++ b/google/cloud/contactcenterinsights/v1/internal/contact_center_insights_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ContactCenterInsightsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/container/v1/internal/cluster_manager_retry_traits.h
+++ b/google/cloud/container/v1/internal/cluster_manager_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ClusterManagerRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/containeranalysis/v1/internal/container_analysis_retry_traits.h
+++ b/google/cloud/containeranalysis/v1/internal/container_analysis_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ContainerAnalysisRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/containeranalysis/v1/internal/grafeas_retry_traits.h
+++ b/google/cloud/containeranalysis/v1/internal/grafeas_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct GrafeasRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/contentwarehouse/v1/internal/document_link_retry_traits.h
+++ b/google/cloud/contentwarehouse/v1/internal/document_link_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct DocumentLinkServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/contentwarehouse/v1/internal/document_retry_traits.h
+++ b/google/cloud/contentwarehouse/v1/internal/document_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct DocumentServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/contentwarehouse/v1/internal/document_schema_retry_traits.h
+++ b/google/cloud/contentwarehouse/v1/internal/document_schema_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct DocumentSchemaServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/contentwarehouse/v1/internal/pipeline_retry_traits.h
+++ b/google/cloud/contentwarehouse/v1/internal/pipeline_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct PipelineServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/contentwarehouse/v1/internal/rule_set_retry_traits.h
+++ b/google/cloud/contentwarehouse/v1/internal/rule_set_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RuleSetServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/contentwarehouse/v1/internal/synonym_set_retry_traits.h
+++ b/google/cloud/contentwarehouse/v1/internal/synonym_set_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SynonymSetServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/datacatalog/lineage/v1/internal/lineage_retry_traits.h
+++ b/google/cloud/datacatalog/lineage/v1/internal/lineage_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct LineageRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/datacatalog/v1/internal/data_catalog_retry_traits.h
+++ b/google/cloud/datacatalog/v1/internal/data_catalog_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct DataCatalogRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/datacatalog/v1/internal/policy_tag_manager_retry_traits.h
+++ b/google/cloud/datacatalog/v1/internal/policy_tag_manager_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct PolicyTagManagerRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/datacatalog/v1/internal/policy_tag_manager_serialization_retry_traits.h
+++ b/google/cloud/datacatalog/v1/internal/policy_tag_manager_serialization_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct PolicyTagManagerSerializationRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/datafusion/v1/internal/data_fusion_retry_traits.h
+++ b/google/cloud/datafusion/v1/internal/data_fusion_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct DataFusionRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/datamigration/v1/internal/data_migration_retry_traits.h
+++ b/google/cloud/datamigration/v1/internal/data_migration_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct DataMigrationServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dataplex/v1/internal/catalog_retry_traits.h
+++ b/google/cloud/dataplex/v1/internal/catalog_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct CatalogServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dataplex/v1/internal/content_retry_traits.h
+++ b/google/cloud/dataplex/v1/internal/content_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ContentServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dataplex/v1/internal/data_scan_retry_traits.h
+++ b/google/cloud/dataplex/v1/internal/data_scan_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct DataScanServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dataplex/v1/internal/data_taxonomy_retry_traits.h
+++ b/google/cloud/dataplex/v1/internal/data_taxonomy_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct DataTaxonomyServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dataplex/v1/internal/dataplex_retry_traits.h
+++ b/google/cloud/dataplex/v1/internal/dataplex_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct DataplexServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dataplex/v1/internal/metadata_retry_traits.h
+++ b/google/cloud/dataplex/v1/internal/metadata_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct MetadataServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dataproc/v1/internal/autoscaling_policy_retry_traits.h
+++ b/google/cloud/dataproc/v1/internal/autoscaling_policy_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct AutoscalingPolicyServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dataproc/v1/internal/batch_controller_retry_traits.h
+++ b/google/cloud/dataproc/v1/internal/batch_controller_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct BatchControllerRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dataproc/v1/internal/cluster_controller_retry_traits.h
+++ b/google/cloud/dataproc/v1/internal/cluster_controller_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ClusterControllerRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dataproc/v1/internal/job_controller_retry_traits.h
+++ b/google/cloud/dataproc/v1/internal/job_controller_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct JobControllerRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dataproc/v1/internal/node_group_controller_retry_traits.h
+++ b/google/cloud/dataproc/v1/internal/node_group_controller_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct NodeGroupControllerRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dataproc/v1/internal/session_controller_retry_traits.h
+++ b/google/cloud/dataproc/v1/internal/session_controller_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SessionControllerRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dataproc/v1/internal/session_template_controller_retry_traits.h
+++ b/google/cloud/dataproc/v1/internal/session_template_controller_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SessionTemplateControllerRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dataproc/v1/internal/workflow_template_retry_traits.h
+++ b/google/cloud/dataproc/v1/internal/workflow_template_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct WorkflowTemplateServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/datastore/admin/v1/internal/datastore_admin_retry_traits.h
+++ b/google/cloud/datastore/admin/v1/internal/datastore_admin_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct DatastoreAdminRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/datastore/v1/internal/datastore_retry_traits.h
+++ b/google/cloud/datastore/v1/internal/datastore_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct DatastoreRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/datastream/v1/internal/datastream_retry_traits.h
+++ b/google/cloud/datastream/v1/internal/datastream_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct DatastreamRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/deploy/v1/internal/cloud_deploy_retry_traits.h
+++ b/google/cloud/deploy/v1/internal/cloud_deploy_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct CloudDeployRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_cx/internal/agents_retry_traits.h
+++ b/google/cloud/dialogflow_cx/internal/agents_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct AgentsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_cx/internal/changelogs_retry_traits.h
+++ b/google/cloud/dialogflow_cx/internal/changelogs_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ChangelogsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_cx/internal/deployments_retry_traits.h
+++ b/google/cloud/dialogflow_cx/internal/deployments_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct DeploymentsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_cx/internal/entity_types_retry_traits.h
+++ b/google/cloud/dialogflow_cx/internal/entity_types_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct EntityTypesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_cx/internal/environments_retry_traits.h
+++ b/google/cloud/dialogflow_cx/internal/environments_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct EnvironmentsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_cx/internal/experiments_retry_traits.h
+++ b/google/cloud/dialogflow_cx/internal/experiments_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ExperimentsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_cx/internal/flows_retry_traits.h
+++ b/google/cloud/dialogflow_cx/internal/flows_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct FlowsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_cx/internal/generators_retry_traits.h
+++ b/google/cloud/dialogflow_cx/internal/generators_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct GeneratorsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_cx/internal/intents_retry_traits.h
+++ b/google/cloud/dialogflow_cx/internal/intents_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct IntentsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_cx/internal/pages_retry_traits.h
+++ b/google/cloud/dialogflow_cx/internal/pages_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct PagesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_cx/internal/security_settings_retry_traits.h
+++ b/google/cloud/dialogflow_cx/internal/security_settings_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SecuritySettingsServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_cx/internal/session_entity_types_retry_traits.h
+++ b/google/cloud/dialogflow_cx/internal/session_entity_types_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SessionEntityTypesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_cx/internal/sessions_retry_traits.h
+++ b/google/cloud/dialogflow_cx/internal/sessions_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SessionsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_cx/internal/test_cases_retry_traits.h
+++ b/google/cloud/dialogflow_cx/internal/test_cases_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct TestCasesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_cx/internal/transition_route_groups_retry_traits.h
+++ b/google/cloud/dialogflow_cx/internal/transition_route_groups_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct TransitionRouteGroupsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_cx/internal/versions_retry_traits.h
+++ b/google/cloud/dialogflow_cx/internal/versions_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct VersionsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_cx/internal/webhooks_retry_traits.h
+++ b/google/cloud/dialogflow_cx/internal/webhooks_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct WebhooksRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_es/internal/agents_retry_traits.h
+++ b/google/cloud/dialogflow_es/internal/agents_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct AgentsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_es/internal/answer_records_retry_traits.h
+++ b/google/cloud/dialogflow_es/internal/answer_records_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct AnswerRecordsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_es/internal/contexts_retry_traits.h
+++ b/google/cloud/dialogflow_es/internal/contexts_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ContextsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_es/internal/conversation_datasets_retry_traits.h
+++ b/google/cloud/dialogflow_es/internal/conversation_datasets_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ConversationDatasetsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_es/internal/conversation_models_retry_traits.h
+++ b/google/cloud/dialogflow_es/internal/conversation_models_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ConversationModelsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_es/internal/conversation_profiles_retry_traits.h
+++ b/google/cloud/dialogflow_es/internal/conversation_profiles_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ConversationProfilesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_es/internal/conversations_retry_traits.h
+++ b/google/cloud/dialogflow_es/internal/conversations_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ConversationsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_es/internal/documents_retry_traits.h
+++ b/google/cloud/dialogflow_es/internal/documents_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct DocumentsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_es/internal/entity_types_retry_traits.h
+++ b/google/cloud/dialogflow_es/internal/entity_types_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct EntityTypesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_es/internal/environments_retry_traits.h
+++ b/google/cloud/dialogflow_es/internal/environments_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct EnvironmentsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_es/internal/fulfillments_retry_traits.h
+++ b/google/cloud/dialogflow_es/internal/fulfillments_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct FulfillmentsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_es/internal/intents_retry_traits.h
+++ b/google/cloud/dialogflow_es/internal/intents_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct IntentsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_es/internal/knowledge_bases_retry_traits.h
+++ b/google/cloud/dialogflow_es/internal/knowledge_bases_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct KnowledgeBasesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_es/internal/participants_retry_traits.h
+++ b/google/cloud/dialogflow_es/internal/participants_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ParticipantsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_es/internal/session_entity_types_retry_traits.h
+++ b/google/cloud/dialogflow_es/internal/session_entity_types_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SessionEntityTypesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_es/internal/sessions_retry_traits.h
+++ b/google/cloud/dialogflow_es/internal/sessions_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SessionsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dialogflow_es/internal/versions_retry_traits.h
+++ b/google/cloud/dialogflow_es/internal/versions_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct VersionsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/discoveryengine/v1/internal/completion_retry_traits.h
+++ b/google/cloud/discoveryengine/v1/internal/completion_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct CompletionServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/discoveryengine/v1/internal/conversational_search_retry_traits.h
+++ b/google/cloud/discoveryengine/v1/internal/conversational_search_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ConversationalSearchServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/discoveryengine/v1/internal/data_store_retry_traits.h
+++ b/google/cloud/discoveryengine/v1/internal/data_store_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct DataStoreServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/discoveryengine/v1/internal/document_retry_traits.h
+++ b/google/cloud/discoveryengine/v1/internal/document_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct DocumentServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/discoveryengine/v1/internal/engine_retry_traits.h
+++ b/google/cloud/discoveryengine/v1/internal/engine_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct EngineServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/discoveryengine/v1/internal/recommendation_retry_traits.h
+++ b/google/cloud/discoveryengine/v1/internal/recommendation_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RecommendationServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/discoveryengine/v1/internal/schema_retry_traits.h
+++ b/google/cloud/discoveryengine/v1/internal/schema_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SchemaServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/discoveryengine/v1/internal/search_retry_traits.h
+++ b/google/cloud/discoveryengine/v1/internal/search_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SearchServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/discoveryengine/v1/internal/site_search_engine_retry_traits.h
+++ b/google/cloud/discoveryengine/v1/internal/site_search_engine_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SiteSearchEngineServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/discoveryengine/v1/internal/user_event_retry_traits.h
+++ b/google/cloud/discoveryengine/v1/internal/user_event_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct UserEventServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/dlp/v2/internal/dlp_retry_traits.h
+++ b/google/cloud/dlp/v2/internal/dlp_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct DlpServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/documentai/v1/internal/document_processor_retry_traits.h
+++ b/google/cloud/documentai/v1/internal/document_processor_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct DocumentProcessorServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/domains/v1/internal/domains_retry_traits.h
+++ b/google/cloud/domains/v1/internal/domains_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct DomainsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/edgecontainer/v1/internal/edge_container_retry_traits.h
+++ b/google/cloud/edgecontainer/v1/internal/edge_container_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct EdgeContainerRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/edgenetwork/v1/internal/edge_network_retry_traits.h
+++ b/google/cloud/edgenetwork/v1/internal/edge_network_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct EdgeNetworkRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/essentialcontacts/v1/internal/essential_contacts_retry_traits.h
+++ b/google/cloud/essentialcontacts/v1/internal/essential_contacts_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct EssentialContactsServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/eventarc/publishing/v1/internal/publisher_retry_traits.h
+++ b/google/cloud/eventarc/publishing/v1/internal/publisher_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct PublisherRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/eventarc/v1/internal/eventarc_retry_traits.h
+++ b/google/cloud/eventarc/v1/internal/eventarc_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct EventarcRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable &&
            status.code() != StatusCode::kUnknown;

--- a/google/cloud/filestore/v1/internal/cloud_filestore_manager_retry_traits.h
+++ b/google/cloud/filestore/v1/internal/cloud_filestore_manager_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct CloudFilestoreManagerRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/functions/v1/internal/cloud_functions_retry_traits.h
+++ b/google/cloud/functions/v1/internal/cloud_functions_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct CloudFunctionsServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/functions/v2/internal/function_retry_traits.h
+++ b/google/cloud/functions/v2/internal/function_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct FunctionServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/gkebackup/v1/internal/backup_for_gke_retry_traits.h
+++ b/google/cloud/gkebackup/v1/internal/backup_for_gke_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct BackupForGKERetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/gkehub/v1/internal/gke_hub_retry_traits.h
+++ b/google/cloud/gkehub/v1/internal/gke_hub_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct GkeHubRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/gkemulticloud/v1/internal/attached_clusters_retry_traits.h
+++ b/google/cloud/gkemulticloud/v1/internal/attached_clusters_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct AttachedClustersRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/gkemulticloud/v1/internal/aws_clusters_retry_traits.h
+++ b/google/cloud/gkemulticloud/v1/internal/aws_clusters_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct AwsClustersRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/gkemulticloud/v1/internal/azure_clusters_retry_traits.h
+++ b/google/cloud/gkemulticloud/v1/internal/azure_clusters_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct AzureClustersRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/iam/admin/v1/internal/iam_retry_traits.h
+++ b/google/cloud/iam/admin/v1/internal/iam_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct IAMRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/iam/credentials/v1/internal/iam_credentials_retry_traits.h
+++ b/google/cloud/iam/credentials/v1/internal/iam_credentials_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct IAMCredentialsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/iam/v1/internal/iam_policy_retry_traits.h
+++ b/google/cloud/iam/v1/internal/iam_policy_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct IAMPolicyRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/iam/v2/internal/policies_retry_traits.h
+++ b/google/cloud/iam/v2/internal/policies_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct PoliciesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/iap/v1/internal/identity_aware_proxy_admin_retry_traits.h
+++ b/google/cloud/iap/v1/internal/identity_aware_proxy_admin_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct IdentityAwareProxyAdminServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/iap/v1/internal/identity_aware_proxy_o_auth_retry_traits.h
+++ b/google/cloud/iap/v1/internal/identity_aware_proxy_o_auth_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct IdentityAwareProxyOAuthServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/ids/v1/internal/ids_retry_traits.h
+++ b/google/cloud/ids/v1/internal/ids_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct IDSRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/kms/inventory/v1/internal/key_dashboard_retry_traits.h
+++ b/google/cloud/kms/inventory/v1/internal/key_dashboard_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct KeyDashboardServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/kms/inventory/v1/internal/key_tracking_retry_traits.h
+++ b/google/cloud/kms/inventory/v1/internal/key_tracking_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct KeyTrackingServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/kms/v1/internal/ekm_retry_traits.h
+++ b/google/cloud/kms/v1/internal/ekm_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct EkmServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/kms/v1/internal/key_management_retry_traits.h
+++ b/google/cloud/kms/v1/internal/key_management_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct KeyManagementServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/language/v1/internal/language_retry_traits.h
+++ b/google/cloud/language/v1/internal/language_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct LanguageServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/language/v2/internal/language_retry_traits.h
+++ b/google/cloud/language/v2/internal/language_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct LanguageServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/logging/v2/internal/config_service_v2_retry_traits.h
+++ b/google/cloud/logging/v2/internal/config_service_v2_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ConfigServiceV2RetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/logging/v2/internal/logging_service_v2_retry_traits.h
+++ b/google/cloud/logging/v2/internal/logging_service_v2_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct LoggingServiceV2RetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kInternal &&
            status.code() != StatusCode::kUnavailable;

--- a/google/cloud/logging/v2/internal/metrics_service_v2_retry_traits.h
+++ b/google/cloud/logging/v2/internal/metrics_service_v2_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct MetricsServiceV2RetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/managedidentities/v1/internal/managed_identities_retry_traits.h
+++ b/google/cloud/managedidentities/v1/internal/managed_identities_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ManagedIdentitiesServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/memcache/v1/internal/cloud_memcache_retry_traits.h
+++ b/google/cloud/memcache/v1/internal/cloud_memcache_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct CloudMemcacheRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/metastore/v1/internal/dataproc_metastore_federation_retry_traits.h
+++ b/google/cloud/metastore/v1/internal/dataproc_metastore_federation_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct DataprocMetastoreFederationRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/metastore/v1/internal/dataproc_metastore_retry_traits.h
+++ b/google/cloud/metastore/v1/internal/dataproc_metastore_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct DataprocMetastoreRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/migrationcenter/v1/internal/migration_center_retry_traits.h
+++ b/google/cloud/migrationcenter/v1/internal/migration_center_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct MigrationCenterRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/monitoring/dashboard/v1/internal/dashboards_retry_traits.h
+++ b/google/cloud/monitoring/dashboard/v1/internal/dashboards_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct DashboardsServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/monitoring/metricsscope/v1/internal/metrics_scopes_retry_traits.h
+++ b/google/cloud/monitoring/metricsscope/v1/internal/metrics_scopes_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct MetricsScopesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/monitoring/v3/internal/alert_policy_retry_traits.h
+++ b/google/cloud/monitoring/v3/internal/alert_policy_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct AlertPolicyServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/monitoring/v3/internal/group_retry_traits.h
+++ b/google/cloud/monitoring/v3/internal/group_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct GroupServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/monitoring/v3/internal/metric_retry_traits.h
+++ b/google/cloud/monitoring/v3/internal/metric_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct MetricServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/monitoring/v3/internal/notification_channel_retry_traits.h
+++ b/google/cloud/monitoring/v3/internal/notification_channel_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct NotificationChannelServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/monitoring/v3/internal/query_retry_traits.h
+++ b/google/cloud/monitoring/v3/internal/query_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct QueryServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/monitoring/v3/internal/service_monitoring_retry_traits.h
+++ b/google/cloud/monitoring/v3/internal/service_monitoring_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ServiceMonitoringServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/monitoring/v3/internal/snooze_retry_traits.h
+++ b/google/cloud/monitoring/v3/internal/snooze_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SnoozeServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/monitoring/v3/internal/uptime_check_retry_traits.h
+++ b/google/cloud/monitoring/v3/internal/uptime_check_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct UptimeCheckServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/netapp/v1/internal/net_app_retry_traits.h
+++ b/google/cloud/netapp/v1/internal/net_app_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct NetAppRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/networkconnectivity/v1/internal/hub_retry_traits.h
+++ b/google/cloud/networkconnectivity/v1/internal/hub_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct HubServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/networkconnectivity/v1/internal/policy_based_routing_retry_traits.h
+++ b/google/cloud/networkconnectivity/v1/internal/policy_based_routing_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct PolicyBasedRoutingServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/networkmanagement/v1/internal/reachability_retry_traits.h
+++ b/google/cloud/networkmanagement/v1/internal/reachability_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ReachabilityServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/networksecurity/v1/internal/network_security_retry_traits.h
+++ b/google/cloud/networksecurity/v1/internal/network_security_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct NetworkSecurityRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/networkservices/v1/internal/dep_retry_traits.h
+++ b/google/cloud/networkservices/v1/internal/dep_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct DepServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/networkservices/v1/internal/network_services_retry_traits.h
+++ b/google/cloud/networkservices/v1/internal/network_services_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct NetworkServicesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/notebooks/v1/internal/managed_notebook_retry_traits.h
+++ b/google/cloud/notebooks/v1/internal/managed_notebook_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ManagedNotebookServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/notebooks/v1/internal/notebook_retry_traits.h
+++ b/google/cloud/notebooks/v1/internal/notebook_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct NotebookServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/notebooks/v2/internal/notebook_retry_traits.h
+++ b/google/cloud/notebooks/v2/internal/notebook_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct NotebookServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/optimization/v1/internal/fleet_routing_retry_traits.h
+++ b/google/cloud/optimization/v1/internal/fleet_routing_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct FleetRoutingRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/orgpolicy/v2/internal/org_policy_retry_traits.h
+++ b/google/cloud/orgpolicy/v2/internal/org_policy_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct OrgPolicyRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/osconfig/agentendpoint/v1/internal/agent_endpoint_retry_traits.h
+++ b/google/cloud/osconfig/agentendpoint/v1/internal/agent_endpoint_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct AgentEndpointServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/osconfig/v1/internal/os_config_retry_traits.h
+++ b/google/cloud/osconfig/v1/internal/os_config_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct OsConfigServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/osconfig/v1/internal/os_config_zonal_retry_traits.h
+++ b/google/cloud/osconfig/v1/internal/os_config_zonal_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct OsConfigZonalServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/oslogin/v1/internal/os_login_retry_traits.h
+++ b/google/cloud/oslogin/v1/internal/os_login_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct OsLoginServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/policysimulator/v1/internal/simulator_retry_traits.h
+++ b/google/cloud/policysimulator/v1/internal/simulator_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SimulatorRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/policytroubleshooter/iam/v3/internal/policy_troubleshooter_retry_traits.h
+++ b/google/cloud/policytroubleshooter/iam/v3/internal/policy_troubleshooter_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct PolicyTroubleshooterRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/policytroubleshooter/v1/internal/iam_checker_retry_traits.h
+++ b/google/cloud/policytroubleshooter/v1/internal/iam_checker_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct IamCheckerRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/privateca/v1/internal/certificate_authority_retry_traits.h
+++ b/google/cloud/privateca/v1/internal/certificate_authority_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct CertificateAuthorityServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable &&
            status.code() != StatusCode::kUnknown;

--- a/google/cloud/profiler/v2/internal/export_retry_traits.h
+++ b/google/cloud/profiler/v2/internal/export_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ExportServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/profiler/v2/internal/profiler_retry_traits.h
+++ b/google/cloud/profiler/v2/internal/profiler_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ProfilerServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/pubsub/admin/internal/subscription_admin_retry_traits.h
+++ b/google/cloud/pubsub/admin/internal/subscription_admin_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SubscriptionAdminRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/pubsub/admin/internal/topic_admin_retry_traits.h
+++ b/google/cloud/pubsub/admin/internal/topic_admin_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct TopicAdminRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/pubsub/internal/schema_retry_traits.h
+++ b/google/cloud/pubsub/internal/schema_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SchemaServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/pubsublite/internal/admin_retry_traits.h
+++ b/google/cloud/pubsublite/internal/admin_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct AdminServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kInternal &&
            status.code() != StatusCode::kUnavailable;

--- a/google/cloud/pubsublite/internal/topic_stats_retry_traits.h
+++ b/google/cloud/pubsublite/internal/topic_stats_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct TopicStatsServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kInternal &&
            status.code() != StatusCode::kUnavailable;

--- a/google/cloud/rapidmigrationassessment/v1/internal/rapid_migration_assessment_retry_traits.h
+++ b/google/cloud/rapidmigrationassessment/v1/internal/rapid_migration_assessment_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RapidMigrationAssessmentRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/recaptchaenterprise/v1/internal/recaptcha_enterprise_retry_traits.h
+++ b/google/cloud/recaptchaenterprise/v1/internal/recaptcha_enterprise_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RecaptchaEnterpriseServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/recommender/v1/internal/recommender_retry_traits.h
+++ b/google/cloud/recommender/v1/internal/recommender_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RecommenderRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/redis/cluster/v1/internal/cloud_redis_cluster_retry_traits.h
+++ b/google/cloud/redis/cluster/v1/internal/cloud_redis_cluster_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct CloudRedisClusterRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/redis/v1/internal/cloud_redis_retry_traits.h
+++ b/google/cloud/redis/v1/internal/cloud_redis_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct CloudRedisRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/resourcemanager/v3/internal/folders_retry_traits.h
+++ b/google/cloud/resourcemanager/v3/internal/folders_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct FoldersRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/resourcemanager/v3/internal/organizations_retry_traits.h
+++ b/google/cloud/resourcemanager/v3/internal/organizations_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct OrganizationsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/resourcemanager/v3/internal/projects_retry_traits.h
+++ b/google/cloud/resourcemanager/v3/internal/projects_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ProjectsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/resourcemanager/v3/internal/tag_bindings_retry_traits.h
+++ b/google/cloud/resourcemanager/v3/internal/tag_bindings_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct TagBindingsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/resourcemanager/v3/internal/tag_holds_retry_traits.h
+++ b/google/cloud/resourcemanager/v3/internal/tag_holds_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct TagHoldsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/resourcemanager/v3/internal/tag_keys_retry_traits.h
+++ b/google/cloud/resourcemanager/v3/internal/tag_keys_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct TagKeysRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/resourcemanager/v3/internal/tag_values_retry_traits.h
+++ b/google/cloud/resourcemanager/v3/internal/tag_values_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct TagValuesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/resourcesettings/v1/internal/resource_settings_retry_traits.h
+++ b/google/cloud/resourcesettings/v1/internal/resource_settings_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ResourceSettingsServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/retail/v2/internal/analytics_retry_traits.h
+++ b/google/cloud/retail/v2/internal/analytics_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct AnalyticsServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/retail/v2/internal/catalog_retry_traits.h
+++ b/google/cloud/retail/v2/internal/catalog_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct CatalogServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/retail/v2/internal/completion_retry_traits.h
+++ b/google/cloud/retail/v2/internal/completion_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct CompletionServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/retail/v2/internal/control_retry_traits.h
+++ b/google/cloud/retail/v2/internal/control_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ControlServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/retail/v2/internal/model_retry_traits.h
+++ b/google/cloud/retail/v2/internal/model_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ModelServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/retail/v2/internal/prediction_retry_traits.h
+++ b/google/cloud/retail/v2/internal/prediction_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct PredictionServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/retail/v2/internal/product_retry_traits.h
+++ b/google/cloud/retail/v2/internal/product_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ProductServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/retail/v2/internal/search_retry_traits.h
+++ b/google/cloud/retail/v2/internal/search_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SearchServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/retail/v2/internal/serving_config_retry_traits.h
+++ b/google/cloud/retail/v2/internal/serving_config_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ServingConfigServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/retail/v2/internal/user_event_retry_traits.h
+++ b/google/cloud/retail/v2/internal/user_event_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct UserEventServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/run/v2/internal/executions_retry_traits.h
+++ b/google/cloud/run/v2/internal/executions_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ExecutionsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/run/v2/internal/jobs_retry_traits.h
+++ b/google/cloud/run/v2/internal/jobs_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct JobsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/run/v2/internal/revisions_retry_traits.h
+++ b/google/cloud/run/v2/internal/revisions_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RevisionsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/run/v2/internal/services_retry_traits.h
+++ b/google/cloud/run/v2/internal/services_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ServicesRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/run/v2/internal/tasks_retry_traits.h
+++ b/google/cloud/run/v2/internal/tasks_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct TasksRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/scheduler/v1/internal/cloud_scheduler_retry_traits.h
+++ b/google/cloud/scheduler/v1/internal/cloud_scheduler_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct CloudSchedulerRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/secretmanager/v1/internal/secret_manager_retry_traits.h
+++ b/google/cloud/secretmanager/v1/internal/secret_manager_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SecretManagerServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/securesourcemanager/v1/internal/secure_source_manager_retry_traits.h
+++ b/google/cloud/securesourcemanager/v1/internal/secure_source_manager_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SecureSourceManagerRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/securitycenter/v1/internal/security_center_retry_traits.h
+++ b/google/cloud/securitycenter/v1/internal/security_center_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SecurityCenterRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/securitycenter/v2/internal/security_center_retry_traits.h
+++ b/google/cloud/securitycenter/v2/internal/security_center_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SecurityCenterRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/securitycentermanagement/v1/internal/security_center_management_retry_traits.h
+++ b/google/cloud/securitycentermanagement/v1/internal/security_center_management_retry_traits.h
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SecurityCenterManagementRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/servicecontrol/v1/internal/quota_controller_retry_traits.h
+++ b/google/cloud/servicecontrol/v1/internal/quota_controller_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct QuotaControllerRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/servicecontrol/v1/internal/service_controller_retry_traits.h
+++ b/google/cloud/servicecontrol/v1/internal/service_controller_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ServiceControllerRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/servicecontrol/v2/internal/service_controller_retry_traits.h
+++ b/google/cloud/servicecontrol/v2/internal/service_controller_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ServiceControllerRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/servicedirectory/v1/internal/lookup_retry_traits.h
+++ b/google/cloud/servicedirectory/v1/internal/lookup_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct LookupServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable &&
            status.code() != StatusCode::kUnknown;

--- a/google/cloud/servicedirectory/v1/internal/registration_retry_traits.h
+++ b/google/cloud/servicedirectory/v1/internal/registration_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct RegistrationServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable &&
            status.code() != StatusCode::kUnknown;

--- a/google/cloud/servicehealth/v1/internal/service_health_retry_traits.h
+++ b/google/cloud/servicehealth/v1/internal/service_health_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ServiceHealthRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/servicemanagement/v1/internal/service_manager_retry_traits.h
+++ b/google/cloud/servicemanagement/v1/internal/service_manager_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ServiceManagerRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/serviceusage/v1/internal/service_usage_retry_traits.h
+++ b/google/cloud/serviceusage/v1/internal/service_usage_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ServiceUsageRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/shell/v1/internal/cloud_shell_retry_traits.h
+++ b/google/cloud/shell/v1/internal/cloud_shell_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct CloudShellServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable &&
            status.code() != StatusCode::kUnknown;

--- a/google/cloud/spanner/admin/internal/database_admin_retry_traits.h
+++ b/google/cloud/spanner/admin/internal/database_admin_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct DatabaseAdminRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/spanner/admin/internal/instance_admin_retry_traits.h
+++ b/google/cloud/spanner/admin/internal/instance_admin_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct InstanceAdminRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/speech/v1/internal/adaptation_retry_traits.h
+++ b/google/cloud/speech/v1/internal/adaptation_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct AdaptationRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/speech/v1/internal/speech_retry_traits.h
+++ b/google/cloud/speech/v1/internal/speech_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SpeechRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/speech/v2/internal/speech_retry_traits.h
+++ b/google/cloud/speech/v2/internal/speech_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SpeechRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/sql/v1/internal/sql_available_database_versions_retry_traits.h
+++ b/google/cloud/sql/v1/internal/sql_available_database_versions_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SqlAvailableDatabaseVersionsServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/sql/v1/internal/sql_backup_runs_retry_traits.h
+++ b/google/cloud/sql/v1/internal/sql_backup_runs_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SqlBackupRunsServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/sql/v1/internal/sql_connect_retry_traits.h
+++ b/google/cloud/sql/v1/internal/sql_connect_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SqlConnectServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/sql/v1/internal/sql_databases_retry_traits.h
+++ b/google/cloud/sql/v1/internal/sql_databases_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SqlDatabasesServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/sql/v1/internal/sql_events_retry_traits.h
+++ b/google/cloud/sql/v1/internal/sql_events_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SqlEventsServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/sql/v1/internal/sql_flags_retry_traits.h
+++ b/google/cloud/sql/v1/internal/sql_flags_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SqlFlagsServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/sql/v1/internal/sql_iam_policies_retry_traits.h
+++ b/google/cloud/sql/v1/internal/sql_iam_policies_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SqlIamPoliciesServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/sql/v1/internal/sql_instance_names_retry_traits.h
+++ b/google/cloud/sql/v1/internal/sql_instance_names_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SqlInstanceNamesServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/sql/v1/internal/sql_instances_retry_traits.h
+++ b/google/cloud/sql/v1/internal/sql_instances_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SqlInstancesServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/sql/v1/internal/sql_operations_retry_traits.h
+++ b/google/cloud/sql/v1/internal/sql_operations_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SqlOperationsServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/sql/v1/internal/sql_regions_retry_traits.h
+++ b/google/cloud/sql/v1/internal/sql_regions_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SqlRegionsServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/sql/v1/internal/sql_ssl_certs_retry_traits.h
+++ b/google/cloud/sql/v1/internal/sql_ssl_certs_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SqlSslCertsServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/sql/v1/internal/sql_tiers_retry_traits.h
+++ b/google/cloud/sql/v1/internal/sql_tiers_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SqlTiersServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/sql/v1/internal/sql_users_retry_traits.h
+++ b/google/cloud/sql/v1/internal/sql_users_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct SqlUsersServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/storagecontrol/v2/internal/storage_control_retry_traits.h
+++ b/google/cloud/storagecontrol/v2/internal/storage_control_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct StorageControlRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kInternal &&

--- a/google/cloud/storageinsights/v1/internal/storage_insights_retry_traits.h
+++ b/google/cloud/storageinsights/v1/internal/storage_insights_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct StorageInsightsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/storagetransfer/v1/internal/storage_transfer_retry_traits.h
+++ b/google/cloud/storagetransfer/v1/internal/storage_transfer_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct StorageTransferServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/support/v2/internal/case_attachment_retry_traits.h
+++ b/google/cloud/support/v2/internal/case_attachment_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct CaseAttachmentServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/support/v2/internal/case_retry_traits.h
+++ b/google/cloud/support/v2/internal/case_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct CaseServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/support/v2/internal/comment_retry_traits.h
+++ b/google/cloud/support/v2/internal/comment_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct CommentServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/talent/v4/internal/company_retry_traits.h
+++ b/google/cloud/talent/v4/internal/company_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct CompanyServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/talent/v4/internal/completion_retry_traits.h
+++ b/google/cloud/talent/v4/internal/completion_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct CompletionRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/talent/v4/internal/event_retry_traits.h
+++ b/google/cloud/talent/v4/internal/event_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct EventServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/talent/v4/internal/job_retry_traits.h
+++ b/google/cloud/talent/v4/internal/job_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct JobServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/talent/v4/internal/tenant_retry_traits.h
+++ b/google/cloud/talent/v4/internal/tenant_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct TenantServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/tasks/v2/internal/cloud_tasks_retry_traits.h
+++ b/google/cloud/tasks/v2/internal/cloud_tasks_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct CloudTasksRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kInternal &&
            status.code() != StatusCode::kUnavailable;

--- a/google/cloud/telcoautomation/v1/internal/telco_automation_retry_traits.h
+++ b/google/cloud/telcoautomation/v1/internal/telco_automation_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct TelcoAutomationRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/texttospeech/v1/internal/text_to_speech_retry_traits.h
+++ b/google/cloud/texttospeech/v1/internal/text_to_speech_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct TextToSpeechRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/timeseriesinsights/v1/internal/timeseries_insights_controller_retry_traits.h
+++ b/google/cloud/timeseriesinsights/v1/internal/timeseries_insights_controller_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct TimeseriesInsightsControllerRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/tpu/v1/internal/tpu_retry_traits.h
+++ b/google/cloud/tpu/v1/internal/tpu_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct TpuRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/tpu/v2/internal/tpu_retry_traits.h
+++ b/google/cloud/tpu/v2/internal/tpu_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct TpuRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/trace/v1/internal/trace_retry_traits.h
+++ b/google/cloud/trace/v1/internal/trace_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct TraceServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/trace/v2/internal/trace_retry_traits.h
+++ b/google/cloud/trace/v2/internal/trace_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct TraceServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/translate/v3/internal/translation_retry_traits.h
+++ b/google/cloud/translate/v3/internal/translation_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct TranslationServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/video/livestream/v1/internal/livestream_retry_traits.h
+++ b/google/cloud/video/livestream/v1/internal/livestream_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct LivestreamServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/video/stitcher/v1/internal/video_stitcher_retry_traits.h
+++ b/google/cloud/video/stitcher/v1/internal/video_stitcher_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct VideoStitcherServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/video/transcoder/v1/internal/transcoder_retry_traits.h
+++ b/google/cloud/video/transcoder/v1/internal/transcoder_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct TranscoderServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/videointelligence/v1/internal/video_intelligence_retry_traits.h
+++ b/google/cloud/videointelligence/v1/internal/video_intelligence_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct VideoIntelligenceServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/vision/v1/internal/image_annotator_retry_traits.h
+++ b/google/cloud/vision/v1/internal/image_annotator_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ImageAnnotatorRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/vision/v1/internal/product_search_retry_traits.h
+++ b/google/cloud/vision/v1/internal/product_search_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ProductSearchRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/vmmigration/v1/internal/vm_migration_retry_traits.h
+++ b/google/cloud/vmmigration/v1/internal/vm_migration_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct VmMigrationRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/vmwareengine/v1/internal/vmware_engine_retry_traits.h
+++ b/google/cloud/vmwareengine/v1/internal/vmware_engine_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct VmwareEngineRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/vpcaccess/v1/internal/vpc_access_retry_traits.h
+++ b/google/cloud/vpcaccess/v1/internal/vpc_access_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct VpcAccessServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable &&
            status.code() != StatusCode::kUnknown;

--- a/google/cloud/webrisk/v1/internal/web_risk_retry_traits.h
+++ b/google/cloud/webrisk/v1/internal/web_risk_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct WebRiskServiceRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/websecurityscanner/v1/internal/web_security_scanner_retry_traits.h
+++ b/google/cloud/websecurityscanner/v1/internal/web_security_scanner_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct WebSecurityScannerRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/workflows/executions/v1/internal/executions_retry_traits.h
+++ b/google/cloud/workflows/executions/v1/internal/executions_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct ExecutionsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/workflows/v1/internal/workflows_retry_traits.h
+++ b/google/cloud/workflows/v1/internal/workflows_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct WorkflowsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/workstations/v1/internal/workstations_retry_traits.h
+++ b/google/cloud/workstations/v1/internal/workstations_retry_traits.h
@@ -29,7 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Define the gRPC status code semantics for retrying requests.
 struct WorkstationsRetryTraits {
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kUnavailable;
   }


### PR DESCRIPTION
https://github.com/googleapis/google-cloud-cpp/issues/14076

Remove redundant inline.

- **cleanup: prepare for clang-tidy 18**
- **run generate-libraries-pr**

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14158)
<!-- Reviewable:end -->
