### PR TITLE
fix(otel): async read write stream tracing

### DIFF
--- a/google/cloud/internal/async_read_write_stream_tracing.h
+++ b/google/cloud/internal/async_read_write_stream_tracing.h
@@ -44,7 +44,11 @@ class AsyncStreamingReadWriteRpcTracing
   }
 
   future<bool> Start() override {
-    auto start_span = internal::MakeSpan("Start");
+    // It is sufficient to set `span_` as the parent of `start_span`, because
+    // the lower levels do not create any spans.
+    opentelemetry::trace::StartSpanOptions options;
+    options.parent = span_->GetContext();
+    auto start_span = internal::MakeSpan("Start", options);
     return impl_->Start().then(
         [this, ss = std::move(start_span)](future<bool> f) {
           EndSpan(*ss);
@@ -89,7 +93,12 @@ class AsyncStreamingReadWriteRpcTracing
   }
 
   future<Status> Finish() override {
-    auto finish_span = internal::MakeSpan("Finish");
+    internal::OTelScope scope(span_);
+    // It is sufficient to set `span_` as the parent of `finish_span`, because
+    // the lower levels do not create any spans.
+    opentelemetry::trace::StartSpanOptions options;
+    options.parent = span_->GetContext();
+    auto finish_span = internal::MakeSpan("Finish", options);
     return impl_->Finish().then(
         [this, fs = std::move(finish_span)](future<Status> f) {
           EndSpan(*fs);


### PR DESCRIPTION
Part of the work for #14371

---

Running the `streaming_pull_subscriber` cpp sample:

![image](https://github.com/googleapis/google-cloud-cpp/assets/23088558/f314fb72-760d-4b99-803c-cd49890da4ff)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14379)
<!-- Reviewable:end -->
