### PR TITLE
refactor: bazel gapics `c*`

### DIFF
--- a/google/cloud/certificatemanager/BUILD.bazel
+++ b/google/cloud/certificatemanager/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -21,59 +23,13 @@ service_dirs = [
     "v1/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/certificatemanager/logging/v1:logging_cc_grpc",
+    "@com_google_googleapis//google/cloud/certificatemanager/v1:certificatemanager_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "certificatemanager",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_certificatemanager",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/certificatemanager/logging/v1:logging_cc_grpc",
-        "@com_google_googleapis//google/cloud/certificatemanager/v1:certificatemanager_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_certificatemanager_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_certificatemanager",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:certificatemanager",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/channel/BUILD.bazel
+++ b/google/cloud/channel/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -21,58 +23,12 @@ service_dirs = [
     "v1/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/channel/v1:channel_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "channel",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_channel",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/channel/v1:channel_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_channel_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_channel",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:channel",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/cloudbuild/BUILD.bazel
+++ b/google/cloud/cloudbuild/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -22,59 +24,13 @@ service_dirs = [
     "v2/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/devtools/cloudbuild/v1:cloudbuild_cc_grpc",
+    "@com_google_googleapis//google/devtools/cloudbuild/v2:cloudbuild_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "cloudbuild",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_cloudbuild",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/devtools/cloudbuild/v1:cloudbuild_cc_grpc",
-        "@com_google_googleapis//google/devtools/cloudbuild/v2:cloudbuild_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_cloudbuild_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_cloudbuild",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:cloudbuild",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/cloudcontrolspartner/BUILD.bazel
+++ b/google/cloud/cloudcontrolspartner/BUILD.bazel
@@ -12,64 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
 service_dirs = ["v1/"]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/cloudcontrolspartner/v1:cloudcontrolspartner_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "cloudcontrolspartner",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_cloudcontrolspartner",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/cloudcontrolspartner/v1:cloudcontrolspartner_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_cloudcontrolspartner_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_cloudcontrolspartner",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:cloudcontrolspartner",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/cloudquotas/BUILD.bazel
+++ b/google/cloud/cloudquotas/BUILD.bazel
@@ -12,64 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
 service_dirs = ["v1/"]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/api/cloudquotas/v1:cloudquotas_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "cloudquotas",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_cloudquotas",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/api/cloudquotas/v1:cloudquotas_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_cloudquotas_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_cloudquotas",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:cloudquotas",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/commerce/BUILD.bazel
+++ b/google/cloud/commerce/BUILD.bazel
@@ -12,64 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
 service_dirs = ["consumer/procurement/v1/"]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/commerce/consumer/procurement/v1:procurement_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "commerce",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_commerce",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/commerce/consumer/procurement/v1:procurement_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_commerce_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_commerce",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:commerce",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/composer/BUILD.bazel
+++ b/google/cloud/composer/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -21,58 +23,12 @@ service_dirs = [
     "v1/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/orchestration/airflow/service/v1:service_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "composer",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_composer",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/orchestration/airflow/service/v1:service_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_composer_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_composer",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:composer",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/confidentialcomputing/BUILD.bazel
+++ b/google/cloud/confidentialcomputing/BUILD.bazel
@@ -12,64 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
 service_dirs = ["v1/"]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/confidentialcomputing/v1:confidentialcomputing_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "confidentialcomputing",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_confidentialcomputing",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/confidentialcomputing/v1:confidentialcomputing_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_confidentialcomputing_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_confidentialcomputing",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:confidentialcomputing",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/config/BUILD.bazel
+++ b/google/cloud/config/BUILD.bazel
@@ -12,64 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
 service_dirs = ["v1/"]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/config/v1:config_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "config",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_config",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/config/v1:config_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_config_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_config",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:config",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/connectors/BUILD.bazel
+++ b/google/cloud/connectors/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -21,58 +23,12 @@ service_dirs = [
     "v1/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/connectors/v1:connectors_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "connectors",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_connectors",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/connectors/v1:connectors_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_connectors_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_connectors",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:connectors",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/contactcenterinsights/BUILD.bazel
+++ b/google/cloud/contactcenterinsights/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -21,58 +23,12 @@ service_dirs = [
     "v1/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/contactcenterinsights/v1:contactcenterinsights_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "contactcenterinsights",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_contactcenterinsights",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/contactcenterinsights/v1:contactcenterinsights_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_contactcenterinsights_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_contactcenterinsights",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:contactcenterinsights",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/container/BUILD.bazel
+++ b/google/cloud/container/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -21,58 +23,12 @@ service_dirs = [
     "v1/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/container/v1:container_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "container",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_container",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/container/v1:container_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_container_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_container",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:container",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/containeranalysis/BUILD.bazel
+++ b/google/cloud/containeranalysis/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -21,59 +23,13 @@ service_dirs = [
     "v1/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/devtools/containeranalysis/v1:containeranalysis_cc_grpc",
+    "@com_google_googleapis//grafeas/v1:grafeas_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "containeranalysis",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_containeranalysis",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/devtools/containeranalysis/v1:containeranalysis_cc_grpc",
-        "@com_google_googleapis//grafeas/v1:grafeas_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_containeranalysis_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_containeranalysis",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:containeranalysis",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/contentwarehouse/BUILD.bazel
+++ b/google/cloud/contentwarehouse/BUILD.bazel
@@ -12,64 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
 service_dirs = ["v1/"]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/contentwarehouse/v1:contentwarehouse_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "contentwarehouse",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_contentwarehouse",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/contentwarehouse/v1:contentwarehouse_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_contentwarehouse_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_contentwarehouse",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:contentwarehouse",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]


### PR DESCRIPTION
Part of the work for #14171 

I used a `vim` recording to produce these changes. It grabs the name of the library, the service_dirs, and any `deps` listed after `grpc_utils`. It makes assumptions about the contents of the `BUILD.bazel` file. Any nuance in the `BUILD.bazel` file, would get deleted.

We have to look at the contents of every `BUILD.bazel` file to make sure they are without nuance. That is why I am batching these PRs in sets of ~10-15. Hopefully that is not too obnoxious.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14175)
<!-- Reviewable:end -->
