### PR TITLE
impl(oauth2): `project_id()` for credential decorators

### DIFF
--- a/google/cloud/internal/oauth2_cached_credentials.cc
+++ b/google/cloud/internal/oauth2_cached_credentials.cc
@@ -74,6 +74,15 @@ StatusOr<std::string> CachedCredentials::universe_domain(
   return impl_->universe_domain(options);
 }
 
+StatusOr<std::string> CachedCredentials::project_id() const {
+  return impl_->project_id();
+}
+
+StatusOr<std::string> CachedCredentials::project_id(
+    Options const& options) const {
+  return impl_->project_id(options);
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace oauth2_internal
 }  // namespace cloud

--- a/google/cloud/internal/oauth2_cached_credentials.h
+++ b/google/cloud/internal/oauth2_cached_credentials.h
@@ -52,6 +52,8 @@ class CachedCredentials : public Credentials {
   std::string KeyId() const override;
   StatusOr<std::string> universe_domain() const override;
   StatusOr<std::string> universe_domain(Options const& options) const override;
+  StatusOr<std::string> project_id() const override;
+  StatusOr<std::string> project_id(Options const& options) const override;
 
  private:
   std::shared_ptr<Credentials> impl_;

--- a/google/cloud/internal/oauth2_cached_credentials_test.cc
+++ b/google/cloud/internal/oauth2_cached_credentials_test.cc
@@ -45,6 +45,9 @@ class MockCredentials : public Credentials {
   MOCK_METHOD(StatusOr<std::string>, universe_domain, (), (const, override));
   MOCK_METHOD(StatusOr<std::string>, universe_domain, (Options const&),
               (const, override));
+  MOCK_METHOD(StatusOr<std::string>, project_id, (), (const, override));
+  MOCK_METHOD(StatusOr<std::string>, project_id, (Options const&),
+              (const, override));
 };
 
 TEST(CachedCredentials, GetTokenUncached) {
@@ -173,6 +176,22 @@ TEST(CachedCredentials, UniverseDomainWithOptions) {
       .WillOnce(Return(StatusOr<std::string>("test-ud.net")));
   CachedCredentials tested(mock);
   EXPECT_THAT(tested.universe_domain(Options{}), IsOkAndHolds("test-ud.net"));
+}
+
+TEST(CachedCredentials, ProjectId) {
+  auto mock = std::make_shared<MockCredentials>();
+  EXPECT_CALL(*mock, project_id())
+      .WillOnce(Return(StatusOr<std::string>("test-project-id")));
+  CachedCredentials tested(mock);
+  EXPECT_THAT(tested.project_id(), IsOkAndHolds("test-project-id"));
+}
+
+TEST(CachedCredentials, ProjectIdWithOptions) {
+  auto mock = std::make_shared<MockCredentials>();
+  EXPECT_CALL(*mock, project_id(_))
+      .WillOnce(Return(StatusOr<std::string>("test-project-id")));
+  CachedCredentials tested(mock);
+  EXPECT_THAT(tested.project_id(Options{}), IsOkAndHolds("test-project-id"));
 }
 
 }  // namespace

--- a/google/cloud/internal/oauth2_logging_credentials.cc
+++ b/google/cloud/internal/oauth2_logging_credentials.cc
@@ -85,6 +85,17 @@ StatusOr<std::string> LoggingCredentials::universe_domain(
   return impl_->universe_domain(options);
 }
 
+StatusOr<std::string> LoggingCredentials::project_id() const {
+  GCP_LOG(DEBUG) << __func__ << "(" << phase_ << ")";
+  return impl_->project_id();
+}
+
+StatusOr<std::string> LoggingCredentials::project_id(
+    Options const& options) const {
+  GCP_LOG(DEBUG) << __func__ << "(" << phase_ << ")";
+  return impl_->project_id(options);
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace oauth2_internal
 }  // namespace cloud

--- a/google/cloud/internal/oauth2_logging_credentials.h
+++ b/google/cloud/internal/oauth2_logging_credentials.h
@@ -56,6 +56,8 @@ class LoggingCredentials : public Credentials {
   std::string KeyId() const override;
   StatusOr<std::string> universe_domain() const override;
   StatusOr<std::string> universe_domain(Options const& options) const override;
+  StatusOr<std::string> project_id() const override;
+  StatusOr<std::string> project_id(Options const& options) const override;
 
  private:
   std::string phase_;

--- a/google/cloud/internal/oauth2_logging_credentials_test.cc
+++ b/google/cloud/internal/oauth2_logging_credentials_test.cc
@@ -47,6 +47,9 @@ class MockCredentials : public Credentials {
   MOCK_METHOD(StatusOr<std::string>, universe_domain, (), (const, override));
   MOCK_METHOD(StatusOr<std::string>, universe_domain, (Options const&),
               (const, override));
+  MOCK_METHOD(StatusOr<std::string>, project_id, (), (const, override));
+  MOCK_METHOD(StatusOr<std::string>, project_id, (Options const&),
+              (const, override));
 };
 
 TEST(LoggingCredentials, GetTokenSuccess) {
@@ -174,6 +177,28 @@ TEST(LoggingCredentials, UniverseDomainWithOptions) {
   EXPECT_THAT(tested.universe_domain(Options{}), IsOkAndHolds("test-ud.net"));
   EXPECT_THAT(log.ExtractLines(),
               Contains(HasSubstr("universe_domain(testing)")).Times(1));
+}
+
+TEST(LoggingCredentials, ProjectId) {
+  auto mock = std::make_shared<MockCredentials>();
+  EXPECT_CALL(*mock, project_id())
+      .WillOnce(Return(StatusOr<std::string>("test-project-id")));
+  ScopedLog log;
+  LoggingCredentials tested("testing", TracingOptions(), mock);
+  EXPECT_THAT(tested.project_id(), IsOkAndHolds("test-project-id"));
+  EXPECT_THAT(log.ExtractLines(),
+              Contains(HasSubstr("project_id(testing)")).Times(1));
+}
+
+TEST(LoggingCredentials, ProjectIdWithOptions) {
+  auto mock = std::make_shared<MockCredentials>();
+  EXPECT_CALL(*mock, project_id(_))
+      .WillOnce(Return(StatusOr<std::string>("test-project-id")));
+  ScopedLog log;
+  LoggingCredentials tested("testing", TracingOptions(), mock);
+  EXPECT_THAT(tested.project_id(Options{}), IsOkAndHolds("test-project-id"));
+  EXPECT_THAT(log.ExtractLines(),
+              Contains(HasSubstr("project_id(testing)")).Times(1));
 }
 
 }  // namespace


### PR DESCRIPTION
Part of the work for #14112

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14240)
<!-- Reviewable:end -->
