### PR TITLE
ci: upb workaround for windows+bazel

### DIFF
--- a/.github/workflows/windows-bazel.yml
+++ b/.github/workflows/windows-bazel.yml
@@ -58,6 +58,30 @@ jobs:
           # From Compute
           - -//google/cloud/compute/...
     steps:
+    # TODO(14314) - remove this VC Toolset workaround
+    - name: Select VC Toolset
+      id: vctoolset
+      shell: bash
+      run: |
+        # upb does not compile with the compiler that comes with the 14.40.33807
+        # VC toolset. To workaround this, we list the available toolset
+        # versions, then pick the latest one that is not 14.40.*. If 14.40.* is
+        # the only compiler version, we use that.
+        #
+        # See https://github.com/protocolbuffers/protobuf/issues/17032 for more
+        # details.
+        toolset_versions=($(ls "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Tools\\MSVC"))
+        echo "Available VC toolsets: ${toolset_versions[@]}"
+        toolset_version=""
+        for v in "${toolset_versions[@]}"; do
+          if [ -z "${toolset_version}" ]; then
+            toolset_version=${v}
+          elif ! echo ${v} | grep -q "^14\.40\."; then
+            toolset_version=${v}
+          fi
+        done
+        echo "Using VC toolset: ${toolset_version}"
+        echo "toolset_version=${toolset_version}" >> "${GITHUB_OUTPUT}"
     - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.checkout-ref }}
@@ -72,6 +96,9 @@ jobs:
     # Note that in other runners the publisher is GitHub. If we trust GitHub
     # to run the VM, we should trust their runners.
     - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # @v1.13.0
+      # TODO(14314) - remove this VC Toolset workaround
+      with:
+        toolset: ${{ steps.vctoolset.outputs.toolset_version }}
     - name: Build google-cloud-cpp
       shell: bash
       run: |
@@ -81,6 +108,8 @@ jobs:
         # Using a short name like this avoids the problem in most cases.
         mkdir -p 'c:\b' || true
         export BAZEL_ROOT='c:\b'
+        # TODO(14314) - remove this VC Toolset workaround
+        export BAZEL_VC_FULL_VERSION=${{ steps.vctoolset.outputs.toolset_version }}
         ci/gha/builds/windows-bazel.sh ${{ matrix.compilation_mode }} ${{ join(matrix.targets, ' ') }}
     env:
       BAZEL_REMOTE_CACHE: https://storage.googleapis.com/cloud-cpp-gha-cache/bazel-cache/${{ matrix.msvc }}/${{ matrix.compilation_mode }}


### PR DESCRIPTION
Workaround mentioned in #14314 

See the related `windows-cmake.yml` changes: #14315 

The difference is how we set the toolset used by the build system. For Bazel, we set the `BAZEL_FULL_VC_VERSION` environment variable: https://bazel.build/configure/windows#build_cpp

---

Tested: https://github.com/googleapis/google-cloud-cpp/actions/runs/9454681140/job/26042798580

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14319)
<!-- Reviewable:end -->
