### PR TITLE
cleanup(otel): suppress maybe unitialized warning

### DIFF
--- a/google/cloud/internal/opentelemetry.h
+++ b/google/cloud/internal/opentelemetry.h
@@ -242,7 +242,7 @@ bool TracingEnabled(Options const& options);
 template <typename Rep, typename Period>
 std::function<void(std::chrono::duration<Rep, Period>)> MakeTracedSleeper(
     Options const& options,
-    std::function<void(std::chrono::duration<Rep, Period>)> const& sleeper,
+    std::function<void(std::chrono::duration<Rep, Period>)> sleeper,
     std::string const& name) {
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
   if (TracingEnabled(options)) {

--- a/google/cloud/internal/opentelemetry.h
+++ b/google/cloud/internal/opentelemetry.h
@@ -246,7 +246,8 @@ std::function<void(std::chrono::duration<Rep, Period>)> MakeTracedSleeper(
     std::string const& name) {
 #ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
   if (TracingEnabled(options)) {
-    return [=](std::chrono::duration<Rep, Period> d) {
+    return [name, sleeper = std::move(sleeper)](
+               std::chrono::duration<Rep, Period> d) {
       // A sleep of 0 is not an interesting event worth tracing.
       if (d == std::chrono::duration<Rep, Period>::zero()) return sleeper(d);
       auto span = MakeSpan(name);


### PR DESCRIPTION
We `std::move(sleeper)` into this function. It should take `sleeper` by value.

Otherwise we get `warning: 'sleeper' may be used uninitialized [-Wmaybe-uninitialized]` errors for every library we build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14343)
<!-- Reviewable:end -->
