### PR TITLE
ci(bazel): dynamically add dependency cache

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -35,6 +35,11 @@ build:macos --host_cxxopt=-std=c++14
 # the project separately.
 build --experimental_convenience_symlinks=ignore
 
+# We mirror critical tarballs from several sources in case the canonical source
+# is temporarily unavailable, e.g., github.com being down. This option and flag
+# automatically rewrites the URLs.
+build --experimental_downloader_config=bazel/downloader.cfg
+
 # It is frustrating when long-running builds/tests fail, but it is even more
 # frustrating when they fail and don't give any output. So, remove the limit.
 build --experimental_ui_max_stdouterr_bytes=-1

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -59,7 +59,6 @@ archive_override(
     patches = ["//bazel:googleapis.modules.patch"],
     strip_prefix = "googleapis-622e10a1e8b2b6908e0ac7448d347a0c1b4130de",
     urls = [
-        "https://storage.googleapis.com/cloud-cpp-community-archive/com_google_googleapis/622e10a1e8b2b6908e0ac7448d347a0c1b4130de.tar.gz",
         "https://github.com/googleapis/googleapis/archive/622e10a1e8b2b6908e0ac7448d347a0c1b4130de.tar.gz",
     ],
 )

--- a/bazel/bzlmod0.bzl
+++ b/bazel/bzlmod0.bzl
@@ -34,7 +34,6 @@ def gl_cpp_bzlmod0(name = None):
         http_archive,
         name = "com_github_curl_curl",
         urls = [
-            "https://storage.googleapis.com/cloud-cpp-community-archive/com_github_curl_curl/curl-7.69.1.tar.gz",
             "https://curl.haxx.se/download/curl-7.69.1.tar.gz",
         ],
         sha256 = "01ae0c123dee45b01bbaef94c0bc00ed2aec89cb2ee0fd598e0d302a6b5e0a98",

--- a/bazel/development0.bzl
+++ b/bazel/development0.bzl
@@ -45,7 +45,6 @@ def gl_cpp_development0(name = None):
         http_archive,
         name = "libpfm",
         urls = [
-            "https://storage.googleapis.com/cloud-cpp-community-archive/libpfm/libpfm-4.11.0.tar.gz",
             "https://sourceforge.net/projects/perfmon2/files/libpfm4/libpfm-4.11.0.tar.gz",
         ],
         sha256 = "5da5f8872bde14b3634c9688d980f68bda28b510268723cc12973eedbab9fecc",
@@ -58,7 +57,6 @@ def gl_cpp_development0(name = None):
         http_archive,
         name = "com_google_benchmark",
         urls = [
-            "https://storage.googleapis.com/cloud-cpp-community-archive/com_google_benchmark/v1.8.4.tar.gz",
             "https://github.com/google/benchmark/archive/v1.8.4.tar.gz",
         ],
         sha256 = "3e7059b6b11fb1bbe28e33e02519398ca94c1818874ebed18e504dc6f709be45",
@@ -71,7 +69,6 @@ def gl_cpp_development0(name = None):
         http_archive,
         name = "com_github_jbeder_yaml_cpp",
         urls = [
-            "https://storage.googleapis.com/cloud-cpp-community-archive/com_github_jbeder_yaml_cpp/0.8.0.tar.gz",
             "https://github.com/jbeder/yaml-cpp/archive/0.8.0.tar.gz",
         ],
         sha256 = "fbe74bbdcee21d656715688706da3c8becfd946d92cd44705cc6098bb23b3a16",

--- a/bazel/development2.bzl
+++ b/bazel/development2.bzl
@@ -34,7 +34,6 @@ def gl_cpp_development2(name = None):
         http_archive,
         name = "com_github_zeux_pugixml",
         urls = [
-            "https://storage.googleapis.com/cloud-cpp-community-archive/com_github_zeux_pugixml/v1.14.tar.gz",
             "https://github.com/zeux/pugixml/archive/v1.14.tar.gz",
         ],
         sha256 = "610f98375424b5614754a6f34a491adbddaaec074e9044577d965160ec103d2e",

--- a/bazel/downloader.cfg
+++ b/bazel/downloader.cfg
@@ -1,0 +1,18 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Automatically provide fallbacks for Bazel downloads.
+
+rewrite (github.com)/(.*) storage.googleapis.com/cloud-cpp-community-archive/$1/$2
+rewrite (github.com)/(.*) $1/$2

--- a/bazel/workspace0.bzl
+++ b/bazel/workspace0.bzl
@@ -61,8 +61,6 @@ def gl_cpp_workspace0(name = None):
         http_archive,
         name = "platforms",
         urls = [
-            "https://storage.googleapis.com/cloud-cpp-community-archive/platforms/platforms-0.0.10.tar.gz",
-            "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
             "https://github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
         ],
         sha256 = "218efe8ee736d26a3572663b374a253c012b716d8af0c07e842e82f238a0a7ee",
@@ -73,7 +71,6 @@ def gl_cpp_workspace0(name = None):
         http_archive,
         name = "rules_cc",
         urls = [
-            "https://storage.googleapis.com/cloud-cpp-community-archive/rules_cc/rules_cc-0.0.9.tar.gz",
             "https://github.com/bazelbuild/rules_cc/releases/download/0.0.9/rules_cc-0.0.9.tar.gz",
         ],
         sha256 = "2037875b9a4456dce4a79d112a8ae885bbc4aad968e6587dca6e64f3a0900cdf",
@@ -85,7 +82,6 @@ def gl_cpp_workspace0(name = None):
         http_archive,
         name = "build_bazel_rules_apple",
         urls = [
-            "https://storage.googleapis.com/cloud-cpp-community-archive/build_bazel_rules_apple/rules_apple.3.6.0.tar.gz",
             "https://github.com/bazelbuild/rules_apple/releases/download/3.6.0/rules_apple.3.6.0.tar.gz",
         ],
         sha256 = "d0f566ad408a6e4d179f0ac4d50a93494a70fcff8fab4c4af0a25b2c241c9b8d",
@@ -96,7 +92,6 @@ def gl_cpp_workspace0(name = None):
         http_archive,
         name = "com_google_absl",
         urls = [
-            "https://storage.googleapis.com/cloud-cpp-community-archive/com_google_absl/20240116.2.tar.gz",
             "https://github.com/abseil/abseil-cpp/archive/20240116.2.tar.gz",
         ],
         sha256 = "733726b8c3a6d39a4120d7e45ea8b41a434cdacde401cba500f14236c49b39dc",
@@ -109,7 +104,6 @@ def gl_cpp_workspace0(name = None):
         http_archive,
         name = "com_google_googletest",
         urls = [
-            "https://storage.googleapis.com/cloud-cpp-community-archive/com_google_googletest/v1.14.0.tar.gz",
             "https://github.com/google/googletest/archive/v1.14.0.tar.gz",
         ],
         sha256 = "8ad598c73ad796e0d8280b082cebd82a630d73e73cd3c70057938a6501bba5d7",
@@ -121,7 +115,6 @@ def gl_cpp_workspace0(name = None):
         http_archive,
         name = "com_google_googleapis",
         urls = [
-            "https://storage.googleapis.com/cloud-cpp-community-archive/com_google_googleapis/622e10a1e8b2b6908e0ac7448d347a0c1b4130de.tar.gz",
             "https://github.com/googleapis/googleapis/archive/622e10a1e8b2b6908e0ac7448d347a0c1b4130de.tar.gz",
         ],
         sha256 = "33c62c03f9479728bdaa1a6553d8b35fa273d010706c75ea85cd8dfe1687586c",
@@ -142,7 +135,6 @@ def gl_cpp_workspace0(name = None):
         http_archive,
         name = "com_google_protobuf",
         urls = [
-            "https://storage.googleapis.com/cloud-cpp-community-archive/com_google_protobuf/v27.2.tar.gz",
             "https://github.com/protocolbuffers/protobuf/archive/v27.2.tar.gz",
         ],
         sha256 = "e4ff2aeb767da6f4f52485c2e72468960ddfe5262483879ef6ad552e52757a77",
@@ -155,7 +147,6 @@ def gl_cpp_workspace0(name = None):
         http_archive,
         name = "boringssl",
         urls = [
-            "https://storage.googleapis.com/cloud-cpp-community-archive/boringssl/82a53d8c902f940eb1310f76a0b96c40c67f632f.tar.gz",
             # Use https://github.com/google/boringssl instead of
             # https://boringssl.googlesource.com/boringssl as the
             # former has a (more) consistent sha256.
@@ -170,7 +161,6 @@ def gl_cpp_workspace0(name = None):
         http_archive,
         name = "com_github_grpc_grpc",
         urls = [
-            "https://storage.googleapis.com/cloud-cpp-community-archive/com_github_grpc_grpc/v1.64.2.tar.gz",
             "https://github.com/grpc/grpc/archive/v1.64.2.tar.gz",
         ],
         sha256 = "c682fc39baefc6e804d735e6b48141157b7213602cc66dbe0bf375b904d8b5f9",
@@ -194,7 +184,6 @@ def gl_cpp_workspace0(name = None):
         http_archive,
         name = "com_github_curl_curl",
         urls = [
-            "https://storage.googleapis.com/cloud-cpp-community-archive/com_github_curl_curl/curl-7.69.1.tar.gz",
             "https://curl.haxx.se/download/curl-7.69.1.tar.gz",
         ],
         sha256 = "01ae0c123dee45b01bbaef94c0bc00ed2aec89cb2ee0fd598e0d302a6b5e0a98",
@@ -207,7 +196,6 @@ def gl_cpp_workspace0(name = None):
         http_archive,
         name = "com_github_nlohmann_json",
         urls = [
-            "https://storage.googleapis.com/cloud-cpp-community-archive/com_github_nlohmann_json/v3.11.3.tar.gz",
             "https://github.com/nlohmann/json/archive/v3.11.3.tar.gz",
         ],
         sha256 = "0d8ef5af7f9794e3263480193c491549b2ba6cc74bb018906202ada498a79406",
@@ -219,7 +207,6 @@ def gl_cpp_workspace0(name = None):
         http_archive,
         name = "com_github_google_crc32c",
         urls = [
-            "https://storage.googleapis.com/cloud-cpp-community-archive/com_github_google_crc32c/1.1.2.tar.gz",
             "https://github.com/google/crc32c/archive/1.1.2.tar.gz",
         ],
         sha256 = "ac07840513072b7fcebda6e821068aa04889018f24e10e46181068fb214d7e56",
@@ -235,7 +222,6 @@ def gl_cpp_workspace0(name = None):
         http_archive,
         name = "io_opentelemetry_cpp",
         urls = [
-            "https://storage.googleapis.com/cloud-cpp-community-archive/io_opentelemetry_cpp/v1.16.0.tar.gz",
             "https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.16.0.tar.gz",
         ],
         sha256 = "2209af23f43094651ddf007d44153c23facd41d9891b9b2d8cbc2dc9bb8064dd",

--- a/external/googleapis/CMakeLists.txt
+++ b/external/googleapis/CMakeLists.txt
@@ -22,7 +22,7 @@ include(GoogleapisConfig)
 
 set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL
     "https://github.com/googleapis/googleapis/archive/${_GOOGLE_CLOUD_CPP_GOOGLEAPIS_COMMIT_SHA}.tar.gz"
-    "https://storage.googleapis.com/cloud-cpp-community-archive/com_google_googleapis/${_GOOGLE_CLOUD_CPP_GOOGLEAPIS_COMMIT_SHA}.tar.gz"
+    "https://storage.googleapis.com/cloud-cpp-community-archive/github.com/googleapis/googleapis/archive/${_GOOGLE_CLOUD_CPP_GOOGLEAPIS_COMMIT_SHA}.tar.gz"
 )
 set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL_HASH
     "${_GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256}")


### PR DESCRIPTION
Use Bazel's downloader config to dynamically rewrite the URLs that need
downloading. That means less hacking of our `MODULE.bazel`, and `*.bzl`
files.

Change the script that maintains the dependency cache to find all the
`bzlmod` dependencies via `bazel mod deps` and some Python scripting.

Part of the work for #11485

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14465)
<!-- Reviewable:end -->
