### PR TITLE
chore(otel): more general factory handling

### DIFF
--- a/google/cloud/opentelemetry/samples/samples.cc
+++ b/google/cloud/opentelemetry/samples/samples.cc
@@ -142,11 +142,12 @@ void CustomTracerProvider(std::vector<std::string> const& argv) {
     auto processor =
         opentelemetry::sdk::trace::BatchSpanProcessorFactory::Create(
             std::move(exporter), options);
-    auto provider = opentelemetry::sdk::trace::TracerProviderFactory::Create(
-        std::move(processor));
 
-    // Set the global trace provider
-    opentelemetry::trace::Provider::SetTracerProvider(std::move(provider));
+    // Create a tracer provider and set it as the global trace provider
+    opentelemetry::trace::Provider::SetTracerProvider(
+        std::shared_ptr<opentelemetry::trace::TracerProvider>(
+            opentelemetry::sdk::trace::TracerProviderFactory::Create(
+                std::move(processor))));
 
     MyApplicationCode();
 

--- a/google/cloud/testing_util/opentelemetry_matchers.cc
+++ b/google/cloud/testing_util/opentelemetry_matchers.cc
@@ -25,6 +25,7 @@
 #include <opentelemetry/trace/provider.h>
 
 namespace {
+
 void AttributeFormatter(
     std::string* out,
     std::pair<std::string const,
@@ -189,10 +190,10 @@ SpanCatcher::SpanCatcher()
   auto processor =
       std::make_unique<opentelemetry::sdk::trace::SimpleSpanProcessor>(
           std::move(exporter));
-  std::shared_ptr<opentelemetry::trace::TracerProvider> provider =
-      opentelemetry::sdk::trace::TracerProviderFactory::Create(
-          std::move(processor));
-  opentelemetry::trace::Provider::SetTracerProvider(std::move(provider));
+  opentelemetry::trace::Provider::SetTracerProvider(
+      std::shared_ptr<opentelemetry::trace::TracerProvider>(
+          opentelemetry::sdk::trace::TracerProviderFactory::Create(
+              std::move(processor))));
 }
 
 SpanCatcher::~SpanCatcher() {


### PR DESCRIPTION
Preparing for `opentelemetry-cpp` `v1.16.0`. #14355

`opentelemetry-cpp` will make a breaking change to the return type of their provider factory functions. We can work around this by handling the returned value more generally.

GCS+gRPC also has such factories, but I did not see it failing in any of the tests against OTel 1.16.0. I am not 100% sure it is being built, to be honest.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14372)
<!-- Reviewable:end -->
