### PR TITLE
cleanup(generator): api version error handling

### DIFF
--- a/generator/internal/http_option_utils.cc
+++ b/generator/internal/http_option_utils.cc
@@ -491,9 +491,9 @@ std::string FormatApiVersionFromPackageName(
   std::vector<std::string> parts =
       absl::StrSplit(method.file()->package(), '.');
   if (absl::StartsWith(parts.back(), "v")) return parts.back();
-  GCP_LOG(FATAL) << "Unrecognized API version in package name: "
-                 << method.file()->package()
-                 << ", method: " << method.full_name();
+  GCP_LOG(FATAL) << "Unrecognized API version in file: "
+                 << method.file()->name()
+                 << ", package: " << method.file()->package();
   return {};  // Suppress clang-tidy warnings
 }
 

--- a/generator/internal/http_option_utils.h
+++ b/generator/internal/http_option_utils.h
@@ -123,7 +123,7 @@ std::string FormatRequestResource(
 /**
  * Parses the package name of the method and returns its API version.
  */
-StatusOr<std::string> FormatApiVersionFromPackageName(
+std::string FormatApiVersionFromPackageName(
     google::protobuf::MethodDescriptor const& method);
 
 }  // namespace generator_internal

--- a/generator/internal/http_option_utils_test.cc
+++ b/generator/internal/http_option_utils_test.cc
@@ -787,7 +787,8 @@ TEST_F(HttpOptionUtilsTest, FormatApiVersionFromPackageNameError) {
       service_file_descriptor->service(0)->method(0);
   EXPECT_DEATH_IF_SUPPORTED(
       FormatApiVersionFromPackageName(*method),
-      "Unrecognized API version in package name: my.service");
+      "Unrecognized API version in file: "
+      "google/foo/v1/service_without_version.proto, package: my.service");
 }
 
 }  // namespace

--- a/generator/internal/longrunning.cc
+++ b/generator/internal/longrunning.cc
@@ -179,10 +179,6 @@ void SetLongrunningOperationServiceVars(
       auto operation_service_extension =
           method->options().GetExtension(google::cloud::operation_service);
       auto api_version = FormatApiVersionFromPackageName(*method);
-      if (!api_version) {
-        GCP_LOG(FATAL) << "Unrecognized API version in package name: "
-                       << method->file()->package();
-      }
 
       if (operation_service_extension == "GlobalOperations") {
         service_vars["longrunning_operation_include_header"] =
@@ -206,7 +202,7 @@ void SetLongrunningOperationServiceVars(
                               rest_internal::DetermineApiVersion("%s", *options),
                               "/projects/", request.project(),
                               "/global/operations/", request.operation()))""",
-            *api_version);
+            api_version);
         service_vars["longrunning_get_operation_path_rest"] = global_lro_path;
         service_vars["longrunning_cancel_operation_path_rest"] =
             global_lro_path;
@@ -231,7 +227,7 @@ void SetLongrunningOperationServiceVars(
             R"""(absl::StrCat("/compute/",
                               rest_internal::DetermineApiVersion("%s", *options),
                               "/locations/global/operations/", request.operation()))""",
-            *api_version);
+            api_version);
         service_vars["longrunning_get_operation_path_rest"] =
             global_org_lro_path;
         service_vars["longrunning_cancel_operation_path_rest"] =
@@ -261,7 +257,7 @@ void SetLongrunningOperationServiceVars(
                               "/projects/", request.project(),
                               "/regions/", request.region(),
                               "/operations/", request.operation()))""",
-            *api_version);
+            api_version);
         service_vars["longrunning_get_operation_path_rest"] = region_lro_path;
         service_vars["longrunning_cancel_operation_path_rest"] =
             region_lro_path;
@@ -290,7 +286,7 @@ void SetLongrunningOperationServiceVars(
                               "/projects/", request.project(),
                               "/zones/", request.zone(),
                               "/operations/", request.operation()))""",
-            *api_version);
+            api_version);
         service_vars["longrunning_get_operation_path_rest"] = zone_lro_path;
         service_vars["longrunning_cancel_operation_path_rest"] = zone_lro_path;
       } else {


### PR DESCRIPTION
Part of the work for #14510 

In practice, this function does not return errors. If it did return an error, we would generate code that doesn't compile, or abort. So just move the abort into the function, and simplify the return type.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14512)
<!-- Reviewable:end -->
