### PR TITLE
ci: change docker root password to a non-empty string

### DIFF
--- a/ci/cloudbuild/dockerfiles/fedora-latest-bazel.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-latest-bazel.Dockerfile
@@ -35,7 +35,7 @@ RUN dnf makecache && dnf install -y java-latest-openjdk-devel
 # inside the container with `su -` and no password. Sudo would not work because
 # we run these containers as the invoking user's uid, which does not exist in
 # the container's /etc/passwd file.
-RUN echo 'root:' | chpasswd
+RUN echo 'root:cloudcxx' | chpasswd
 
 WORKDIR /var/tmp/build
 

--- a/ci/cloudbuild/dockerfiles/fedora-latest-cmake.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-latest-cmake.Dockerfile
@@ -46,7 +46,7 @@ RUN dnf makecache && dnf install -y pugixml-devel yaml-cpp-devel
 # inside the container with `su -` and no password. Sudo would not work because
 # we run these containers as the invoking user's uid, which does not exist in
 # the container's /etc/passwd file.
-RUN echo 'root:' | chpasswd
+RUN echo "root:cloudcxx" | chpasswd
 
 # Fedora's version of `pkg-config` (https://github.com/pkgconf/pkgconf) is slow
 # when handling `.pc` files with lots of `Requires:` deps.  This problem is

--- a/ci/cloudbuild/dockerfiles/fedora-latest-cxx14.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-latest-cxx14.Dockerfile
@@ -41,7 +41,7 @@ RUN dnf makecache && dnf install -y java-latest-openjdk-devel
 # inside the container with `su -` and no password. Sudo would not work because
 # we run these containers as the invoking user's uid, which does not exist in
 # the container's /etc/passwd file.
-RUN echo 'root:' | chpasswd
+RUN echo 'root:cloudcxx' | chpasswd
 
 # Fedora's version of `pkg-config` (https://github.com/pkgconf/pkgconf) is slow
 # when handling `.pc` files with lots of `Requires:` deps, which happens with

--- a/ci/cloudbuild/dockerfiles/fedora-latest-cxx20.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-latest-cxx20.Dockerfile
@@ -43,7 +43,7 @@ RUN dnf makecache && dnf install -y java-latest-openjdk-devel
 # inside the container with `su -` and no password. Sudo would not work because
 # we run these containers as the invoking user's uid, which does not exist in
 # the container's /etc/passwd file.
-RUN echo 'root:' | chpasswd
+RUN echo 'root:cloudcxx' | chpasswd
 
 # Fedora's version of `pkg-config` (https://github.com/pkgconf/pkgconf) is slow
 # when handling `.pc` files with lots of `Requires:` deps, which happens with

--- a/ci/cloudbuild/dockerfiles/fedora-latest-publish-docs.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-latest-publish-docs.Dockerfile
@@ -44,7 +44,7 @@ RUN dnf makecache && dnf install -y libxslt
 # inside the container with `su -` and no password. Sudo would not work because
 # we run these containers as the invoking user's uid, which does not exist in
 # the container's /etc/passwd file.
-RUN echo 'root:' | chpasswd
+RUN echo 'root:cloudcxx' | chpasswd
 
 # We would prefer to say `dnf install -y doxygen`, but Fedora 40 ships with
 # Doxygen 1.10.0 and we need fixes that were released in Doxygen 1.11.0. Also,

--- a/ci/cloudbuild/dockerfiles/fedora-m32.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-m32.Dockerfile
@@ -59,7 +59,7 @@ RUN dnf makecache && dnf install -y java-latest-openjdk-devel
 # inside the container with `su -` and no password. Sudo would not work because
 # we run these containers as the invoking user's uid, which does not exist in
 # the container's /etc/passwd file.
-RUN echo 'root:' | chpasswd
+RUN echo 'root:cloudcxx' | chpasswd
 
 # Fedora's version of `pkg-config` (https://github.com/pkgconf/pkgconf) is slow
 # when handling `.pc` files with lots of `Requires:` deps, which happens with

--- a/ci/cloudbuild/dockerfiles/fedora-msan.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-msan.Dockerfile
@@ -35,7 +35,7 @@ RUN dnf makecache && dnf install -y java-latest-openjdk-devel
 # inside the container with `su -` and no password. Sudo would not work because
 # we run these containers as the invoking user's uid, which does not exist in
 # the container's /etc/passwd file.
-RUN echo 'root:' | chpasswd
+RUN echo 'root:cloudcxx' | chpasswd
 
 WORKDIR /var/tmp/build
 


### PR DESCRIPTION
Set the docker root password to `cloudcxx`, because empty password doesn't work for `su -` in docker container.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14470)
<!-- Reviewable:end -->
