### PR TITLE
cleanup(storage): no parametric XML tests

### DIFF
--- a/google/cloud/storage/tests/object_checksum_integration_test.cc
+++ b/google/cloud/storage/tests/object_checksum_integration_test.cc
@@ -34,8 +34,7 @@ using ::testing::Not;
 using ::testing::Pair;
 
 class ObjectChecksumIntegrationTest
-    : public google::cloud::storage::testing::StorageIntegrationTest,
-      public ::testing::WithParamInterface<std::string> {
+    : public google::cloud::storage::testing::StorageIntegrationTest {
  protected:
   void SetUp() override {
     bucket_name_ = google::cloud::internal::GetEnv(
@@ -48,7 +47,7 @@ class ObjectChecksumIntegrationTest
 };
 
 /// @test Verify that CRC32C checksums are enabled by default.
-TEST_P(ObjectChecksumIntegrationTest, InsertObjectDefault) {
+TEST_F(ObjectChecksumIntegrationTest, InsertObjectDefault) {
   auto client = MakeIntegrationTestClient();
   auto object_name = MakeRandomObjectName();
   auto meta = client.InsertObject(bucket_name_, object_name, LoremIpsum(),
@@ -63,7 +62,7 @@ TEST_P(ObjectChecksumIntegrationTest, InsertObjectDefault) {
 }
 
 /// @test Verify that `DisableCrc32cChecksum(true)` works as expected.
-TEST_P(ObjectChecksumIntegrationTest, InsertObjectExplicitDisable) {
+TEST_F(ObjectChecksumIntegrationTest, InsertObjectExplicitDisable) {
   auto client = MakeIntegrationTestClient();
   auto object_name = MakeRandomObjectName();
   auto meta = client.InsertObject(bucket_name_, object_name, LoremIpsum(),
@@ -79,7 +78,7 @@ TEST_P(ObjectChecksumIntegrationTest, InsertObjectExplicitDisable) {
 }
 
 /// @test Verify that `DisableCrc32cChecksum(false)` works as expected.
-TEST_P(ObjectChecksumIntegrationTest, InsertObjectExplicitEnable) {
+TEST_F(ObjectChecksumIntegrationTest, InsertObjectExplicitEnable) {
   auto client = MakeIntegrationTestClient();
   auto object_name = MakeRandomObjectName();
 
@@ -95,7 +94,7 @@ TEST_P(ObjectChecksumIntegrationTest, InsertObjectExplicitEnable) {
   }
 }
 
-TEST_P(ObjectChecksumIntegrationTest, InsertObjectWithValueSuccess) {
+TEST_F(ObjectChecksumIntegrationTest, InsertObjectWithValueSuccess) {
   auto client = MakeIntegrationTestClient();
   auto object_name = MakeRandomObjectName();
 
@@ -112,7 +111,7 @@ TEST_P(ObjectChecksumIntegrationTest, InsertObjectWithValueSuccess) {
   }
 }
 
-TEST_P(ObjectChecksumIntegrationTest, InsertObjectWithValueFailure) {
+TEST_F(ObjectChecksumIntegrationTest, InsertObjectWithValueFailure) {
   // TODO(#14385) - the emulator does not support this feature for gRPC.
   if (UsingEmulator() && UsingGrpc()) GTEST_SKIP();
 
@@ -289,7 +288,7 @@ TEST_F(ObjectChecksumIntegrationTest, WriteObjectUploadBadChecksum) {
 }
 
 /// @test Verify that CRC32C checksums are computed by default on downloads.
-TEST_P(ObjectChecksumIntegrationTest, ReadObjectDefault) {
+TEST_F(ObjectChecksumIntegrationTest, ReadObjectDefault) {
   // TODO(#14385) - the emulator does not support this feature for gRPC.
   if (UsingEmulator() && UsingGrpc()) GTEST_SKIP();
 
@@ -311,7 +310,7 @@ TEST_P(ObjectChecksumIntegrationTest, ReadObjectDefault) {
 
 /// @test Verify that CRC32C checksum mismatches are reported by default on
 /// downloads.
-TEST_P(ObjectChecksumIntegrationTest, ReadObjectCorruptedByServerGetc) {
+TEST_F(ObjectChecksumIntegrationTest, ReadObjectCorruptedByServerGetc) {
   // This test is disabled when not using the emulator as it relies on the
   // emulator to inject faults. The emulator does not support this type of fault
   // injection for gRPC either.
@@ -350,7 +349,7 @@ TEST_P(ObjectChecksumIntegrationTest, ReadObjectCorruptedByServerGetc) {
 
 /// @test Verify that CRC32C checksum mismatches are reported by default on
 /// downloads.
-TEST_P(ObjectChecksumIntegrationTest, ReadObjectCorruptedByServerRead) {
+TEST_F(ObjectChecksumIntegrationTest, ReadObjectCorruptedByServerRead) {
   // This test is disabled when not using the emulator as it relies on the
   // emulator to inject faults. The emulator does not support this type of fault
   // injection for gRPC either.
@@ -378,10 +377,6 @@ TEST_P(ObjectChecksumIntegrationTest, ReadObjectCorruptedByServerRead) {
   EXPECT_NE(stream.received_hash(), stream.computed_hash());
   EXPECT_EQ(stream.received_hash(), meta->crc32c());
 }
-
-INSTANTIATE_TEST_SUITE_P(ObjectChecksumIntegrationTestJson,
-                         ObjectChecksumIntegrationTest,
-                         ::testing::Values("JSON"));
 
 }  // anonymous namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/tests/object_hash_integration_test.cc
+++ b/google/cloud/storage/tests/object_hash_integration_test.cc
@@ -38,8 +38,7 @@ using ::testing::Not;
 using ::testing::Pair;
 
 class ObjectHashIntegrationTest
-    : public google::cloud::storage::testing::StorageIntegrationTest,
-      public ::testing::WithParamInterface<std::string> {
+    : public google::cloud::storage::testing::StorageIntegrationTest {
  protected:
   void SetUp() override {
     bucket_name_ = google::cloud::internal::GetEnv(
@@ -52,7 +51,7 @@ class ObjectHashIntegrationTest
 };
 
 /// @test Verify that MD5 hashes are disabled by default in InsertObject().
-TEST_P(ObjectHashIntegrationTest, InsertObjectDefault) {
+TEST_F(ObjectHashIntegrationTest, InsertObjectDefault) {
   auto client = MakeIntegrationTestClient();
   auto object_name = MakeRandomObjectName();
   auto meta =
@@ -68,7 +67,7 @@ TEST_P(ObjectHashIntegrationTest, InsertObjectDefault) {
 }
 
 /// @test Verify that MD5 hashes can be explicitly disabled in InsertObject().
-TEST_P(ObjectHashIntegrationTest, InsertObjectExplicitDisable) {
+TEST_F(ObjectHashIntegrationTest, InsertObjectExplicitDisable) {
   auto client = MakeIntegrationTestClient();
   auto object_name = MakeRandomObjectName();
 
@@ -85,7 +84,7 @@ TEST_P(ObjectHashIntegrationTest, InsertObjectExplicitDisable) {
 }
 
 /// @test Verify that MD5 hashes can be explicitly enabled in InsertObject().
-TEST_P(ObjectHashIntegrationTest, InsertObjectExplicitEnable) {
+TEST_F(ObjectHashIntegrationTest, InsertObjectExplicitEnable) {
   auto client = MakeIntegrationTestClient();
   auto object_name = MakeRandomObjectName();
 
@@ -102,7 +101,7 @@ TEST_P(ObjectHashIntegrationTest, InsertObjectExplicitEnable) {
 }
 
 /// @test Verify that valid MD5 hash values work in InsertObject().
-TEST_P(ObjectHashIntegrationTest, InsertObjectWithValueSuccess) {
+TEST_F(ObjectHashIntegrationTest, InsertObjectWithValueSuccess) {
   auto client = MakeIntegrationTestClient();
   auto object_name = MakeRandomObjectName();
   auto meta =
@@ -119,7 +118,7 @@ TEST_P(ObjectHashIntegrationTest, InsertObjectWithValueSuccess) {
 }
 
 /// @test Verify that incorrect MD5 hash values work in InsertObject().
-TEST_P(ObjectHashIntegrationTest, InsertObjectWithValueFailure) {
+TEST_F(ObjectHashIntegrationTest, InsertObjectWithValueFailure) {
   // TODO(#14385) - the emulator does not support this feature for gRPC.
   if (UsingEmulator() && UsingGrpc()) GTEST_SKIP();
 
@@ -282,7 +281,7 @@ TEST_F(ObjectHashIntegrationTest, WriteObjectUploadBadChecksum) {
 }
 
 /// @test Verify that MD5 hashes are disabled by default on downloads.
-TEST_P(ObjectHashIntegrationTest, ReadObjectDefault) {
+TEST_F(ObjectHashIntegrationTest, ReadObjectDefault) {
   // TODO(#14385) - the emulator does not support this feature for gRPC.
   if (UsingEmulator() && UsingGrpc()) GTEST_SKIP();
 
@@ -303,7 +302,7 @@ TEST_P(ObjectHashIntegrationTest, ReadObjectDefault) {
 
 /// @test Verify that MD5 hashes mismatches are reported (if enabled) on
 /// downloads.
-TEST_P(ObjectHashIntegrationTest, ReadObjectCorruptedByServerGetc) {
+TEST_F(ObjectHashIntegrationTest, ReadObjectCorruptedByServerGetc) {
   // This test is disabled when not using the emulator as it relies on the
   // emulator to inject faults. The emulator does not support this type of fault
   // injection for gRPC either.
@@ -342,7 +341,7 @@ TEST_P(ObjectHashIntegrationTest, ReadObjectCorruptedByServerGetc) {
 
 /// @test Verify that MD5 hashes mismatches are reported (if enabled) on
 /// downloads.
-TEST_P(ObjectHashIntegrationTest, ReadObjectCorruptedByServerRead) {
+TEST_F(ObjectHashIntegrationTest, ReadObjectCorruptedByServerRead) {
   // This test is disabled when not using the emulator as it relies on the
   // emulator to inject faults. The emulator does not support this type of fault
   // injection for gRPC either.
@@ -371,9 +370,6 @@ TEST_P(ObjectHashIntegrationTest, ReadObjectCorruptedByServerRead) {
   EXPECT_NE(stream.received_hash(), stream.computed_hash());
   EXPECT_EQ(stream.received_hash(), meta->md5_hash());
 }
-
-INSTANTIATE_TEST_SUITE_P(ObjectHashIntegrationTestJson,
-                         ObjectHashIntegrationTest, ::testing::Values("JSON"));
 
 }  // anonymous namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
We used to have a few parametric tests to validate working with the XML
and JSON transport, but we no longer support XML, and the tests only
used the "JSON" parameter.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14523)
<!-- Reviewable:end -->
