### PR TITLE
fix(GCS+gRPC): scale timeout for downloads

### DIFF
--- a/google/cloud/storage/internal/grpc/scale_stall_timeout_test.cc
+++ b/google/cloud/storage/internal/grpc/scale_stall_timeout_test.cc
@@ -41,6 +41,10 @@ TEST(ScaleStallTimeout, Simple) {
   EXPECT_EQ(ScaleStallTimeout(1s, 1'000'000, 1'000'000), 1'000ms);
   EXPECT_EQ(ScaleStallTimeout(1s, 1'000, 1'000'000), 1'000ms);
   EXPECT_EQ(ScaleStallTimeout(1s, 1, 1'000'000), 1'000ms);
+
+  auto constexpr kMiB = 1024 * 1024;
+  EXPECT_EQ(ScaleStallTimeout(10s, 20 * kMiB, 2 * kMiB), 1000ms);
+  EXPECT_EQ(ScaleStallTimeout(10s, 10 * kMiB, 2 * kMiB), 2000ms);
 }
 
 TEST(ScaleStallTimeout, Unexpected) {

--- a/google/cloud/storage/internal/grpc/stub.cc
+++ b/google/cloud/storage/internal/grpc/stub.cc
@@ -434,7 +434,10 @@ GrpcStub::ReadObject(rest_internal::RestContext& context,
   GrpcObjectReadSource::TimerSource timer_source = [] {
     return make_ready_future(false);
   };
-  auto const timeout = options.get<storage::DownloadStallTimeoutOption>();
+  auto const timeout = ScaleStallTimeout(
+      options.get<storage::DownloadStallTimeoutOption>(),
+      options.get<storage::DownloadStallMinimumRateOption>(),
+      google::storage::v2::ServiceConstants::MAX_READ_CHUNK_BYTES);
   if (timeout != std::chrono::seconds(0)) {
     // Change to an active timer.
     timer_source = [timeout, cq = background_->cq()]() mutable {


### PR DESCRIPTION
The progress timeouts need to be scaled because the data arrives in
quantums on (roughly) 2MiB blocks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14430)
<!-- Reviewable:end -->
