### PR TITLE
cleanup(pubsub): use `Status` factory functions

### DIFF
--- a/google/cloud/pubsub/internal/batching_publisher_connection.cc
+++ b/google/cloud/pubsub/internal/batching_publisher_connection.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/pubsub/internal/batching_publisher_connection.h"
+#include "google/cloud/internal/make_status.h"
 
 namespace google {
 namespace cloud {
@@ -33,8 +34,8 @@ struct Batch {
     }
     if (static_cast<std::size_t>(response->message_ids_size()) !=
         waiters.size()) {
-      SatisfyAllWaiters(
-          Status(StatusCode::kUnknown, "mismatched message id count"));
+      SatisfyAllWaiters(internal::UnknownError("mismatched message id count",
+                                               GCP_ERROR_INFO()));
       return;
     }
     int idx = 0;

--- a/google/cloud/pubsub/internal/blocking_publisher_connection_impl.cc
+++ b/google/cloud/pubsub/internal/blocking_publisher_connection_impl.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/pubsub/internal/blocking_publisher_connection_impl.h"
 #include "google/cloud/pubsub/internal/publisher_stub_factory.h"
+#include "google/cloud/internal/make_status.h"
 #include "google/cloud/internal/retry_loop.h"
 
 namespace google {
@@ -48,8 +49,8 @@ StatusOr<std::string> BlockingPublisherConnectionImpl::Publish(
       current, request, __func__);
   if (!response) return std::move(response).status();
   if (response->message_ids_size() != 1) {
-    return Status(StatusCode::kInternal,
-                  "invalid response, mismatched ID count");
+    return internal::InternalError("invalid response, mismatched ID count",
+                                   GCP_ERROR_INFO());
   }
   return std::move(*response->mutable_message_ids(0));
 }

--- a/google/cloud/pubsub/internal/default_pull_ack_handler.cc
+++ b/google/cloud/pubsub/internal/default_pull_ack_handler.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/pubsub/internal/pull_lease_manager_factory.h"
 #include "google/cloud/pubsub/options.h"
 #include "google/cloud/internal/async_retry_loop.h"
+#include "google/cloud/internal/make_status.h"
 #include <google/pubsub/v1/pubsub.pb.h>
 #include <memory>
 
@@ -72,8 +73,8 @@ future<Status> DefaultPullAckHandler::ack() {
         },
         google::cloud::internal::MakeImmutableOptions({}), request, __func__);
   }
-  return make_ready_future(
-      Status(StatusCode::kFailedPrecondition, "session already shutdown"));
+  return make_ready_future(internal::FailedPreconditionError(
+      "session already shutdown", GCP_ERROR_INFO()));
 }
 
 future<Status> DefaultPullAckHandler::nack() {
@@ -93,8 +94,8 @@ future<Status> DefaultPullAckHandler::nack() {
         },
         google::cloud::internal::MakeImmutableOptions({}), request, __func__);
   }
-  return make_ready_future(
-      Status(StatusCode::kFailedPrecondition, "session already shutdown"));
+  return make_ready_future(internal::FailedPreconditionError(
+      "session already shutdown", GCP_ERROR_INFO()));
 }
 
 std::int32_t DefaultPullAckHandler::delivery_attempt() const {

--- a/google/cloud/pubsub/internal/default_pull_lease_manager.cc
+++ b/google/cloud/pubsub/internal/default_pull_lease_manager.cc
@@ -99,7 +99,7 @@ future<Status> DefaultPullLeaseManager::ExtendLease(
       [stub = std::move(stub), deadline = now + extension, clock = clock_,
        impl = impl_](auto cq, auto context, auto options, auto const& request) {
         if (deadline < clock->Now()) {
-          return make_ready_future(internal::FailedPreconditionError(
+          return make_ready_future(internal::DeadlineExceededError(
               "lease already expired", GCP_ERROR_INFO()));
         }
         context->set_deadline((std::min)(deadline, context->deadline()));

--- a/google/cloud/pubsub/internal/extend_leases_with_retry.cc
+++ b/google/cloud/pubsub/internal/extend_leases_with_retry.cc
@@ -182,7 +182,7 @@ class ExtendLeasesHandle
   google::pubsub::v1::ModifyAckDeadlineRequest request_;
   std::unique_ptr<pubsub::BackoffPolicy> backoff_ = ExactlyOnceBackoffPolicy();
   Status last_status_ =
-      internal::UnknownError("Exhausted before start", GCP_ERROR_INFO());
+	      internal::UnknownError("Exhausted before start");
   int attempts_ = 0;
 };
 

--- a/google/cloud/pubsub/internal/extend_leases_with_retry.cc
+++ b/google/cloud/pubsub/internal/extend_leases_with_retry.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/pubsub/internal/batch_callback.h"
 #include "google/cloud/pubsub/internal/exactly_once_policies.h"
 #include "google/cloud/completion_queue.h"
+#include "google/cloud/internal/make_status.h"
 #include "google/cloud/log.h"
 #include "absl/strings/match.h"
 #include <algorithm>
@@ -180,7 +181,8 @@ class ExtendLeasesHandle
   CompletionQueue cq_;
   google::pubsub::v1::ModifyAckDeadlineRequest request_;
   std::unique_ptr<pubsub::BackoffPolicy> backoff_ = ExactlyOnceBackoffPolicy();
-  Status last_status_ = Status(StatusCode::kUnknown, "Exhausted before start");
+  Status last_status_ =
+      internal::UnknownError("Exhausted before start", GCP_ERROR_INFO());
   int attempts_ = 0;
 };
 

--- a/google/cloud/pubsub/internal/extend_leases_with_retry.cc
+++ b/google/cloud/pubsub/internal/extend_leases_with_retry.cc
@@ -181,8 +181,7 @@ class ExtendLeasesHandle
   CompletionQueue cq_;
   google::pubsub::v1::ModifyAckDeadlineRequest request_;
   std::unique_ptr<pubsub::BackoffPolicy> backoff_ = ExactlyOnceBackoffPolicy();
-  Status last_status_ =
-	      internal::UnknownError("Exhausted before start");
+  Status last_status_ = internal::UnknownError("Exhausted before start");
   int attempts_ = 0;
 };
 

--- a/google/cloud/pubsub/internal/flow_controlled_publisher_connection.cc
+++ b/google/cloud/pubsub/internal/flow_controlled_publisher_connection.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/pubsub/internal/flow_controlled_publisher_connection.h"
+#include "google/cloud/internal/make_status.h"
 #include <algorithm>
 
 namespace google {
@@ -21,7 +22,8 @@ namespace pubsub_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 StatusOr<std::string> RejectMessage() {
-  return Status(StatusCode::kFailedPrecondition, "Publisher is full");
+  return internal::FailedPreconditionError("Publisher is full",
+                                           GCP_ERROR_INFO());
 }
 }  // namespace
 

--- a/google/cloud/pubsub/internal/rejects_with_ordering_key.cc
+++ b/google/cloud/pubsub/internal/rejects_with_ordering_key.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/pubsub/internal/rejects_with_ordering_key.h"
+#include "google/cloud/internal/make_status.h"
 
 namespace google {
 namespace cloud {
@@ -21,11 +22,12 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 future<StatusOr<std::string>> RejectsWithOrderingKey::Publish(PublishParams p) {
   if (!p.message.ordering_key().empty()) {
-    return google::cloud::make_ready_future(StatusOr<std::string>(
-        Status(StatusCode::kInvalidArgument,
-               "Attempted to publish a message with an ordering"
-               " key with a publisher that does not have message"
-               " ordering enabled.")));
+    return google::cloud::make_ready_future(
+        StatusOr<std::string>(internal::InvalidArgumentError(
+            "Attempted to publish a message with an ordering"
+            " key with a publisher that does not have message"
+            " ordering enabled.",
+            GCP_ERROR_INFO())));
   }
   return connection_->Publish(std::move(p));
 }

--- a/google/cloud/pubsub/internal/streaming_subscription_batch_source.cc
+++ b/google/cloud/pubsub/internal/streaming_subscription_batch_source.cc
@@ -271,8 +271,7 @@ void StreamingSubscriptionBatchSource::StartStream(
       "subscription=" + internal::UrlEncode(request.subscription()));
   auto stream = stub_->AsyncStreamingPull(cq_, std::move(context), options_);
   if (!stream) {
-    OnRetryFailure(
-        internal::FailedPreconditionError("null stream", GCP_ERROR_INFO()));
+    OnRetryFailure(internal::UnknownError("null stream", GCP_ERROR_INFO()));
     return;
   }
   shutdown_manager_->StartOperation(__func__, "InitialStart", [&] {

--- a/google/cloud/pubsub/internal/streaming_subscription_batch_source.cc
+++ b/google/cloud/pubsub/internal/streaming_subscription_batch_source.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/pubsub/internal/exactly_once_policies.h"
 #include "google/cloud/pubsub/internal/extend_leases_with_retry.h"
 #include "google/cloud/internal/async_retry_loop.h"
+#include "google/cloud/internal/make_status.h"
 #include "google/cloud/internal/url_encode.h"
 #include "google/cloud/log.h"
 #include "google/cloud/opentelemetry_options.h"
@@ -270,7 +271,8 @@ void StreamingSubscriptionBatchSource::StartStream(
       "subscription=" + internal::UrlEncode(request.subscription()));
   auto stream = stub_->AsyncStreamingPull(cq_, std::move(context), options_);
   if (!stream) {
-    OnRetryFailure(Status(StatusCode::kUnknown, "null stream"));
+    OnRetryFailure(
+        internal::FailedPreconditionError("null stream", GCP_ERROR_INFO()));
     return;
   }
   shutdown_manager_->StartOperation(__func__, "InitialStart", [&] {

--- a/google/cloud/pubsub/internal/subscription_concurrency_control.cc
+++ b/google/cloud/pubsub/internal/subscription_concurrency_control.cc
@@ -20,6 +20,7 @@
 #include "google/cloud/pubsub/internal/tracing_batch_callback.h"
 #include "google/cloud/pubsub/options.h"
 #include "google/cloud/pubsub/subscription.h"
+#include "google/cloud/internal/make_status.h"
 #include "google/cloud/log.h"
 #include "google/cloud/opentelemetry_options.h"
 
@@ -42,13 +43,13 @@ class AckHandlerImpl : public pubsub::ExactlyOnceAckHandler::Impl {
 
   future<Status> ack() override {
     if (auto s = source_.lock()) return s->AckMessage(ack_id_);
-    return make_ready_future(
-        Status(StatusCode::kFailedPrecondition, "session already shutdown"));
+    return make_ready_future(internal::FailedPreconditionError(
+        "session already shutdown", GCP_ERROR_INFO()));
   }
   future<Status> nack() override {
     if (auto s = source_.lock()) return s->NackMessage(ack_id_);
-    return make_ready_future(
-        Status(StatusCode::kFailedPrecondition, "session already shutdown"));
+    return make_ready_future(internal::FailedPreconditionError(
+        "session already shutdown", GCP_ERROR_INFO()));
   }
   std::int32_t delivery_attempt() const override { return delivery_attempt_; }
   std::string ack_id() override { return ack_id_; }


### PR DESCRIPTION
Part of the work for https://github.com/googleapis/google-cloud-cpp/issues/14107

Found the cases using:
```
git grep -e 'StatusCode::k' --and --not -e 'StatusCode::kUnimplemented' --and --not -e 'StatusCode::kOk' -- '*.cc' ':!*_test.cc' | grep pubsub/internal
```


Then used find and replace with regex & added the header
Search
```
Status\(StatusCode::kUnknown, "(.*)"\)
```
Replace
```
internal::UnknownError("$1", GCP_ERROR_INFO())
```

Header
```
#include "google/cloud/internal/make_status.h"
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14169)
<!-- Reviewable:end -->
