### PR TITLE
impl(bigquery): Modified row data processing for Query apis

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/common_v2_resources.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/common_v2_resources.cc
@@ -622,6 +622,46 @@ void from_json(nlohmann::json const& j, QueryParameter& q) {
   SafeGetTo(q.parameter_type, j, "parameterType");
   SafeGetTo(q.parameter_value, j, "parameterValue");
 }
+
+void to_json(nlohmann::json& j, RowData const& r) {
+  j = nlohmann::json{{"f", r.columns}};
+}
+void from_json(nlohmann::json const& j, RowData& r) {
+  SafeGetTo(r.columns, j, "f");
+}
+
+void to_json(nlohmann::json& j, ColumnData const& c) {
+  j = nlohmann::json{{"v", c.value}};
+}
+void from_json(nlohmann::json const& j, ColumnData& c) {
+  SafeGetTo(c.value, j, "v");
+}
+
+bool operator==(ColumnData const& lhs, ColumnData const& rhs) {
+  return lhs.value == rhs.value;
+}
+
+bool operator==(RowData const& lhs, RowData const& rhs) {
+  return std::equal(lhs.columns.begin(), lhs.columns.end(),
+                    rhs.columns.begin());
+}
+
+std::string ColumnData::DebugString(absl::string_view name,
+                                    TracingOptions const& options,
+                                    int indent) const {
+  return internal::DebugFormatter(name, options, indent)
+      .StringField("value", value)
+      .Build();
+}
+
+std::string RowData::DebugString(absl::string_view name,
+                                 TracingOptions const& options,
+                                 int indent) const {
+  return internal::DebugFormatter(name, options, indent)
+      .Field("columns", columns)
+      .Build();
+}
+
 // NOLINTEND(misc-no-recursion)
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/common_v2_resources.h
+++ b/google/cloud/bigquery/v2/minimal/internal/common_v2_resources.h
@@ -314,6 +314,27 @@ void to_json(nlohmann::json& j, Struct const& s);
 void from_json(nlohmann::json const& j, Struct& s);
 bool operator==(Struct const& lhs, Struct const& rhs);
 
+struct ColumnData {
+  std::string value;
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
+};
+void to_json(nlohmann::json& j, ColumnData const& c);
+void from_json(nlohmann::json const& j, ColumnData& c);
+bool operator==(ColumnData const& lhs, ColumnData const& rhs);
+
+struct RowData {
+  std::vector<ColumnData> columns;
+
+  std::string DebugString(absl::string_view name,
+                          TracingOptions const& options = {},
+                          int indent = 0) const;
+};
+void to_json(nlohmann::json& j, RowData const& r);
+void from_json(nlohmann::json const& j, RowData& r);
+bool operator==(RowData const& lhs, RowData const& rhs);
+
 // Represents the system variables that can be given to a query job.
 // System variables can be used to check information during query execution.
 //

--- a/google/cloud/bigquery/v2/minimal/internal/job_response.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response.cc
@@ -240,7 +240,7 @@ StatusOr<QueryResponse> QueryResponse::BuildFromHttpResponse(
   if (json->contains("rows")) {
     for (auto const& kv : json->at("rows").items()) {
       auto const& json_struct_obj = kv.value();
-      auto const& row = json_struct_obj.get<Struct>();
+      auto const& row = json_struct_obj.get<RowData>();
       query_results.rows.push_back(row);
     }
   }
@@ -394,7 +394,7 @@ GetQueryResultsResponse::BuildFromHttpResponse(
   if (json->contains("rows")) {
     for (auto const& kv : json->at("rows").items()) {
       auto const& json_struct_obj = kv.value();
-      auto const& row = json_struct_obj.get<Struct>();
+      auto const& row = json_struct_obj.get<RowData>();
       get_query_results.rows.push_back(row);
     }
   }

--- a/google/cloud/bigquery/v2/minimal/internal/job_response.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response.h
@@ -113,7 +113,7 @@ struct PostQueryResults {
 
   TableSchema schema;
   JobReference job_reference;
-  std::vector<Struct> rows;
+  std::vector<RowData> rows;
   std::vector<ErrorProto> errors;
   SessionInfo session_info;
   DmlStats dml_stats;
@@ -151,7 +151,7 @@ struct GetQueryResults {
   bool job_complete = false;
   bool cache_hit = false;
 
-  std::vector<Struct> rows;
+  std::vector<RowData> rows;
   std::vector<ErrorProto> errors;
 
   std::string DebugString(absl::string_view name,

--- a/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
@@ -1991,32 +1991,21 @@ TEST(QueryResponseTest, DebugString) {
       response->DebugString("QueryResponse", TracingOptions{}),
       R"(QueryResponse {)"
       R"( http_response {)"
-      R"( status_code: 200)"
-      R"( payload: REDACTED)"
-      R"( })"
+      R"( status_code: 200 payload: REDACTED })"
       R"( query_results {)"
-      R"( kind: "query-kind")"
-      R"( page_token: "np123")"
-      R"( total_rows: 1000)"
-      R"( total_bytes_processed: 1000)"
-      R"( num_dml_affected_rows: 5)"
-      R"( job_complete: true)"
-      R"( cache_hit: true)"
-      R"( rows { fields {)"
-      R"( key: "bool-key")"
-      R"( value { value_kind: true } })"
-      R"( fields { key: "double-key")"
-      R"( value { value_kind: 3.4 })"
-      R"( } fields { key: "string-key" value { value_kind: "val3" } } })"
-      R"( schema { fields {)"
-      R"( name: "fname-1" type: "" mode: "fmode" description: "")"
-      R"( collation: "" default_value_expression: "" max_length: 0)"
-      R"( precision: 0 scale: 0)"
-      R"( categories { } policy_tags { })"
+      R"( kind: "query-kind" page_token: "np123")"
+      R"( total_rows: 1000 total_bytes_processed: 1000 num_dml_affected_rows: 5)"
+      R"( job_complete: true cache_hit: true)"
+      R"( rows { columns { value: "col1" } columns { value: "col2" })"
+      R"( columns { value: "col3" } columns { value: "col4" })"
+      R"( columns { value: "col5" } columns { value: "col6" } })"
+      R"( schema { fields { name: "fname-1" type: "" mode: "fmode")"
+      R"( description: "" collation: "" default_value_expression: "")"
+      R"( max_length: 0 precision: 0 scale: 0 categories { } policy_tags { })"
       R"( rounding_mode { value: "" } range_element_type { type: "" } } })"
       R"( job_reference { project_id: "p123" job_id: "j123" location: "useast" })"
-      R"( session_info { session_id: "123" })"
-      R"( dml_stats { inserted_row_count: 10 deleted_row_count: 10 updated_row_count: 10 } } })");
+      R"( session_info { session_id: "123" } dml_stats { inserted_row_count: 10)"
+      R"( deleted_row_count: 10 updated_row_count: 10 } } })");
 
   EXPECT_EQ(
       response->DebugString(
@@ -2025,20 +2014,18 @@ TEST(QueryResponseTest, DebugString) {
       R"(QueryResponse { http_response {)"
       R"( status_code: 200 payload: REDACTED })"
       R"( query_results { kind: "query-k...<truncated>...")"
-      R"( page_token: "np123" total_rows: 1000)"
-      R"( total_bytes_processed: 1000 num_dml_affected_rows: 5)"
-      R"( job_complete: true cache_hit: true)"
-      R"( rows { fields { key: "bool-key" value { value_kind: true } })"
-      R"( fields { key: "double-key" value { value_kind: 3.4 } })"
-      R"( fields { key: "string-key" value { value_kind: "val3" } } })"
+      R"( page_token: "np123" total_rows: 1000 total_bytes_processed: 1000)"
+      R"( num_dml_affected_rows: 5 job_complete: true cache_hit: true)"
+      R"( rows { columns { value: "col1" } columns { value: "col2" })"
+      R"( columns { value: "col3" } columns { value: "col4" })"
+      R"( columns { value: "col5" } columns { value: "col6" } })"
       R"( schema { fields { name: "fname-1" type: "" mode: "fmode")"
       R"( description: "" collation: "" default_value_expression: "")"
-      R"( max_length: 0 precision: 0 scale: 0 categories { })"
-      R"( policy_tags { })"
+      R"( max_length: 0 precision: 0 scale: 0 categories { } policy_tags { })"
       R"( rounding_mode { value: "" } range_element_type { type: "" } } })"
       R"( job_reference { project_id: "p123" job_id: "j123" location: "useast" })"
-      R"( session_info { session_id: "123" } dml_stats { inserted_row_count: 10)"
-      R"( deleted_row_count: 10 updated_row_count: 10 } } })");
+      R"( session_info { session_id: "123" } dml_stats {)"
+      R"( inserted_row_count: 10 deleted_row_count: 10 updated_row_count: 10 } } })");
 
   EXPECT_EQ(response->DebugString("QueryResponse", TracingOptions{}.SetOptions(
                                                        "single_line_mode=F")),
@@ -2056,23 +2043,23 @@ TEST(QueryResponseTest, DebugString) {
     job_complete: true
     cache_hit: true
     rows {
-      fields {
-        key: "bool-key"
-        value {
-          value_kind: true
-        }
+      columns {
+        value: "col1"
       }
-      fields {
-        key: "double-key"
-        value {
-          value_kind: 3.4
-        }
+      columns {
+        value: "col2"
       }
-      fields {
-        key: "string-key"
-        value {
-          value_kind: "val3"
-        }
+      columns {
+        value: "col3"
+      }
+      columns {
+        value: "col4"
+      }
+      columns {
+        value: "col5"
+      }
+      columns {
+        value: "col6"
       }
     }
     schema {
@@ -2157,31 +2144,17 @@ TEST(GetQueryResultsResponseTest, DebugString) {
 
   EXPECT_EQ(
       response->DebugString("GetQueryResultsResponse", TracingOptions{}),
-      R"(GetQueryResultsResponse {)"
-      R"( http_response {)"
-      R"( status_code: 200)"
-      R"( payload: REDACTED)"
-      R"( })"
-      R"( get_query_results {)"
-      R"( kind: "query-kind")"
-      R"( etag: "query-etag")"
-      R"( page_token: "np123")"
-      R"( total_rows: 1000)"
-      R"( total_bytes_processed: 1000)"
-      R"( num_dml_affected_rows: 5)"
-      R"( job_complete: true)"
-      R"( cache_hit: true)"
-      R"( rows { fields {)"
-      R"( key: "bool-key")"
-      R"( value { value_kind: true } })"
-      R"( fields { key: "double-key")"
-      R"( value { value_kind: 3.4 })"
-      R"( } fields { key: "string-key" value { value_kind: "val3" } } })"
-      R"( schema { fields {)"
-      R"( name: "fname-1" type: "" mode: "fmode" description: "")"
-      R"( collation: "" default_value_expression: "" max_length: 0)"
-      R"( precision: 0 scale: 0)"
-      R"( categories { } policy_tags { })"
+      R"(GetQueryResultsResponse { http_response {)"
+      R"( status_code: 200 payload: REDACTED } get_query_results {)"
+      R"( kind: "query-kind" etag: "query-etag" page_token: "np123")"
+      R"( total_rows: 1000 total_bytes_processed: 1000)"
+      R"( num_dml_affected_rows: 5 job_complete: true cache_hit: true)"
+      R"( rows { columns { value: "col1" } columns { value: "col2" })"
+      R"( columns { value: "col3" } columns { value: "col4" })"
+      R"( columns { value: "col5" } columns { value: "col6" } })"
+      R"( schema { fields { name: "fname-1" type: "" mode: "fmode")"
+      R"( description: "" collation: "" default_value_expression: "")"
+      R"( max_length: 0 precision: 0 scale: 0 categories { } policy_tags { })"
       R"( rounding_mode { value: "" } range_element_type { type: "" } } })"
       R"( job_reference { project_id: "p123" job_id: "j123" location: "useast" } } })");
 
@@ -2192,17 +2165,15 @@ TEST(GetQueryResultsResponseTest, DebugString) {
       R"(GetQueryResultsResponse { http_response {)"
       R"( status_code: 200 payload: REDACTED })"
       R"( get_query_results { kind: "query-k...<truncated>...")"
-      R"( etag: "query-e...<truncated>...")"
-      R"( page_token: "np123" total_rows: 1000)"
-      R"( total_bytes_processed: 1000 num_dml_affected_rows: 5)"
-      R"( job_complete: true cache_hit: true)"
-      R"( rows { fields { key: "bool-key" value { value_kind: true } })"
-      R"( fields { key: "double-key" value { value_kind: 3.4 } })"
-      R"( fields { key: "string-key" value { value_kind: "val3" } } })"
+      R"( etag: "query-e...<truncated>..." page_token: "np123")"
+      R"( total_rows: 1000 total_bytes_processed: 1000)"
+      R"( num_dml_affected_rows: 5 job_complete: true cache_hit: true)"
+      R"( rows { columns { value: "col1" } columns { value: "col2" })"
+      R"( columns { value: "col3" } columns { value: "col4" })"
+      R"( columns { value: "col5" } columns { value: "col6" } })"
       R"( schema { fields { name: "fname-1" type: "" mode: "fmode")"
       R"( description: "" collation: "" default_value_expression: "")"
-      R"( max_length: 0 precision: 0 scale: 0 categories { })"
-      R"( policy_tags { })"
+      R"( max_length: 0 precision: 0 scale: 0 categories { } policy_tags { })"
       R"( rounding_mode { value: "" } range_element_type { type: "" } } })"
       R"( job_reference { project_id: "p123" job_id: "j123" location: "useast" } } })");
 
@@ -2224,23 +2195,23 @@ TEST(GetQueryResultsResponseTest, DebugString) {
     job_complete: true
     cache_hit: true
     rows {
-      fields {
-        key: "bool-key"
-        value {
-          value_kind: true
-        }
+      columns {
+        value: "col1"
       }
-      fields {
-        key: "double-key"
-        value {
-          value_kind: 3.4
-        }
+      columns {
+        value: "col2"
       }
-      fields {
-        key: "string-key"
-        value {
-          value_kind: "val3"
-        }
+      columns {
+        value: "col3"
+      }
+      columns {
+        value: "col4"
+      }
+      columns {
+        value: "col5"
+      }
+      columns {
+        value: "col6"
       }
     }
     schema {

--- a/google/cloud/bigquery/v2/minimal/testing/common_v2_test_utils.cc
+++ b/google/cloud/bigquery/v2/minimal/testing/common_v2_test_utils.cc
@@ -21,12 +21,14 @@ namespace cloud {
 namespace bigquery_v2_minimal_testing {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+using ::google::cloud::bigquery_v2_minimal_internal::ColumnData;
 using ::google::cloud::bigquery_v2_minimal_internal::ConnectionProperty;
 using ::google::cloud::bigquery_v2_minimal_internal::DatasetReference;
 using ::google::cloud::bigquery_v2_minimal_internal::QueryParameter;
 using ::google::cloud::bigquery_v2_minimal_internal::QueryParameterStructType;
 using ::google::cloud::bigquery_v2_minimal_internal::QueryParameterType;
 using ::google::cloud::bigquery_v2_minimal_internal::QueryParameterValue;
+using ::google::cloud::bigquery_v2_minimal_internal::RowData;
 using ::google::cloud::bigquery_v2_minimal_internal::StandardSqlDataType;
 using ::google::cloud::bigquery_v2_minimal_internal::StandardSqlField;
 using ::google::cloud::bigquery_v2_minimal_internal::StandardSqlStructType;
@@ -157,6 +159,18 @@ SystemVariables MakeSystemVariables() {
   expected.values.fields.insert({"string-key", val3});
 
   return expected;
+}
+
+RowData MakeRowData() {
+  RowData result;
+  result.columns.push_back(ColumnData{"col1"});
+  result.columns.push_back(ColumnData{"col2"});
+  result.columns.push_back(ColumnData{"col3"});
+  result.columns.push_back(ColumnData{"col4"});
+  result.columns.push_back(ColumnData{"col5"});
+  result.columns.push_back(ColumnData{"col6"});
+
+  return result;
 }
 
 void AssertParamValueEquals(QueryParameterValue& expected,

--- a/google/cloud/bigquery/v2/minimal/testing/common_v2_test_utils.h
+++ b/google/cloud/bigquery/v2/minimal/testing/common_v2_test_utils.h
@@ -30,6 +30,7 @@ bigquery_v2_minimal_internal::QueryParameter MakeQueryParameter();
 bigquery_v2_minimal_internal::SystemVariables MakeSystemVariables();
 bigquery_v2_minimal_internal::DatasetReference MakeDatasetReference();
 bigquery_v2_minimal_internal::ConnectionProperty MakeConnectionProperty();
+bigquery_v2_minimal_internal::RowData MakeRowData();
 
 void AssertParamValueEquals(
     bigquery_v2_minimal_internal::QueryParameterValue& expected,

--- a/google/cloud/bigquery/v2/minimal/testing/job_query_test_utils.cc
+++ b/google/cloud/bigquery/v2/minimal/testing/job_query_test_utils.cc
@@ -37,7 +37,7 @@ using ::google::cloud::bigquery_v2_minimal_internal::QueryRequest;
 using ::google::cloud::bigquery_v2_minimal_testing::MakeConnectionProperty;
 using ::google::cloud::bigquery_v2_minimal_testing::MakeDatasetReference;
 using ::google::cloud::bigquery_v2_minimal_testing::MakeQueryParameter;
-using ::google::cloud::bigquery_v2_minimal_testing::MakeSystemVariables;
+using ::google::cloud::bigquery_v2_minimal_testing::MakeRowData;
 using ::google::cloud::bigquery_v2_minimal_testing::MakeTable;
 
 using ::testing::IsEmpty;
@@ -158,7 +158,7 @@ PostQueryResults MakePostQueryResults() {
   expected.kind = "query-kind";
   expected.num_dml_affected_rows = 5;
   expected.page_token = "np123";
-  expected.rows.push_back(MakeSystemVariables().values);
+  expected.rows.push_back(MakeRowData());
 
   expected.schema = MakeTable().schema;
   expected.total_bytes_processed = 1000;
@@ -181,7 +181,7 @@ GetQueryResults MakeGetQueryResults() {
   expected.etag = "query-etag";
   expected.num_dml_affected_rows = 5;
   expected.page_token = "np123";
-  expected.rows.push_back(MakeSystemVariables().values);
+  expected.rows.push_back(MakeRowData());
 
   expected.schema = MakeTable().schema;
   expected.total_bytes_processed = 1000;


### PR DESCRIPTION
This PR contains the following changes

1) Modified structures for row data processing for Query APIs. Existing `Struct` and `Value` structures and respective parsing logic, do not work based on the json returned from the server. I have added new structures which keeps the processing simpler in the client library layer. For our specific usecase we have to go through the schema of each column anyways in our layer so complex row and value processing is not needed for the query apis in the client library layer, and is also not feasible at this layer.

2) Unit tests changes for the above.

3) Please note that I am still keeping the `Struct` and `Value` structures for the following reasons:

- Change is specific to Query APIs only. If in the future we determine that these structures are not needed for other APIs as well then I'll send a PR for cleaning them up and using the new simplified structure for all APIs. At this point, we can't make that decision.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14284)
<!-- Reviewable:end -->
