### PR TITLE
ci: ignore quota flakes in policysimulator quickstart

### DIFF
--- a/google/cloud/policysimulator/CMakeLists.txt
+++ b/google/cloud/policysimulator/CMakeLists.txt
@@ -30,6 +30,8 @@ if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
             cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
             $<TARGET_FILE:policysimulator_quickstart> GOOGLE_CLOUD_PROJECT
             GOOGLE_CLOUD_CPP_POLICYSIMULATOR_RESOURCE)
-    set_tests_properties(policysimulator_quickstart
-                         PROPERTIES LABELS "integration-test;quickstart")
+    set_tests_properties(
+        policysimulator_quickstart
+        PROPERTIES LABELS "integration-test;quickstart" SKIP_REGULAR_EXPRESSION
+                   "RESOURCE_EXHAUSTED")
 endif ()


### PR DESCRIPTION
Fixes #14643 

If you are unfamiliar with `SKIP_REGULAR_EXPRESSION`, see: https://cmake.org/cmake/help/latest/prop_test/SKIP_REGULAR_EXPRESSION.html

... but a better explainer is here: https://gist.github.com/pudnax/141f0f114c5530d435eea5cd80ccbd11

Basically:
- the quickstart always runs
- if it passes, the test is marked as passing
- if it fails and "RESOURCE_EXHAUSTED" is in the output, the test is marked as skipped
- if it fails and "RESOURCE_EXHAUSTED" is not in the output, the test is failed

That seems like what we want.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14644)
<!-- Reviewable:end -->
