### PR TITLE
ci: clang-tidy for oauth2, storagecontrol

### DIFF
--- a/ci/lib/shard.sh
+++ b/ci/lib/shard.sh
@@ -55,8 +55,11 @@ readonly PUBSUB_SHARD=(
 
 readonly STORAGE_SHARD=(
   storage
+  storagecontrol
   experimental-storage_grpc
-  # universe_domain is included because its deps are already built by storage.
+  # oauth2 and universe_domain are included because their deps are already built
+  # by storage.
+  oauth2
   universe_domain
 )
 

--- a/google/cloud/storagecontrol/v2/samples/storage_control_folder_samples.cc
+++ b/google/cloud/storagecontrol/v2/samples/storage_control_folder_samples.cc
@@ -147,11 +147,11 @@ void AutoRun(std::vector<std::string> const& argv) {
   auto client = storagecontrol::StorageControlClient(
       storagecontrol::MakeStorageControlConnection());
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
-  auto const prefix = "storage-control-samples";
-  auto const folder_id = prefix + std::string{"-"} +
+  auto const prefix = std::string{"storage-control-samples"};
+  auto const folder_id = prefix + "-" +
                          google::cloud::internal::Sample(
                              generator, 32, "abcdefghijklmnopqrstuvwxyz");
-  auto const dest_folder_id = prefix + std::string{"-"} +
+  auto const dest_folder_id = prefix + "-" +
                               google::cloud::internal::Sample(
                                   generator, 32, "abcdefghijklmnopqrstuvwxyz");
   auto const create_time_limit =


### PR DESCRIPTION
My opinion on: https://github.com/googleapis/google-cloud-cpp/pull/14332#discussion_r1639714674

Also, I notice that `oauth2` previously escaped `clang-tidy`. Throwing it in the storage shard makes some sense.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14338)
<!-- Reviewable:end -->
