### PR TITLE
cleanup(generator): Add missing deprecation tag

### DIFF
--- a/generator/internal/client_generator.cc
+++ b/generator/internal/client_generator.cc
@@ -188,6 +188,7 @@ R"""(  std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
                 {method_string},
                 {"\n"},
                 {FormatStartMethodComments(is_method_deprecated)},
+                {deprecation_macro},
                 {IsResponseTypeEmpty,
                  // clang-format off
                     "  Status\n",

--- a/google/cloud/securitycenter/v1/security_center_client.h
+++ b/google/cloud/securitycenter/v1/security_center_client.h
@@ -2162,6 +2162,7 @@ class SecurityCenterClient {
   /// [`NoAwaitTag`]: @ref google::cloud::NoAwaitTag
   ///
   // clang-format on
+  GOOGLE_CLOUD_CPP_DEPRECATED("This RPC is deprecated.")
   StatusOr<google::longrunning::Operation> RunAssetDiscovery(
       ExperimentalTag, NoAwaitTag, std::string const& parent,
       Options opts = {});


### PR DESCRIPTION
Add `deprecation_macro` that is missed in #14553

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14559)
<!-- Reviewable:end -->
