### PR TITLE
fix(GCS+gRPC): reads resume only after some data

### DIFF
--- a/google/cloud/storage/async/resume_policy.cc
+++ b/google/cloud/storage/async/resume_policy.cc
@@ -43,13 +43,18 @@ class LimitedErrorCountResumePolicyImpl : public ResumePolicy {
   int maximum_resumes_;
 };
 
-class UnlimitedErrorCountResumePolicyImpl : public ResumePolicy {
+class StopOnConsecutiveErrorsResumePolicyImpl : public ResumePolicy {
  public:
-  UnlimitedErrorCountResumePolicyImpl() = default;
-  ~UnlimitedErrorCountResumePolicyImpl() override = default;
+  StopOnConsecutiveErrorsResumePolicyImpl() = default;
+  ~StopOnConsecutiveErrorsResumePolicyImpl() override = default;
 
-  void OnStartSuccess() override {}
-  Action OnFinish(Status const&) override { return kContinue; }
+  void OnStartSuccess() override { next_action_ = kContinue; }
+  Action OnFinish(Status const&) override {
+    return std::exchange(next_action_, kStop);
+  }
+
+ private:
+  Action next_action_ = kContinue;
 };
 
 }  // namespace
@@ -62,9 +67,9 @@ ResumePolicyFactory LimitedErrorCountResumePolicy(int maximum_resumes) {
   };
 }
 
-ResumePolicyFactory UnlimitedErrorCountResumePolicy() {
+ResumePolicyFactory StopOnConsecutiveErrorsResumePolicy() {
   return []() -> std::unique_ptr<ResumePolicy> {
-    return std::make_unique<UnlimitedErrorCountResumePolicyImpl>();
+    return std::make_unique<StopOnConsecutiveErrorsResumePolicyImpl>();
   };
 }
 

--- a/google/cloud/storage/async/resume_policy.h
+++ b/google/cloud/storage/async/resume_policy.h
@@ -61,8 +61,9 @@ struct ResumePolicyOption {
 /// Returns a factory which resumes up to @p maximum_resumes times.
 ResumePolicyFactory LimitedErrorCountResumePolicy(int maximum_resumes);
 
-/// Returns a factory which resumes forever.
-ResumePolicyFactory UnlimitedErrorCountResumePolicy();
+/// Returns a factory which resumes as long as the previous attempt connected
+/// successfully.
+ResumePolicyFactory StopOnConsecutiveErrorsResumePolicy();
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage_experimental

--- a/google/cloud/storage/async/resume_policy_test.cc
+++ b/google/cloud/storage/async/resume_policy_test.cc
@@ -53,10 +53,19 @@ TEST(ResumePolicy, LimitedErrorCountResumePolicy) {
   EXPECT_EQ(p3->OnFinish(TransientError()), ResumePolicy::kStop);
 }
 
-TEST(ResumePolicy, UnlimitedErrorCountResumePolicy) {
-  auto policy = UnlimitedErrorCountResumePolicy()();
+TEST(ResumePolicy, StopOnConsecutiveErrorsResumePolicy) {
+  auto policy = StopOnConsecutiveErrorsResumePolicy()();
   ASSERT_THAT(policy, NotNull());
+  policy->OnStartSuccess();
   EXPECT_EQ(policy->OnFinish(TransientError()), ResumePolicy::kContinue);
+  policy->OnStartSuccess();
+  EXPECT_EQ(policy->OnFinish(TransientError()), ResumePolicy::kContinue);
+  policy->OnStartSuccess();
+  EXPECT_EQ(policy->OnFinish(TransientError()), ResumePolicy::kContinue);
+  policy->OnStartSuccess();
+  EXPECT_EQ(policy->OnFinish(TransientError()), ResumePolicy::kContinue);
+  EXPECT_EQ(policy->OnFinish(TransientError()), ResumePolicy::kStop);
+  EXPECT_EQ(policy->OnFinish(TransientError()), ResumePolicy::kStop);
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/async/connection_impl_read_test.cc
+++ b/google/cloud/storage/internal/async/connection_impl_read_test.cc
@@ -535,7 +535,7 @@ TEST_F(AsyncConnectionImplTest, ReadObjectDetectBadMessageChecksum) {
   auto mock_resume_policy_factory =
       []() -> std::unique_ptr<storage_experimental::ResumePolicy> {
     auto policy = std::make_unique<MockResumePolicy>();
-    EXPECT_CALL(*policy, OnStartSuccess).Times(1);
+    EXPECT_CALL(*policy, OnStartSuccess).Times(0);  // Never resumed
     EXPECT_CALL(*policy, OnFinish(StatusIs(StatusCode::kInvalidArgument)))
         .WillOnce(Return(storage_experimental::ResumePolicy::kStop));
     return policy;
@@ -630,7 +630,7 @@ TEST_F(AsyncConnectionImplTest, ReadObjectDetectBadFullChecksum) {
   auto mock_resume_policy_factory =
       []() -> std::unique_ptr<storage_experimental::ResumePolicy> {
     auto policy = std::make_unique<MockResumePolicy>();
-    EXPECT_CALL(*policy, OnStartSuccess).Times(1);
+    EXPECT_CALL(*policy, OnStartSuccess).Times(2);  // Per Read() sucess
     EXPECT_CALL(*policy, OnFinish).Times(0);
     return policy;
   };

--- a/google/cloud/storage/internal/async/connection_impl_read_test.cc
+++ b/google/cloud/storage/internal/async/connection_impl_read_test.cc
@@ -630,7 +630,7 @@ TEST_F(AsyncConnectionImplTest, ReadObjectDetectBadFullChecksum) {
   auto mock_resume_policy_factory =
       []() -> std::unique_ptr<storage_experimental::ResumePolicy> {
     auto policy = std::make_unique<MockResumePolicy>();
-    EXPECT_CALL(*policy, OnStartSuccess).Times(2);  // Per Read() sucess
+    EXPECT_CALL(*policy, OnStartSuccess).Times(2);  // Per Read() success
     EXPECT_CALL(*policy, OnFinish).Times(0);
     return policy;
   };

--- a/google/cloud/storage/internal/async/default_options.cc
+++ b/google/cloud/storage/internal/async/default_options.cc
@@ -65,7 +65,7 @@ Options DefaultOptionsAsync(Options opts) {
       std::move(opts),
       Options{}
           .set<storage_experimental::ResumePolicyOption>(
-              storage_experimental::UnlimitedErrorCountResumePolicy())
+              storage_experimental::StopOnConsecutiveErrorsResumePolicy())
           .set<storage_experimental::IdempotencyPolicyOption>(
               storage_experimental::MakeStrictIdempotencyPolicy)
           .set<storage_experimental::EnableCrc32cValidationOption>(true));

--- a/google/cloud/storage/internal/async/reader_connection_resume.cc
+++ b/google/cloud/storage/internal/async/reader_connection_resume.cc
@@ -55,6 +55,7 @@ future<ReadResponse> AsyncReaderConnectionResume::Read(
 
 future<ReadResponse> AsyncReaderConnectionResume::OnRead(ReadResponse r) {
   if (absl::holds_alternative<storage_experimental::ReadPayload>(r)) {
+    resume_policy_->OnStartSuccess();
     auto response = absl::get<storage_experimental::ReadPayload>(std::move(r));
     hash_validator_->ProcessHashValues(
         ReadPayloadImpl::GetObjectHashes(response).value_or(
@@ -97,7 +98,6 @@ future<ReadResponse> AsyncReaderConnectionResume::OnResume(
     return make_ready_future(ReadResponse(std::move(connection).status()));
   }
   received_bytes_ = 0;
-  resume_policy_->OnStartSuccess();
   std::unique_lock<std::mutex> lk(mu_);
   impl_ = *std::move(connection);
   return Read(std::move(lk));

--- a/google/cloud/storage/internal/async/reader_connection_resume_test.cc
+++ b/google/cloud/storage/internal/async/reader_connection_resume_test.cc
@@ -185,7 +185,7 @@ TEST(AsyncReaderConnectionResume, Resume) {
       });
 
   auto resume_policy = std::make_unique<MockResumePolicy>();
-  EXPECT_CALL(*resume_policy, OnStartSuccess).Times(3);
+  EXPECT_CALL(*resume_policy, OnStartSuccess).Times(5);  // Per Read() success
   EXPECT_CALL(*resume_policy, OnFinish)
       .WillRepeatedly(Return(ResumePolicy::kContinue));
 
@@ -257,7 +257,7 @@ TEST(AsyncReaderConnectionResume, HashValidation) {
   });
 
   auto resume_policy = std::make_unique<MockResumePolicy>();
-  EXPECT_CALL(*resume_policy, OnStartSuccess).Times(1);
+  EXPECT_CALL(*resume_policy, OnStartSuccess).Times(2);  // Per Read() success
   EXPECT_CALL(*resume_policy, OnFinish).Times(0);
 
   AsyncReaderConnectionResume tested(
@@ -317,7 +317,7 @@ TEST(AsyncReaderConnectionResume, HashValidationWithError) {
   });
 
   auto resume_policy = std::make_unique<MockResumePolicy>();
-  EXPECT_CALL(*resume_policy, OnStartSuccess).Times(1);
+  EXPECT_CALL(*resume_policy, OnStartSuccess).Times(2);  // Per Read() success
   EXPECT_CALL(*resume_policy, OnFinish).Times(0);
 
   AsyncReaderConnectionResume tested(
@@ -345,7 +345,7 @@ TEST(AsyncReaderConnectionResume, Cancel) {
   });
 
   auto resume_policy = std::make_unique<MockResumePolicy>();
-  EXPECT_CALL(*resume_policy, OnStartSuccess).Times(1);
+  EXPECT_CALL(*resume_policy, OnStartSuccess).Times(0);  // Per Read() success
   EXPECT_CALL(*resume_policy, OnFinish)
       .WillRepeatedly(Return(ResumePolicy::kStop));
 
@@ -374,7 +374,7 @@ TEST(AsyncReaderConnectionResume, GetRequestMetadata) {
   });
 
   auto resume_policy = std::make_unique<MockResumePolicy>();
-  EXPECT_CALL(*resume_policy, OnStartSuccess).Times(1);
+  EXPECT_CALL(*resume_policy, OnStartSuccess).Times(0);  // Per Read() success
   EXPECT_CALL(*resume_policy, OnFinish)
       .WillRepeatedly(Return(ResumePolicy::kStop));
 
@@ -416,7 +416,7 @@ TEST(AsyncReaderConnectionResume, ResumeUpdatesOffset) {
   }
 
   auto resume_policy = std::make_unique<MockResumePolicy>();
-  EXPECT_CALL(*resume_policy, OnStartSuccess).Times(4);
+  EXPECT_CALL(*resume_policy, OnStartSuccess).Times(3);  // Per Read() success
   EXPECT_CALL(*resume_policy, OnFinish)
       .WillRepeatedly(Return(ResumePolicy::kContinue));
 
@@ -449,7 +449,7 @@ TEST(AsyncReaderConnectionResume, StopOnReconnectError) {
       .WillOnce([&] { return make_ready_future(MakeMockReaderTransient()); });
 
   auto resume_policy = std::make_unique<MockResumePolicy>();
-  EXPECT_CALL(*resume_policy, OnStartSuccess).Times(1);
+  EXPECT_CALL(*resume_policy, OnStartSuccess).Times(2);  // Per Read() success
   EXPECT_CALL(*resume_policy, OnFinish)
       .WillRepeatedly(Return(ResumePolicy::kContinue));
 
@@ -483,7 +483,7 @@ TEST(AsyncReaderConnectionResume, StopAfterTooManyReconnects) {
   });
 
   auto resume_policy = std::make_unique<MockResumePolicy>();
-  EXPECT_CALL(*resume_policy, OnStartSuccess).Times(3);
+  EXPECT_CALL(*resume_policy, OnStartSuccess).Times(2);  // Once per Read()
   EXPECT_CALL(*resume_policy, OnFinish)
       .WillOnce(Return(ResumePolicy::kContinue))
       .WillOnce(Return(ResumePolicy::kContinue))


### PR DESCRIPTION
By default we want to resume downloads on any error, as long as at least
some data was received. Even if the final status of the stream is scary
(say `NOT_FOUND`), we know the previous attempt was working. Seems
worthwhile to attempt a resume in this case. We also don't want to
believe a resume was "successful" until at least some data was received.
We don't get errors until the first `Read()` attempt.

Fixes #14578

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14579)
<!-- Reviewable:end -->
