### PR TITLE
fix: quickstarts build with bazel

### DIFF
--- a/ci/cloudbuild/builds/quickstart-bazel.sh
+++ b/ci/cloudbuild/builds/quickstart-bazel.sh
@@ -25,7 +25,6 @@ export CC=gcc
 export CXX=g++
 
 mapfile -t args < <(bazel::common_args)
-args+=(--noenable_bzlmod)
 for lib in $(quickstart::libraries); do
   io::log_h2 "Running Bazel quickstart for ${lib}"
   env -C "${PROJECT_ROOT}/google/cloud/${lib}/quickstart" \

--- a/google/cloud/accessapproval/quickstart/.bazelrc
+++ b/google/cloud/accessapproval/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/accesscontextmanager/quickstart/.bazelrc
+++ b/google/cloud/accesscontextmanager/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/advisorynotifications/quickstart/.bazelrc
+++ b/google/cloud/advisorynotifications/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/aiplatform/quickstart/.bazelrc
+++ b/google/cloud/aiplatform/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/alloydb/quickstart/.bazelrc
+++ b/google/cloud/alloydb/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/apigateway/quickstart/.bazelrc
+++ b/google/cloud/apigateway/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/apigeeconnect/quickstart/.bazelrc
+++ b/google/cloud/apigeeconnect/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/apikeys/quickstart/.bazelrc
+++ b/google/cloud/apikeys/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/appengine/quickstart/.bazelrc
+++ b/google/cloud/appengine/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/apphub/quickstart/.bazelrc
+++ b/google/cloud/apphub/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/artifactregistry/quickstart/.bazelrc
+++ b/google/cloud/artifactregistry/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/asset/quickstart/.bazelrc
+++ b/google/cloud/asset/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/assuredworkloads/quickstart/.bazelrc
+++ b/google/cloud/assuredworkloads/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/automl/quickstart/.bazelrc
+++ b/google/cloud/automl/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/backupdr/quickstart/.bazelrc
+++ b/google/cloud/backupdr/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/baremetalsolution/quickstart/.bazelrc
+++ b/google/cloud/baremetalsolution/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/batch/quickstart/.bazelrc
+++ b/google/cloud/batch/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/beyondcorp/quickstart/.bazelrc
+++ b/google/cloud/beyondcorp/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/bigquery/quickstart/.bazelrc
+++ b/google/cloud/bigquery/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/bigquerycontrol/quickstart/.bazelrc
+++ b/google/cloud/bigquerycontrol/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/bigtable/quickstart/.bazelrc
+++ b/google/cloud/bigtable/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/billing/quickstart/.bazelrc
+++ b/google/cloud/billing/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/binaryauthorization/quickstart/.bazelrc
+++ b/google/cloud/binaryauthorization/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/certificatemanager/quickstart/.bazelrc
+++ b/google/cloud/certificatemanager/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/channel/quickstart/.bazelrc
+++ b/google/cloud/channel/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/cloudbuild/quickstart/.bazelrc
+++ b/google/cloud/cloudbuild/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/cloudcontrolspartner/quickstart/.bazelrc
+++ b/google/cloud/cloudcontrolspartner/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/cloudquotas/quickstart/.bazelrc
+++ b/google/cloud/cloudquotas/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/commerce/quickstart/.bazelrc
+++ b/google/cloud/commerce/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/composer/quickstart/.bazelrc
+++ b/google/cloud/composer/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/compute/quickstart/.bazelrc
+++ b/google/cloud/compute/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/confidentialcomputing/quickstart/.bazelrc
+++ b/google/cloud/confidentialcomputing/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/config/quickstart/.bazelrc
+++ b/google/cloud/config/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/connectors/quickstart/.bazelrc
+++ b/google/cloud/connectors/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/contactcenterinsights/quickstart/.bazelrc
+++ b/google/cloud/contactcenterinsights/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/container/quickstart/.bazelrc
+++ b/google/cloud/container/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/containeranalysis/quickstart/.bazelrc
+++ b/google/cloud/containeranalysis/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/contentwarehouse/quickstart/.bazelrc
+++ b/google/cloud/contentwarehouse/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/datacatalog/quickstart/.bazelrc
+++ b/google/cloud/datacatalog/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/datafusion/quickstart/.bazelrc
+++ b/google/cloud/datafusion/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/datamigration/quickstart/.bazelrc
+++ b/google/cloud/datamigration/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/dataplex/quickstart/.bazelrc
+++ b/google/cloud/dataplex/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/dataproc/quickstart/.bazelrc
+++ b/google/cloud/dataproc/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/datastore/quickstart/.bazelrc
+++ b/google/cloud/datastore/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/datastream/quickstart/.bazelrc
+++ b/google/cloud/datastream/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/deploy/quickstart/.bazelrc
+++ b/google/cloud/deploy/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/developerconnect/quickstart/.bazelrc
+++ b/google/cloud/developerconnect/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/dialogflow_cx/quickstart/.bazelrc
+++ b/google/cloud/dialogflow_cx/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/dialogflow_es/quickstart/.bazelrc
+++ b/google/cloud/dialogflow_es/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/discoveryengine/quickstart/.bazelrc
+++ b/google/cloud/discoveryengine/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/dlp/quickstart/.bazelrc
+++ b/google/cloud/dlp/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/documentai/quickstart/.bazelrc
+++ b/google/cloud/documentai/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/domains/quickstart/.bazelrc
+++ b/google/cloud/domains/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/edgecontainer/quickstart/.bazelrc
+++ b/google/cloud/edgecontainer/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/edgenetwork/quickstart/.bazelrc
+++ b/google/cloud/edgenetwork/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/essentialcontacts/quickstart/.bazelrc
+++ b/google/cloud/essentialcontacts/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/eventarc/quickstart/.bazelrc
+++ b/google/cloud/eventarc/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/filestore/quickstart/.bazelrc
+++ b/google/cloud/filestore/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/functions/quickstart/.bazelrc
+++ b/google/cloud/functions/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/gkebackup/quickstart/.bazelrc
+++ b/google/cloud/gkebackup/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/gkehub/quickstart/.bazelrc
+++ b/google/cloud/gkehub/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/gkemulticloud/quickstart/.bazelrc
+++ b/google/cloud/gkemulticloud/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/iam/quickstart/.bazelrc
+++ b/google/cloud/iam/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/iap/quickstart/.bazelrc
+++ b/google/cloud/iap/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/ids/quickstart/.bazelrc
+++ b/google/cloud/ids/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/kms/quickstart/.bazelrc
+++ b/google/cloud/kms/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/language/quickstart/.bazelrc
+++ b/google/cloud/language/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/logging/quickstart/.bazelrc
+++ b/google/cloud/logging/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/managedidentities/quickstart/.bazelrc
+++ b/google/cloud/managedidentities/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/managedkafka/quickstart/.bazelrc
+++ b/google/cloud/managedkafka/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/memcache/quickstart/.bazelrc
+++ b/google/cloud/memcache/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/metastore/quickstart/.bazelrc
+++ b/google/cloud/metastore/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/migrationcenter/quickstart/.bazelrc
+++ b/google/cloud/migrationcenter/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/monitoring/quickstart/.bazelrc
+++ b/google/cloud/monitoring/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/netapp/quickstart/.bazelrc
+++ b/google/cloud/netapp/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/networkconnectivity/quickstart/.bazelrc
+++ b/google/cloud/networkconnectivity/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/networkmanagement/quickstart/.bazelrc
+++ b/google/cloud/networkmanagement/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/networksecurity/quickstart/.bazelrc
+++ b/google/cloud/networksecurity/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/networkservices/quickstart/.bazelrc
+++ b/google/cloud/networkservices/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/notebooks/quickstart/.bazelrc
+++ b/google/cloud/notebooks/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/opentelemetry/quickstart/.bazelrc
+++ b/google/cloud/opentelemetry/quickstart/.bazelrc
@@ -42,3 +42,6 @@ build --@google_cloud_cpp//:enable_opentelemetry
 #
 # Note that the flag is not required for OpenTelemetry versions >= v1.16.0. In
 # fact, the flag may be removed in future versions of OpenTelemetry.
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/optimization/quickstart/.bazelrc
+++ b/google/cloud/optimization/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/orgpolicy/quickstart/.bazelrc
+++ b/google/cloud/orgpolicy/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/osconfig/quickstart/.bazelrc
+++ b/google/cloud/osconfig/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/oslogin/quickstart/.bazelrc
+++ b/google/cloud/oslogin/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/policysimulator/quickstart/.bazelrc
+++ b/google/cloud/policysimulator/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/policytroubleshooter/quickstart/.bazelrc
+++ b/google/cloud/policytroubleshooter/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/privateca/quickstart/.bazelrc
+++ b/google/cloud/privateca/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/privilegedaccessmanager/quickstart/.bazelrc
+++ b/google/cloud/privilegedaccessmanager/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/profiler/quickstart/.bazelrc
+++ b/google/cloud/profiler/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/publicca/quickstart/.bazelrc
+++ b/google/cloud/publicca/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/pubsub/quickstart/.bazelrc
+++ b/google/cloud/pubsub/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/pubsublite/quickstart/.bazelrc
+++ b/google/cloud/pubsublite/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/rapidmigrationassessment/quickstart/.bazelrc
+++ b/google/cloud/rapidmigrationassessment/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/recaptchaenterprise/quickstart/.bazelrc
+++ b/google/cloud/recaptchaenterprise/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/recommender/quickstart/.bazelrc
+++ b/google/cloud/recommender/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/redis/quickstart/.bazelrc
+++ b/google/cloud/redis/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/resourcemanager/quickstart/.bazelrc
+++ b/google/cloud/resourcemanager/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/resourcesettings/quickstart/.bazelrc
+++ b/google/cloud/resourcesettings/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/retail/quickstart/.bazelrc
+++ b/google/cloud/retail/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/run/quickstart/.bazelrc
+++ b/google/cloud/run/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/scheduler/quickstart/.bazelrc
+++ b/google/cloud/scheduler/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/secretmanager/quickstart/.bazelrc
+++ b/google/cloud/secretmanager/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/securesourcemanager/quickstart/.bazelrc
+++ b/google/cloud/securesourcemanager/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/securitycenter/quickstart/.bazelrc
+++ b/google/cloud/securitycenter/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/securitycentermanagement/quickstart/.bazelrc
+++ b/google/cloud/securitycentermanagement/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/servicecontrol/quickstart/.bazelrc
+++ b/google/cloud/servicecontrol/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/servicedirectory/quickstart/.bazelrc
+++ b/google/cloud/servicedirectory/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/servicehealth/quickstart/.bazelrc
+++ b/google/cloud/servicehealth/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/servicemanagement/quickstart/.bazelrc
+++ b/google/cloud/servicemanagement/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/serviceusage/quickstart/.bazelrc
+++ b/google/cloud/serviceusage/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/shell/quickstart/.bazelrc
+++ b/google/cloud/shell/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/spanner/quickstart/.bazelrc
+++ b/google/cloud/spanner/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/speech/quickstart/.bazelrc
+++ b/google/cloud/speech/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/sql/quickstart/.bazelrc
+++ b/google/cloud/sql/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/storage/quickstart/.bazelrc
+++ b/google/cloud/storage/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/storagecontrol/quickstart/.bazelrc
+++ b/google/cloud/storagecontrol/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/storageinsights/quickstart/.bazelrc
+++ b/google/cloud/storageinsights/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/storagetransfer/quickstart/.bazelrc
+++ b/google/cloud/storagetransfer/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/support/quickstart/.bazelrc
+++ b/google/cloud/support/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/talent/quickstart/.bazelrc
+++ b/google/cloud/talent/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/tasks/quickstart/.bazelrc
+++ b/google/cloud/tasks/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/telcoautomation/quickstart/.bazelrc
+++ b/google/cloud/telcoautomation/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/texttospeech/quickstart/.bazelrc
+++ b/google/cloud/texttospeech/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/timeseriesinsights/quickstart/.bazelrc
+++ b/google/cloud/timeseriesinsights/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/tpu/quickstart/.bazelrc
+++ b/google/cloud/tpu/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/trace/quickstart/.bazelrc
+++ b/google/cloud/trace/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/translate/quickstart/.bazelrc
+++ b/google/cloud/translate/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/video/quickstart/.bazelrc
+++ b/google/cloud/video/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/videointelligence/quickstart/.bazelrc
+++ b/google/cloud/videointelligence/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/vision/quickstart/.bazelrc
+++ b/google/cloud/vision/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/vmmigration/quickstart/.bazelrc
+++ b/google/cloud/vmmigration/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/vmwareengine/quickstart/.bazelrc
+++ b/google/cloud/vmwareengine/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/vpcaccess/quickstart/.bazelrc
+++ b/google/cloud/vpcaccess/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/webrisk/quickstart/.bazelrc
+++ b/google/cloud/webrisk/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/websecurityscanner/quickstart/.bazelrc
+++ b/google/cloud/websecurityscanner/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/workflows/quickstart/.bazelrc
+++ b/google/cloud/workflows/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod

--- a/google/cloud/workstations/quickstart/.bazelrc
+++ b/google/cloud/workstations/quickstart/.bazelrc
@@ -28,3 +28,6 @@ build:macos --host_cxxopt=-std=c++14
 # runs inside a docker image or if one builds a quickstart and then builds
 # the project separately.
 build --experimental_convenience_symlinks=ignore
+
+#Our quickstarts do not yet support bzlmod
+build --noenable_bzlmod


### PR DESCRIPTION
Fixes #14625 

Our quickstarts should probably support both bazel and bzlmod.... But right now they support neither. So make them work with plain old bazel.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14633)
<!-- Reviewable:end -->
