### PR TITLE
cleanup(otel): move test, and guard it

### DIFF
--- a/google/cloud/opentelemetry/integration_tests/trace_exporter_integration_test.cc
+++ b/google/cloud/opentelemetry/integration_tests/trace_exporter_integration_test.cc
@@ -14,12 +14,8 @@
 
 #include "google/cloud/opentelemetry/trace_exporter.h"
 #include "google/cloud/trace/v1/trace_client.h"
-#include "google/cloud/common_options.h"
-#include "google/cloud/credentials.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/opentelemetry.h"
-#include "google/cloud/testing_util/opentelemetry_matchers.h"
-#include "google/cloud/testing_util/scoped_environment.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <opentelemetry/sdk/trace/simple_processor.h>
@@ -35,8 +31,6 @@ namespace otel {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-using ::google::cloud::testing_util::InstallSpanCatcher;
-using ::google::cloud::testing_util::ScopedEnvironment;
 using ::testing::ElementsAre;
 using ::testing::Eq;
 using ::testing::IsEmpty;
@@ -113,26 +107,6 @@ TEST(TraceExporter, Basic) {
   }
   ASSERT_STATUS_OK(trace) << "Trace did not show up in Cloud Trace";
   EXPECT_THAT(trace->spans(), ElementsAre(TraceSpan(name)));
-}
-
-TEST(TraceExporter, NoInfiniteExportLoop14611) {
-  auto span_catcher = InstallSpanCatcher();
-
-  ScopedEnvironment env{"GOOGLE_CLOUD_CPP_OPENTELEMETRY_TRACING", "ON"};
-
-  auto project = Project("test-project");
-  auto options = Options{}
-                     .set<EndpointOption>("localhost:1")
-                     .set<UnifiedCredentialsOption>(MakeInsecureCredentials());
-  auto exporter = MakeTraceExporter(project, options);
-
-  // Simulate an export which should not create any additional spans.
-  auto recordable = exporter->MakeRecordable();
-  recordable->SetName("span");
-  (void)exporter->Export({&recordable, 1});
-
-  // Verify that no spans were created.
-  EXPECT_THAT(span_catcher->GetSpans(), IsEmpty());
 }
 
 }  // namespace

--- a/google/cloud/opentelemetry/trace_exporter_test.cc
+++ b/google/cloud/opentelemetry/trace_exporter_test.cc
@@ -14,7 +14,10 @@
 
 #include "google/cloud/opentelemetry/trace_exporter.h"
 #include "google/cloud/trace/v2/mocks/mock_trace_connection.h"
+#include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/internal/make_status.h"
+#include "google/cloud/testing_util/opentelemetry_matchers.h"
 #include "google/cloud/testing_util/scoped_environment.h"
 #include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/version.h"
@@ -112,6 +115,32 @@ TEST(TraceExporter, LogsOnError) {
       Contains(AllOf(HasSubstr("Cloud Trace Export"), HasSubstr("1 span(s)"),
                      HasSubstr("UNAVAILABLE"), HasSubstr("try again later"))));
 }
+
+#ifdef GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
+using ::google::cloud::testing_util::InstallSpanCatcher;
+using ::google::cloud::testing_util::ScopedEnvironment;
+using ::testing::IsEmpty;
+
+TEST(TraceExporter, NoInfiniteExportLoop14611) {
+  auto span_catcher = InstallSpanCatcher();
+
+  ScopedEnvironment env{"GOOGLE_CLOUD_CPP_OPENTELEMETRY_TRACING", "ON"};
+
+  auto project = Project("test-project");
+  auto options = Options{}
+                     .set<EndpointOption>("localhost:1")
+                     .set<UnifiedCredentialsOption>(MakeInsecureCredentials());
+  auto exporter = MakeTraceExporter(project, options);
+
+  // Simulate an export which should not create any additional spans.
+  auto recordable = exporter->MakeRecordable();
+  recordable->SetName("span");
+  (void)exporter->Export({&recordable, 1});
+
+  // Verify that no spans were created.
+  EXPECT_THAT(span_catcher->GetSpans(), IsEmpty());
+}
+#endif  // GOOGLE_CLOUD_CPP_HAVE_OPENTELEMETRY
 
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
I made a bad decision in this commit, so revert it: https://github.com/googleapis/google-cloud-cpp/pull/14612/commits/8150ba796fe2778dfef46d43aa67c1cd16a3a420

This will make the import to google3 go more smoothly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14642)
<!-- Reviewable:end -->
