### PR TITLE
ci: use `bzlmod` for `asan` build

### DIFF
--- a/ci/cloudbuild/builds/asan.sh
+++ b/ci/cloudbuild/builds/asan.sh
@@ -23,13 +23,7 @@ source module ci/cloudbuild/builds/lib/integration.sh
 source module ci/lib/io.sh
 
 mapfile -t args < <(bazel::common_args)
-args+=(
-  --config=asan
-  # TODO(#11485) - asan claims ODR violations when building googleapis and gRPC
-  #   under bzlmod. Disable for now.
-  #   https://github.com/bazelbuild/bazel-central-registry/issues/2334
-  --noenable_bzlmod
-)
+args+=(--config=asan)
 io::run bazel test "${args[@]}" --test_tag_filters=-integration-test "${BAZEL_TARGETS[@]}"
 
 mapfile -t integration_args < <(integration::bazel_args)


### PR DESCRIPTION
The ODR problems are fixed in the Bazel Central Registry modules.

Part of the work for #11485

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14447)
<!-- Reviewable:end -->
