### PR TITLE
fix(GCS+gRPC): delay resume until Finish() returns

### DIFF
--- a/google/cloud/storage/internal/async/connection_impl_read_test.cc
+++ b/google/cloud/storage/internal/async/connection_impl_read_test.cc
@@ -571,7 +571,6 @@ TEST_F(AsyncConnectionImplTest, ReadObjectDetectBadMessageChecksum) {
 
   EXPECT_THAT(data.get(),
               VariantWith<Status>(StatusIs(StatusCode::kInvalidArgument)));
-
 }
 
 TEST_F(AsyncConnectionImplTest, ReadObjectDetectBadFullChecksum) {

--- a/google/cloud/storage/internal/async/reader_connection_impl.h
+++ b/google/cloud/storage/internal/async/reader_connection_impl.h
@@ -52,7 +52,7 @@ class AsyncReaderConnectionImpl
 
  private:
   future<ReadResponse> OnRead(absl::optional<ProtoPayload> r);
-
+  future<ReadResponse> HandleHashError(Status status);
   future<ReadResponse> DoFinish();
 
   google::cloud::internal::ImmutableOptions options_;

--- a/google/cloud/storage/internal/async/reader_connection_impl.h
+++ b/google/cloud/storage/internal/async/reader_connection_impl.h
@@ -20,6 +20,7 @@
 #include "google/cloud/internal/async_streaming_read_rpc.h"
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include "absl/types/optional.h"
 #include <google/storage/v2/storage.pb.h>
 #include <cstdint>
 #include <memory>
@@ -59,7 +60,7 @@ class AsyncReaderConnectionImpl
   std::shared_ptr<storage::internal::HashFunction> hash_;
   std::unique_ptr<StreamingRpc> impl_;
   std::shared_ptr<storage::internal::HashFunction> hash_function_;
-  std::int64_t offset_ = 0;
+  absl::optional<std::int64_t> offset_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
Another case where we need to wait for `Finish()` before deleting the
underlying RPC.  This is slightly wasteful, as we could start the resume
while the `Finish()` operation is running.  We can improve that later,
once the code no longer crashes.

Fixes #14568

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14569)
<!-- Reviewable:end -->
