### PR TITLE
cleanup(build): fix typo in windows-cmake.sh

### DIFF
--- a/ci/gha/builds/windows-cmake.sh
+++ b/ci/gha/builds/windows-cmake.sh
@@ -21,7 +21,7 @@ source module ci/gha/builds/lib/windows.sh
 source module ci/gha/builds/lib/cmake.sh
 source module ci/gha/builds/lib/ctest.sh
 
-# Usage: macos-cmake.sh <build-type> <value for GOOGLE_CLOUD_CPP_ENABLE>
+# Usage: windows-cmake.sh <build-type> <value for GOOGLE_CLOUD_CPP_ENABLE>
 #
 # The build-type sets `-DCMAKE_BUILD_TYPE`, typically Release or Debug.
 #


### PR DESCRIPTION
Fix typo, should be `windows` in windows-cmake.sh rather than `macos`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14455)
<!-- Reviewable:end -->
