### PR TITLE
doc: add googleapis update step for release

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -10,6 +10,19 @@ project that need to create a new release. We expect the reader to be familiar
 the project itself, [git][git-docs], [GitHub][github-guides], and
 [semantic versioning](https://semver.org).
 
+## 0. Update googleapis SHA and generate libraries
+
+Ensure that our released version includes an up-to-date SHA of the service proto
+definitions.
+
+### a. Execute the renovate script
+
+`external/googleapis/renovate.sh`
+
+### b. Submit and merge a PR containing the changes.
+
+### c. Allow for overnight CI builds to execute before proceeding.
+
 ## 1. Preparing for a release
 
 To create a new release you need to perform some maintenance tasks, these are

--- a/release/README.md
+++ b/release/README.md
@@ -14,8 +14,8 @@ the project itself, [git][git-docs], [GitHub][github-guides], and
 
 In order to ensure that our released version includes a SHA of the service proto
 definitions that is both current and stable ([googleapis-sha-update-policy]),
-make sure that the commit SHA was updated at least 5 days prior, but no more
-than 7 days prior (TODO(#13062): automate this update process).
+aim for a commit SHA from 5-7 days ago (TODO(#13062): automate this update
+process).
 
 ## 1. Preparing for a release
 

--- a/release/README.md
+++ b/release/README.md
@@ -10,18 +10,12 @@ project that need to create a new release. We expect the reader to be familiar
 the project itself, [git][git-docs], [GitHub][github-guides], and
 [semantic versioning](https://semver.org).
 
-## 0. Update googleapis SHA and generate libraries
+## 0. Verify most recent googleapis SHA adheres to policy
 
-Ensure that our released version includes an up-to-date SHA of the service proto
-definitions.
-
-### a. Execute the renovate script
-
-`external/googleapis/renovate.sh`
-
-### b. Submit and merge a PR containing the changes.
-
-### c. Allow for overnight CI builds to execute before proceeding.
+In order to ensure that our released version includes a SHA of the service proto
+definitions that is both current and stable ([googleapis-sha-update-policy]),
+make sure that the commit SHA was updated at least 5 days prior, but no more
+than 7 days prior (TODO(#13062): automate this update process).
 
 ## 1. Preparing for a release
 
@@ -415,6 +409,7 @@ ______________________________________________________________________
 [git-docs]: https://git-scm.com/doc
 [github-branch-settings]: https://github.com/googleapis/google-cloud-cpp/settings/branches
 [github-guides]: https://guides.github.com/
+[googleapis-sha-update-policy]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/adr/2024-08-13-googleapis-sha-update-policy.md
 [pr#138]: https://github.com/conda-forge/google-cloud-cpp-feedstock/pull/138
 [pr#32391]: https://github.com/microsoft/vcpkg/pull/32391
 [sha512]: https://learn.microsoft.com/en-us/vcpkg/maintainers/functions/vcpkg_from_github#sha512


### PR DESCRIPTION
In order to make sure that our monthly release has an updated googleapis SHA, potentially containing updates that service owners are interested in, update it just prior to release.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14618)
<!-- Reviewable:end -->
