### PR TITLE
refactor: bazel gapic helper

### DIFF
--- a/bazel/gapic.bzl
+++ b/bazel/gapic.bzl
@@ -1,0 +1,79 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A definition for the typical C++ GAPIC library."""
+
+def cc_gapic_library(name, service_dirs = [], googleapis_deps = []):
+    """Defines targets for the typical fully generated GAPIC library
+
+    Args:
+        name: The name of the library, e.g. `accessapproval`
+
+        service_dirs: The list of service directories. e.g. `["v1/"]`
+
+        googlapis_deps: The googleapis-defined cc_grpc_library definitions that
+            this library depends on.
+    """
+
+    src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+
+    native.filegroup(
+        name = "srcs",
+        srcs = native.glob([d + "*.cc" for d in src_dirs]),
+    )
+
+    native.filegroup(
+        name = "hdrs",
+        srcs = native.glob([d + "*.h" for d in src_dirs]),
+    )
+
+    native.filegroup(
+        name = "public_hdrs",
+        srcs = native.glob([d + "*.h" for d in service_dirs]),
+        visibility = ["//:__pkg__"],
+    )
+
+    native.filegroup(
+        name = "mocks",
+        srcs = native.glob([d + "mocks/*.h" for d in service_dirs]),
+        visibility = ["//:__pkg__"],
+    )
+
+    native.cc_library(
+        name = "google_cloud_cpp_" + name,
+        srcs = [":srcs"],
+        hdrs = [":hdrs"],
+        visibility = ["//:__pkg__"],
+        deps = ["//:common", "//:grpc_utils"] + googleapis_deps,
+    )
+
+    native.cc_library(
+        name = "google_cloud_cpp_" + name + "_mocks",
+        hdrs = [":mocks"],
+        visibility = ["//:__pkg__"],
+        deps = [
+            ":google_cloud_cpp_" + name,
+            "@com_google_googletest//:gtest",
+        ],
+    )
+
+    [native.cc_test(
+        name = sample.replace("/", "_").replace(".cc", ""),
+        srcs = [sample],
+        tags = ["integration-test"],
+        deps = [
+            "//:" + name,
+            "//google/cloud/testing_util:google_cloud_cpp_testing_private",
+        ],
+    ) for sample in native.glob([d + "samples/*.cc" for d in service_dirs])]

--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -398,67 +398,23 @@ void GenerateBuild(std::ostream& os,
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
 service_dirs = ["$service_subdirectory$"]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//$directory$:$library$_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "$library$",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_$library$",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//$directory$:$library$_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_$library$_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_$library$",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:$library$",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]
 )""";
   google::protobuf::io::OstreamOutputStream output(&os);
   google::protobuf::io::Printer printer(&output, '$');

--- a/generator/internal/scaffold_generator_test.cc
+++ b/generator/internal/scaffold_generator_test.cc
@@ -283,7 +283,8 @@ TEST_F(ScaffoldGenerator, Build) {
   auto const actual = std::move(os).str();
   EXPECT_THAT(actual, HasSubstr("2034"));
   EXPECT_THAT(actual, Not(HasSubstr("$copyright_year$")));
-  EXPECT_THAT(actual, HasSubstr(R"""(name = "google_cloud_cpp_test",)"""));
+  EXPECT_THAT(actual, HasSubstr(R"""(cc_gapic_library)"""));
+  EXPECT_THAT(actual, HasSubstr(R"""(name = "test",)"""));
   EXPECT_THAT(
       actual,
       HasSubstr(

--- a/google/cloud/accessapproval/BUILD.bazel
+++ b/google/cloud/accessapproval/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -21,58 +23,12 @@ service_dirs = [
     "v1/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/accessapproval/v1:accessapproval_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "accessapproval",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_accessapproval",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/accessapproval/v1:accessapproval_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_accessapproval_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_accessapproval",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:accessapproval",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]


### PR DESCRIPTION
The interesting part of #14171

Add a helper to handle most of the `BUILD.bazel` definitions.

Demonstrate how to use the helper in one library.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14173)
<!-- Reviewable:end -->
