### PR TITLE
ci: workaround bazel startup error

### DIFF
--- a/ci/cloudbuild/builds/lib/cloudcxxrc.sh
+++ b/ci/cloudbuild/builds/lib/cloudcxxrc.sh
@@ -36,9 +36,14 @@ fi
 function bazel::has_no_tests() {
   local target=$1
   shift
+  if [[ "${#BAZEL_TARGETS[@]}" -eq 0 ]]; then
+    return 0
+  fi
   query_expr="$(printf '+ %s' "${BAZEL_TARGETS[@]}")"
   query_expr="tests(${query_expr:2} intersect ${target})"
-  if ! bazel query --noshow_progress "${query_expr}" | grep -q "${target}"; then
+  # Tolerate failures in `bazel` as a workaround for:
+  #   https://github.com/bazelbuild/bazel/issues/14787
+  if ! (bazel query --noshow_progress "${query_expr}" || true) | grep -q "${target}"; then
     return 0
   fi
   return 1


### PR DESCRIPTION
Bazel can return an error if `stdout` is closed, which can be a problem
in pipelines.

More info at https://github.com/bazelbuild/bazel/issues/14787
