### PR TITLE
impl(oauth2): add `project_id()` to `Credentials`

### DIFF
--- a/google/cloud/internal/oauth2_compute_engine_credentials.h
+++ b/google/cloud/internal/oauth2_compute_engine_credentials.h
@@ -114,8 +114,9 @@ class ComputeEngineCredentials : public Credentials {
   /**
    * Returns the project id from the Metadata Server (MDS).
    */
-  StatusOr<std::string> project_id() const;
-  StatusOr<std::string> project_id(google::cloud::Options const& options) const;
+  StatusOr<std::string> project_id() const override;
+  StatusOr<std::string> project_id(
+      google::cloud::Options const& options) const override;
 
   /**
    * Returns the email or alias of this credential's service account.

--- a/google/cloud/internal/oauth2_credentials.cc
+++ b/google/cloud/internal/oauth2_credentials.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/internal/oauth2_credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
+#include "google/cloud/internal/make_status.h"
 #include "google/cloud/internal/oauth2_universe_domain.h"
 
 namespace google {
@@ -34,6 +35,15 @@ StatusOr<std::string> Credentials::universe_domain() const {
 StatusOr<std::string> Credentials::universe_domain(
     google::cloud::Options const&) const {
   return universe_domain();
+}
+
+StatusOr<std::string> Credentials::project_id() const {
+  return internal::UnimplementedError("unimplemented", GCP_ERROR_INFO());
+}
+
+StatusOr<std::string> Credentials::project_id(
+    google::cloud::Options const&) const {
+  return project_id();
 }
 
 StatusOr<std::pair<std::string, std::string>> AuthorizationHeader(

--- a/google/cloud/internal/oauth2_credentials.h
+++ b/google/cloud/internal/oauth2_credentials.h
@@ -88,6 +88,18 @@ class Credentials {
   /// `Options`, is used. Otherwise the default retry policy is used.
   virtual StatusOr<std::string> universe_domain(
       google::cloud::Options const& options) const;
+
+  /**
+   * Return the project (if any) associated with the credentials.
+   *
+   * Some credential types, notably service account credentials and compute
+   * engine credentials, have an associated project. This project is needed in
+   * the implementation of GCS+gRPC metrics.
+   */
+  virtual StatusOr<std::string> project_id() const;
+
+  /// @copydoc project_id()
+  virtual StatusOr<std::string> project_id(Options const&) const;
 };
 
 /**

--- a/google/cloud/internal/oauth2_credentials.h
+++ b/google/cloud/internal/oauth2_credentials.h
@@ -90,11 +90,18 @@ class Credentials {
       google::cloud::Options const& options) const;
 
   /**
-   * Return the project (if any) associated with the credentials.
+   * Return the project associated with the credentials.
    *
-   * Some credential types, notably service account credentials and compute
-   * engine credentials, have an associated project. This project is needed in
-   * the implementation of GCS+gRPC metrics.
+   * This function may return an error, for example:
+   *
+   * - The credential type does not have an associated project id, e.g. user
+   *   credentials
+   * - The credential type should have an associated project id, but it is not
+   *   present, e.g., a service account key file with a missing `project_id`
+   *   field.
+   * - The credential type should have an associated project id, but it was
+   *   not possible to retrieve it, e.g., compute engine credentials with a
+   *   transient failure fetching the project id from the metadata service.
    */
   virtual StatusOr<std::string> project_id() const;
 

--- a/google/cloud/internal/oauth2_credentials_test.cc
+++ b/google/cloud/internal/oauth2_credentials_test.cc
@@ -24,7 +24,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::google::cloud::internal::UnavailableError;
+using ::google::cloud::testing_util::IsOk;
 using ::testing::IsEmpty;
+using ::testing::Not;
 using ::testing::Pair;
 using ::testing::Return;
 
@@ -79,6 +81,12 @@ TEST(Credentials, AuthorizationHeaderJoinedError) {
   EXPECT_CALL(mock, GetToken).WillOnce(Return(UnavailableError("try-again")));
   auto actual = AuthorizationHeaderJoined(mock);
   EXPECT_EQ(actual.status(), UnavailableError("try-again"));
+}
+
+TEST(Credentials, ProjectId) {
+  MockCredentials mock;
+  EXPECT_THAT(mock.project_id(), Not(IsOk()));
+  EXPECT_THAT(mock.project_id({}), Not(IsOk()));
 }
 
 }  // namespace

--- a/google/cloud/internal/oauth2_service_account_credentials.cc
+++ b/google/cloud/internal/oauth2_service_account_credentials.cc
@@ -292,7 +292,7 @@ StatusOr<std::string> ServiceAccountCredentials::project_id() const {
 
 StatusOr<std::string> ServiceAccountCredentials::project_id(
     Options const&) const {
-  // universe_domain is stored locally, so any retry options are unnecessary.
+  // project_id() is stored locally, so any retry options are unnecessary.
   return project_id();
 }
 

--- a/google/cloud/internal/oauth2_service_account_credentials.h
+++ b/google/cloud/internal/oauth2_service_account_credentials.h
@@ -233,8 +233,8 @@ class ServiceAccountCredentials : public oauth2_internal::Credentials {
   StatusOr<std::string> universe_domain() const override;
   StatusOr<std::string> universe_domain(Options const&) const override;
 
-  StatusOr<std::string> project_id() const;
-  StatusOr<std::string> project_id(Options const&) const;
+  StatusOr<std::string> project_id() const override;
+  StatusOr<std::string> project_id(Options const&) const override;
 
  private:
   bool UseOAuth();


### PR DESCRIPTION
This will let us retrieve the project id associated with a credentials
type. Not all credential types have a project id associated with them,
and therefore they do not all implement this API.

Part of the work for #14112

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14170)
<!-- Reviewable:end -->
