### PR TITLE
cleanup: use the correct option for clang abi compat

### DIFF
--- a/cmake/GoogleCloudCppCommonOptions.cmake
+++ b/cmake/GoogleCloudCppCommonOptions.cmake
@@ -61,7 +61,7 @@ function (google_cloud_cpp_add_common_options target)
 
     # Add `-fclang-abi-compat=17` if supported *AND* requested.
     if (GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_CLANG_ABI_COMPAT_17
-        AND GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_CLANG_ABI_COMPAT_17)
+        AND GOOGLE_CLOUD_CPP_ENABLE_CLANG_ABI_COMPAT_17)
         target_compile_options(${target} PUBLIC "-fclang-abi-compat=17")
     endif ()
 


### PR DESCRIPTION
https://github.com/googleapis/google-cloud-cpp/issues/14076

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14188)
<!-- Reviewable:end -->
