### PR TITLE
impl(GCS+gRPC): metrics exporter vs. connection options

### DIFF
--- a/google/cloud/storage/internal/grpc/metrics_exporter_options.h
+++ b/google/cloud/storage/internal/grpc/metrics_exporter_options.h
@@ -27,14 +27,14 @@ namespace cloud {
 namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-/**
- * Returns the monitoring options given the (fully populated) options for
- * Storage.
- */
+/// Returns the monitoring exporter options given the project and resource.
 Options MetricsExporterOptions(
     Project const& project,
-    opentelemetry::sdk::resource::Resource const& resource,
-    Options const& options);
+    opentelemetry::sdk::resource::Resource const& resource);
+
+/// Returns the monitoring exporter connection options given the fully populated
+/// storage options.
+Options MetricsExporterConnectionOptions(Options const& options);
 
 #endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 


### PR DESCRIPTION
I need to separate the options for the metrics exporter vs. the options
for the metrics exporter *connection*.

Part of the work for #13998

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14252)
<!-- Reviewable:end -->
