### PR TITLE
chore: checkers

### DIFF
--- a/ci/cloudbuild/notifiers/logs/function/function.cc
+++ b/ci/cloudbuild/notifiers/logs/function/function.cc
@@ -114,7 +114,8 @@ std::string const& destination() {
 auto HtmlHead(std::string const& pr, std::string const& sha) {
   std::ostringstream os;
   os << "<head><meta charset=\"utf-8\">\n";
-  os << "<title>" << "PR #" << pr << " google-cloud-cpp@" << sha.substr(0, 7)
+  os << "<title>"
+     << "PR #" << pr << " google-cloud-cpp@" << sha.substr(0, 7)
      << "</title>\n";
   os << "<style>\n";
   os << "tr:nth-child(even) {background: #FFF}\n";

--- a/docfx/doxygen2markdown.cc
+++ b/docfx/doxygen2markdown.cc
@@ -180,7 +180,8 @@ bool AppendIfXRefSect(std::ostream& os, MarkdownContext const& ctx,
   auto const title = std::string_view{node.child_value("xreftitle")};
   if (title == "Deprecated") {
     // The GCP site has a special representation for deprecated elements.
-    os << R"""(<aside class="deprecated"><b>Deprecated:</b>)""" << "\n";
+    os << R"""(<aside class="deprecated"><b>Deprecated:</b>)"""
+       << "\n";
     AppendDescriptionType(os, ctx, node.child("xrefdescription"));
     os << "\n</aside>";
     return true;
@@ -366,8 +367,8 @@ bool AppendIfRef(std::ostream& os, MarkdownContext const& ctx,
   // DocFX YAML supports `xref:` as the syntax to cross link other documents
   // generated from the same DoxFX YAML source:
   //    https://dotnet.github.io/docfx/tutorial/links_and_cross_references.html#using-cross-reference
-  os << "[" << ref << "]" << "(xref:" << node.attribute("refid").as_string()
-     << ")";
+  os << "[" << ref << "]"
+     << "(xref:" << node.attribute("refid").as_string() << ")";
   return true;
 }
 

--- a/google/cloud/bigquery/v2/minimal/benchmarks/dataset_benchmark_programs.cc
+++ b/google/cloud/bigquery/v2/minimal/benchmarks/dataset_benchmark_programs.cc
@@ -165,13 +165,16 @@ int main(int argc, char* argv[]) {
     if (config.wants_help) {
       config.PrintUsage();
     }
-    std::cout << "Exiting..." << "\n" << std::flush;
+    std::cout << "Exiting..."
+              << "\n"
+              << std::flush;
     ;
     return 0;
   }
   std::cout << "# Dataset Benchmark STARTED For GetDataset() and "
                "ListDatasets() APIs with test duration as ["
-            << config.test_duration.count() << "] seconds" << "\n"
+            << config.test_duration.count() << "] seconds"
+            << "\n"
             << std::flush;
 
   DatasetBenchmark benchmark(config);
@@ -230,7 +233,9 @@ int main(int argc, char* argv[]) {
                                    "GetDataset()", combined.get_results);
   Benchmark::PrintThroughputResult(std::cout, "Throughput-Results",
                                    "ListDatasets()", combined.list_results);
-  std::cout << "# Dataset Benchmark ENDED" << "\n" << std::flush;
+  std::cout << "# Dataset Benchmark ENDED"
+            << "\n"
+            << std::flush;
 
   return 0;
 }

--- a/google/cloud/bigquery/v2/minimal/benchmarks/job_cancel_benchmark_programs.cc
+++ b/google/cloud/bigquery/v2/minimal/benchmarks/job_cancel_benchmark_programs.cc
@@ -137,12 +137,15 @@ int main(int argc, char* argv[]) {
                 << std::flush;
       config.PrintUsage();
     }
-    std::cout << "Exiting..." << "\n" << std::flush;
+    std::cout << "Exiting..."
+              << "\n"
+              << std::flush;
     return 0;
   }
   std::cout << "# Job Benchmark STARTED For CancelJob() API with test "
                "duration as ["
-            << config.test_duration.count() << "] seconds" << "\n"
+            << config.test_duration.count() << "] seconds"
+            << "\n"
             << std::flush;
 
   JobBenchmark benchmark(config);
@@ -192,7 +195,9 @@ int main(int argc, char* argv[]) {
 
   Benchmark::PrintThroughputResult(std::cout, "Throughput-Results",
                                    "CancelJob()", combined.cancel_job_results);
-  std::cout << "# Job Benchmark ENDED" << "\n" << std::flush;
+  std::cout << "# Job Benchmark ENDED"
+            << "\n"
+            << std::flush;
 
   return 0;
 }

--- a/google/cloud/bigquery/v2/minimal/benchmarks/job_insert_benchmark_programs.cc
+++ b/google/cloud/bigquery/v2/minimal/benchmarks/job_insert_benchmark_programs.cc
@@ -166,12 +166,15 @@ int main(int argc, char* argv[]) {
           << std::flush;
       config.PrintUsage();
     }
-    std::cout << "Exiting..." << "\n" << std::flush;
+    std::cout << "Exiting..."
+              << "\n"
+              << std::flush;
     return 0;
   }
   std::cout << "# Job Benchmark STARTED For InsertJob() API with test "
                "duration as ["
-            << config.test_duration.count() << "] seconds" << "\n"
+            << config.test_duration.count() << "] seconds"
+            << "\n"
             << std::flush;
 
   JobBenchmark benchmark(config);

--- a/google/cloud/bigquery/v2/minimal/benchmarks/job_query_benchmark_programs.cc
+++ b/google/cloud/bigquery/v2/minimal/benchmarks/job_query_benchmark_programs.cc
@@ -168,12 +168,15 @@ int main(int argc, char* argv[]) {
                 << std::flush;
       config.PrintUsage();
     }
-    std::cout << "Exiting..." << "\n" << std::flush;
+    std::cout << "Exiting..."
+              << "\n"
+              << std::flush;
     return 0;
   }
   std::cout << "# Job Benchmark STARTED For GetQueryResults() and "
                "Query() APIs with test duration as ["
-            << config.test_duration.count() << "] seconds" << "\n"
+            << config.test_duration.count() << "] seconds"
+            << "\n"
             << std::flush;
 
   JobBenchmark benchmark(config);
@@ -231,7 +234,9 @@ int main(int argc, char* argv[]) {
                                    combined.get_query_results);
   Benchmark::PrintThroughputResult(std::cout, "Throughput-Results", "Query()",
                                    combined.query_results);
-  std::cout << "# Job Benchmark ENDED" << "\n" << std::flush;
+  std::cout << "# Job Benchmark ENDED"
+            << "\n"
+            << std::flush;
 
   return 0;
 }

--- a/google/cloud/bigquery/v2/minimal/benchmarks/job_readonly_benchmark_programs.cc
+++ b/google/cloud/bigquery/v2/minimal/benchmarks/job_readonly_benchmark_programs.cc
@@ -170,12 +170,15 @@ int main(int argc, char* argv[]) {
           << std::flush;
       config.PrintUsage();
     }
-    std::cout << "Exiting..." << "\n" << std::flush;
+    std::cout << "Exiting..."
+              << "\n"
+              << std::flush;
     return 0;
   }
   std::cout << "# Job Benchmark STARTED For GetJob() and "
                "ListJobs() APIs with test duration as ["
-            << config.test_duration.count() << "] seconds" << "\n"
+            << config.test_duration.count() << "] seconds"
+            << "\n"
             << std::flush;
 
   JobBenchmark benchmark(config);
@@ -231,7 +234,9 @@ int main(int argc, char* argv[]) {
                                    combined.get_results);
   Benchmark::PrintThroughputResult(std::cout, "Throughput-Results",
                                    "ListJobs()", combined.list_results);
-  std::cout << "# Job Benchmark ENDED" << "\n" << std::flush;
+  std::cout << "# Job Benchmark ENDED"
+            << "\n"
+            << std::flush;
 
   return 0;
 }

--- a/google/cloud/bigquery/v2/minimal/benchmarks/project_benchmark_programs.cc
+++ b/google/cloud/bigquery/v2/minimal/benchmarks/project_benchmark_programs.cc
@@ -148,12 +148,15 @@ int main(int argc, char* argv[]) {
     if (config.wants_help) {
       config.PrintUsage();
     }
-    std::cout << "Exiting..." << "\n" << std::flush;
+    std::cout << "Exiting..."
+              << "\n"
+              << std::flush;
     return 0;
   }
   std::cout << "# Project Benchmark STARTED For ListProjects() API with test "
                "duration as ["
-            << config.test_duration.count() << "] seconds" << "\n"
+            << config.test_duration.count() << "] seconds"
+            << "\n"
             << std::flush;
 
   ProjectBenchmark benchmark(config);
@@ -204,7 +207,9 @@ int main(int argc, char* argv[]) {
 
   Benchmark::PrintThroughputResult(std::cout, "Throughput-Results",
                                    "ListProjects()", combined.list_results);
-  std::cout << "# Project Benchmark ENDED" << "\n" << std::flush;
+  std::cout << "# Project Benchmark ENDED"
+            << "\n"
+            << std::flush;
 
   return 0;
 }

--- a/google/cloud/bigquery/v2/minimal/benchmarks/table_benchmark_programs.cc
+++ b/google/cloud/bigquery/v2/minimal/benchmarks/table_benchmark_programs.cc
@@ -165,12 +165,15 @@ int main(int argc, char* argv[]) {
     if (config.wants_help) {
       config.PrintUsage();
     }
-    std::cout << "Exiting..." << "\n" << std::flush;
+    std::cout << "Exiting..."
+              << "\n"
+              << std::flush;
     return 0;
   }
   std::cout << "# Table Benchmark STARTED For GetTable() and "
                "ListTables() APIs with test duration as ["
-            << config.test_duration.count() << "] seconds" << "\n"
+            << config.test_duration.count() << "] seconds"
+            << "\n"
             << std::flush;
 
   TableBenchmark benchmark(config);
@@ -226,7 +229,9 @@ int main(int argc, char* argv[]) {
                                    "GetTable()", combined.get_results);
   Benchmark::PrintThroughputResult(std::cout, "Throughput-Results",
                                    "ListTables()", combined.list_results);
-  std::cout << "# Table Benchmark ENDED" << "\n" << std::flush;
+  std::cout << "# Table Benchmark ENDED"
+            << "\n"
+            << std::flush;
 
   return 0;
 }

--- a/google/cloud/bigtable/iam_policy.cc
+++ b/google/cloud/bigtable/iam_policy.cc
@@ -39,8 +39,8 @@ google::iam::v1::Policy IamPolicy(
 }
 
 std::ostream& operator<<(std::ostream& os, google::iam::v1::Policy const& rhs) {
-  os << "IamPolicy={version=" << rhs.version()
-     << ", bindings=" << "IamBindings={";
+  os << "IamPolicy={version=" << rhs.version() << ", bindings="
+     << "IamBindings={";
   bool first = true;
   for (auto const& binding : rhs.bindings()) {
     os << (first ? "" : ", ") << binding;

--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -419,7 +419,8 @@ StatusOr<std::size_t> CurlImpl::Read(absl::Span<char> output) {
 
 std::size_t CurlImpl::WriteCallback(absl::Span<char> response) {
   handle_.FlushDebug(__func__);
-  TRACE_STATE() << ", begin" << ", size=" << response.size();
+  TRACE_STATE() << ", begin"
+                << ", size=" << response.size();
 
   // This transfer is closing, so just return zero. That will make libcurl
   // finish any pending work, and will return the handle_ pointer from
@@ -630,8 +631,9 @@ StatusOr<int> CurlImpl::PerformWork() {
         // is better to give a meaningful error message in this case.
         std::ostringstream os;
         os << __func__ << " unknown handle returned by curl_multi_info_read()"
-           << ", msg.msg=[" << msg->msg << "]" << ", result=["
-           << msg->data.result << "]=" << curl_easy_strerror(msg->data.result);
+           << ", msg.msg=[" << msg->msg << "]"
+           << ", result=[" << msg->data.result
+           << "]=" << curl_easy_strerror(msg->data.result);
         return internal::UnknownError(std::move(os).str());
       }
 

--- a/google/cloud/log.cc
+++ b/google/cloud/log.cc
@@ -79,9 +79,10 @@ std::ostream& operator<<(std::ostream& os, Severity x) {
 }
 
 std::ostream& operator<<(std::ostream& os, LogRecord const& rhs) {
-  return os << Timestamp{rhs.timestamp} << " [" << rhs.severity << "]" << " <"
-            << rhs.thread_id << ">" << " " << rhs.message << " ("
-            << rhs.filename << ':' << rhs.lineno << ')';
+  return os << Timestamp{rhs.timestamp} << " [" << rhs.severity << "]"
+            << " <" << rhs.thread_id << ">"
+            << " " << rhs.message << " (" << rhs.filename << ':' << rhs.lineno
+            << ')';
 }
 
 LogSink::LogSink()

--- a/google/cloud/pubsub/benchmarks/endurance.cc
+++ b/google/cloud/pubsub/benchmarks/endurance.cc
@@ -206,7 +206,8 @@ int main(int argc, char* argv[]) {
     };
   }
 
-  std::cout << "# Running Cloud Pub/Sub experiment" << "\n# Start time: "
+  std::cout << "# Running Cloud Pub/Sub experiment"
+            << "\n# Start time: "
             << google::cloud::internal::FormatRfc3339(
                    std::chrono::system_clock::now())
             << "\n# Configured topic: " << configured_topic

--- a/google/cloud/pubsub/benchmarks/throughput.cc
+++ b/google/cloud/pubsub/benchmarks/throughput.cc
@@ -515,7 +515,8 @@ void PrintSubscriber(std::ostream& os, Config const& config) {
 }
 
 void Print(std::ostream& os, Config const& config) {
-  os << "# Running Cloud Pub/Sub experiment" << "\n# Start time: "
+  os << "# Running Cloud Pub/Sub experiment"
+     << "\n# Start time: "
      << google::cloud::internal::FormatRfc3339(std::chrono::system_clock::now())
      << "\n# Endpoint: " << config.endpoint
      << "\n# Topic ID: " << config.topic_id

--- a/google/cloud/pubsub/integration_tests/subscriber_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/subscriber_integration_test.cc
@@ -296,7 +296,8 @@ TEST_F(SubscriberIntegrationTest, StreamingSubscriptionBatchSource) {
               }
               ack_count += r.response->received_messages_size();
               std::cout << "callback(" << r.response->received_messages_size()
-                        << ")" << ", ack_count=" << ack_count
+                        << ")"
+                        << ", ack_count=" << ack_count
                         << ", received_ids.size()=" << received_ids.size()
                         << std::endl;
             }

--- a/google/cloud/pubsub/internal/session_shutdown_manager.cc
+++ b/google/cloud/pubsub/internal/session_shutdown_manager.cc
@@ -31,8 +31,8 @@ std::string FormatOps(std::unordered_map<std::string, int> const& ops) {
 
 SessionShutdownManager::~SessionShutdownManager() {
   if (signaled_) return;
-  GCP_LOG(TRACE) << __func__ << "() - do signal" << ", shutdown=" << shutdown_
-                 << ", signaled=" << signaled_
+  GCP_LOG(TRACE) << __func__ << "() - do signal"
+                 << ", shutdown=" << shutdown_ << ", signaled=" << signaled_
                  << ", outstanding_operations=" << outstanding_operations_
                  << ", result=" << result_ << ", ops=" << FormatOps(ops_);
   signaled_ = true;

--- a/google/cloud/pubsub/samples/schema_samples.cc
+++ b/google/cloud/pubsub/samples/schema_samples.cc
@@ -157,7 +157,8 @@ void GetSchema(google::cloud::pubsub::SchemaServiceClient client,
     auto schema = client.GetSchema(request);
     if (!schema) throw std::move(schema).status();
 
-    std::cout << "The schema exists and its metadata is:" << "\n"
+    std::cout << "The schema exists and its metadata is:"
+              << "\n"
               << schema->DebugString() << "\n";
   }
   //! [END pubsub_get_schema] [get-schema]
@@ -179,7 +180,8 @@ void GetSchemaRevision(google::cloud::pubsub::SchemaServiceClient client,
     auto schema = client.GetSchema(request);
     if (!schema) throw std::move(schema).status();
 
-    std::cout << "The schema revision exists and its metadata is:" << "\n"
+    std::cout << "The schema revision exists and its metadata is:"
+              << "\n"
               << schema->DebugString() << "\n";
   }
   //! [END pubsub_get_schema_revision]
@@ -253,7 +255,8 @@ void DeleteSchemaRevision(google::cloud::pubsub::SchemaServiceClient client,
     auto schema = client.DeleteSchemaRevision(request);
     if (!schema) throw std::move(schema).status();
 
-    std::cout << "Deleted schema. Its metadata is:" << "\n"
+    std::cout << "Deleted schema. Its metadata is:"
+              << "\n"
               << schema->DebugString() << "\n";
   }
   //! [END pubsub_delete_schema_revision]

--- a/google/cloud/spanner/benchmarks/benchmarks_config.cc
+++ b/google/cloud/spanner/benchmarks/benchmarks_config.cc
@@ -37,7 +37,8 @@ std::ostream& operator<<(std::ostream& os, Config const& config) {
             << "\n# Minimum Channels: " << config.minimum_channels
             << "\n# Maximum Channels: " << config.maximum_channels
             << "\n# Iteration Duration: " << config.iteration_duration.count()
-            << "s" << "\n# Table Size: " << config.table_size
+            << "s"
+            << "\n# Table Size: " << config.table_size
             << "\n# Query Size: " << config.query_size
             << "\n# Use Only Stubs: " << config.use_only_stubs
             << "\n# Use Only Clients: " << config.use_only_clients

--- a/google/cloud/spanner/samples/postgresql_samples.cc
+++ b/google/cloud/spanner/samples/postgresql_samples.cc
@@ -874,7 +874,8 @@ void CreateSequence(
   if (!metadata) throw std::move(metadata).status();
   std::cout << "Created `Seq` sequence and `Customers` table,"
             << " where the key column `CustomerId`"
-            << " uses the sequence as a default value," << " new DDL:\n"
+            << " uses the sequence as a default value,"
+            << " new DDL:\n"
             << metadata->DebugString();
   auto commit = client.Commit(
       [&client](google::cloud::spanner::Transaction txn)
@@ -970,7 +971,8 @@ void DropSequence(
   if (!metadata) throw std::move(metadata).status();
   std::cout << "Altered `Customers` table to"
             << " drop DEFAULT from `CustomerId` column,"
-            << " and dropped the `Seq` sequence," << " new DDL:\n"
+            << " and dropped the `Seq` sequence,"
+            << " new DDL:\n"
             << metadata->DebugString();
 }
 // [END spanner_postgresql_drop_sequence]

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -4319,7 +4319,8 @@ void CreateSequence(
   if (!metadata) throw std::move(metadata).status();
   std::cout << "Created `Seq` sequence and `Customers` table,"
             << " where the key column `CustomerId`"
-            << " uses the sequence as a default value," << " new DDL:\n"
+            << " uses the sequence as a default value,"
+            << " new DDL:\n"
             << metadata->DebugString();
   auto commit = client.Commit(
       [&client](google::cloud::spanner::Transaction txn)
@@ -4421,7 +4422,8 @@ void DropSequence(
   if (!metadata) throw std::move(metadata).status();
   std::cout << "Altered `Customers` table to"
             << " drop DEFAULT from `CustomerId` column,"
-            << " and dropped the `Seq` sequence," << " new DDL:\n"
+            << " and dropped the `Seq` sequence,"
+            << " new DDL:\n"
             << metadata->DebugString();
 }
 // [END spanner_drop_sequence]

--- a/google/cloud/storage/compose_many_test.cc
+++ b/google/cloud/storage/compose_many_test.cc
@@ -47,10 +47,11 @@ ObjectMetadata MockObject(std::string const& bucket_name,
         "timeStorageClassUpdated": "2018-05-19T19:31:34Z",
         "updated": "2018-05-19T19:31:24Z",
 )""";
-  text << R"("bucket": ")" << bucket_name << "\"," << R"("generation": ")"
-       << generation << "\"," << R"("id": ")" << bucket_name << "/"
-       << object_name << "/" << generation << "\"," << R"("name": ")"
-       << object_name << "\"}";
+  text << R"("bucket": ")" << bucket_name << "\","
+       << R"("generation": ")" << generation << "\","
+       << R"("id": ")" << bucket_name << "/" << object_name << "/" << generation
+       << "\","
+       << R"("name": ")" << object_name << "\"}";
   return internal::ObjectMetadataParser::FromString(text.str()).value();
 }
 

--- a/google/cloud/storage/iam_policy.cc
+++ b/google/cloud/storage/iam_policy.cc
@@ -483,8 +483,8 @@ std::vector<NativeIamBinding> const& NativeIamPolicy::bindings() const {
 }
 
 std::ostream& operator<<(std::ostream& os, NativeIamPolicy const& rhs) {
-  os << "NativeIamPolicy={version=" << rhs.version()
-     << ", bindings=" << "NativeIamBindings={";
+  os << "NativeIamPolicy={version=" << rhs.version() << ", bindings="
+     << "NativeIamBindings={";
   bool first = true;
   for (auto const& binding : rhs.bindings()) {
     os << (first ? "" : ", ") << binding;

--- a/google/cloud/storage/internal/hmac_key_requests.cc
+++ b/google/cloud/storage/internal/hmac_key_requests.cc
@@ -55,7 +55,8 @@ StatusOr<CreateHmacKeyResponse> CreateHmacKeyResponse::FromHttpResponse(
 
 std::ostream& operator<<(std::ostream& os, CreateHmacKeyResponse const& r) {
   return os << "CreateHmacKeyResponse={metadata=" << r.metadata
-            << ", secret=[censored]" << "}";
+            << ", secret=[censored]"
+            << "}";
 }
 
 std::ostream& operator<<(std::ostream& os, ListHmacKeysRequest const& r) {

--- a/google/cloud/storage/internal/object_requests.cc
+++ b/google/cloud/storage/internal/object_requests.cc
@@ -514,8 +514,8 @@ HashValues FinishHashes(UploadChunkRequest const& request) {
 
 std::ostream& operator<<(std::ostream& os, UploadChunkRequest const& r) {
   os << "UploadChunkRequest={upload_session_url=" << r.upload_session_url()
-     << ", range=<" << r.RangeHeader() << ">" << ", known_object_hashes={"
-     << Format(r.known_object_hashes()) << "}";
+     << ", range=<" << r.RangeHeader() << ">"
+     << ", known_object_hashes={" << Format(r.known_object_hashes()) << "}";
   r.DumpOptions(os, ", ");
   os << ", payload={";
   auto constexpr kMaxOutputBytes = 128;

--- a/google/cloud/storage/policy_document.cc
+++ b/google/cloud/storage/policy_document.cc
@@ -50,8 +50,8 @@ std::ostream& operator<<(std::ostream& os, PolicyDocumentV4 const& rhs) {
 }
 
 std::ostream& operator<<(std::ostream& os, PolicyDocumentResult const& rhs) {
-  return os << "PolicyDocumentResult={" << "access_id=" << rhs.access_id
-            << ", expiration="
+  return os << "PolicyDocumentResult={"
+            << "access_id=" << rhs.access_id << ", expiration="
             << google::cloud::internal::FormatRfc3339(rhs.expiration)
             << ", policy=" << rhs.policy << ", signature=" << rhs.signature
             << "}";
@@ -68,8 +68,9 @@ std::string FormatDateForForm(PolicyDocumentV4Result const&) {
 }
 
 std::ostream& operator<<(std::ostream& os, PolicyDocumentV4Result const& rhs) {
-  return os << "PolicyDocumentV4Result={" << "url=" << rhs.url
-            << ", access_id=" << rhs.access_id << ", expiration="
+  return os << "PolicyDocumentV4Result={"
+            << "url=" << rhs.url << ", access_id=" << rhs.access_id
+            << ", expiration="
             << google::cloud::internal::FormatRfc3339(rhs.expiration)
             << ", policy=" << rhs.policy << ", signature=" << rhs.signature
             << ", signing_algorithm=" << rhs.signing_algorithm << "}";

--- a/google/cloud/testing_util/opentelemetry_matchers.cc
+++ b/google/cloud/testing_util/opentelemetry_matchers.cc
@@ -109,7 +109,8 @@ std::ostream& operator<<(std::ostream& os, SpanData const& rhs) {
   for (auto const& link : rhs.GetLinks()) {
     os << sep << "Link {span_context="
        << google::cloud::testing_util::ToString(link.GetSpanContext()) << ","
-       << line_sep << "\t" << "attributes=["
+       << line_sep << "\t"
+       << "attributes=["
        << absl::StrJoin(link.GetAttributes(), ", ", AttributeFormatter) << "]}";
     sep = ", \n\t\t\t";
   }


### PR DESCRIPTION
Our `gcb-checkers` docker image picked up a new version of `clang-format`. We adapt accordingly.

Locally I had to run `docker system prune -a` to clear the cache and get the latest image.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14298)
<!-- Reviewable:end -->
