### PR TITLE
refactor(storage): make some code more testable

### DIFF
--- a/google/cloud/storage/internal/connection_impl.h
+++ b/google/cloud/storage/internal/connection_impl.h
@@ -71,9 +71,6 @@ class StorageConnectionImpl
   StatusOr<ObjectMetadata> GetObjectMetadata(
       GetObjectMetadataRequest const& request) override;
 
-  /// Call ReadObject() but do not wrap the result in a RetryObjectReadSource.
-  StatusOr<std::unique_ptr<ObjectReadSource>> ReadObjectNotWrapped(
-      ReadObjectRangeRequest const&, RetryPolicy&, BackoffPolicy&);
   StatusOr<std::unique_ptr<ObjectReadSource>> ReadObject(
       ReadObjectRangeRequest const&) override;
 

--- a/google/cloud/storage/internal/connection_impl_object_test.cc
+++ b/google/cloud/storage/internal/connection_impl_object_test.cc
@@ -134,7 +134,7 @@ TEST(StorageConnectionImpl, ReadObjectTooManyFailures) {
       StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->ReadObject(ReadObjectRangeRequest()).status();
-  EXPECT_THAT(response, StoppedOnTooManyTransients("ReadObjectNotWrapped"));
+  EXPECT_THAT(response, StoppedOnTooManyTransients("ReadObject"));
   EXPECT_THAT(transient.captured_tokens(), RetryLoopUsesSingleToken());
   EXPECT_THAT(transient.captured_authority_options(), RetryLoopUsesOptions());
 }
@@ -148,7 +148,7 @@ TEST(StorageConnectionImpl, ReadObjectPermanentFailure) {
       StorageConnectionImpl::Create(std::move(mock), RetryTestOptions());
   google::cloud::internal::OptionsSpan span(client->options());
   auto response = client->ReadObject(ReadObjectRangeRequest()).status();
-  EXPECT_THAT(response, StoppedOnPermanentError("ReadObjectNotWrapped"));
+  EXPECT_THAT(response, StoppedOnPermanentError("ReadObject"));
   EXPECT_THAT(permanent.captured_tokens(), RetryLoopUsesSingleToken());
   EXPECT_THAT(permanent.captured_authority_options(), RetryLoopUsesOptions());
 }

--- a/google/cloud/storage/internal/retry_object_read_source.cc
+++ b/google/cloud/storage/internal/retry_object_read_source.cc
@@ -25,7 +25,6 @@ namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 
-using ::google::cloud::internal::CurrentOptions;
 using ::google::cloud::internal::OptionsSpan;
 
 std::uint64_t InitialOffset(OffsetDirection const& offset_direction,
@@ -37,11 +36,14 @@ std::uint64_t InitialOffset(OffsetDirection const& offset_direction,
 }
 
 RetryObjectReadSource::RetryObjectReadSource(
-    std::shared_ptr<StorageConnectionImpl> connection,
+    ReadSourceFactory factory,
+    google::cloud::internal::ImmutableOptions current,
     ReadObjectRangeRequest request, std::unique_ptr<ObjectReadSource> child,
     std::unique_ptr<RetryPolicy> retry_policy,
-    std::unique_ptr<BackoffPolicy> backoff_policy)
-    : connection_(std::move(connection)),
+    std::unique_ptr<BackoffPolicy> backoff_policy,
+    std::function<void(std::chrono::milliseconds)> backoff)
+    : factory_(std::move(factory)),
+      current_(std::move(current)),
       request_(std::move(request)),
       child_(std::move(child)),
       retry_policy_prototype_(std::move(retry_policy)),
@@ -49,7 +51,19 @@ RetryObjectReadSource::RetryObjectReadSource(
       offset_direction_(request_.HasOption<ReadLast>() ? kFromEnd
                                                        : kFromBeginning),
       current_offset_(InitialOffset(offset_direction_, request_)),
-      span_options_(CurrentOptions()) {}
+      backoff_(std::move(backoff)) {}
+
+RetryObjectReadSource::RetryObjectReadSource(
+    ReadSourceFactory factory,
+    google::cloud::internal::ImmutableOptions current,
+    ReadObjectRangeRequest request, std::unique_ptr<ObjectReadSource> child,
+    std::unique_ptr<RetryPolicy> retry_policy,
+    std::unique_ptr<BackoffPolicy> backoff_policy)
+    : RetryObjectReadSource(
+          std::move(factory), std::move(current), std::move(request),
+          std::move(child), std::move(retry_policy), std::move(backoff_policy),
+          [](std::chrono::milliseconds d) { std::this_thread::sleep_for(d); }) {
+}
 
 StatusOr<ReadSourceResult> RetryObjectReadSource::Read(char* buf,
                                                        std::size_t n) {
@@ -74,7 +88,7 @@ StatusOr<ReadSourceResult> RetryObjectReadSource::Read(char* buf,
   auto retry_policy = retry_policy_prototype_->clone();
   int counter = 0;
   for (; !result && retry_policy->OnFailure(result.status());
-       std::this_thread::sleep_for(backoff_policy->OnCompletion()),
+       backoff_(backoff_policy->OnCompletion()),
        result = child_->Read(buf, n)) {
     // A Read() request failed, most likely that means the connection failed or
     // stalled. The current child might no longer be usable, so we will try to
@@ -134,9 +148,8 @@ Status RetryObjectReadSource::MakeChild(RetryPolicy& retry_policy,
     return Status{};
   };
 
-  OptionsSpan const span(span_options_);
-  auto child =
-      connection_->ReadObjectNotWrapped(request_, retry_policy, backoff_policy);
+  OptionsSpan const span(current_);
+  auto child = factory_(request_, retry_policy, backoff_policy);
   if (!child) return std::move(child).status();
   if (!is_gunzipped_) return on_success(*std::move(child));
 
@@ -148,7 +161,7 @@ Status RetryObjectReadSource::MakeChild(RetryPolicy& retry_policy,
 
   // Try again, eventually the retry policy will expire and this will fail.
   if (!retry_policy.OnFailure(child.status())) return std::move(child).status();
-  std::this_thread::sleep_for(backoff_policy.OnCompletion());
+  backoff_(backoff_policy.OnCompletion());
 
   return MakeChild(retry_policy, backoff_policy);
 }

--- a/google/cloud/storage/internal/retry_object_read_source.cc
+++ b/google/cloud/storage/internal/retry_object_read_source.cc
@@ -37,13 +37,13 @@ std::uint64_t InitialOffset(OffsetDirection const& offset_direction,
 
 RetryObjectReadSource::RetryObjectReadSource(
     ReadSourceFactory factory,
-    google::cloud::internal::ImmutableOptions current,
+    google::cloud::internal::ImmutableOptions options,
     ReadObjectRangeRequest request, std::unique_ptr<ObjectReadSource> child,
     std::unique_ptr<RetryPolicy> retry_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy,
     std::function<void(std::chrono::milliseconds)> backoff)
     : factory_(std::move(factory)),
-      current_(std::move(current)),
+      options_(std::move(options)),
       request_(std::move(request)),
       child_(std::move(child)),
       retry_policy_prototype_(std::move(retry_policy)),
@@ -55,12 +55,12 @@ RetryObjectReadSource::RetryObjectReadSource(
 
 RetryObjectReadSource::RetryObjectReadSource(
     ReadSourceFactory factory,
-    google::cloud::internal::ImmutableOptions current,
+    google::cloud::internal::ImmutableOptions options,
     ReadObjectRangeRequest request, std::unique_ptr<ObjectReadSource> child,
     std::unique_ptr<RetryPolicy> retry_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy)
     : RetryObjectReadSource(
-          std::move(factory), std::move(current), std::move(request),
+          std::move(factory), std::move(options), std::move(request),
           std::move(child), std::move(retry_policy), std::move(backoff_policy),
           [](std::chrono::milliseconds d) { std::this_thread::sleep_for(d); }) {
 }
@@ -148,7 +148,7 @@ Status RetryObjectReadSource::MakeChild(RetryPolicy& retry_policy,
     return Status{};
   };
 
-  OptionsSpan const span(current_);
+  OptionsSpan const span(options_);
   auto child = factory_(request_, retry_policy, backoff_policy);
   if (!child) return std::move(child).status();
   if (!is_gunzipped_) return on_success(*std::move(child));

--- a/google/cloud/storage/internal/retry_object_read_source.h
+++ b/google/cloud/storage/internal/retry_object_read_source.h
@@ -48,14 +48,14 @@ class RetryObjectReadSource : public ObjectReadSource {
           ReadObjectRangeRequest const&, RetryPolicy&, BackoffPolicy&)>;
 
   RetryObjectReadSource(ReadSourceFactory factory,
-                        google::cloud::internal::ImmutableOptions current,
+                        google::cloud::internal::ImmutableOptions options,
                         ReadObjectRangeRequest request,
                         std::unique_ptr<ObjectReadSource> child,
                         std::unique_ptr<RetryPolicy> retry_policy,
                         std::unique_ptr<BackoffPolicy> backoff_policy,
                         std::function<void(std::chrono::milliseconds)> backoff);
   RetryObjectReadSource(ReadSourceFactory factory,
-                        google::cloud::internal::ImmutableOptions current,
+                        google::cloud::internal::ImmutableOptions options,
                         ReadObjectRangeRequest request,
                         std::unique_ptr<ObjectReadSource> child,
                         std::unique_ptr<RetryPolicy> retry_policy,
@@ -72,7 +72,7 @@ class RetryObjectReadSource : public ObjectReadSource {
       std::unique_ptr<ObjectReadSource> child, std::int64_t count) const;
 
   ReadSourceFactory factory_;
-  google::cloud::internal::ImmutableOptions current_;
+  google::cloud::internal::ImmutableOptions options_;
   ReadObjectRangeRequest request_;
   std::unique_ptr<ObjectReadSource> child_;
   absl::optional<std::int64_t> generation_;


### PR DESCRIPTION
This just changes `storage::internal::RetryObjectReadSource` to make the
class more testable. The backoff function is provided as an argument, so
it can be mocked. Likewise, the code to start new downloads is provided
by a factory function.

Incidentally, I captured the current options using
`internal::ImmutableOptions`, saving a number of copies in the process.

Part of the work for #14424

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14429)
<!-- Reviewable:end -->
