### PR TITLE
ci: reduce spanner CreateInstance rpcs in daily build

### DIFF
--- a/google/cloud/spanner/admin/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/instance_admin_integration_test.cc
@@ -215,10 +215,9 @@ TEST_F(InstanceAdminClientTest, InstanceCRUDOperations) {
 }
 
 TEST_F(InstanceAdminClientTest, CreateInstanceStartAwait) {
-  if (!Emulator() && !RunSlowInstanceTests()) {
-    GTEST_SKIP() << "skipping slow instance tests; set "
-                 << "GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS=instance"
-                 << " to override";
+  if (!Emulator()) {
+    GTEST_SKIP() << "skipping, as there is a quota on CreateInstance requests "
+                    "against production.";
   }
 
   Instance in(ProjectId(), spanner_testing::RandomInstanceName(generator_));

--- a/google/cloud/spanner/admin/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/instance_admin_integration_test.cc
@@ -157,10 +157,10 @@ TEST_F(InstanceAdminClientTest, InstanceReadOperations) {
 
 /// @test Verify the basic CRUD operations for instances work.
 TEST_F(InstanceAdminClientTest, InstanceCRUDOperations) {
-  if (!Emulator() && !RunSlowInstanceTests()) {
-    GTEST_SKIP() << "skipping slow instance tests; set "
-                 << "GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS=instance"
-                 << " to override";
+  if (!Emulator()) {
+    GTEST_SKIP() << "skipping, as there is a quota on CreateInstance requests "
+                    "against production, and other integration tests cover "
+                    "generated client functions for LROs.";
   }
 
   std::string instance_id = spanner_testing::RandomInstanceName(generator_);
@@ -211,43 +211,6 @@ TEST_F(InstanceAdminClientTest, InstanceCRUDOperations) {
     }
   }
 
-  EXPECT_STATUS_OK(client_.DeleteInstance(in.FullName()));
-}
-
-TEST_F(InstanceAdminClientTest, CreateInstanceStartAwait) {
-  if (!Emulator()) {
-    GTEST_SKIP() << "skipping, as there is a quota on CreateInstance requests "
-                    "against production.";
-  }
-
-  Instance in(ProjectId(), spanner_testing::RandomInstanceName(generator_));
-
-  auto config_name = spanner_testing::PickInstanceConfig(
-      in.project(), generator_,
-      [](google::spanner::admin::instance::v1::InstanceConfig const& config) {
-        return absl::StrContains(config.name(), "/regional-us-west");
-      });
-  ASSERT_FALSE(config_name.empty()) << "could not get an instance config";
-
-  auto operation =
-      client_.CreateInstance(ExperimentalTag{}, NoAwaitTag{},
-                             CreateInstanceRequestBuilder(in, config_name)
-                                 .SetDisplayName("test-display-name")
-                                 .SetNodeCount(1)
-                                 .SetLabels({{"label-key", "label-value"}})
-                                 .Build());
-  ASSERT_STATUS_OK(operation);
-
-  // Verify that an error is returned if there is a mismatch between the rpc
-  // that returned the operation and the rpc in which is it used.
-  auto instance_config =
-      client_.CreateInstanceConfig(ExperimentalTag{}, *operation).get();
-  EXPECT_THAT(instance_config, StatusIs(StatusCode::kInvalidArgument));
-
-  auto instance = client_.CreateInstance(ExperimentalTag{}, *operation).get();
-  ASSERT_STATUS_OK(instance);
-  EXPECT_EQ(instance->name(), in.FullName());
-  EXPECT_EQ(instance->display_name(), "test-display-name");
   EXPECT_STATUS_OK(client_.DeleteInstance(in.FullName()));
 }
 
@@ -360,24 +323,30 @@ TEST_F(InstanceAdminClientTest, InstanceConfigUserManaged) {
                 Eq("updated-value"));
   }
 
-  std::string instance_id = spanner_testing::RandomInstanceName(generator_);
-  Instance in(project, instance_id);
-  auto instance =
-      client_
-          .CreateInstance(CreateInstanceRequestBuilder(in, user_config->name())
-                              .SetDisplayName("test-display-name")
-                              .SetProcessingUnits(100)
-                              .SetLabels({{"label-key", "label-value"}})
-                              .Build())
-          .get();
-  EXPECT_THAT(instance, IsOk());
-  if (instance) {
-    EXPECT_EQ(instance->name(), in.FullName());
-    EXPECT_EQ(instance->config(), user_config->name());
-    EXPECT_EQ(instance->display_name(), "test-display-name");
-    EXPECT_EQ(instance->processing_units(), 100);
-    EXPECT_EQ(instance->labels().at("label-key"), "label-value");
-    EXPECT_THAT(client_.DeleteInstance(instance->name()), IsOk());
+  if (Emulator()) {
+    // there is a quota on CreateInstance requests against production, so only
+    // create an instance to verify the config when running against the
+    // emulator.
+    std::string instance_id = spanner_testing::RandomInstanceName(generator_);
+    Instance in(project, instance_id);
+    auto instance =
+        client_
+            .CreateInstance(
+                CreateInstanceRequestBuilder(in, user_config->name())
+                    .SetDisplayName("test-display-name")
+                    .SetProcessingUnits(100)
+                    .SetLabels({{"label-key", "label-value"}})
+                    .Build())
+            .get();
+    EXPECT_THAT(instance, IsOk());
+    if (instance) {
+      EXPECT_EQ(instance->name(), in.FullName());
+      EXPECT_EQ(instance->config(), user_config->name());
+      EXPECT_EQ(instance->display_name(), "test-display-name");
+      EXPECT_EQ(instance->processing_units(), 100);
+      EXPECT_EQ(instance->labels().at("label-key"), "label-value");
+      EXPECT_THAT(client_.DeleteInstance(instance->name()), IsOk());
+    }
   }
 
   EXPECT_THAT(client_.DeleteInstanceConfig(user_config->name()), IsOk());

--- a/google/cloud/spanner/admin/integration_tests/instance_admin_rest_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/instance_admin_rest_integration_test.cc
@@ -259,9 +259,10 @@ TEST_F(InstanceAdminClientRestTest, InstanceCRUDOperations) {
 }
 
 TEST_F(InstanceAdminClientRestTest, CreateInstanceStartAwait) {
-  if (!Emulator()) {
-    GTEST_SKIP() << "skipping, as there is a quota on CreateInstance requests "
-                    "against production.";
+  if (!Emulator() && !RunSlowInstanceTests()) {
+    GTEST_SKIP() << "skipping slow instance tests; set "
+                 << "GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS=instance"
+                 << " to override";
   }
 
   Instance in(ProjectId(), spanner_testing::RandomInstanceName(generator_));
@@ -281,6 +282,8 @@ TEST_F(InstanceAdminClientRestTest, CreateInstanceStartAwait) {
                                  .SetLabels({{"label-key", "label-value"}})
                                  .Build());
   ASSERT_STATUS_OK(operation);
+  // Verify that an error is returned if there is a mismatch between the RPC
+  // that returned the operation and the RPC in which is it used.
   auto instance_config =
       client_.CreateInstanceConfig(ExperimentalTag{}, *operation).get();
   EXPECT_THAT(instance_config, StatusIs(StatusCode::kInvalidArgument));

--- a/google/cloud/spanner/admin/integration_tests/instance_admin_rest_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/instance_admin_rest_integration_test.cc
@@ -259,10 +259,9 @@ TEST_F(InstanceAdminClientRestTest, InstanceCRUDOperations) {
 }
 
 TEST_F(InstanceAdminClientRestTest, CreateInstanceStartAwait) {
-  if (!Emulator() && !RunSlowInstanceTests()) {
-    GTEST_SKIP() << "skipping slow instance tests; set "
-                 << "GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS=instance"
-                 << " to override";
+  if (!Emulator()) {
+    GTEST_SKIP() << "skipping, as there is a quota on CreateInstance requests "
+                    "against production.";
   }
 
   Instance in(ProjectId(), spanner_testing::RandomInstanceName(generator_));


### PR DESCRIPTION
We have been seeing flakes in our `integration-daily` build.

e.g. https://console.cloud.google.com/cloud-build/builds;region=us-east1/2f83568c-9612-44d5-aafe-5c03e9f7a319?project=936212892354

```
google/cloud/spanner/admin/integration_tests/instance_admin_integration_test.cc:187: Failure
Value of: instance
Expected: code is equal to OK and message is anything
  Actual: 176-byte object <00-46 02-C8 BC-7F 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 ... 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00>, whose status is RESOURCE_EXHAUSTED: Error in non-idempotent operation: Quota exceeded for quota metric 'Instance create requests' and limit 'Instance create requests per minute' of service 'spanner.googleapis.com' for consumer 'project_number:936212892354'. error_info={reason=RATE_LIMIT_EXCEEDED, domain=googleapis.com, metadata={gcloud-cpp.retry.reason=non-idempotent, gcloud-cpp.retry.original-message=Quota exceeded for quota metric 'Instance create requests' and limit 'Instance create requests per minute' of service 'spanner.googleapis.com' for consumer 'project_number:936212892354'., quota_location=global, gcloud-cpp.retry.function=CreateInstance, service=spanner.googleapis.com, quota_limit=AdminInstanceCreateMethodQuotaPerMinutePerProject, quota_metric=spanner.googleapis.com/admin_instance_create_method_quota, quota_limit_value=5, consumer=projects/936212892354}}, with a code that isn't equal to OK, but a message that is anything
```

So reduce the `CreateInstance` calls that run against prod. In testing GAPIC LRO's we will prefer to use `CreateDatabase` instead of `CreateInstance`.

The gRPC transcoding tests are left as is to keep their coverage the same.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14468)
<!-- Reviewable:end -->
