### PR TITLE
cleanup(generator): fewer HttpInfo code paths 2

### DIFF
--- a/generator/internal/http_option_utils.h
+++ b/generator/internal/http_option_utils.h
@@ -89,11 +89,9 @@ absl::optional<QueryParameterInfo> DetermineQueryParameterInfo(
  * Sets the "method_http_query_parameters" value in method_vars based on the
  * parsed_http_info.
  */
-void SetHttpQueryParameters(
-    absl::variant<absl::monostate, HttpSimpleInfo, HttpExtensionInfo>
-        parsed_http_info,
-    google::protobuf::MethodDescriptor const& method,
-    VarsDictionary& method_vars);
+void SetHttpQueryParameters(HttpExtensionInfo const& info,
+                            google::protobuf::MethodDescriptor const& method,
+                            VarsDictionary& method_vars);
 
 /**
  * Determines if the method contains a routing header as specified in AIP-4222.


### PR DESCRIPTION
Part of the work for #14510 

There is only one case, so remove the `HttpSimpleInfo`, `absl::monostate` branches in `SetHttpQueryParameters`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14535)
<!-- Reviewable:end -->
