### PR TITLE
ci: support mixed GCC and Clang 18 builds

### DIFF
--- a/cmake/GoogleCloudCppCommonOptions.cmake
+++ b/cmake/GoogleCloudCppCommonOptions.cmake
@@ -18,6 +18,10 @@ option(GOOGLE_CLOUD_CPP_ENABLE_WERROR
        "If set, compiles the library with -Werror and /WX (MSVC)." OFF)
 mark_as_advanced(GOOGLE_CLOUD_CPP_ENABLE_WERROR)
 
+option(GOOGLE_CLOUD_CPP_ENABLE_CLANG_ABI_COMPAT_17
+       "If set, compiles with -fclang-abi-compat=17." OFF)
+mark_as_advanced(GOOGLE_CLOUD_CPP_ENABLE_CLANG_ABI_COMPAT_17)
+
 # Find out what flags turn on all available warnings and turn those warnings
 # into errors.
 include(CheckCXXCompilerFlag)
@@ -28,6 +32,7 @@ check_cxx_compiler_flag(-Wconversion
 check_cxx_compiler_flag(-Wno-sign-conversion
                         GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WNO_SIGN_CONVERSION)
 check_cxx_compiler_flag(-Werror GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WERROR)
+check_cxx_compiler_flag(-fclang-abi-compat=17 GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_CLANG_ABI_COMPAT_17)
 
 #[=======================================================================[.rst:
 google_cloud_cpp_add_common_options(target [NO_WARNINGS])
@@ -52,6 +57,12 @@ function (google_cloud_cpp_add_common_options target)
     # possible to compile the library (and its dependencies) with C++17 or
     # higher.
     target_compile_features(${target} PUBLIC cxx_std_14)
+
+    # Add `-fclang-abi-compat=17` if supported *AND* requested.
+    if (GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_CLANG_ABI_COMPAT_17 AND
+        GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_CLANG_ABI_COMPAT_17)
+        target_compile_options(${target} PUBLIC "-fclang-abi-compat=17")
+    endif ()
 
     if (MSVC)
         target_compile_options(${target} PRIVATE "/bigobj")

--- a/cmake/GoogleCloudCppCommonOptions.cmake
+++ b/cmake/GoogleCloudCppCommonOptions.cmake
@@ -32,7 +32,8 @@ check_cxx_compiler_flag(-Wconversion
 check_cxx_compiler_flag(-Wno-sign-conversion
                         GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WNO_SIGN_CONVERSION)
 check_cxx_compiler_flag(-Werror GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WERROR)
-check_cxx_compiler_flag(-fclang-abi-compat=17 GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_CLANG_ABI_COMPAT_17)
+check_cxx_compiler_flag(-fclang-abi-compat=17
+                        GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_CLANG_ABI_COMPAT_17)
 
 #[=======================================================================[.rst:
 google_cloud_cpp_add_common_options(target [NO_WARNINGS])
@@ -59,8 +60,8 @@ function (google_cloud_cpp_add_common_options target)
     target_compile_features(${target} PUBLIC cxx_std_14)
 
     # Add `-fclang-abi-compat=17` if supported *AND* requested.
-    if (GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_CLANG_ABI_COMPAT_17 AND
-        GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_CLANG_ABI_COMPAT_17)
+    if (GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_CLANG_ABI_COMPAT_17
+        AND GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_CLANG_ABI_COMPAT_17)
         target_compile_options(${target} PUBLIC "-fclang-abi-compat=17")
     endif ()
 


### PR DESCRIPTION
Part of the work for #14076

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14168)
<!-- Reviewable:end -->
