### PR TITLE
impl(dataproc): add include for lro metadata type

### DIFF
--- a/generator/generator_config.textproto
+++ b/generator/generator_config.textproto
@@ -1827,6 +1827,7 @@ service {
 
 service {
   service_proto_path: "google/cloud/dataproc/v1/node_groups.proto"
+  additional_proto_files: ["google/cloud/dataproc/v1/operations.proto"]
   product_path: "google/cloud/dataproc/v1"
   initial_copyright_year: "2023"
   retryable_status_codes: ["kUnavailable"]

--- a/google/cloud/dataproc/v1/internal/node_group_controller_stub.h
+++ b/google/cloud/dataproc/v1/internal/node_group_controller_stub.h
@@ -25,6 +25,7 @@
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/dataproc/v1/node_groups.grpc.pb.h>
+#include <google/cloud/dataproc/v1/operations.pb.h>
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <utility>

--- a/google/cloud/dataproc/v1/node_group_controller_connection.h
+++ b/google/cloud/dataproc/v1/node_group_controller_connection.h
@@ -31,6 +31,7 @@
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/dataproc/v1/node_groups.pb.h>
+#include <google/cloud/dataproc/v1/operations.pb.h>
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 #include <string>


### PR DESCRIPTION
With the Await function checking the LRO metadata type, we need to ensure the appropriate pb.h file is included.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14386)
<!-- Reviewable:end -->
