### PR TITLE
impl: reservoir sample for span events

### DIFF
--- a/google/cloud/opentelemetry/internal/recordable.cc
+++ b/google/cloud/opentelemetry/internal/recordable.cc
@@ -351,7 +351,7 @@ void Recordable::AddEventImpl(
     auto& collection = *events.mutable_time_event();
     // Always preserve the first and last events. The rest are randomly sampled
     // using https://en.wikipedia.org/wiki/Reservoir_sampling
-    if (k < static_cast<std::int64_t>(collection.size() - 1)) {
+    if (k + 1 < collection.size()) {
       // This is the normal reservoir sampling case. One of the elements in the
       // collections[1..size-1] range is removed. Moving the remaining elements
       // preserves the order.

--- a/google/cloud/opentelemetry/internal/recordable.cc
+++ b/google/cloud/opentelemetry/internal/recordable.cc
@@ -352,15 +352,13 @@ void Recordable::AddEventImpl(
     // Always preserve the first and last events. The rest are randomly sampled
     // using https://en.wikipedia.org/wiki/Reservoir_sampling
     if (k + 1 < collection.size()) {
-      // This is the normal reservoir sampling case. One of the elements in the
-      // collections[1..size-1] range is removed. Moving the remaining elements
-      // preserves the order.
-      collection.erase(std::next(collection.begin(), k + 1));
-    } else {
-      // Just remove the last element, so we can insert the newest element and
-      // preserve the last element ever received.
-      collection.RemoveLast();
+      // This is the normal reservoir sampling case. We swap the last element
+      // and the element to be removed.
+      collection.SwapElements(k + 1, collection.size() - 1);
     }
+    // Just remove the last element, so we can insert the newest element and
+    // preserve the last element ever received.
+    collection.RemoveLast();
   }
 
   auto& event = *events.add_time_event();

--- a/google/cloud/opentelemetry/internal/recordable.h
+++ b/google/cloud/opentelemetry/internal/recordable.h
@@ -22,6 +22,9 @@
 #include <opentelemetry/common/attribute_value.h>
 #include <opentelemetry/sdk/trace/recordable.h>
 #include <opentelemetry/version.h>
+#include <cstdint>
+#include <functional>
+#include <utility>
 
 namespace google {
 namespace cloud {
@@ -98,7 +101,10 @@ void AddAttribute(
  */
 class Recordable final : public opentelemetry::sdk::trace::Recordable {
  public:
-  explicit Recordable(Project project) : project_(std::move(project)) {}
+  using Generator = std::function<std::int64_t(std::int64_t end)>;
+
+  explicit Recordable(Project project, Generator generator)
+      : project_(std::move(project)), generator_(std::move(generator)) {}
 
   bool valid() const { return valid_; }
 
@@ -165,6 +171,8 @@ class Recordable final : public opentelemetry::sdk::trace::Recordable {
 
   std::string scope_name_;
   std::string scope_version_;
+  Generator generator_;
+  std::int64_t timed_event_count_ = 0;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/opentelemetry/internal/recordable.h
+++ b/google/cloud/opentelemetry/internal/recordable.h
@@ -22,7 +22,6 @@
 #include <opentelemetry/common/attribute_value.h>
 #include <opentelemetry/sdk/trace/recordable.h>
 #include <opentelemetry/version.h>
-#include <cstdint>
 #include <functional>
 #include <utility>
 
@@ -101,7 +100,7 @@ void AddAttribute(
  */
 class Recordable final : public opentelemetry::sdk::trace::Recordable {
  public:
-  using Generator = std::function<std::int64_t(std::int64_t end)>;
+  using Generator = std::function<int(int)>;
 
   explicit Recordable(Project project, Generator generator)
       : project_(std::move(project)), generator_(std::move(generator)) {}
@@ -172,7 +171,7 @@ class Recordable final : public opentelemetry::sdk::trace::Recordable {
   std::string scope_name_;
   std::string scope_version_;
   Generator generator_;
-  std::int64_t timed_event_count_ = 0;
+  int timed_event_count_ = 0;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/opentelemetry/internal/recordable_test.cc
+++ b/google/cloud/opentelemetry/internal/recordable_test.cc
@@ -185,8 +185,8 @@ Matcher<v2::Span::Link const&> Link(
 auto TestGenerator() {
   // Initialize using the googletest seed.
   auto generator = internal::DefaultPRNG(::testing::FLAGS_gtest_random_seed);
-  return [g = std::move(generator)](std::int64_t size) mutable {
-    return std::uniform_int_distribution<std::int64_t>(0, size - 1)(g);
+  return [g = std::move(generator)](int size) mutable {
+    return std::uniform_int_distribution<int>(0, size - 1)(g);
   };
 }
 

--- a/google/cloud/opentelemetry/internal/recordable_test.cc
+++ b/google/cloud/opentelemetry/internal/recordable_test.cc
@@ -457,13 +457,12 @@ TEST(Recordable, DropsNewEventAtLimit) {
   }
   auto proto = std::move(rec).as_proto();
   EXPECT_EQ(proto.time_events().dropped_annotations_count(), 10);
-  EXPECT_THAT(proto.time_events().time_event(), SizeIs(kSpanAnnotationLimit));
-  EXPECT_THAT(proto.time_events().time_event(0),
-              TimeEvent(_, Annotation("event0", _)));
-  EXPECT_THAT(
-      proto.time_events().time_event(kSpanAnnotationLimit - 1),
-      TimeEvent(_, Annotation(
-                       "event" + std::to_string(kSpanAnnotationLimit + 9), _)));
+  auto event_matcher = [](int i) {
+    return TimeEvent(_, Annotation("event" + std::to_string(i), _));
+  };
+  EXPECT_THAT(proto.time_events().time_event(),
+              AllOf(SizeIs(kSpanAnnotationLimit), Contains(event_matcher(0)),
+                    Contains(event_matcher(kSpanAnnotationLimit + 9))));
 }
 
 TEST(Recordable, DropsNewEventAttributeAtLimit) {

--- a/google/cloud/opentelemetry/trace_exporter.cc
+++ b/google/cloud/opentelemetry/trace_exporter.cc
@@ -15,7 +15,10 @@
 #include "google/cloud/opentelemetry/trace_exporter.h"
 #include "google/cloud/trace/v2/trace_client.h"
 #include "google/cloud/internal/noexcept_action.h"
+#include "google/cloud/internal/random.h"
 #include "google/cloud/log.h"
+#include <mutex>
+#include <random>
 
 namespace google {
 namespace cloud {
@@ -23,17 +26,35 @@ namespace otel {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+class ThreadSafeGenerator {
+ public:
+  ThreadSafeGenerator() : generator_(internal::MakeDefaultPRNG()) {}
+
+  auto generate(std::size_t size) {
+    std::lock_guard<std::mutex> lk(mu_);
+    return std::uniform_int_distribution<std::int64_t>(0, size - 1)(generator_);
+  }
+
+ private:
+  std::mutex mu_;
+  internal::DefaultPRNG generator_;
+};
+
 class TraceExporter final : public opentelemetry::sdk::trace::SpanExporter {
  public:
   explicit TraceExporter(Project project,
                          std::shared_ptr<trace_v2::TraceServiceConnection> conn)
-      : project_(std::move(project)), client_(std::move(conn)) {}
+      : project_(std::move(project)),
+        client_(std::move(conn)),
+        generator_([state = std::make_shared<ThreadSafeGenerator>()](
+                       std::size_t size) { return state->generate(size); }) {}
 
   std::unique_ptr<opentelemetry::sdk::trace::Recordable>
   MakeRecordable() noexcept override {
     auto recordable = internal::NoExceptAction<
-        std::unique_ptr<opentelemetry::sdk::trace::Recordable>>(
-        [&] { return std::make_unique<otel_internal::Recordable>(project_); });
+        std::unique_ptr<opentelemetry::sdk::trace::Recordable>>([&] {
+      return std::make_unique<otel_internal::Recordable>(project_, generator_);
+    });
     if (recordable) return *std::move(recordable);
     GCP_LOG(WARNING) << "Exception thrown while creating span.";
     return nullptr;
@@ -76,6 +97,7 @@ class TraceExporter final : public opentelemetry::sdk::trace::SpanExporter {
 
   Project project_;
   trace_v2::TraceServiceClient client_;
+  otel_internal::Recordable::Generator generator_;
 };
 
 }  // namespace


### PR DESCRIPTION
We can only upload 32 events per span to Cloud Trace. Some spans may
have a lot more. Use a reservoir sampler to randomly select which events
are sent.  The first and last event are always preserved because they
usually contain something more important than any middle events.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14407)
<!-- Reviewable:end -->
