### PR TITLE
cleanup(otel): bazel flag is obsolete

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -52,7 +52,6 @@ common:macos --repo_env=BAZEL_NO_APPLE_CPP_TOOLCHAIN=1
 test --test_env=GTEST_SHUFFLE --test_env=GTEST_RANDOM_SEED
 
 # By default, build the library with OpenTelemetry
-build --@io_opentelemetry_cpp//api:with_abseil
 build --//:enable_opentelemetry
 
 # Don't show warnings when building external dependencies. This still shows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,31 @@ breaking changes in the upcoming 3.x release. This release is scheduled for
 
 ## v2.27.0 - TBD
 
-* We have stopped testing on CentOS 7, Debian 10 (Buster), and RockyLinux 8 as
+- We have stopped testing on CentOS 7, Debian 10 (Buster), and RockyLinux 8 as
   these distros are EOL or in some form of "security only" support period.
   Note that we used CentOS 7 as a proxy for testing RedHat Enterprise Linux 7.
+
+### [OpenTelemetry](/google/cloud/opentelemetry/README.md)
+
+#### Bazel
+
+The `--io_opentelemetry_cpp//api:with_abseil` flag was marked as deprecated in
+OpenTelemetry v1.16.0. It may be removed in future versions.
+
+In previous versions of `opentelemetry-cpp`, this flag was required for
+compatibility with Abseil. It is no longer necessary, as `opentelemetry-cpp` is
+compiled with Abseil by default.
+
+We have stopped using the flag to validate Bazel build configurations with
+OpenTelemetry tracing enabled.
+
+If you are building `google-cloud-cpp` with `opentelemetry-cpp` < v1.16.0, you
+will need to supply the flag for compatibility with Abseil. The following can be
+added to your `.bazelrc` file.
+
+```bash
+build --@io_opentelemetry_cpp//api:with_abseil
+```
 
 ## v2.26.0 - 2024-07
 

--- a/ci/verify_current_targets/.bazelrc
+++ b/ci/verify_current_targets/.bazelrc
@@ -35,7 +35,3 @@ common --noenable_bzlmod
 # TODO(#13311) - remove once gRPC works with Bazel v7 or when gRPC stops using
 #     `apple_rules`.
 common:macos --repo_env=BAZEL_NO_APPLE_CPP_TOOLCHAIN=1
-
-# Build OpenTelemetry assuming Abseil exists. Otherwise we get symbol conflicts
-# between the Abseil implementation and the copy in OTel.
-build --@io_opentelemetry_cpp//api:with_abseil

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -126,9 +126,9 @@ quickstart guides also cover this use-case.
 `google-cloud-cpp` also has an **optional** dependency on the following
 libraries:
 
-| Library                           | Minimum version | Description                |
-| --------------------------------- | --------------- | -------------------------- |
-| [OpenTelemetry][opentelemetry-gh] | 1.9.1           | An observability framework |
+| Library                           | Minimum version | Description                    |
+| --------------------------------- | --------------- | ------------------------------ |
+| [OpenTelemetry][opentelemetry-gh] | 1.9.1           | An observability framework[^7] |
 
 Note that these libraries may also depend on other libraries. The following
 instructions include steps to install these indirect dependencies too.
@@ -1531,6 +1531,9 @@ cmake --build cmake-out --target install
     workaround conflicts between system pre-processor macros and symbols used in
     the Protobuf-generated code.
 
+[^7]: See the [OpenTelemetry quickstart][otel-qs] for detailed instructions on how
+    to enable and build this optional dependency.
+
 [abseil-gh]: https://github.com/abseil/abseil-cpp
 [abseil/abseil-cpp#696]: https://github.com/abseil/abseil-cpp/issues/696
 [crc32c-gh]: https://github.com/google/crc32c
@@ -1543,6 +1546,7 @@ cmake --build cmake-out --target install
 [nlohmann-json-gh]: https://github.com/nlohmann/json
 [openssl-gh]: https://github.com/openssl/openssl
 [opentelemetry-gh]: https://github.com/open-telemetry/opentelemetry-cpp
+[otel-qs]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/opentelemetry/quickstart#opentelemetry-dependency
 [protobuf-gh]: https://github.com/protocolbuffers/protobuf
 [spanner-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/spanner#readme
 [storage-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/storage#readme

--- a/google/cloud/BUILD.bazel
+++ b/google/cloud/BUILD.bazel
@@ -45,17 +45,9 @@ capture_build_info(
 )
 
 config_setting(
-    name = "enable_opentelemetry_valid",
+    name = "enable_opentelemetry",
     flag_values = {
         "//:enable_opentelemetry": "true",
-        "@io_opentelemetry_cpp//api:with_abseil": "true",
-    },
-)
-
-config_setting(
-    name = "disable_opentelemetry",
-    flag_values = {
-        "//:enable_opentelemetry": "false",
     },
 )
 
@@ -70,7 +62,7 @@ cc_library(
     srcs = google_cloud_cpp_common_srcs + ["internal/build_info.cc"],
     hdrs = google_cloud_cpp_common_hdrs,
     defines = select({
-        ":enable_opentelemetry_valid": [
+        ":enable_opentelemetry": [
             # Enable OpenTelemetry features in google-cloud-cpp
             "GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY",
         ],
@@ -89,24 +81,6 @@ cc_library(
         ],
         "//conditions:default": [],
     }),
-    target_compatible_with = select(
-        {
-            ":enable_opentelemetry_valid": [],
-            ":disable_opentelemetry": [],
-        },
-        # else, OpenTelemetry is enabled, but with an invalid configuration.
-        no_match_error = """
-
-
-You requested OpenTelemetry support for `google-cloud-cpp`, but OpenTelemetry is
-configured without Abseil support. This configuration will result in ODR
-violations, and possibly build-time errors, as OpenTelemetry redefines Abseil
-symbols in this case, and `google-cloud-cpp` uses Abseil directly too.
-
-To fix this problem, supply the `--@io_opentelemetry_cpp//api:with_abseil` flag
-to your build command, or set this value in your `.bazelrc` file(s).
-""",
-    ),
     visibility = [
         ":__subpackages__",
         "//:__pkg__",
@@ -121,7 +95,7 @@ to your build command, or set this value in your `.bazelrc` file(s).
         "@com_google_absl//absl/types:span",
         "@com_google_absl//absl/types:variant",
     ] + select({
-        ":enable_opentelemetry_valid": [
+        ":enable_opentelemetry": [
             "@io_opentelemetry_cpp//api",
         ],
         "//conditions:default": [],

--- a/google/cloud/opentelemetry/quickstart/.bazelrc
+++ b/google/cloud/opentelemetry/quickstart/.bazelrc
@@ -30,5 +30,15 @@ build:macos --host_cxxopt=-std=c++14
 build --experimental_convenience_symlinks=ignore
 
 # Enable OpenTelemetry tracing instrumentation for google-cloud-cpp.
-build --@io_opentelemetry_cpp//api:with_abseil
 build --@google_cloud_cpp//:enable_opentelemetry
+
+# OpenTelemetry versions < v1.16.0 are not compatible with Abseil
+# out-of-the-box. If you are using a version of OpenTelemetry < v1.16.0,
+# uncomment the following configuration:
+#
+# ```
+# build --@io_opentelemetry_cpp//api:with_abseil
+# ```
+#
+# Note that the flag is not required for OpenTelemetry versions >= v1.16.0. In
+# fact, the flag may be removed in future versions of OpenTelemetry.

--- a/google/cloud/opentelemetry/quickstart/README.md
+++ b/google/cloud/opentelemetry/quickstart/README.md
@@ -84,7 +84,7 @@ enables OpenTelemetry tracing instrumentation in `google-cloud-cpp`.
 build --@google_cloud_cpp//:enable_opentelemetry
 ```
 
-If you are using an OpenTelemetry version < v1.16.0, you must also supply the
+If you are using an OpenTelemetry version \< v1.16.0, you must also supply the
 following flag for compatibility with Abseil. Without this flag, the above
 `bazel build ...` command will fail.
 

--- a/google/cloud/opentelemetry/quickstart/README.md
+++ b/google/cloud/opentelemetry/quickstart/README.md
@@ -76,16 +76,20 @@ flags when compiling `opentelemetry-cpp`.
 
 ### Details
 
-Note the following two feature flags explicitly set in the `.bazelrc`. Together,
-these flags enable OpenTelemetry tracing instrumentation in `google-cloud-cpp`.
-Without these flags, the above `bazel build ...` command would fail.
+Note the following feature flag explicitly set in the `.bazelrc`. This flag
+enables OpenTelemetry tracing instrumentation in `google-cloud-cpp`.
 
 ```bash
-# Required for OpenTelemetry + Abseil compatibility
-build --@io_opentelemetry_cpp//api:with_abseil
-
 # Enables tracing instrumentation in google-cloud-cpp
 build --@google_cloud_cpp//:enable_opentelemetry
+```
+
+If you are using an OpenTelemetry version < v1.16.0, you must also supply the
+following flag for compatibility with Abseil. Without this flag, the above
+`bazel build ...` command will fail.
+
+```bash
+build --@io_opentelemetry_cpp//api:with_abseil
 ```
 
 Also note that we explicitly load OpenTelemetry's dependencies in the

--- a/google/cloud/testing_util/BUILD.bazel
+++ b/google/cloud/testing_util/BUILD.bazel
@@ -45,7 +45,7 @@ cc_library(
         "@com_google_absl//absl/debugging:symbolize",
         "@com_google_googletest//:gtest_main",
     ] + select({
-        "//google/cloud:enable_opentelemetry_valid": [
+        "//google/cloud:enable_opentelemetry": [
             "@io_opentelemetry_cpp//exporters/memory:in_memory_span_exporter",
             "@io_opentelemetry_cpp//sdk/src/trace",
         ],


### PR DESCRIPTION
In `v1.16.0`, OpenTelemetry started compiling with Abseil all the time with Bazel. See https://github.com/open-telemetry/opentelemetry-cpp/pull/2679

This means their `--io_opentelemetry_cpp//api:with_abseil` flag is now obsolete. Yay. That is good moving forward.

They plan to remove the flag in the future.

The annoying this is that we cannot know which version of OpenTelemetry a downstream target is using. So we will not know if the flag is required or if the flag has been removed. Yuck.

I think our best path forward is to adapt to the change, and try to alert customers to configuration errors through documentation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14416)
<!-- Reviewable:end -->
