### PR TITLE
chore(otel): use newer messaging semantic conventions

### DIFF
--- a/google/cloud/pubsub/internal/blocking_publisher_tracing_connection.cc
+++ b/google/cloud/pubsub/internal/blocking_publisher_tracing_connection.cc
@@ -42,7 +42,7 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> StartPublishSpan(
       {{sc::kMessagingSystem, "gcp_pubsub"},
        {sc::kMessagingDestinationName, topic.topic_id()},
        {"gcp.project_id", topic.project_id()},
-       {sc::kMessagingOperation, "create"},
+       {/*sc::kMessagingOperationType=*/"messaging.operation.type", "create"},
        {/*sc::kMessagingMessageEnvelopeSize=*/"messaging.message.envelope.size",
         static_cast<std::int64_t>(MessageSize(m))},
        {sc::kCodeFunction, "pubsub::BlockingPublisher::Publish"}},

--- a/google/cloud/pubsub/internal/publisher_tracing_connection.cc
+++ b/google/cloud/pubsub/internal/publisher_tracing_connection.cc
@@ -52,7 +52,7 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> StartPublishSpan(
       {{sc::kMessagingSystem, "gcp_pubsub"},
        {sc::kMessagingDestinationName, topic.topic_id()},
        {"gcp.project_id", topic.project_id()},
-       {sc::kMessagingOperation, "create"},
+       {/*sc::kMessagingOperationType=*/"messaging.operation.type", "create"},
        {/*sc::kMessagingMessageEnvelopeSize=*/"messaging.message.envelope.size",
         static_cast<std::int64_t>(MessageSize(m))},
        {sc::kCodeFunction, "pubsub::PublisherConnection::Publish"}},

--- a/google/cloud/pubsub/internal/publisher_tracing_connection_test.cc
+++ b/google/cloud/pubsub/internal/publisher_tracing_connection_test.cc
@@ -95,7 +95,9 @@ TEST(PublisherTracingConnectionTest, PublishSpanOnSuccess) {
               OTelAttribute<std::int64_t>(/*sc::kMessagingMessageEnvelopeSize=*/
                                           "messaging.message.envelope.size",
                                           45),
-              OTelAttribute<std::string>(sc::kMessagingOperation, "create"),
+              OTelAttribute<std::string>(
+                  /*sc::kMessagingOperationType=*/"messaging.operation.type",
+                  "create"),
               OTelAttribute<std::string>(sc::kMessagingMessageId, "test-id-0"),
               OTelAttribute<std::string>(
                   sc::kCodeFunction,
@@ -137,7 +139,9 @@ TEST(PublisherTracingConnectionTest, PublishSpanOnError) {
               OTelAttribute<std::string>(
                   "messaging.gcp_pubsub.message.ordering_key",
                   "ordering-key-0"),
-              OTelAttribute<std::string>(sc::kMessagingOperation, "create"),
+              OTelAttribute<std::string>(
+                  /*sc::kMessagingOperationType=*/"messaging.operation.type",
+                  "create"),
               OTelAttribute<int>("gl-cpp.status_code", kErrorCode),
               OTelAttribute<std::int64_t>(/*sc::kMessagingMessageEnvelopeSize=*/
                                           "messaging.message.envelope.size",

--- a/google/cloud/pubsub/internal/subscriber_tracing_connection.cc
+++ b/google/cloud/pubsub/internal/subscriber_tracing_connection.cc
@@ -42,7 +42,7 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> StartPullSpan() {
   auto span = internal::MakeSpan(
       subscription.subscription_id() + " receive",
       {{sc::kMessagingSystem, "gcp_pubsub"},
-       {sc::kMessagingOperation, "receive"},
+       {/*sc::kMessagingOperationType=*/"messaging.operation.type", "receive"},
        {sc::kCodeFunction, "pubsub::SubscriberConnection::Pull"},
        {"gcp.project_id", subscription.project_id()},
        {sc::kMessagingDestinationName, subscription.subscription_id()}},

--- a/google/cloud/pubsub/internal/subscriber_tracing_connection_test.cc
+++ b/google/cloud/pubsub/internal/subscriber_tracing_connection_test.cc
@@ -152,10 +152,12 @@ TEST(SubscriberTracingConnectionTest, PullAttributes) {
                              SpanHasAttributes(OTelAttribute<std::string>(
                                  sc::kCodeFunction,
                                  "pubsub::SubscriberConnection::Pull")))));
-  EXPECT_THAT(spans,
-              Contains(AllOf(SpanNamed("test-subscription receive"),
-                             SpanHasAttributes(OTelAttribute<std::string>(
-                                 sc::kMessagingOperation, "receive")))));
+  EXPECT_THAT(
+      spans, Contains(AllOf(
+                 SpanNamed("test-subscription receive"),
+                 SpanHasAttributes(OTelAttribute<std::string>(
+                     /*sc::kMessagingOperationType=*/"messaging.operation.type",
+                     "receive")))));
   EXPECT_THAT(spans,
               Contains(AllOf(SpanNamed("test-subscription receive"),
                              SpanHasAttributes(OTelAttribute<std::string>(

--- a/google/cloud/pubsub/internal/tracing_batch_callback.cc
+++ b/google/cloud/pubsub/internal/tracing_batch_callback.cc
@@ -55,7 +55,8 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> StartSubscribeSpan(
   auto span = internal::MakeSpan(
       subscription.subscription_id() + " subscribe",
       {{sc::kMessagingSystem, "gcp_pubsub"},
-       {sc::kMessagingOperation, "subscribe"},
+       {/*sc::kMessagingOperationType=*/"messaging.operation.type",
+        "subscribe"},
        {"gcp.project_id", subscription.project_id()},
        {sc::kMessagingDestinationName, subscription.subscription_id()},
        {sc::kMessagingMessageId, m.message_id()},
@@ -207,7 +208,7 @@ class TracingBatchCallback : public BatchCallback {
     auto span = internal::MakeSpan(
         subscription_.subscription_id() + " modack",
         {{sc::kMessagingSystem, "gcp_pubsub"},
-         {sc::kMessagingOperation, "extend"},
+         {/*sc::kMessagingOperationType=*/"messaging.operation.type", "extend"},
          {sc::kMessagingBatchMessageCount,
           static_cast<int64_t>(request.ack_ids().size())},
          {"messaging.gcp_pubsub.message.ack_deadline_seconds",

--- a/google/cloud/pubsub/internal/tracing_batch_callback_test.cc
+++ b/google/cloud/pubsub/internal/tracing_batch_callback_test.cc
@@ -159,7 +159,9 @@ TEST(TracingBatchCallback, StartAndEndModackSpanForOneMessage) {
           SpanHasAttributes(
               OTelAttribute<std::string>(sc::kMessagingSystem, "gcp_pubsub"),
               OTelAttribute<std::string>("gcp.project_id", "test-project"),
-              OTelAttribute<std::string>(sc::kMessagingOperation, "extend"),
+              OTelAttribute<std::string>(
+                  /*sc::kMessagingOperationType=*/"messaging.operation.type",
+                  "extend"),
               OTelAttribute<int64_t>(sc::kMessagingBatchMessageCount, 1),
               OTelAttribute<int64_t>(
                   "messaging.gcp_pubsub.message.ack_deadline_seconds", 10),
@@ -195,7 +197,9 @@ TEST(TracingBatchCallback, StartAndEndModackSpanForMultipleMessages) {
           SpanHasAttributes(
               OTelAttribute<std::string>(sc::kMessagingSystem, "gcp_pubsub"),
               OTelAttribute<std::string>("gcp.project_id", "test-project"),
-              OTelAttribute<std::string>(sc::kMessagingOperation, "extend"),
+              OTelAttribute<std::string>(
+                  /*sc::kMessagingOperationType=*/"messaging.operation.type",
+                  "extend"),
               OTelAttribute<int64_t>(sc::kMessagingBatchMessageCount, 2),
               OTelAttribute<int64_t>(
                   "messaging.gcp_pubsub.message.ack_deadline_seconds", 10),
@@ -246,7 +250,9 @@ TEST(TracingBatchCallback, SubscribeAttributes) {
           SpanHasAttributes(
               OTelAttribute<std::string>(sc::kMessagingSystem, "gcp_pubsub"),
               OTelAttribute<std::string>("gcp.project_id", "test-project"),
-              OTelAttribute<std::string>(sc::kMessagingOperation, "subscribe"),
+              OTelAttribute<std::string>(
+                  /*sc::kMessagingOperationType=*/"messaging.operation.type",
+                  "subscribe"),
               OTelAttribute<std::string>(sc::kMessagingMessageId, "id-0"),
               OTelAttribute<std::string>("messaging.gcp_pubsub.message.ack_id",
                                          "ack-id-0"),

--- a/google/cloud/pubsub/internal/tracing_batch_sink.cc
+++ b/google/cloud/pubsub/internal/tracing_batch_sink.cc
@@ -69,8 +69,8 @@ auto MakeParent(Links const& links, Spans const& message_spans,
                          {{sc::kMessagingBatchMessageCount,
                            static_cast<std::int64_t>(message_spans.size())},
                           {sc::kCodeFunction, "BatchSink::AsyncPublish"},
-                          {/*sc::kMessagingOperation=*/
-                           "messaging.operation", "publish"},
+                          {/*sc::kMessagingOperationType=*/
+                           "messaging.operation.type", "publish"},
                           {sc::kThreadId, internal::CurrentThreadId()},
                           {sc::kMessagingSystem, "gcp_pubsub"},
                           {/*sc::kServerAddress=*/"server.address", endpoint},

--- a/google/cloud/pubsub/internal/tracing_batch_sink_test.cc
+++ b/google/cloud/pubsub/internal/tracing_batch_sink_test.cc
@@ -205,10 +205,12 @@ TEST(TracingBatchSink, PublishSpanHasAttributes) {
                          SpanNamed("test-topic publish"),
                          SpanHasAttributes(OTelAttribute<std::string>(
                              sc::kCodeFunction, "BatchSink::AsyncPublish")))));
-  EXPECT_THAT(spans,
-              Contains(AllOf(SpanNamed("test-topic publish"),
-                             SpanHasAttributes(OTelAttribute<std::string>(
-                                 sc::kMessagingOperation, "publish")))));
+  EXPECT_THAT(
+      spans, Contains(AllOf(
+                 SpanNamed("test-topic publish"),
+                 SpanHasAttributes(OTelAttribute<std::string>(
+                     /*sc::kMessagingOperationType=*/"messaging.operation.type",
+                     "publish")))));
   EXPECT_THAT(spans,
               Contains(AllOf(SpanNamed("test-topic publish"),
                              SpanHasAttributes(OTelAttribute<std::string>(

--- a/google/cloud/pubsub/internal/tracing_exactly_once_ack_handler.cc
+++ b/google/cloud/pubsub/internal/tracing_exactly_once_ack_handler.cc
@@ -75,7 +75,8 @@ class TracingExactlyOnceAckHandler
          {sc::kMessagingDestinationName, sub.subscription_id()},
          {"messaging.gcp_pubsub.message.delivery_attempt",
           static_cast<int32_t>(delivery_attempt())},
-         {sc::kMessagingOperation, "settle"}},
+         {/*sc::kMessagingOperationType=*/"messaging.operation.type",
+          "settle"}},
         std::move(links), options);
     auto scope = internal::OTelScope(span);
     return internal::EndSpan(std::move(span), child_->ack());
@@ -104,7 +105,8 @@ class TracingExactlyOnceAckHandler
          {sc::kMessagingDestinationName, sub.subscription_id()},
          {"messaging.gcp_pubsub.message.delivery_attempt",
           static_cast<int32_t>(delivery_attempt())},
-         {sc::kMessagingOperation, "settle"}},
+         {/*sc::kMessagingOperationType=*/"messaging.operation.type",
+          "settle"}},
         std::move(links), options);
 
     auto scope = internal::OTelScope(span);

--- a/google/cloud/pubsub/internal/tracing_exactly_once_ack_handler_test.cc
+++ b/google/cloud/pubsub/internal/tracing_exactly_once_ack_handler_test.cc
@@ -164,7 +164,9 @@ TEST(TracingAckHandlerTest, AckAttributes) {
           SpanHasAttributes(
               OTelAttribute<std::string>(sc::kMessagingSystem, "gcp_pubsub"),
               OTelAttribute<std::string>("gcp.project_id", "test-project"),
-              OTelAttribute<std::string>(sc::kMessagingOperation, "settle"),
+              OTelAttribute<std::string>(
+                  /*sc::kMessagingOperationType=*/"messaging.operation.type",
+                  "settle"),
               OTelAttribute<std::string>(sc::kCodeFunction,
                                          "pubsub::AckHandler::ack"),
               OTelAttribute<std::int32_t>(
@@ -270,7 +272,9 @@ TEST(TracingAckHandlerTest, NackAttributes) {
           SpanHasAttributes(
               OTelAttribute<std::string>(sc::kMessagingSystem, "gcp_pubsub"),
               OTelAttribute<std::string>("gcp.project_id", "test-project"),
-              OTelAttribute<std::string>(sc::kMessagingOperation, "settle"),
+              OTelAttribute<std::string>(
+                  /*sc::kMessagingOperationType=*/"messaging.operation.type",
+                  "settle"),
               OTelAttribute<std::string>(sc::kCodeFunction,
                                          "pubsub::AckHandler::nack"),
               OTelAttribute<std::int32_t>(

--- a/google/cloud/pubsub/internal/tracing_pull_ack_handler.cc
+++ b/google/cloud/pubsub/internal/tracing_pull_ack_handler.cc
@@ -67,7 +67,8 @@ class TracingPullAckHandler : public pubsub::PullAckHandler::Impl {
     TracingAttributes attributes = MakeSharedAttributes(ack_id, subscription);
     attributes.emplace_back(
         std::make_pair(sc::kCodeFunction, "pubsub::PullAckHandler::ack"));
-    attributes.emplace_back(std::make_pair(sc::kMessagingOperation, "ack"));
+    attributes.emplace_back(std::make_pair(
+        /*sc::kMessagingOperationType=*/"messaging.operation.type", "ack"));
     auto span =
         internal::MakeSpan(subscription.subscription_id() + " ack", attributes,
                            CreateLinks(consumer_span_context_), options);
@@ -92,7 +93,8 @@ class TracingPullAckHandler : public pubsub::PullAckHandler::Impl {
     TracingAttributes attributes = MakeSharedAttributes(ack_id, subscription);
     attributes.emplace_back(
         std::make_pair(sc::kCodeFunction, "pubsub::PullAckHandler::nack"));
-    attributes.emplace_back(std::make_pair(sc::kMessagingOperation, "nack"));
+    attributes.emplace_back(std::make_pair(
+        /*sc::kMessagingOperationType=*/"messaging.operation.type", "nack"));
     auto span =
         internal::MakeSpan(subscription.subscription_id() + " nack", attributes,
                            CreateLinks(consumer_span_context_), options);

--- a/google/cloud/pubsub/internal/tracing_pull_ack_handler_test.cc
+++ b/google/cloud/pubsub/internal/tracing_pull_ack_handler_test.cc
@@ -112,10 +112,12 @@ TEST(TracingAckHandlerTest, AckAttributes) {
               Contains(AllOf(SpanNamed("test-subscription ack"),
                              SpanHasAttributes(OTelAttribute<std::string>(
                                  "gcp.project_id", "test-project")))));
-  EXPECT_THAT(spans,
-              Contains(AllOf(SpanNamed("test-subscription ack"),
-                             SpanHasAttributes(OTelAttribute<std::string>(
-                                 sc::kMessagingOperation, "ack")))));
+  EXPECT_THAT(
+      spans, Contains(AllOf(
+                 SpanNamed("test-subscription ack"),
+                 SpanHasAttributes(OTelAttribute<std::string>(
+                     /*sc::kMessagingOperationType=*/"messaging.operation.type",
+                     "ack")))));
   EXPECT_THAT(
       spans,
       Contains(AllOf(SpanNamed("test-subscription ack"),
@@ -182,10 +184,12 @@ TEST(TracingAckHandlerTest, NackAttributes) {
               Contains(AllOf(SpanNamed("test-subscription nack"),
                              SpanHasAttributes(OTelAttribute<std::string>(
                                  sc::kMessagingSystem, "gcp_pubsub")))));
-  EXPECT_THAT(spans,
-              Contains(AllOf(SpanNamed("test-subscription nack"),
-                             SpanHasAttributes(OTelAttribute<std::string>(
-                                 sc::kMessagingOperation, "nack")))));
+  EXPECT_THAT(
+      spans, Contains(AllOf(
+                 SpanNamed("test-subscription nack"),
+                 SpanHasAttributes(OTelAttribute<std::string>(
+                     /*sc::kMessagingOperationType=*/"messaging.operation.type",
+                     "nack")))));
   EXPECT_THAT(spans,
               Contains(AllOf(SpanNamed("test-subscription nack"),
                              SpanHasAttributes(OTelAttribute<std::string>(

--- a/google/cloud/pubsub/internal/tracing_pull_lease_manager.cc
+++ b/google/cloud/pubsub/internal/tracing_pull_lease_manager.cc
@@ -58,7 +58,7 @@ class TracingPullLeaseManagerImpl : public PullLeaseManagerImpl {
     auto span = internal::MakeSpan(
         subscription_.subscription_id() + " modack",
         {{sc::kMessagingSystem, "gcp_pubsub"},
-         {sc::kMessagingOperation, "modack"},
+         {/*sc::kMessagingOperationType=*/"messaging.operation.type", "modack"},
          {sc::kCodeFunction, "pubsub::PullLeaseManager::ExtendLease"},
          {"messaging.gcp_pubsub.message.ack_id", ack_id_},
          {"messaging.gcp_pubsub.message.ack_deadline_seconds",

--- a/google/cloud/pubsub/internal/tracing_pull_lease_manager_test.cc
+++ b/google/cloud/pubsub/internal/tracing_pull_lease_manager_test.cc
@@ -172,10 +172,12 @@ TEST(TracingPullLeaseManagerImplTest, AsyncModifyAckDeadlineAttributes) {
               Contains(AllOf(SpanNamed("test-subscription modack"),
                              SpanHasAttributes(OTelAttribute<std::string>(
                                  sc::kMessagingSystem, "gcp_pubsub")))));
-  EXPECT_THAT(spans,
-              Contains(AllOf(SpanNamed("test-subscription modack"),
-                             SpanHasAttributes(OTelAttribute<std::string>(
-                                 sc::kMessagingOperation, "modack")))));
+  EXPECT_THAT(
+      spans, Contains(AllOf(
+                 SpanNamed("test-subscription modack"),
+                 SpanHasAttributes(OTelAttribute<std::string>(
+                     /*sc::kMessagingOperationType=*/"messaging.operation.type",
+                     "modack")))));
   EXPECT_THAT(spans,
               Contains(AllOf(SpanNamed("test-subscription modack"),
                              SpanHasAttributes(OTelAttribute<std::string>(

--- a/google/cloud/storage/internal/async/reader_connection_tracing_test.cc
+++ b/google/cloud/storage/internal/async/reader_connection_tracing_test.cc
@@ -106,16 +106,21 @@ TEST(ReaderConnectionTracing, WithError) {
               AllOf(
                   EventNamed("gl-cpp.read"),
                   SpanEventAttributesAre(
-                      OTelAttribute<std::int64_t>(sc::kMessageId, 1),
-                      OTelAttribute<std::string>(sc::kMessageType, "RECEIVED"),
+                      OTelAttribute<std::int64_t>(
+                          /*sc::kRpcMessageId=*/"rpc.message.id", 1),
+                      OTelAttribute<std::string>(
+                          /*sc::kRpcMessageType=*/"rpc.message.type",
+                          "RECEIVED"),
                       OTelAttribute<std::int64_t>("message.starting_offset", 0),
                       OTelAttribute<std::string>(sc::kThreadId, _))),
-              AllOf(
-                  EventNamed("gl-cpp.read"),
-                  SpanEventAttributesAre(
-                      OTelAttribute<std::int64_t>(sc::kMessageId, 2),
-                      OTelAttribute<std::string>(sc::kMessageType, "RECEIVED"),
-                      OTelAttribute<std::string>(sc::kThreadId, _)))))));
+              AllOf(EventNamed("gl-cpp.read"),
+                    SpanEventAttributesAre(
+                        OTelAttribute<std::int64_t>(
+                            /*sc::kRpcMessageId=*/"rpc.message.id", 2),
+                        OTelAttribute<std::string>(
+                            /*sc::kRpcMessageType=*/"rpc.message.type",
+                            "RECEIVED"),
+                        OTelAttribute<std::string>(sc::kThreadId, _)))))));
 }
 
 TEST(ReaderConnectionTracing, WithSuccess) {
@@ -159,24 +164,31 @@ TEST(ReaderConnectionTracing, WithSuccess) {
               AllOf(
                   EventNamed("gl-cpp.read"),
                   SpanEventAttributesAre(
-                      OTelAttribute<std::int64_t>(sc::kMessageId, 1),
-                      OTelAttribute<std::string>(sc::kMessageType, "RECEIVED"),
+                      OTelAttribute<std::int64_t>(
+                          /*sc::kRpcMessageId=*/"rpc.message.id", 1),
+                      OTelAttribute<std::string>(
+                          /*sc::kRpcMessageType=*/"rpc.message.type",
+                          "RECEIVED"),
                       OTelAttribute<std::int64_t>("message.starting_offset", 0),
                       OTelAttribute<std::string>(sc::kThreadId, _))),
-              AllOf(
-                  EventNamed("gl-cpp.read"),
-                  SpanEventAttributesAre(
-                      OTelAttribute<std::int64_t>(sc::kMessageId, 2),
-                      OTelAttribute<std::string>(sc::kMessageType, "RECEIVED"),
-                      OTelAttribute<std::int64_t>("message.starting_offset",
-                                                  1024),
-                      OTelAttribute<std::string>(sc::kThreadId, _))),
-              AllOf(
-                  EventNamed("gl-cpp.read"),
-                  SpanEventAttributesAre(
-                      OTelAttribute<std::int64_t>(sc::kMessageId, 3),
-                      OTelAttribute<std::string>(sc::kMessageType, "RECEIVED"),
-                      OTelAttribute<std::string>(sc::kThreadId, _)))))));
+              AllOf(EventNamed("gl-cpp.read"),
+                    SpanEventAttributesAre(
+                        OTelAttribute<std::int64_t>(
+                            /*sc::kRpcMessageId=*/"rpc.message.id", 2),
+                        OTelAttribute<std::string>(
+                            /*sc::kRpcMessageType=*/"rpc.message.type",
+                            "RECEIVED"),
+                        OTelAttribute<std::int64_t>("message.starting_offset",
+                                                    1024),
+                        OTelAttribute<std::string>(sc::kThreadId, _))),
+              AllOf(EventNamed("gl-cpp.read"),
+                    SpanEventAttributesAre(
+                        OTelAttribute<std::int64_t>(
+                            /*sc::kRpcMessageId=*/"rpc.message.id", 3),
+                        OTelAttribute<std::string>(
+                            /*sc::kRpcMessageType=*/"rpc.message.type",
+                            "RECEIVED"),
+                        OTelAttribute<std::string>(sc::kThreadId, _)))))));
 
   auto const metadata = actual->GetRequestMetadata();
   EXPECT_THAT(metadata.headers,

--- a/google/cloud/storage/internal/async/writer_connection_tracing.cc
+++ b/google/cloud/storage/internal/async/writer_connection_tracing.cc
@@ -61,13 +61,14 @@ class AsyncWriterConnectionTracing
     auto size = static_cast<std::uint64_t>(p.size());
     return impl_->Write(std::move(p))
         .then([count = ++sent_count_, span = span_, size](auto f) {
-          span->AddEvent("gl-cpp.write",
-                         {
-                             {sc::kMessageType, "SENT"},
-                             {sc::kMessageId, count},
-                             {sc::kThreadId, internal::CurrentThreadId()},
-                             {"gl-cpp.size", size},
-                         });
+          span->AddEvent(
+              "gl-cpp.write",
+              {
+                  {/*sc::kRpcMessageType=*/"rpc.message.type", "SENT"},
+                  {/*sc::kRpcMessageId=*/"rpc.message.id", count},
+                  {sc::kThreadId, internal::CurrentThreadId()},
+                  {"gl-cpp.size", size},
+              });
           auto status = f.get();
           if (!status.ok()) return internal::EndSpan(*span, std::move(status));
           return status;
@@ -80,13 +81,14 @@ class AsyncWriterConnectionTracing
     auto size = static_cast<std::uint64_t>(p.size());
     return impl_->Finalize(std::move(p))
         .then([count = ++sent_count_, span = span_, size](auto f) {
-          span->AddEvent("gl-cpp.finalize",
-                         {
-                             {sc::kMessageType, "SENT"},
-                             {sc::kMessageId, count},
-                             {sc::kThreadId, internal::CurrentThreadId()},
-                             {"gl-cpp.size", size},
-                         });
+          span->AddEvent(
+              "gl-cpp.finalize",
+              {
+                  {/*sc::kRpcMessageType=*/"rpc.message.type", "SENT"},
+                  {/*sc::kRpcMessageId=*/"rpc.message.id", count},
+                  {sc::kThreadId, internal::CurrentThreadId()},
+                  {"gl-cpp.size", size},
+              });
           return internal::EndSpan(*span, f.get());
         });
   }
@@ -96,13 +98,14 @@ class AsyncWriterConnectionTracing
     auto size = static_cast<std::uint64_t>(p.size());
     return impl_->Flush(std::move(p))
         .then([count = ++sent_count_, span = span_, size](auto f) {
-          span->AddEvent("gl-cpp.flush",
-                         {
-                             {sc::kMessageType, "SENT"},
-                             {sc::kMessageId, count},
-                             {sc::kThreadId, internal::CurrentThreadId()},
-                             {"gl-cpp.size", size},
-                         });
+          span->AddEvent(
+              "gl-cpp.flush",
+              {
+                  {/*sc::kRpcMessageType=*/"rpc.message.type", "SENT"},
+                  {/*sc::kRpcMessageId=*/"rpc.message.id", count},
+                  {sc::kThreadId, internal::CurrentThreadId()},
+                  {"gl-cpp.size", size},
+              });
           auto status = f.get();
           if (!status.ok()) return internal::EndSpan(*span, std::move(status));
           return status;
@@ -112,12 +115,13 @@ class AsyncWriterConnectionTracing
   future<StatusOr<std::int64_t>> Query() override {
     internal::OTelScope scope(span_);
     return impl_->Query().then([count = ++recv_count_, span = span_](auto f) {
-      span->AddEvent("gl-cpp.query",
-                     {
-                         {sc::kMessageType, "RECEIVE"},
-                         {sc::kMessageId, count},
-                         {sc::kThreadId, internal::CurrentThreadId()},
-                     });
+      span->AddEvent(
+          "gl-cpp.query",
+          {
+              {/*sc::kRpcMessageType=*/"rpc.message.type", "RECEIVE"},
+              {/*sc::kRpcMessageId=*/"rpc.message.id", count},
+              {sc::kThreadId, internal::CurrentThreadId()},
+          });
       auto response = f.get();
       if (!response) return internal::EndSpan(*span, std::move(response));
       return response;

--- a/google/cloud/storage/internal/async/writer_connection_tracing_test.cc
+++ b/google/cloud/storage/internal/async/writer_connection_tracing_test.cc
@@ -55,8 +55,9 @@ using ::testing::VariantWith;
 auto ExpectSent(std::int64_t id, std::uint64_t size) {
   namespace sc = ::opentelemetry::trace::SemanticConventions;
   return SpanEventAttributesAre(
-      OTelAttribute<std::string>(sc::kMessageType, "SENT"),
-      OTelAttribute<std::int64_t>(sc::kMessageId, id),
+      OTelAttribute<std::string>(/*sc::kRpcMessageType=*/"rpc.message.type",
+                                 "SENT"),
+      OTelAttribute<std::int64_t>(/*sc::kRpcMessageId=*/"rpc.message.id", id),
       OTelAttribute<std::string>(sc::kThreadId, _),
       OTelAttribute<std::uint64_t>("gl-cpp.size", size));
 }
@@ -73,8 +74,10 @@ auto ExpectQuery(std::int64_t id) {
   namespace sc = ::opentelemetry::trace::SemanticConventions;
   return AllOf(EventNamed("gl-cpp.query"),
                SpanEventAttributesAre(
-                   OTelAttribute<std::string>(sc::kMessageType, "RECEIVE"),
-                   OTelAttribute<std::int64_t>(sc::kMessageId, id),
+                   OTelAttribute<std::string>(
+                       /*sc::kRpcMessageType=*/"rpc.message.type", "RECEIVE"),
+                   OTelAttribute<std::int64_t>(
+                       /*sc::kRpcMessageId=*/"rpc.message.id", id),
                    OTelAttribute<std::string>(sc::kThreadId, _)));
 }
 


### PR DESCRIPTION
Preparing for `opentelemetry-cpp` `v1.16.0`. #14355

They will deprecate some semantic convention types.

In this PR, we adopt the new semantic conventions, but they are not available in the oldest OTel we support, so we must hardcode the values.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14373)
<!-- Reviewable:end -->
