### PR TITLE
cleanup(storage): simplify integration test init

### DIFF
--- a/google/cloud/storage/testing/storage_integration_test.h
+++ b/google/cloud/storage/testing/storage_integration_test.h
@@ -49,6 +49,9 @@ class StorageIntegrationTest
   static google::cloud::StatusOr<google::cloud::storage::Client>
   MakeIntegrationTestClient();
 
+  static google::cloud::storage::Client MakeIntegrationTestClient(
+      google::cloud::Options opts);
+
   /**
    * Return a client with retry policies suitable for CreateBucket() class.
    *
@@ -57,17 +60,7 @@ class StorageIntegrationTest
    * one bucket every two seconds, suggesting that the default backoff should be
    * at least that long.
    */
-  static google::cloud::StatusOr<google::cloud::storage::Client>
-  MakeBucketIntegrationTestClient();
-
-  /// Like MakeIntegrationTestClient() but with a custom retry policy
-  static google::cloud::StatusOr<google::cloud::storage::Client>
-  MakeIntegrationTestClient(std::unique_ptr<RetryPolicy> retry_policy);
-
-  /// Like MakeIntegrationTestClient() but with custom retry and bucket policies
-  static google::cloud::StatusOr<google::cloud::storage::Client>
-  MakeIntegrationTestClient(std::unique_ptr<RetryPolicy> retry_policy,
-                            std::unique_ptr<BackoffPolicy> backoff_policy);
+  static google::cloud::storage::Client MakeBucketIntegrationTestClient();
 
   static std::unique_ptr<BackoffPolicy> TestBackoffPolicy();
   static std::unique_ptr<RetryPolicy> TestRetryPolicy();

--- a/google/cloud/storage/tests/grpc_default_object_acl_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_default_object_acl_integration_test.cc
@@ -45,12 +45,11 @@ TEST_F(GrpcDefaultObjectAclIntegrationTest, AclCRUD) {
 
   std::string bucket_name = MakeRandomBucketName();
   auto client = MakeBucketIntegrationTestClient();
-  ASSERT_STATUS_OK(client);
 
   // Create a new bucket to run the test, with the "private"
   // PredefinedDefaultObjectAcl, so we know what the contents of the ACL will
   // be.
-  auto metadata = client->CreateBucketForProject(
+  auto metadata = client.CreateBucketForProject(
       bucket_name, project_id, BucketMetadata(),
       PredefinedDefaultObjectAcl("authenticatedRead"), Projection("full"));
   ASSERT_STATUS_OK(metadata);
@@ -70,38 +69,38 @@ TEST_F(GrpcDefaultObjectAclIntegrationTest, AclCRUD) {
       << " this result.";
 
   auto const existing_entity = metadata->default_acl().front();
-  auto current_acl = client->ListDefaultObjectAcl(bucket_name);
+  auto current_acl = client.ListDefaultObjectAcl(bucket_name);
   ASSERT_STATUS_OK(current_acl);
   EXPECT_THAT(AclEntityNames(*current_acl),
               Contains(existing_entity.entity()).Times(1));
 
   auto get_acl =
-      client->GetDefaultObjectAcl(bucket_name, existing_entity.entity());
+      client.GetDefaultObjectAcl(bucket_name, existing_entity.entity());
   ASSERT_STATUS_OK(get_acl);
   EXPECT_EQ(*get_acl, existing_entity);
 
   auto not_found_acl =
-      client->GetDefaultObjectAcl(bucket_name, "not-found-entity");
+      client.GetDefaultObjectAcl(bucket_name, "not-found-entity");
   EXPECT_THAT(not_found_acl, StatusIs(StatusCode::kNotFound));
 
-  auto create_acl = client->CreateDefaultObjectAcl(
+  auto create_acl = client.CreateDefaultObjectAcl(
       bucket_name, viewers, ObjectAccessControl::ROLE_READER());
   ASSERT_STATUS_OK(create_acl);
 
-  current_acl = client->ListDefaultObjectAcl(bucket_name);
+  current_acl = client.ListDefaultObjectAcl(bucket_name);
   ASSERT_STATUS_OK(current_acl);
   EXPECT_THAT(AclEntityNames(*current_acl),
               Contains(create_acl->entity()).Times(1));
 
-  auto c2 = client->CreateDefaultObjectAcl(bucket_name, viewers,
-                                           ObjectAccessControl::ROLE_READER());
+  auto c2 = client.CreateDefaultObjectAcl(bucket_name, viewers,
+                                          ObjectAccessControl::ROLE_READER());
   ASSERT_STATUS_OK(c2);
   // There is no guarantee that the ETag remains unchanged, even if the
   // operation has no effect.  Reset the one field that might change.
   create_acl->set_etag(c2->etag());
   EXPECT_EQ(*create_acl, *c2);
 
-  auto updated_acl = client->UpdateDefaultObjectAcl(
+  auto updated_acl = client.UpdateDefaultObjectAcl(
       bucket_name, ObjectAccessControl().set_entity(viewers).set_role(
                        ObjectAccessControl::ROLE_OWNER()));
   ASSERT_STATUS_OK(updated_acl);
@@ -109,41 +108,41 @@ TEST_F(GrpcDefaultObjectAclIntegrationTest, AclCRUD) {
   EXPECT_EQ(updated_acl->role(), ObjectAccessControl::ROLE_OWNER());
 
   // "Updating" an entity that does not exist should create the entity
-  auto delete_acl = client->DeleteDefaultObjectAcl(bucket_name, viewers);
+  auto delete_acl = client.DeleteDefaultObjectAcl(bucket_name, viewers);
   ASSERT_STATUS_OK(delete_acl);
-  updated_acl = client->UpdateDefaultObjectAcl(
+  updated_acl = client.UpdateDefaultObjectAcl(
       bucket_name, ObjectAccessControl().set_entity(viewers).set_role(
                        ObjectAccessControl::ROLE_OWNER()));
   ASSERT_STATUS_OK(updated_acl);
 
   auto patched_acl =
-      client->PatchDefaultObjectAcl(bucket_name, viewers,
-                                    ObjectAccessControlPatchBuilder().set_role(
-                                        ObjectAccessControl::ROLE_READER()));
+      client.PatchDefaultObjectAcl(bucket_name, viewers,
+                                   ObjectAccessControlPatchBuilder().set_role(
+                                       ObjectAccessControl::ROLE_READER()));
   ASSERT_STATUS_OK(patched_acl);
   EXPECT_EQ(patched_acl->entity(), create_acl->entity());
   EXPECT_EQ(patched_acl->role(), ObjectAccessControl::ROLE_READER());
 
   // "Patching" an entity that does not exist should create the entity
-  delete_acl = client->DeleteDefaultObjectAcl(bucket_name, viewers);
+  delete_acl = client.DeleteDefaultObjectAcl(bucket_name, viewers);
   ASSERT_STATUS_OK(delete_acl);
   patched_acl =
-      client->PatchDefaultObjectAcl(bucket_name, viewers,
-                                    ObjectAccessControlPatchBuilder().set_role(
-                                        ObjectAccessControl::ROLE_READER()));
+      client.PatchDefaultObjectAcl(bucket_name, viewers,
+                                   ObjectAccessControlPatchBuilder().set_role(
+                                       ObjectAccessControl::ROLE_READER()));
   ASSERT_STATUS_OK(patched_acl);
   EXPECT_EQ(patched_acl->entity(), create_acl->entity());
   EXPECT_EQ(patched_acl->role(), ObjectAccessControl::ROLE_READER());
 
-  delete_acl = client->DeleteDefaultObjectAcl(bucket_name, viewers);
+  delete_acl = client.DeleteDefaultObjectAcl(bucket_name, viewers);
   ASSERT_STATUS_OK(delete_acl);
 
-  current_acl = client->ListDefaultObjectAcl(bucket_name);
+  current_acl = client.ListDefaultObjectAcl(bucket_name);
   ASSERT_STATUS_OK(current_acl);
   EXPECT_THAT(AclEntityNames(*current_acl),
               Not(Contains(create_acl->entity())));
 
-  auto status = client->DeleteBucket(bucket_name);
+  auto status = client.DeleteBucket(bucket_name);
   ASSERT_STATUS_OK(status);
 }
 

--- a/google/cloud/storage/tests/grpc_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_integration_test.cc
@@ -63,14 +63,13 @@ class GrpcIntegrationTest
 
 TEST_P(GrpcIntegrationTest, ObjectCRUD) {
   auto bucket_client = MakeBucketIntegrationTestClient();
-  ASSERT_STATUS_OK(bucket_client);
 
   auto client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   auto bucket_name = MakeRandomBucketName();
   auto object_name = MakeRandomObjectName();
-  auto bucket_metadata = bucket_client->CreateBucketForProject(
+  auto bucket_metadata = bucket_client.CreateBucketForProject(
       bucket_name, project_id(), BucketMetadata());
   ASSERT_STATUS_OK(bucket_metadata);
 
@@ -91,20 +90,19 @@ TEST_P(GrpcIntegrationTest, ObjectCRUD) {
       bucket_name, object_name, Generation(object_metadata->generation()));
   EXPECT_STATUS_OK(delete_object_status);
 
-  auto delete_bucket_status = bucket_client->DeleteBucket(bucket_name);
+  auto delete_bucket_status = bucket_client.DeleteBucket(bucket_name);
   EXPECT_STATUS_OK(delete_bucket_status);
 }
 
 TEST_P(GrpcIntegrationTest, WriteResume) {
   auto bucket_client = MakeBucketIntegrationTestClient();
-  ASSERT_STATUS_OK(bucket_client);
 
   auto client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   auto bucket_name = MakeRandomBucketName();
   auto object_name = MakeRandomObjectName();
-  auto bucket_metadata = bucket_client->CreateBucketForProject(
+  auto bucket_metadata = bucket_client.CreateBucketForProject(
       bucket_name, project_id(), BucketMetadata());
   ASSERT_STATUS_OK(bucket_metadata);
 
@@ -142,20 +140,19 @@ TEST_P(GrpcIntegrationTest, WriteResume) {
   auto status = client->DeleteObject(bucket_name, object_name);
   EXPECT_STATUS_OK(status);
 
-  auto delete_bucket_status = bucket_client->DeleteBucket(bucket_name);
+  auto delete_bucket_status = bucket_client.DeleteBucket(bucket_name);
   EXPECT_STATUS_OK(delete_bucket_status);
 }
 
 TEST_P(GrpcIntegrationTest, InsertLarge) {
   auto bucket_client = MakeBucketIntegrationTestClient();
-  ASSERT_STATUS_OK(bucket_client);
 
   auto client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   auto bucket_name = MakeRandomBucketName();
   auto object_name = MakeRandomObjectName();
-  auto bucket_metadata = bucket_client->CreateBucketForProject(
+  auto bucket_metadata = bucket_client.CreateBucketForProject(
       bucket_name, project_id(), BucketMetadata());
   ASSERT_STATUS_OK(bucket_metadata);
   ScheduleForDelete(*bucket_metadata);
@@ -174,14 +171,13 @@ TEST_P(GrpcIntegrationTest, InsertLarge) {
 
 TEST_P(GrpcIntegrationTest, StreamLargeChunks) {
   auto bucket_client = MakeBucketIntegrationTestClient();
-  ASSERT_STATUS_OK(bucket_client);
 
   auto client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   auto bucket_name = MakeRandomBucketName();
   auto object_name = MakeRandomObjectName();
-  auto bucket_metadata = bucket_client->CreateBucketForProject(
+  auto bucket_metadata = bucket_client.CreateBucketForProject(
       bucket_name, project_id(), BucketMetadata());
   ASSERT_STATUS_OK(bucket_metadata);
   ScheduleForDelete(*std::move(bucket_metadata));

--- a/google/cloud/storage/tests/grpc_notification_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_notification_integration_test.cc
@@ -54,36 +54,35 @@ TEST_F(GrpcNotificationIntegrationTest, NotificationCRUD) {
 
   std::string bucket_name = MakeRandomBucketName();
   auto client = MakeBucketIntegrationTestClient();
-  ASSERT_STATUS_OK(client);
 
   auto metadata =
-      client->CreateBucketForProject(bucket_name, project_id, BucketMetadata());
+      client.CreateBucketForProject(bucket_name, project_id, BucketMetadata());
   ASSERT_STATUS_OK(metadata);
   ScheduleForDelete(*metadata);
 
   auto marker = google::cloud::internal::Sample(
       generator_, 16, "abcdefghijklmnopqrstuvwxyz0123456789");
-  auto create = client->CreateNotification(
+  auto create = client.CreateNotification(
       bucket_name, topic_name,
       NotificationMetadata().upsert_custom_attributes("test-key", marker));
   ASSERT_STATUS_OK(create);
   EXPECT_THAT(create->custom_attributes(), Contains(Pair("test-key", marker)));
 
-  auto get = client->GetNotification(bucket_name, create->id());
+  auto get = client.GetNotification(bucket_name, create->id());
   ASSERT_STATUS_OK(get);
   EXPECT_EQ(*create, *get);
 
-  auto list = client->ListNotifications(bucket_name);
+  auto list = client.ListNotifications(bucket_name);
   ASSERT_STATUS_OK(list);
   EXPECT_THAT(*list, ElementsAre(*get));
 
-  auto delete_status = client->DeleteNotification(bucket_name, create->id());
+  auto delete_status = client.DeleteNotification(bucket_name, create->id());
   ASSERT_STATUS_OK(delete_status);
 
-  auto not_found = client->GetNotification(bucket_name, create->id());
+  auto not_found = client.GetNotification(bucket_name, create->id());
   EXPECT_THAT(not_found, StatusIs(StatusCode::kNotFound));
 
-  auto empty_list = client->ListNotifications(bucket_name);
+  auto empty_list = client.ListNotifications(bucket_name);
   ASSERT_STATUS_OK(empty_list);
   EXPECT_THAT(*empty_list, IsEmpty());
 }

--- a/google/cloud/storage/tests/object_list_objects_versions_integration_test.cc
+++ b/google/cloud/storage/tests/object_list_objects_versions_integration_test.cc
@@ -39,13 +39,12 @@ using ObjectListObjectsVersionsIntegrationTest =
 
 TEST_F(ObjectListObjectsVersionsIntegrationTest, ListObjectsVersions) {
   auto bucket_client = MakeBucketIntegrationTestClient();
-  ASSERT_STATUS_OK(bucket_client);
 
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = MakeRandomBucketName();
-  auto create = bucket_client->CreateBucketForProject(
+  auto create = bucket_client.CreateBucketForProject(
       bucket_name, project_id_,
       BucketMetadata{}.set_versioning(BucketVersioning{true}));
   ASSERT_STATUS_OK(create) << bucket_name;

--- a/google/cloud/storage/tests/thread_integration_test.cc
+++ b/google/cloud/storage/tests/thread_integration_test.cc
@@ -95,12 +95,11 @@ std::vector<ObjectNameList> DivideIntoEqualSizedGroups(
 TEST_F(ThreadIntegrationTest, Unshared) {
   std::string bucket_name = MakeRandomBucketName();
   auto bucket_client = MakeBucketIntegrationTestClient();
-  ASSERT_STATUS_OK(bucket_client);
 
-  StatusOr<Client> client = MakeIntegrationTestClient();
+  auto client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
-  StatusOr<BucketMetadata> meta = bucket_client->CreateBucketForProject(
+  StatusOr<BucketMetadata> meta = bucket_client.CreateBucketForProject(
       bucket_name, project_id_,
       BucketMetadata()
           .set_storage_class(storage_class::Standard())
@@ -146,7 +145,7 @@ TEST_F(ThreadIntegrationTest, Unshared) {
                  });
   for (auto& t : tasks) t.get();
 
-  auto delete_status = bucket_client->DeleteBucket(bucket_name);
+  auto delete_status = bucket_client.DeleteBucket(bucket_name);
   ASSERT_STATUS_OK(delete_status);
 }
 


### PR DESCRIPTION
This is the first step to clean up the integration test initialization.
It removes unused code in the common initialization function, avoids
using `StatusOr<>` when it makes no sense, and prefers using `Options{}`
instead of multiple overloads.

I stopped here because `MakeBucketIntegrationTestClient()` is not used
in as many places and I think it will make this change easier to grok.