### PR TITLE
test(bigtable): speed up coverage startup time

### DIFF
--- a/google/cloud/bigtable/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/bigtable/ci/run_integration_tests_emulator_bazel.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../../../ci/lib/init.sh"
 source module /ci/cloudbuild/builds/lib/cloudcxxrc.sh
+source module ci/lib/io.sh
 
 if [[ $# -lt 1 ]]; then
   echo "Usage: $(basename "$0") <bazel-program> [bazel-test-args]"
@@ -45,6 +46,13 @@ CBT_INSTANCE_ADMIN_EMULATOR_START=(
   --
   //google/cloud/bigtable/tests:instance_admin_emulator
 )
+# We need to build `instance_admin_emulator` without coverage, so it can start
+# up quickly.
+if [[ "${BAZEL_VERB}" == "coverage" ]]; then
+  io::run "${BAZEL_BIN}" build "${bazel_test_args[@]}" \
+    //google/cloud/bigtable/tests:instance_admin_emulator
+fi
+
 source module /google/cloud/bigtable/tools/run_emulator_utils.sh
 
 # These can only run against production

--- a/google/cloud/bigtable/tools/run_emulator_utils.sh
+++ b/google/cloud/bigtable/tools/run_emulator_utils.sh
@@ -35,13 +35,13 @@ function kill_emulators() {
   wait "${INSTANCE_ADMIN_EMULATOR_PID}" >/dev/null 2>&1 || echo -n "+"
   echo "."
 
-  for log in emulator.log bigtable-instance-emulator.log; do
+  for log in emulator.log instance-admin-emulator.log; do
     echo "================ ${log} ================"
     cat --number --show-nonprinting "${HOME}/${log}" | head || true
-    cat --number --show-nonprinting "${BINARY_DIR}/${log}" | head || true
+    cat --number --show-nonprinting "${BINARY_DIR:-}/${log}" | head || true
     echo "================ ${log} ================"
     cat --number --show-nonprinting "${HOME}/${log}" | tail || true
-    cat --number --show-nonprinting "${BINARY_DIR}/${log}" | tail || true
+    cat --number --show-nonprinting "${BINARY_DIR:-}/${log}" | tail || true
     echo "================ ${log} ================"
   done
 }
@@ -97,7 +97,8 @@ function start_emulators() {
   EMULATOR_PID=$!
 
   # The path to this command must be set by the caller.
-  env -C "${PROJECT_ROOT}" "${CBT_INSTANCE_ADMIN_EMULATOR_START[@]}" "${instance_admin_emulator_port}" >instance-admin-emulator.log 2>&1 </dev/null &
+  echo env -C "${PROJECT_ROOT}" "${CBT_INSTANCE_ADMIN_EMULATOR_START[@]}" "${instance_admin_emulator_port}" >instance-admin-emulator.log 2>&1
+  env -C "${PROJECT_ROOT}" "${CBT_INSTANCE_ADMIN_EMULATOR_START[@]}" "${instance_admin_emulator_port}" >>instance-admin-emulator.log 2>&1 </dev/null &
   INSTANCE_ADMIN_EMULATOR_PID=$!
 
   wait_until_emulator_connects "localhost:${emulator_port}" "ls"


### PR DESCRIPTION
The coverage build may be slow to start because it needs to compile the
bigtable emulator with different flags. We cannot use `bazel run` to run
a binary compiled with coverage support.

I also fixed some mistakes in the emulator log dumps.

Part of the work for #11485

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14446)
<!-- Reviewable:end -->
