### PR TITLE
ci: fix windows+cmake+x86 builds

### DIFF
--- a/.github/workflows/windows-cmake.yml
+++ b/.github/workflows/windows-cmake.yml
@@ -237,6 +237,7 @@ jobs:
         .build/vcpkg/bootstrap-vcpkg.sh -disableMetrics
         # TODO(14314) - remove this VC Toolset workaround
         echo "set(VCPKG_PLATFORM_TOOLSET_VERSION ${{ steps.vctoolset.outputs.toolset_version }})" >> .build/vcpkg/triplets/x64-windows.cmake
+        echo "set(VCPKG_PLATFORM_TOOLSET_VERSION ${{ steps.vctoolset.outputs.toolset_version }})" >> .build/vcpkg/triplets/x86-windows.cmake
     # go/github-actions#gha-bestpractices explains why we use a SHA instead of
     # a named version for this runner. We could avoid using this runner with the
     # ideas from:


### PR DESCRIPTION
It is not enough to just write to `${{ matrix.arch }}-windows.cmake`. Apparently the `x86` build builds some of the deps using the `x64-windows` triplet and others as the `x86-windows` triplet.

Tested: https://github.com/googleapis/google-cloud-cpp/actions/runs/9452556490

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14318)
<!-- Reviewable:end -->
