### PR TITLE
cleanup(generator): fewer HttpInfo code paths

### DIFF
--- a/generator/internal/http_option_utils.h
+++ b/generator/internal/http_option_utils.h
@@ -61,11 +61,9 @@ HttpExtensionInfo ParseHttpExtension(
  *   method_http_verb
  *   method_rest_path
  */
-void SetHttpDerivedMethodVars(
-    absl::variant<absl::monostate, HttpSimpleInfo, HttpExtensionInfo>
-        parsed_http_info,
-    google::protobuf::MethodDescriptor const& method,
-    VarsDictionary& method_vars);
+void SetHttpDerivedMethodVars(HttpExtensionInfo const& info,
+                              google::protobuf::MethodDescriptor const& method,
+                              VarsDictionary& method_vars);
 
 struct QueryParameterInfo {
   protobuf::FieldDescriptor::CppType cpp_type;


### PR DESCRIPTION
Part of the work for #14510 

There is only one case, so remove the `HttpSimpleInfo`, `absl::monostate` branches in `SetHttpDerivedMethodVars`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14534)
<!-- Reviewable:end -->
