### PR TITLE
cleanup(storage): fix IWYU warnings

### DIFF
--- a/google/cloud/storage/auto_finalize_test.cc
+++ b/google/cloud/storage/auto_finalize_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/storage/auto_finalize.h"
 #include <gmock/gmock.h>
 #include <sstream>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/bucket_access_control_test.cc
+++ b/google/cloud/storage/bucket_access_control_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/storage/internal/bucket_access_control_parser.h"
 #include "google/cloud/storage/internal/bucket_acl_requests.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/bucket_cors_entry_test.cc
+++ b/google/cloud/storage/bucket_cors_entry_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/storage/bucket_cors_entry.h"
 #include <gmock/gmock.h>
 #include <sstream>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/bucket_iam_configuration_test.cc
+++ b/google/cloud/storage/bucket_iam_configuration_test.cc
@@ -16,6 +16,8 @@
 #include "absl/time/time.h"
 #include <gmock/gmock.h>
 #include <sstream>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/bucket_metadata.cc
+++ b/google/cloud/storage/bucket_metadata.cc
@@ -20,6 +20,8 @@
 #include "google/cloud/status.h"
 #include "absl/strings/str_format.h"
 #include <nlohmann/json.hpp>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/bucket_metadata_test.cc
+++ b/google/cloud/storage/bucket_metadata_test.cc
@@ -21,6 +21,8 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <nlohmann/json.hpp>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/bucket_soft_delete_policy_test.cc
+++ b/google/cloud/storage/bucket_soft_delete_policy_test.cc
@@ -17,6 +17,7 @@
 #include "absl/time/time.h"
 #include <gmock/gmock.h>
 #include <sstream>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -26,6 +26,7 @@
 #include "absl/strings/str_split.h"
 #include <fstream>
 #include <memory>
+#include <string>
 #include <thread>
 #include <utility>
 

--- a/google/cloud/storage/client_bucket_acl_test.cc
+++ b/google/cloud/storage/client_bucket_acl_test.cc
@@ -20,6 +20,7 @@
 #include "google/cloud/storage/testing/client_unit_test.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/client_bucket_test.cc
+++ b/google/cloud/storage/client_bucket_test.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <algorithm>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/client_object_copy_test.cc
+++ b/google/cloud/storage/client_object_copy_test.cc
@@ -20,6 +20,7 @@
 #include "google/cloud/storage/testing/client_unit_test.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/client_object_test.cc
+++ b/google/cloud/storage/client_object_test.cc
@@ -22,6 +22,8 @@
 #include "google/cloud/storage/testing/temp_file.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/client_options.cc
+++ b/google/cloud/storage/client_options.cc
@@ -30,7 +30,9 @@
 #include <cstdlib>
 #include <set>
 #include <sstream>
+#include <string>
 #include <thread>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/client_options_test.cc
+++ b/google/cloud/storage/client_options_test.cc
@@ -27,6 +27,8 @@
 #include <gmock/gmock.h>
 #include <cstdlib>
 #include <fstream>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/client_service_account_test.cc
+++ b/google/cloud/storage/client_service_account_test.cc
@@ -22,6 +22,7 @@
 #include "google/cloud/testing_util/scoped_environment.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/client_sign_policy_document_test.cc
+++ b/google/cloud/storage/client_sign_policy_document_test.cc
@@ -22,6 +22,8 @@
 #include "google/cloud/internal/format_time_point.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/client_sign_url_test.cc
+++ b/google/cloud/storage/client_sign_url_test.cc
@@ -20,6 +20,7 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include "google/cloud/universe_domain_options.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/client_test.cc
+++ b/google/cloud/storage/client_test.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <chrono>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/client_write_object_test.cc
+++ b/google/cloud/storage/client_write_object_test.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <fstream>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/compose_many_test.cc
+++ b/google/cloud/storage/compose_many_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/storage/testing/mock_client.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/delete_by_prefix_test.cc
+++ b/google/cloud/storage/delete_by_prefix_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/storage/testing/mock_client.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/hashing_options.cc
+++ b/google/cloud/storage/hashing_options.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/storage/internal/crc32c.h"
 #include "google/cloud/storage/internal/md5hash.h"
 #include "google/cloud/internal/big_endian.h"
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/hashing_options_test.cc
+++ b/google/cloud/storage/hashing_options_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/hashing_options.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/hmac_key_metadata_test.cc
+++ b/google/cloud/storage/hmac_key_metadata_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/storage/internal/hmac_key_requests.h"
 #include "google/cloud/internal/format_time_point.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/iam_policy.cc
+++ b/google/cloud/storage/iam_policy.cc
@@ -17,6 +17,8 @@
 #include "absl/types/optional.h"
 #include <nlohmann/json.hpp>
 #include <sstream>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/idempotency_policy_test.cc
+++ b/google/cloud/storage/idempotency_policy_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/storage/idempotency_policy.h"
 #include "google/cloud/storage/iam_policy.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/lifecycle_rule.cc
+++ b/google/cloud/storage/lifecycle_rule.cc
@@ -16,6 +16,8 @@
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include <algorithm>
 #include <iostream>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/lifecycle_rule_test.cc
+++ b/google/cloud/storage/lifecycle_rule_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/storage_class.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/list_buckets_reader_test.cc
+++ b/google/cloud/storage/list_buckets_reader_test.cc
@@ -19,6 +19,8 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <nlohmann/json.hpp>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/list_hmac_keys_reader_test.cc
+++ b/google/cloud/storage/list_hmac_keys_reader_test.cc
@@ -20,6 +20,8 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <nlohmann/json.hpp>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/list_objects_and_prefixes_reader_test.cc
+++ b/google/cloud/storage/list_objects_and_prefixes_reader_test.cc
@@ -18,6 +18,8 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <nlohmann/json.hpp>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/list_objects_reader_test.cc
+++ b/google/cloud/storage/list_objects_reader_test.cc
@@ -19,6 +19,8 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <nlohmann/json.hpp>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/notification_metadata.cc
+++ b/google/cloud/storage/notification_metadata.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/storage/internal/notification_requests.h"
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include <nlohmann/json.hpp>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/notification_metadata_test.cc
+++ b/google/cloud/storage/notification_metadata_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/notification_event_type.h"
 #include "google/cloud/storage/notification_payload_format.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/object_access_control_test.cc
+++ b/google/cloud/storage/object_access_control_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/storage/internal/object_access_control_parser.h"
 #include "google/cloud/storage/internal/object_acl_requests.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/object_metadata.cc
+++ b/google/cloud/storage/object_metadata.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include "google/cloud/internal/format_time_point.h"
 #include <nlohmann/json.hpp>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/object_metadata_test.cc
+++ b/google/cloud/storage/object_metadata_test.cc
@@ -18,6 +18,8 @@
 #include "google/cloud/internal/parse_rfc3339.h"
 #include <gmock/gmock.h>
 #include <sstream>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/object_read_stream.cc
+++ b/google/cloud/storage/object_read_stream.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/storage/object_read_stream.h"
 #include "google/cloud/internal/make_status.h"
 #include "google/cloud/log.h"
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/object_retention_test.cc
+++ b/google/cloud/storage/object_retention_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/internal/format_time_point.h"
 #include <gmock/gmock.h>
 #include <sstream>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/object_stream_test.cc
+++ b/google/cloud/storage/object_stream_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/storage/internal/storage_connection.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/object_write_stream.cc
+++ b/google/cloud/storage/object_write_stream.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/storage/internal/hash_function.h"
 #include "google/cloud/storage/internal/hash_validator.h"
 #include "google/cloud/internal/make_status.h"
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/parallel_uploads_test.cc
+++ b/google/cloud/storage/parallel_uploads_test.cc
@@ -27,6 +27,8 @@
 #include <gmock/gmock.h>
 #include <cstdio>
 #include <stack>
+#include <string>
+#include <utility>
 #ifdef __linux__
 #include <sys/stat.h>
 #include <unistd.h>

--- a/google/cloud/storage/policy_document.cc
+++ b/google/cloud/storage/policy_document.cc
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <iostream>
 #include <numeric>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/policy_document_test.cc
+++ b/google/cloud/storage/policy_document_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/internal/format_time_point.h"
 #include "google/cloud/internal/parse_rfc3339.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/signed_url_options_test.cc
+++ b/google/cloud/storage/signed_url_options_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/signed_url_options.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/storage_class_test.cc
+++ b/google/cloud/storage/storage_class_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/storage_class.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/storage_iam_policy_test.cc
+++ b/google/cloud/storage/storage_iam_policy_test.cc
@@ -16,7 +16,9 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <nlohmann/json.hpp>
+#include <string>
 #include <type_traits>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/storage_version_test.cc
+++ b/google/cloud/storage/storage_version_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/storage/version.h"
 #include "google/cloud/internal/build_info.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/version.cc
+++ b/google/cloud/storage/version.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/storage/version.h"
 #include "google/cloud/internal/api_client_header.h"
 #include <limits>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/well_known_headers.cc
+++ b/google/cloud/storage/well_known_headers.cc
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <iomanip>
 #include <iostream>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/well_known_headers_test.cc
+++ b/google/cloud/storage/well_known_headers_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/well_known_headers.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/well_known_parameters.cc
+++ b/google/cloud/storage/well_known_parameters.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/well_known_parameters.h"
 #include <map>
+#include <string>
 
 namespace google {
 namespace cloud {


### PR DESCRIPTION
There are so many IWYU warnings that I cannot see the useful warnings.
It is easier to just add the `#includes` than to fight the tooling.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14526)
<!-- Reviewable:end -->
