### PR TITLE
impl(generator): handle bigquery pagination

### DIFF
--- a/generator/internal/pagination.cc
+++ b/generator/internal/pagination.cc
@@ -35,6 +35,24 @@ bool FieldExistsAndIsType(Descriptor const& d, std::string const& field_name,
   return (field != nullptr && field->type() == field_type);
 }
 
+// Checks that the `field_name` has a message type of any of the names in
+// `message_names`.
+bool FieldExistsAndIsMessage(Descriptor const& d, std::string const& field_name,
+                             std::vector<std::string> const& message_names) {
+  FieldDescriptor const* field = d.FindFieldByName(field_name);
+  if (field == nullptr) return false;
+  if (field->type() != FieldDescriptor::TYPE_MESSAGE) return false;
+  google::protobuf::Descriptor const* descriptor = field->message_type();
+  if (descriptor == nullptr) return false;
+  if (std::any_of(message_names.begin(), message_names.end(),
+                  [descriptor](auto message_name) {
+                    return message_name == descriptor->full_name();
+                  })) {
+    return true;
+  };
+  return false;
+}
+
 // https://google.aip.dev/client-libraries/4233
 google::cloud::optional<PaginationInfo> DetermineAIP4233Pagination(
     MethodDescriptor const& method) {
@@ -121,13 +139,62 @@ google::cloud::optional<PaginationInfo> DetermineAlternatePagination(
   return PaginationInfo{items->name(), items->message_type(), {}};
 }
 
+// For the BigQuery v2 proto definitions, the paging conventions
+// do not adhere to aip-4233 for the following rpcs:
+//   - JobService.ListJobs
+//   - JobService.GetQueryResults
+//   - TableService.ListTables
+//   - DatasetService.ListDatasets
+//   - ModelService.ListModels
+//   - TableDataService.List
+// This method adds custom code to handle these cases.
+google::cloud::optional<PaginationInfo> DetermineBigQueryPagination(
+    MethodDescriptor const& method) {
+  Descriptor const* request_message = method.input_type();
+  Descriptor const* response_message = method.output_type();
+
+  if (!(FieldExistsAndIsMessage(
+            *request_message, "max_results",
+            {"google.protobuf.UInt32Value", "google.protobuf.Int32Value"}) ||
+        FieldExistsAndIsType(*request_message, "max_results",
+                             FieldDescriptor::TYPE_UINT32)) ||
+      !FieldExistsAndIsType(*request_message, "page_token",
+                            FieldDescriptor::TYPE_STRING) ||
+      !FieldExistsAndIsType(*response_message, "next_page_token",
+                            FieldDescriptor::TYPE_STRING)) {
+    return {};
+  }
+
+  std::unordered_map<std::string, std::string> items_map = {
+      {"jobs", "google.cloud.bigquery.v2.ListFormatJob"},
+      {"datasets", "google.cloud.bigquery.v2.ListFormatDataset"},
+      {"models", "google.cloud.bigquery.v2.Model"},
+      {"rows", "google.protobuf.Struct"},
+      {"tables", "google.cloud.bigquery.v2.ListFormatTable"}};
+  for (auto const& kv : items_map) {
+    auto field_name = kv.first;
+    auto field_type_message_name = kv.second;
+    if (FieldExistsAndIsMessage(*response_message, field_name,
+                                {field_type_message_name})) {
+      FieldDescriptor const* items =
+          response_message->FindFieldByName(field_name);
+      if (!items->is_repeated()) return {};
+      return PaginationInfo{items->name(), items->message_type(), {}};
+    }
+  }
+
+  return {};
+}
+
 }  // namespace
 
 google::cloud::optional<PaginationInfo> DeterminePagination(
     MethodDescriptor const& method) {
   auto result = DetermineAIP4233Pagination(method);
   if (result) return result;
-  return DetermineAlternatePagination(method);
+  result = DetermineAlternatePagination(method);
+  if (result) return result;
+  return DetermineBigQueryPagination(method);
 }
 
 bool IsPaginated(MethodDescriptor const& method) {


### PR DESCRIPTION
Closes https://github.com/googleapis/google-cloud-cpp/issues/14281

BigQuery's proto pagination fields differ in 2 ways that our generator does not currently handle: 
1) the max_size field is not always a uint32, but can also be a "google.protobuf.UInt32Value" or "google.protobuf.Int32Value"
2) the name of the repeated field in the response that should be paginated is not always "items".

We use to recognize if the `max_size` field on the request proto for the method to determine if we should generate pagination info and we use the repeated message field to provide the pagination info.

This PR adds custom parsing to the protos to see if pagination should be added for BQ protos.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14307)
<!-- Reviewable:end -->
