### PR TITLE
cleanup(compute): sort service_dirs

### DIFF
--- a/google/cloud/compute/service_dirs.bzl
+++ b/google/cloud/compute/service_dirs.bzl
@@ -17,7 +17,6 @@
 """Automatically generated unit tests list - DO NOT EDIT."""
 
 service_dirs = [
-    "future_reservations/v1/",
     "accelerator_types/v1/",
     "addresses/v1/",
     "autoscalers/v1/",
@@ -29,6 +28,7 @@ service_dirs = [
     "firewall_policies/v1/",
     "firewalls/v1/",
     "forwarding_rules/v1/",
+    "future_reservations/v1/",
     "global_addresses/v1/",
     "global_forwarding_rules/v1/",
     "global_network_endpoint_groups/v1/",


### PR DESCRIPTION
`clang-tidy-compute` enforces that these things are sorted, but it only runs on CI.

* GCB: https://console.cloud.google.com/cloud-build/builds;region=us-east1/448e7048-59d0-4b78-9834-7fab8df9ac3f;tab=detail?project=cloud-cpp-testing-resources
* Raw: https://storage.googleapis.com/cloud-cpp-community-publiclogs/logs/google-cloud-cpp/main/aa75123f5c40c84901971820f65fa542891c5ee6/fedora-latest-cmake-clang-tidy-compute/log-448e7048-59d0-4b78-9834-7fab8df9ac3f.txt

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14641)
<!-- Reviewable:end -->
