### PR TITLE
ci: use gha free runners

### DIFF
--- a/.github/workflows/macos-bazel.yml
+++ b/.github/workflows/macos-bazel.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   bazel:
     name: bazel + ${{ matrix.os }}
-    runs-on: macos-latest
+    runs-on: macos-14
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -22,7 +22,7 @@ jobs:
       # Continue other builds even if one fails
       fail-fast: false
       matrix:
-        os: [ macos-13 ]
+        os: [ macos-14 ]
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/macos-bazel.yml
+++ b/.github/workflows/macos-bazel.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   bazel:
     name: bazel + ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}-large
+    runs-on: macos-latest
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/macos-cmake.yml
+++ b/.github/workflows/macos-cmake.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   cmake:
     name: cmake + ${{ matrix.os }} + ${{ matrix.shard }}
-    runs-on: ${{ matrix.os }}-xlarge
+    runs-on: macos-latest
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/macos-cmake.yml
+++ b/.github/workflows/macos-cmake.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   cmake:
     name: cmake + ${{ matrix.os }} + ${{ matrix.shard }}
-    runs-on: macos-latest
+    runs-on: macos-14
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         exclude-from-full-trick: [ true ]
-        os: [ macos-13 ]
+        os: [ macos-14 ]
         shard: [ Core, Compute, Shard1, Other ]
         exclude:
         # Only full builds include shards with generated code.

--- a/.github/workflows/windows-bazel.yml
+++ b/.github/workflows/windows-bazel.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   bazel:
     name: bazel + ${{ matrix.msvc }} + ${{ matrix.compilation_mode }}
-    runs-on: windows-latest
+    runs-on: windows-2022
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/windows-bazel.yml
+++ b/.github/workflows/windows-bazel.yml
@@ -14,9 +14,7 @@ permissions:
 jobs:
   bazel:
     name: bazel + ${{ matrix.msvc }} + ${{ matrix.compilation_mode }}
-    runs-on:
-      group: cpp-runners
-      labels: 'windows-2022'
+    runs-on: windows-latest
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/windows-cmake.yml
+++ b/.github/workflows/windows-cmake.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   cmake:
     name: cmake + ${{ matrix.msvc }} + ${{ matrix.arch }} + ${{ matrix.build_type }} + ${{ matrix.shard }}
-    runs-on: windows-latest
+    runs-on: windows-2022
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -67,7 +67,7 @@ jobs:
       run: |
         echo "vcpkg-version=$(cat ci/etc/vcpkg-version.txt)" >> "${GITHUB_OUTPUT}"
         core1_features=(bigtable pubsub pubsublite)
-        core2_features=(spanner storage)        
+        core2_features=(spanner storage)
         # These are the libraries with the most "clients". To build the list
         # run something like this and create shards:
         #
@@ -86,7 +86,7 @@ jobs:
           dialogflow_cx
           dialogflow_es
           aiplatform
-        )    
+        )
         shard2_features=(
           policytroubleshooter
           profiler
@@ -177,11 +177,11 @@ jobs:
           # it out.
           skipped_features=(null)
           skipped_features+=("${core1_features[@]}")
-          skipped_features+=("${core2_features[@]}")        
+          skipped_features+=("${core2_features[@]}")
           skipped_features+=(compute)
           skipped_features+=("${shard1_features[@]}")
           skipped_features+=("${shard2_features[@]}")
-          skipped_features+=("${shard3_features[@]}")                        
+          skipped_features+=("${shard3_features[@]}")
           # We use vcpkg in this build, which ships with Protobuf v21.x.
           # Both `asset` and `channel` require Protobuf >= 23.x to compile on
           # Windows.

--- a/.github/workflows/windows-cmake.yml
+++ b/.github/workflows/windows-cmake.yml
@@ -18,9 +18,7 @@ permissions:
 jobs:
   cmake:
     name: cmake + ${{ matrix.msvc }} + ${{ matrix.arch }} + ${{ matrix.build_type }} + ${{ matrix.shard }}
-    runs-on:
-      group: cpp-runners
-      labels: 'windows-2022'
+    runs-on: windows-latest
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -32,11 +30,17 @@ jobs:
         msvc: [ msvc-2022 ]
         build_type: [ Debug, Release ]
         arch: [ x64, x86 ]
-        shard: [Core, Compute, Other]
+        shard: [Core1, Core2, Compute, Shard1, Shard2, Shard3, Other]
         exclude:
         # Also skip shards (Compute and Other) that contain only generated code.
         - exclude-from-full-trick: ${{ ! inputs.full-matrix }}
           shard: Compute
+        - exclude-from-full-trick: ${{ ! inputs.full-matrix }}
+          shard: Shard1
+        - exclude-from-full-trick: ${{ ! inputs.full-matrix }}
+          shard: Shard2
+        - exclude-from-full-trick: ${{ ! inputs.full-matrix }}
+          shard: Shard3
         - exclude-from-full-trick: ${{ ! inputs.full-matrix }}
           shard: Other
         # No need to duplicate testing with x86 mode and Debug mode
@@ -62,15 +66,122 @@ jobs:
       shell: bash
       run: |
         echo "vcpkg-version=$(cat ci/etc/vcpkg-version.txt)" >> "${GITHUB_OUTPUT}"
-        core_features=(bigtable pubsub pubsublite spanner storage)
-        if [[ "${{ matrix.shard }}" == "Core" ]]; then
-          features="$(printf ",%s" "${core_features[@]}")"
+        core1_features=(bigtable pubsub pubsublite)
+        core2_features=(spanner storage)        
+        # These are the libraries with the most "clients". To build the list
+        # run something like this and create shards:
+        #
+        # git grep -l 'class.*Client' 'google/cloud/**_client.h' |
+        #    egrep -v "(bigtable/|internal/|pubsub/|spanner/|storage/)" |
+        #    cut -f -3 -d/| sort | uniq -c | sort -n |
+        #    awk '{ s += $1; print s, $0}'
+        #
+        shard1_features=(
+          appengine
+          dataproc
+          discoveryengine
+          monitoring
+          retail
+          sql
+          dialogflow_cx
+          dialogflow_es
+          aiplatform
+        )    
+        shard2_features=(
+          policytroubleshooter
+          profiler
+          pubsublite
+          redis
+          securitycenter
+          servicedirectory
+          tpu
+          trace
+          vision
+          workflows
+          beyondcorp
+          billing
+          binaryauthorization
+          gkemulticloud
+          logging
+          notebooks
+          osconfig
+          servicecontrol
+          speech
+          support
+          video
+          datacatalog
+          iam
+          kms
+          run
+          talent
+          contentwarehouse
+          dataplex
+          bigquery
+          resourcemanager
+        )
+        shard3_features=(
+          securesourcemanager
+          securitycentermanagement
+          servicehealth
+          servicemanagement
+          serviceusage
+          shell
+          storagecontrol
+          storageinsights
+          storagetransfer
+          tasks
+          telcoautomation
+          texttospeech
+          timeseriesinsights
+          translate
+          videointelligence
+          vmmigration
+          vmwareengine
+          vpcaccess
+          webrisk
+          websecurityscanner
+          workstations
+          automl
+          cloudbuild
+          cloudcontrolspartner
+          composer
+          containeranalysis
+          datastore
+          eventarc
+          functions
+          iap
+          language
+          metastore
+          networkconnectivity
+          networkservices
+        )
+        if [[ "${{ matrix.shard }}" == "Core1" ]]; then
+          features="$(printf ",%s" "${core1_features[@]}")"
+          echo "features=${features:1}" >> "${GITHUB_OUTPUT}"
+        elif [[ "${{ matrix.shard }}" == "Core2" ]]; then
+          features="$(printf ",%s" "${core2_features[@]}")"
           echo "features=${features:1}" >> "${GITHUB_OUTPUT}"
         elif [[ "${{matrix.shard}}" == "Compute" ]]; then
           echo "features=compute" >> "${GITHUB_OUTPUT}"
+        elif [[ "${{matrix.shard}}" == "Shard1" ]]; then
+          features="$(printf ",%s" "${shard1_features[@]}")"
+          echo "features=${features:1}" >> "${GITHUB_OUTPUT}"
+        elif [[ "${{matrix.shard}}" == "Shard2" ]]; then
+          features="$(printf ",%s" "${shard2_features[@]}")"
+          echo "features=${features:1}" >> "${GITHUB_OUTPUT}"
+        elif [[ "${{matrix.shard}}" == "Shard3" ]]; then
+          features="$(printf ",%s" "${shard3_features[@]}")"
+          echo "features=${features:1}" >> "${GITHUB_OUTPUT}"
         else
-          skipped_features=("${core_features[@]}")
+          # The "-" before the first element gets consumed somewhere, so pad
+          # it out.
+          skipped_features=(null)
+          skipped_features+=("${core1_features[@]}")
+          skipped_features+=("${core2_features[@]}")        
           skipped_features+=(compute)
+          skipped_features+=("${shard1_features[@]}")
+          skipped_features+=("${shard2_features[@]}")
+          skipped_features+=("${shard3_features[@]}")                        
           # We use vcpkg in this build, which ships with Protobuf v21.x.
           # Both `asset` and `channel` require Protobuf >= 23.x to compile on
           # Windows.


### PR DESCRIPTION
In order to accommodate the reduced disk size on the free runners, the sharding factor has been increased for the windows+cmake builds. With this additional sharding, all the windows+cmake builds are expected to pass and all the macos+cmake builds are expected to pass. bazel builds are likely going to fail until they can be similarly sharded.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14290)
<!-- Reviewable:end -->
