### PR TITLE
ci: support external read-only cache for untrusted PRs

### DIFF
--- a/.github/workflows/macos-bazel.yml
+++ b/.github/workflows/macos-bazel.yml
@@ -7,6 +7,14 @@ on:
         required: true
         description: "The ref we want to compile"
         type: string
+      bazel-cache-mode:
+        required: true
+        description: "READ_WRITE or READ_ONLY"
+        type: string
+      execute-integration-tests:
+        required: true
+        description: "Integration tests require credentials."
+        type: boolean
 
 permissions:
   contents: read
@@ -129,13 +137,17 @@ jobs:
       with:
         ref: ${{ inputs.checkout-ref }}
     - uses: google-github-actions/auth@v2
+      if: ${{ inputs.bazel-cache-mode == 'READ_WRITE' }}
       with:
         create_credentials_file: true
         credentials_json: ${{ secrets.BUILD_CACHE_KEY }}
     - name: Install bash >= 5.x
       run: brew install bash
     - name: Build google-cloud-cpp
-      run: ci/gha/builds/macos-bazel.sh ${{ join(matrix.targets, ' ') }}
+      run: |
+        export BAZEL_REMOTE_CACHE_RW_MODE=${{ inputs.bazel-cache-mode }}
+        export EXECUTE_INTEGRATION_TESTS=${{ inputs.execute-integration-tests }}
+        ci/gha/builds/macos-bazel.sh ${{ join(matrix.targets, ' ') }}
     env:
-      BAZEL_REMOTE_CACHE: https://storage.googleapis.com/cloud-cpp-gha-cache/bazel-cache/${{ matrix.os }}
+      BAZEL_REMOTE_CACHE: https://storage.googleapis.com/cloud-cpp-community-gha-cache/bazel-cache/${{ matrix.os }}
       GHA_TEST_BUCKET: "gcs-grpc-team-cloud-cpp-testing-bucket"

--- a/.github/workflows/macos-cmake.yml
+++ b/.github/workflows/macos-cmake.yml
@@ -11,6 +11,14 @@ on:
         required: true
         description: "Build the full matrix"
         type: boolean
+      sccache-mode:
+        required: true
+        description: "READ_WRITE or DISABLED"
+        type: string
+      vcpkg-cache-mode:
+        required: true
+        description: "read or readwrite"
+        type: string
 
 permissions:
   contents: read
@@ -42,6 +50,7 @@ jobs:
       with:
         ref: ${{ inputs.checkout-ref }}
     - uses: google-github-actions/auth@v2
+      if: ${{ inputs.sccache-mode == 'READ_WRITE' && inputs.vcpkg-cache-mode == 'readwrite' }}
       with:
         create_credentials_file: true
         credentials_json: ${{ secrets.BUILD_CACHE_KEY }}
@@ -112,6 +121,7 @@ jobs:
         curl -fsSL -o cmake.rb https://raw.githubusercontent.com/Homebrew/homebrew-core/fd21fcf239bcd0231c9fed5719403ec128151af4/Formula/cmake.rb
         brew install cmake.rb
     - name: Download and Install sccache
+      if: ${{ inputs.sccache-mode != 'DISABLED' }}
       working-directory: "${{runner.temp}}"
       run: |
         curl -fsSL https://github.com/mozilla/sccache/releases/download/v0.5.4/sccache-v0.5.4-x86_64-apple-darwin.tar.gz | \
@@ -130,10 +140,9 @@ jobs:
         export VCPKG_ROOT="${{ runner.temp }}/vcpkg"
         /opt/homebrew/bin/bash ci/gha/builds/macos-cmake.sh ${{ steps.dynamic.outputs.features }}
     env:
-      BAZEL_REMOTE_CACHE: https://storage.googleapis.com/cloud-cpp-gha-cache/bazel-cache/${{ matrix.os }}
-      SCCACHE_GCS_BUCKET: cloud-cpp-gha-cache
+      SCCACHE_GCS_BUCKET: cloud-cpp-community-gha-cache
       SCCACHE_GCS_KEY_PREFIX: sccache/${{ matrix.os }}
-      SCCACHE_GCS_RW_MODE: READ_WRITE
+      SCCACHE_GCS_RW_MODE: ${{ inputs.sccache-mode }}
       SCCACHE_IGNORE_SERVER_IO_ERROR: 1
-      VCPKG_BINARY_SOURCES: x-gcs,gs://cloud-cpp-gha-cache/vcpkg-cache/${{ matrix.os }},readwrite
+      VCPKG_BINARY_SOURCES: x-gcs,gs://cloud-cpp-community-gha-cache/vcpkg-cache/${{ matrix.os }},${{ inputs.vcpkg-cache-mode }}
       GHA_TEST_BUCKET: "gcs-grpc-team-cloud-cpp-testing-bucket"

--- a/.github/workflows/test-runner-untrusted.yml
+++ b/.github/workflows/test-runner-untrusted.yml
@@ -43,6 +43,57 @@ jobs:
   # in separate files to keep the size of this file under control. Note how
   # the additional jobs inherit any secrets needed to use the remote caches and
   # receive what version to checkout as an input.
+  macos-bazel:
+    # Build the full matrix only on push events to the default branch, or
+    # when PR gets the has a `gha:full-build` label, or when it had the
+    # label already and it gets a new commit.
+    if: |-
+      ${{
+        github.event_name == 'schedule' ||
+        github.event_name == 'push' ||
+        contains(github.event.pull_request.labels.*.name, 'gha:full-build')
+      }}
+    name: macOS-Bazel
+    needs: [pre-flight]
+    uses: ./.github/workflows/macos-bazel.yml
+    with:
+      checkout-ref: ${{ needs.pre-flight.outputs.checkout-sha }}
+      bazel-cache-mode: 'READ_ONLY'
+      execute-integration-tests: false
+  windows-bazel:
+    # Build the full matrix only on push events to the default branch, or
+    # when PR gets the has a `gha:full-build` label, or when it had the
+    # label already and it gets a new commit.
+    if: |-
+      ${{
+        github.event_name == 'schedule' ||
+        github.event_name == 'push' ||
+        contains(github.event.pull_request.labels.*.name, 'gha:full-build')
+      }}
+    name: Windows-Bazel
+    needs: [pre-flight]
+    uses: ./.github/workflows/windows-bazel.yml
+    with:
+      checkout-ref: ${{ needs.pre-flight.outputs.checkout-sha }}
+      bazel-cache-mode: 'READ_ONLY'
+      execute-integration-tests: false
+  macos-cmake:
+    name: macOS-CMake
+    needs: [pre-flight]
+    uses: ./.github/workflows/macos-cmake.yml
+    with:
+      checkout-ref: ${{ needs.pre-flight.outputs.checkout-sha }}
+      # Build the full matrix only on push events to the default branch, or
+      # when PR gets the has a `gha:full-build` label, or when it had the
+      # label already and it gets a new commit.
+      full-matrix: |-
+        ${{
+          github.event_name == 'schedule' ||
+          github.event_name == 'push' ||
+          contains(github.event.pull_request.labels.*.name, 'gha:full-build')
+        }}
+      sccache-mode: 'DISABLED'
+      vcpkg-cache-mode: 'read'
   windows-cmake:
     name: Windows-CMake
     needs: [pre-flight]
@@ -59,3 +110,5 @@ jobs:
           github.event_name == 'workflow_dispatch' ||
           contains(github.event.pull_request.labels.*.name, 'gha:full-build'))
         }}
+      sccache-mode: 'DISABLED'
+      vcpkg-cache-mode: 'read'

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -97,6 +97,8 @@ jobs:
     uses: ./.github/workflows/macos-bazel.yml
     with:
       checkout-ref: ${{ needs.pre-flight.outputs.checkout-sha }}
+      bazel-cache-mode: 'READ_WRITE'
+      execute-integration-tests: true
     secrets: inherit
   windows-bazel:
     # Build the full matrix only on push events to the default branch, or
@@ -113,6 +115,8 @@ jobs:
     uses: ./.github/workflows/windows-bazel.yml
     with:
       checkout-ref: ${{ needs.pre-flight.outputs.checkout-sha }}
+      bazel-cache-mode: 'READ_WRITE'
+      execute-integration-tests: true
     secrets: inherit
   macos-cmake:
     name: macOS-CMake
@@ -129,6 +133,8 @@ jobs:
           github.event_name == 'push' ||
           contains(github.event.pull_request.labels.*.name, 'gha:full-build')
         }}
+      sccache-mode: 'READ_WRITE'
+      vcpkg-cache-mode: 'readwrite'
     secrets: inherit
   windows-cmake:
     name: Windows-CMake
@@ -145,6 +151,8 @@ jobs:
           github.event_name == 'push' ||
           contains(github.event.pull_request.labels.*.name, 'gha:full-build')
         }}
+      sccache-mode: 'READ_WRITE'
+      vcpkg-cache-mode: 'readwrite'
     secrets: inherit
   notify:
     name: Notify-Google-Chat

--- a/.github/workflows/windows-bazel.yml
+++ b/.github/workflows/windows-bazel.yml
@@ -7,6 +7,14 @@ on:
         required: true
         description: "The ref we want to compile"
         type: string
+      bazel-cache-mode:
+        required: true
+        description: "READ_WRITE or READ_ONLY"
+        type: string
+      execute-integration-tests:
+        required: true
+        description: "Integration tests require credentials."
+        type: boolean
 
 permissions:
   contents: read
@@ -86,6 +94,7 @@ jobs:
       with:
         ref: ${{ inputs.checkout-ref }}
     - uses: google-github-actions/auth@v2
+      if: ${{ inputs.bazel-cache-mode == 'READ_WRITE' }}
       with:
         create_credentials_file: true
         credentials_json: ${{ secrets.BUILD_CACHE_KEY }}
@@ -110,7 +119,9 @@ jobs:
         export BAZEL_ROOT='c:\b'
         # TODO(14314) - remove this VC Toolset workaround
         export BAZEL_VC_FULL_VERSION=${{ steps.vctoolset.outputs.toolset_version }}
+        export BAZEL_REMOTE_CACHE_RW_MODE=${{ inputs.bazel-cache-mode }}
+        export EXECUTE_INTEGRATION_TESTS=${{ inputs.execute-integration-tests }}
         ci/gha/builds/windows-bazel.sh ${{ matrix.compilation_mode }} ${{ join(matrix.targets, ' ') }}
     env:
-      BAZEL_REMOTE_CACHE: https://storage.googleapis.com/cloud-cpp-gha-cache/bazel-cache/${{ matrix.msvc }}/${{ matrix.compilation_mode }}
+      BAZEL_REMOTE_CACHE: https://storage.googleapis.com/cloud-cpp-community-gha-cache/bazel-cache/${{ matrix.msvc }}/${{ matrix.compilation_mode }}
       GHA_TEST_BUCKET: "gcs-grpc-team-cloud-cpp-testing-bucket"

--- a/.github/workflows/windows-cmake.yml
+++ b/.github/workflows/windows-cmake.yml
@@ -11,6 +11,14 @@ on:
         required: true
         description: "Build the full matrix"
         type: boolean
+      sccache-mode:
+        required: true
+        description: "READ_WRITE or DISABLED"
+        type: string
+      vcpkg-cache-mode:
+        required: true
+        description: "read or readwrite"
+        type: string
 
 permissions:
   contents: read
@@ -51,6 +59,7 @@ jobs:
       with:
         ref: ${{ inputs.checkout-ref }}
     - uses: google-github-actions/auth@v2
+      if: ${{ inputs.sccache-mode == 'READ_WRITE' && inputs.vcpkg-cache-mode == 'readwrite' }}
       with:
         create_credentials_file: true
         credentials_json: ${{ secrets.BUILD_CACHE_KEY }}
@@ -220,6 +229,7 @@ jobs:
         (sleep 60  ; choco install -y cmake --version 3.29.2) || \
         (sleep 120 ; choco install -y cmake --version 3.29.2)
     - name: Download and Install sccache
+      if: ${{ inputs.sccache-mode != 'DISABLED' }}
       working-directory: "${{runner.temp}}"
       shell: bash
       run: |
@@ -259,10 +269,10 @@ jobs:
         export CMAKE_OUT='c:\b'
         ci/gha/builds/windows-cmake.sh ${{ matrix.build_type }} ${{ steps.dynamic.outputs.features }}
     env:
-      SCCACHE_GCS_BUCKET: cloud-cpp-gha-cache
+      SCCACHE_GCS_BUCKET: cloud-cpp-community-gha-cache
       SCCACHE_GCS_KEY_PREFIX: sccache/${{ matrix.msvc }}/${{ matrix.arch}}/${{ matrix.build_type }}
-      SCCACHE_GCS_RW_MODE: READ_WRITE
+      SCCACHE_GCS_RW_MODE: ${{ inputs.sccache-mode }}
       SCCACHE_IGNORE_SERVER_IO_ERROR: 1
-      VCPKG_BINARY_SOURCES: x-gcs,gs://cloud-cpp-gha-cache/vcpkg-cache/${{ matrix.msvc }},readwrite
+      VCPKG_BINARY_SOURCES: x-gcs,gs://cloud-cpp-community-gha-cache/vcpkg-cache/${{ matrix.msvc }},${{ inputs.vcpkg-cache-mode }}
       VCPKG_TRIPLET: ${{ matrix.arch }}-windows
       GHA_TEST_BUCKET: "gcs-grpc-team-cloud-cpp-testing-bucket"

--- a/ci/gha/builds/lib/bazel.sh
+++ b/ci/gha/builds/lib/bazel.sh
@@ -45,7 +45,11 @@ function bazel::test_args() {
   )
   if [[ -n "${BAZEL_REMOTE_CACHE:-}" ]]; then
     args+=("--remote_cache=${BAZEL_REMOTE_CACHE}")
-    args+=("--google_default_credentials")
+    if [[ "${BAZEL_REMOTE_CACHE_RW_MODE}" == "READ_WRITE" ]]; then
+      args+=("--google_default_credentials")
+    else
+      args+=("--remote_upload_local_results=false")
+    fi
     # See https://docs.bazel.build/versions/main/remote-caching.html#known-issues
     # and https://github.com/bazelbuild/bazel/issues/3360
     args+=("--experimental_guard_against_concurrent_changes")

--- a/ci/gha/builds/macos-bazel.sh
+++ b/ci/gha/builds/macos-bazel.sh
@@ -50,10 +50,12 @@ time {
     //google/cloud:status_test "${targets[@]}"
 }
 
-TIMEFORMAT="==> 🕑 Storage integration tests done in %R seconds"
-if [[ -n "${GHA_TEST_BUCKET:-}" ]]; then
-  time {
-    io::run bazelisk "${args[@]}" test "${test_args[@]}" "${integration_test_args[@]}" \
-      //google/cloud/storage/tests/...
-  }
+if [[ "${EXECUTE_INTEGRATION_TESTS}" == "true" ]]; then
+  TIMEFORMAT="==> 🕑 Storage integration tests done in %R seconds"
+  if [[ -n "${GHA_TEST_BUCKET:-}" ]]; then
+    time {
+      io::run bazelisk "${args[@]}" test "${test_args[@]}" "${integration_test_args[@]}" \
+        //google/cloud/storage/tests/...
+    }
+  fi
 fi

--- a/ci/gha/builds/windows-bazel.sh
+++ b/ci/gha/builds/windows-bazel.sh
@@ -46,15 +46,17 @@ time {
   io::run bazelisk "${args[@]}" test "${test_args[@]}" --test_tag_filters=-integration-test -- //google/cloud:status_test "$@"
 }
 
-TIMEFORMAT="==> 🕑 Storage integration tests done in %R seconds"
-if [[ -n "${GHA_TEST_BUCKET:-}" ]]; then
-  time {
-    # gRPC requires a local roots.pem on Windows
-    #   https://github.com/grpc/grpc/issues/16571
-    curl -fsSL -o "${HOME}/roots.pem" https://pki.google.com/roots.pem
+if [[ "${EXECUTE_INTEGRATION_TESTS}" == "true" ]]; then
+  TIMEFORMAT="==> 🕑 Storage integration tests done in %R seconds"
+  if [[ -n "${GHA_TEST_BUCKET:-}" ]]; then
+    time {
+      # gRPC requires a local roots.pem on Windows
+      #   https://github.com/grpc/grpc/issues/16571
+      curl -fsSL -o "${HOME}/roots.pem" https://pki.google.com/roots.pem
 
-    io::run bazelisk "${args[@]}" test "${test_args[@]}" "${integration_test_args[@]}" \
-      --test_env=GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="${HOME}/roots.pem" \
-      //google/cloud/storage/tests/...
-  }
+      io::run bazelisk "${args[@]}" test "${test_args[@]}" "${integration_test_args[@]}" \
+        --test_env=GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="${HOME}/roots.pem" \
+        //google/cloud/storage/tests/...
+    }
+  fi
 fi


### PR DESCRIPTION
While sccache is unavailable in a read_only mode, both the bazel-cache and vcpkg-cache can be used without credentials.
Integration tests, since they require credentials, will not be run by workflows started by test-runner-untrusted.yml.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14570)
<!-- Reviewable:end -->
