### PR TITLE
refactor: bazel gapics for IAM, BQ

### DIFF
--- a/bazel/gapic.bzl
+++ b/bazel/gapic.bzl
@@ -76,4 +76,4 @@ def cc_gapic_library(name, service_dirs = [], googleapis_deps = []):
             "//:" + name,
             "//google/cloud/testing_util:google_cloud_cpp_testing_private",
         ],
-    ) for sample in native.glob([d + "samples/*.cc" for d in service_dirs])]
+    ) for sample in native.glob([d + "samples/*_samples.cc" for d in service_dirs])]

--- a/google/cloud/bigquery/BUILD.bazel
+++ b/google/cloud/bigquery/BUILD.bazel
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
 load(":bigquery_rest_testing.bzl", "bigquery_rest_testing_hdrs", "bigquery_rest_testing_srcs")
 load(":bigquery_rest_unit_tests.bzl", "bigquery_rest_unit_tests")
 load(":google_cloud_cpp_bigquery_rest.bzl", "google_cloud_cpp_bigquery_rest_hdrs", "google_cloud_cpp_bigquery_rest_srcs")
@@ -35,72 +36,23 @@ service_dirs = [
 
 src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/bigquery/analyticshub/v1:analyticshub_cc_grpc",
+    "@com_google_googleapis//google/cloud/bigquery/biglake/v1:biglake_cc_grpc",
+    "@com_google_googleapis//google/cloud/bigquery/connection/v1:connection_cc_grpc",
+    "@com_google_googleapis//google/cloud/bigquery/datapolicies/v1:datapolicies_cc_grpc",
+    "@com_google_googleapis//google/cloud/bigquery/datatransfer/v1:datatransfer_cc_grpc",
+    "@com_google_googleapis//google/cloud/bigquery/logging/v1:logging_cc_grpc",
+    "@com_google_googleapis//google/cloud/bigquery/migration/v2:migration_cc_grpc",
+    "@com_google_googleapis//google/cloud/bigquery/reservation/v1:reservation_cc_grpc",
+    "@com_google_googleapis//google/cloud/bigquery/storage/v1:storage_cc_grpc",
+]
+
+cc_gapic_library(
+    name = "bigquery",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_bigquery",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/bigquery/analyticshub/v1:analyticshub_cc_grpc",
-        "@com_google_googleapis//google/cloud/bigquery/biglake/v1:biglake_cc_grpc",
-        "@com_google_googleapis//google/cloud/bigquery/connection/v1:connection_cc_grpc",
-        "@com_google_googleapis//google/cloud/bigquery/datapolicies/v1:datapolicies_cc_grpc",
-        "@com_google_googleapis//google/cloud/bigquery/datatransfer/v1:datatransfer_cc_grpc",
-        "@com_google_googleapis//google/cloud/bigquery/logging/v1:logging_cc_grpc",
-        "@com_google_googleapis//google/cloud/bigquery/migration/v2:migration_cc_grpc",
-        "@com_google_googleapis//google/cloud/bigquery/reservation/v1:reservation_cc_grpc",
-        "@com_google_googleapis//google/cloud/bigquery/storage/v1:storage_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_bigquery_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_bigquery",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-mock_samples_glob = ["samples/mock_*.cc"]
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:bigquery",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob(
-    include = [d + "samples/*.cc" for d in service_dirs],
-    exclude = mock_samples_glob,
-)]
 
 [cc_test(
     name = sample.replace("/", "_").replace(".cc", ""),
@@ -110,7 +62,7 @@ mock_samples_glob = ["samples/mock_*.cc"]
         "//:bigquery_mocks",
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
     ],
-) for sample in glob(mock_samples_glob)]
+) for sample in glob(["samples/mock_*.cc"])]
 
 cc_library(
     name = "google_cloud_cpp_bigquery_rest",

--- a/google/cloud/iam/BUILD.bazel
+++ b/google/cloud/iam/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -24,71 +26,18 @@ service_dirs = [
     "v2/",
 ]
 
-src_dirs = service_dirs + [d + "internal/" for d in service_dirs]
+googleapis_deps = [
+    "@com_google_googleapis//google/iam/admin/v1:admin_cc_grpc",
+    "@com_google_googleapis//google/iam/credentials/v1:credentials_cc_grpc",
+    "@com_google_googleapis//google/iam/v1:iam_cc_grpc",
+    "@com_google_googleapis//google/iam/v2:iam_cc_grpc",
+]
 
-filegroup(
-    name = "srcs",
-    srcs = glob([d + "*.cc" for d in src_dirs]),
+cc_gapic_library(
+    name = "iam",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob([d + "*.h" for d in src_dirs]),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_iam",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    visibility = ["//:__pkg__"],
-    # Do not sort: grpc++ must come last
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/iam/admin/v1:admin_cc_grpc",
-        "@com_google_googleapis//google/iam/credentials/v1:credentials_cc_grpc",
-        "@com_google_googleapis//google/iam/v1:iam_cc_grpc",
-        "@com_google_googleapis//google/iam/v2:iam_cc_grpc",
-        "@com_github_grpc_grpc//:grpc++",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_iam_mocks",
-    hdrs = [":mocks"],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_iam",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-mock_samples_glob = [d + "samples/mock_*.cc" for d in service_dirs]
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:iam",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob(
-    include = [d + "samples/*.cc" for d in service_dirs],
-    exclude = mock_samples_glob,
-)]
 
 [cc_test(
     name = sample.replace("/", "_").replace(".cc", ""),
@@ -98,4 +47,4 @@ mock_samples_glob = [d + "samples/mock_*.cc" for d in service_dirs]
         "//:iam_mocks",
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
     ],
-) for sample in glob(mock_samples_glob)]
+) for sample in glob(["samples/mock_*.cc"])]


### PR DESCRIPTION
Part of the work for #14171 

These two libraries have handwritten mock samples, which need to depend on the `*_mocks` libraries. We will glob on something more specific, and handle the mock sample targets individually in the BUILD file.

Note that in CMake, we add dependencies to these targets after they are defined by the common helper. We should consider using the `*_samples.cc` glob too, for the sake of consistency.

Only `securitycenter` remains, which has a special `target_compatible_with` field. That field goes away with Protobuf v27. I am tempted to just wait it out.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14213)
<!-- Reviewable:end -->
