### PR TITLE
cleanup(generator): remove unused code

### DIFF
--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -815,8 +815,6 @@ std::map<std::string, VarsDictionary> CreateMethodVars(
   for (int i = 0; i < service.method_count(); i++) {
     auto const& method = *service.method(i);
     VarsDictionary method_vars;
-    method_vars["method_return_doxygen_link"] =
-        FormatDoxygenLink(*method.output_type());
     method_vars["idempotency"] = DefaultIdempotencyFromHttpOperation(method);
     if (!idempotency_overrides.empty()) {
       auto iter = idempotency_overrides.find(

--- a/generator/internal/descriptor_utils.h
+++ b/generator/internal/descriptor_utils.h
@@ -33,12 +33,6 @@ namespace cloud {
 namespace generator_internal {
 
 /**
- * Create a formatted doxygen link referencing the @p message_type.
- */
-// TODO(#11545): relocate this function to a separate header.
-std::string FormatDoxygenLink(google::protobuf::Descriptor const& message_type);
-
-/**
  * Extracts service wide substitution data required by all class generators from
  * the provided descriptor.
  */

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -1258,10 +1258,6 @@ INSTANTIATE_TEST_SUITE_P(
                              "google::protobuf::Empty"),
         MethodVarsTestValues("my.service.v1.Service.Method0", "idempotency",
                              "kNonIdempotent"),
-        MethodVarsTestValues("my.service.v1.Service.Method0",
-                             "method_return_doxygen_link",
-                             "@googleapis_link{google::protobuf::Empty,google/"
-                             "protobuf/well_known.proto#L5}"),
         // Method1
         MethodVarsTestValues("my.service.v1.Service.Method1", "method_name",
                              "Method1"),
@@ -1271,10 +1267,6 @@ INSTANTIATE_TEST_SUITE_P(
                              "my::service::v1::Bar"),
         MethodVarsTestValues("my.service.v1.Service.Method1", "response_type",
                              "my::service::v1::Bar"),
-        MethodVarsTestValues("my.service.v1.Service.Method1",
-                             "method_return_doxygen_link",
-                             "@googleapis_link{my::service::v1::Bar,google/"
-                             "foo/v1/service.proto#L19}"),
         // Method2
         MethodVarsTestValues("my.service.v1.Service.Method2",
                              "longrunning_metadata_type",

--- a/generator/internal/pagination.cc
+++ b/generator/internal/pagination.cc
@@ -15,6 +15,7 @@
 #include "generator/internal/pagination.h"
 #include "generator/internal/codegen_utils.h"
 #include "generator/internal/descriptor_utils.h"
+#include "generator/internal/doxygen.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/log.h"
 #include "google/cloud/optional.h"


### PR DESCRIPTION
Note that `FormatDoxygenLink(...)` is declared in:

https://github.com/googleapis/google-cloud-cpp/blob/d9adf56750af9c9d0917115b7d9ef36ed19d03ae/generator/internal/doxygen.h#L25-L27

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14616)
<!-- Reviewable:end -->
