### PR TITLE
ci: fix publish-docs uploads

### DIFF
--- a/ci/cloudbuild/builds/publish-docs.sh
+++ b/ci/cloudbuild/builds/publish-docs.sh
@@ -103,9 +103,9 @@ function stage_docfx() {
   fi
 
   version="$(jq -r .version <"${path}/docs.metadata.json")"
-  tar -C "${path}" -zcf "/tmp/cpp-${feature}-${version}.tar.gz" . >>"${log}" 2>&1
+  tar -C "${path}" -zcf "/tmp/docfx-cpp-${feature}-${version}.tar.gz" . >>"${log}" 2>&1
   export TIMEFORMAT="${feature} completed in %0lR"
-  if time ci/retry-command.sh 3 120 gcloud storage cp "/tmp/cpp-${feature}-${version}.tar.gz" "gs://${bucket}" >>"${log}" 2>&1; then
+  if time ci/retry-command.sh 3 120 gcloud storage cp "/tmp/docfx-cpp-${feature}-${version}.tar.gz" "gs://${bucket}" >>"${log}" 2>&1; then
     echo "SUCCESS" >>"${log}"
   fi
 }


### PR DESCRIPTION
In #13853, in unrolling `docuploader`, we dropped the `--destination-prefix`, which was `docfx-`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14345)
<!-- Reviewable:end -->
