### PR TITLE
cleanup(bigtable): unused using when no otel

### DIFF
--- a/google/cloud/bigtable/internal/mutate_rows_limiter_test.cc
+++ b/google/cloud/bigtable/internal/mutate_rows_limiter_test.cc
@@ -32,7 +32,6 @@ namespace {
 using Clock = ThrottlingMutateRowsLimiter::Clock;
 using ::google::cloud::bigtable::experimental::BulkApplyThrottlingOption;
 using ::google::cloud::testing_util::FakeSteadyClock;
-using ::google::cloud::testing_util::MockCompletionQueueImpl;
 using ::testing::Contains;
 using ::testing::HasSubstr;
 using ::testing::IsEmpty;
@@ -282,6 +281,7 @@ TEST(MakeMutateRowsLimiter, LoggingDisabled) {
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 using ::google::cloud::testing_util::DisableTracing;
 using ::google::cloud::testing_util::EnableTracing;
+using ::google::cloud::testing_util::MockCompletionQueueImpl;
 using ::google::cloud::testing_util::SpanNamed;
 
 TEST(MakeMutateRowsLimiter, TracingEnabled) {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14264)
<!-- Reviewable:end -->
