### PR TITLE
cleanup(storage): prepare for clang-tidy 18

### DIFF
--- a/google/cloud/storage/internal/retry_object_read_source.cc
+++ b/google/cloud/storage/internal/retry_object_read_source.cc
@@ -113,7 +113,7 @@ StatusOr<ReadSourceResult> RetryObjectReadSource::Read(char* buf,
 
 bool RetryObjectReadSource::HandleResult(StatusOr<ReadSourceResult> const& r) {
   if (!r) return false;
-  if (r->generation) generation_ = *r->generation;
+  if (r->generation) generation_ = r->generation;
   if (r->transformation.value_or("") == "gunzipped") is_gunzipped_ = true;
   // Since decompressive transcoding does not respect `ReadLast()` we need
   // to ensure the offset is incremented, so the discard loop works.

--- a/google/cloud/storage/lifecycle_rule.cc
+++ b/google/cloud/storage/lifecycle_rule.cc
@@ -27,7 +27,7 @@ absl::optional<std::vector<std::string>> MergeStringListConditions(
     absl::optional<std::vector<std::string>> result,
     absl::optional<std::vector<std::string>> const& rhs) {
   if (!rhs.has_value()) return result;
-  if (!result.has_value()) return *rhs;
+  if (!result.has_value()) return rhs;
 
   std::sort(result->begin(), result->end());
   std::vector<std::string> b = *rhs;
@@ -96,7 +96,7 @@ void MergeDaysSinceNoncurrent(LifecycleRuleCondition& result,
     result.days_since_noncurrent_time = std::max(
         *result.days_since_noncurrent_time, *rhs.days_since_noncurrent_time);
   } else {
-    result.days_since_noncurrent_time = *rhs.days_since_noncurrent_time;
+    result.days_since_noncurrent_time = rhs.days_since_noncurrent_time;
   }
 }
 
@@ -118,7 +118,7 @@ void MergeDaysSinceCustomTime(LifecycleRuleCondition& result,
     result.days_since_custom_time =
         std::max(*result.days_since_custom_time, *rhs.days_since_custom_time);
   } else {
-    result.days_since_custom_time = *rhs.days_since_custom_time;
+    result.days_since_custom_time = rhs.days_since_custom_time;
   }
 }
 void MergeCustomTimeBefore(LifecycleRuleCondition& result,


### PR DESCRIPTION
#14076

```
Step #2: /workspace/google/cloud/storage/internal/retry_object_read_source.cc:116:36: error: conversion from 'absl::optional<long>' into 'long' and back into 'absl::optional<long>', remove potentially error-prone optional dereference [bugprone-optional-value-conversion,-warnings-as-errors]
Step #2:   116 |   if (r->generation) generation_ = *r->generation;
Step #2:       |                                    ^
Step #2: /workspace/google/cloud/storage/internal/retry_object_read_source.cc:116:36: note: remove '*' to silence this warning
Step #2:   116 |   if (r->generation) generation_ = *r->generation;
Step #2:       |                                    ^
Step #2: 36659 warnings generated.
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14205)
<!-- Reviewable:end -->
