### PR TITLE
cleanup(compute): simpler BUILD file

### DIFF
--- a/google/cloud/compute/BUILD.bazel
+++ b/google/cloud/compute/BUILD.bazel
@@ -19,11 +19,16 @@ package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-[compute_library(d, []) for d in operation_service_dirs]
+[compute_library(
+    service_dir = d,
+) for d in operation_service_dirs]
 
 operations = [":google_cloud_cpp_compute_" + d.replace("/v1/", "") for d in operation_service_dirs]
 
-[compute_library(d, operations) for d in service_dirs]
+[compute_library(
+    inner_deps = operations,
+    service_dir = d,
+) for d in service_dirs]
 
 [cc_test(
     # Sample names include the name of the client, which is unique. Removing

--- a/google/cloud/compute/BUILD.bazel
+++ b/google/cloud/compute/BUILD.bazel
@@ -12,78 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load(":compute_library.bzl", "compute_library")
 load(":service_dirs.bzl", "operation_service_dirs", "service_dirs")
 
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
-# Service C++ files and mocks targets
-[[
-    filegroup(
-        name = service.replace("/v1/", "_srcs"),
-        srcs = glob([service + "*.cc"]) + glob([service + "internal/*.cc"]),
-    ),
-    filegroup(
-        name = service.replace("/v1/", "_hdrs"),
-        srcs = glob([service + "*.h"]) + glob([service + "internal/*.h"]),
-    ),
-    filegroup(
-        name = service.replace("/v1/", "_public_hdrs"),
-        srcs = glob([service + "*.h"]),
-        visibility = ["//:__pkg__"],
-    ),
-    filegroup(
-        name = service.replace("/v1/", "_mock_hdrs"),
-        srcs = glob([service + "mocks/*.h"]),
-        visibility = ["//:__pkg__"],
-    ),
-    cc_library(
-        name = "google_cloud_cpp_compute_" + service.replace("/v1/", "_mocks"),
-        hdrs = [":" + service.replace("/v1/", "_mock_hdrs")],
-        visibility = ["//:__pkg__"],
-        deps = [
-            ":google_cloud_cpp_compute_" + service.replace("/v1/", ""),
-            "@com_google_googletest//:gtest",
-        ],
-    ),
-] for service in service_dirs + operation_service_dirs]
+[compute_library(d, []) for d in operation_service_dirs]
 
-# Operation services
-[cc_library(
-    name = "google_cloud_cpp_compute_" + service.replace("/v1/", ""),
-    srcs = [":" + service.replace("/v1/", "_srcs")],
-    hdrs = [":" + service.replace("/v1/", "_hdrs")],
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "//google/cloud:google_cloud_cpp_rest_internal",
-        "//google/cloud:google_cloud_cpp_rest_protobuf_internal",
-        "//protos:system_includes",
-        "//protos/google/cloud/compute:cc_proto",
-    ],
-) for service in operation_service_dirs]
+operations = [":google_cloud_cpp_compute_" + d.replace("/v1/", "") for d in operation_service_dirs]
 
-# Services
-[cc_library(
-    name = "google_cloud_cpp_compute_" + service.replace("/v1/", ""),
-    srcs = [":" + service.replace("/v1/", "_srcs")],
-    hdrs = [":" + service.replace("/v1/", "_hdrs")],
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_compute_global_operations",
-        ":google_cloud_cpp_compute_global_organization_operations",
-        ":google_cloud_cpp_compute_region_operations",
-        ":google_cloud_cpp_compute_zone_operations",
-        "//:common",
-        "//:grpc_utils",
-        "//google/cloud:google_cloud_cpp_rest_internal",
-        "//google/cloud:google_cloud_cpp_rest_protobuf_internal",
-        "//protos:system_includes",
-        "//protos/google/cloud/compute:cc_proto",
-    ],
-) for service in service_dirs]
+[compute_library(d, operations) for d in service_dirs]
 
 [cc_test(
     # Sample names include the name of the client, which is unique. Removing
@@ -95,4 +35,4 @@ licenses(["notice"])  # Apache 2.0
         ":google_cloud_cpp_compute_" + sample[0:sample.find("/v")],
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
     ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]
+) for sample in glob([d + "samples/*.cc" for d in service_dirs + operation_service_dirs])]

--- a/google/cloud/compute/compute_library.bzl
+++ b/google/cloud/compute/compute_library.bzl
@@ -1,0 +1,73 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def compute_library(service_dir, inner_deps = []):
+    """Defines targets for a compute resource library
+
+    Args:
+        service_dir: The service directory. e.g. "disks/v1/"
+
+        inner_deps: Other libraries that this library depends on. In practice,
+            these are the compute_*_operations libraries.
+    """
+
+    d = service_dir
+    service = d.replace("/v1/", "")
+
+    native.filegroup(
+        name = service + "_srcs",
+        srcs = native.glob([d + "*.cc", d + "internal/*.cc"]),
+    )
+
+    native.filegroup(
+        name = service + "_hdrs",
+        srcs = native.glob([d + "*.h", d + "internal/*.h"]),
+    )
+
+    native.filegroup(
+        name = service + "_public_hdrs",
+        srcs = native.glob([d + "*.h"]),
+        visibility = ["//:__pkg__"],
+    )
+
+    native.filegroup(
+        name = service + "_mock_hdrs",
+        srcs = native.glob([d + "mocks/*.h"]),
+        visibility = ["//:__pkg__"],
+    )
+
+    native.cc_library(
+        name = "google_cloud_cpp_compute_" + service + "_mocks",
+        hdrs = [":" + service + "_mock_hdrs"],
+        visibility = ["//:__pkg__"],
+        deps = [
+            ":google_cloud_cpp_compute_" + service,
+            "@com_google_googletest//:gtest",
+        ],
+    )
+
+    native.cc_library(
+        name = "google_cloud_cpp_compute_" + service,
+        srcs = [":" + service + "_srcs"],
+        hdrs = [":" + service + "_hdrs"],
+        visibility = ["//:__pkg__"],
+        deps = [
+            "//:common",
+            "//:grpc_utils",
+            "//google/cloud:google_cloud_cpp_rest_internal",
+            "//google/cloud:google_cloud_cpp_rest_protobuf_internal",
+            "//protos:system_includes",
+            "//protos/google/cloud/compute:cc_proto",
+        ] + inner_deps,
+    )


### PR DESCRIPTION
Noticed while working on #14108 

The `service.replace("/v1/", ...)` are distracting. Factor this thing out to a function where we can use a local variable to store the service name.

While we're here, build all of the samples.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14225)
<!-- Reviewable:end -->
