### PR TITLE
test(storage): skip some gRPC integration tests

### DIFF
--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -140,14 +140,18 @@ TEST_F(BucketIntegrationTest, BasicCRUD) {
   EXPECT_EQ(1, patched->lifecycle().rule.size());
 
   // Patch the metadata again, this time remove billing and website settings.
-  patched = client->PatchBucket(
-      bucket_name, BucketMetadataPatchBuilder().ResetWebsite().ResetBilling());
-  ASSERT_STATUS_OK(patched);
-  // It does not matter if the `billing` compound is set. Only that it has the
-  // same effect as-if it was not set, i.e., it has the default value.
-  EXPECT_EQ(patched->billing_as_optional().value_or(BucketBilling{false}),
-            BucketBilling{false});
-  EXPECT_FALSE(patched->has_website());
+  // The emulator does not support this feature for gRPC.
+  if (!UsingEmulator() || !UsingGrpc()) {
+    patched = client->PatchBucket(
+        bucket_name,
+        BucketMetadataPatchBuilder().ResetWebsite().ResetBilling());
+    ASSERT_STATUS_OK(patched);
+    // It does not matter if the `billing` compound is set. Only that it has the
+    // same effect as-if it was not set, i.e., it has the default value.
+    EXPECT_EQ(patched->billing_as_optional().value_or(BucketBilling{false}),
+              BucketBilling{false});
+    EXPECT_FALSE(patched->has_website());
+  }
 
   auto status = client->DeleteBucket(bucket_name);
   ASSERT_STATUS_OK(status);
@@ -565,6 +569,8 @@ TEST_F(BucketIntegrationTest, GetMetadata) {
 }
 
 TEST_F(BucketIntegrationTest, GetMetadataFields) {
+  // TODO(#14385) - the emulator does not support this feature for gRPC.
+  if (UsingEmulator() && UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -698,6 +704,8 @@ TEST_F(BucketIntegrationTest, AccessControlCRUD) {
 }
 
 TEST_F(BucketIntegrationTest, DefaultObjectAccessControlCRUD) {
+  // TODO(#14385) - the emulator does not support this feature for gRPC.
+  if (UsingEmulator() && UsingGrpc()) GTEST_SKIP();
   std::string bucket_name = MakeRandomBucketName();
   StatusOr<Client> client = MakeBucketIntegrationTestClient();
   ASSERT_STATUS_OK(client);
@@ -767,6 +775,8 @@ TEST_F(BucketIntegrationTest, DefaultObjectAccessControlCRUD) {
 }
 
 TEST_F(BucketIntegrationTest, NotificationsCRUD) {
+  // TODO(#14385) - the emulator does not support this feature for gRPC.
+  if (!UsingEmulator() && UsingGrpc()) GTEST_SKIP();
   std::string bucket_name = MakeRandomBucketName();
   StatusOr<Client> client = MakeBucketIntegrationTestClient();
   ASSERT_STATUS_OK(client);
@@ -1176,6 +1186,9 @@ TEST_F(BucketIntegrationTest, DeleteDefaultAccessControlFailure) {
 }
 
 TEST_F(BucketIntegrationTest, NativeIamWithRequestedPolicyVersion) {
+  // TODO(#14385) - the emulator does not support this feature for gRPC.
+  if (UsingEmulator() && UsingGrpc()) GTEST_SKIP();
+
   std::string bucket_name = MakeRandomBucketName();
   StatusOr<Client> client = MakeBucketIntegrationTestClient();
   ASSERT_STATUS_OK(client);

--- a/google/cloud/storage/tests/curl_sign_blob_integration_test.cc
+++ b/google/cloud/storage/tests/curl_sign_blob_integration_test.cc
@@ -41,6 +41,8 @@ class CurlSignBlobIntegrationTest
 };
 
 TEST_F(CurlSignBlobIntegrationTest, Simple) {
+  // TODO(#14385) - the emulator does not support this feature for gRPC.
+  if (UsingEmulator() && UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 

--- a/google/cloud/storage/tests/object_file_integration_test.cc
+++ b/google/cloud/storage/tests/object_file_integration_test.cc
@@ -32,10 +32,12 @@ namespace {
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::AnyOf;
+using ::testing::Contains;
 using ::testing::ElementsAreArray;
 using ::testing::Eq;
 using ::testing::HasSubstr;
 using ::testing::Not;
+using ::testing::Pair;
 
 class ObjectFileIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {
@@ -552,9 +554,8 @@ TEST_F(ObjectFileIntegrationTest, ResumableUploadFileCustomHeader) {
   auto expected_str = expected.str();
   ASSERT_EQ(expected_str.size(), meta->size());
 
-  EXPECT_THAT(meta->metadata(),
-              ::testing::Contains(::testing::Pair("x_emulator_custom_header",
-                                                  "custom_header_value")));
+  EXPECT_THAT(meta->metadata(), Contains(Pair("x_emulator_custom_header",
+                                              "custom_header_value")));
 
   // Create an iostream to read the object back.
   auto stream = client->ReadObject(bucket_name_, object_name);

--- a/google/cloud/storage/tests/object_hash_integration_test.cc
+++ b/google/cloud/storage/tests/object_hash_integration_test.cc
@@ -199,12 +199,13 @@ TEST_F(ObjectHashIntegrationTest, WriteObjectExplicitEnable) {
   EXPECT_THAT(os.computed_hash(), HasSubstr(ComputeMD5Hash(LoremIpsum())));
   EXPECT_THAT(os.received_hash(), HasSubstr(ComputeMD5Hash(LoremIpsum())));
   if (meta->has_metadata("x_emulator_upload")) {
-    ASSERT_THAT(meta->metadata(), Contains(Pair("x_emulator_no_crc32c", _)));
     if (UsingGrpc()) {
+      EXPECT_THAT(meta->metadata(), Contains(Pair("x_emulator_no_crc32c", _)));
       EXPECT_THAT(meta->metadata(), Contains(Pair("x_emulator_md5", _)));
     } else {
       // REST cannot send the checksums computed at the end of the upload.
-      ASSERT_THAT(meta->metadata(), Contains(Pair("x_emulator_no_md5", _)));
+      EXPECT_THAT(meta->metadata(), Contains(Pair("x_emulator_no_crc32c", _)));
+      EXPECT_THAT(meta->metadata(), Contains(Pair("x_emulator_no_md5", _)));
     }
   }
 }

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -364,6 +364,9 @@ TEST_F(ObjectIntegrationTest, BasicReadWriteBinary) {
 }
 
 TEST_F(ObjectIntegrationTest, EncryptedReadWrite) {
+  // TODO(#14385) - the emulator does not support this feature for gRPC.
+  if (UsingEmulator() && UsingGrpc()) GTEST_SKIP();
+
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 

--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -311,6 +311,9 @@ TEST_F(ObjectMediaIntegrationTest, ReadFromSpill) {
 
 /// @test Read the last chunk of an object by setting ReadLast option.
 TEST_F(ObjectMediaIntegrationTest, ReadLastChunkReadLast) {
+  // TODO(#14385) - the emulator does not support this feature for gRPC.
+  if (UsingEmulator() && UsingGrpc()) GTEST_SKIP();
+
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -523,7 +526,8 @@ TEST_F(ObjectMediaIntegrationTest, ConnectionFailureUploadFile) {
 }
 
 TEST_F(ObjectMediaIntegrationTest, StreamingReadTimeout) {
-  if (!UsingEmulator()) GTEST_SKIP();
+  // The emulator does not support this type of fault injection for gRPC.
+  if (!UsingEmulator() || UsingGrpc()) GTEST_SKIP();
   auto options = ClientOptions::CreateDefaultClientOptions();
   ASSERT_STATUS_OK(options);
 
@@ -555,7 +559,8 @@ TEST_F(ObjectMediaIntegrationTest, StreamingReadTimeout) {
 }
 
 TEST_F(ObjectMediaIntegrationTest, StreamingReadTimeoutContinues) {
-  if (!UsingEmulator()) GTEST_SKIP();
+  // The emulator does not support this type of fault injection for gRPC.
+  if (!UsingEmulator() || UsingGrpc()) GTEST_SKIP();
 
   Client client(
       Options{}

--- a/google/cloud/storage/tests/object_rewrite_integration_test.cc
+++ b/google/cloud/storage/tests/object_rewrite_integration_test.cc
@@ -29,7 +29,10 @@ namespace {
 
 using ::google::cloud::storage::testing::CountMatchingEntities;
 using ::google::cloud::testing_util::IsOk;
+using ::testing::AllOf;
+using ::testing::Contains;
 using ::testing::Not;
+using ::testing::ResultOf;
 
 class ObjectRewriteIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {
@@ -77,6 +80,8 @@ TEST_F(ObjectRewriteIntegrationTest, Copy) {
 }
 
 TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclAuthenticatedRead) {
+  // TODO(#14385) - the emulator does not support this feature for gRPC.
+  if (UsingEmulator() && UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -94,11 +99,17 @@ TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclAuthenticatedRead) {
   ASSERT_STATUS_OK(meta);
   ScheduleForDelete(*meta);
 
-  EXPECT_LT(0, CountMatchingEntities(meta->acl(),
-                                     ObjectAccessControl()
-                                         .set_entity("allAuthenticatedUsers")
-                                         .set_role("READER")))
-      << *meta;
+  EXPECT_THAT(
+      meta->acl(),
+      Contains(
+          AllOf(ResultOf(
+                    "entity is",
+                    [](ObjectAccessControl const& acl) { return acl.entity(); },
+                    "allAuthenticatedUsers"),
+                ResultOf(
+                    "role is",
+                    [](ObjectAccessControl const& acl) { return acl.role(); },
+                    "READER"))));
 }
 
 TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclBucketOwnerFullControl) {
@@ -131,6 +142,8 @@ TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclBucketOwnerFullControl) {
 }
 
 TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclBucketOwnerRead) {
+  // TODO(#14385) - the emulator does not support this feature for gRPC.
+  if (UsingEmulator() && UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -153,10 +166,18 @@ TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclBucketOwnerRead) {
       DestinationPredefinedAcl::BucketOwnerRead(), Projection::Full());
   ASSERT_STATUS_OK(meta);
   ScheduleForDelete(*meta);
-  EXPECT_LT(0, CountMatchingEntities(
-                   meta->acl(),
-                   ObjectAccessControl().set_entity(owner).set_role("READER")))
-      << *meta;
+
+  EXPECT_THAT(
+      meta->acl(),
+      Contains(
+          AllOf(ResultOf(
+                    "entity is",
+                    [](ObjectAccessControl const& acl) { return acl.entity(); },
+                    owner),
+                ResultOf(
+                    "role is",
+                    [](ObjectAccessControl const& acl) { return acl.role(); },
+                    "READER"))));
 }
 
 TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclPrivate) {
@@ -177,14 +198,23 @@ TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclPrivate) {
   ASSERT_STATUS_OK(meta);
   ScheduleForDelete(*meta);
   ASSERT_TRUE(meta->has_owner());
-  EXPECT_LT(0, CountMatchingEntities(meta->acl(),
-                                     ObjectAccessControl()
-                                         .set_entity(meta->owner().entity)
-                                         .set_role("OWNER")))
-      << *meta;
+
+  EXPECT_THAT(
+      meta->acl(),
+      Contains(
+          AllOf(ResultOf(
+                    "entity is",
+                    [](ObjectAccessControl const& acl) { return acl.entity(); },
+                    meta->owner().entity),
+                ResultOf(
+                    "role is",
+                    [](ObjectAccessControl const& acl) { return acl.role(); },
+                    "OWNER"))));
 }
 
 TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclProjectPrivate) {
+  // TODO(#14385) - the emulator does not support this feature for gRPC.
+  if (UsingEmulator() && UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -202,14 +232,23 @@ TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclProjectPrivate) {
   ASSERT_STATUS_OK(meta);
   ScheduleForDelete(*meta);
   ASSERT_TRUE(meta->has_owner());
-  EXPECT_LT(0, CountMatchingEntities(meta->acl(),
-                                     ObjectAccessControl()
-                                         .set_entity(meta->owner().entity)
-                                         .set_role("OWNER")))
-      << *meta;
+
+  EXPECT_THAT(
+      meta->acl(),
+      Contains(
+          AllOf(ResultOf(
+                    "entity is",
+                    [](ObjectAccessControl const& acl) { return acl.entity(); },
+                    meta->owner().entity),
+                ResultOf(
+                    "role is",
+                    [](ObjectAccessControl const& acl) { return acl.role(); },
+                    "OWNER"))));
 }
 
 TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclPublicRead) {
+  // TODO(#14385) - the emulator does not support this feature for gRPC.
+  if (UsingEmulator() && UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -226,11 +265,18 @@ TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclPublicRead) {
       DestinationPredefinedAcl::PublicRead(), Projection::Full());
   ASSERT_STATUS_OK(meta);
   ScheduleForDelete(*meta);
-  EXPECT_LT(
-      0, CountMatchingEntities(
-             meta->acl(),
-             ObjectAccessControl().set_entity("allUsers").set_role("READER")))
-      << *meta;
+
+  EXPECT_THAT(
+      meta->acl(),
+      Contains(
+          AllOf(ResultOf(
+                    "entity is",
+                    [](ObjectAccessControl const& acl) { return acl.entity(); },
+                    "allUsers"),
+                ResultOf(
+                    "role is",
+                    [](ObjectAccessControl const& acl) { return acl.role(); },
+                    "READER"))));
 }
 
 TEST_F(ObjectRewriteIntegrationTest, ComposeSimple) {
@@ -258,6 +304,8 @@ TEST_F(ObjectRewriteIntegrationTest, ComposeSimple) {
 }
 
 TEST_F(ObjectRewriteIntegrationTest, ComposedUsingEncryptedObject) {
+  // TODO(#14385) - the emulator does not support this feature for gRPC.
+  if (UsingEmulator() && UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -313,6 +361,8 @@ TEST_F(ObjectRewriteIntegrationTest, RewriteSimple) {
 }
 
 TEST_F(ObjectRewriteIntegrationTest, RewriteEncrypted) {
+  // TODO(#14385) - the emulator does not support this feature for gRPC.
+  if (UsingEmulator() && UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 


### PR DESCRIPTION
The testbench does not support the features used by these tests. We may
consider removing the tests, the unit tests are enough for gRPC, and we
could (now) write unit tests for JSON too.

Motivated by #14385

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14388)
<!-- Reviewable:end -->
