### PR TITLE
test(storage): deflake decompressive transcoding test

### DIFF
--- a/google/cloud/storage/tests/decompressive_transcoding_integration_test.cc
+++ b/google/cloud/storage/tests/decompressive_transcoding_integration_test.cc
@@ -64,10 +64,7 @@ auto constexpr kFirstLine =
 TEST_F(DecompressiveTranscodingIntegrationTest, WriteAndReadJson) {
   if (UsingGrpc()) GTEST_SKIP();
 
-  auto client = MakeIntegrationTestClient(
-      Options{}
-          .set<TransferStallTimeoutOption>(std::chrono::seconds(3))
-          .set<RetryPolicyOption>(LimitedErrorCountRetryPolicy(5).clone()));
+  auto client = MakeIntegrationTestClient();
 
   auto object_name = MakeRandomObjectName();
   auto insert = client.InsertObject(
@@ -93,10 +90,7 @@ TEST_F(DecompressiveTranscodingIntegrationTest, WriteAndReadJson) {
 }
 
 TEST_F(DecompressiveTranscodingIntegrationTest, WriteAndReadCompressedJson) {
-  auto client = MakeIntegrationTestClient(
-      Options{}
-          .set<TransferStallTimeoutOption>(std::chrono::seconds(3))
-          .set<RetryPolicyOption>(LimitedErrorCountRetryPolicy(5).clone()));
+  auto client = MakeIntegrationTestClient();
 
   auto object_name = MakeRandomObjectName();
   auto insert = client.InsertObject(
@@ -127,9 +121,7 @@ TEST_F(DecompressiveTranscodingIntegrationTest, ResumeGunzippedDownloadJson) {
   auto client = MakeIntegrationTestClient(
       Options{}
           .set<MaximumCurlSocketRecvSizeOption>(16 * 1024)
-          .set<DownloadBufferSizeOption>(1024)
-          .set<TransferStallTimeoutOption>(std::chrono::seconds(3))
-          .set<RetryPolicyOption>(LimitedErrorCountRetryPolicy(5).clone()));
+          .set<DownloadBufferSizeOption>(1024));
 
   auto object_name = MakeRandomObjectName();
   auto insert = client.InsertObject(


### PR DESCRIPTION
Use timeouts more appropriate for gRPC, specially after the gRPC timeout
scaling fixes.

Part of the work for #14543

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14549)
<!-- Reviewable:end -->
