### PR TITLE
feat(securitycenter): re-enable on windows

### DIFF
--- a/google/cloud/securitycenter/BUILD.bazel
+++ b/google/cloud/securitycenter/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
@@ -22,82 +24,13 @@ service_dirs = [
     "v2/",
 ]
 
-code_glob = [d + i + f for d in service_dirs for i in [
-    "",
-    "internal/",
-] for f in [
-    "*.h",
-    "*.cc",
-]]
+googleapis_deps = [
+    "@com_google_googleapis//google/cloud/securitycenter/v1:securitycenter_cc_grpc",
+    "@com_google_googleapis//google/cloud/securitycenter/v2:securitycenter_cc_grpc",
+]
 
-sources_glob = [d + "internal/*_sources.cc" for d in service_dirs]
-
-filegroup(
-    name = "srcs",
-    srcs = glob(sources_glob),
+cc_gapic_library(
+    name = "securitycenter",
+    googleapis_deps = googleapis_deps,
+    service_dirs = service_dirs,
 )
-
-filegroup(
-    name = "hdrs",
-    srcs = glob(
-        include = code_glob,
-        exclude = sources_glob,
-    ),
-)
-
-filegroup(
-    name = "public_hdrs",
-    srcs = glob([d + "*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-filegroup(
-    name = "mocks",
-    srcs = glob([d + "mocks/*.h" for d in service_dirs]),
-    visibility = ["//:__pkg__"],
-)
-
-cc_library(
-    name = "google_cloud_cpp_securitycenter",
-    srcs = [":srcs"],
-    hdrs = [":hdrs"],
-    # Cannot compile on Windows - the protos have enum values that
-    # conflict with some system macros.
-    target_compatible_with = select({
-        "@platforms//os:windows": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/cloud/securitycenter/v1:securitycenter_cc_grpc",
-        "@com_google_googleapis//google/cloud/securitycenter/v2:securitycenter_cc_grpc",
-    ],
-)
-
-cc_library(
-    name = "google_cloud_cpp_securitycenter_mocks",
-    hdrs = [":mocks"],
-    # Cannot compile on Windows - the protos have enum values that
-    # conflict with some system macros.
-    target_compatible_with = select({
-        "@platforms//os:windows": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
-    visibility = ["//:__pkg__"],
-    deps = [
-        ":google_cloud_cpp_securitycenter",
-        "@com_google_googletest//:gtest",
-    ],
-)
-
-[cc_test(
-    name = sample.replace("/", "_").replace(".cc", ""),
-    srcs = [sample],
-    tags = ["integration-test"],
-    deps = [
-        "//:securitycenter",
-        "//google/cloud/testing_util:google_cloud_cpp_testing_private",
-    ],
-) for sample in glob([d + "samples/*.cc" for d in service_dirs])]

--- a/google/cloud/securitycenter/CMakeLists.txt
+++ b/google/cloud/securitycenter/CMakeLists.txt
@@ -14,11 +14,11 @@
 # limitations under the License.
 # ~~~
 
-if (WIN32)
+if (WIN32 AND (Protobuf_VERSION VERSION_LESS 27.0))
     message(
         WARNING "Cannot build google/cloud/securitycenter on Windows"
                 " - the protos have enum names that conflict with some system"
-                " macros.")
+                " macros. Update to protobuf >= 27.0.")
     return()
 endif ()
 


### PR DESCRIPTION
I am told that the macros are resolved in protobuf v27, which we now test with.

While we're here, refactor the Bazel file in accordance with #14171

YOLO

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14282)
<!-- Reviewable:end -->
