### PR TITLE
cleanup: change README and main.dox for generated libraries to require no editing of service description

### DIFF
--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -347,7 +347,7 @@ void GenerateReadme(std::ostream& os,
   auto constexpr kText1 = R"""(# $title$ C++ Client Library
 $construction$
 This directory contains an idiomatic C++ client library for the
-[$title$][cloud-service-docs], a service to $description$
+[$title$][cloud-service-docs].
 
 $status$ note that the Google Cloud C++ client
 libraries do **not** follow [Semantic Versioning](https://semver.org/).
@@ -514,8 +514,7 @@ void GenerateDoxygenMainPage(
 
 @mainpage $title$ C++ Client Library
 
-An idiomatic C++ client library for the [$title$][cloud-service-docs], a service
-to $description$
+An idiomatic C++ client library for the [$title$][cloud-service-docs].
 
 $status$ note that the Google Cloud C++ client libraries do **not** follow
 [Semantic Versioning](https://semver.org/).

--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -349,6 +349,8 @@ $construction$
 This directory contains an idiomatic C++ client library for the
 [$title$][cloud-service-docs].
 
+$description$
+
 $status$ note that the Google Cloud C++ client
 libraries do **not** follow [Semantic Versioning](https://semver.org/).
 
@@ -515,6 +517,8 @@ void GenerateDoxygenMainPage(
 @mainpage $title$ C++ Client Library
 
 An idiomatic C++ client library for the [$title$][cloud-service-docs].
+
+$description$
 
 $status$ note that the Google Cloud C++ client libraries do **not** follow
 [Semantic Versioning](https://semver.org/).

--- a/generator/internal/scaffold_generator_test.cc
+++ b/generator/internal/scaffold_generator_test.cc
@@ -105,7 +105,6 @@ nlohmann::json MockIndex() {
       {"majorversion", "v1"},
       {"hostName", "test.googleapis.com"},
       {"title", "Test Only API"},
-      {"description", "Provides a placeholder to write this test."},
       {"configFile", "test_v1.yaml"},
   };
   return nlohmann::json{{"apis", std::vector<nlohmann::json>{api}}};
@@ -186,8 +185,6 @@ TEST_F(ScaffoldGenerator, Vars) {
   EXPECT_THAT(
       ga,
       AllOf(Contains(Pair("title", "Test Only API")),
-            Contains(Pair("description",
-                          "Provides a placeholder to write this test.")),
             Contains(Pair("library", "test")),
             Contains(Pair("service_subdirectory", "v1/")),
             Contains(Pair("product_options_page", "google-cloud-test-options")),
@@ -201,8 +198,6 @@ TEST_F(ScaffoldGenerator, Vars) {
   EXPECT_THAT(
       experimental,
       AllOf(Contains(Pair("title", "Test Only API")),
-            Contains(Pair("description",
-                          "Provides a placeholder to write this test.")),
             Contains(Pair("library", "test")),
             Contains(Pair("service_subdirectory", "v1/")),
             Contains(Pair("product_options_page", "google-cloud-test-options")),
@@ -315,8 +310,7 @@ TEST_F(ScaffoldGenerator, DoxygenMainPage) {
   GenerateDoxygenMainPage(os, vars);
   auto const actual = std::move(os).str();
   EXPECT_THAT(actual, HasSubstr(R"""(
-An idiomatic C++ client library for the [Test Only API][cloud-service-docs], a service
-to Provides a placeholder to write this test.
+An idiomatic C++ client library for the [Test Only API][cloud-service-docs].
 )"""));
   EXPECT_THAT(actual, HasSubstr(R"""(
 [cloud-service-docs]: https://cloud.google.com/test/docs

--- a/generator/internal/scaffold_generator_test.cc
+++ b/generator/internal/scaffold_generator_test.cc
@@ -105,6 +105,7 @@ nlohmann::json MockIndex() {
       {"majorversion", "v1"},
       {"hostName", "test.googleapis.com"},
       {"title", "Test Only API"},
+      {"description", "Provides a placeholder to write this test."},
       {"configFile", "test_v1.yaml"},
   };
   return nlohmann::json{{"apis", std::vector<nlohmann::json>{api}}};
@@ -185,6 +186,8 @@ TEST_F(ScaffoldGenerator, Vars) {
   EXPECT_THAT(
       ga,
       AllOf(Contains(Pair("title", "Test Only API")),
+            Contains(Pair("description",
+                          "Provides a placeholder to write this test.")),
             Contains(Pair("library", "test")),
             Contains(Pair("service_subdirectory", "v1/")),
             Contains(Pair("product_options_page", "google-cloud-test-options")),
@@ -198,6 +201,8 @@ TEST_F(ScaffoldGenerator, Vars) {
   EXPECT_THAT(
       experimental,
       AllOf(Contains(Pair("title", "Test Only API")),
+            Contains(Pair("description",
+                          "Provides a placeholder to write this test.")),
             Contains(Pair("library", "test")),
             Contains(Pair("service_subdirectory", "v1/")),
             Contains(Pair("product_options_page", "google-cloud-test-options")),
@@ -311,6 +316,8 @@ TEST_F(ScaffoldGenerator, DoxygenMainPage) {
   auto const actual = std::move(os).str();
   EXPECT_THAT(actual, HasSubstr(R"""(
 An idiomatic C++ client library for the [Test Only API][cloud-service-docs].
+
+Provides a placeholder to write this test.
 )"""));
   EXPECT_THAT(actual, HasSubstr(R"""(
 [cloud-service-docs]: https://cloud.google.com/test/docs


### PR DESCRIPTION
Closes https://github.com/googleapis/google-cloud-cpp/issues/12629

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14167)
<!-- Reviewable:end -->
