### PR TITLE
cleanup(generator): simplify http info parsing

### DIFF
--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_stub.cc
@@ -58,7 +58,7 @@ DefaultGoldenKitchenSinkRestStub::GenerateIdToken(
       google::test::admin::database::v1::GenerateIdTokenRequest const& request) {
   return rest_internal::Post<google::test::admin::database::v1::GenerateIdTokenResponse>(
       *service_, rest_context, request, false,
-      absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/token:generate"),
+      absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/", "token", ":generate"),
       rest_internal::TrimEmptyQueryParameters({std::make_pair("name", request.name()),
         std::make_pair("audience", request.audience()),
         std::make_pair("include_email", (request.include_email() ? "1" : "0"))}));
@@ -71,7 +71,7 @@ DefaultGoldenKitchenSinkRestStub::WriteLogEntries(
       google::test::admin::database::v1::WriteLogEntriesRequest const& request) {
   return rest_internal::Post<google::test::admin::database::v1::WriteLogEntriesResponse>(
       *service_, rest_context, request, false,
-      absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/entries:write"),
+      absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/", "entries", ":write"),
       rest_internal::TrimEmptyQueryParameters({std::make_pair("log_name", request.log_name())}));
 }
 
@@ -103,7 +103,7 @@ Status DefaultGoldenKitchenSinkRestStub::DoNothing(
       google::protobuf::Empty const& request) {
   return rest_internal::Post<google::cloud::rest_internal::EmptyResponseType>(
       *service_, rest_context, request, false,
-      absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/doNothing"));
+      absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/", "doNothing"));
 }
 
 Status DefaultGoldenKitchenSinkRestStub::ExplicitRouting1(

--- a/generator/integration_tests/golden/v1/internal/golden_rest_only_rest_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_rest_only_rest_stub.cc
@@ -47,7 +47,7 @@ Status DefaultGoldenRestOnlyRestStub::Noop(
       google::protobuf::Empty const& request) {
   return rest_internal::Post<google::cloud::rest_internal::EmptyResponseType>(
       *service_, rest_context, request, false,
-      absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/noop"));
+      absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/", "noop"));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -1262,9 +1262,6 @@ INSTANTIATE_TEST_SUITE_P(
                              "method_return_doxygen_link",
                              "@googleapis_link{google::protobuf::Empty,google/"
                              "protobuf/well_known.proto#L5}"),
-        MethodVarsTestValues("my.service.v1.Service.Method0",
-                             "method_http_query_parameters",
-                             "my.service.v1.Service.Method0"),
         // Method1
         MethodVarsTestValues("my.service.v1.Service.Method1", "method_name",
                              "Method1"),

--- a/generator/internal/http_option_utils.h
+++ b/generator/internal/http_option_utils.h
@@ -48,8 +48,8 @@ struct HttpExtensionInfo {
  * for the provided method per AIP-4222. Output is also used for gRPC/HTTP
  * transcoding and REST transport.
  */
-absl::variant<absl::monostate, HttpSimpleInfo, HttpExtensionInfo>
-ParseHttpExtension(google::protobuf::MethodDescriptor const& method);
+HttpExtensionInfo ParseHttpExtension(
+    google::protobuf::MethodDescriptor const& method);
 
 /**
  * Sets the following method_vars based on the provided parsed_http_info:

--- a/generator/internal/http_option_utils_test.cc
+++ b/generator/internal/http_option_utils_test.cc
@@ -30,7 +30,11 @@ using ::google::protobuf::DescriptorPool;
 using ::google::protobuf::FileDescriptor;
 using ::google::protobuf::FileDescriptorProto;
 using ::google::protobuf::MethodDescriptor;
+using ::testing::ElementsAre;
 using ::testing::Eq;
+using ::testing::HasSubstr;
+using ::testing::IsEmpty;
+using ::testing::Pair;
 using ::testing::SizeIs;
 
 char const* const kHttpProto =
@@ -431,16 +435,12 @@ TEST_F(HttpOptionUtilsTest, ParseHttpExtensionWithPrefixAndSuffix) {
   MethodDescriptor const* method =
       service_file_descriptor->service(0)->method(2);
   auto info = ParseHttpExtension(*method);
-  ASSERT_TRUE(absl::holds_alternative<HttpExtensionInfo>(info));
-  auto extension_info = absl::get<HttpExtensionInfo>(info);
-  EXPECT_THAT(extension_info.url_path,
+  EXPECT_THAT(info.url_path,
               Eq("/v1/{parent=projects/*/instances/*}/databases"));
-  ASSERT_THAT(extension_info.field_substitutions, SizeIs(1));
-  EXPECT_THAT(extension_info.field_substitutions[0].first, Eq("parent"));
-  EXPECT_THAT(extension_info.field_substitutions[0].second,
-              Eq("projects/*/instances/*"));
-  EXPECT_THAT(extension_info.body, Eq("*"));
-  EXPECT_THAT(extension_info.http_verb, Eq("Post"));
+  EXPECT_THAT(info.field_substitutions,
+              ElementsAre(Pair("parent", "projects/*/instances/*")));
+  EXPECT_THAT(info.body, Eq("*"));
+  EXPECT_THAT(info.http_verb, Eq("Post"));
 }
 
 TEST_F(HttpOptionUtilsTest,
@@ -450,14 +450,11 @@ TEST_F(HttpOptionUtilsTest,
   MethodDescriptor const* method =
       service_file_descriptor->service(0)->method(6);
   auto info = ParseHttpExtension(*method);
-  ASSERT_TRUE(absl::holds_alternative<HttpExtensionInfo>(info));
-  auto extension_info = absl::get<HttpExtensionInfo>(info);
-  EXPECT_THAT(extension_info.url_path, Eq("/v1/projects/{project}/databases"));
-  ASSERT_THAT(extension_info.field_substitutions, SizeIs(1));
-  EXPECT_THAT(extension_info.field_substitutions[0].first, Eq("project"));
-  EXPECT_THAT(extension_info.field_substitutions[0].second, Eq("project"));
-  EXPECT_THAT(extension_info.body, Eq("body"));
-  EXPECT_THAT(extension_info.http_verb, Eq("Post"));
+  EXPECT_THAT(info.url_path, Eq("/v1/projects/{project}/databases"));
+  EXPECT_THAT(info.field_substitutions,
+              ElementsAre(Pair("project", "project")));
+  EXPECT_THAT(info.body, Eq("body"));
+  EXPECT_THAT(info.http_verb, Eq("Post"));
 }
 
 TEST_F(HttpOptionUtilsTest,
@@ -467,17 +464,13 @@ TEST_F(HttpOptionUtilsTest,
   MethodDescriptor const* method =
       service_file_descriptor->service(0)->method(7);
   auto info = ParseHttpExtension(*method);
-  ASSERT_TRUE(absl::holds_alternative<HttpExtensionInfo>(info));
-  auto extension_info = absl::get<HttpExtensionInfo>(info);
-  EXPECT_THAT(extension_info.url_path,
+  EXPECT_THAT(info.url_path,
               Eq("/v1/projects/{project}/instances/{instance}/databases"));
-  ASSERT_THAT(extension_info.field_substitutions, SizeIs(2));
-  EXPECT_THAT(extension_info.field_substitutions[0].first, Eq("project"));
-  EXPECT_THAT(extension_info.field_substitutions[0].second, Eq("project"));
-  EXPECT_THAT(extension_info.field_substitutions[1].first, Eq("instance"));
-  EXPECT_THAT(extension_info.field_substitutions[1].second, Eq("instance"));
-  EXPECT_THAT(extension_info.body, Eq("*"));
-  EXPECT_THAT(extension_info.http_verb, Eq("Post"));
+  EXPECT_THAT(
+      info.field_substitutions,
+      ElementsAre(Pair("project", "project"), Pair("instance", "instance")));
+  EXPECT_THAT(info.body, Eq("*"));
+  EXPECT_THAT(info.http_verb, Eq("Post"));
 }
 
 TEST_F(HttpOptionUtilsTest, ParseHttpExtensionWithOnlyPrefix) {
@@ -486,29 +479,23 @@ TEST_F(HttpOptionUtilsTest, ParseHttpExtensionWithOnlyPrefix) {
   MethodDescriptor const* method =
       service_file_descriptor->service(0)->method(1);
   auto info = ParseHttpExtension(*method);
-  ASSERT_TRUE(absl::holds_alternative<HttpExtensionInfo>(info));
-  auto extension_info = absl::get<HttpExtensionInfo>(info);
-  EXPECT_THAT(extension_info.url_path,
-              Eq("/v1/{name=projects/*/instances/*/backups/*}"));
-  ASSERT_THAT(extension_info.field_substitutions, SizeIs(1));
-  EXPECT_THAT(extension_info.field_substitutions[0].first, Eq("name"));
-  EXPECT_THAT(extension_info.field_substitutions[0].second,
-              Eq("projects/*/instances/*/backups/*"));
-  EXPECT_THAT(extension_info.body, Eq(""));
-  EXPECT_THAT(extension_info.http_verb, Eq("Delete"));
+  EXPECT_THAT(info.url_path, Eq("/v1/{name=projects/*/instances/*/backups/*}"));
+  EXPECT_THAT(info.field_substitutions,
+              ElementsAre(Pair("name", "projects/*/instances/*/backups/*")));
+  EXPECT_THAT(info.body, Eq(""));
+  EXPECT_THAT(info.http_verb, Eq("Delete"));
 }
 
-TEST_F(HttpOptionUtilsTest, ParseHttpExtensionSimpleInfo) {
+TEST_F(HttpOptionUtilsTest, ParseHttpExtensionSimple) {
   FileDescriptor const* service_file_descriptor =
       pool_.FindFileByName("google/foo/v1/service.proto");
   MethodDescriptor const* method =
       service_file_descriptor->service(0)->method(3);
   auto info = ParseHttpExtension(*method);
-  ASSERT_TRUE(absl::holds_alternative<HttpSimpleInfo>(info));
-  auto extension_info = absl::get<HttpSimpleInfo>(info);
-  EXPECT_THAT(extension_info.url_path, Eq("/v1/foo"));
-  EXPECT_THAT(extension_info.body, Eq("*"));
-  EXPECT_THAT(extension_info.http_verb, Eq("Get"));
+  EXPECT_THAT(info.url_path, Eq("/v1/foo"));
+  EXPECT_THAT(info.field_substitutions, IsEmpty());
+  EXPECT_THAT(info.body, Eq("*"));
+  EXPECT_THAT(info.http_verb, Eq("Get"));
 }
 
 TEST_F(HttpOptionUtilsTest,
@@ -518,13 +505,11 @@ TEST_F(HttpOptionUtilsTest,
   MethodDescriptor const* method =
       service_file_descriptor->service(0)->method(5);
   auto info = ParseHttpExtension(*method);
-  ASSERT_TRUE(absl::holds_alternative<HttpExtensionInfo>(info));
-  auto extension_info = absl::get<HttpExtensionInfo>(info);
-  EXPECT_THAT(extension_info.url_path,
+  EXPECT_THAT(info.url_path,
               Eq("/v1/projects/{project=project}/instances/{instance=instance}/"
                  "databases"));
-  EXPECT_THAT(extension_info.body, Eq("*"));
-  EXPECT_THAT(extension_info.http_verb, Eq("Post"));
+  EXPECT_THAT(info.body, Eq("*"));
+  EXPECT_THAT(info.http_verb, Eq("Post"));
 }
 
 TEST_F(HttpOptionUtilsTest, SetHttpDerivedMethodVarsSimpleInfo) {
@@ -537,10 +522,10 @@ TEST_F(HttpOptionUtilsTest, SetHttpDerivedMethodVarsSimpleInfo) {
   EXPECT_THAT(vars.at("method_http_verb"), Eq("Delete"));
   EXPECT_THAT(
       vars.at("method_rest_path"),
-      Eq(R"""(absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/simple"))"""));
+      Eq(R"""(absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/", "simple"))"""));
   EXPECT_THAT(
       vars.at("method_rest_path_async"),
-      Eq(R"""(absl::StrCat("/", rest_internal::DetermineApiVersion("v1", *options), "/simple"))"""));
+      Eq(R"""(absl::StrCat("/", rest_internal::DetermineApiVersion("v1", *options), "/", "simple"))"""));
 }
 
 TEST_F(HttpOptionUtilsTest, SetHttpDerivedMethodVarsExtensionInfoSingleParam) {

--- a/generator/internal/http_option_utils_test.cc
+++ b/generator/internal/http_option_utils_test.cc
@@ -32,10 +32,8 @@ using ::google::protobuf::FileDescriptorProto;
 using ::google::protobuf::MethodDescriptor;
 using ::testing::ElementsAre;
 using ::testing::Eq;
-using ::testing::HasSubstr;
 using ::testing::IsEmpty;
 using ::testing::Pair;
-using ::testing::SizeIs;
 
 char const* const kHttpProto =
     "syntax = \"proto3\";\n"

--- a/google/cloud/compute/firewall_policies/v1/internal/firewall_policies_rest_stub.cc
+++ b/google/cloud/compute/firewall_policies/v1/internal/firewall_policies_rest_stub.cc
@@ -339,9 +339,10 @@ DefaultFirewallPoliciesRestStub::AsyncInsertFirewallPolicy(
             rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
                 *service, *rest_context, request.firewall_policy_resource(),
                 false,
-                absl::StrCat("/compute/",
+                absl::StrCat("/", "compute", "/",
                              rest_internal::DetermineApiVersion("v1", *options),
-                             "/locations/global/firewallPolicies"),
+                             "/", "locations", "/", "global", "/",
+                             "firewallPolicies"),
                 rest_internal::TrimEmptyQueryParameters(
                     {std::make_pair("parent_id", request.parent_id()),
                      std::make_pair("request_id", request.request_id())})));
@@ -365,9 +366,9 @@ DefaultFirewallPoliciesRestStub::InsertFirewallPolicy(
         InsertFirewallPolicyRequest const& request) {
   return rest_internal::Post<google::cloud::cpp::compute::v1::Operation>(
       *service_, rest_context, request.firewall_policy_resource(), false,
-      absl::StrCat("/compute/",
-                   rest_internal::DetermineApiVersion("v1", options),
-                   "/locations/global/firewallPolicies"),
+      absl::StrCat("/", "compute", "/",
+                   rest_internal::DetermineApiVersion("v1", options), "/",
+                   "locations", "/", "global", "/", "firewallPolicies"),
       rest_internal::TrimEmptyQueryParameters(
           {std::make_pair("parent_id", request.parent_id()),
            std::make_pair("request_id", request.request_id())}));
@@ -382,9 +383,9 @@ DefaultFirewallPoliciesRestStub::ListFirewallPolicies(
   return rest_internal::Get<
       google::cloud::cpp::compute::v1::FirewallPolicyList>(
       *service_, rest_context, request, false,
-      absl::StrCat("/compute/",
-                   rest_internal::DetermineApiVersion("v1", options),
-                   "/locations/global/firewallPolicies"),
+      absl::StrCat("/", "compute", "/",
+                   rest_internal::DetermineApiVersion("v1", options), "/",
+                   "locations", "/", "global", "/", "firewallPolicies"),
       rest_internal::TrimEmptyQueryParameters(
           {std::make_pair("filter", request.filter()),
            std::make_pair("max_results", std::to_string(request.max_results())),
@@ -405,9 +406,10 @@ DefaultFirewallPoliciesRestStub::ListAssociations(
   return rest_internal::Get<google::cloud::cpp::compute::v1::
                                 FirewallPoliciesListAssociationsResponse>(
       *service_, rest_context, request, false,
-      absl::StrCat("/compute/",
-                   rest_internal::DetermineApiVersion("v1", options),
-                   "/locations/global/firewallPolicies/listAssociations"),
+      absl::StrCat("/", "compute", "/",
+                   rest_internal::DetermineApiVersion("v1", options), "/",
+                   "locations", "/", "global", "/", "firewallPolicies", "/",
+                   "listAssociations"),
       rest_internal::TrimEmptyQueryParameters(
           {std::make_pair("target_resource", request.target_resource())}));
 }

--- a/google/cloud/compute/global_organization_operations/v1/internal/global_organization_operations_rest_stub.cc
+++ b/google/cloud/compute/global_organization_operations/v1/internal/global_organization_operations_rest_stub.cc
@@ -81,9 +81,9 @@ DefaultGlobalOrganizationOperationsRestStub::ListGlobalOrganizationOperations(
         ListGlobalOrganizationOperationsRequest const& request) {
   return rest_internal::Get<google::cloud::cpp::compute::v1::OperationList>(
       *service_, rest_context, request, false,
-      absl::StrCat("/compute/",
-                   rest_internal::DetermineApiVersion("v1", options),
-                   "/locations/global/operations"),
+      absl::StrCat("/", "compute", "/",
+                   rest_internal::DetermineApiVersion("v1", options), "/",
+                   "locations", "/", "global", "/", "operations"),
       rest_internal::TrimEmptyQueryParameters(
           {std::make_pair("filter", request.filter()),
            std::make_pair("max_results", std::to_string(request.max_results())),

--- a/google/cloud/sql/v1/internal/sql_flags_rest_stub.cc
+++ b/google/cloud/sql/v1/internal/sql_flags_rest_stub.cc
@@ -46,8 +46,8 @@ DefaultSqlFlagsServiceRestStub::List(
     google::cloud::sql::v1::SqlFlagsListRequest const& request) {
   return rest_internal::Get<google::cloud::sql::v1::FlagsListResponse>(
       *service_, rest_context, request, true,
-      absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options),
-                   "/flags"),
+      absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/",
+                   "flags"),
       rest_internal::TrimEmptyQueryParameters(
           {std::make_pair("database_version", request.database_version())}));
 }


### PR DESCRIPTION
Part of the work for #14510 

Only ever return an `HttpExtensionInfo`, which we pass on to functions that accept a `variant<HttpExtensionInfo, HttpSimpleInfo, absl::monostate>`. I will clean up those functions in a follow up PR.

The generated code diff speaks for itself. 

---

The removed expectation from `descriptor_utils_test.cc` originates from here:

https://github.com/googleapis/google-cloud-cpp/blob/eb1232de7ee83ae2e34000ce0ec87cc93b423166/generator/internal/http_option_utils.cc#L326-L330

The test rpc does not have a `google.api.http` annotation, so we don't care about the `method_http_query_parameters` variable.

---

While we're here use some container matchers in our tests so we get better error messages.

There are some tests that use
```cc
EXPECT_THAT(map.at("key"), Eq("value))
```

that could be
```cc
EXPECT_THAT(map, Contains(Pair("key", "value")))
```

I can update them in a follow up to keep this diff smaller.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14522)
<!-- Reviewable:end -->
