### PR TITLE
fix(bigtable): sanitize RowRange proto input

### DIFF
--- a/google/cloud/bigtable/row_range.cc
+++ b/google/cloud/bigtable/row_range.cc
@@ -20,6 +20,23 @@ namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace btproto = ::google::bigtable::v2;
 
+RowRange::RowRange(::google::bigtable::v2::RowRange rhs)
+    : row_range_(std::move(rhs)) {
+  // The service treats an empty end key as end of table. Some of our
+  // intersection logic does not, though. So we are best off sanitizing the
+  // input, by clearing the end key if it is empty.
+  if (row_range_.has_end_key_closed()) {
+    if (internal::IsEmptyRowKey(row_range_.end_key_closed())) {
+      row_range_.clear_end_key_closed();
+    }
+  }
+  if (row_range_.has_end_key_open()) {
+    if (internal::IsEmptyRowKey(row_range_.end_key_open())) {
+      row_range_.clear_end_key_open();
+    }
+  }
+}
+
 bool RowRange::IsEmpty() const {
   RowKeyType unused;
   // We do not want to copy the strings unnecessarily, so initialize a reference

--- a/google/cloud/bigtable/row_range.h
+++ b/google/cloud/bigtable/row_range.h
@@ -26,19 +26,19 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
 /**
  * Define the interfaces to create row key ranges.
  *
  * Example:
  * @code
  * // Create a range for the keys starting with the given prefix.
- * auto range = bigtable::RowRange("foo/");
+ * auto range = bigtable::RowRange::StartingAt("foo/");
  * @endcode
  */
 class RowRange {
  public:
-  explicit RowRange(::google::bigtable::v2::RowRange rhs)
-      : row_range_(std::move(rhs)) {}
+  explicit RowRange(::google::bigtable::v2::RowRange rhs);
 
   RowRange(RowRange&&) = default;
   RowRange& operator=(RowRange&&) = default;

--- a/google/cloud/bigtable/row_range_test.cc
+++ b/google/cloud/bigtable/row_range_test.cc
@@ -735,6 +735,18 @@ TEST(RowRangeTest, IntersectEndingAtEndingAt) {
   EXPECT_EQ(R::EndingAt("k"), std::get<1>(tuple));
 }
 
+TEST(RowRangeTest, SanitizesInput) {
+  google::bigtable::v2::RowRange proto;
+  proto.set_start_key_open("");
+  proto.set_end_key_open("");
+  auto rr = RowRange(proto);
+  EXPECT_FALSE(rr.IsEmpty());
+
+  proto.set_end_key_closed("");
+  rr = RowRange(std::move(proto));
+  EXPECT_FALSE(rr.IsEmpty());
+}
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable


### PR DESCRIPTION
Sanitize input for the ctor from protos. Hopefully the comment in the code explains why we want to do this.
Also correct the documentation for this class.

I considered deprecating the constructor that takes a proto, but it is too complicated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14651)
<!-- Reviewable:end -->
