### PR TITLE
ci: pin vc++ compiler toolset

### DIFF
--- a/.github/workflows/windows-bazel.yml
+++ b/.github/workflows/windows-bazel.yml
@@ -72,6 +72,8 @@ jobs:
     # Note that in other runners the publisher is GitHub. If we trust GitHub
     # to run the VM, we should trust their runners.
     - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # @v1.13.0
+      with:
+        toolset: 14.39
     - name: Build google-cloud-cpp
       shell: bash
       run: |

--- a/.github/workflows/windows-cmake.yml
+++ b/.github/workflows/windows-cmake.yml
@@ -220,6 +220,7 @@ jobs:
     - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # @v1.13.0
       with:
         arch: ${{ matrix.arch }}
+        toolset: 14.39
     - name: Build google-cloud-cpp
       shell: bash
       run: |


### PR DESCRIPTION
Avoid https://github.com/microsoft/vcpkg/issues/39177

... maybe? I don't know. I wouldn't bet on this working. I just figured I'd try something.

https://github.com/marketplace/actions/setup-msvc-developer-command-prompt

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14308)
<!-- Reviewable:end -->
