### PR TITLE
cleanup(generator): remove unused var

### DIFF
--- a/generator/internal/http_option_utils.cc
+++ b/generator/internal/http_option_utils.cc
@@ -200,7 +200,6 @@ void SetHttpDerivedMethodVars(
     //   get: "/v1/foo/bar"
     void operator()(HttpSimpleInfo const& info) {
       method_vars["method_http_verb"] = info.http_verb;
-      method_vars["method_request_params"] = method.full_name();
       if (absl::StrContains(info.url_path, info.api_version)) {
         std::string needle = absl::StrFormat("/%s/", info.api_version);
         auto url_path = absl::string_view(info.url_path);

--- a/generator/internal/http_option_utils_test.cc
+++ b/generator/internal/http_option_utils_test.cc
@@ -534,8 +534,6 @@ TEST_F(HttpOptionUtilsTest, SetHttpDerivedMethodVarsSimpleInfo) {
       service_file_descriptor->service(0)->method(0);
   VarsDictionary vars;
   SetHttpDerivedMethodVars(ParseHttpExtension(*method), *method, vars);
-  EXPECT_THAT(vars.at("method_request_params"),
-              Eq("my.package.v1.Service.Method0"));
   EXPECT_THAT(vars.at("method_http_verb"), Eq("Delete"));
   EXPECT_THAT(
       vars.at("method_rest_path"),


### PR DESCRIPTION
Part of the work for #14510 

This was being set to a nonsense value, so stop setting it and checking for it.

This is how we use the `method_request_params` variable:

https://github.com/googleapis/google-cloud-cpp/blob/a86e887fe2756935a51d4d93b42e45a0fdde7812/generator/internal/metadata_decorator_generator.cc#L45-L48

Note that `HasHttpRoutingHeader() == false` when something is a `HttpSimpleInfo`.

https://github.com/googleapis/google-cloud-cpp/blob/a86e887fe2756935a51d4d93b42e45a0fdde7812/generator/internal/http_option_utils.cc#L430-L433

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14517)
<!-- Reviewable:end -->
