### PR TITLE
doc: use correct path in codegen command

### DIFF
--- a/doc/contributor/howto-guide-adding-generated-libraries.md
+++ b/doc/contributor/howto-guide-adding-generated-libraries.md
@@ -91,7 +91,7 @@ and add the new service.
 Find the list of `.proto` files that will need to be included:
 
 ```shell
-find "${bazel_output_base}/external/com_google_googleapis/${subdir}" -name '*.proto' -print0 |
+find "${bazel_output_base}/external/googleapis~/${subdir}" -name '*.proto' -print0 |
   xargs -0 grep -l '^service'
 ```
 

--- a/doc/contributor/howto-guide-adding-generated-libraries.md
+++ b/doc/contributor/howto-guide-adding-generated-libraries.md
@@ -145,8 +145,8 @@ Then run the micro-generator to create the scaffold and the C++ sources:
 ```shell
 bazel run \
   //generator:google-cloud-cpp-codegen -- \
-  --protobuf_proto_path="${bazel_output_base}"/external/com_google_protobuf/src \
-  --googleapis_proto_path="${bazel_output_base}"/external/com_google_googleapis \
+  --protobuf_proto_path="${bazel_output_base}"/external/protobuf~/src \
+  --googleapis_proto_path="${bazel_output_base}"/external/googleapis~ \
   --discovery_proto_path="${PWD}/protos" \
   --output_path="${PWD}" \
   --config_file="${PWD}/generator/generator_config.textproto" \

--- a/generator/integration_tests/README.md
+++ b/generator/integration_tests/README.md
@@ -7,8 +7,8 @@ output in unexpected ways. If you need to update these files, use this command:
 bazel_output_base="$(bazel info output_base)"
 bazel run \
   //generator:google-cloud-cpp-codegen -- \
-  --protobuf_proto_path="${bazel_output_base}/external/com_google_protobuf/src" \
-  --googleapis_proto_path="${bazel_output_base}/external/com_google_googleapis" \
+  --protobuf_proto_path="${bazel_output_base}/external/protobuf~/src" \
+  --googleapis_proto_path="${bazel_output_base}/external/googleapis~" \
   --golden_proto_path="${PWD}" \
   --output_path="${PWD}" \
   --update_ci=false \


### PR DESCRIPTION
The old path will cause an exception,

```
terminate called after throwing an instance of 'nlohmann::json_abi_v3_11_3::detail::type_error'
  what():  [json.exception.type_error.305] cannot use operator[] with a string argument with null
Aborted
```

Replace with new path which we already have in `generate-libraries.sh`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14487)
<!-- Reviewable:end -->
