### PR TITLE
cleanup(storage): fix MOAR IWYU warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ of what it's like to use one of these C++ libraries.
 ```cc
 #include "google/cloud/storage/client.h"
 #include <iostream>
+#include <string>
 
 int main(int argc, char* argv[]) {
   if (argc != 2) {

--- a/google/cloud/storage/README.md
+++ b/google/cloud/storage/README.md
@@ -23,6 +23,7 @@ this library.
 ```cc
 #include "google/cloud/storage/client.h"
 #include <iostream>
+#include <string>
 
 int main(int argc, char* argv[]) {
   if (argc != 2) {

--- a/google/cloud/storage/async/bucket_name.cc
+++ b/google/cloud/storage/async/bucket_name.cc
@@ -18,6 +18,7 @@
 #include "absl/strings/match.h"
 #include "absl/strings/strip.h"
 #include <ostream>
+#include <string>
 #include <utility>
 
 namespace google {

--- a/google/cloud/storage/async/bucket_name_test.cc
+++ b/google/cloud/storage/async/bucket_name_test.cc
@@ -17,6 +17,7 @@
 #include <gmock/gmock.h>
 #include <sstream>
 #include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/async/client.cc
+++ b/google/cloud/storage/async/client.cc
@@ -18,7 +18,9 @@
 #include "google/cloud/storage/internal/async/default_options.h"
 #include "google/cloud/storage/internal/grpc/stub.h"
 #include "google/cloud/grpc_options.h"
+#include <string>
 #include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/async/client.h
+++ b/google/cloud/storage/async/client.h
@@ -28,6 +28,9 @@
 #include "google/cloud/internal/group_options.h"
 #include "google/cloud/status_or.h"
 #include <google/storage/v2/storage.pb.h>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/async/client_test.cc
+++ b/google/cloud/storage/async/client_test.cc
@@ -22,6 +22,7 @@
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
 #include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/async/object_responses.h
+++ b/google/cloud/storage/async/object_responses.h
@@ -26,6 +26,7 @@
 #include <cstdint>
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace google {

--- a/google/cloud/storage/async/reader_test.cc
+++ b/google/cloud/storage/async/reader_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/testing_util/async_sequencer.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/async/rewriter_test.cc
+++ b/google/cloud/storage/async/rewriter_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/storage/testing/canonical_errors.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/async/token_test.cc
+++ b/google/cloud/storage/async/token_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/storage/async/token.h"
 #include <gmock/gmock.h>
 #include <type_traits>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/async/write_payload.h
+++ b/google/cloud/storage/async/write_payload.h
@@ -21,6 +21,7 @@
 #include "absl/strings/cord.h"
 #include <cstdint>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace google {

--- a/google/cloud/storage/async/writer.h
+++ b/google/cloud/storage/async/writer.h
@@ -24,6 +24,7 @@
 #include "absl/types/variant.h"
 #include <google/storage/v2/storage.pb.h>
 #include <memory>
+#include <string>
 #include <utility>
 
 namespace google {

--- a/google/cloud/storage/async/writer_test.cc
+++ b/google/cloud/storage/async/writer_test.cc
@@ -17,6 +17,8 @@
 #include "google/cloud/storage/testing/canonical_errors.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/benchmarks/aggregate_download_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/aggregate_download_throughput_benchmark.cc
@@ -31,7 +31,9 @@
 #include <iomanip>
 #include <random>
 #include <sstream>
+#include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 namespace {

--- a/google/cloud/storage/benchmarks/aggregate_download_throughput_options.cc
+++ b/google/cloud/storage/benchmarks/aggregate_download_throughput_options.cc
@@ -18,7 +18,9 @@
 #include "google/cloud/internal/make_status.h"
 #include <iterator>
 #include <sstream>
+#include <string>
 #include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/benchmarks/aggregate_upload_throughput_options.cc
+++ b/google/cloud/storage/benchmarks/aggregate_upload_throughput_options.cc
@@ -17,7 +17,9 @@
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include <iterator>
 #include <sstream>
+#include <string>
 #include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/benchmarks/benchmark_make_random_test.cc
+++ b/google/cloud/storage/benchmarks/benchmark_make_random_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/benchmarks/benchmark_utils.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/benchmarks/benchmark_utils.cc
+++ b/google/cloud/storage/benchmarks/benchmark_utils.cc
@@ -29,6 +29,9 @@
 #include "absl/time/time.h"
 #include <future>
 #include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/benchmarks/benchmark_utils.h
+++ b/google/cloud/storage/benchmarks/benchmark_utils.h
@@ -28,6 +28,7 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/benchmarks/bounded_queue.h
+++ b/google/cloud/storage/benchmarks/bounded_queue.h
@@ -19,6 +19,7 @@
 #include <condition_variable>
 #include <deque>
 #include <mutex>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/benchmarks/create_dataset_options.cc
+++ b/google/cloud/storage/benchmarks/create_dataset_options.cc
@@ -15,7 +15,9 @@
 #include "google/cloud/storage/benchmarks/create_dataset_options.h"
 #include "google/cloud/internal/make_status.h"
 #include <sstream>
+#include <string>
 #include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/benchmarks/storage_file_transfer_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_file_transfer_benchmark.cc
@@ -24,7 +24,9 @@
 #include <future>
 #include <iomanip>
 #include <sstream>
+#include <string>
 #include <utility>
+#include <vector>
 
 namespace {
 namespace gcs = ::google::cloud::storage;

--- a/google/cloud/storage/benchmarks/storage_parallel_uploads_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_parallel_uploads_benchmark.cc
@@ -25,7 +25,9 @@
 #include <future>
 #include <iomanip>
 #include <sstream>
+#include <string>
 #include <utility>
+#include <vector>
 
 namespace {
 namespace gcs = ::google::cloud::storage;

--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -29,6 +29,9 @@
 #include <future>
 #include <set>
 #include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace {
 namespace gcs = ::google::cloud::storage;

--- a/google/cloud/storage/benchmarks/throughput_experiment.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment.cc
@@ -20,6 +20,8 @@
 #include "google/cloud/storage/internal/grpc/ctype_cord_workaround.h"
 #include "google/cloud/grpc_error_delegate.h"
 #include <google/storage/v2/storage.grpc.pb.h>
+#include <string>
+#include <utility>
 #endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
 #include <curl/curl.h>
 #include <iterator>

--- a/google/cloud/storage/benchmarks/throughput_experiment_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment_test.cc
@@ -17,6 +17,8 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/benchmarks/throughput_options.cc
+++ b/google/cloud/storage/benchmarks/throughput_options.cc
@@ -20,6 +20,9 @@
 #include "absl/strings/str_split.h"
 #include "absl/time/time.h"
 #include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/benchmarks/throughput_result.h
+++ b/google/cloud/storage/benchmarks/throughput_result.h
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/benchmarks/benchmark_utils.h"
 #include <chrono>
 #include <cstdint>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/benchmarks/throughput_result_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_result_test.cc
@@ -20,6 +20,8 @@
 #include "absl/strings/match.h"
 #include <gmock/gmock.h>
 #include <algorithm>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/examples/storage_async_mock_samples.cc
+++ b/google/cloud/storage/examples/storage_async_mock_samples.cc
@@ -18,6 +18,7 @@
 #include <gmock/gmock.h>
 #include <iostream>
 #include <string>
+#include <utility>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_async_samples.cc
+++ b/google/cloud/storage/examples/storage_async_samples.cc
@@ -29,6 +29,7 @@
 #include <map>
 #include <random>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace {

--- a/google/cloud/storage/examples/storage_bucket_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_acl_samples.cc
@@ -17,7 +17,10 @@
 #include "google/cloud/internal/getenv.h"
 #include <functional>
 #include <iostream>
+#include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_bucket_autoclass_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_autoclass_samples.cc
@@ -17,7 +17,10 @@
 #include "google/cloud/internal/getenv.h"
 #include <functional>
 #include <iostream>
+#include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_bucket_cors_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_cors_samples.cc
@@ -17,7 +17,10 @@
 #include "google/cloud/internal/getenv.h"
 #include <functional>
 #include <iostream>
+#include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_bucket_default_kms_key_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_default_kms_key_samples.cc
@@ -17,7 +17,10 @@
 #include "google/cloud/internal/getenv.h"
 #include <functional>
 #include <iostream>
+#include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_bucket_iam_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_iam_samples.cc
@@ -16,7 +16,10 @@
 #include "google/cloud/storage/examples/storage_examples_common.h"
 #include "google/cloud/internal/getenv.h"
 #include <iostream>
+#include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_bucket_object_retention_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_object_retention_samples.cc
@@ -17,7 +17,10 @@
 #include "google/cloud/internal/getenv.h"
 #include <functional>
 #include <iostream>
+#include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_bucket_requester_pays_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_requester_pays_samples.cc
@@ -17,7 +17,10 @@
 #include "google/cloud/internal/getenv.h"
 #include <functional>
 #include <iostream>
+#include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -17,6 +17,9 @@
 #include "google/cloud/internal/getenv.h"
 #include <functional>
 #include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_bucket_soft_delete_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_soft_delete_samples.cc
@@ -17,7 +17,10 @@
 #include "google/cloud/internal/getenv.h"
 #include <functional>
 #include <iostream>
+#include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_client_initialization_samples.cc
+++ b/google/cloud/storage/examples/storage_client_initialization_samples.cc
@@ -21,6 +21,8 @@
 #include <iostream>
 #include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_client_mock_samples.cc
+++ b/google/cloud/storage/examples/storage_client_mock_samples.cc
@@ -18,6 +18,7 @@
 #include <gmock/gmock.h>
 #include <iostream>
 #include <string>
+#include <utility>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_client_per_operation_samples.cc
+++ b/google/cloud/storage/examples/storage_client_per_operation_samples.cc
@@ -21,6 +21,8 @@
 #include <iostream>
 #include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_default_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_default_object_acl_samples.cc
@@ -17,7 +17,10 @@
 #include "google/cloud/internal/getenv.h"
 #include <functional>
 #include <iostream>
+#include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_event_based_hold_samples.cc
+++ b/google/cloud/storage/examples/storage_event_based_hold_samples.cc
@@ -17,7 +17,10 @@
 #include "google/cloud/internal/getenv.h"
 #include <functional>
 #include <iostream>
+#include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_examples_common.cc
+++ b/google/cloud/storage/examples/storage_examples_common.cc
@@ -18,6 +18,9 @@
 #include "absl/strings/match.h"
 #include <regex>
 #include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/examples/storage_examples_common_test.cc
+++ b/google/cloud/storage/examples/storage_examples_common_test.cc
@@ -15,6 +15,8 @@
 #include "google/cloud/storage/examples/storage_examples_common.h"
 #include "google/cloud/testing_util/scoped_environment.h"
 #include <gmock/gmock.h>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/examples/storage_grpc_samples.cc
+++ b/google/cloud/storage/examples/storage_grpc_samples.cc
@@ -25,6 +25,9 @@
 //! [grpc-includes] [END storage_grpc_quickstart]
 #include <iostream>
 #include <map>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace {
 namespace examples = ::google::cloud::storage::examples;

--- a/google/cloud/storage/examples/storage_lifecycle_management_samples.cc
+++ b/google/cloud/storage/examples/storage_lifecycle_management_samples.cc
@@ -17,7 +17,10 @@
 #include "google/cloud/internal/getenv.h"
 #include <functional>
 #include <iostream>
+#include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_notification_samples.cc
+++ b/google/cloud/storage/examples/storage_notification_samples.cc
@@ -16,7 +16,10 @@
 #include "google/cloud/storage/examples/storage_examples_common.h"
 #include "google/cloud/internal/getenv.h"
 #include <iostream>
+#include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_object_acl_samples.cc
@@ -17,7 +17,10 @@
 #include "google/cloud/internal/getenv.h"
 #include <functional>
 #include <iostream>
+#include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_object_cmek_samples.cc
+++ b/google/cloud/storage/examples/storage_object_cmek_samples.cc
@@ -17,7 +17,10 @@
 #include "google/cloud/internal/getenv.h"
 #include <functional>
 #include <iostream>
+#include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_object_csek_samples.cc
+++ b/google/cloud/storage/examples/storage_object_csek_samples.cc
@@ -21,6 +21,8 @@
 #include <map>
 #include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_object_file_transfer_samples.cc
+++ b/google/cloud/storage/examples/storage_object_file_transfer_samples.cc
@@ -19,6 +19,9 @@
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_object_hold_samples.cc
+++ b/google/cloud/storage/examples/storage_object_hold_samples.cc
@@ -16,6 +16,9 @@
 #include "google/cloud/storage/examples/storage_examples_common.h"
 #include "google/cloud/internal/getenv.h"
 #include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_object_preconditions_samples.cc
+++ b/google/cloud/storage/examples/storage_object_preconditions_samples.cc
@@ -21,6 +21,8 @@
 #include <map>
 #include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_object_resumable_write_samples.cc
+++ b/google/cloud/storage/examples/storage_object_resumable_write_samples.cc
@@ -20,6 +20,8 @@
 #include <map>
 #include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 namespace {
 std::string StartResumableUpload(google::cloud::storage::Client client,

--- a/google/cloud/storage/examples/storage_object_retention_samples.cc
+++ b/google/cloud/storage/examples/storage_object_retention_samples.cc
@@ -16,6 +16,9 @@
 #include "google/cloud/storage/examples/storage_examples_common.h"
 #include "google/cloud/internal/getenv.h"
 #include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_object_rewrite_samples.cc
+++ b/google/cloud/storage/examples/storage_object_rewrite_samples.cc
@@ -18,6 +18,9 @@
 #include <functional>
 #include <iostream>
 #include <map>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -22,6 +22,8 @@
 #include <map>
 #include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_object_versioning_samples.cc
+++ b/google/cloud/storage/examples/storage_object_versioning_samples.cc
@@ -17,7 +17,10 @@
 #include "google/cloud/internal/getenv.h"
 #include <functional>
 #include <iostream>
+#include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_otel_samples.cc
+++ b/google/cloud/storage/examples/storage_otel_samples.cc
@@ -28,6 +28,7 @@
 #include <iostream>
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace {

--- a/google/cloud/storage/examples/storage_policy_doc_samples.cc
+++ b/google/cloud/storage/examples/storage_policy_doc_samples.cc
@@ -17,7 +17,10 @@
 #include "google/cloud/internal/getenv.h"
 #include <iostream>
 #include <sstream>
+#include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_public_object_samples.cc
+++ b/google/cloud/storage/examples/storage_public_object_samples.cc
@@ -17,6 +17,9 @@
 #include "google/cloud/internal/getenv.h"
 #include <functional>
 #include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_quickstart.cc
+++ b/google/cloud/storage/examples/storage_quickstart.cc
@@ -18,6 +18,9 @@
 // [START storage_quickstart]
 #include "google/cloud/storage/client.h"
 #include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
 // [END storage_quickstart]
 
 namespace {

--- a/google/cloud/storage/examples/storage_retention_policy_samples.cc
+++ b/google/cloud/storage/examples/storage_retention_policy_samples.cc
@@ -17,7 +17,10 @@
 #include "google/cloud/internal/getenv.h"
 #include <functional>
 #include <iostream>
+#include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_service_account_samples.cc
+++ b/google/cloud/storage/examples/storage_service_account_samples.cc
@@ -16,6 +16,9 @@
 #include "google/cloud/storage/examples/storage_examples_common.h"
 #include "google/cloud/internal/getenv.h"
 #include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_signed_url_v2_samples.cc
+++ b/google/cloud/storage/examples/storage_signed_url_v2_samples.cc
@@ -16,6 +16,9 @@
 #include "google/cloud/storage/examples/storage_examples_common.h"
 #include "google/cloud/internal/getenv.h"
 #include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_signed_url_v4_samples.cc
+++ b/google/cloud/storage/examples/storage_signed_url_v4_samples.cc
@@ -16,6 +16,9 @@
 #include "google/cloud/storage/examples/storage_examples_common.h"
 #include "google/cloud/internal/getenv.h"
 #include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/google/cloud/storage/examples/storage_website_samples.cc
+++ b/google/cloud/storage/examples/storage_website_samples.cc
@@ -17,7 +17,10 @@
 #include "google/cloud/internal/getenv.h"
 #include <chrono>
 #include <iostream>
+#include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 namespace {
 

--- a/google/cloud/storage/internal/access_control_common_parser_test.cc
+++ b/google/cloud/storage/internal/access_control_common_parser_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <nlohmann/json.hpp>
+#include <string>
 // This file contains tests for deprecated functions, we need to disable the
 // warnings
 #include "google/cloud/internal/disable_deprecation_warnings.inc"

--- a/google/cloud/storage/internal/base64.cc
+++ b/google/cloud/storage/internal/base64.cc
@@ -15,6 +15,9 @@
 #include "google/cloud/storage/internal/base64.h"
 #include "google/cloud/internal/base64_transforms.h"
 #include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/base64_test.cc
+++ b/google/cloud/storage/internal/base64_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/storage/internal/base64.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/bucket_access_control_parser.cc
+++ b/google/cloud/storage/internal/bucket_access_control_parser.cc
@@ -16,6 +16,8 @@
 #include "google/cloud/storage/internal/access_control_common_parser.h"
 #include "google/cloud/storage/internal/metadata_parser.h"
 #include <nlohmann/json.hpp>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/bucket_acl_requests.cc
+++ b/google/cloud/storage/internal/bucket_acl_requests.cc
@@ -17,6 +17,8 @@
 #include "google/cloud/storage/internal/metadata_parser.h"
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include <iostream>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/bucket_acl_requests.h
+++ b/google/cloud/storage/internal/bucket_acl_requests.h
@@ -22,6 +22,7 @@
 #include "google/cloud/storage/well_known_parameters.h"
 #include <iosfwd>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace google {

--- a/google/cloud/storage/internal/bucket_acl_requests_test.cc
+++ b/google/cloud/storage/internal/bucket_acl_requests_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <nlohmann/json.hpp>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/bucket_metadata_parser.cc
+++ b/google/cloud/storage/internal/bucket_metadata_parser.cc
@@ -21,6 +21,9 @@
 #include "absl/strings/str_format.h"
 #include <nlohmann/json.hpp>
 #include <functional>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/bucket_requests.cc
+++ b/google/cloud/storage/internal/bucket_requests.cc
@@ -20,6 +20,9 @@
 #include "google/cloud/internal/format_time_point.h"
 #include <nlohmann/json.hpp>
 #include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/bucket_requests.h
+++ b/google/cloud/storage/internal/bucket_requests.h
@@ -24,6 +24,7 @@
 #include "google/cloud/storage/well_known_parameters.h"
 #include <iosfwd>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace google {

--- a/google/cloud/storage/internal/bucket_requests_test.cc
+++ b/google/cloud/storage/internal/bucket_requests_test.cc
@@ -23,6 +23,9 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <nlohmann/json.hpp>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/common_metadata_parser.h
+++ b/google/cloud/storage/internal/common_metadata_parser.h
@@ -20,6 +20,7 @@
 #include "google/cloud/status.h"
 #include <nlohmann/json.hpp>
 #include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/complex_option.h
+++ b/google/cloud/storage/internal/complex_option.h
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/version.h"
 #include "absl/types/optional.h"
 #include <iostream>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/compute_engine_util_test.cc
+++ b/google/cloud/storage/internal/compute_engine_util_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/storage/internal/compute_engine_util.h"
 #include "google/cloud/testing_util/scoped_environment.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/connection_impl.cc
+++ b/google/cloud/storage/internal/connection_impl.cc
@@ -20,8 +20,10 @@
 #include <chrono>
 #include <functional>
 #include <sstream>
+#include <string>
 #include <thread>
 #include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/connection_impl.h
+++ b/google/cloud/storage/internal/connection_impl.h
@@ -22,6 +22,7 @@
 #include "google/cloud/storage/version.h"
 #include "google/cloud/internal/invocation_id_generator.h"
 #include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/connection_impl_bucket_acl_test.cc
+++ b/google/cloud/storage/internal/connection_impl_bucket_acl_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/testing/mock_generic_stub.h"
 #include "google/cloud/storage/testing/retry_tests.h"
 #include <gmock/gmock.h>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/connection_impl_bucket_test.cc
+++ b/google/cloud/storage/internal/connection_impl_bucket_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/testing/mock_generic_stub.h"
 #include "google/cloud/storage/testing/retry_tests.h"
 #include <gmock/gmock.h>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/connection_impl_default_object_acl_test.cc
+++ b/google/cloud/storage/internal/connection_impl_default_object_acl_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/testing/mock_generic_stub.h"
 #include "google/cloud/storage/testing/retry_tests.h"
 #include <gmock/gmock.h>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/connection_impl_notifications_test.cc
+++ b/google/cloud/storage/internal/connection_impl_notifications_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/testing/mock_generic_stub.h"
 #include "google/cloud/storage/testing/retry_tests.h"
 #include <gmock/gmock.h>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/connection_impl_object_acl_test.cc
+++ b/google/cloud/storage/internal/connection_impl_object_acl_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/testing/mock_generic_stub.h"
 #include "google/cloud/storage/testing/retry_tests.h"
 #include <gmock/gmock.h>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/connection_impl_object_copy_test.cc
+++ b/google/cloud/storage/internal/connection_impl_object_copy_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/testing/mock_generic_stub.h"
 #include "google/cloud/storage/testing/retry_tests.h"
 #include <gmock/gmock.h>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/connection_impl_object_test.cc
+++ b/google/cloud/storage/internal/connection_impl_object_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/testing/mock_generic_stub.h"
 #include "google/cloud/storage/testing/retry_tests.h"
 #include <gmock/gmock.h>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/connection_impl_service_account_test.cc
+++ b/google/cloud/storage/internal/connection_impl_service_account_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/testing/mock_generic_stub.h"
 #include "google/cloud/storage/testing/retry_tests.h"
 #include <gmock/gmock.h>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/connection_impl_sign_blob_test.cc
+++ b/google/cloud/storage/internal/connection_impl_sign_blob_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/testing/mock_generic_stub.h"
 #include "google/cloud/storage/testing/retry_tests.h"
 #include <gmock/gmock.h>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/connection_impl_test.cc
+++ b/google/cloud/storage/internal/connection_impl_test.cc
@@ -22,6 +22,8 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <memory>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/crc32c_benchmark.cc
+++ b/google/cloud/storage/internal/crc32c_benchmark.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/storage/internal/crc32c.h"
 #include <benchmark/benchmark.h>
 #include <crc32c/crc32c.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/crc32c_test.cc
+++ b/google/cloud/storage/internal/crc32c_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/internal/crc32c.h"
 #include <gmock/gmock.h>
+#include <string>
 #include <vector>
 
 namespace google {

--- a/google/cloud/storage/internal/default_object_acl_requests.cc
+++ b/google/cloud/storage/internal/default_object_acl_requests.cc
@@ -19,6 +19,8 @@
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include <nlohmann/json.hpp>
 #include <iostream>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/default_object_acl_requests.h
+++ b/google/cloud/storage/internal/default_object_acl_requests.h
@@ -23,6 +23,7 @@
 #include "google/cloud/storage/well_known_parameters.h"
 #include <iosfwd>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace google {

--- a/google/cloud/storage/internal/default_object_acl_requests_test.cc
+++ b/google/cloud/storage/internal/default_object_acl_requests_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <nlohmann/json.hpp>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/generate_message_boundary.cc
+++ b/google/cloud/storage/internal/generate_message_boundary.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/internal/generate_message_boundary.h"
 #include <algorithm>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/generate_message_boundary_test.cc
+++ b/google/cloud/storage/internal/generate_message_boundary_test.cc
@@ -17,6 +17,7 @@
 #include <gmock/gmock.h>
 #include <algorithm>
 #include <cctype>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/generic_object_request.h
+++ b/google/cloud/storage/internal/generic_object_request.h
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/internal/generic_request.h"
 #include "google/cloud/storage/version.h"
 #include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/generic_stub_adapter.cc
+++ b/google/cloud/storage/internal/generic_stub_adapter.cc
@@ -17,6 +17,9 @@
 #include "google/cloud/storage/internal/storage_connection.h"
 #include "google/cloud/version.h"
 #include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/hash_function.cc
+++ b/google/cloud/storage/internal/hash_function.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/storage/internal/hash_function_impl.h"
 #include "google/cloud/storage/internal/object_requests.h"
 #include <memory>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/hash_function_impl.h
+++ b/google/cloud/storage/internal/hash_function_impl.h
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/hash_function_impl_test.cc
+++ b/google/cloud/storage/internal/hash_function_impl_test.cc
@@ -19,6 +19,8 @@
 #include "google/cloud/storage/testing/upload_hash_cases.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/hash_validator.h
+++ b/google/cloud/storage/internal/hash_validator.h
@@ -19,6 +19,7 @@
 #include "google/cloud/storage/version.h"
 #include <memory>
 #include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/hash_validator_impl.h
+++ b/google/cloud/storage/internal/hash_validator_impl.h
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/internal/hash_validator.h"
 #include "google/cloud/storage/version.h"
 #include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/hash_validator_test.cc
+++ b/google/cloud/storage/internal/hash_validator_test.cc
@@ -19,6 +19,8 @@
 #include "google/cloud/storage/internal/object_requests.h"
 #include "google/cloud/storage/testing/upload_hash_cases.h"
 #include <gmock/gmock.h>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/hash_values_test.cc
+++ b/google/cloud/storage/internal/hash_values_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/internal/hash_values.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/hmac_key_requests.cc
+++ b/google/cloud/storage/internal/hmac_key_requests.cc
@@ -16,6 +16,8 @@
 #include "google/cloud/storage/internal/hmac_key_metadata_parser.h"
 #include "google/cloud/storage/internal/metadata_parser.h"
 #include <iostream>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/hmac_key_requests.h
+++ b/google/cloud/storage/internal/hmac_key_requests.h
@@ -22,6 +22,7 @@
 #include "google/cloud/storage/version.h"
 #include <iosfwd>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace google {

--- a/google/cloud/storage/internal/hmac_key_requests_test.cc
+++ b/google/cloud/storage/internal/hmac_key_requests_test.cc
@@ -16,6 +16,8 @@
 #include "google/cloud/storage/internal/hmac_key_metadata_parser.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/http_response.cc
+++ b/google/cloud/storage/internal/http_response.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/internal/rest_parse_json_error.h"
 #include "google/cloud/internal/rest_response.h"
 #include <iostream>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/http_response_test.cc
+++ b/google/cloud/storage/internal/http_response_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <nlohmann/json.hpp>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/impersonate_service_account_credentials_test.cc
+++ b/google/cloud/storage/internal/impersonate_service_account_credentials_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/lifecycle_rule_parser.cc
+++ b/google/cloud/storage/internal/lifecycle_rule_parser.cc
@@ -15,7 +15,9 @@
 #include "google/cloud/storage/internal/lifecycle_rule_parser.h"
 #include "google/cloud/storage/internal/metadata_parser.h"
 #include "google/cloud/internal/make_status.h"
+#include <string>
 #include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/logging_stub.cc
+++ b/google/cloud/storage/internal/logging_stub.cc
@@ -15,7 +15,9 @@
 #include "google/cloud/storage/internal/logging_stub.h"
 #include "google/cloud/internal/invoke_result.h"
 #include "google/cloud/log.h"
+#include <string>
 #include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/logging_stub.h
+++ b/google/cloud/storage/internal/logging_stub.h
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/internal/generic_stub.h"
 #include "google/cloud/storage/version.h"
 #include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/logging_stub_test.cc
+++ b/google/cloud/storage/internal/logging_stub_test.cc
@@ -19,6 +19,9 @@
 #include "google/cloud/storage/testing/mock_generic_stub.h"
 #include "google/cloud/log.h"
 #include <gmock/gmock.h>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/make_jwt_assertion_test.cc
+++ b/google/cloud/storage/internal/make_jwt_assertion_test.cc
@@ -18,6 +18,8 @@
 #include "absl/strings/str_split.h"
 #include <gmock/gmock.h>
 #include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/md5hash.cc
+++ b/google/cloud/storage/internal/md5hash.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/storage/internal/md5hash.h"
 #include <algorithm>
 #include <array>
+#include <vector>
 #ifdef _WIN32
 #include <Windows.h>
 #include <wincrypt.h>

--- a/google/cloud/storage/internal/md5hash_test.cc
+++ b/google/cloud/storage/internal/md5hash_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/internal/md5hash.h"
 #include <gmock/gmock.h>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/metadata_parser.cc
+++ b/google/cloud/storage/internal/metadata_parser.cc
@@ -18,6 +18,8 @@
 #include "google/cloud/internal/throw_delegate.h"
 #include "absl/strings/numbers.h"
 #include <sstream>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/metadata_parser.h
+++ b/google/cloud/storage/internal/metadata_parser.h
@@ -20,6 +20,7 @@
 #include "google/cloud/status_or.h"
 #include <nlohmann/json.hpp>
 #include <chrono>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/metadata_parser_test.cc
+++ b/google/cloud/storage/internal/metadata_parser_test.cc
@@ -16,6 +16,8 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <limits>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/notification_metadata_parser.cc
+++ b/google/cloud/storage/internal/notification_metadata_parser.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/storage/internal/metadata_parser.h"
 #include "google/cloud/internal/make_status.h"
 #include <iostream>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/notification_requests.cc
+++ b/google/cloud/storage/internal/notification_requests.cc
@@ -18,6 +18,8 @@
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include "google/cloud/internal/make_status.h"
 #include <iostream>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/notification_requests.h
+++ b/google/cloud/storage/internal/notification_requests.h
@@ -22,6 +22,7 @@
 #include "google/cloud/storage/well_known_parameters.h"
 #include <iosfwd>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace google {

--- a/google/cloud/storage/internal/notification_requests_test.cc
+++ b/google/cloud/storage/internal/notification_requests_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/notification_payload_format.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/object_access_control_parser.cc
+++ b/google/cloud/storage/internal/object_access_control_parser.cc
@@ -16,6 +16,8 @@
 #include "google/cloud/storage/internal/access_control_common_parser.h"
 #include "google/cloud/storage/internal/metadata_parser.h"
 #include <nlohmann/json.hpp>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/object_acl_requests.cc
+++ b/google/cloud/storage/internal/object_acl_requests.cc
@@ -19,6 +19,8 @@
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include "google/cloud/internal/make_status.h"
 #include <iostream>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/object_acl_requests.h
+++ b/google/cloud/storage/internal/object_acl_requests.h
@@ -23,6 +23,7 @@
 #include "google/cloud/storage/well_known_parameters.h"
 #include <iosfwd>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace google {

--- a/google/cloud/storage/internal/object_acl_requests_test.cc
+++ b/google/cloud/storage/internal/object_acl_requests_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/storage/internal/object_access_control_parser.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/object_metadata_parser.cc
+++ b/google/cloud/storage/internal/object_metadata_parser.cc
@@ -18,6 +18,9 @@
 #include "google/cloud/internal/format_time_point.h"
 #include <nlohmann/json.hpp>
 #include <functional>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/object_read_source.h
+++ b/google/cloud/storage/internal/object_read_source.h
@@ -21,6 +21,8 @@
 #include "google/cloud/status_or.h"
 #include "absl/types/optional.h"
 #include <cstdint>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/object_read_streambuf.cc
+++ b/google/cloud/storage/internal/object_read_streambuf.cc
@@ -17,6 +17,9 @@
 #include "google/cloud/storage/internal/hash_function.h"
 #include "google/cloud/internal/make_status.h"
 #include <cstring>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/object_read_streambuf.h
+++ b/google/cloud/storage/internal/object_read_streambuf.h
@@ -25,6 +25,7 @@
 #include <iostream>
 #include <map>
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace google {

--- a/google/cloud/storage/internal/object_read_streambuf_test.cc
+++ b/google/cloud/storage/internal/object_read_streambuf_test.cc
@@ -15,6 +15,8 @@
 #include "google/cloud/storage/internal/object_read_streambuf.h"
 #include "google/cloud/storage/testing/mock_client.h"
 #include <gmock/gmock.h>
+#include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/object_requests.cc
+++ b/google/cloud/storage/internal/object_requests.cc
@@ -22,6 +22,9 @@
 #include "absl/strings/str_split.h"
 #include <cinttypes>
 #include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -37,6 +37,7 @@
 #include <memory>
 #include <numeric>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace google {

--- a/google/cloud/storage/internal/object_requests_test.cc
+++ b/google/cloud/storage/internal/object_requests_test.cc
@@ -19,6 +19,9 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <nlohmann/json.hpp>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/object_write_streambuf.cc
+++ b/google/cloud/storage/internal/object_write_streambuf.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/storage/version.h"
 #include "google/cloud/internal/make_status.h"
 #include <sstream>
+#include <string>
 #include <utility>
 
 namespace google {

--- a/google/cloud/storage/internal/object_write_streambuf.h
+++ b/google/cloud/storage/internal/object_write_streambuf.h
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/object_write_streambuf_test.cc
+++ b/google/cloud/storage/internal/object_write_streambuf_test.cc
@@ -19,6 +19,8 @@
 #include "google/cloud/storage/testing/mock_generic_stub.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/patch_builder.cc
+++ b/google/cloud/storage/internal/patch_builder.cc
@@ -19,6 +19,7 @@
 #include <nlohmann/json.hpp>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace google {

--- a/google/cloud/storage/internal/patch_builder_test.cc
+++ b/google/cloud/storage/internal/patch_builder_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/storage/internal/patch_builder_details.h"
 #include <gmock/gmock.h>
 #include <nlohmann/json.hpp>
+#include <string>
 #include <vector>
 
 namespace google {

--- a/google/cloud/storage/internal/policy_document_request.cc
+++ b/google/cloud/storage/internal/policy_document_request.cc
@@ -22,6 +22,9 @@
 #include <nlohmann/json.hpp>
 #include <iomanip>
 #include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/policy_document_request.h
+++ b/google/cloud/storage/internal/policy_document_request.h
@@ -23,6 +23,7 @@
 #include "absl/types/optional.h"
 #include <chrono>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace google {

--- a/google/cloud/storage/internal/policy_document_request_test.cc
+++ b/google/cloud/storage/internal/policy_document_request_test.cc
@@ -17,6 +17,8 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/request_project_id.h
+++ b/google/cloud/storage/internal/request_project_id.h
@@ -22,6 +22,7 @@
 #include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
 #include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/retry_object_read_source.cc
+++ b/google/cloud/storage/internal/retry_object_read_source.cc
@@ -20,6 +20,7 @@
 #include <string>
 #include <thread>
 #include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/retry_object_read_source_test.cc
+++ b/google/cloud/storage/internal/retry_object_read_source_test.cc
@@ -22,6 +22,8 @@
 #include "google/cloud/testing_util/opentelemetry_matchers.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/service_account_requests.h
+++ b/google/cloud/storage/internal/service_account_requests.h
@@ -20,6 +20,7 @@
 #include "google/cloud/storage/well_known_parameters.h"
 #include <iosfwd>
 #include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/sign_blob_requests.cc
+++ b/google/cloud/storage/internal/sign_blob_requests.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include "google/cloud/internal/make_status.h"
 #include <nlohmann/json.hpp>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/sign_blob_requests.h
+++ b/google/cloud/storage/internal/sign_blob_requests.h
@@ -20,6 +20,7 @@
 #include "google/cloud/storage/version.h"
 #include "google/cloud/status_or.h"
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace google {

--- a/google/cloud/storage/internal/sign_blob_requests_test.cc
+++ b/google/cloud/storage/internal/sign_blob_requests_test.cc
@@ -15,6 +15,8 @@
 #include "google/cloud/storage/internal/sign_blob_requests.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/signed_url_requests.cc
+++ b/google/cloud/storage/internal/signed_url_requests.cc
@@ -22,6 +22,9 @@
 #include <algorithm>
 #include <cctype>
 #include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/signed_url_requests.h
+++ b/google/cloud/storage/internal/signed_url_requests.h
@@ -26,6 +26,7 @@
 #include <iosfwd>
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace google {

--- a/google/cloud/storage/internal/signed_url_requests_test.cc
+++ b/google/cloud/storage/internal/signed_url_requests_test.cc
@@ -17,6 +17,8 @@
 #include "google/cloud/internal/parse_rfc3339.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/storage_stub_factory.cc
+++ b/google/cloud/storage/internal/storage_stub_factory.cc
@@ -26,6 +26,9 @@
 #include "google/cloud/internal/unified_grpc_credentials.h"
 #include "google/cloud/log.h"
 #include <grpcpp/grpcpp.h>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/storage_stub_factory_test.cc
+++ b/google/cloud/storage/internal/storage_stub_factory_test.cc
@@ -26,6 +26,8 @@
 #include "google/cloud/testing_util/validate_metadata.h"
 #include "google/cloud/testing_util/validate_propagator.h"
 #include <gmock/gmock.h>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/tracing_connection.h
+++ b/google/cloud/storage/internal/tracing_connection.h
@@ -18,6 +18,8 @@
 #include "google/cloud/storage/internal/storage_connection.h"
 #include "google/cloud/storage/version.h"
 #include <memory>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/tracing_connection_test.cc
+++ b/google/cloud/storage/internal/tracing_connection_test.cc
@@ -21,6 +21,8 @@
 #include "google/cloud/testing_util/opentelemetry_matchers.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/tracing_object_read_source_test.cc
+++ b/google/cloud/storage/internal/tracing_object_read_source_test.cc
@@ -20,6 +20,7 @@
 #include "google/cloud/testing_util/opentelemetry_matchers.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
 #include <utility>
 
 namespace google {

--- a/google/cloud/storage/internal/tuple_filter_test.cc
+++ b/google/cloud/storage/internal/tuple_filter_test.cc
@@ -14,6 +14,8 @@
 
 #include "google/cloud/storage/internal/tuple_filter.h"
 #include <gmock/gmock.h>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/unified_rest_credentials_test.cc
+++ b/google/cloud/storage/internal/unified_rest_credentials_test.cc
@@ -24,6 +24,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <random>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/mocks/mock_async_writer_connection.h
+++ b/google/cloud/storage/mocks/mock_async_writer_connection.h
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/async/writer_connection.h"
 #include "google/cloud/version.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/oauth2/authorized_user_credentials.cc
+++ b/google/cloud/storage/oauth2/authorized_user_credentials.cc
@@ -14,6 +14,8 @@
 
 #include "google/cloud/storage/oauth2/authorized_user_credentials.h"
 #include <nlohmann/json.hpp>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/oauth2/authorized_user_credentials.h
+++ b/google/cloud/storage/oauth2/authorized_user_credentials.h
@@ -31,6 +31,7 @@
 #include <iostream>
 #include <mutex>
 #include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/oauth2/authorized_user_credentials_test.cc
+++ b/google/cloud/storage/oauth2/authorized_user_credentials_test.cc
@@ -23,6 +23,9 @@
 #include <gmock/gmock.h>
 #include <nlohmann/json.hpp>
 #include <cstring>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/oauth2/compute_engine_credentials.cc
+++ b/google/cloud/storage/oauth2/compute_engine_credentials.cc
@@ -16,6 +16,8 @@
 #include "google/cloud/internal/oauth2_cached_credentials.h"
 #include "google/cloud/internal/oauth2_compute_engine_credentials.h"
 #include <nlohmann/json.hpp>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/oauth2/compute_engine_credentials.h
+++ b/google/cloud/storage/oauth2/compute_engine_credentials.h
@@ -33,6 +33,7 @@
 #include <mutex>
 #include <set>
 #include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/oauth2/compute_engine_credentials_test.cc
+++ b/google/cloud/storage/oauth2/compute_engine_credentials_test.cc
@@ -25,6 +25,8 @@
 #include <nlohmann/json.hpp>
 #include <chrono>
 #include <cstring>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/oauth2/google_credentials.cc
+++ b/google/cloud/storage/oauth2/google_credentials.cc
@@ -26,6 +26,8 @@
 #include <fstream>
 #include <iterator>
 #include <memory>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/oauth2/google_credentials_test.cc
+++ b/google/cloud/storage/oauth2/google_credentials_test.cc
@@ -27,6 +27,7 @@
 #include "absl/strings/match.h"
 #include <gmock/gmock.h>
 #include <fstream>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/oauth2/service_account_credentials.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials.cc
@@ -24,6 +24,8 @@
 #include <nlohmann/json.hpp>
 #include <array>
 #include <cstdio>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/oauth2/service_account_credentials.h
+++ b/google/cloud/storage/oauth2/service_account_credentials.h
@@ -39,6 +39,7 @@
 #include <mutex>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace google {

--- a/google/cloud/storage/oauth2/service_account_credentials_test.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials_test.cc
@@ -31,6 +31,8 @@
 #include <nlohmann/json.hpp>
 #include <chrono>
 #include <fstream>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/quickstart/quickstart.cc
+++ b/google/cloud/storage/quickstart/quickstart.cc
@@ -15,6 +15,7 @@
 //! [all]
 #include "google/cloud/storage/client.h"
 #include <iostream>
+#include <string>
 
 int main(int argc, char* argv[]) {
   if (argc != 2) {

--- a/google/cloud/storage/quickstart/quickstart_async.cc
+++ b/google/cloud/storage/quickstart/quickstart_async.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/async/client.h"
 #include <iostream>
+#include <string>
 
 int main(int argc, char* argv[]) {
   if (argc != 2) {

--- a/google/cloud/storage/quickstart/quickstart_grpc.cc
+++ b/google/cloud/storage/quickstart/quickstart_grpc.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/grpc_plugin.h"
 #include <iostream>
+#include <string>
 
 int main(int argc, char* argv[]) {
   if (argc != 2) {

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -19,6 +19,8 @@
 #include "google/cloud/storage/internal/storage_connection.h"
 #include <gmock/gmock.h>
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/testing/mock_generic_stub.h
+++ b/google/cloud/storage/testing/mock_generic_stub.h
@@ -17,6 +17,8 @@
 
 #include "google/cloud/storage/internal/generic_stub.h"
 #include <gmock/gmock.h>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/testing/mock_hash_function.h
+++ b/google/cloud/storage/testing/mock_hash_function.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/storage/internal/hash_function.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/testing/mock_hash_validator.h
+++ b/google/cloud/storage/testing/mock_hash_validator.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/storage/internal/hash_validator.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/testing/mock_http_request.h
+++ b/google/cloud/storage/testing/mock_http_request.h
@@ -22,6 +22,7 @@
 #include <gmock/gmock.h>
 #include <nlohmann/json.hpp>
 #include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/testing/remove_stale_buckets.cc
+++ b/google/cloud/storage/testing/remove_stale_buckets.cc
@@ -14,6 +14,8 @@
 
 #include "google/cloud/storage/testing/remove_stale_buckets.h"
 #include <regex>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/testing/remove_stale_buckets_test.cc
+++ b/google/cloud/storage/testing/remove_stale_buckets_test.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/internal/format_time_point.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <nlohmann/json.hpp>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/testing/retry_http_request.cc
+++ b/google/cloud/storage/testing/retry_http_request.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/internal/make_status.h"
 #include "google/cloud/internal/rest_client.h"
 #include <chrono>
+#include <string>
 #include <thread>
 #include <utility>
 

--- a/google/cloud/storage/testing/retry_tests.cc
+++ b/google/cloud/storage/testing/retry_tests.cc
@@ -20,6 +20,9 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <algorithm>
 #include <chrono>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/testing/storage_integration_test.cc
+++ b/google/cloud/storage/testing/storage_integration_test.cc
@@ -23,6 +23,8 @@
 #include "google/cloud/testing_util/scoped_environment.h"
 #include "absl/strings/match.h"
 #include <nlohmann/json.hpp>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/testing/storage_integration_test.h
+++ b/google/cloud/storage/testing/storage_integration_test.h
@@ -25,6 +25,7 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 namespace google {

--- a/google/cloud/storage/testing/temp_file.cc
+++ b/google/cloud/storage/testing/temp_file.cc
@@ -18,6 +18,7 @@
 #include <gmock/gmock.h>
 #include <cstdio>
 #include <fstream>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/testing/write_base64.cc
+++ b/google/cloud/storage/testing/write_base64.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/storage/testing/write_base64.h"
 #include "google/cloud/storage/internal/base64.h"
 #include <fstream>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/alternative_endpoint_integration_test.cc
+++ b/google/cloud/storage/tests/alternative_endpoint_integration_test.cc
@@ -21,6 +21,8 @@
 #include "absl/strings/str_split.h"
 #include <gmock/gmock.h>
 #include <fstream>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/async_client_integration_test.cc
+++ b/google/cloud/storage/tests/async_client_integration_test.cc
@@ -24,6 +24,9 @@
 #include <gmock/gmock.h>
 #include <algorithm>
 #include <numeric>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/auto_finalize_integration_test.cc
+++ b/google/cloud/storage/tests/auto_finalize_integration_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <fstream>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/bucket_acl_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_acl_integration_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <iterator>
+#include <string>
 #include <vector>
 
 namespace google {

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -21,7 +21,10 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <chrono>
+#include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/create_client_integration_test.cc
+++ b/google/cloud/storage/tests/create_client_integration_test.cc
@@ -21,6 +21,8 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <fstream>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/curl_sign_blob_integration_test.cc
+++ b/google/cloud/storage/tests/curl_sign_blob_integration_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/decompressive_transcoding_integration_test.cc
+++ b/google/cloud/storage/tests/decompressive_transcoding_integration_test.cc
@@ -20,7 +20,9 @@
 #include "absl/strings/str_split.h"
 #include <gmock/gmock.h>
 #include <fstream>
+#include <string>
 #include <thread>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/default_object_acl_integration_test.cc
+++ b/google/cloud/storage/tests/default_object_acl_integration_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <iterator>
+#include <string>
 #include <vector>
 
 namespace google {

--- a/google/cloud/storage/tests/error_injection_integration_test.cc
+++ b/google/cloud/storage/tests/error_injection_integration_test.cc
@@ -20,6 +20,8 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include "absl/types/optional.h"
 #include <gmock/gmock.h>
+#include <string>
+#include <vector>
 #ifndef _WIN32
 #include <dlfcn.h>
 #endif  // _WIN32

--- a/google/cloud/storage/tests/grpc_bucket_metadata_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_bucket_metadata_integration_test.cc
@@ -18,6 +18,7 @@
 #include <gmock/gmock.h>
 #include <algorithm>
 #include <iterator>
+#include <string>
 #include <vector>
 
 namespace google {

--- a/google/cloud/storage/tests/grpc_hmac_key_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_hmac_key_integration_test.cc
@@ -16,6 +16,8 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/grpc_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_integration_test.cc
@@ -17,6 +17,8 @@
 #include "google/cloud/testing_util/setenv.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
+#include <utility>
 #include <vector>
 
 namespace google {

--- a/google/cloud/storage/tests/grpc_object_media_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_object_media_integration_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <utility>
 #include <vector>
 
 namespace google {

--- a/google/cloud/storage/tests/grpc_object_metadata_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_object_metadata_integration_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
 #include <vector>
 
 namespace google {

--- a/google/cloud/storage/tests/key_file_integration_test.cc
+++ b/google/cloud/storage/tests/key_file_integration_test.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/internal/rest_request.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/notification_integration_test.cc
+++ b/google/cloud/storage/tests/notification_integration_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/object_basic_crud_integration_test.cc
+++ b/google/cloud/storage/tests/object_basic_crud_integration_test.cc
@@ -27,6 +27,8 @@
 #include <memory>
 #include <regex>
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/object_checksum_integration_test.cc
+++ b/google/cloud/storage/tests/object_checksum_integration_test.cc
@@ -18,6 +18,8 @@
 #include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/object_compose_many_integration_test.cc
+++ b/google/cloud/storage/tests/object_compose_many_integration_test.cc
@@ -25,6 +25,8 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/object_file_integration_test.cc
+++ b/google/cloud/storage/tests/object_file_integration_test.cc
@@ -21,7 +21,9 @@
 #include <gmock/gmock.h>
 #include <cstdio>
 #include <fstream>
+#include <string>
 #include <thread>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/object_file_multi_threaded_test.cc
+++ b/google/cloud/storage/tests/object_file_multi_threaded_test.cc
@@ -22,7 +22,9 @@
 #include <cstdio>
 #include <fstream>
 #include <future>
+#include <string>
 #include <thread>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/object_hash_integration_test.cc
+++ b/google/cloud/storage/tests/object_hash_integration_test.cc
@@ -22,6 +22,8 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <regex>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/object_insert_integration_test.cc
+++ b/google/cloud/storage/tests/object_insert_integration_test.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <regex>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -26,6 +26,8 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -21,7 +21,9 @@
 #include <gmock/gmock.h>
 #include <cstdio>
 #include <fstream>
+#include <string>
 #include <thread>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/object_parallel_upload_integration_test.cc
+++ b/google/cloud/storage/tests/object_parallel_upload_integration_test.cc
@@ -25,6 +25,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/object_plenty_clients_simultaneously_integration_test.cc
+++ b/google/cloud/storage/tests/object_plenty_clients_simultaneously_integration_test.cc
@@ -26,6 +26,8 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/object_read_large_integration_test.cc
+++ b/google/cloud/storage/tests/object_read_large_integration_test.cc
@@ -20,6 +20,7 @@
 #include <fstream>
 #include <iterator>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace google {

--- a/google/cloud/storage/tests/object_read_range_integration_test.cc
+++ b/google/cloud/storage/tests/object_read_range_integration_test.cc
@@ -18,6 +18,8 @@
 #include "google/cloud/testing_util/scoped_environment.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/object_resumable_parallel_upload_integration_test.cc
+++ b/google/cloud/storage/tests/object_resumable_parallel_upload_integration_test.cc
@@ -26,6 +26,8 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/object_resumable_write_integration_test.cc
+++ b/google/cloud/storage/tests/object_resumable_write_integration_test.cc
@@ -17,7 +17,9 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
 #include <thread>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/object_rewrite_integration_test.cc
+++ b/google/cloud/storage/tests/object_rewrite_integration_test.cc
@@ -20,6 +20,8 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <regex>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/object_write_streambuf_integration_test.cc
+++ b/google/cloud/storage/tests/object_write_streambuf_integration_test.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
 #include <utility>
 
 namespace google {

--- a/google/cloud/storage/tests/service_account_credentials_integration_test.cc
+++ b/google/cloud/storage/tests/service_account_credentials_integration_test.cc
@@ -22,6 +22,8 @@
 #include <gmock/gmock.h>
 #include <nlohmann/json.hpp>
 #include <chrono>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/service_account_integration_test.cc
+++ b/google/cloud/storage/tests/service_account_integration_test.cc
@@ -17,6 +17,8 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/signed_url_conformance_test.cc
+++ b/google/cloud/storage/tests/signed_url_conformance_test.cc
@@ -28,7 +28,10 @@
 #include <google/protobuf/util/json_util.h>
 #include <gmock/gmock.h>
 #include <fstream>
+#include <string>
 #include <type_traits>
+#include <utility>
+#include <vector>
 
 /**
  * @file

--- a/google/cloud/storage/tests/signed_url_integration_test.cc
+++ b/google/cloud/storage/tests/signed_url_integration_test.cc
@@ -21,6 +21,7 @@
 #include <gmock/gmock.h>
 #include <chrono>
 #include <functional>
+#include <string>
 #include <thread>
 
 namespace google {

--- a/google/cloud/storage/tests/slow_reader_chunk_integration_test.cc
+++ b/google/cloud/storage/tests/slow_reader_chunk_integration_test.cc
@@ -19,7 +19,9 @@
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
 #include <thread>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/slow_reader_stream_integration_test.cc
+++ b/google/cloud/storage/tests/slow_reader_stream_integration_test.cc
@@ -19,7 +19,9 @@
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
 #include <thread>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/small_reads_integration_test.cc
+++ b/google/cloud/storage/tests/small_reads_integration_test.cc
@@ -18,7 +18,9 @@
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
 #include <thread>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/smoke_test_async.cc
+++ b/google/cloud/storage/tests/smoke_test_async.cc
@@ -21,6 +21,7 @@
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
 #include <tuple>
 #include <utility>
 

--- a/google/cloud/storage/tests/smoke_test_grpc.cc
+++ b/google/cloud/storage/tests/smoke_test_grpc.cc
@@ -21,6 +21,7 @@
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/smoke_test_rest.cc
+++ b/google/cloud/storage/tests/smoke_test_rest.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/thread_integration_test.cc
+++ b/google/cloud/storage/tests/thread_integration_test.cc
@@ -23,7 +23,9 @@
 #include <gmock/gmock.h>
 #include <algorithm>
 #include <future>
+#include <string>
 #include <thread>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/tracing_integration_test.cc
+++ b/google/cloud/storage/tests/tracing_integration_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/tests/unified_credentials_integration_test.cc
+++ b/google/cloud/storage/tests/unified_credentials_integration_test.cc
@@ -22,6 +22,8 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <fstream>
+#include <string>
+#include <utility>
 
 namespace google {
 namespace cloud {


### PR DESCRIPTION
My glob expressions missed a lot of them. This pass I am fixing
`std::move`, `std::string`, and `std::vector`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14529)
<!-- Reviewable:end -->
