### PR TITLE
impl(storage): trace spans for `ReadObject` backoffs

### DIFF
--- a/google/cloud/storage/internal/retry_object_read_source.cc
+++ b/google/cloud/storage/internal/retry_object_read_source.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/internal/retry_object_read_source.h"
 #include "google/cloud/internal/make_status.h"
+#include "google/cloud/internal/opentelemetry.h"
 #include <algorithm>
 #include <sstream>
 #include <string>
@@ -52,7 +53,10 @@ RetryObjectReadSource::RetryObjectReadSource(
       offset_direction_(request_.HasOption<ReadLast>() ? kFromEnd
                                                        : kFromBeginning),
       current_offset_(InitialOffset(offset_direction_, request_)),
-      backoff_(std::move(backoff)) {}
+      backoff_(std::move(backoff)) {
+  backoff_ = google::cloud::internal::MakeTracedSleeper(
+      *options_, std::move(backoff_), "Backoff");
+}
 
 RetryObjectReadSource::RetryObjectReadSource(
     ReadSourceFactory factory,

--- a/google/cloud/storage/internal/retry_object_read_source.cc
+++ b/google/cloud/storage/internal/retry_object_read_source.cc
@@ -53,10 +53,8 @@ RetryObjectReadSource::RetryObjectReadSource(
       offset_direction_(request_.HasOption<ReadLast>() ? kFromEnd
                                                        : kFromBeginning),
       current_offset_(InitialOffset(offset_direction_, request_)),
-      backoff_(std::move(backoff)) {
-  backoff_ = google::cloud::internal::MakeTracedSleeper(
-      *options_, std::move(backoff_), "Backoff");
-}
+      backoff_(google::cloud::internal::MakeTracedSleeper(
+          *options_, std::move(backoff), "Backoff")) {}
 
 RetryObjectReadSource::RetryObjectReadSource(
     ReadSourceFactory factory,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14472)
<!-- Reviewable:end -->
