### PR TITLE
ci: fix public logs link

### DIFF
--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -28,7 +28,7 @@ options:
     'GENERATE_GOLDEN_ONLY=',
     'UPDATED_DISCOVERY_DOCUMENT=',
     'CONSOLE_LOG_URL=https://console.cloud.google.com/cloud-build/builds;region=${_POOL_REGION}/${BUILD_ID};tab=detail?project=${PROJECT_ID}',
-    'RAW_LOG_URL=https://storage.googleapis.com/${_LOGS_BUCKET}/logs/google-cloud-cpp/${_TRIGGER_SOURCE}/${COMMIT_SHA}/${_DISTRO}-${_BUILD_NAME}/log-${BUILD_ID}.txt'
+    'RAW_LOG_URL=https://storage.googleapis.com/${_LOGS_BUCKET}/logs/google-cloud-cpp/${_TRIGGER_SOURCE}/${COMMIT_SHA}/${_DISTRO}-${_BUILD_NAME}-${_SHARD}/log-${BUILD_ID}.txt'
   ]
   substitutionOption: 'ALLOW_LOOSE'
   volumes:


### PR DESCRIPTION
Mirror the `logsBucket` path:

https://github.com/dbolduc/google-cloud-cpp/blob/2519bb74bfb849be1df98152d55f750ed195013a/ci/cloudbuild/cloudbuild.yaml#L68

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14418)
<!-- Reviewable:end -->
