### PR TITLE
impl(rest): set ReadFunctionAbort via RAII

### DIFF
--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -493,7 +493,7 @@ class CurlImpl::ReadFunctionAbortGuard {
   ~ReadFunctionAbortGuard() {
     // If curl_closed_ is true, then the handle has already been recycled and
     // attempting to set an option on it will error.
-    if (impl_.curl_closed_) {
+    if (!impl_.curl_closed_) {
       impl_.handle_.SetOptionUnchecked(CURLOPT_READFUNCTION,
                                        &ReadFunctionAbort);
     }

--- a/google/cloud/internal/curl_impl.h
+++ b/google/cloud/internal/curl_impl.h
@@ -107,6 +107,7 @@ class CurlImpl {
   std::size_t HeaderCallback(absl::Span<char> response);
 
  private:
+  class ReadFunctionAbortGuard;
   Status MakeRequestImpl(RestContext& context);
   StatusOr<std::size_t> ReadImpl(RestContext& context, absl::Span<char> output);
 


### PR DESCRIPTION
Leverage RAII to ensure the `CURLOPT_READFUNCTION` is set to `ReadFunctionAbort` regardless if `MakeRequestImpl` returns normally or if an exception is thrown.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14617)
<!-- Reviewable:end -->
