### PR TITLE
cleanup: prepare for clang-tidy 18

### DIFF
--- a/google/cloud/spanner/internal/partial_result_set_source.h
+++ b/google/cloud/spanner/internal/partial_result_set_source.h
@@ -85,6 +85,7 @@ class PartialResultSetSource : public spanner::ResultSourceInterface {
   // any data in (or previously in) `rows_`. When disengaged, we have already
   // delivered data that would be replayed, so resumption is disabled until we
   // see a new token.
+  // NOLINTNEXTLINE(readability-redundant-member-init)
   absl::optional<std::string> resume_token_ = std::string{};
 
   // `Value`s that could be combined into `rows_` when we have enough to fill

--- a/google/cloud/spanner/internal/partial_result_set_source.h
+++ b/google/cloud/spanner/internal/partial_result_set_source.h
@@ -85,7 +85,7 @@ class PartialResultSetSource : public spanner::ResultSourceInterface {
   // any data in (or previously in) `rows_`. When disengaged, we have already
   // delivered data that would be replayed, so resumption is disabled until we
   // see a new token.
-  absl::optional<std::string> resume_token_ = std::string{};
+  absl::optional<std::string> resume_token_ = "";
 
   // `Value`s that could be combined into `rows_` when we have enough to fill
   // an entire row, plus a token that would resume the stream after such rows.

--- a/google/cloud/spanner/internal/partial_result_set_source.h
+++ b/google/cloud/spanner/internal/partial_result_set_source.h
@@ -85,7 +85,6 @@ class PartialResultSetSource : public spanner::ResultSourceInterface {
   // any data in (or previously in) `rows_`. When disengaged, we have already
   // delivered data that would be replayed, so resumption is disabled until we
   // see a new token.
-  // NOLINTNEXTLINE(readability-redundant-member-init)
   absl::optional<std::string> resume_token_ = std::string{};
 
   // `Value`s that could be combined into `rows_` when we have enough to fill


### PR DESCRIPTION
#14076


Change to an empty string

Repro: https://godbolt.org/z/5W54Yj6Po
Fix: https://godbolt.org/z/Ws3KPbohc

```
.o -c /workspace/google/cloud/spanner/internal/partial_result_set_resume_test.cc
/workspace/google/cloud/spanner/internal/partial_result_set_source.h:88:47: error: initializer for member 'resume_token_' is redundant [readability-redundant-member-init,-warnings-as-errors]
   88 |   absl::optional<std::string> resume_token_ = std::string{};
   ```

Filed a bug as well https://github.com/llvm/llvm-project/issues/91605

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14183)
<!-- Reviewable:end -->
