### PR TITLE
impl(generator): format variables for lro await

### DIFF
--- a/generator/internal/longrunning.cc
+++ b/generator/internal/longrunning.cc
@@ -95,6 +95,9 @@ bool IsLongrunningMetadataTypeUsedAsResponse(MethodDescriptor const& method) {
 void SetLongrunningOperationMethodVars(
     google::protobuf::MethodDescriptor const& method,
     VarsDictionary& method_vars) {
+  method_vars["longrunning_operation_type"] =
+      ProtoNameToCppName(method.output_type()->full_name());
+
   if (method.output_type()->full_name() == "google.longrunning.Operation") {
     auto operation_info =
         method.options().GetExtension(google::longrunning::operation_info);
@@ -194,6 +197,10 @@ void SetLongrunningOperationServiceVars(
       r.set_project(request.project());
       r.set_operation(op);
 )""";
+        service_vars["longrunning_await_set_operation_fields"] = R"""(
+      r.set_project(info.project);
+      r.set_operation(info.operation);
+)""";
         auto global_lro_path = absl::StrFormat(
             R"""(absl::StrCat("/compute/",
                               rest_internal::DetermineApiVersion("%s", *options),
@@ -216,6 +223,9 @@ void SetLongrunningOperationServiceVars(
             "DeleteOperationRequest";
         service_vars["longrunning_set_operation_fields"] = R"""(
       r.set_operation(op);
+)""";
+        service_vars["longrunning_await_set_operation_fields"] = R"""(
+      r.set_operation(info.operation);
 )""";
         auto global_org_lro_path = absl::StrFormat(
             R"""(absl::StrCat("/compute/",
@@ -240,6 +250,11 @@ void SetLongrunningOperationServiceVars(
       r.set_region(request.region());
       r.set_operation(op);
 )""";
+        service_vars["longrunning_await_set_operation_fields"] = R"""(
+      r.set_project(info.project);
+      r.set_region(info.region);
+      r.set_operation(info.operation);
+)""";
         auto region_lro_path = absl::StrFormat(
             R"""(absl::StrCat("/compute/",
                               rest_internal::DetermineApiVersion("%s", *options),
@@ -263,6 +278,11 @@ void SetLongrunningOperationServiceVars(
       r.set_project(request.project());
       r.set_zone(request.zone());
       r.set_operation(op);
+)""";
+        service_vars["longrunning_await_set_operation_fields"] = R"""(
+      r.set_project(info.project);
+      r.set_zone(info.zone);
+      r.set_operation(info.operation);
 )""";
         auto zone_lro_path = absl::StrFormat(
             R"""(absl::StrCat("/compute/",

--- a/generator/internal/longrunning_test.cc
+++ b/generator/internal/longrunning_test.cc
@@ -535,6 +535,8 @@ TEST_F(LongrunningVarsTest,
       service_file_descriptor->service(0)->method(1);
   VarsDictionary vars;
   SetLongrunningOperationMethodVars(*method, vars);
+  EXPECT_THAT(vars, Contains(Pair("longrunning_operation_type",
+                                  "google::longrunning::Operation")));
   EXPECT_THAT(vars, Contains(Pair("longrunning_metadata_type",
                                   "google::protobuf::Struct")));
   EXPECT_THAT(vars, Contains(Pair("longrunning_response_type",
@@ -580,6 +582,8 @@ TEST_F(LongrunningVarsTest, SetLongrunningOperationMethodVarsBespokeLRO) {
   EXPECT_FALSE(IsGRPCLongrunningOperation(*method));
   EXPECT_TRUE(IsHttpLongrunningOperation(*method));
   SetLongrunningOperationMethodVars(*method, vars);
+  EXPECT_THAT(vars, Contains(Pair("longrunning_operation_type",
+                                  "my::service::v1::Operation")));
   EXPECT_THAT(vars, Contains(Pair("longrunning_response_type",
                                   "my::service::v1::Operation")));
   EXPECT_THAT(vars, Contains(Pair("longrunning_deduced_response_message_type",
@@ -638,6 +642,11 @@ TEST_F(LongrunningVarsTest, SetLongrunningOperationServiceVarsNonGRPCGlobal) {
       r.set_project(request.project());
       r.set_operation(op);
 )""")));
+  EXPECT_THAT(vars,
+              Contains(Pair("longrunning_await_set_operation_fields", R"""(
+      r.set_project(info.project);
+      r.set_operation(info.operation);
+)""")));
   EXPECT_THAT(vars, Contains(Pair("longrunning_get_operation_path_rest",
                                   R"""(absl::StrCat("/compute/",
                               rest_internal::DetermineApiVersion("v1", *options),
@@ -674,6 +683,10 @@ TEST_F(LongrunningVarsTest,
   EXPECT_THAT(vars, Contains(Pair("longrunning_set_operation_fields", R"""(
       r.set_operation(op);
 )""")));
+  EXPECT_THAT(vars,
+              Contains(Pair("longrunning_await_set_operation_fields", R"""(
+      r.set_operation(info.operation);
+)""")));
   EXPECT_THAT(vars, Contains(Pair("longrunning_get_operation_path_rest",
                                   R"""(absl::StrCat("/compute/",
                               rest_internal::DetermineApiVersion("v1", *options),
@@ -706,6 +719,12 @@ TEST_F(LongrunningVarsTest, SetLongrunningOperationServiceVarsNonGRPCRegion) {
       r.set_project(request.project());
       r.set_region(request.region());
       r.set_operation(op);
+)""")));
+  EXPECT_THAT(vars,
+              Contains(Pair("longrunning_await_set_operation_fields", R"""(
+      r.set_project(info.project);
+      r.set_region(info.region);
+      r.set_operation(info.operation);
 )""")));
   EXPECT_THAT(vars, Contains(Pair("longrunning_get_operation_path_rest",
                                   R"""(absl::StrCat("/compute/",
@@ -743,6 +762,12 @@ TEST_F(LongrunningVarsTest, SetLongrunningOperationServiceVarsNonGRPCZone) {
       r.set_project(request.project());
       r.set_zone(request.zone());
       r.set_operation(op);
+)""")));
+  EXPECT_THAT(vars,
+              Contains(Pair("longrunning_await_set_operation_fields", R"""(
+      r.set_project(info.project);
+      r.set_zone(info.zone);
+      r.set_operation(info.operation);
 )""")));
   EXPECT_THAT(vars, Contains(Pair("longrunning_get_operation_path_rest",
                                   R"""(absl::StrCat("/compute/",


### PR DESCRIPTION
part of the work for #7658 

Create substitution variables for the Operation type of the LRO. In the case of compute type LROs, format the code that sets the request fields for the polling and cancel rpcs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14330)
<!-- Reviewable:end -->
