### PR TITLE
impl: add Await methods to poll already started LRO

### DIFF
--- a/google/cloud/internal/async_long_running_operation_test.cc
+++ b/google/cloud/internal/async_long_running_operation_test.cc
@@ -308,6 +308,151 @@ TEST(AsyncLongRunningTest, RequestPollThenCancel) {
   EXPECT_THAT(actual, StatusIs(StatusCode::kCancelled));
 }
 
+TEST(AsyncLongRunningTest, AwaitPollThenSuccessMetadata) {
+  Response expected;
+  expected.set_seconds(123456);
+  google::longrunning::Operation starting_op;
+  starting_op.set_name("test-op-name");
+  google::longrunning::Operation done_op = starting_op;
+  done_op.set_done(true);
+  done_op.mutable_metadata()->PackFrom(expected);
+
+  auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
+  EXPECT_CALL(*mock_cq, MakeRelativeTimer)
+      .WillOnce([](std::chrono::nanoseconds) {
+        return make_ready_future(
+            make_status_or(std::chrono::system_clock::now()));
+      });
+  CompletionQueue cq(mock_cq);
+
+  auto mock = std::make_shared<MockStub>();
+  EXPECT_CALL(*mock, AsyncGetOperation)
+      .WillOnce([&](CompletionQueue&, auto, ImmutableOptions const& options,
+                    google::longrunning::GetOperationRequest const&) {
+        EXPECT_EQ(options->get<StringOption>(), CurrentTestName());
+        return make_ready_future(make_status_or(done_op));
+      });
+  auto polling_policy = std::make_unique<MockPollingPolicy>();
+  EXPECT_CALL(*polling_policy, clone()).Times(0);
+  EXPECT_CALL(*polling_policy, OnFailure).Times(0);
+  EXPECT_CALL(*polling_policy, WaitPeriod)
+      .WillRepeatedly(Return(std::chrono::milliseconds(1)));
+  auto current =
+      MakeImmutableOptions(Options{}.set<StringOption>(CurrentTestName()));
+  auto actual = AsyncAwaitLongRunningOperation<Response>(
+                    cq, current, starting_op, MakePoll(mock), MakeCancel(mock),
+                    &ExtractLongRunningResultMetadata<Response>,
+                    std::move(polling_policy), "test-function")
+                    .get();
+  OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
+  ASSERT_THAT(actual, IsOk());
+  EXPECT_THAT(*actual, IsProtoEqual(expected));
+}
+
+TEST(AsyncLongRunningTest, AwaitPollThenSuccessResponse) {
+  Response expected;
+  expected.set_seconds(123456);
+  google::longrunning::Operation starting_op;
+  starting_op.set_name("test-op-name");
+  google::longrunning::Operation done_op = starting_op;
+  done_op.set_done(true);
+  done_op.mutable_response()->PackFrom(expected);
+
+  auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
+  EXPECT_CALL(*mock_cq, MakeRelativeTimer)
+      .WillOnce([](std::chrono::nanoseconds) {
+        return make_ready_future(
+            make_status_or(std::chrono::system_clock::now()));
+      });
+  CompletionQueue cq(mock_cq);
+
+  auto mock = std::make_shared<MockStub>();
+  EXPECT_CALL(*mock, AsyncGetOperation)
+      .WillOnce([&](CompletionQueue&, auto, ImmutableOptions const& options,
+                    google::longrunning::GetOperationRequest const&) {
+        EXPECT_EQ(options->get<StringOption>(), CurrentTestName());
+        return make_ready_future(make_status_or(done_op));
+      });
+  auto polling_policy = std::make_unique<MockPollingPolicy>();
+  EXPECT_CALL(*polling_policy, clone()).Times(0);
+  EXPECT_CALL(*polling_policy, OnFailure).Times(0);
+  EXPECT_CALL(*polling_policy, WaitPeriod)
+      .WillRepeatedly(Return(std::chrono::milliseconds(1)));
+  auto current =
+      MakeImmutableOptions(Options{}.set<StringOption>(CurrentTestName()));
+  auto actual = AsyncAwaitLongRunningOperation<Response>(
+                    cq, current, starting_op, MakePoll(mock), MakeCancel(mock),
+                    &ExtractLongRunningResultResponse<Response>,
+                    std::move(polling_policy), "test-function")
+                    .get();
+  OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
+  ASSERT_THAT(actual, IsOk());
+  EXPECT_THAT(*actual, IsProtoEqual(expected));
+}
+
+TEST(AsyncLongRunningTest, AwaitPollThenCancel) {
+  google::longrunning::Operation starting_op;
+  starting_op.set_name("test-op-name");
+
+  auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
+  AsyncSequencer<void> timer;
+  EXPECT_CALL(*mock_cq, MakeRelativeTimer)
+      .WillRepeatedly([&timer](std::chrono::nanoseconds) {
+        return timer.PushBack().then([](future<void>) {
+          return make_status_or(std::chrono::system_clock::now());
+        });
+      });
+  CompletionQueue cq(mock_cq);
+
+  auto mock = std::make_shared<MockStub>();
+  EXPECT_CALL(*mock, AsyncGetOperation)
+      .WillOnce([&](CompletionQueue&, auto, ImmutableOptions const& options,
+                    google::longrunning::GetOperationRequest const&) {
+        EXPECT_EQ(options->get<StringOption>(), CurrentTestName());
+        return make_ready_future(make_status_or(starting_op));
+      })
+      .WillOnce([&](CompletionQueue&, auto, ImmutableOptions const& options,
+                    google::longrunning::GetOperationRequest const&) {
+        EXPECT_EQ(options->get<StringOption>(), CurrentTestName());
+        return make_ready_future(StatusOr<google::longrunning::Operation>(
+            Status{StatusCode::kCancelled, "cancelled"}));
+      });
+  EXPECT_CALL(*mock, AsyncCancelOperation)
+      .WillOnce([&](CompletionQueue&, auto, ImmutableOptions const& options,
+                    google::longrunning::CancelOperationRequest const&) {
+        EXPECT_EQ(options->get<StringOption>(), CurrentTestName());
+        return make_ready_future(Status{});
+      });
+  auto polling_policy = std::make_unique<MockPollingPolicy>();
+  EXPECT_CALL(*polling_policy, clone()).Times(0);
+  EXPECT_CALL(*polling_policy, OnFailure)
+      .WillRepeatedly([](Status const& status) {
+        return status.code() != StatusCode::kCancelled;
+      });
+  EXPECT_CALL(*polling_policy, WaitPeriod)
+      .WillRepeatedly(Return(std::chrono::milliseconds(1)));
+  auto current =
+      MakeImmutableOptions(Options{}.set<StringOption>(CurrentTestName()));
+  auto pending = AsyncAwaitLongRunningOperation<Response>(
+      cq, current, starting_op, MakePoll(mock), MakeCancel(mock),
+      &ExtractLongRunningResultMetadata<Response>, std::move(polling_policy),
+      "test-function");
+
+  // Wait until the polling loop is backing off for a second time.
+  timer.PopFront().set_value();
+  auto t = timer.PopFront();
+  {
+    // cancel the long running operation
+    OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
+    pending.cancel();
+  }
+  // release timer
+  t.set_value();
+  OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
+  auto actual = pending.get();
+  EXPECT_THAT(actual, StatusIs(StatusCode::kCancelled));
+}
+
 }  // namespace
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/async_rest_long_running_operation_custom.h
+++ b/google/cloud/internal/async_rest_long_running_operation_custom.h
@@ -71,6 +71,40 @@ future<StatusOr<ReturnType>> AsyncRestLongRunningOperation(
       });
 }
 
+/*
+ * AsyncAwaitRestLongRunningOperation for services that do not conform to
+ * AIP-151.
+ */
+template <typename ReturnType, typename OperationType,
+          typename GetOperationRequestType, typename CancelOperationRequestType,
+          typename CompletionQueue>
+future<StatusOr<ReturnType>> AsyncRestAwaitLongRunningOperation(
+    CompletionQueue cq, internal::ImmutableOptions options,
+    OperationType operation,
+    AsyncRestPollLongRunningOperation<OperationType, GetOperationRequestType>
+        poll,
+    AsyncRestCancelLongRunningOperation<CancelOperationRequestType> cancel,
+    LongRunningOperationValueExtractor<ReturnType, OperationType>
+        value_extractor,
+    std::unique_ptr<PollingPolicy> polling_policy, char const* location,
+    std::function<bool(OperationType const&)> is_operation_done,
+    std::function<void(std::string const&, GetOperationRequestType&)>
+        get_request_set_operation_name,
+    std::function<void(std::string const&, CancelOperationRequestType&)>
+        cancel_request_set_operation_name) {
+  auto loc = std::string{location};
+  return AsyncRestPollingLoop<OperationType, GetOperationRequestType,
+                              CancelOperationRequestType>(
+             std::move(cq), std::move(options),
+             make_ready_future(StatusOr<OperationType>(operation)),
+             std::move(poll), std::move(cancel), std::move(polling_policy),
+             std::move(location), is_operation_done,
+             get_request_set_operation_name, cancel_request_set_operation_name)
+      .then([value_extractor, loc](future<StatusOr<OperationType>> g) {
+        return value_extractor(g.get(), loc);
+      });
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace rest_internal
 }  // namespace cloud


### PR DESCRIPTION
part of the work for #7658 

Add variations of existing `AsyncLongRunningOperation` template functions that do not start the LRO, but accept an Operation type from an already started LRO.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14329)
<!-- Reviewable:end -->
