### PR TITLE
fix(GCS+gRPC): RPC lifetime was too short

### DIFF
--- a/google/cloud/testing_util/async_sequencer.h
+++ b/google/cloud/testing_util/async_sequencer.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/future.h"
 #include "google/cloud/version.h"
+#include <algorithm>
 #include <condition_variable>
 #include <deque>
 #include <mutex>
@@ -103,8 +104,13 @@ class AsyncSequencer {
 
   std::size_t MaxSize() const { return max_size_; }
 
+  bool empty() const {
+    std::lock_guard<std::mutex> lk(mu_);
+    return queue_.empty();
+  }
+
  private:
-  std::mutex mu_;
+  mutable std::mutex mu_;
   std::condition_variable cv_;
   std::deque<std::pair<promise<T>, std::string>> queue_;
   std::size_t max_size_ = 0;


### PR DESCRIPTION
The gRPC rules require asynchronous RPCs (including asynchronous
streaming RPCs) to remain alive until `Finish()` **completes**. That is,
until the callback for `Finish()` is invoked. The code
could destroy them as soon as `Finish()` was **invoked**.

Fixes #14562 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14561)
<!-- Reviewable:end -->
