### PR TITLE
doc: fix typo in ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -107,8 +107,8 @@ defined, there are separate `${library}::*Client` objects.
 
 These are some examples:
 
-- Bigtable has a [`bigtable::DataClient`](/google/cloud/bigtable/data_client.h) client. It
-  also has two admin clients:
+- Bigtable has a [`bigtable::DataClient`](/google/cloud/bigtable/data_client.h)
+  client. It also has two admin clients:
   [`bigtable_admin::BigtableInstanceAdminClient`](/google/cloud/bigtable/admin/bigtable_instance_admin_client.h)
   and
   [`bigtable_admin::BigtableTableAdminClient`](/google/cloud/bigtable/admin/bigtable_table_admin_client.h).

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -107,7 +107,7 @@ defined, there are separate `${library}::*Client` objects.
 
 These are some examples:
 
-- Bigtable has a [`bigtable::Table`](/google/cloud/bigtable/table.h) client. It
+- Bigtable has a [`bigtable::DataClient`](/google/cloud/bigtable/data_client.h) client. It
   also has two admin clients:
   [`bigtable_admin::BigtableInstanceAdminClient`](/google/cloud/bigtable/admin/bigtable_instance_admin_client.h)
   and


### PR DESCRIPTION
Fix the typo of text and link.

`DataClient` is the client class, instead of `Table`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14471)
<!-- Reviewable:end -->
