### PR TITLE
imp(generator): remove unnecessary check in processing rest path

### DIFF
--- a/generator/internal/http_option_utils.cc
+++ b/generator/internal/http_option_utils.cc
@@ -67,9 +67,9 @@ struct RestPathVisitor {
   void operator()(std::string const& s) {
     path.emplace_back(
         [piece = s, api = api_version](
-            google::protobuf::MethodDescriptor const& method, bool is_async) {
+            google::protobuf::MethodDescriptor const&, bool is_async) {
           if (piece != api) return absl::StrFormat("\"%s\"", piece);
-          if (IsLongrunningOperation(method) || is_async) {
+          if (is_async) {
             return absl::StrFormat(
                 "rest_internal::DetermineApiVersion(\"%s\", *options)", api);
           }


### PR DESCRIPTION
With the impending addition of synchronous LRO method overloads in the stub, checking for `IsLongrunningOperation` becomes incorrect. Turns out, it's actually redundant as the generator indicates `async` where it's appropriate.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14339)
<!-- Reviewable:end -->
