### PR TITLE
chore: update universe_domain demos WORKSPACE.bazel

### DIFF
--- a/google/cloud/universe_domain/demo/WORKSPACE.bazel
+++ b/google/cloud/universe_domain/demo/WORKSPACE.bazel
@@ -19,9 +19,6 @@ workspace(name = "demo")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # Fetch the Google Cloud C++ libraries.
-# NOTE: Update this version and SHA256 as needed.
-# TODO(#13494): update the version to a commit SHA that contains the necessary
-# changes.
 http_archive(
     name = "google_cloud_cpp",
     sha256 = "333fe00210ce1a6f0c1b51c232438a316eaf2c7a1724f75d0b2c64f8fc456aa7",


### PR DESCRIPTION
fixes #13494 

renovate-bot is updating the SHA, just needed to remove the TODO

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14621)
<!-- Reviewable:end -->
