### PR TITLE
cleanup(bigtable): fix some IWYU problems

### DIFF
--- a/google/cloud/bigtable/internal/legacy_async_row_reader_test.cc
+++ b/google/cloud/bigtable/internal/legacy_async_row_reader_test.cc
@@ -23,6 +23,8 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include "google/cloud/testing_util/validate_metadata.h"
 #include <gmock/gmock.h>
+#include <iomanip>
+#include <sstream>
 #include <thread>
 
 namespace google {

--- a/google/cloud/bigtable/tests/table_sample_rows_integration_test.cc
+++ b/google/cloud/bigtable/tests/table_sample_rows_integration_test.cc
@@ -23,8 +23,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <chrono>
+#include <iomanip>
 #include <memory>
-#include <ostream>
+#include <sstream>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
In this case, missing `#include <iomanip>` which was implicitly included
via googletest.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14479)
<!-- Reviewable:end -->
