### PR TITLE
cleanup(generator): fewer query params already in body

### DIFF
--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_stub.cc
@@ -58,10 +58,7 @@ DefaultGoldenKitchenSinkRestStub::GenerateIdToken(
       google::test::admin::database::v1::GenerateIdTokenRequest const& request) {
   return rest_internal::Post<google::test::admin::database::v1::GenerateIdTokenResponse>(
       *service_, rest_context, request, false,
-      absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/", "token", ":generate"),
-      rest_internal::TrimEmptyQueryParameters({std::make_pair("name", request.name()),
-        std::make_pair("audience", request.audience()),
-        std::make_pair("include_email", (request.include_email() ? "1" : "0"))}));
+      absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/", "token", ":generate"));
 }
 
 StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
@@ -71,8 +68,7 @@ DefaultGoldenKitchenSinkRestStub::WriteLogEntries(
       google::test::admin::database::v1::WriteLogEntriesRequest const& request) {
   return rest_internal::Post<google::test::admin::database::v1::WriteLogEntriesResponse>(
       *service_, rest_context, request, false,
-      absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/", "entries", ":write"),
-      rest_internal::TrimEmptyQueryParameters({std::make_pair("log_name", request.log_name())}));
+      absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/", "entries", ":write"));
 }
 
 StatusOr<google::test::admin::database::v1::ListLogsResponse>
@@ -112,9 +108,7 @@ Status DefaultGoldenKitchenSinkRestStub::ExplicitRouting1(
       google::test::admin::database::v1::ExplicitRoutingRequest const& request) {
   return rest_internal::Post<google::cloud::rest_internal::EmptyResponseType>(
       *service_, rest_context, request, false,
-      absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/", request.table_name(), ":explicitRouting1"),
-      rest_internal::TrimEmptyQueryParameters({std::make_pair("app_profile_id", request.app_profile_id()),
-        std::make_pair("no_regex_needed", request.no_regex_needed())}));
+      absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/", request.table_name(), ":explicitRouting1"));
 }
 
 Status DefaultGoldenKitchenSinkRestStub::ExplicitRouting2(
@@ -123,9 +117,7 @@ Status DefaultGoldenKitchenSinkRestStub::ExplicitRouting2(
       google::test::admin::database::v1::ExplicitRoutingRequest const& request) {
   return rest_internal::Post<google::cloud::rest_internal::EmptyResponseType>(
       *service_, rest_context, request, false,
-      absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/", request.table_name(), ":explicitRouting2"),
-      rest_internal::TrimEmptyQueryParameters({std::make_pair("app_profile_id", request.app_profile_id()),
-        std::make_pair("no_regex_needed", request.no_regex_needed())}));
+      absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/", request.table_name(), ":explicitRouting2"));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_stub.cc
@@ -71,8 +71,7 @@ DefaultGoldenThingAdminRestStub::AsyncCreateDatabase(
       p.set_value(rest_internal::Post<google::longrunning::Operation>(
           *service, *rest_context, request,
           false,
-          absl::StrCat("/", rest_internal::DetermineApiVersion("v1", *options), "/", request.parent(), "/", "databases"),
-      rest_internal::TrimEmptyQueryParameters({std::make_pair("create_statement", request.create_statement())})));
+          absl::StrCat("/", rest_internal::DetermineApiVersion("v1", *options), "/", request.parent(), "/", "databases")));
     },
     std::move(p), service_, request, std::move(rest_context),
     std::move(options)};
@@ -91,8 +90,7 @@ DefaultGoldenThingAdminRestStub::CreateDatabase(
       google::test::admin::database::v1::CreateDatabaseRequest const& request) {
   return rest_internal::Post<google::longrunning::Operation>(
       *service_, rest_context, request, false,
-      absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/", request.parent(), "/", "databases"),
-      rest_internal::TrimEmptyQueryParameters({std::make_pair("create_statement", request.create_statement())}));
+      absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/", request.parent(), "/", "databases"));
 }
 
 StatusOr<google::test::admin::database::v1::Database>
@@ -118,8 +116,7 @@ DefaultGoldenThingAdminRestStub::AsyncUpdateDatabaseDdl(
       p.set_value(rest_internal::Patch<google::longrunning::Operation>(
           *service, *rest_context, request,
           false,
-          absl::StrCat("/", rest_internal::DetermineApiVersion("v1", *options), "/", request.database(), "/", "ddl"),
-      rest_internal::TrimEmptyQueryParameters({std::make_pair("operation_id", request.operation_id())})));
+          absl::StrCat("/", rest_internal::DetermineApiVersion("v1", *options), "/", request.database(), "/", "ddl")));
     },
     std::move(p), service_, request, std::move(rest_context),
     std::move(options)};
@@ -138,8 +135,7 @@ DefaultGoldenThingAdminRestStub::UpdateDatabaseDdl(
       google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) {
   return rest_internal::Patch<google::longrunning::Operation>(
       *service_, rest_context, request, false,
-      absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/", request.database(), "/", "ddl"),
-      rest_internal::TrimEmptyQueryParameters({std::make_pair("operation_id", request.operation_id())}));
+      absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/", request.database(), "/", "ddl"));
 }
 
 Status DefaultGoldenThingAdminRestStub::DropDatabase(
@@ -283,9 +279,7 @@ DefaultGoldenThingAdminRestStub::AsyncRestoreDatabase(
       p.set_value(rest_internal::Post<google::longrunning::Operation>(
           *service, *rest_context, request,
           false,
-          absl::StrCat("/", rest_internal::DetermineApiVersion("v1", *options), "/", request.parent(), "/", "databases", ":restore"),
-      rest_internal::TrimEmptyQueryParameters({std::make_pair("database_id", request.database_id()),
-        std::make_pair("backup", request.backup())})));
+          absl::StrCat("/", rest_internal::DetermineApiVersion("v1", *options), "/", request.parent(), "/", "databases", ":restore")));
     },
     std::move(p), service_, request, std::move(rest_context),
     std::move(options)};
@@ -304,9 +298,7 @@ DefaultGoldenThingAdminRestStub::RestoreDatabase(
       google::test::admin::database::v1::RestoreDatabaseRequest const& request) {
   return rest_internal::Post<google::longrunning::Operation>(
       *service_, rest_context, request, false,
-      absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/", request.parent(), "/", "databases", ":restore"),
-      rest_internal::TrimEmptyQueryParameters({std::make_pair("database_id", request.database_id()),
-        std::make_pair("backup", request.backup())}));
+      absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/", request.parent(), "/", "databases", ":restore"));
 }
 
 StatusOr<google::test::admin::database::v1::ListDatabaseOperationsResponse>

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -1304,11 +1304,7 @@ INSTANTIATE_TEST_SUITE_P(
                              "@googleapis_link{my::service::v1::Bar,google/"
                              "foo/v1/service.proto#L19}"),
         MethodVarsTestValues("my.service.v1.Service.Method2",
-                             "method_http_query_parameters", R"""(,
-      rest_internal::TrimEmptyQueryParameters({std::make_pair("number", std::to_string(request.number())),
-        std::make_pair("name", request.name()),
-        std::make_pair("toggle", (request.toggle() ? "1" : "0")),
-        std::make_pair("title", request.title())}))"""),
+                             "method_http_query_parameters", ""),
         // Method3
         MethodVarsTestValues("my.service.v1.Service.Method3",
                              "longrunning_metadata_type",
@@ -1423,11 +1419,7 @@ INSTANTIATE_TEST_SUITE_P(
             R"""(absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/", request.namespace_().name()))"""),
         // Method9
         MethodVarsTestValues("my.service.v1.Service.Method9",
-                             "method_http_query_parameters",
-                             R"""(,
-      rest_internal::TrimEmptyQueryParameters({std::make_pair("page_size", std::to_string(request.page_size())),
-        std::make_pair("page_token", request.page_token()),
-        std::make_pair("name", request.name())}))"""),
+                             "method_http_query_parameters", ""),
         // Method11
         MethodVarsTestValues("my.service.v1.Service.Method11",
                              "request_resource", "request.foo_resource()"),

--- a/generator/internal/http_option_utils.cc
+++ b/generator/internal/http_option_utils.cc
@@ -238,6 +238,12 @@ absl::optional<QueryParameterInfo> DetermineQueryParameterInfo(
 void SetHttpQueryParameters(HttpExtensionInfo const& info,
                             google::protobuf::MethodDescriptor const& method,
                             VarsDictionary& method_vars) {
+  if (info.body == "*") {
+    // All request fields are included in the body of the HTTP request. None of
+    // them should be query parameters.
+    method_vars["method_http_query_parameters"] = "";
+    return;
+  }
   // The url field contains a token, or tokens, surrounded by curly braces:
   //   patch: "/v1/{parent=projects/*/instances/*}/databases"
   //   patch: "/v1/projects/{project}/instances/{instance}/databases"

--- a/generator/internal/http_option_utils_test.cc
+++ b/generator/internal/http_option_utils_test.cc
@@ -605,20 +605,6 @@ TEST_F(HttpOptionUtilsTest, SetHttpQueryParametersGetWithParams) {
   EXPECT_THAT(vars.at("method_http_query_parameters"), Eq(""));
 }
 
-TEST_F(HttpOptionUtilsTest, SetHttpGetQueryParametersGetPaginated) {
-  FileDescriptor const* service_file_descriptor =
-      pool_.FindFileByName("google/foo/v1/service.proto");
-  MethodDescriptor const* method =
-      service_file_descriptor->service(0)->method(3);
-  VarsDictionary vars;
-  SetHttpQueryParameters(ParseHttpExtension(*method), *method, vars);
-  EXPECT_THAT(vars.at("method_http_query_parameters"), Eq(R"""(,
-      rest_internal::TrimEmptyQueryParameters({std::make_pair("page_size", std::to_string(request.page_size())),
-        std::make_pair("page_token", request.page_token()),
-        std::make_pair("name", request.name()),
-        std::make_pair("include_foo", (request.include_foo() ? "1" : "0"))}))"""));
-}
-
 TEST_F(HttpOptionUtilsTest,
        SetHttpGetQueryParametersGetWellKnownTypesPaginated) {
   FileDescriptor const* service_file_descriptor =

--- a/google/cloud/compute/backend_buckets/v1/internal/backend_buckets_rest_stub.cc
+++ b/google/cloud/compute/backend_buckets/v1/internal/backend_buckets_rest_stub.cc
@@ -167,10 +167,7 @@ DefaultBackendBucketsRestStub::AsyncDeleteSignedUrlKey(
                              "/", "projects", "/", request.project(), "/",
                              "global", "/", "backendBuckets", "/",
                              request.backend_bucket(), "/",
-                             "deleteSignedUrlKey"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("key_name", request.key_name()),
-                     std::make_pair("request_id", request.request_id())})));
+                             "deleteSignedUrlKey")));
       },
       std::move(p),
       service_,
@@ -195,10 +192,7 @@ DefaultBackendBucketsRestStub::DeleteSignedUrlKey(
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "global", "/",
                    "backendBuckets", "/", request.backend_bucket(), "/",
-                   "deleteSignedUrlKey"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("key_name", request.key_name()),
-           std::make_pair("request_id", request.request_id())}));
+                   "deleteSignedUrlKey"));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::BackendBucket>

--- a/google/cloud/compute/backend_services/v1/internal/backend_services_rest_stub.cc
+++ b/google/cloud/compute/backend_services/v1/internal/backend_services_rest_stub.cc
@@ -193,10 +193,7 @@ DefaultBackendServicesRestStub::AsyncDeleteSignedUrlKey(
                              "/", "projects", "/", request.project(), "/",
                              "global", "/", "backendServices", "/",
                              request.backend_service(), "/",
-                             "deleteSignedUrlKey"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("key_name", request.key_name()),
-                     std::make_pair("request_id", request.request_id())})));
+                             "deleteSignedUrlKey")));
       },
       std::move(p),
       service_,
@@ -221,10 +218,7 @@ DefaultBackendServicesRestStub::DeleteSignedUrlKey(
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "global", "/",
                    "backendServices", "/", request.backend_service(), "/",
-                   "deleteSignedUrlKey"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("key_name", request.key_name()),
-           std::make_pair("request_id", request.request_id())}));
+                   "deleteSignedUrlKey"));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::BackendService>

--- a/google/cloud/compute/disks/v1/internal/disks_rest_stub.cc
+++ b/google/cloud/compute/disks/v1/internal/disks_rest_stub.cc
@@ -617,9 +617,7 @@ DefaultDisksRestStub::AsyncStopAsyncReplication(
                              rest_internal::DetermineApiVersion("v1", *options),
                              "/", "projects", "/", request.project(), "/",
                              "zones", "/", request.zone(), "/", "disks", "/",
-                             request.disk(), "/", "stopAsyncReplication"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("request_id", request.request_id())})));
+                             request.disk(), "/", "stopAsyncReplication")));
       },
       std::move(p),
       service_,
@@ -644,9 +642,7 @@ DefaultDisksRestStub::StopAsyncReplication(
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "zones", "/",
                    request.zone(), "/", "disks", "/", request.disk(), "/",
-                   "stopAsyncReplication"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("request_id", request.request_id())}));
+                   "stopAsyncReplication"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/firewall_policies/v1/internal/firewall_policies_rest_stub.cc
+++ b/google/cloud/compute/firewall_policies/v1/internal/firewall_policies_rest_stub.cc
@@ -173,11 +173,7 @@ DefaultFirewallPoliciesRestStub::AsyncCloneRules(
                              rest_internal::DetermineApiVersion("v1", *options),
                              "/", "locations", "/", "global", "/",
                              "firewallPolicies", "/", request.firewall_policy(),
-                             "/", "cloneRules"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("request_id", request.request_id()),
-                     std::make_pair("source_firewall_policy",
-                                    request.source_firewall_policy())})));
+                             "/", "cloneRules")));
       },
       std::move(p),
       service_,
@@ -201,11 +197,7 @@ DefaultFirewallPoliciesRestStub::CloneRules(
       absl::StrCat("/", "compute", "/",
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "locations", "/", "global", "/", "firewallPolicies", "/",
-                   request.firewall_policy(), "/", "cloneRules"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("request_id", request.request_id()),
-           std::make_pair("source_firewall_policy",
-                          request.source_firewall_policy())}));
+                   request.firewall_policy(), "/", "cloneRules"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -433,10 +425,7 @@ DefaultFirewallPoliciesRestStub::AsyncMove(
                              rest_internal::DetermineApiVersion("v1", *options),
                              "/", "locations", "/", "global", "/",
                              "firewallPolicies", "/", request.firewall_policy(),
-                             "/", "move"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("parent_id", request.parent_id()),
-                     std::make_pair("request_id", request.request_id())})));
+                             "/", "move")));
       },
       std::move(p),
       service_,
@@ -460,10 +449,7 @@ DefaultFirewallPoliciesRestStub::Move(
       absl::StrCat("/", "compute", "/",
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "locations", "/", "global", "/", "firewallPolicies", "/",
-                   request.firewall_policy(), "/", "move"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("parent_id", request.parent_id()),
-           std::make_pair("request_id", request.request_id())}));
+                   request.firewall_policy(), "/", "move"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -590,10 +576,7 @@ DefaultFirewallPoliciesRestStub::AsyncRemoveAssociation(
                              rest_internal::DetermineApiVersion("v1", *options),
                              "/", "locations", "/", "global", "/",
                              "firewallPolicies", "/", request.firewall_policy(),
-                             "/", "removeAssociation"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("name", request.name()),
-                     std::make_pair("request_id", request.request_id())})));
+                             "/", "removeAssociation")));
       },
       std::move(p),
       service_,
@@ -617,10 +600,7 @@ DefaultFirewallPoliciesRestStub::RemoveAssociation(
       absl::StrCat("/", "compute", "/",
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "locations", "/", "global", "/", "firewallPolicies", "/",
-                   request.firewall_policy(), "/", "removeAssociation"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("name", request.name()),
-           std::make_pair("request_id", request.request_id())}));
+                   request.firewall_policy(), "/", "removeAssociation"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -642,11 +622,7 @@ DefaultFirewallPoliciesRestStub::AsyncRemoveRule(
                              rest_internal::DetermineApiVersion("v1", *options),
                              "/", "locations", "/", "global", "/",
                              "firewallPolicies", "/", request.firewall_policy(),
-                             "/", "removeRule"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("priority",
-                                    std::to_string(request.priority())),
-                     std::make_pair("request_id", request.request_id())})));
+                             "/", "removeRule")));
       },
       std::move(p),
       service_,
@@ -670,10 +646,7 @@ DefaultFirewallPoliciesRestStub::RemoveRule(
       absl::StrCat("/", "compute", "/",
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "locations", "/", "global", "/", "firewallPolicies", "/",
-                   request.firewall_policy(), "/", "removeRule"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("priority", std::to_string(request.priority())),
-           std::make_pair("request_id", request.request_id())}));
+                   request.firewall_policy(), "/", "removeRule"));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>

--- a/google/cloud/compute/global_network_endpoint_groups/v1/internal/global_network_endpoint_groups_rest_stub.cc
+++ b/google/cloud/compute/global_network_endpoint_groups/v1/internal/global_network_endpoint_groups_rest_stub.cc
@@ -317,14 +317,7 @@ DefaultGlobalNetworkEndpointGroupsRestStub::ListNetworkEndpoints(
           "/", "compute", "/",
           rest_internal::DetermineApiVersion("v1", options), "/", "projects",
           "/", request.project(), "/", "global", "/", "networkEndpointGroups",
-          "/", request.network_endpoint_group(), "/", "listNetworkEndpoints"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("filter", request.filter()),
-           std::make_pair("max_results", std::to_string(request.max_results())),
-           std::make_pair("order_by", request.order_by()),
-           std::make_pair("page_token", request.page_token()),
-           std::make_pair("return_partial_success",
-                          (request.return_partial_success() ? "1" : "0"))}));
+          "/", request.network_endpoint_group(), "/", "listNetworkEndpoints"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/instance_group_manager_resize_requests/v1/internal/instance_group_manager_resize_requests_rest_stub.cc
+++ b/google/cloud/compute/instance_group_manager_resize_requests/v1/internal/instance_group_manager_resize_requests_rest_stub.cc
@@ -69,9 +69,7 @@ DefaultInstanceGroupManagerResizeRequestsRestStub::AsyncCancel(
                     "projects", "/", request.project(), "/", "zones", "/",
                     request.zone(), "/", "instanceGroupManagers", "/",
                     request.instance_group_manager(), "/", "resizeRequests",
-                    "/", request.resize_request(), "/", "cancel"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("request_id", request.request_id())})));
+                    "/", request.resize_request(), "/", "cancel")));
       },
       std::move(p),
       service_,
@@ -97,9 +95,7 @@ DefaultInstanceGroupManagerResizeRequestsRestStub::Cancel(
                    "projects", "/", request.project(), "/", "zones", "/",
                    request.zone(), "/", "instanceGroupManagers", "/",
                    request.instance_group_manager(), "/", "resizeRequests", "/",
-                   request.resize_request(), "/", "cancel"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("request_id", request.request_id())}));
+                   request.resize_request(), "/", "cancel"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/instance_group_managers/v1/internal/instance_group_managers_rest_stub.cc
+++ b/google/cloud/compute/instance_group_managers/v1/internal/instance_group_managers_rest_stub.cc
@@ -532,14 +532,7 @@ DefaultInstanceGroupManagersRestStub::ListManagedInstances(
                    "projects", "/", request.project(), "/", "zones", "/",
                    request.zone(), "/", "instanceGroupManagers", "/",
                    request.instance_group_manager(), "/",
-                   "listManagedInstances"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("filter", request.filter()),
-           std::make_pair("max_results", std::to_string(request.max_results())),
-           std::make_pair("order_by", request.order_by()),
-           std::make_pair("page_token", request.page_token()),
-           std::make_pair("return_partial_success",
-                          (request.return_partial_success() ? "1" : "0"))}));
+                   "listManagedInstances"));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::
@@ -558,14 +551,7 @@ DefaultInstanceGroupManagersRestStub::ListPerInstanceConfigs(
                    "projects", "/", request.project(), "/", "zones", "/",
                    request.zone(), "/", "instanceGroupManagers", "/",
                    request.instance_group_manager(), "/",
-                   "listPerInstanceConfigs"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("filter", request.filter()),
-           std::make_pair("max_results", std::to_string(request.max_results())),
-           std::make_pair("order_by", request.order_by()),
-           std::make_pair("page_token", request.page_token()),
-           std::make_pair("return_partial_success",
-                          (request.return_partial_success() ? "1" : "0"))}));
+                   "listPerInstanceConfigs"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -756,10 +742,7 @@ DefaultInstanceGroupManagersRestStub::AsyncResize(
                              "/", "projects", "/", request.project(), "/",
                              "zones", "/", request.zone(), "/",
                              "instanceGroupManagers", "/",
-                             request.instance_group_manager(), "/", "resize"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("request_id", request.request_id()),
-                     std::make_pair("size", std::to_string(request.size()))})));
+                             request.instance_group_manager(), "/", "resize")));
       },
       std::move(p),
       service_,
@@ -784,10 +767,7 @@ DefaultInstanceGroupManagersRestStub::Resize(
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "zones", "/",
                    request.zone(), "/", "instanceGroupManagers", "/",
-                   request.instance_group_manager(), "/", "resize"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("request_id", request.request_id()),
-           std::make_pair("size", std::to_string(request.size()))}));
+                   request.instance_group_manager(), "/", "resize"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/instances/v1/internal/instances_rest_stub.cc
+++ b/google/cloud/compute/instances/v1/internal/instances_rest_stub.cc
@@ -357,12 +357,7 @@ DefaultInstancesRestStub::AsyncDeleteAccessConfig(
                              "/", "projects", "/", request.project(), "/",
                              "zones", "/", request.zone(), "/", "instances",
                              "/", request.instance(), "/",
-                             "deleteAccessConfig"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("access_config", request.access_config()),
-                     std::make_pair("network_interface",
-                                    request.network_interface()),
-                     std::make_pair("request_id", request.request_id())})));
+                             "deleteAccessConfig")));
       },
       std::move(p),
       service_,
@@ -387,11 +382,7 @@ DefaultInstancesRestStub::DeleteAccessConfig(
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "zones", "/",
                    request.zone(), "/", "instances", "/", request.instance(),
-                   "/", "deleteAccessConfig"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("access_config", request.access_config()),
-           std::make_pair("network_interface", request.network_interface()),
-           std::make_pair("request_id", request.request_id())}));
+                   "/", "deleteAccessConfig"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -413,10 +404,7 @@ DefaultInstancesRestStub::AsyncDetachDisk(
                              rest_internal::DetermineApiVersion("v1", *options),
                              "/", "projects", "/", request.project(), "/",
                              "zones", "/", request.zone(), "/", "instances",
-                             "/", request.instance(), "/", "detachDisk"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("device_name", request.device_name()),
-                     std::make_pair("request_id", request.request_id())})));
+                             "/", request.instance(), "/", "detachDisk")));
       },
       std::move(p),
       service_,
@@ -441,10 +429,7 @@ DefaultInstancesRestStub::DetachDisk(
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "zones", "/",
                    request.zone(), "/", "instances", "/", request.instance(),
-                   "/", "detachDisk"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("device_name", request.device_name()),
-           std::make_pair("request_id", request.request_id())}));
+                   "/", "detachDisk"));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Instance>
@@ -686,9 +671,7 @@ DefaultInstancesRestStub::AsyncPerformMaintenance(
                              "/", "projects", "/", request.project(), "/",
                              "zones", "/", request.zone(), "/", "instances",
                              "/", request.instance(), "/",
-                             "performMaintenance"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("request_id", request.request_id())})));
+                             "performMaintenance")));
       },
       std::move(p),
       service_,
@@ -713,9 +696,7 @@ DefaultInstancesRestStub::PerformMaintenance(
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "zones", "/",
                    request.zone(), "/", "instances", "/", request.instance(),
-                   "/", "performMaintenance"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("request_id", request.request_id())}));
+                   "/", "performMaintenance"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -791,9 +772,7 @@ DefaultInstancesRestStub::AsyncReset(
                              rest_internal::DetermineApiVersion("v1", *options),
                              "/", "projects", "/", request.project(), "/",
                              "zones", "/", request.zone(), "/", "instances",
-                             "/", request.instance(), "/", "reset"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("request_id", request.request_id())})));
+                             "/", request.instance(), "/", "reset")));
       },
       std::move(p),
       service_,
@@ -817,9 +796,7 @@ DefaultInstancesRestStub::Reset(
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "zones", "/",
                    request.zone(), "/", "instances", "/", request.instance(),
-                   "/", "reset"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("request_id", request.request_id())}));
+                   "/", "reset"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -840,9 +817,7 @@ DefaultInstancesRestStub::AsyncResume(
                              rest_internal::DetermineApiVersion("v1", *options),
                              "/", "projects", "/", request.project(), "/",
                              "zones", "/", request.zone(), "/", "instances",
-                             "/", request.instance(), "/", "resume"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("request_id", request.request_id())})));
+                             "/", request.instance(), "/", "resume")));
       },
       std::move(p),
       service_,
@@ -866,9 +841,7 @@ DefaultInstancesRestStub::Resume(
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "zones", "/",
                    request.zone(), "/", "instances", "/", request.instance(),
-                   "/", "resume"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("request_id", request.request_id())}));
+                   "/", "resume"));
 }
 
 Status DefaultInstancesRestStub::SendDiagnosticInterrupt(
@@ -905,12 +878,7 @@ DefaultInstancesRestStub::AsyncSetDeletionProtection(
                              "/", "projects", "/", request.project(), "/",
                              "zones", "/", request.zone(), "/", "instances",
                              "/", request.resource(), "/",
-                             "setDeletionProtection"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair(
-                         "deletion_protection",
-                         (request.deletion_protection() ? "1" : "0")),
-                     std::make_pair("request_id", request.request_id())})));
+                             "setDeletionProtection")));
       },
       std::move(p),
       service_,
@@ -935,11 +903,7 @@ DefaultInstancesRestStub::SetDeletionProtection(
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "zones", "/",
                    request.zone(), "/", "instances", "/", request.resource(),
-                   "/", "setDeletionProtection"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("deletion_protection",
-                          (request.deletion_protection() ? "1" : "0")),
-           std::make_pair("request_id", request.request_id())}));
+                   "/", "setDeletionProtection"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -961,12 +925,8 @@ DefaultInstancesRestStub::AsyncSetDiskAutoDelete(
                              rest_internal::DetermineApiVersion("v1", *options),
                              "/", "projects", "/", request.project(), "/",
                              "zones", "/", request.zone(), "/", "instances",
-                             "/", request.instance(), "/", "setDiskAutoDelete"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("auto_delete",
-                                    (request.auto_delete() ? "1" : "0")),
-                     std::make_pair("device_name", request.device_name()),
-                     std::make_pair("request_id", request.request_id())})));
+                             "/", request.instance(), "/",
+                             "setDiskAutoDelete")));
       },
       std::move(p),
       service_,
@@ -991,11 +951,7 @@ DefaultInstancesRestStub::SetDiskAutoDelete(
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "zones", "/",
                    request.zone(), "/", "instances", "/", request.instance(),
-                   "/", "setDiskAutoDelete"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("auto_delete", (request.auto_delete() ? "1" : "0")),
-           std::make_pair("device_name", request.device_name()),
-           std::make_pair("request_id", request.request_id())}));
+                   "/", "setDiskAutoDelete"));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>
@@ -1611,13 +1567,7 @@ DefaultInstancesRestStub::AsyncSimulateMaintenanceEvent(
                              "/", "projects", "/", request.project(), "/",
                              "zones", "/", request.zone(), "/", "instances",
                              "/", request.instance(), "/",
-                             "simulateMaintenanceEvent"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("request_id", request.request_id()),
-                     std::make_pair(
-                         "with_extended_notifications",
-                         (request.with_extended_notifications() ? "1"
-                                                                : "0"))})));
+                             "simulateMaintenanceEvent")));
       },
       std::move(p),
       service_,
@@ -1642,12 +1592,7 @@ DefaultInstancesRestStub::SimulateMaintenanceEvent(
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "zones", "/",
                    request.zone(), "/", "instances", "/", request.instance(),
-                   "/", "simulateMaintenanceEvent"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("request_id", request.request_id()),
-           std::make_pair(
-               "with_extended_notifications",
-               (request.with_extended_notifications() ? "1" : "0"))}));
+                   "/", "simulateMaintenanceEvent"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -1668,9 +1613,7 @@ DefaultInstancesRestStub::AsyncStart(
                              rest_internal::DetermineApiVersion("v1", *options),
                              "/", "projects", "/", request.project(), "/",
                              "zones", "/", request.zone(), "/", "instances",
-                             "/", request.instance(), "/", "start"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("request_id", request.request_id())})));
+                             "/", request.instance(), "/", "start")));
       },
       std::move(p),
       service_,
@@ -1694,9 +1637,7 @@ DefaultInstancesRestStub::Start(
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "zones", "/",
                    request.zone(), "/", "instances", "/", request.instance(),
-                   "/", "start"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("request_id", request.request_id())}));
+                   "/", "start"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -1772,11 +1713,7 @@ DefaultInstancesRestStub::AsyncStop(
                              rest_internal::DetermineApiVersion("v1", *options),
                              "/", "projects", "/", request.project(), "/",
                              "zones", "/", request.zone(), "/", "instances",
-                             "/", request.instance(), "/", "stop"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("discard_local_ssd",
-                                    (request.discard_local_ssd() ? "1" : "0")),
-                     std::make_pair("request_id", request.request_id())})));
+                             "/", request.instance(), "/", "stop")));
       },
       std::move(p),
       service_,
@@ -1800,11 +1737,7 @@ DefaultInstancesRestStub::Stop(
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "zones", "/",
                    request.zone(), "/", "instances", "/", request.instance(),
-                   "/", "stop"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("discard_local_ssd",
-                          (request.discard_local_ssd() ? "1" : "0")),
-           std::make_pair("request_id", request.request_id())}));
+                   "/", "stop"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -1825,11 +1758,7 @@ DefaultInstancesRestStub::AsyncSuspend(
                              rest_internal::DetermineApiVersion("v1", *options),
                              "/", "projects", "/", request.project(), "/",
                              "zones", "/", request.zone(), "/", "instances",
-                             "/", request.instance(), "/", "suspend"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("discard_local_ssd",
-                                    (request.discard_local_ssd() ? "1" : "0")),
-                     std::make_pair("request_id", request.request_id())})));
+                             "/", request.instance(), "/", "suspend")));
       },
       std::move(p),
       service_,
@@ -1853,11 +1782,7 @@ DefaultInstancesRestStub::Suspend(
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "zones", "/",
                    request.zone(), "/", "instances", "/", request.instance(),
-                   "/", "suspend"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("discard_local_ssd",
-                          (request.discard_local_ssd() ? "1" : "0")),
-           std::make_pair("request_id", request.request_id())}));
+                   "/", "suspend"));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::TestPermissionsResponse>

--- a/google/cloud/compute/network_firewall_policies/v1/internal/network_firewall_policies_rest_stub.cc
+++ b/google/cloud/compute/network_firewall_policies/v1/internal/network_firewall_policies_rest_stub.cc
@@ -184,11 +184,7 @@ DefaultNetworkFirewallPoliciesRestStub::AsyncCloneRules(
                              rest_internal::DetermineApiVersion("v1", *options),
                              "/", "projects", "/", request.project(), "/",
                              "global", "/", "firewallPolicies", "/",
-                             request.firewall_policy(), "/", "cloneRules"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("request_id", request.request_id()),
-                     std::make_pair("source_firewall_policy",
-                                    request.source_firewall_policy())})));
+                             request.firewall_policy(), "/", "cloneRules")));
       },
       std::move(p),
       service_,
@@ -213,11 +209,7 @@ DefaultNetworkFirewallPoliciesRestStub::CloneRules(
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "global", "/",
                    "firewallPolicies", "/", request.firewall_policy(), "/",
-                   "cloneRules"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("request_id", request.request_id()),
-           std::make_pair("source_firewall_policy",
-                          request.source_firewall_policy())}));
+                   "cloneRules"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -536,10 +528,7 @@ DefaultNetworkFirewallPoliciesRestStub::AsyncRemoveAssociation(
                              "/", "projects", "/", request.project(), "/",
                              "global", "/", "firewallPolicies", "/",
                              request.firewall_policy(), "/",
-                             "removeAssociation"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("name", request.name()),
-                     std::make_pair("request_id", request.request_id())})));
+                             "removeAssociation")));
       },
       std::move(p),
       service_,
@@ -564,10 +553,7 @@ DefaultNetworkFirewallPoliciesRestStub::RemoveAssociation(
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "global", "/",
                    "firewallPolicies", "/", request.firewall_policy(), "/",
-                   "removeAssociation"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("name", request.name()),
-           std::make_pair("request_id", request.request_id())}));
+                   "removeAssociation"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -589,11 +575,7 @@ DefaultNetworkFirewallPoliciesRestStub::AsyncRemoveRule(
                              rest_internal::DetermineApiVersion("v1", *options),
                              "/", "projects", "/", request.project(), "/",
                              "global", "/", "firewallPolicies", "/",
-                             request.firewall_policy(), "/", "removeRule"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("priority",
-                                    std::to_string(request.priority())),
-                     std::make_pair("request_id", request.request_id())})));
+                             request.firewall_policy(), "/", "removeRule")));
       },
       std::move(p),
       service_,
@@ -618,10 +600,7 @@ DefaultNetworkFirewallPoliciesRestStub::RemoveRule(
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "global", "/",
                    "firewallPolicies", "/", request.firewall_policy(), "/",
-                   "removeRule"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("priority", std::to_string(request.priority())),
-           std::make_pair("request_id", request.request_id())}));
+                   "removeRule"));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>

--- a/google/cloud/compute/networks/v1/internal/networks_rest_stub.cc
+++ b/google/cloud/compute/networks/v1/internal/networks_rest_stub.cc
@@ -392,9 +392,7 @@ DefaultNetworksRestStub::AsyncSwitchToCustomMode(
                              rest_internal::DetermineApiVersion("v1", *options),
                              "/", "projects", "/", request.project(), "/",
                              "global", "/", "networks", "/", request.network(),
-                             "/", "switchToCustomMode"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("request_id", request.request_id())})));
+                             "/", "switchToCustomMode")));
       },
       std::move(p),
       service_,
@@ -419,9 +417,7 @@ DefaultNetworksRestStub::SwitchToCustomMode(
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "global", "/",
                    "networks", "/", request.network(), "/",
-                   "switchToCustomMode"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("request_id", request.request_id())}));
+                   "switchToCustomMode"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/node_groups/v1/internal/node_groups_rest_stub.cc
+++ b/google/cloud/compute/node_groups/v1/internal/node_groups_rest_stub.cc
@@ -349,14 +349,7 @@ DefaultNodeGroupsRestStub::ListNodes(
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "zones", "/",
                    request.zone(), "/", "nodeGroups", "/", request.node_group(),
-                   "/", "listNodes"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("filter", request.filter()),
-           std::make_pair("max_results", std::to_string(request.max_results())),
-           std::make_pair("order_by", request.order_by()),
-           std::make_pair("page_token", request.page_token()),
-           std::make_pair("return_partial_success",
-                          (request.return_partial_success() ? "1" : "0"))}));
+                   "/", "listNodes"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/projects/v1/internal/projects_rest_stub.cc
+++ b/google/cloud/compute/projects/v1/internal/projects_rest_stub.cc
@@ -63,9 +63,7 @@ DefaultProjectsRestStub::AsyncDisableXpnHost(
                 absl::StrCat("/", "compute", "/",
                              rest_internal::DetermineApiVersion("v1", *options),
                              "/", "projects", "/", request.project(), "/",
-                             "disableXpnHost"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("request_id", request.request_id())})));
+                             "disableXpnHost")));
       },
       std::move(p),
       service_,
@@ -88,9 +86,7 @@ DefaultProjectsRestStub::DisableXpnHost(
       *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/",
                    rest_internal::DetermineApiVersion("v1", options), "/",
-                   "projects", "/", request.project(), "/", "disableXpnHost"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("request_id", request.request_id())}));
+                   "projects", "/", request.project(), "/", "disableXpnHost"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -162,9 +158,7 @@ DefaultProjectsRestStub::AsyncEnableXpnHost(
                 absl::StrCat("/", "compute", "/",
                              rest_internal::DetermineApiVersion("v1", *options),
                              "/", "projects", "/", request.project(), "/",
-                             "enableXpnHost"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("request_id", request.request_id())})));
+                             "enableXpnHost")));
       },
       std::move(p),
       service_,
@@ -187,9 +181,7 @@ DefaultProjectsRestStub::EnableXpnHost(
       *service_, rest_context, request, false,
       absl::StrCat("/", "compute", "/",
                    rest_internal::DetermineApiVersion("v1", options), "/",
-                   "projects", "/", request.project(), "/", "enableXpnHost"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("request_id", request.request_id())}));
+                   "projects", "/", request.project(), "/", "enableXpnHost"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/public_advertised_prefixes/v1/internal/public_advertised_prefixes_rest_stub.cc
+++ b/google/cloud/compute/public_advertised_prefixes/v1/internal/public_advertised_prefixes_rest_stub.cc
@@ -68,9 +68,7 @@ DefaultPublicAdvertisedPrefixesRestStub::AsyncAnnounce(
                              "/", "projects", "/", request.project(), "/",
                              "global", "/", "publicAdvertisedPrefixes", "/",
                              request.public_advertised_prefix(), "/",
-                             "announce"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("request_id", request.request_id())})));
+                             "announce")));
       },
       std::move(p),
       service_,
@@ -95,9 +93,7 @@ DefaultPublicAdvertisedPrefixesRestStub::Announce(
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "global", "/",
                    "publicAdvertisedPrefixes", "/",
-                   request.public_advertised_prefix(), "/", "announce"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("request_id", request.request_id())}));
+                   request.public_advertised_prefix(), "/", "announce"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -313,9 +309,7 @@ DefaultPublicAdvertisedPrefixesRestStub::AsyncWithdraw(
                              "/", "projects", "/", request.project(), "/",
                              "global", "/", "publicAdvertisedPrefixes", "/",
                              request.public_advertised_prefix(), "/",
-                             "withdraw"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("request_id", request.request_id())})));
+                             "withdraw")));
       },
       std::move(p),
       service_,
@@ -340,9 +334,7 @@ DefaultPublicAdvertisedPrefixesRestStub::Withdraw(
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "global", "/",
                    "publicAdvertisedPrefixes", "/",
-                   request.public_advertised_prefix(), "/", "withdraw"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("request_id", request.request_id())}));
+                   request.public_advertised_prefix(), "/", "withdraw"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/public_delegated_prefixes/v1/internal/public_delegated_prefixes_rest_stub.cc
+++ b/google/cloud/compute/public_delegated_prefixes/v1/internal/public_delegated_prefixes_rest_stub.cc
@@ -93,9 +93,7 @@ DefaultPublicDelegatedPrefixesRestStub::AsyncAnnounce(
                     rest_internal::DetermineApiVersion("v1", *options), "/",
                     "projects", "/", request.project(), "/", "regions", "/",
                     request.region(), "/", "publicDelegatedPrefixes", "/",
-                    request.public_delegated_prefix(), "/", "announce"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("request_id", request.request_id())})));
+                    request.public_delegated_prefix(), "/", "announce")));
       },
       std::move(p),
       service_,
@@ -120,9 +118,7 @@ DefaultPublicDelegatedPrefixesRestStub::Announce(
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "regions", "/",
                    request.region(), "/", "publicDelegatedPrefixes", "/",
-                   request.public_delegated_prefix(), "/", "announce"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("request_id", request.request_id())}));
+                   request.public_delegated_prefix(), "/", "announce"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -341,9 +337,7 @@ DefaultPublicDelegatedPrefixesRestStub::AsyncWithdraw(
                     rest_internal::DetermineApiVersion("v1", *options), "/",
                     "projects", "/", request.project(), "/", "regions", "/",
                     request.region(), "/", "publicDelegatedPrefixes", "/",
-                    request.public_delegated_prefix(), "/", "withdraw"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("request_id", request.request_id())})));
+                    request.public_delegated_prefix(), "/", "withdraw")));
       },
       std::move(p),
       service_,
@@ -368,9 +362,7 @@ DefaultPublicDelegatedPrefixesRestStub::Withdraw(
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "regions", "/",
                    request.region(), "/", "publicDelegatedPrefixes", "/",
-                   request.public_delegated_prefix(), "/", "withdraw"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("request_id", request.request_id())}));
+                   request.public_delegated_prefix(), "/", "withdraw"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/region_disks/v1/internal/region_disks_rest_stub.cc
+++ b/google/cloud/compute/region_disks/v1/internal/region_disks_rest_stub.cc
@@ -606,9 +606,8 @@ DefaultRegionDisksRestStub::AsyncStopAsyncReplication(
                              rest_internal::DetermineApiVersion("v1", *options),
                              "/", "projects", "/", request.project(), "/",
                              "regions", "/", request.region(), "/", "disks",
-                             "/", request.disk(), "/", "stopAsyncReplication"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("request_id", request.request_id())})));
+                             "/", request.disk(), "/",
+                             "stopAsyncReplication")));
       },
       std::move(p),
       service_,
@@ -633,9 +632,7 @@ DefaultRegionDisksRestStub::StopAsyncReplication(
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "regions", "/",
                    request.region(), "/", "disks", "/", request.disk(), "/",
-                   "stopAsyncReplication"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("request_id", request.request_id())}));
+                   "stopAsyncReplication"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/region_instance_group_managers/v1/internal/region_instance_group_managers_rest_stub.cc
+++ b/google/cloud/compute/region_instance_group_managers/v1/internal/region_instance_group_managers_rest_stub.cc
@@ -514,14 +514,7 @@ DefaultRegionInstanceGroupManagersRestStub::ListManagedInstances(
                    "projects", "/", request.project(), "/", "regions", "/",
                    request.region(), "/", "instanceGroupManagers", "/",
                    request.instance_group_manager(), "/",
-                   "listManagedInstances"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("filter", request.filter()),
-           std::make_pair("max_results", std::to_string(request.max_results())),
-           std::make_pair("order_by", request.order_by()),
-           std::make_pair("page_token", request.page_token()),
-           std::make_pair("return_partial_success",
-                          (request.return_partial_success() ? "1" : "0"))}));
+                   "listManagedInstances"));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::
@@ -540,14 +533,7 @@ DefaultRegionInstanceGroupManagersRestStub::ListPerInstanceConfigs(
                    "projects", "/", request.project(), "/", "regions", "/",
                    request.region(), "/", "instanceGroupManagers", "/",
                    request.instance_group_manager(), "/",
-                   "listPerInstanceConfigs"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("filter", request.filter()),
-           std::make_pair("max_results", std::to_string(request.max_results())),
-           std::make_pair("order_by", request.order_by()),
-           std::make_pair("page_token", request.page_token()),
-           std::make_pair("return_partial_success",
-                          (request.return_partial_success() ? "1" : "0"))}));
+                   "listPerInstanceConfigs"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -739,10 +725,7 @@ DefaultRegionInstanceGroupManagersRestStub::AsyncResize(
                              "/", "projects", "/", request.project(), "/",
                              "regions", "/", request.region(), "/",
                              "instanceGroupManagers", "/",
-                             request.instance_group_manager(), "/", "resize"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("request_id", request.request_id()),
-                     std::make_pair("size", std::to_string(request.size()))})));
+                             request.instance_group_manager(), "/", "resize")));
       },
       std::move(p),
       service_,
@@ -767,10 +750,7 @@ DefaultRegionInstanceGroupManagersRestStub::Resize(
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "regions", "/",
                    request.region(), "/", "instanceGroupManagers", "/",
-                   request.instance_group_manager(), "/", "resize"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("request_id", request.request_id()),
-           std::make_pair("size", std::to_string(request.size()))}));
+                   request.instance_group_manager(), "/", "resize"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/region_network_endpoint_groups/v1/internal/region_network_endpoint_groups_rest_stub.cc
+++ b/google/cloud/compute/region_network_endpoint_groups/v1/internal/region_network_endpoint_groups_rest_stub.cc
@@ -324,14 +324,7 @@ DefaultRegionNetworkEndpointGroupsRestStub::ListNetworkEndpoints(
                    "projects", "/", request.project(), "/", "regions", "/",
                    request.region(), "/", "networkEndpointGroups", "/",
                    request.network_endpoint_group(), "/",
-                   "listNetworkEndpoints"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("filter", request.filter()),
-           std::make_pair("max_results", std::to_string(request.max_results())),
-           std::make_pair("order_by", request.order_by()),
-           std::make_pair("page_token", request.page_token()),
-           std::make_pair("return_partial_success",
-                          (request.return_partial_success() ? "1" : "0"))}));
+                   "listNetworkEndpoints"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/region_network_firewall_policies/v1/internal/region_network_firewall_policies_rest_stub.cc
+++ b/google/cloud/compute/region_network_firewall_policies/v1/internal/region_network_firewall_policies_rest_stub.cc
@@ -188,11 +188,7 @@ DefaultRegionNetworkFirewallPoliciesRestStub::AsyncCloneRules(
                              "/", "projects", "/", request.project(), "/",
                              "regions", "/", request.region(), "/",
                              "firewallPolicies", "/", request.firewall_policy(),
-                             "/", "cloneRules"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("request_id", request.request_id()),
-                     std::make_pair("source_firewall_policy",
-                                    request.source_firewall_policy())})));
+                             "/", "cloneRules")));
       },
       std::move(p),
       service_,
@@ -217,11 +213,7 @@ DefaultRegionNetworkFirewallPoliciesRestStub::CloneRules(
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "regions", "/",
                    request.region(), "/", "firewallPolicies", "/",
-                   request.firewall_policy(), "/", "cloneRules"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("request_id", request.request_id()),
-           std::make_pair("source_firewall_policy",
-                          request.source_firewall_policy())}));
+                   request.firewall_policy(), "/", "cloneRules"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -567,10 +559,7 @@ DefaultRegionNetworkFirewallPoliciesRestStub::AsyncRemoveAssociation(
                              "/", "projects", "/", request.project(), "/",
                              "regions", "/", request.region(), "/",
                              "firewallPolicies", "/", request.firewall_policy(),
-                             "/", "removeAssociation"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("name", request.name()),
-                     std::make_pair("request_id", request.request_id())})));
+                             "/", "removeAssociation")));
       },
       std::move(p),
       service_,
@@ -595,10 +584,7 @@ DefaultRegionNetworkFirewallPoliciesRestStub::RemoveAssociation(
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "regions", "/",
                    request.region(), "/", "firewallPolicies", "/",
-                   request.firewall_policy(), "/", "removeAssociation"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("name", request.name()),
-           std::make_pair("request_id", request.request_id())}));
+                   request.firewall_policy(), "/", "removeAssociation"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>
@@ -621,11 +607,7 @@ DefaultRegionNetworkFirewallPoliciesRestStub::AsyncRemoveRule(
                              "/", "projects", "/", request.project(), "/",
                              "regions", "/", request.region(), "/",
                              "firewallPolicies", "/", request.firewall_policy(),
-                             "/", "removeRule"),
-                rest_internal::TrimEmptyQueryParameters(
-                    {std::make_pair("priority",
-                                    std::to_string(request.priority())),
-                     std::make_pair("request_id", request.request_id())})));
+                             "/", "removeRule")));
       },
       std::move(p),
       service_,
@@ -650,10 +632,7 @@ DefaultRegionNetworkFirewallPoliciesRestStub::RemoveRule(
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "regions", "/",
                    request.region(), "/", "firewallPolicies", "/",
-                   request.firewall_policy(), "/", "removeRule"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("priority", std::to_string(request.priority())),
-           std::make_pair("request_id", request.request_id())}));
+                   request.firewall_policy(), "/", "removeRule"));
 }
 
 StatusOr<google::cloud::cpp::compute::v1::Policy>

--- a/google/cloud/compute/region_security_policies/v1/internal/region_security_policies_rest_stub.cc
+++ b/google/cloud/compute/region_security_policies/v1/internal/region_security_policies_rest_stub.cc
@@ -397,9 +397,7 @@ DefaultRegionSecurityPoliciesRestStub::AsyncRemoveRule(
                              "/", "projects", "/", request.project(), "/",
                              "regions", "/", request.region(), "/",
                              "securityPolicies", "/", request.security_policy(),
-                             "/", "removeRule"),
-                rest_internal::TrimEmptyQueryParameters({std::make_pair(
-                    "priority", std::to_string(request.priority()))})));
+                             "/", "removeRule")));
       },
       std::move(p),
       service_,
@@ -424,9 +422,7 @@ DefaultRegionSecurityPoliciesRestStub::RemoveRule(
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "regions", "/",
                    request.region(), "/", "securityPolicies", "/",
-                   request.security_policy(), "/", "removeRule"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("priority", std::to_string(request.priority()))}));
+                   request.security_policy(), "/", "removeRule"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/compute/security_policies/v1/internal/security_policies_rest_stub.cc
+++ b/google/cloud/compute/security_policies/v1/internal/security_policies_rest_stub.cc
@@ -437,9 +437,7 @@ DefaultSecurityPoliciesRestStub::AsyncRemoveRule(
                              rest_internal::DetermineApiVersion("v1", *options),
                              "/", "projects", "/", request.project(), "/",
                              "global", "/", "securityPolicies", "/",
-                             request.security_policy(), "/", "removeRule"),
-                rest_internal::TrimEmptyQueryParameters({std::make_pair(
-                    "priority", std::to_string(request.priority()))})));
+                             request.security_policy(), "/", "removeRule")));
       },
       std::move(p),
       service_,
@@ -464,9 +462,7 @@ DefaultSecurityPoliciesRestStub::RemoveRule(
                    rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "global", "/",
                    "securityPolicies", "/", request.security_policy(), "/",
-                   "removeRule"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("priority", std::to_string(request.priority()))}));
+                   "removeRule"));
 }
 
 future<StatusOr<google::cloud::cpp::compute::v1::Operation>>

--- a/google/cloud/spanner/admin/internal/database_admin_rest_stub.cc
+++ b/google/cloud/spanner/admin/internal/database_admin_rest_stub.cc
@@ -75,13 +75,7 @@ DefaultDatabaseAdminRestStub::AsyncCreateDatabase(
             *service, *rest_context, request, false,
             absl::StrCat("/",
                          rest_internal::DetermineApiVersion("v1", *options),
-                         "/", request.parent(), "/", "databases"),
-            rest_internal::TrimEmptyQueryParameters(
-                {std::make_pair("create_statement", request.create_statement()),
-                 std::make_pair("database_dialect",
-                                std::to_string(request.database_dialect())),
-                 std::make_pair("proto_descriptors",
-                                request.proto_descriptors())})));
+                         "/", request.parent(), "/", "databases")));
       },
       std::move(p),
       service_,
@@ -103,12 +97,7 @@ DefaultDatabaseAdminRestStub::CreateDatabase(
   return rest_internal::Post<google::longrunning::Operation>(
       *service_, rest_context, request, false,
       absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/",
-                   request.parent(), "/", "databases"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("create_statement", request.create_statement()),
-           std::make_pair("database_dialect",
-                          std::to_string(request.database_dialect())),
-           std::make_pair("proto_descriptors", request.proto_descriptors())}));
+                   request.parent(), "/", "databases"));
 }
 
 StatusOr<google::spanner::admin::database::v1::Database>
@@ -177,11 +166,7 @@ DefaultDatabaseAdminRestStub::AsyncUpdateDatabaseDdl(
             *service, *rest_context, request, false,
             absl::StrCat("/",
                          rest_internal::DetermineApiVersion("v1", *options),
-                         "/", request.database(), "/", "ddl"),
-            rest_internal::TrimEmptyQueryParameters(
-                {std::make_pair("operation_id", request.operation_id()),
-                 std::make_pair("proto_descriptors",
-                                request.proto_descriptors())})));
+                         "/", request.database(), "/", "ddl")));
       },
       std::move(p),
       service_,
@@ -203,10 +188,7 @@ DefaultDatabaseAdminRestStub::UpdateDatabaseDdl(
   return rest_internal::Patch<google::longrunning::Operation>(
       *service_, rest_context, request, false,
       absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/",
-                   request.database(), "/", "ddl"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("operation_id", request.operation_id()),
-           std::make_pair("proto_descriptors", request.proto_descriptors())}));
+                   request.database(), "/", "ddl"));
 }
 
 Status DefaultDatabaseAdminRestStub::DropDatabase(
@@ -319,10 +301,7 @@ DefaultDatabaseAdminRestStub::AsyncCopyBackup(
             *service, *rest_context, request, false,
             absl::StrCat("/",
                          rest_internal::DetermineApiVersion("v1", *options),
-                         "/", request.parent(), "/", "backups", ":copy"),
-            rest_internal::TrimEmptyQueryParameters(
-                {std::make_pair("backup_id", request.backup_id()),
-                 std::make_pair("source_backup", request.source_backup())})));
+                         "/", request.parent(), "/", "backups", ":copy")));
       },
       std::move(p),
       service_,
@@ -343,10 +322,7 @@ DefaultDatabaseAdminRestStub::CopyBackup(
   return rest_internal::Post<google::longrunning::Operation>(
       *service_, rest_context, request, false,
       absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/",
-                   request.parent(), "/", "backups", ":copy"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("backup_id", request.backup_id()),
-           std::make_pair("source_backup", request.source_backup())}));
+                   request.parent(), "/", "backups", ":copy"));
 }
 
 StatusOr<google::spanner::admin::database::v1::Backup>
@@ -412,10 +388,7 @@ DefaultDatabaseAdminRestStub::AsyncRestoreDatabase(
             *service, *rest_context, request, false,
             absl::StrCat("/",
                          rest_internal::DetermineApiVersion("v1", *options),
-                         "/", request.parent(), "/", "databases", ":restore"),
-            rest_internal::TrimEmptyQueryParameters(
-                {std::make_pair("database_id", request.database_id()),
-                 std::make_pair("backup", request.backup())})));
+                         "/", request.parent(), "/", "databases", ":restore")));
       },
       std::move(p),
       service_,
@@ -437,10 +410,7 @@ DefaultDatabaseAdminRestStub::RestoreDatabase(
   return rest_internal::Post<google::longrunning::Operation>(
       *service_, rest_context, request, false,
       absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/",
-                   request.parent(), "/", "databases", ":restore"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("database_id", request.database_id()),
-           std::make_pair("backup", request.backup())}));
+                   request.parent(), "/", "databases", ":restore"));
 }
 
 StatusOr<google::spanner::admin::database::v1::ListDatabaseOperationsResponse>

--- a/google/cloud/spanner/admin/internal/instance_admin_rest_stub.cc
+++ b/google/cloud/spanner/admin/internal/instance_admin_rest_stub.cc
@@ -89,12 +89,7 @@ DefaultInstanceAdminRestStub::AsyncCreateInstanceConfig(
             *service, *rest_context, request, false,
             absl::StrCat("/",
                          rest_internal::DetermineApiVersion("v1", *options),
-                         "/", request.parent(), "/", "instanceConfigs"),
-            rest_internal::TrimEmptyQueryParameters(
-                {std::make_pair("instance_config_id",
-                                request.instance_config_id()),
-                 std::make_pair("validate_only",
-                                (request.validate_only() ? "1" : "0"))})));
+                         "/", request.parent(), "/", "instanceConfigs")));
       },
       std::move(p),
       service_,
@@ -116,11 +111,7 @@ DefaultInstanceAdminRestStub::CreateInstanceConfig(
   return rest_internal::Post<google::longrunning::Operation>(
       *service_, rest_context, request, false,
       absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/",
-                   request.parent(), "/", "instanceConfigs"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("instance_config_id", request.instance_config_id()),
-           std::make_pair("validate_only",
-                          (request.validate_only() ? "1" : "0"))}));
+                   request.parent(), "/", "instanceConfigs"));
 }
 
 future<StatusOr<google::longrunning::Operation>>
@@ -138,9 +129,7 @@ DefaultInstanceAdminRestStub::AsyncUpdateInstanceConfig(
             *service, *rest_context, request, false,
             absl::StrCat("/",
                          rest_internal::DetermineApiVersion("v1", *options),
-                         "/", request.instance_config().name()),
-            rest_internal::TrimEmptyQueryParameters({std::make_pair(
-                "validate_only", (request.validate_only() ? "1" : "0"))})));
+                         "/", request.instance_config().name())));
       },
       std::move(p),
       service_,
@@ -162,9 +151,7 @@ DefaultInstanceAdminRestStub::UpdateInstanceConfig(
   return rest_internal::Patch<google::longrunning::Operation>(
       *service_, rest_context, request, false,
       absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/",
-                   request.instance_config().name()),
-      rest_internal::TrimEmptyQueryParameters({std::make_pair(
-          "validate_only", (request.validate_only() ? "1" : "0"))}));
+                   request.instance_config().name()));
 }
 
 Status DefaultInstanceAdminRestStub::DeleteInstanceConfig(
@@ -258,9 +245,7 @@ DefaultInstanceAdminRestStub::AsyncCreateInstance(
             *service, *rest_context, request, false,
             absl::StrCat("/",
                          rest_internal::DetermineApiVersion("v1", *options),
-                         "/", request.parent(), "/", "instances"),
-            rest_internal::TrimEmptyQueryParameters(
-                {std::make_pair("instance_id", request.instance_id())})));
+                         "/", request.parent(), "/", "instances")));
       },
       std::move(p),
       service_,
@@ -282,9 +267,7 @@ DefaultInstanceAdminRestStub::CreateInstance(
   return rest_internal::Post<google::longrunning::Operation>(
       *service_, rest_context, request, false,
       absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/",
-                   request.parent(), "/", "instances"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("instance_id", request.instance_id())}));
+                   request.parent(), "/", "instances"));
 }
 
 future<StatusOr<google::longrunning::Operation>>
@@ -397,9 +380,7 @@ DefaultInstanceAdminRestStub::AsyncCreateInstancePartition(
             *service, *rest_context, request, false,
             absl::StrCat("/",
                          rest_internal::DetermineApiVersion("v1", *options),
-                         "/", request.parent(), "/", "instancePartitions"),
-            rest_internal::TrimEmptyQueryParameters({std::make_pair(
-                "instance_partition_id", request.instance_partition_id())})));
+                         "/", request.parent(), "/", "instancePartitions")));
       },
       std::move(p),
       service_,
@@ -421,9 +402,7 @@ DefaultInstanceAdminRestStub::CreateInstancePartition(
   return rest_internal::Post<google::longrunning::Operation>(
       *service_, rest_context, request, false,
       absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/",
-                   request.parent(), "/", "instancePartitions"),
-      rest_internal::TrimEmptyQueryParameters({std::make_pair(
-          "instance_partition_id", request.instance_partition_id())}));
+                   request.parent(), "/", "instancePartitions"));
 }
 
 Status DefaultInstanceAdminRestStub::DeleteInstancePartition(

--- a/google/cloud/sql/v1/internal/sql_connect_rest_stub.cc
+++ b/google/cloud/sql/v1/internal/sql_connect_rest_stub.cc
@@ -62,10 +62,7 @@ DefaultSqlConnectServiceRestStub::GenerateEphemeralCert(
       *service_, rest_context, request, true,
       absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "instances", "/",
-                   request.instance(), ":generateEphemeralCert"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("public_key", request.public_key()),
-           std::make_pair("access_token", request.access_token())}));
+                   request.instance(), ":generateEphemeralCert"));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/sql/v1/internal/sql_instances_rest_stub.cc
+++ b/google/cloud/sql/v1/internal/sql_instances_rest_stub.cc
@@ -370,17 +370,7 @@ DefaultSqlInstancesServiceRestStub::VerifyExternalSyncSettings(
       *service_, rest_context, request, true,
       absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "instances", "/",
-                   request.instance(), "/", "verifyExternalSyncSettings"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("verify_connection_only",
-                          (request.verify_connection_only() ? "1" : "0")),
-           std::make_pair("sync_mode", std::to_string(request.sync_mode())),
-           std::make_pair("verify_replication_only",
-                          (request.verify_replication_only() ? "1" : "0")),
-           std::make_pair("migration_type",
-                          std::to_string(request.migration_type())),
-           std::make_pair("sync_parallel_level",
-                          std::to_string(request.sync_parallel_level()))}));
+                   request.instance(), "/", "verifyExternalSyncSettings"));
 }
 
 StatusOr<google::cloud::sql::v1::Operation>
@@ -393,15 +383,7 @@ DefaultSqlInstancesServiceRestStub::StartExternalSync(
       *service_, rest_context, request, true,
       absl::StrCat("/", rest_internal::DetermineApiVersion("v1", options), "/",
                    "projects", "/", request.project(), "/", "instances", "/",
-                   request.instance(), "/", "startExternalSync"),
-      rest_internal::TrimEmptyQueryParameters(
-          {std::make_pair("sync_mode", std::to_string(request.sync_mode())),
-           std::make_pair("skip_verification",
-                          (request.skip_verification() ? "1" : "0")),
-           std::make_pair("sync_parallel_level",
-                          std::to_string(request.sync_parallel_level())),
-           std::make_pair("migration_type",
-                          std::to_string(request.migration_type()))}));
+                   request.instance(), "/", "startExternalSync"));
 }
 
 StatusOr<google::cloud::sql::v1::Operation>


### PR DESCRIPTION
Part of the work for #14492 

When `body = "*"`, we include the whole `request` as the payload. This means we do not need to include any individual fields in the request as query parameters.

Spec:
https://github.com/googleapis/googleapis/blob/a91d1a37cb86a0e49fdc21d8b4416eb1c2a083ec/google/api/http.proto#L169-L173

---

I removed a failing unit test which was setting a different expectation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14560)
<!-- Reviewable:end -->
