### PR TITLE
cleanup(generator): comment substitutions

### DIFF
--- a/generator/integration_tests/golden/v1/golden_thing_admin_client.h
+++ b/generator/integration_tests/golden/v1/golden_thing_admin_client.h
@@ -181,7 +181,7 @@ class GoldenThingAdminClient {
   ///  new database.  The database ID must conform to the regular expression
   ///  `[a-z][a-z0-9_\-]*[a-z0-9]` and be between 2 and 30 characters in length.
   ///  If the database ID is a reserved word or if it contains a hyphen, the
-  ///  database ID must be enclosed in backticks (`` ` ``).
+  ///  database ID must be enclosed in backticks.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   /// @return A [`future`] that becomes satisfied when the LRO

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -201,120 +201,6 @@ struct ParameterCommentSubstitution {
   std::size_t uses = 0;
 };
 
-auto constexpr kDialogflowCXEnvironmentIdProto1 = R"""(
- list all environments for. Format: `projects/<Project
- ID>/locations/<Location ID>/agents/<Agent ID>/environments/<Environment
- ID>`.)""";
-
-auto constexpr kDialogflowCXEnvironmentIdCpp1 = R"""(
- list all environments for. Format:
-
- @code
- projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/environments/<Environment ID>
- @endcode)""";
-
-auto constexpr kDialogflowCXEnvironmentIdProto2 = R"""(
- Format: `projects/<Project ID>/locations/<Location ID>/agents/<Agent
- ID>/environments/<Environment ID>`.)""";
-
-auto constexpr kDialogflowCXEnvironmentIdCpp2 = R"""(
- Format:
-
- @code
- projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/environments/<Environment ID>
- @endcode)""";
-
-auto constexpr kDialogflowCXSessionIdProto = R"""(
- Format: `projects/<Project ID>/locations/<Location ID>/agents/<Agent
- ID>/sessions/<Session ID>` or `projects/<Project ID>/locations/<Location
- ID>/agents/<Agent ID>/environments/<Environment ID>/sessions/<Session ID>`.)""";
-
-auto constexpr kDialogflowCXSessionIdCpp = R"""(
- Format:
-
- @code
- projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/sessions/<Session ID>
- @endcode
-
- or
-
- @code
- projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/environments/<Environment ID>/sessions/<Session ID>
- @endcode)""";
-
-auto constexpr kDialogflowCXEntityTypeIdProto = R"""(
- Format: `projects/<Project ID>/locations/<Location ID>/agents/<Agent
- ID>/sessions/<Session ID>/entityTypes/<Entity Type ID>` or
- `projects/<Project ID>/locations/<Location ID>/agents/<Agent
- ID>/environments/<Environment ID>/sessions/<Session ID>/entityTypes/<Entity
- Type ID>`. If `Environment ID` is not specified, we assume default 'draft'
- environment.)""";
-
-auto constexpr kDialogflowCXEntityTypeIdCpp = R"""(
- Format:
-
- @code
- projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/sessions/<Session ID>/entityTypes/<Entity Type ID>
- @endcode
-
- or
-
- @code
- projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/environments/<Environment ID>/sessions/<Session ID>/entityTypes/<Entity Type ID>
- @endcode
-
- If `Environment ID` is not specified, we assume the default 'draft'
- environment.)""";
-
-auto constexpr kDialogflowESSessionIdProto =
-    R"""( `projects/<Project ID>/agent/sessions/<Session ID>` or `projects/<Project
- ID>/agent/environments/<Environment ID>/users/<User ID>/sessions/<Session
- ID>`.)""";
-
-auto constexpr kDialogflowESSessionIdCpp = R"""(
- @code
- projects/<Project ID>/agent/sessions/<Session ID>
- @endcode
-
- or
-
- @code
- projects/<Project ID>/agent/environments/<Environment ID>/users/<User ID>/sessions/<Session ID>
- @endcode)""";
-
-auto constexpr kDialogflowESContextIdProto =
-    R"""( `projects/<Project ID>/agent/sessions/<Session ID>/contexts/<Context ID>`
- or `projects/<Project ID>/agent/environments/<Environment ID>/users/<User
- ID>/sessions/<Session ID>/contexts/<Context ID>`.)""";
-
-auto constexpr kDialogflowESContextIdCpp = R"""(
- @code
- projects/<Project ID>/agent/sessions/<Session ID>/contexts/<Context ID>
- @endcode
-
- or
-
- @code
- projects/<Project ID>/agent/environments/<Environment ID>/users/<User ID>/sessions/<Session ID>/contexts/<Context ID>`
- @endcode)""";
-
-auto constexpr kDialogflowESSessionEntityTypeDisplayNameProto =
-    R"""( `projects/<Project ID>/agent/sessions/<Session ID>/entityTypes/<Entity Type
- Display Name>` or `projects/<Project ID>/agent/environments/<Environment
- ID>/users/<User ID>/sessions/<Session ID>/entityTypes/<Entity Type Display
- Name>`.)""";
-
-auto constexpr kDialogflowESSessionEntityTypeDisplayNameCpp = R"""(
- @code
- projects/<Project ID>/agent/sessions/<Session ID>/entityTypes/<Entity Type Display Name>
- @endcode
-
- or
-
- @code
- projects/<Project ID>/agent/environments/<Environment ID>/users/<User ID>/sessions/<Session ID>/entityTypes/<Entity Type Display Name>
- @endcode)""";
-
 auto constexpr kLoggingConfigClientProto1 =
     R"""( The resource name of the link:
 
@@ -354,21 +240,33 @@ ParameterCommentSubstitution substitutions[] = {
      " `projects/<project>/instances/<instance>/"
      "tables/<table>/authorizedViews/<authorized_view>`"},
 
-    // From dialogflow/cx/v3.
-    {kDialogflowCXEnvironmentIdProto1, kDialogflowCXEnvironmentIdCpp1},
-    {kDialogflowCXEnvironmentIdProto2, kDialogflowCXEnvironmentIdCpp2},
-    {kDialogflowCXSessionIdProto, kDialogflowCXSessionIdCpp},
-    {kDialogflowCXEntityTypeIdProto, kDialogflowCXEntityTypeIdCpp},
+    // There a number of comments (almost all from DialogFlow) that
+    // - use single code quotes
+    // - are broken up over multiple lines
+    // - contain variables in angle brackets
+    //
+    // Doxygen thinks these are unrecognized HTML tags. To work around this, we
+    // remove the line breaks, so the code quotes occupy a single line.
+    {"agents/\n <Agent ID>", "agents/<Agent ID>"},
     {"<Agent\n ID>", "<Agent ID>"},
+    {"<Agent ID>/\n testCases/", "<Agent ID>/testCases/"},
+    {"<Agent ID>/\n environments/", "<Agent ID>/environments/"},
+    {"<Conversation\n ID>", "<Conversation ID>"},
+    {"<Conversation Model\n ID>", "<Conversation Model ID>"},
+    {"<Entity Type Display\n Name>", "<Entity Type Display Name>"},
+    {"<Entity Type\n Display Name>", "<Entity Type Display Name>"},
+    {"<Entity\n Type ID>", "<Entity Type ID>"},
+    {"<Environment\n ID>", "<Environment ID>"},
     {"<Location\n ID>", "<Location ID>"},
+    {"<Project\n ID>", "<Project ID>"},
+    {"<Project\n Number>", "<Project Number>"},
+    {"<Session\n ID>", "<Session ID>"},
     {"<Transition\n Route Group ID>", "<Transition Route Group ID>"},
-    {"<Agent ID>.", "<Agent ID>`."},  // missing close quote
+    {"<User\n ID>", "<User ID>"},
+    {"<User ID>/\n sessions/", "<User ID>/sessions/"},
 
-    // From dialogflow/v2.
-    {kDialogflowESSessionIdProto, kDialogflowESSessionIdCpp},
-    {kDialogflowESContextIdProto, kDialogflowESContextIdCpp},
-    {kDialogflowESSessionEntityTypeDisplayNameProto,
-     kDialogflowESSessionEntityTypeDisplayNameCpp},
+    // Missing closed quote in dialogflow
+    {"<Agent ID>.", "<Agent ID>`."},
 
     // From logging/v2.
     {kLoggingConfigClientProto1, kLoggingConfigClientCpp1},
@@ -390,10 +288,17 @@ ParameterCommentSubstitution substitutions[] = {
     // Doxygen gets confused by single quotes in code spans:
     //    https://www.doxygen.nl/manual/markdown.html#mddox_code_spans
     // The workaround is to double quote these:
-    {R"""(`{instance} = '-'`)""", R"""(``{instance} = '-'``)"""},
-    {R"""(`{cluster} = '-'`)""", R"""(``{cluster} = '-'``)"""},
+    {R"""(`{instance} = '-'`)""", R"""(`{instance} = "-"`)"""},
+    {R"""(`{cluster} = '-'`)""", R"""(`{cluster} = "-"`)"""},
     {R"""(`projects/<Project ID or '-'>`)""",
-     R"""(``projects/<Project ID or '-'>``)"""},
+     R"""(`projects/<Project ID or "-">`)"""},
+    // These appear in google/api/servicemanagement/v1/servicemanager.proto
+    {R"""(`filter='status=SUCCESS'`)""", R"""(`filter="status=SUCCESS"`)"""},
+    {R"""(`filter='strategy=TrafficPercentStrategy'`)""",
+     R"""(`filter="strategy=TrafficPercentStrategy"`)"""},
+
+    // Spanner attempts to explain what a backtick is.
+    {R"""(backticks (`` ` ``).)""", R"""(backticks.)"""},
 
     // Further trim some initial paragraphs for long descriptions.
     {R"""( The included patch
@@ -412,14 +317,6 @@ ParameterCommentSubstitution substitutions[] = {
      R"""(and the `PATCH` request body would specify the new value.)"""},
     {"fields. Some eligible fields are:", "fields."},
     {" The allowable fields to\n update are:", ""},
-
-    // These appear in google/api/servicemanagement/v1/servicemanager.proto
-    // Doxygen gets confused by single quotes in code spans:
-    //    https://www.doxygen.nl/manual/markdown.html#mddox_code_spans
-    // The workaround is to double quote these:
-    {"`filter='status=SUCCESS'`", "``filter='status=SUCCESS'``"},
-    {"`filter='strategy=TrafficPercentStrategy'`",
-     "``filter='strategy=TrafficPercentStrategy'``"},
 
     {"conversionWorkspace/123/mappingRules/"
      "rule123@c7cfa2a8c7cfa2a8c7cfa2a8c7cfa2a8",

--- a/generator/internal/format_method_comments.cc
+++ b/generator/internal/format_method_comments.cc
@@ -153,12 +153,25 @@ struct MethodCommentSubstitution {
   std::size_t uses = 0;
 };
 
-MethodCommentSubstitution substitutions[] = {
-    {"\n", "\n  ///"},
+auto constexpr kDialogflowEsConversationsProto = R"""(
+ `create_time_epoch_microseconds >
+ [first item's create_time of previous request]` and empty page_token.)""";
 
+auto constexpr kDialogflowEsConversationsCpp = R"""(
+ `create_time_epoch_microseconds > [first item's create_time of previous request]`
+ and empty page_token.)""";
+
+MethodCommentSubstitution substitutions[] = {
     // From google/logging/v2/logging_config.proto
     {R"""(Gets a view on a log bucket..)""",
      R"""(Gets a view on a log bucket.)"""},
+
+    // From google/dialogflow/v2/conversation.proto
+    {kDialogflowEsConversationsProto, kDialogflowEsConversationsCpp},
+
+    // Add Doxygen-style comments
+    {"\n", "\n  ///"},
+
 };
 
 }  // namespace

--- a/google/cloud/bigtable/admin/bigtable_instance_admin_client.h
+++ b/google/cloud/bigtable/admin/bigtable_instance_admin_client.h
@@ -613,7 +613,7 @@ class BigtableInstanceAdminClient {
   ///
   /// @param parent  Required. The unique name of the instance for which a list of clusters is
   ///  requested. Values are of the form
-  ///  `projects/{project}/instances/{instance}`. Use ``{instance} = '-'`` to list
+  ///  `projects/{project}/instances/{instance}`. Use `{instance} = "-"` to list
   ///  Clusters for all Instances in a project, e.g.,
   ///  `projects/myproject/instances/-`.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -980,7 +980,7 @@ class BigtableInstanceAdminClient {
   /// @param parent  Required. The unique name of the instance for which a list of app profiles
   ///  is requested. Values are of the form
   ///  `projects/{project}/instances/{instance}`.
-  ///  Use ``{instance} = '-'`` to list AppProfiles for all Instances in a project,
+  ///  Use `{instance} = "-"` to list AppProfiles for all Instances in a project,
   ///  e.g., `projects/myproject/instances/-`.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.

--- a/google/cloud/bigtable/admin/bigtable_table_admin_client.h
+++ b/google/cloud/bigtable/admin/bigtable_table_admin_client.h
@@ -1366,7 +1366,7 @@ class BigtableTableAdminClient {
   ///
   /// @param parent  Required. The cluster to list backups from.  Values are of the
   ///  form `projects/{project}/instances/{instance}/clusters/{cluster}`.
-  ///  Use ``{cluster} = '-'`` to list backups for all clusters in an instance,
+  ///  Use `{cluster} = "-"` to list backups for all clusters in an instance,
   ///  e.g., `projects/{project}/instances/{instance}/clusters/-`.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.

--- a/google/cloud/contactcenterinsights/v1/contact_center_insights_client.h
+++ b/google/cloud/contactcenterinsights/v1/contact_center_insights_client.h
@@ -1773,9 +1773,7 @@ class ContactCenterInsightsClient {
   /// Creates a phrase matcher.
   ///
   /// @param parent  Required. The parent resource of the phrase matcher. Required. The location
-  ///  to create a phrase matcher for. Format: `projects/<Project
-  ///  ID>/locations/<Location ID>` or `projects/<Project
-  ///  Number>/locations/<Location ID>`
+  ///  to create a phrase matcher for. Format: `projects/<Project ID>/locations/<Location ID>` or `projects/<Project Number>/locations/<Location ID>`
   /// @param phrase_matcher  Required. The phrase matcher resource to create.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.

--- a/google/cloud/dialogflow_cx/deployments_client.h
+++ b/google/cloud/dialogflow_cx/deployments_client.h
@@ -95,11 +95,7 @@ class DeploymentsClient {
   /// [Environment][google.cloud.dialogflow.cx.v3.Environment].
   ///
   /// @param parent  Required. The [Environment][google.cloud.dialogflow.cx.v3.Environment] to
-  ///  list all environments for. Format:
-  ///  @n
-  ///  @code
-  ///  projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/environments/<Environment ID>
-  ///  @endcode
+  ///  list all environments for. Format: `projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/environments/<Environment ID>`.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   /// @return a [StreamRange](@ref google::cloud::StreamRange)

--- a/google/cloud/dialogflow_cx/environments_client.h
+++ b/google/cloud/dialogflow_cx/environments_client.h
@@ -478,11 +478,7 @@ class EnvironmentsClient {
   /// [Environment][google.cloud.dialogflow.cx.v3.Environment].
   ///
   /// @param name  Required. Resource name of the environment to look up the history for.
-  ///  Format:
-  ///  @n
-  ///  @code
-  ///  projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/environments/<Environment ID>
-  ///  @endcode
+  ///  Format: `projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/environments/<Environment ID>`.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   /// @return a [StreamRange](@ref google::cloud::StreamRange)
@@ -612,8 +608,7 @@ class EnvironmentsClient {
   /// Fetches a list of continuous test results for a given environment.
   ///
   /// @param parent  Required. The environment to list results for.
-  ///  Format: `projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/
-  ///  environments/<Environment ID>`.
+  ///  Format: `projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/environments/<Environment ID>`.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   /// @return a [StreamRange](@ref google::cloud::StreamRange)

--- a/google/cloud/dialogflow_cx/experiments_client.h
+++ b/google/cloud/dialogflow_cx/experiments_client.h
@@ -95,11 +95,7 @@ class ExperimentsClient {
   /// [Environment][google.cloud.dialogflow.cx.v3.Environment].
   ///
   /// @param parent  Required. The [Environment][google.cloud.dialogflow.cx.v3.Environment] to
-  ///  list all environments for. Format:
-  ///  @n
-  ///  @code
-  ///  projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/environments/<Environment ID>
-  ///  @endcode
+  ///  list all environments for. Format: `projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/environments/<Environment ID>`.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   /// @return a [StreamRange](@ref google::cloud::StreamRange)

--- a/google/cloud/dialogflow_cx/session_entity_types_client.h
+++ b/google/cloud/dialogflow_cx/session_entity_types_client.h
@@ -96,17 +96,7 @@ class SessionEntityTypesClient {
   /// Returns the list of all session entity types in the specified session.
   ///
   /// @param parent  Required. The session to list all session entity types from.
-  ///  Format:
-  ///  @n
-  ///  @code
-  ///  projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/sessions/<Session ID>
-  ///  @endcode
-  ///  @n
-  ///  or
-  ///  @n
-  ///  @code
-  ///  projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/environments/<Environment ID>/sessions/<Session ID>
-  ///  @endcode
+  ///  Format: `projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/sessions/<Session ID>` or `projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/environments/<Environment ID>/sessions/<Session ID>`.
   ///  If `Environment ID` is not specified, we assume default 'draft'
   ///  environment.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -184,19 +174,8 @@ class SessionEntityTypesClient {
   /// Retrieves the specified session entity type.
   ///
   /// @param name  Required. The name of the session entity type.
-  ///  Format:
-  ///  @n
-  ///  @code
-  ///  projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/sessions/<Session ID>/entityTypes/<Entity Type ID>
-  ///  @endcode
-  ///  @n
-  ///  or
-  ///  @n
-  ///  @code
-  ///  projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/environments/<Environment ID>/sessions/<Session ID>/entityTypes/<Entity Type ID>
-  ///  @endcode
-  ///  @n
-  ///  If `Environment ID` is not specified, we assume the default 'draft'
+  ///  Format: `projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/sessions/<Session ID>/entityTypes/<Entity Type ID>` or
+  ///  `projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/environments/<Environment ID>/sessions/<Session ID>/entityTypes/<Entity Type ID>`. If `Environment ID` is not specified, we assume default 'draft'
   ///  environment.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
@@ -256,17 +235,7 @@ class SessionEntityTypesClient {
   /// Creates a session entity type.
   ///
   /// @param parent  Required. The session to create a session entity type for.
-  ///  Format:
-  ///  @n
-  ///  @code
-  ///  projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/sessions/<Session ID>
-  ///  @endcode
-  ///  @n
-  ///  or
-  ///  @n
-  ///  @code
-  ///  projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/environments/<Environment ID>/sessions/<Session ID>
-  ///  @endcode
+  ///  Format: `projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/sessions/<Session ID>` or `projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/environments/<Environment ID>/sessions/<Session ID>`.
   ///  If `Environment ID` is not specified, we assume default 'draft'
   ///  environment.
   /// @param session_entity_type  Required. The session entity type to create.
@@ -332,19 +301,8 @@ class SessionEntityTypesClient {
   /// Updates the specified session entity type.
   ///
   /// @param session_entity_type  Required. The session entity type to update.
-  ///  Format:
-  ///  @n
-  ///  @code
-  ///  projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/sessions/<Session ID>/entityTypes/<Entity Type ID>
-  ///  @endcode
-  ///  @n
-  ///  or
-  ///  @n
-  ///  @code
-  ///  projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/environments/<Environment ID>/sessions/<Session ID>/entityTypes/<Entity Type ID>
-  ///  @endcode
-  ///  @n
-  ///  If `Environment ID` is not specified, we assume the default 'draft'
+  ///  Format: `projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/sessions/<Session ID>/entityTypes/<Entity Type ID>` or
+  ///  `projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/environments/<Environment ID>/sessions/<Session ID>/entityTypes/<Entity Type ID>`. If `Environment ID` is not specified, we assume default 'draft'
   ///  environment.
   /// @param update_mask  The mask to control which fields get updated.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -408,19 +366,8 @@ class SessionEntityTypesClient {
   /// Deletes the specified session entity type.
   ///
   /// @param name  Required. The name of the session entity type to delete.
-  ///  Format:
-  ///  @n
-  ///  @code
-  ///  projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/sessions/<Session ID>/entityTypes/<Entity Type ID>
-  ///  @endcode
-  ///  @n
-  ///  or
-  ///  @n
-  ///  @code
-  ///  projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/environments/<Environment ID>/sessions/<Session ID>/entityTypes/<Entity Type ID>
-  ///  @endcode
-  ///  @n
-  ///  If `Environment ID` is not specified, we assume the default 'draft'
+  ///  Format: `projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/sessions/<Session ID>/entityTypes/<Entity Type ID>` or
+  ///  `projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/environments/<Environment ID>/sessions/<Session ID>/entityTypes/<Entity Type ID>`. If `Environment ID` is not specified, we assume default 'draft'
   ///  environment.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.

--- a/google/cloud/dialogflow_cx/test_cases_client.h
+++ b/google/cloud/dialogflow_cx/test_cases_client.h
@@ -635,8 +635,7 @@ class TestCasesClient {
   /// results are kept for each test case.
   ///
   /// @param parent  Required. The test case to list results for.
-  ///  Format: `projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/
-  ///  testCases/<TestCase ID>`. Specify a `-` as a wildcard for TestCase ID to
+  ///  Format: `projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/testCases/<TestCase ID>`. Specify a `-` as a wildcard for TestCase ID to
   ///  list results across multiple test cases.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.

--- a/google/cloud/dialogflow_cx/versions_client.h
+++ b/google/cloud/dialogflow_cx/versions_client.h
@@ -528,8 +528,7 @@ class VersionsClient {
   /// @param base_version  Required. Name of the base flow version to compare with the target version.
   ///  Use version ID `0` to indicate the draft version of the specified flow.
   ///  @n
-  ///  Format: `projects/<Project ID>/locations/<Location ID>/agents/
-  ///  <Agent ID>/flows/<Flow ID>/versions/<Version ID>`.
+  ///  Format: `projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/flows/<Flow ID>/versions/<Version ID>`.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   /// @return the result of the RPC. The response message type

--- a/google/cloud/dialogflow_es/agents_client.h
+++ b/google/cloud/dialogflow_es/agents_client.h
@@ -269,7 +269,7 @@ class AgentsClient {
   /// Sub-Collections](https://cloud.google.com/apis/design/design_patterns#list_sub-collections).
   ///
   /// @param parent  Required. The project to list agents from.
-  ///  Format: ``projects/<Project ID or '-'>``.
+  ///  Format: `projects/<Project ID or "-">`.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   /// @return a [StreamRange](@ref google::cloud::StreamRange)

--- a/google/cloud/dialogflow_es/contexts_client.h
+++ b/google/cloud/dialogflow_es/contexts_client.h
@@ -92,8 +92,7 @@ class ContextsClient {
   ///
   /// @param parent  Required. The session to list all contexts from.
   ///  Format: `projects/<Project ID>/agent/sessions/<Session ID>` or
-  ///  `projects/<Project ID>/agent/environments/<Environment ID>/users/<User
-  ///  ID>/sessions/<Session ID>`.
+  ///  `projects/<Project ID>/agent/environments/<Environment ID>/users/<User ID>/sessions/<Session ID>`.
   ///  If `Environment ID` is not specified, we assume default 'draft'
   ///  environment. If `User ID` is not specified, we assume default '-' user.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -170,16 +169,8 @@ class ContextsClient {
   /// Retrieves the specified context.
   ///
   /// @param name  Required. The name of the context. Format:
-  ///  @n
-  ///  @code
-  ///  projects/<Project ID>/agent/sessions/<Session ID>/contexts/<Context ID>
-  ///  @endcode
-  ///  @n
-  ///  or
-  ///  @n
-  ///  @code
-  ///  projects/<Project ID>/agent/environments/<Environment ID>/users/<User ID>/sessions/<Session ID>/contexts/<Context ID>`
-  ///  @endcode
+  ///  `projects/<Project ID>/agent/sessions/<Session ID>/contexts/<Context ID>`
+  ///  or `projects/<Project ID>/agent/environments/<Environment ID>/users/<User ID>/sessions/<Session ID>/contexts/<Context ID>`.
   ///  If `Environment ID` is not specified, we assume default 'draft'
   ///  environment. If `User ID` is not specified, we assume default '-' user.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -241,8 +232,7 @@ class ContextsClient {
   ///
   /// @param parent  Required. The session to create a context for.
   ///  Format: `projects/<Project ID>/agent/sessions/<Session ID>` or
-  ///  `projects/<Project ID>/agent/environments/<Environment ID>/users/<User
-  ///  ID>/sessions/<Session ID>`.
+  ///  `projects/<Project ID>/agent/environments/<Environment ID>/users/<User ID>/sessions/<Session ID>`.
   ///  If `Environment ID` is not specified, we assume default 'draft'
   ///  environment. If `User ID` is not specified, we assume default '-' user.
   /// @param context  Required. The context to create.
@@ -363,16 +353,8 @@ class ContextsClient {
   /// Deletes the specified context.
   ///
   /// @param name  Required. The name of the context to delete. Format:
-  ///  @n
-  ///  @code
-  ///  projects/<Project ID>/agent/sessions/<Session ID>/contexts/<Context ID>
-  ///  @endcode
-  ///  @n
-  ///  or
-  ///  @n
-  ///  @code
-  ///  projects/<Project ID>/agent/environments/<Environment ID>/users/<User ID>/sessions/<Session ID>/contexts/<Context ID>`
-  ///  @endcode
+  ///  `projects/<Project ID>/agent/sessions/<Session ID>/contexts/<Context ID>`
+  ///  or `projects/<Project ID>/agent/environments/<Environment ID>/users/<User ID>/sessions/<Session ID>/contexts/<Context ID>`.
   ///  If `Environment ID` is not specified, we assume default 'draft'
   ///  environment. If `User ID` is not specified, we assume default '-' user.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -424,16 +406,7 @@ class ContextsClient {
   /// Deletes all active contexts in the specified session.
   ///
   /// @param parent  Required. The name of the session to delete all contexts from. Format:
-  ///  @n
-  ///  @code
-  ///  projects/<Project ID>/agent/sessions/<Session ID>
-  ///  @endcode
-  ///  @n
-  ///  or
-  ///  @n
-  ///  @code
-  ///  projects/<Project ID>/agent/environments/<Environment ID>/users/<User ID>/sessions/<Session ID>
-  ///  @endcode
+  ///  `projects/<Project ID>/agent/sessions/<Session ID>` or `projects/<Project ID>/agent/environments/<Environment ID>/users/<User ID>/sessions/<Session ID>`.
   ///  If `Environment ID` is not specified we assume default 'draft' environment.
   ///  If `User ID` is not specified, we assume default '-' user.
   /// @param opts Optional. Override the class-level options, such as retry and

--- a/google/cloud/dialogflow_es/conversation_models_client.h
+++ b/google/cloud/dialogflow_es/conversation_models_client.h
@@ -524,8 +524,7 @@ class ConversationModelsClient {
   /// Gets an evaluation of conversation model.
   ///
   /// @param name  Required. The conversation model evaluation resource name. Format:
-  ///  `projects/<Project ID>/conversationModels/<Conversation Model
-  ///  ID>/evaluations/<Evaluation ID>`
+  ///  `projects/<Project ID>/conversationModels/<Conversation Model ID>/evaluations/<Evaluation ID>`
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   /// @return the result of the RPC. The response message type

--- a/google/cloud/dialogflow_es/conversations_client.h
+++ b/google/cloud/dialogflow_es/conversations_client.h
@@ -275,8 +275,7 @@ class ConversationsClient {
   /// Retrieves the specific conversation.
   ///
   /// @param name  Required. The name of the conversation. Format:
-  ///  `projects/<Project ID>/locations/<Location ID>/conversations/<Conversation
-  ///  ID>`.
+  ///  `projects/<Project ID>/locations/<Location ID>/conversations/<Conversation ID>`.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   /// @return the result of the RPC. The response message type
@@ -392,8 +391,8 @@ class ConversationsClient {
   /// Lists messages that belong to a given conversation.
   /// `messages` are ordered by `create_time` in descending order. To fetch
   /// updates without duplication, send request with filter
-  /// `create_time_epoch_microseconds >
-  /// [first item's create_time of previous request]` and empty page_token.
+  /// `create_time_epoch_microseconds > [first item's create_time of previous request]`
+  /// and empty page_token.
   ///
   /// @param parent  Required. The name of the conversation to list messages for.
   ///  Format: `projects/<Project ID>/locations/<Location ID>/conversations/<Conversation ID>`
@@ -431,8 +430,8 @@ class ConversationsClient {
   /// Lists messages that belong to a given conversation.
   /// `messages` are ordered by `create_time` in descending order. To fetch
   /// updates without duplication, send request with filter
-  /// `create_time_epoch_microseconds >
-  /// [first item's create_time of previous request]` and empty page_token.
+  /// `create_time_epoch_microseconds > [first item's create_time of previous request]`
+  /// and empty page_token.
   ///
   /// @param request Unary RPCs, such as the one wrapped by this
   ///     function, receive a single `request` proto message which includes all

--- a/google/cloud/dialogflow_es/intents_client.h
+++ b/google/cloud/dialogflow_es/intents_client.h
@@ -92,8 +92,7 @@ class IntentsClient {
   /// Returns the list of all intents in the specified agent.
   ///
   /// @param parent  Required. The agent to list all intents from.
-  ///  Format: `projects/<Project ID>/agent` or `projects/<Project
-  ///  ID>/locations/<Location ID>/agent`.
+  ///  Format: `projects/<Project ID>/agent` or `projects/<Project ID>/locations/<Location ID>/agent`.
   ///  @n
   ///  Alternatively, you can specify the environment to list intents for.
   ///  Format: `projects/<Project ID>/agent/environments/<Environment ID>`
@@ -134,8 +133,7 @@ class IntentsClient {
   /// Returns the list of all intents in the specified agent.
   ///
   /// @param parent  Required. The agent to list all intents from.
-  ///  Format: `projects/<Project ID>/agent` or `projects/<Project
-  ///  ID>/locations/<Location ID>/agent`.
+  ///  Format: `projects/<Project ID>/agent` or `projects/<Project ID>/locations/<Location ID>/agent`.
   ///  @n
   ///  Alternatively, you can specify the environment to list intents for.
   ///  Format: `projects/<Project ID>/agent/environments/<Environment ID>`

--- a/google/cloud/dialogflow_es/participants_client.h
+++ b/google/cloud/dialogflow_es/participants_client.h
@@ -154,8 +154,7 @@ class ParticipantsClient {
   /// Retrieves a conversation participant.
   ///
   /// @param name  Required. The name of the participant. Format:
-  ///  `projects/<Project ID>/locations/<Location ID>/conversations/<Conversation
-  ///  ID>/participants/<Participant ID>`.
+  ///  `projects/<Project ID>/locations/<Location ID>/conversations/<Conversation ID>/participants/<Participant ID>`.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   /// @return the result of the RPC. The response message type

--- a/google/cloud/dialogflow_es/session_entity_types_client.h
+++ b/google/cloud/dialogflow_es/session_entity_types_client.h
@@ -101,8 +101,7 @@ class SessionEntityTypesClient {
   ///
   /// @param parent  Required. The session to list all session entity types from.
   ///  Format: `projects/<Project ID>/agent/sessions/<Session ID>` or
-  ///  `projects/<Project ID>/agent/environments/<Environment ID>/users/<User ID>/
-  ///  sessions/<Session ID>`.
+  ///  `projects/<Project ID>/agent/environments/<Environment ID>/users/<User ID>/sessions/<Session ID>`.
   ///  If `Environment ID` is not specified, we assume default 'draft'
   ///  environment. If `User ID` is not specified, we assume default '-' user.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -188,16 +187,7 @@ class SessionEntityTypesClient {
   /// with Google Assistant integration.
   ///
   /// @param name  Required. The name of the session entity type. Format:
-  ///  @n
-  ///  @code
-  ///  projects/<Project ID>/agent/sessions/<Session ID>/entityTypes/<Entity Type Display Name>
-  ///  @endcode
-  ///  @n
-  ///  or
-  ///  @n
-  ///  @code
-  ///  projects/<Project ID>/agent/environments/<Environment ID>/users/<User ID>/sessions/<Session ID>/entityTypes/<Entity Type Display Name>
-  ///  @endcode
+  ///  `projects/<Project ID>/agent/sessions/<Session ID>/entityTypes/<Entity Type Display Name>` or `projects/<Project ID>/agent/environments/<Environment ID>/users/<User ID>/sessions/<Session ID>/entityTypes/<Entity Type Display Name>`.
   ///  If `Environment ID` is not specified, we assume default 'draft'
   ///  environment. If `User ID` is not specified, we assume default '-' user.
   /// @param opts Optional. Override the class-level options, such as retry and
@@ -269,8 +259,7 @@ class SessionEntityTypesClient {
   ///
   /// @param parent  Required. The session to create a session entity type for.
   ///  Format: `projects/<Project ID>/agent/sessions/<Session ID>` or
-  ///  `projects/<Project ID>/agent/environments/<Environment ID>/users/<User ID>/
-  ///  sessions/<Session ID>`.
+  ///  `projects/<Project ID>/agent/environments/<Environment ID>/users/<User ID>/sessions/<Session ID>`.
   ///  If `Environment ID` is not specified, we assume default 'draft'
   ///  environment. If `User ID` is not specified, we assume default '-' user.
   /// @param session_entity_type  Required. The session entity type to create.
@@ -449,16 +438,7 @@ class SessionEntityTypesClient {
   /// with Google Assistant integration.
   ///
   /// @param name  Required. The name of the entity type to delete. Format:
-  ///  @n
-  ///  @code
-  ///  projects/<Project ID>/agent/sessions/<Session ID>/entityTypes/<Entity Type Display Name>
-  ///  @endcode
-  ///  @n
-  ///  or
-  ///  @n
-  ///  @code
-  ///  projects/<Project ID>/agent/environments/<Environment ID>/users/<User ID>/sessions/<Session ID>/entityTypes/<Entity Type Display Name>
-  ///  @endcode
+  ///  `projects/<Project ID>/agent/sessions/<Session ID>/entityTypes/<Entity Type Display Name>` or `projects/<Project ID>/agent/environments/<Environment ID>/users/<User ID>/sessions/<Session ID>/entityTypes/<Entity Type Display Name>`.
   ///  If `Environment ID` is not specified, we assume default 'draft'
   ///  environment. If `User ID` is not specified, we assume default '-' user.
   /// @param opts Optional. Override the class-level options, such as retry and

--- a/google/cloud/dialogflow_es/sessions_client.h
+++ b/google/cloud/dialogflow_es/sessions_client.h
@@ -106,8 +106,7 @@ class SessionsClient {
   ///
   /// @param session  Required. The name of the session this query is sent to. Format:
   ///  `projects/<Project ID>/agent/sessions/<Session ID>`, or
-  ///  `projects/<Project ID>/agent/environments/<Environment ID>/users/<User
-  ///  ID>/sessions/<Session ID>`. If `Environment ID` is not specified, we assume
+  ///  `projects/<Project ID>/agent/environments/<Environment ID>/users/<User ID>/sessions/<Session ID>`. If `Environment ID` is not specified, we assume
   ///  default 'draft' environment (`Environment ID` might be referred to as
   ///  environment name at some places). If `User ID` is not specified, we are
   ///  using "-". It's up to the API caller to choose an appropriate `Session ID`

--- a/google/cloud/servicemanagement/v1/service_manager_client.h
+++ b/google/cloud/servicemanagement/v1/service_manager_client.h
@@ -802,11 +802,11 @@ class ServiceManagerClient {
   ///  @n
   ///   -- By [status]
   ///   [google.api.servicemanagement.v1.Rollout.RolloutStatus]. For example,
-  ///   ``filter='status=SUCCESS'``
+  ///   `filter="status=SUCCESS"`
   ///  @n
   ///   -- By [strategy]
   ///   [google.api.servicemanagement.v1.Rollout.strategy]. For example,
-  ///   ``filter='strategy=TrafficPercentStrategy'``
+  ///   `filter="strategy=TrafficPercentStrategy"`
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   /// @return a [StreamRange](@ref google::cloud::StreamRange)

--- a/google/cloud/spanner/admin/database_admin_client.h
+++ b/google/cloud/spanner/admin/database_admin_client.h
@@ -186,7 +186,7 @@ class DatabaseAdminClient {
   ///  new database.  The database ID must conform to the regular expression
   ///  `[a-z][a-z0-9_\-]*[a-z0-9]` and be between 2 and 30 characters in length.
   ///  If the database ID is a reserved word or if it contains a hyphen, the
-  ///  database ID must be enclosed in backticks (`` ` ``).
+  ///  database ID must be enclosed in backticks.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   /// @return A [`future`] that becomes satisfied when the LRO


### PR DESCRIPTION
Part of the work for #14207 

Doxygen 1.11.0 has some new struggles with our documents.
- double backticks don't work.
- single backticks broken over multiple lines don't work.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14362)
<!-- Reviewable:end -->
