### PR TITLE
impl(otel): general-purpose metric name formatter

### DIFF
--- a/google/cloud/opentelemetry/internal/time_series.h
+++ b/google/cloud/opentelemetry/internal/time_series.h
@@ -21,6 +21,8 @@
 #include <google/api/monitored_resource.pb.h>
 #include <google/monitoring/v3/metric_service.pb.h>
 #include <opentelemetry/sdk/metrics/metric_reader.h>
+#include <functional>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -35,7 +37,7 @@ auto constexpr kMaxTimeSeriesPerRequest = 200;
 google::api::Metric ToMetric(
     opentelemetry::sdk::metrics::MetricData const& metric_data,
     opentelemetry::sdk::metrics::PointAttributes const& attributes,
-    std::string const& prefix);
+    std::function<std::string(std::string)> const& metrics_name_formatter);
 
 google::monitoring::v3::TimeSeries ToTimeSeries(
     opentelemetry::sdk::metrics::MetricData const& metric_data,
@@ -73,7 +75,7 @@ google::api::MonitoredResource ToMonitoredResource(
  */
 std::vector<google::monitoring::v3::TimeSeries> ToTimeSeries(
     opentelemetry::sdk::metrics::ResourceMetrics const& data,
-    std::string const& prefix);
+    std::function<std::string(std::string)> const& metrics_name_formatter);
 
 /**
  * Convert from OpenTelemetry metrics to Cloud Monitoring protos.

--- a/google/cloud/opentelemetry/monitoring_exporter.h
+++ b/google/cloud/opentelemetry/monitoring_exporter.h
@@ -20,7 +20,9 @@
 #include "google/cloud/project.h"
 #include "google/cloud/version.h"
 #include <opentelemetry/sdk/metrics/push_metric_exporter.h>
+#include <functional>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -28,14 +30,15 @@ namespace otel_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /**
- * The prefix prepended to metric names.
+ * Change formatting for metric names.
  *
- * The default value is "workload.googleapis.com/". Note the trailing slash.
+ * The default formatter prefixes the name with "workload.googleapis.com/".
+ * Note the trailing slash.
  *
  * @see https://cloud.google.com/monitoring/api/v3/naming-conventions for
  *   understanding Google's naming conventions.
  *
- * The typical values for [user metrics] are:
+ * Common prefixes for [user metrics] are:
  * - "workload.googleapis.com/"
  * - "custom.googleapis.com/"
  * - "external.googleapis.com/user/"
@@ -47,8 +50,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * [prometheus]: https://prometheus.io/
  * [user metrics]: https://cloud.google.com/monitoring/custom-metrics#identifier
  */
-struct MetricPrefixOption {
-  using Type = std::string;
+struct MetricNameFormatterOption {
+  using Type = std::function<std::string(std::string)>;
 };
 
 /**

--- a/google/cloud/opentelemetry/monitoring_exporter_test.cc
+++ b/google/cloud/opentelemetry/monitoring_exporter_test.cc
@@ -217,7 +217,7 @@ TEST(MonitoringExporter, ExportFailureWithInvalidArgument) {
                      HasSubstr("INVALID_ARGUMENT"), HasSubstr("nope"))));
 }
 
-TEST(MonitoringExporter, CustomPrefix) {
+TEST(MonitoringExporter, CustomFormatter) {
   auto mock =
       std::make_shared<monitoring_v3_mocks::MockMetricServiceConnection>();
   EXPECT_CALL(*mock, CreateTimeSeries)
@@ -230,8 +230,8 @@ TEST(MonitoringExporter, CustomPrefix) {
             return Status();
           });
 
-  auto options = Options{}.set<otel_internal::MetricPrefixOption>(
-      "custom.googleapis.com/");
+  auto options = Options{}.set<otel_internal::MetricNameFormatterOption>(
+      [](std::string const& s) { return "custom.googleapis.com/" + s; });
   auto exporter = otel_internal::MakeMonitoringExporter(
       Project("test-project"), std::move(mock), options);
   auto data = MakeResourceMetrics(/*expected_time_series_count=*/2);

--- a/google/cloud/storage/internal/grpc/metrics_exporter_impl.cc
+++ b/google/cloud/storage/internal/grpc/metrics_exporter_impl.cc
@@ -118,7 +118,9 @@ void EnableGrpcMetricsImpl(ExporterConfig config) {
   labels.erase("instance_id");
   labels.erase("api");
   config.exporter_options.set<otel_internal::ServiceTimeSeriesOption>(false)
-      .set<otel_internal::MetricPrefixOption>("workload.googleapis.com/")
+      .set<otel_internal::MetricNameFormatterOption>([](std::string s) {
+        return "workload.googleapis.com/" + std::move(s);
+      })
       .set<otel_internal::MonitoredResourceOption>(
           std::move(monitored_resource));
   // END TODO(#13998) - end of code to erase.

--- a/google/cloud/storage/internal/grpc/metrics_exporter_impl_test.cc
+++ b/google/cloud/storage/internal/grpc/metrics_exporter_impl_test.cc
@@ -73,7 +73,7 @@ TEST(GrpcMetricsExporter, EnabledResourceProject) {
   EXPECT_TRUE(
       config->exporter_options.has<otel_internal::MonitoredResourceOption>());
   EXPECT_TRUE(
-      config->exporter_options.has<otel_internal::MetricPrefixOption>());
+      config->exporter_options.has<otel_internal::MetricNameFormatterOption>());
   EXPECT_TRUE(
       config->exporter_options.get<otel_internal::ServiceTimeSeriesOption>());
   EXPECT_GT(config->reader_options.export_interval_millis,
@@ -91,7 +91,7 @@ TEST(GrpcMetricsExporter, EnabledOptionsProject) {
   EXPECT_TRUE(
       config->exporter_options.has<otel_internal::MonitoredResourceOption>());
   EXPECT_TRUE(
-      config->exporter_options.has<otel_internal::MetricPrefixOption>());
+      config->exporter_options.has<otel_internal::MetricNameFormatterOption>());
   EXPECT_TRUE(
       config->exporter_options.get<otel_internal::ServiceTimeSeriesOption>());
   EXPECT_GT(config->reader_options.export_interval_millis,
@@ -110,7 +110,7 @@ TEST(GrpcMetricsExporter, EnabledWithTimeout) {
   EXPECT_TRUE(
       config->exporter_options.has<otel_internal::MonitoredResourceOption>());
   EXPECT_TRUE(
-      config->exporter_options.has<otel_internal::MetricPrefixOption>());
+      config->exporter_options.has<otel_internal::MetricNameFormatterOption>());
   EXPECT_TRUE(
       config->exporter_options.get<otel_internal::ServiceTimeSeriesOption>());
   EXPECT_EQ(config->reader_options.export_interval_millis,

--- a/google/cloud/storage/internal/grpc/metrics_exporter_options.cc
+++ b/google/cloud/storage/internal/grpc/metrics_exporter_options.cc
@@ -70,7 +70,8 @@ Options MetricsExporterOptions(
 
   return Options{}
       .set<otel_internal::ServiceTimeSeriesOption>(true)
-      .set<otel_internal::MetricPrefixOption>("storage.googleapis.com/")
+      .set<otel_internal::MetricNameFormatterOption>(
+          [](auto s) { return "storage.googleapis.com/" + s; })
       .set<otel_internal::MonitoredResourceOption>(
           std::move(monitored_resource));
 }


### PR DESCRIPTION
Let the application provide a function to format metric names. In some
cases we want to do more than prepend a prefix.

Fixes #14304, motivated by #13998

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14378)
<!-- Reviewable:end -->
