### PR TITLE
fix: workaround missing SHA256 macros in MinGW-w64

### DIFF
--- a/google/cloud/internal/sha256_hash.cc
+++ b/google/cloud/internal/sha256_hash.cc
@@ -30,6 +30,11 @@ namespace {
 Sha256Type Sha256Hash(void const* data, std::size_t count) {
   Sha256Type hash;
 #ifdef _WIN32
+// Workaround missing macros in MinGW-w64:
+//     https://github.com/mingw-w64/mingw-w64/issues/49
+#ifndef BCRYPT_SHA256_ALG_HANDLE
+#define BCRYPT_SHA256_ALG_HANDLE ((BCRYPT_ALG_HANDLE)0x00000041)
+#endif
   BCryptHash(BCRYPT_SHA256_ALG_HANDLE, nullptr, 0,
              static_cast<PUCHAR>(const_cast<void*>(data)),
              static_cast<ULONG>(count), hash.data(),

--- a/google/cloud/internal/sha256_hmac.cc
+++ b/google/cloud/internal/sha256_hmac.cc
@@ -38,6 +38,11 @@ Sha256Type Sha256HmacImpl(absl::Span<T const> key, unsigned char const* data,
                           std::size_t count) {
   Sha256Type hash;
 #ifdef _WIN32
+// Workaround missing macros in MinGW-w64:
+//     https://github.com/mingw-w64/mingw-w64/issues/49
+#ifndef BCRYPT_HMAC_SHA256_ALG_HANDLE
+#define BCRYPT_HMAC_SHA256_ALG_HANDLE ((BCRYPT_ALG_HANDLE)0x000000b1)
+#endif
   BCryptHash(BCRYPT_HMAC_SHA256_ALG_HANDLE,
              reinterpret_cast<PUCHAR>(const_cast<T*>(key.data())),
              static_cast<ULONG>(key.size()), const_cast<PUCHAR>(data),


### PR DESCRIPTION
Fixes #14436

If you need to verify the values, consider:

https://github.com/wine-mirror/wine/blob/94fd0561b740dbb94608a8c4b3e1283e345e8c7a/include/bcrypt.h#L450
https://github.com/wine-mirror/wine/blob/94fd0561b740dbb94608a8c4b3e1283e345e8c7a/include/bcrypt.h#L457

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14437)
<!-- Reviewable:end -->
