### PR TITLE
fix(common): censor Bearer tokens over HTTP/2

### DIFF
--- a/google/cloud/internal/curl_wrappers_test.cc
+++ b/google/cloud/internal/curl_wrappers_test.cc
@@ -131,6 +131,31 @@ header2: value2
   }
 }
 
+TEST(CurlWrappers, DebugInfo) {
+  struct TestCasse {
+    std::string input;
+    std::string expected;
+  } cases[] = {
+      {R"""(no-marker-no-nl)""", R"""(== curl(Info): no-marker-no-nl)"""},
+      {R"""(no-marker-w-nl
+)""",
+       R"""(== curl(Info): no-marker-w-nl
+)"""},
+
+      {R"""([HTTP/2] [1] [authorization: Bearer 012345678901234567890123456789)""",
+       R"""(== curl(Info): [HTTP/2] [1] [authorization: Bearer 012345678901234567890123456789)"""},
+      {R"""([HTTP/2] [1] [authorization: Bearer 01234567890123456789012345678912)""",
+       R"""(== curl(Info): [HTTP/2] [1] [authorization: Bearer 01234567890123456789012345678912)"""},
+
+      {R"""([HTTP/2] [1] [authorization: Bearer 012345678901234567890123456789123456)""",
+       R"""(== curl(Info): [HTTP/2] [1] [authorization: Bearer 01234567890123456789012345678912...<truncated>...)"""},
+  };
+
+  for (auto const& test : cases) {
+    EXPECT_EQ(test.expected, DebugInfo(test.input.data(), test.input.size()));
+  }
+}
+
 TEST(CurlWrappers, CurlInitializeOptions) {
   auto defaults = CurlInitializeOptions({});
   EXPECT_TRUE(defaults.get<EnableCurlSslLockingOption>());


### PR DESCRIPTION
Our logs censored Bearer tokens over HTTP/1.x.  These tokens appear in the "info" callbacks, not the "header" callbacks for HTTP/2, and we failed to censor the tokens in that case.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14564)
<!-- Reviewable:end -->
