### PR TITLE
fix(otel): avoid infinite trace export loop

### DIFF
--- a/google/cloud/opentelemetry/integration_tests/trace_exporter_integration_test.cc
+++ b/google/cloud/opentelemetry/integration_tests/trace_exporter_integration_test.cc
@@ -14,8 +14,12 @@
 
 #include "google/cloud/opentelemetry/trace_exporter.h"
 #include "google/cloud/trace/v1/trace_client.h"
+#include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/opentelemetry.h"
+#include "google/cloud/testing_util/opentelemetry_matchers.h"
+#include "google/cloud/testing_util/scoped_environment.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <opentelemetry/sdk/trace/simple_processor.h>
@@ -31,6 +35,8 @@ namespace otel {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+using ::google::cloud::testing_util::InstallSpanCatcher;
+using ::google::cloud::testing_util::ScopedEnvironment;
 using ::testing::ElementsAre;
 using ::testing::Eq;
 using ::testing::IsEmpty;
@@ -107,6 +113,26 @@ TEST(TraceExporter, Basic) {
   }
   ASSERT_STATUS_OK(trace) << "Trace did not show up in Cloud Trace";
   EXPECT_THAT(trace->spans(), ElementsAre(TraceSpan(name)));
+}
+
+TEST(TraceExporter, NoInfiniteExportLoop14611) {
+  auto span_catcher = InstallSpanCatcher();
+
+  ScopedEnvironment env{"GOOGLE_CLOUD_CPP_OPENTELEMETRY_TRACING", "ON"};
+
+  auto project = Project("test-project");
+  auto options = Options{}
+                     .set<EndpointOption>("localhost:1")
+                     .set<UnifiedCredentialsOption>(MakeInsecureCredentials());
+  auto exporter = MakeTraceExporter(project, options);
+
+  // Simulate an export which should not create any additional spans.
+  auto recordable = exporter->MakeRecordable();
+  recordable->SetName("span");
+  (void)exporter->Export({&recordable, 1});
+
+  // Verify that no spans were created.
+  EXPECT_THAT(span_catcher->GetSpans(), IsEmpty());
 }
 
 }  // namespace

--- a/google/cloud/opentelemetry/trace_exporter_test.cc
+++ b/google/cloud/opentelemetry/trace_exporter_test.cc
@@ -14,10 +14,7 @@
 
 #include "google/cloud/opentelemetry/trace_exporter.h"
 #include "google/cloud/trace/v2/mocks/mock_trace_connection.h"
-#include "google/cloud/common_options.h"
-#include "google/cloud/credentials.h"
 #include "google/cloud/internal/make_status.h"
-#include "google/cloud/testing_util/opentelemetry_matchers.h"
 #include "google/cloud/testing_util/scoped_environment.h"
 #include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/version.h"
@@ -33,14 +30,12 @@ namespace otel {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-using ::google::cloud::testing_util::InstallSpanCatcher;
 using ::google::cloud::testing_util::ScopedEnvironment;
 using ::google::cloud::testing_util::ScopedLog;
 using ::google::devtools::cloudtrace::v2::BatchWriteSpansRequest;
 using ::testing::Contains;
 using ::testing::ElementsAre;
 using ::testing::HasSubstr;
-using ::testing::IsEmpty;
 using ::testing::Return;
 
 std::vector<std::string> SpanNames(BatchWriteSpansRequest const& request) {
@@ -116,26 +111,6 @@ TEST(TraceExporter, LogsOnError) {
       log.ExtractLines(),
       Contains(AllOf(HasSubstr("Cloud Trace Export"), HasSubstr("1 span(s)"),
                      HasSubstr("UNAVAILABLE"), HasSubstr("try again later"))));
-}
-
-TEST(TraceExporter, NoInfiniteExportLoop14611) {
-  auto span_catcher = InstallSpanCatcher();
-
-  ScopedEnvironment env{"GOOGLE_CLOUD_CPP_OPENTELEMETRY_TRACING", "ON"};
-
-  auto project = Project("test-project");
-  auto options = Options{}
-                     .set<EndpointOption>("localhost:1")
-                     .set<UnifiedCredentialsOption>(MakeInsecureCredentials());
-  auto exporter = MakeTraceExporter(project, options);
-
-  // Simulate an export which should not create any additional spans.
-  auto recordable = exporter->MakeRecordable();
-  recordable->SetName("span");
-  (void)exporter->Export({&recordable, 1});
-
-  // Verify that no spans were created.
-  EXPECT_THAT(span_catcher->GetSpans(), IsEmpty());
 }
 
 }  // namespace

--- a/google/cloud/trace/v2/internal/trace_option_defaults.cc
+++ b/google/cloud/trace/v2/internal/trace_option_defaults.cc
@@ -21,6 +21,7 @@
 #include "google/cloud/trace/v2/trace_options.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
+#include "google/cloud/opentelemetry_options.h"
 #include <memory>
 #include <utility>
 
@@ -54,6 +55,10 @@ Options TraceServiceDefaultOptions(Options options) {
     options.set<trace_v2::TraceServiceConnectionIdempotencyPolicyOption>(
         trace_v2::MakeDefaultTraceServiceConnectionIdempotencyPolicy());
   }
+  // Explicitly disable tracing for the Cloud Trace client which implements the
+  // Cloud Trace Exporter. Otherwise, we can end up with an infinite loop where
+  // the export creates spans, which requires another export.
+  options.set<OpenTelemetryTracingOption>(false);
 
   return options;
 }


### PR DESCRIPTION
Fixes #14611 

Avoid an infinite export loop when `GOOGLE_CLOUD_CPP_OPENTELEMETRY_TRACING` is set by never tracing the Cloud Trace client.

While the solution is not good, it seemed less bad than the alternatives listed in the parent issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14612)
<!-- Reviewable:end -->
