### PR TITLE
ci(gcb): do not allow Kaniko failures

### DIFF
--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -82,14 +82,12 @@ steps:
     '--image-download-retry=3',
     '--push-retry=3'
   ]
-  allowFailure: true
 
   # Pull the docker image. The step running 'ci/cloud/build.sh' would do this
   # automatically, and also fill the log with about 2-3 pages of noise.
 - name: '${_POOL_REGION}-docker.pkg.dev/${PROJECT_ID}/gcb/${_IMAGE}:${BUILD_ID}'
   id: 'download-runner-image'
   entrypoint: '/bin/true'
-  allowFailure: true
 
   # Runs the specified build in the image that was created in the first step.
 - name: '${_POOL_REGION}-docker.pkg.dev/${PROJECT_ID}/gcb/${_IMAGE}:${BUILD_ID}'


### PR DESCRIPTION
I removed the second attempt to run Kaniko (because it never worked), but did not remove the attributes to keep going after the first attempt failed.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14202)
<!-- Reviewable:end -->
