### PR TITLE
cleanup: prepare for clang-tidy 18

### DIFF
--- a/google/cloud/internal/future_fwd.h
+++ b/google/cloud/internal/future_fwd.h
@@ -22,22 +22,28 @@ namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 // Forward declare the promise type so we can write some helpers.
 template <typename R>
+// NOLINTNEXTLINE(readability-identifier-naming)
 class promise;
 
 // Forward declare the future type so we can write some helpers.
 template <typename R>
+// NOLINTNEXTLINE(readability-identifier-naming)
 class future;
 
 // Forward declare the specializations for references.
 template <typename R>
+// NOLINTNEXTLINE(readability-identifier-naming)
 class promise<R&>;
 template <typename R>
+// NOLINTNEXTLINE(readability-identifier-naming)
 class future<R&>;
 
 // Forward declare the specialization for `void`.
 template <>
+// NOLINTNEXTLINE(readability-identifier-naming)
 class promise<void>;
 template <>
+// NOLINTNEXTLINE(readability-identifier-naming)
 class future<void>;
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud

--- a/google/cloud/internal/future_impl.h
+++ b/google/cloud/internal/future_impl.h
@@ -43,6 +43,7 @@ std::exception_ptr MakeFutureError(std::future_errc ec);
 
 // Forward declare the implementation type as we will need it for some helpers.
 template <typename T>
+// NOLINTNEXTLINE(readability-identifier-naming)
 class future_shared_state;
 
 /**


### PR DESCRIPTION
Add nolint for places where the class case is not capitalized.

#14076

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14182)
<!-- Reviewable:end -->
