### PR TITLE
ci: fix trigger to run on CI

### DIFF
--- a/ci/cloudbuild/triggers/bazel-otel-abi-2-ci.yaml
+++ b/ci/cloudbuild/triggers/bazel-otel-abi-2-ci.yaml
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+createTime: '2023-12-13T16:53:04.793743056Z'
 filename: ci/cloudbuild/cloudbuild.yaml
 github:
   name: google-cloud-cpp
   owner: googleapis
-  pullRequest:
+  push:
     branch: ^main$
-    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 id: abfbaa6f-e1a0-4298-af45-78f9dc1a9831
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
 name: bazel-otel-abi-2-ci


### PR DESCRIPTION
This was running on PRs. I also uploaded it to GCB with:

```
ci/cloudbuild/trigger.sh --import ci/cloudbuild/triggers/bazel-otel-abi-2-ci.yaml 
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14632)
<!-- Reviewable:end -->
