### PR TITLE
chore: update patch release process

### DIFF
--- a/ci/cloudbuild/convert-to-branch-triggers.sh
+++ b/ci/cloudbuild/convert-to-branch-triggers.sh
@@ -41,7 +41,10 @@ function convert_triggers() {
   for file in "$@"; do
     sed -i \
       -e "s/^name: /name: ${name_prefix}-/" \
-      -e "s/branch: .*/branch: ${branch}/" "${file}"
+      -e "s/branch: .*/branch: ${branch}/" "${file}" \
+      -e "/^createTime: /d" \
+      -e "/^id: /d" \
+      -e "/^resourceName: /d"
   done
 }
 export -f convert_triggers
@@ -98,5 +101,7 @@ if [[ -z "${BRANCH}" ]]; then
   BRANCH="$(parent)"
 fi
 
+# We want to pass the string as-is, not expand the variables therein.
+# shellcheck disable=SC2016
 git ls-files -z -- ci/cloudbuild/triggers/*.yaml |
-  xargs -P "$(nproc)" -n 10 -0 bash -c "convert_triggers \"${BRANCH}\" \"\$@\""
+  xargs -P "$(nproc)" -n 10 -0 bash -c 'convert_triggers "${BRANCH}" "$@"' _

--- a/release/README.md
+++ b/release/README.md
@@ -349,7 +349,7 @@ In your development fork:
   triggers.
   - Update the Google Cloud Build trigger definitions to compile this branch:
     ```shell
-    ci/cloudbuild/convert-to-branch-triggers.sh
+    ci/cloudbuild/convert-to-branch-triggers.sh --branch "${BRANCH}"
     ```
   - Actually create the triggers in GCB:
     ```shell
@@ -359,7 +359,7 @@ In your development fork:
     ```
   - Remove any old triggers for the same major version, e.g.:
     ```shell
-    cloud builds triggers list \
+    gcloud builds triggers list \
         --project=cloud-cpp-testing-resources \
         --filter=name:v2-10-x --format='value(id)' | \
         xargs -n 1 gcloud builds triggers delete \


### PR DESCRIPTION
We need to clear the `id` field when we clone the trigger. Otherwise, when we upload, it will overwrite the existing trigger, which we do not want to lose.

Also, `convert_triggers` was skipping every 10th trigger. So fix that.