### PR TITLE
fix: do not persist the keys loaded from PKCS#12 on Windows

### DIFF
--- a/google/cloud/internal/win32/parse_service_account_p12_file.cc
+++ b/google/cloud/internal/win32/parse_service_account_p12_file.cc
@@ -121,9 +121,7 @@ StatusOr<UniqueCertStore> OpenP12File(std::string const& source) {
 StatusOr<UniqueCertContext> GetCertificate(HCERTSTORE certstore,
                                            std::string const& source) {
   // Get the certificate from the store.
-  PCCERT_CONTEXT cert_raw = CertFindCertificateInStore(
-      certstore, X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, 0, CERT_FIND_ANY,
-      nullptr, nullptr);
+  PCCERT_CONTEXT cert_raw = CertEnumCertificatesInStore(certstore, nullptr);
   if (cert_raw == nullptr) {
     return InvalidArgumentError(
         absl::StrCat("No certificate found in PKCS#12 file (", source, ")"),


### PR DESCRIPTION
As part of investigating #14349, I noticed that the `PFXImportCertStore` function persists the keys on disk by default. This PR fixes that by passing the `PKCS12_NO_PERSIST_KEY` flag, and geting a preallocated `HCRYPTPROV` to get the certificate's key.

Validated locally by running `_build/Default/google/cloud/storage/oauth2_service_account_credentials_test.exe --gtest_filter=ServiceAccountCredentialsTest.ParseSimpleP12 --gtest_repeat=-1` and letting the test run hundreds of times. I'm not sure if this will fix the occasional CI failures, but this looks like an improvement to me.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14645)
<!-- Reviewable:end -->
