### PR TITLE
cleanup: use Status factory functions in testing_util/*

### DIFF
--- a/google/cloud/testing_util/fake_completion_queue_impl.cc
+++ b/google/cloud/testing_util/fake_completion_queue_impl.cc
@@ -36,7 +36,8 @@ class FakeAsyncTimer : public internal::AsyncGrpcOperation {
   bool Notify(bool ok) override {
     internal::OptionsSpan span(options_);
     if (!ok) {
-      promise_.set_value(internal::CancelledError("timer canceled", GCP_ERROR_INFO()));
+      promise_.set_value(
+          internal::CancelledError("timer canceled", GCP_ERROR_INFO()));
     } else {
       promise_.set_value(deadline_);
     }

--- a/google/cloud/testing_util/fake_completion_queue_impl.cc
+++ b/google/cloud/testing_util/fake_completion_queue_impl.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/testing_util/fake_completion_queue_impl.h"
+#include "google/cloud/internal/make_status.h"
 #include "google/cloud/options.h"
 
 namespace google {
@@ -35,7 +36,7 @@ class FakeAsyncTimer : public internal::AsyncGrpcOperation {
   bool Notify(bool ok) override {
     internal::OptionsSpan span(options_);
     if (!ok) {
-      promise_.set_value(Status(StatusCode::kCancelled, "timer canceled"));
+      promise_.set_value(internal::CancelledError("timer canceled", GCP_ERROR_INFO()));
     } else {
       promise_.set_value(deadline_);
     }

--- a/google/cloud/testing_util/mock_grpc_authentication_strategy.cc
+++ b/google/cloud/testing_util/mock_grpc_authentication_strategy.cc
@@ -28,7 +28,8 @@ std::shared_ptr<MockAuthenticationStrategy> MakeTypicalMockAuth() {
   auto auth = std::make_shared<MockAuthenticationStrategy>();
   EXPECT_CALL(*auth, ConfigureContext)
       .WillOnce([](grpc::ClientContext&) {
-        return internal::InvalidArgumentError("cannot-set-credentials", GCP_ERROR_INFO());
+        return internal::InvalidArgumentError("cannot-set-credentials",
+                                              GCP_ERROR_INFO());
       })
       .WillOnce([](grpc::ClientContext& context) {
         context.set_credentials(
@@ -43,8 +44,8 @@ std::shared_ptr<MockAuthenticationStrategy> MakeTypicalAsyncMockAuth() {
   auto auth = std::make_shared<MockAuthenticationStrategy>();
   EXPECT_CALL(*auth, AsyncConfigureContext)
       .WillOnce([](auto) {
-        return make_ready_future(ReturnType(
-            internal::InvalidArgumentError("cannot-set-credentials", GCP_ERROR_INFO())));
+        return make_ready_future(ReturnType(internal::InvalidArgumentError(
+            "cannot-set-credentials", GCP_ERROR_INFO())));
       })
       .WillOnce([](auto context) {
         context->set_credentials(

--- a/google/cloud/testing_util/mock_grpc_authentication_strategy.cc
+++ b/google/cloud/testing_util/mock_grpc_authentication_strategy.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/testing_util/mock_grpc_authentication_strategy.h"
+#include "google/cloud/internal/make_status.h"
 #include <grpcpp/grpcpp.h>
 
 namespace google {
@@ -27,7 +28,7 @@ std::shared_ptr<MockAuthenticationStrategy> MakeTypicalMockAuth() {
   auto auth = std::make_shared<MockAuthenticationStrategy>();
   EXPECT_CALL(*auth, ConfigureContext)
       .WillOnce([](grpc::ClientContext&) {
-        return Status(StatusCode::kInvalidArgument, "cannot-set-credentials");
+        return internal::InvalidArgumentError("cannot-set-credentials", GCP_ERROR_INFO());
       })
       .WillOnce([](grpc::ClientContext& context) {
         context.set_credentials(
@@ -43,7 +44,7 @@ std::shared_ptr<MockAuthenticationStrategy> MakeTypicalAsyncMockAuth() {
   EXPECT_CALL(*auth, AsyncConfigureContext)
       .WillOnce([](auto) {
         return make_ready_future(ReturnType(
-            Status(StatusCode::kInvalidArgument, "cannot-set-credentials")));
+            internal::InvalidArgumentError("cannot-set-credentials", GCP_ERROR_INFO())));
       })
       .WillOnce([](auto context) {
         context->set_credentials(


### PR DESCRIPTION
https://github.com/googleapis/google-cloud-cpp/issues/14107

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14192)
<!-- Reviewable:end -->
