### PR TITLE
cleanup(storage): prepare for clang 18

### DIFF
--- a/google/cloud/storage/internal/async/writer_connection_buffered.cc
+++ b/google/cloud/storage/internal/async/writer_connection_buffered.cc
@@ -161,7 +161,7 @@ class AsyncWriterConnectionBufferedState
       result = p.get_future();
       flush_handlers_.push_back(MakeLwmWaiter(std::move(p)));
     }
-    (void)StartWriting(std::move(lk));
+    StartWriting(std::move(lk));
     return result;
   }
 


### PR DESCRIPTION
https://github.com/googleapis/google-cloud-cpp/issues/14076

```
Step #2: /workspace/google/cloud/storage/internal/async/writer_connection_buffered.cc:164:5: error: redundant explicit casting to the same type 'void' as the sub-expression, remove this casting [readability-redundant-casting,-warnings-as-errors]
Step #2:   164 |     (void)StartWriting(std::move(lk));
Step #2:       |     ^~~~~~
Step #2: /workspace/google/cloud/storage/internal/async/writer_connection_buffered.cc:168:8: note: source type originates from the invocation of this method
Step #2:   168 |   void StartWriting(std::unique_lock<std::mutex> lk) {
Step #2:       |   ~~~~ ^
Step #2: 53615 warnings generated.
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14211)
<!-- Reviewable:end -->
