### PR TITLE
fix(bazel): use upstream cares, zlib

### DIFF
--- a/bazel/curl.BUILD
+++ b/bazel/curl.BUILD
@@ -444,10 +444,9 @@ cc_library(
     }),
     visibility = ["//visibility:public"],
     deps = [
-        # Use the same version of zlib and c-ares that gRPC does.
-        "//external:madler_zlib",
-        "//external:cares",
         ":define-ca-bundle-location",
+        "@com_github_cares_cares//:ares",
+        "@zlib",
     ] + select({
         ":windows": [],
         "//conditions:default": [


### PR DESCRIPTION
cc @mering 

We should use the upstream versions of `zlib` and `c-ares`. We should not assume gRPC will place these in an `//external/...` directory. (In fact, gRPC has moved them to a `//third_party/...` directory).

Tested with: `ci/cloudbuild/build.sh -t grpc-at-head`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14331)
<!-- Reviewable:end -->
