### PR TITLE
cleanup(generator): protobuf::io::Printer ctor

### DIFF
--- a/generator/internal/printer.h
+++ b/generator/internal/printer.h
@@ -39,8 +39,8 @@ class Printer {
   Printer(google::protobuf::compiler::GeneratorContext* generator_context,
           std::string const& file_name)
       : output_(generator_context->Open(file_name)),
-        printer_(std::make_unique<google::protobuf::io::Printer>(
-            output_.get(), '$', nullptr)) {}
+        printer_(
+            std::make_unique<google::protobuf::io::Printer>(output_.get())) {}
 
   Printer(Printer const&) = delete;
   Printer& operator=(Printer const&) = delete;


### PR DESCRIPTION
Comments say this ctor will be deprecated.

https://github.com/protocolbuffers/protobuf/blob/82e83ddc95330bbd988ba874ea5aa37d343d4490/src/google/protobuf/io/printer.h#L505-L509

Note that `$` is the default delimiter: https://github.com/protocolbuffers/protobuf/blob/82e83ddc95330bbd988ba874ea5aa37d343d4490/src/google/protobuf/io/printer.h#L457

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14196)
<!-- Reviewable:end -->
