### PR TITLE
docs(quickstart): Replace deprecated RPC in the sample code

### DIFF
--- a/google/cloud/edgenetwork/CMakeLists.txt
+++ b/google/cloud/edgenetwork/CMakeLists.txt
@@ -29,7 +29,8 @@ if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
         COMMAND
             cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
             $<TARGET_FILE:edgenetwork_quickstart> GOOGLE_CLOUD_PROJECT
-            GOOGLE_CLOUD_CPP_TEST_REGION)
+            GOOGLE_CLOUD_CPP_TEST_REGION GOOGLE_CLOUD_CPP_TEST_ZONE)
     set_tests_properties(edgenetwork_quickstart
-                         PROPERTIES LABELS "integration-test;quickstart")
+                         PROPERTIES LABELS "integration-test;quickstart"
+                         PASS_REGULAR_EXPRESSION "message of Resource 'zones/.*' was not found")
 endif ()

--- a/google/cloud/edgenetwork/CMakeLists.txt
+++ b/google/cloud/edgenetwork/CMakeLists.txt
@@ -30,7 +30,8 @@ if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
             cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
             $<TARGET_FILE:edgenetwork_quickstart> GOOGLE_CLOUD_PROJECT
             GOOGLE_CLOUD_CPP_TEST_REGION GOOGLE_CLOUD_CPP_TEST_ZONE)
-    set_tests_properties(edgenetwork_quickstart
-                         PROPERTIES LABELS "integration-test;quickstart"
-                         PASS_REGULAR_EXPRESSION "message of Resource 'zones/.*' was not found")
+    set_tests_properties(
+        edgenetwork_quickstart
+        PROPERTIES LABELS "integration-test;quickstart" PASS_REGULAR_EXPRESSION
+                   "message of Resource 'zones/.*' was not found")
 endif ()

--- a/google/cloud/edgenetwork/README.md
+++ b/google/cloud/edgenetwork/README.md
@@ -33,7 +33,8 @@ int main(int argc, char* argv[]) try {
   auto client =
       edgenetwork::EdgeNetworkClient(edgenetwork::MakeEdgeNetworkConnection());
 
-  for (auto r : client.ListNetworks(location.FullName() + "/zones/" + argv[3])) {
+  for (auto r :
+       client.ListNetworks(location.FullName() + "/zones/" + argv[3])) {
     if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }

--- a/google/cloud/edgenetwork/README.md
+++ b/google/cloud/edgenetwork/README.md
@@ -22,7 +22,7 @@ this library.
 #include <iostream>
 
 int main(int argc, char* argv[]) try {
-  if (argc != 3) {
+  if (argc != 4) {
     std::cerr << "Usage: " << argv[0] << " project-id location-id\n";
     return 1;
   }
@@ -33,7 +33,7 @@ int main(int argc, char* argv[]) try {
   auto client =
       edgenetwork::EdgeNetworkClient(edgenetwork::MakeEdgeNetworkConnection());
 
-  for (auto r : client.ListZones(location.FullName())) {
+  for (auto r : client.ListNetworks(location.FullName() + "/zones/" + argv[3])) {
     if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }

--- a/google/cloud/edgenetwork/README.md
+++ b/google/cloud/edgenetwork/README.md
@@ -23,7 +23,7 @@ this library.
 
 int main(int argc, char* argv[]) try {
   if (argc != 4) {
-    std::cerr << "Usage: " << argv[0] << " project-id location-id\n";
+    std::cerr << "Usage: " << argv[0] << " project-id location-id zone-id\n";
     return 1;
   }
 

--- a/google/cloud/edgenetwork/quickstart/quickstart.cc
+++ b/google/cloud/edgenetwork/quickstart/quickstart.cc
@@ -19,7 +19,7 @@
 
 int main(int argc, char* argv[]) try {
   if (argc != 4) {
-    std::cerr << "Usage: " << argv[0] << " project-id location-id\n";
+    std::cerr << "Usage: " << argv[0] << " project-id location-id zone-id\n";
     return 1;
   }
 

--- a/google/cloud/edgenetwork/quickstart/quickstart.cc
+++ b/google/cloud/edgenetwork/quickstart/quickstart.cc
@@ -18,7 +18,7 @@
 #include <iostream>
 
 int main(int argc, char* argv[]) try {
-  if (argc != 3) {
+  if (argc != 4) {
     std::cerr << "Usage: " << argv[0] << " project-id location-id\n";
     return 1;
   }
@@ -29,7 +29,7 @@ int main(int argc, char* argv[]) try {
   auto client =
       edgenetwork::EdgeNetworkClient(edgenetwork::MakeEdgeNetworkConnection());
 
-  for (auto r : client.ListZones(location.FullName())) {
+  for (auto r : client.ListNetworks(location.FullName() + "/zones/" + argv[3])) {
     if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }

--- a/google/cloud/edgenetwork/quickstart/quickstart.cc
+++ b/google/cloud/edgenetwork/quickstart/quickstart.cc
@@ -29,7 +29,8 @@ int main(int argc, char* argv[]) try {
   auto client =
       edgenetwork::EdgeNetworkClient(edgenetwork::MakeEdgeNetworkConnection());
 
-  for (auto r : client.ListNetworks(location.FullName() + "/zones/" + argv[3])) {
+  for (auto r :
+       client.ListNetworks(location.FullName() + "/zones/" + argv[3])) {
     if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }


### PR DESCRIPTION
Replace the deprecated RPC `ListZones` with `ListNetworks` in the quickstart sample code. The deprecation information is in `google/cloud/edgenetwork/v1/service.proto`.

We don't have a zone in the our test project's test location, so a NOT_FOUND error is expected in the test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14545)
<!-- Reviewable:end -->
