### PR TITLE
fix(bazel): do not reference repo name

### DIFF
--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -401,7 +401,7 @@ void GenerateBuild(std::ostream& os,
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/accessapproval/BUILD.bazel
+++ b/google/cloud/accessapproval/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/accesscontextmanager/BUILD.bazel
+++ b/google/cloud/accesscontextmanager/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/advisorynotifications/BUILD.bazel
+++ b/google/cloud/advisorynotifications/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/aiplatform/BUILD.bazel
+++ b/google/cloud/aiplatform/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/alloydb/BUILD.bazel
+++ b/google/cloud/alloydb/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/apigateway/BUILD.bazel
+++ b/google/cloud/apigateway/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/apigeeconnect/BUILD.bazel
+++ b/google/cloud/apigeeconnect/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/apikeys/BUILD.bazel
+++ b/google/cloud/apikeys/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/appengine/BUILD.bazel
+++ b/google/cloud/appengine/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/apphub/BUILD.bazel
+++ b/google/cloud/apphub/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/artifactregistry/BUILD.bazel
+++ b/google/cloud/artifactregistry/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/asset/BUILD.bazel
+++ b/google/cloud/asset/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/assuredworkloads/BUILD.bazel
+++ b/google/cloud/assuredworkloads/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/automl/BUILD.bazel
+++ b/google/cloud/automl/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/backupdr/BUILD.bazel
+++ b/google/cloud/backupdr/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/baremetalsolution/BUILD.bazel
+++ b/google/cloud/baremetalsolution/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/batch/BUILD.bazel
+++ b/google/cloud/batch/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/beyondcorp/BUILD.bazel
+++ b/google/cloud/beyondcorp/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/bigquery/BUILD.bazel
+++ b/google/cloud/bigquery/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 load(":bigquery_rest_testing.bzl", "bigquery_rest_testing_hdrs", "bigquery_rest_testing_srcs")
 load(":bigquery_rest_unit_tests.bzl", "bigquery_rest_unit_tests")
 load(":google_cloud_cpp_bigquery_rest.bzl", "google_cloud_cpp_bigquery_rest_hdrs", "google_cloud_cpp_bigquery_rest_srcs")

--- a/google/cloud/billing/BUILD.bazel
+++ b/google/cloud/billing/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/binaryauthorization/BUILD.bazel
+++ b/google/cloud/binaryauthorization/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/certificatemanager/BUILD.bazel
+++ b/google/cloud/certificatemanager/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/channel/BUILD.bazel
+++ b/google/cloud/channel/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/cloudbuild/BUILD.bazel
+++ b/google/cloud/cloudbuild/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/cloudcontrolspartner/BUILD.bazel
+++ b/google/cloud/cloudcontrolspartner/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/cloudquotas/BUILD.bazel
+++ b/google/cloud/cloudquotas/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/commerce/BUILD.bazel
+++ b/google/cloud/commerce/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/composer/BUILD.bazel
+++ b/google/cloud/composer/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/confidentialcomputing/BUILD.bazel
+++ b/google/cloud/confidentialcomputing/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/config/BUILD.bazel
+++ b/google/cloud/config/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/connectors/BUILD.bazel
+++ b/google/cloud/connectors/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/contactcenterinsights/BUILD.bazel
+++ b/google/cloud/contactcenterinsights/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/container/BUILD.bazel
+++ b/google/cloud/container/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/containeranalysis/BUILD.bazel
+++ b/google/cloud/containeranalysis/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/contentwarehouse/BUILD.bazel
+++ b/google/cloud/contentwarehouse/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/datacatalog/BUILD.bazel
+++ b/google/cloud/datacatalog/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/datafusion/BUILD.bazel
+++ b/google/cloud/datafusion/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/datamigration/BUILD.bazel
+++ b/google/cloud/datamigration/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/dataplex/BUILD.bazel
+++ b/google/cloud/dataplex/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/dataproc/BUILD.bazel
+++ b/google/cloud/dataproc/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/datastore/BUILD.bazel
+++ b/google/cloud/datastore/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/datastream/BUILD.bazel
+++ b/google/cloud/datastream/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/deploy/BUILD.bazel
+++ b/google/cloud/deploy/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/dialogflow_cx/BUILD.bazel
+++ b/google/cloud/dialogflow_cx/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/dialogflow_es/BUILD.bazel
+++ b/google/cloud/dialogflow_es/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/discoveryengine/BUILD.bazel
+++ b/google/cloud/discoveryengine/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/dlp/BUILD.bazel
+++ b/google/cloud/dlp/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/documentai/BUILD.bazel
+++ b/google/cloud/documentai/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/domains/BUILD.bazel
+++ b/google/cloud/domains/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/edgecontainer/BUILD.bazel
+++ b/google/cloud/edgecontainer/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/edgenetwork/BUILD.bazel
+++ b/google/cloud/edgenetwork/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/essentialcontacts/BUILD.bazel
+++ b/google/cloud/essentialcontacts/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/eventarc/BUILD.bazel
+++ b/google/cloud/eventarc/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/filestore/BUILD.bazel
+++ b/google/cloud/filestore/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/functions/BUILD.bazel
+++ b/google/cloud/functions/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/gkebackup/BUILD.bazel
+++ b/google/cloud/gkebackup/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/gkehub/BUILD.bazel
+++ b/google/cloud/gkehub/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/gkemulticloud/BUILD.bazel
+++ b/google/cloud/gkemulticloud/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/iam/BUILD.bazel
+++ b/google/cloud/iam/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/iap/BUILD.bazel
+++ b/google/cloud/iap/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/ids/BUILD.bazel
+++ b/google/cloud/ids/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/kms/BUILD.bazel
+++ b/google/cloud/kms/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/language/BUILD.bazel
+++ b/google/cloud/language/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/logging/BUILD.bazel
+++ b/google/cloud/logging/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/managedidentities/BUILD.bazel
+++ b/google/cloud/managedidentities/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/memcache/BUILD.bazel
+++ b/google/cloud/memcache/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/metastore/BUILD.bazel
+++ b/google/cloud/metastore/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/migrationcenter/BUILD.bazel
+++ b/google/cloud/migrationcenter/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/monitoring/BUILD.bazel
+++ b/google/cloud/monitoring/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/netapp/BUILD.bazel
+++ b/google/cloud/netapp/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/networkconnectivity/BUILD.bazel
+++ b/google/cloud/networkconnectivity/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/networkmanagement/BUILD.bazel
+++ b/google/cloud/networkmanagement/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/networksecurity/BUILD.bazel
+++ b/google/cloud/networksecurity/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/networkservices/BUILD.bazel
+++ b/google/cloud/networkservices/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/notebooks/BUILD.bazel
+++ b/google/cloud/notebooks/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/optimization/BUILD.bazel
+++ b/google/cloud/optimization/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/orgpolicy/BUILD.bazel
+++ b/google/cloud/orgpolicy/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/osconfig/BUILD.bazel
+++ b/google/cloud/osconfig/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/oslogin/BUILD.bazel
+++ b/google/cloud/oslogin/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/policysimulator/BUILD.bazel
+++ b/google/cloud/policysimulator/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/policytroubleshooter/BUILD.bazel
+++ b/google/cloud/policytroubleshooter/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/privateca/BUILD.bazel
+++ b/google/cloud/privateca/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/profiler/BUILD.bazel
+++ b/google/cloud/profiler/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/publicca/BUILD.bazel
+++ b/google/cloud/publicca/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/rapidmigrationassessment/BUILD.bazel
+++ b/google/cloud/rapidmigrationassessment/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/recaptchaenterprise/BUILD.bazel
+++ b/google/cloud/recaptchaenterprise/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/recommender/BUILD.bazel
+++ b/google/cloud/recommender/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/redis/BUILD.bazel
+++ b/google/cloud/redis/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/resourcemanager/BUILD.bazel
+++ b/google/cloud/resourcemanager/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/resourcesettings/BUILD.bazel
+++ b/google/cloud/resourcesettings/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/retail/BUILD.bazel
+++ b/google/cloud/retail/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/run/BUILD.bazel
+++ b/google/cloud/run/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/scheduler/BUILD.bazel
+++ b/google/cloud/scheduler/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/secretmanager/BUILD.bazel
+++ b/google/cloud/secretmanager/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/securesourcemanager/BUILD.bazel
+++ b/google/cloud/securesourcemanager/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/securitycenter/BUILD.bazel
+++ b/google/cloud/securitycenter/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/securitycentermanagement/BUILD.bazel
+++ b/google/cloud/securitycentermanagement/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/servicecontrol/BUILD.bazel
+++ b/google/cloud/servicecontrol/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/servicedirectory/BUILD.bazel
+++ b/google/cloud/servicedirectory/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/servicehealth/BUILD.bazel
+++ b/google/cloud/servicehealth/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/servicemanagement/BUILD.bazel
+++ b/google/cloud/servicemanagement/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/serviceusage/BUILD.bazel
+++ b/google/cloud/serviceusage/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/shell/BUILD.bazel
+++ b/google/cloud/shell/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/speech/BUILD.bazel
+++ b/google/cloud/speech/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/storagecontrol/BUILD.bazel
+++ b/google/cloud/storagecontrol/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/storageinsights/BUILD.bazel
+++ b/google/cloud/storageinsights/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/storagetransfer/BUILD.bazel
+++ b/google/cloud/storagetransfer/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/support/BUILD.bazel
+++ b/google/cloud/support/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/talent/BUILD.bazel
+++ b/google/cloud/talent/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/tasks/BUILD.bazel
+++ b/google/cloud/tasks/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/telcoautomation/BUILD.bazel
+++ b/google/cloud/telcoautomation/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/texttospeech/BUILD.bazel
+++ b/google/cloud/texttospeech/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/timeseriesinsights/BUILD.bazel
+++ b/google/cloud/timeseriesinsights/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/tpu/BUILD.bazel
+++ b/google/cloud/tpu/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/trace/BUILD.bazel
+++ b/google/cloud/trace/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/translate/BUILD.bazel
+++ b/google/cloud/translate/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/video/BUILD.bazel
+++ b/google/cloud/video/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/videointelligence/BUILD.bazel
+++ b/google/cloud/videointelligence/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/vision/BUILD.bazel
+++ b/google/cloud/vision/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/vmmigration/BUILD.bazel
+++ b/google/cloud/vmmigration/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/vmwareengine/BUILD.bazel
+++ b/google/cloud/vmwareengine/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/vpcaccess/BUILD.bazel
+++ b/google/cloud/vpcaccess/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/webrisk/BUILD.bazel
+++ b/google/cloud/webrisk/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/websecurityscanner/BUILD.bazel
+++ b/google/cloud/websecurityscanner/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/workflows/BUILD.bazel
+++ b/google/cloud/workflows/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/google/cloud/workstations/BUILD.bazel
+++ b/google/cloud/workstations/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@google_cloud_cpp//bazel:gapic.bzl", "cc_gapic_library")
+load("//bazel:gapic.bzl", "cc_gapic_library")
 
 package(default_visibility = ["//visibility:private"])
 


### PR DESCRIPTION
Dependents may give our repo any name. We should not be referencing our own project's name.

Bug introduced as part of #14173 

To make the changes, I ran:
```cc
sed -i "s;@google_cloud_cpp//bazel:gapic.bzl;//bazel:gapic.bzl;" $(git ls-files)
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14287)
<!-- Reviewable:end -->
