### PR TITLE
fix(bigquery): Fixes parsing of null type values returned from BQ server

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/common_v2_resources.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/common_v2_resources.cc
@@ -634,11 +634,11 @@ void to_json(nlohmann::json& j, ColumnData const& c) {
   j = nlohmann::json{{"v", c.value}};
 }
 void from_json(nlohmann::json const& j, ColumnData& c) {
-  SafeGetTo(c.value, j, "v");
+  SafeGetToWithNullable(c.value, c.is_null, j, "v");
 }
 
 bool operator==(ColumnData const& lhs, ColumnData const& rhs) {
-  return lhs.value == rhs.value;
+  return (lhs.value == rhs.value && lhs.is_null == rhs.is_null);
 }
 
 bool operator==(RowData const& lhs, RowData const& rhs) {
@@ -651,6 +651,7 @@ std::string ColumnData::DebugString(absl::string_view name,
                                     int indent) const {
   return internal::DebugFormatter(name, options, indent)
       .StringField("value", value)
+      .Field("is_null", is_null)
       .Build();
 }
 

--- a/google/cloud/bigquery/v2/minimal/internal/common_v2_resources.h
+++ b/google/cloud/bigquery/v2/minimal/internal/common_v2_resources.h
@@ -316,6 +316,7 @@ bool operator==(Struct const& lhs, Struct const& rhs);
 
 struct ColumnData {
   std::string value;
+  bool is_null{false};
   std::string DebugString(absl::string_view name,
                           TracingOptions const& options = {},
                           int indent = 0) const;

--- a/google/cloud/bigquery/v2/minimal/internal/common_v2_resources.h
+++ b/google/cloud/bigquery/v2/minimal/internal/common_v2_resources.h
@@ -316,6 +316,7 @@ bool operator==(Struct const& lhs, Struct const& rhs);
 
 struct ColumnData {
   std::string value;
+  // TODO(#14387): Use absl::optional instead.
   bool is_null{false};
   std::string DebugString(absl::string_view name,
                           TracingOptions const& options = {},

--- a/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
@@ -1996,9 +1996,9 @@ TEST(QueryResponseTest, DebugString) {
       R"( kind: "query-kind" page_token: "np123")"
       R"( total_rows: 1000 total_bytes_processed: 1000 num_dml_affected_rows: 5)"
       R"( job_complete: true cache_hit: true)"
-      R"( rows { columns { value: "col1" } columns { value: "col2" })"
-      R"( columns { value: "col3" } columns { value: "col4" })"
-      R"( columns { value: "col5" } columns { value: "col6" } })"
+      R"( rows { columns { value: "col1" is_null: false } columns { value: "col2" is_null: false })"
+      R"( columns { value: "col3" is_null: false } columns { value: "col4" is_null: false })"
+      R"( columns { value: "col5" is_null: false } columns { value: "col6" is_null: false } })"
       R"( schema { fields { name: "fname-1" type: "" mode: "fmode")"
       R"( description: "" collation: "" default_value_expression: "")"
       R"( max_length: 0 precision: 0 scale: 0 categories { } policy_tags { })"
@@ -2016,9 +2016,9 @@ TEST(QueryResponseTest, DebugString) {
       R"( query_results { kind: "query-k...<truncated>...")"
       R"( page_token: "np123" total_rows: 1000 total_bytes_processed: 1000)"
       R"( num_dml_affected_rows: 5 job_complete: true cache_hit: true)"
-      R"( rows { columns { value: "col1" } columns { value: "col2" })"
-      R"( columns { value: "col3" } columns { value: "col4" })"
-      R"( columns { value: "col5" } columns { value: "col6" } })"
+      R"( rows { columns { value: "col1" is_null: false } columns { value: "col2" is_null: false })"
+      R"( columns { value: "col3" is_null: false } columns { value: "col4" is_null: false })"
+      R"( columns { value: "col5" is_null: false } columns { value: "col6" is_null: false } })"
       R"( schema { fields { name: "fname-1" type: "" mode: "fmode")"
       R"( description: "" collation: "" default_value_expression: "")"
       R"( max_length: 0 precision: 0 scale: 0 categories { } policy_tags { })"
@@ -2045,21 +2045,27 @@ TEST(QueryResponseTest, DebugString) {
     rows {
       columns {
         value: "col1"
+        is_null: false
       }
       columns {
         value: "col2"
+        is_null: false
       }
       columns {
         value: "col3"
+        is_null: false
       }
       columns {
         value: "col4"
+        is_null: false
       }
       columns {
         value: "col5"
+        is_null: false
       }
       columns {
         value: "col6"
+        is_null: false
       }
     }
     schema {
@@ -2149,9 +2155,9 @@ TEST(GetQueryResultsResponseTest, DebugString) {
       R"( kind: "query-kind" etag: "query-etag" page_token: "np123")"
       R"( total_rows: 1000 total_bytes_processed: 1000)"
       R"( num_dml_affected_rows: 5 job_complete: true cache_hit: true)"
-      R"( rows { columns { value: "col1" } columns { value: "col2" })"
-      R"( columns { value: "col3" } columns { value: "col4" })"
-      R"( columns { value: "col5" } columns { value: "col6" } })"
+      R"( rows { columns { value: "col1" is_null: false } columns { value: "col2" is_null: false })"
+      R"( columns { value: "col3" is_null: false } columns { value: "col4" is_null: false })"
+      R"( columns { value: "col5" is_null: false } columns { value: "col6" is_null: false } })"
       R"( schema { fields { name: "fname-1" type: "" mode: "fmode")"
       R"( description: "" collation: "" default_value_expression: "")"
       R"( max_length: 0 precision: 0 scale: 0 categories { } policy_tags { })"
@@ -2168,9 +2174,9 @@ TEST(GetQueryResultsResponseTest, DebugString) {
       R"( etag: "query-e...<truncated>..." page_token: "np123")"
       R"( total_rows: 1000 total_bytes_processed: 1000)"
       R"( num_dml_affected_rows: 5 job_complete: true cache_hit: true)"
-      R"( rows { columns { value: "col1" } columns { value: "col2" })"
-      R"( columns { value: "col3" } columns { value: "col4" })"
-      R"( columns { value: "col5" } columns { value: "col6" } })"
+      R"( rows { columns { value: "col1" is_null: false } columns { value: "col2" is_null: false })"
+      R"( columns { value: "col3" is_null: false } columns { value: "col4" is_null: false })"
+      R"( columns { value: "col5" is_null: false } columns { value: "col6" is_null: false } })"
       R"( schema { fields { name: "fname-1" type: "" mode: "fmode")"
       R"( description: "" collation: "" default_value_expression: "")"
       R"( max_length: 0 precision: 0 scale: 0 categories { } policy_tags { })"
@@ -2197,21 +2203,27 @@ TEST(GetQueryResultsResponseTest, DebugString) {
     rows {
       columns {
         value: "col1"
+        is_null: false
       }
       columns {
         value: "col2"
+        is_null: false
       }
       columns {
         value: "col3"
+        is_null: false
       }
       columns {
         value: "col4"
+        is_null: false
       }
       columns {
         value: "col5"
+        is_null: false
       }
       columns {
         value: "col6"
+        is_null: false
       }
     }
     schema {

--- a/google/cloud/bigquery/v2/minimal/internal/json_utils_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/json_utils_test.cc
@@ -251,7 +251,7 @@ TEST(JsonUtilsTest, SafeGetToNullValue) {
   EXPECT_EQ(val, "");
 }
 
-TEST(JsonUtilsTest, SafeGetToWithNullable_NullValue) {
+TEST(JsonUtilsTest, SafeGetToWithNullableNullValue) {
   auto const* const key = "project_id";
   auto constexpr kJsonText = R"({"project_id":null})";
   auto json = nlohmann::json::parse(kJsonText, nullptr, false);
@@ -264,7 +264,7 @@ TEST(JsonUtilsTest, SafeGetToWithNullable_NullValue) {
   EXPECT_TRUE(is_null);
 }
 
-TEST(JsonUtilsTest, SafeGetToWithNullable_NonNull) {
+TEST(JsonUtilsTest, SafeGetToWithNullableNonNull) {
   auto const* const key = "project_id";
   auto constexpr kJsonText = R"({"project_id":"123"})";
   auto json = nlohmann::json::parse(kJsonText, nullptr, false);

--- a/google/cloud/bigquery/v2/minimal/internal/json_utils_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/json_utils_test.cc
@@ -240,6 +240,43 @@ TEST(JsonUtilsTest, RemoveEmptyObjects) {
   EXPECT_EQ(expected, json.dump());
 }
 
+TEST(JsonUtilsTest, SafeGetToNullValue) {
+  auto const* const key = "project_id";
+  auto constexpr kJsonText = R"({"project_id":null})";
+  auto json = nlohmann::json::parse(kJsonText, nullptr, false);
+  EXPECT_TRUE(json.is_object());
+
+  std::string val;
+  EXPECT_TRUE(SafeGetTo(val, json, key));
+  EXPECT_EQ(val, "");
+}
+
+TEST(JsonUtilsTest, SafeGetToWithNullable_NullValue) {
+  auto const* const key = "project_id";
+  auto constexpr kJsonText = R"({"project_id":null})";
+  auto json = nlohmann::json::parse(kJsonText, nullptr, false);
+  EXPECT_TRUE(json.is_object());
+
+  std::string val;
+  bool is_null;
+  EXPECT_TRUE(SafeGetToWithNullable(val, is_null, json, key));
+  EXPECT_EQ(val, "");
+  EXPECT_TRUE(is_null);
+}
+
+TEST(JsonUtilsTest, SafeGetToWithNullable_NonNull) {
+  auto const* const key = "project_id";
+  auto constexpr kJsonText = R"({"project_id":"123"})";
+  auto json = nlohmann::json::parse(kJsonText, nullptr, false);
+  EXPECT_TRUE(json.is_object());
+
+  std::string val;
+  bool is_null;
+  EXPECT_TRUE(SafeGetToWithNullable(val, is_null, json, key));
+  EXPECT_EQ(val, "123");
+  EXPECT_FALSE(is_null);
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud


### PR DESCRIPTION
This PR includes the following changes for json parsing related to null values, based on what is returned from BQ Server API

1. BQ query response can contain null values for row/column data as shown below

```
"rows": [
    {
      "f": [
        {
          "v": null
        },
        {
          "v": "Test String 6"
        },
        {
          "v": null
        }
      ]
    },
```
Due to the above json `get_to` method crashes with a type exception . The fix checks for null value before calling `get_to` in json_utils.h

2) From the client perspective, we need to be able to distingush an empty string from a null value so that client api can work properly hence an additional `is_null` member has been added to `ColumnData` struct.

3) Unit test changes for all of the above.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14384)
<!-- Reviewable:end -->
