### PR TITLE
test(storage): disable metrics in integration tests

### DIFF
--- a/google/cloud/storage/testing/storage_integration_test.cc
+++ b/google/cloud/storage/testing/storage_integration_test.cc
@@ -80,6 +80,9 @@ Options StorageIntegrationTest::MakeTestOptions(Options opts) {
   if (auto v = GetEnv("GOOGLE_CLOUD_CPP_STORAGE_TEST_TARGET_API_VERSION")) {
     fallback.set<google::cloud::storage::internal::TargetApiVersionOption>(*v);
   }
+#if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
+  fallback.set<storage_experimental::EnableGrpcMetricsOption>(false);
+#endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
   return google::cloud::internal::MergeOptions(std::move(opts), fallback);
 }
 


### PR DESCRIPTION
Integration tests are flaky enough without the GCS+gRPC metrics enabled
by default. And the logs are also hard to grok with the additional
metrics.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14575)
<!-- Reviewable:end -->
