### PR TITLE
cleanup(generator): fewer HttpInfo code paths 3

### DIFF
--- a/generator/internal/http_option_utils.cc
+++ b/generator/internal/http_option_utils.cc
@@ -426,24 +426,12 @@ bool HasHttpAnnotation(MethodDescriptor const& method) {
   return method.options().HasExtension(google::api::http);
 }
 
-std::string FormatRequestResource(
-    google::protobuf::Descriptor const& request,
-    absl::variant<absl::monostate, HttpSimpleInfo, HttpExtensionInfo> const&
-        parsed_http_info) {
-  struct HttpInfoVisitor {
-    std::string operator()(HttpExtensionInfo const& info) { return info.body; }
-    std::string operator()(HttpSimpleInfo const& info) { return info.body; }
-    std::string operator()(absl::monostate) { return ""; }
-  };
-
-  std::string body_field_name =
-      absl::visit(HttpInfoVisitor{}, parsed_http_info);
-  if (body_field_name.empty()) return "request";
-
+std::string FormatRequestResource(google::protobuf::Descriptor const& request,
+                                  HttpExtensionInfo const& info) {
   std::string field_name;
   for (int i = 0; i != request.field_count(); ++i) {
     auto const* field = request.field(i);
-    if (field->name() == body_field_name) {
+    if (field->name() == info.body) {
       field_name = FieldName(field);
     }
   }

--- a/generator/internal/http_option_utils.h
+++ b/generator/internal/http_option_utils.h
@@ -115,10 +115,8 @@ bool HasHttpAnnotation(google::protobuf::MethodDescriptor const& method);
  *  [json_name = __json_request_body] that field is returned. Otherwise, the
  *  entire request is used.
  */
-std::string FormatRequestResource(
-    google::protobuf::Descriptor const& request,
-    absl::variant<absl::monostate, HttpSimpleInfo, HttpExtensionInfo> const&
-        parsed_http_info);
+std::string FormatRequestResource(google::protobuf::Descriptor const& request,
+                                  HttpExtensionInfo const& info);
 
 /**
  * Parses the package name of the method and returns its API version.

--- a/generator/internal/http_option_utils_test.cc
+++ b/generator/internal/http_option_utils_test.cc
@@ -717,9 +717,8 @@ TEST_F(HttpOptionUtilsTest, FormatRequestResourceFailedParse) {
       pool_.FindFileByName("google/foo/v1/service.proto");
   MethodDescriptor const* method =
       service_file_descriptor->service(0)->method(2);
-  auto result = FormatRequestResource(
-      *method->input_type(),
-      absl::variant<absl::monostate, HttpSimpleInfo, HttpExtensionInfo>());
+  auto result =
+      FormatRequestResource(*method->input_type(), HttpExtensionInfo{});
   EXPECT_THAT(result, Eq("request"));
 }
 


### PR DESCRIPTION
Part of the work for #14510 

There is only one case, so remove the `HttpSimpleInfo`, `absl::monostate` branches in `FormatRequestResource`