### PR TITLE
ci: also disable integration tests for untrusted GHA cmake workflows

### DIFF
--- a/.github/workflows/macos-cmake.yml
+++ b/.github/workflows/macos-cmake.yml
@@ -19,6 +19,10 @@ on:
         required: true
         description: "read or readwrite"
         type: string
+      execute-integration-tests:
+        required: true
+        description: "Integration tests require credentials."
+        type: boolean
 
 permissions:
   contents: read
@@ -138,6 +142,7 @@ jobs:
     - name: Build google-cloud-cpp
       run: |
         export VCPKG_ROOT="${{ runner.temp }}/vcpkg"
+        export EXECUTE_INTEGRATION_TESTS=${{ inputs.execute-integration-tests }}
         /opt/homebrew/bin/bash ci/gha/builds/macos-cmake.sh ${{ steps.dynamic.outputs.features }}
     env:
       SCCACHE_GCS_BUCKET: cloud-cpp-community-gha-cache

--- a/.github/workflows/test-runner-untrusted.yml
+++ b/.github/workflows/test-runner-untrusted.yml
@@ -94,6 +94,7 @@ jobs:
         }}
       sccache-mode: 'DISABLED'
       vcpkg-cache-mode: 'read'
+      execute-integration-tests: false
   windows-cmake:
     name: Windows-CMake
     needs: [pre-flight]
@@ -112,3 +113,4 @@ jobs:
         }}
       sccache-mode: 'DISABLED'
       vcpkg-cache-mode: 'read'
+      execute-integration-tests: false

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -135,6 +135,7 @@ jobs:
         }}
       sccache-mode: 'READ_WRITE'
       vcpkg-cache-mode: 'readwrite'
+      execute-integration-tests: true
     secrets: inherit
   windows-cmake:
     name: Windows-CMake
@@ -153,6 +154,7 @@ jobs:
         }}
       sccache-mode: 'READ_WRITE'
       vcpkg-cache-mode: 'readwrite'
+      execute-integration-tests: true
     secrets: inherit
   notify:
     name: Notify-Google-Chat

--- a/.github/workflows/windows-cmake.yml
+++ b/.github/workflows/windows-cmake.yml
@@ -19,6 +19,10 @@ on:
         required: true
         description: "read or readwrite"
         type: string
+      execute-integration-tests:
+        required: true
+        description: "Integration tests require credentials."
+        type: boolean
 
 permissions:
   contents: read
@@ -267,6 +271,7 @@ jobs:
         # Put the CMake output in a directory with more space and keep it short
         # to avoid running into the MSVC limits.
         export CMAKE_OUT='c:\b'
+        export EXECUTE_INTEGRATION_TESTS=${{ inputs.execute-integration-tests }}
         ci/gha/builds/windows-cmake.sh ${{ matrix.build_type }} ${{ steps.dynamic.outputs.features }}
     env:
       SCCACHE_GCS_BUCKET: cloud-cpp-community-gha-cache

--- a/ci/gha/builds/macos-cmake.sh
+++ b/ci/gha/builds/macos-cmake.sh
@@ -52,11 +52,13 @@ time {
   io::run ctest "${ctest_args[@]}" --test-dir cmake-out -LE integration-test
 }
 
-TIMEFORMAT="==> 🕑 Storage integration tests done in %R seconds"
-if [[ -n "${GHA_TEST_BUCKET:-}" ]]; then
-  time {
-    export GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME="${GHA_TEST_BUCKET}"
-    io::run ctest "${ctest_args[@]}" --repeat until-pass:3 \
-      --test-dir cmake-out -L integration-test-gha
-  }
+if [[ "${EXECUTE_INTEGRATION_TESTS}" == "true" ]]; then
+  TIMEFORMAT="==> 🕑 Storage integration tests done in %R seconds"
+  if [[ -n "${GHA_TEST_BUCKET:-}" ]]; then
+    time {
+      export GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME="${GHA_TEST_BUCKET}"
+      io::run ctest "${ctest_args[@]}" --repeat until-pass:3 \
+        --test-dir cmake-out -L integration-test-gha
+    }
+  fi
 fi

--- a/ci/gha/builds/windows-cmake.sh
+++ b/ci/gha/builds/windows-cmake.sh
@@ -75,15 +75,17 @@ time {
   io::run ctest "${ctest_args[@]}" --test-dir "${CMAKE_OUT}" -LE integration-test
 }
 
-TIMEFORMAT="==> 🕑 Storage integration tests done in %R seconds"
-if [[ -n "${GHA_TEST_BUCKET:-}" ]]; then
-  time {
-    # gRPC requires a local roots.pem on Windows
-    #   https://github.com/grpc/grpc/issues/16571
-    curl -fsSL -o "${HOME}/roots.pem" https://pki.google.com/roots.pem
-    export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="${HOME}/roots.pem"
+if [[ "${EXECUTE_INTEGRATION_TESTS}" == "true" ]]; then
+  TIMEFORMAT="==> 🕑 Storage integration tests done in %R seconds"
+  if [[ -n "${GHA_TEST_BUCKET:-}" ]]; then
+    time {
+      # gRPC requires a local roots.pem on Windows
+      #   https://github.com/grpc/grpc/issues/16571
+      curl -fsSL -o "${HOME}/roots.pem" https://pki.google.com/roots.pem
+      export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="${HOME}/roots.pem"
 
-    export GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME="${GHA_TEST_BUCKET}"
-    io::run ctest "${ctest_args[@]}" --test-dir "${CMAKE_OUT}" -L integration-test-gha
-  }
+      export GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME="${GHA_TEST_BUCKET}"
+      io::run ctest "${ctest_args[@]}" --test-dir "${CMAKE_OUT}" -L integration-test-gha
+    }
+  fi
 fi


### PR DESCRIPTION
Missed these in the previous PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14573)
<!-- Reviewable:end -->
