### PR TITLE
refactor: bazel gapics `i*`,`k*`,`l*`,`p*`,`r*`,

### DIFF
--- a/google/cloud/iap/BUILD.bazel
+++ b/google/cloud/iap/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -21,58 +23,12 @@ service_dirs = [
     "v1/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/iap/v1:iap_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "iap",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_iap",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/iap/v1:iap_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_iap_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_iap",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:iap",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/ids/BUILD.bazel
+++ b/google/cloud/ids/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -21,58 +23,12 @@ service_dirs = [
     "v1/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/ids/v1:ids_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "ids",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_ids",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/ids/v1:ids_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_ids_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_ids",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:ids",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/kms/BUILD.bazel
+++ b/google/cloud/kms/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -22,59 +24,13 @@ service_dirs = [
     "v1/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/kms/inventory/v1:inventory_cc_grpc",
+    "@com_google_googleapis//google/cloud/kms/v1:kms_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "kms",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_kms",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/kms/inventory/v1:inventory_cc_grpc",
-        "@com_google_googleapis//google/cloud/kms/v1:kms_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_kms_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_kms",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:kms",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/language/BUILD.bazel
+++ b/google/cloud/language/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -22,59 +24,13 @@ service_dirs = [
     "v2/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/language/v1:language_cc_grpc",
+    "@com_google_googleapis//google/cloud/language/v2:language_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "language",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_language",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/language/v1:language_cc_grpc",
-        "@com_google_googleapis//google/cloud/language/v2:language_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_language_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_language",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:language",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/logging/BUILD.bazel
+++ b/google/cloud/logging/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -21,58 +23,12 @@ service_dirs = [
     "v2/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/logging/v2:logging_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "logging",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_logging",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/logging/v2:logging_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_logging_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_logging",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:logging",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/policysimulator/BUILD.bazel
+++ b/google/cloud/policysimulator/BUILD.bazel
@@ -12,64 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
 service_dirs = ["v1/"]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/policysimulator/v1:policysimulator_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "policysimulator",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_policysimulator",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/policysimulator/v1:policysimulator_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_policysimulator_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_policysimulator",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:policysimulator",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/policytroubleshooter/BUILD.bazel
+++ b/google/cloud/policytroubleshooter/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -22,60 +24,14 @@ service_dirs = [
     "iam/v3/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/policytroubleshooter/iam/v3:iam_cc_grpc",
+    "@com_google_googleapis//google/cloud/policytroubleshooter/v1:policytroubleshooter_cc_grpc",
+    "@com_google_googleapis//google/iam/v2:iam_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "policytroubleshooter",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_policytroubleshooter",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/policytroubleshooter/iam/v3:iam_cc_grpc",
-        "@com_google_googleapis//google/cloud/policytroubleshooter/v1:policytroubleshooter_cc_grpc",
-        "@com_google_googleapis//google/iam/v2:iam_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_policytroubleshooter_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_policytroubleshooter",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:policytroubleshooter",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/privateca/BUILD.bazel
+++ b/google/cloud/privateca/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -21,58 +23,12 @@ service_dirs = [
     "v1/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/security/privateca/v1:privateca_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "privateca",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_privateca",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/security/privateca/v1:privateca_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_privateca_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_privateca",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:privateca",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/profiler/BUILD.bazel
+++ b/google/cloud/profiler/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -21,58 +23,12 @@ service_dirs = [
     "v2/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/devtools/cloudprofiler/v2:cloudprofiler_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "profiler",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_profiler",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/devtools/cloudprofiler/v2:cloudprofiler_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_profiler_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_profiler",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:profiler",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/rapidmigrationassessment/BUILD.bazel
+++ b/google/cloud/rapidmigrationassessment/BUILD.bazel
@@ -12,64 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
 service_dirs = ["v1/"]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/rapidmigrationassessment/v1:rapidmigrationassessment_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "rapidmigrationassessment",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_rapidmigrationassessment",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/rapidmigrationassessment/v1:rapidmigrationassessment_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_rapidmigrationassessment_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_rapidmigrationassessment",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:rapidmigrationassessment",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/recaptchaenterprise/BUILD.bazel
+++ b/google/cloud/recaptchaenterprise/BUILD.bazel
@@ -12,64 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
 service_dirs = ["v1/"]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/recaptchaenterprise/v1:recaptchaenterprise_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "recaptchaenterprise",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_recaptchaenterprise",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/recaptchaenterprise/v1:recaptchaenterprise_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_recaptchaenterprise_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_recaptchaenterprise",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:recaptchaenterprise",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/recommender/BUILD.bazel
+++ b/google/cloud/recommender/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -21,58 +23,12 @@ service_dirs = [
     "v1/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/recommender/v1:recommender_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "recommender",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_recommender",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/recommender/v1:recommender_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_recommender_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_recommender",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:recommender",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/redis/BUILD.bazel
+++ b/google/cloud/redis/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -22,59 +24,13 @@ service_dirs = [
     "cluster/v1/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/redis/cluster/v1:cluster_cc_grpc",
+    "@com_google_googleapis//google/cloud/redis/v1:redis_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "redis",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_redis",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/redis/cluster/v1:cluster_cc_grpc",
-        "@com_google_googleapis//google/cloud/redis/v1:redis_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_redis_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_redis",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:redis",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/resourcemanager/BUILD.bazel
+++ b/google/cloud/resourcemanager/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -21,58 +23,12 @@ service_dirs = [
     "v3/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/resourcemanager/v3:resourcemanager_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "resourcemanager",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_resourcemanager",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/resourcemanager/v3:resourcemanager_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_resourcemanager_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_resourcemanager",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:resourcemanager",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/resourcesettings/BUILD.bazel
+++ b/google/cloud/resourcesettings/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -21,58 +23,12 @@ service_dirs = [
     "v1/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/resourcesettings/v1:resourcesettings_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "resourcesettings",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_resourcesettings",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/resourcesettings/v1:resourcesettings_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_resourcesettings_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_resourcesettings",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:resourcesettings",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/retail/BUILD.bazel
+++ b/google/cloud/retail/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -21,58 +23,12 @@ service_dirs = [
     "v2/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/retail/v2:retail_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "retail",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_retail",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/retail/v2:retail_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_retail_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_retail",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:retail",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/run/BUILD.bazel
+++ b/google/cloud/run/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -21,58 +23,12 @@ service_dirs = [
     "v2/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/run/v2:run_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "run",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_run",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/run/v2:run_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_run_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_run",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:run",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]


### PR DESCRIPTION
Part of the work for #14171 

I used a `vim` recording to produce these changes. It grabs the name of the library, the service_dirs, and any `deps` listed after `grpc_utils`. It makes assumptions about the contents of the `BUILD.bazel` file. Any nuance in the `BUILD.bazel` file, would get deleted.

We have to look at the contents of every `BUILD.bazel` file to make sure they are without nuance. That is why I am batching these PRs in sets of ~10-15. Hopefully that is not too obnoxious.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14178)
<!-- Reviewable:end -->
