### PR TITLE
cleanup(otel): missing metrics module

### DIFF
--- a/google/cloud/opentelemetry/CMakeLists.txt
+++ b/google/cloud/opentelemetry/CMakeLists.txt
@@ -98,6 +98,7 @@ google_cloud_cpp_add_pkgconfig(
     "google_cloud_cpp_rest_internal"
     "google_cloud_cpp_monitoring"
     "google_cloud_cpp_trace"
+    "opentelemetry_metrics"
     "opentelemetry_resources"
     "opentelemetry_trace")
 


### PR DESCRIPTION
`cleanup` and not a `fix` because the `opentelemetry::sdk::metrics::*` symbols that wouldn't link are not used by any public APIs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14266)
<!-- Reviewable:end -->
