### PR TITLE
ci: reblance windows shards

### DIFF
--- a/.github/workflows/windows-cmake.yml
+++ b/.github/workflows/windows-cmake.yml
@@ -109,7 +109,7 @@ jobs:
         # run something like this and create shards:
         #
         # git grep -l 'class.*Client' 'google/cloud/**_client.h' |
-        #    egrep -v "(bigtable/|internal/|pubsub/|spanner/|storage/)" |
+        #    egrep -v "(bigtable/|internal/|pubsub/|pubsublite/|spanner/|storage/)" |
         #    cut -f -3 -d/| sort | uniq -c | sort -n |
         #    awk '{ s += $1; print s, $0}'
         #
@@ -125,16 +125,6 @@ jobs:
           aiplatform
         )
         shard2_features=(
-          policytroubleshooter
-          profiler
-          pubsublite
-          redis
-          securitycenter
-          servicedirectory
-          tpu
-          trace
-          vision
-          workflows
           beyondcorp
           billing
           binaryauthorization
@@ -154,6 +144,7 @@ jobs:
           contentwarehouse
           dataplex
           bigquery
+          bigquerycontrol
           resourcemanager
         )
         shard3_features=(
@@ -191,6 +182,15 @@ jobs:
           metastore
           networkconnectivity
           networkservices
+          policytroubleshooter
+          profiler
+          redis
+          securitycenter
+          servicedirectory
+          tpu
+          trace
+          vision
+          workflows
         )
         if [[ "${{ matrix.shard }}" == "Core1" ]]; then
           features="$(printf ",%s" "${core1_features[@]}")"


### PR DESCRIPTION
We have been seeing build failures due to running out of space. Specifically on Windows + CMake + Debug + Shard2 e.g.:

https://github.com/googleapis/google-cloud-cpp/actions/runs/10174328835

So rebalance the shards. Note that we skip `pubsublite` which is large, and already included in the pubsub shard.

Tested: https://github.com/googleapis/google-cloud-cpp/actions/runs/10184345439/job/28171467848

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14593)
<!-- Reviewable:end -->
