### PR TITLE
cleanup(docs): prepare for doxygen 1.11.0

### DIFF
--- a/google/cloud/doc/error-handling.dox
+++ b/google/cloud/doc/error-handling.dox
@@ -30,7 +30,7 @@ during troubleshooting.
 
 ## Stream Ranges
 
-Some functions return [StreamRange<S>], where `S` is a `StatusOr<T>`. These
+Some functions return `StreamRange<S>`, where `S` is a `StatusOr<T>`. These
 ranges provide [input iterators] that paginate or stream results from a service,
 offering a more idiomatic API.  The value type in these iterators is
 `StatusOr<T>` because the stream may fail after it has successfully returned


### PR DESCRIPTION
Part of the work for #14207 

Doxygen sees an open `<S>` and fails because there is no `</S>`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14361)
<!-- Reviewable:end -->
