### PR TITLE
refactor(spanner): prepare for upcoming SessionPool work

### DIFF
--- a/google/cloud/spanner/internal/session.h
+++ b/google/cloud/spanner/internal/session.h
@@ -29,7 +29,11 @@ namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /**
- * A class that represents a Session.
+ * Sessions are a central concept in the Spanner Cloud API: all Spanner
+ * reads/writes are performed through a session. A session must be created
+ * before any non-admin operation can be performed. Once created, a session
+ * persists until it is destroyed by the client, or is reclaimed due to
+ * inactivity.
  *
  * This class is thread-safe.
  */
@@ -59,6 +63,7 @@ class Session {
  private:
   // Give `SessionPool` access to the private methods below.
   friend class SessionPool;
+
   std::shared_ptr<Channel> const& channel() const { return channel_; }
 
   // The caller is responsible for ensuring these methods are used in a

--- a/google/cloud/spanner/internal/session.h
+++ b/google/cloud/spanner/internal/session.h
@@ -29,10 +29,10 @@ namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /**
- * Sessions are a central concept in the Spanner Cloud API: all Spanner
+ * Sessions are a central concept in the Cloud Spanner API. All Spanner
  * reads/writes are performed through a session. A session must be created
  * before any non-admin operation can be performed. Once created, a session
- * persists until it is destroyed by the client, or is reclaimed due to
+ * persists until it is destroyed by the client, or reclaimed due to
  * inactivity.
  *
  * This class is thread-safe.

--- a/google/cloud/spanner/internal/session_pool.h
+++ b/google/cloud/spanner/internal/session_pool.h
@@ -84,10 +84,10 @@ class SessionPool : public std::enable_shared_from_this<SessionPool> {
   /**
    * Allocate a `Session` from the pool, creating a new one if necessary.
    *
-   * The returned `SessionHolder` will return the `Session` to this pool, unless
-   * `dissociate_from_pool` is true, in which case it is not returned to the
-   * pool.  This is used in partitioned operations, since we don't know when all
-   * parties are done using the session.
+   * The returned `SessionHolder` will return the `Session` to this pool,
+   * unless `dissociate_from_pool` is true, in which case it is not returned
+   * to the pool.  This is used in partitioned operations, since we don't
+   * know when all parties are done using the session.
    *
    * @return a `SessionHolder` on success (which is guaranteed not to be
    * `nullptr`), or an error.
@@ -122,6 +122,13 @@ class SessionPool : public std::enable_shared_from_this<SessionPool> {
     int session_count;
   };
   enum class WaitForSessionAllocation { kWait, kNoWait };
+
+  // Allocate a session from the pool.
+  StatusOr<SessionHolder> Allocate(std::unique_lock<std::mutex>,
+                                   bool dissociate_from_pool);
+
+  // Returns a stub to use by round-robining between the channels.
+  std::shared_ptr<SpannerStub> GetStub(std::unique_lock<std::mutex>);
 
   // Release session back to the pool.
   void Release(std::unique_ptr<Session> session);


### PR DESCRIPTION
Split `Allocate()` and `GetStub()` into lock-acquiring and lock-consuming parts.  This will facilitate future work where two paths will separately call into the lock-consuming parts.

Also improve the `Session` class comment while we're here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14203)
<!-- Reviewable:end -->
