### PR TITLE
refactor: bazel gapics `s*`

### DIFF
--- a/google/cloud/scheduler/BUILD.bazel
+++ b/google/cloud/scheduler/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -21,58 +23,12 @@ service_dirs = [
     "v1/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/scheduler/v1:scheduler_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "scheduler",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_scheduler",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/scheduler/v1:scheduler_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_scheduler_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_scheduler",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:scheduler",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/secretmanager/BUILD.bazel
+++ b/google/cloud/secretmanager/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -21,58 +23,12 @@ service_dirs = [
     "v1/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/secretmanager/v1:secretmanager_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "secretmanager",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_secretmanager",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/secretmanager/v1:secretmanager_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_secretmanager_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_secretmanager",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:secretmanager",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/securesourcemanager/BUILD.bazel
+++ b/google/cloud/securesourcemanager/BUILD.bazel
@@ -12,64 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
 service_dirs = ["v1/"]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/securesourcemanager/v1:securesourcemanager_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "securesourcemanager",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_securesourcemanager",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/securesourcemanager/v1:securesourcemanager_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_securesourcemanager_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_securesourcemanager",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:securesourcemanager",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/securitycentermanagement/BUILD.bazel
+++ b/google/cloud/securitycentermanagement/BUILD.bazel
@@ -12,64 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
 service_dirs = ["v1/"]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/securitycentermanagement/v1:securitycentermanagement_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "securitycentermanagement",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_securitycentermanagement",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/securitycentermanagement/v1:securitycentermanagement_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_securitycentermanagement_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_securitycentermanagement",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:securitycentermanagement",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/servicecontrol/BUILD.bazel
+++ b/google/cloud/servicecontrol/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -22,59 +24,13 @@ service_dirs = [
     "v2/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/api/servicecontrol/v1:servicecontrol_cc_grpc",
+    "@com_google_googleapis//google/api/servicecontrol/v2:servicecontrol_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "servicecontrol",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_servicecontrol",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/api/servicecontrol/v1:servicecontrol_cc_grpc",
-        "@com_google_googleapis//google/api/servicecontrol/v2:servicecontrol_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_servicecontrol_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_servicecontrol",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:servicecontrol",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/servicedirectory/BUILD.bazel
+++ b/google/cloud/servicedirectory/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -21,58 +23,12 @@ service_dirs = [
     "v1/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/servicedirectory/v1:servicedirectory_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "servicedirectory",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_servicedirectory",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/servicedirectory/v1:servicedirectory_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_servicedirectory_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_servicedirectory",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:servicedirectory",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/servicehealth/BUILD.bazel
+++ b/google/cloud/servicehealth/BUILD.bazel
@@ -12,65 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
 service_dirs = ["v1/"]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/servicehealth/logging/v1:logging_cc_grpc",
+    "@com_google_googleapis//google/cloud/servicehealth/v1:servicehealth_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "servicehealth",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_servicehealth",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/servicehealth/logging/v1:logging_cc_grpc",
-        "@com_google_googleapis//google/cloud/servicehealth/v1:servicehealth_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_servicehealth_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_servicehealth",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:servicehealth",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/servicemanagement/BUILD.bazel
+++ b/google/cloud/servicemanagement/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -21,58 +23,12 @@ service_dirs = [
     "v1/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/api/servicemanagement/v1:servicemanagement_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "servicemanagement",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_servicemanagement",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/api/servicemanagement/v1:servicemanagement_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_servicemanagement_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_servicemanagement",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:servicemanagement",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/serviceusage/BUILD.bazel
+++ b/google/cloud/serviceusage/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -21,58 +23,12 @@ service_dirs = [
     "v1/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/api/serviceusage/v1:serviceusage_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "serviceusage",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_serviceusage",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/api/serviceusage/v1:serviceusage_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_serviceusage_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_serviceusage",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:serviceusage",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/shell/BUILD.bazel
+++ b/google/cloud/shell/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -21,58 +23,12 @@ service_dirs = [
     "v1/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/shell/v1:shell_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "shell",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_shell",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/shell/v1:shell_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_shell_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_shell",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:shell",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/speech/BUILD.bazel
+++ b/google/cloud/speech/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -22,59 +24,13 @@ service_dirs = [
     "v2/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/speech/v1:speech_cc_grpc",
+    "@com_google_googleapis//google/cloud/speech/v2:speech_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "speech",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_speech",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/speech/v1:speech_cc_grpc",
-        "@com_google_googleapis//google/cloud/speech/v2:speech_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_speech_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_speech",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:speech",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/storagecontrol/BUILD.bazel
+++ b/google/cloud/storagecontrol/BUILD.bazel
@@ -12,64 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
 service_dirs = ["v2/"]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/storage/control/v2:control_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "storagecontrol",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_storagecontrol",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/storage/control/v2:control_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_storagecontrol_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_storagecontrol",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:storagecontrol",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/storageinsights/BUILD.bazel
+++ b/google/cloud/storageinsights/BUILD.bazel
@@ -12,64 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
 service_dirs = ["v1/"]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/storageinsights/v1:storageinsights_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "storageinsights",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_storageinsights",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/storageinsights/v1:storageinsights_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_storageinsights_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_storageinsights",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:storageinsights",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/storagetransfer/BUILD.bazel
+++ b/google/cloud/storagetransfer/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -21,58 +23,12 @@ service_dirs = [
     "v1/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/storagetransfer/v1:storagetransfer_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "storagetransfer",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_storagetransfer",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/storagetransfer/v1:storagetransfer_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_storagetransfer_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_storagetransfer",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:storagetransfer",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/support/BUILD.bazel
+++ b/google/cloud/support/BUILD.bazel
@@ -12,64 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
 service_dirs = ["v2/"]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/support/v2:support_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "support",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_support",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/support/v2:support_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_support_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_support",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:support",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]


### PR DESCRIPTION
Part of the work for #14171 

I used a `vim` recording to produce these changes. It grabs the name of the library, the service_dirs, and any `deps` listed after `grpc_utils`. It makes assumptions about the contents of the `BUILD.bazel` file. Any nuance in the `BUILD.bazel` file, would get deleted.

We have to look at the contents of every `BUILD.bazel` file to make sure they are without nuance. That is why I am batching these PRs in sets of ~10-15. Hopefully that is not too obnoxious.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14186)
<!-- Reviewable:end -->
