### PR TITLE
feat(otel): capture error message in traces (again)

### DIFF
--- a/google/cloud/internal/opentelemetry.cc
+++ b/google/cloud/internal/opentelemetry.cc
@@ -100,8 +100,11 @@ void EndSpanImpl(opentelemetry::trace::Span& span, Status const& status) {
     span.End();
     return;
   }
+  // Note that the Cloud Trace UI drops the span's status, so we also write it
+  // as an attribute.
   span.SetStatus(opentelemetry::trace::StatusCode::kError, status.message());
   span.SetAttribute("gl-cpp.status_code", static_cast<int>(status.code()));
+  span.SetAttribute("gl-cpp.error.message", status.message());
   auto const& ei = status.error_info();
   if (!ei.reason().empty()) {
     span.SetAttribute("gcloud.error.reason", ei.reason());

--- a/google/cloud/internal/opentelemetry_test.cc
+++ b/google/cloud/internal/opentelemetry_test.cc
@@ -184,7 +184,9 @@ TEST(OpenTelemetry, EndSpanImplFail) {
       spans,
       ElementsAre(AllOf(
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "not good"),
-          SpanHasAttributes(OTelAttribute<int>("gl-cpp.status_code", code)))));
+          SpanHasAttributes(OTelAttribute<int>("gl-cpp.status_code", code),
+                            OTelAttribute<std::string>("gl-cpp.error.message",
+                                                       "not good")))));
 }
 
 TEST(OpenTelemetry, EndSpanImplErrorInfo) {
@@ -201,6 +203,7 @@ TEST(OpenTelemetry, EndSpanImplErrorInfo) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "not good"),
           SpanHasAttributes(
               OTelAttribute<int>("gl-cpp.status_code", code),
+              OTelAttribute<std::string>("gl-cpp.error.message", "not good"),
               OTelAttribute<std::string>("gcloud.error.reason", "reason")))));
 
   span = MakeSpan("domain");
@@ -213,6 +216,7 @@ TEST(OpenTelemetry, EndSpanImplErrorInfo) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "not good"),
           SpanHasAttributes(
               OTelAttribute<int>("gl-cpp.status_code", code),
+              OTelAttribute<std::string>("gl-cpp.error.message", "not good"),
               OTelAttribute<std::string>("gcloud.error.domain", "domain")))));
 
   span = MakeSpan("metadata");
@@ -225,6 +229,7 @@ TEST(OpenTelemetry, EndSpanImplErrorInfo) {
           SpanWithStatus(opentelemetry::trace::StatusCode::kError, "not good"),
           SpanHasAttributes(
               OTelAttribute<int>("gl-cpp.status_code", code),
+              OTelAttribute<std::string>("gl-cpp.error.message", "not good"),
               OTelAttribute<std::string>("gcloud.error.metadata.k1", "v1"),
               OTelAttribute<std::string>("gcloud.error.metadata.k2", "v2")))));
 }


### PR DESCRIPTION
With this PR, applications that enable OpenTelemetry tracing, and use the Cloud Trace exporter, will be able to see error messages in the UI.

This change also makes it easier to filter client library errors only in the Cloud Trace UI with:

```
label:gl-cpp.error.message
``` 

---

Other attributes use the domain: `gcloud.error.*`. I will update them to use `gl-cpp.error.*` in a follow up PR.

I also think we should change `gl-cpp.status_code` from an `int` to a human readable `string`. I will address that in a follow up PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14389)
<!-- Reviewable:end -->
