### PR TITLE
cleanup(generator): make static variable trivially destructible

### DIFF
--- a/generator/internal/http_option_utils.cc
+++ b/generator/internal/http_option_utils.cc
@@ -399,9 +399,9 @@ std::string FormatApiVersionFromPackageName(
 std::string FormatApiVersionFromUrlPattern(std::string const& url_pattern,
                                            std::string const& file_name) {
   std::vector<std::string> parts = absl::StrSplit(url_pattern, '/');
-  static std::regex const kRe{R"(v\d+)"};
+  static auto const* const kVersion = new std::regex{R"(v\d+)"};
   for (auto const& part : parts) {
-    if (std::regex_match(part, kRe)) {
+    if (std::regex_match(part, *kVersion)) {
       return part;
     }
   }


### PR DESCRIPTION
Following the [comment](https://github.com/googleapis/google-cloud-cpp/pull/14595#pullrequestreview-2211120461).

[Static variable should be trivially destructible](https://google.github.io/styleguide/cppguide.html#Static_and_Global_Variables).

`std::is_trivially_destructible<std::regex>()` is `false`.
`std::is_trivially_destructible<std::regex*>()` is `true`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14599)
<!-- Reviewable:end -->
