### PR TITLE
fix(backupdr): include logging protos with cmake

### DIFF
--- a/ci/cloudbuild/builds/cmake-install.sh
+++ b/ci/cloudbuild/builds/cmake-install.sh
@@ -70,6 +70,9 @@ expected_dirs+=(
   # no RPC services in google/cloud/appengine/logging
   ./include/google/appengine/logging
   ./include/google/appengine/logging/v1
+  # no RPC services in google/cloud/backupdr/logging
+  ./include/google/cloud/backupdr/logging
+  ./include/google/cloud/backupdr/logging/v1
   # no RPC services in google/cloud/bigquery/logging
   ./include/google/cloud/bigquery/logging
   ./include/google/cloud/bigquery/logging/v1

--- a/external/googleapis/protolists/backupdr.list
+++ b/external/googleapis/protolists/backupdr.list
@@ -1,1 +1,3 @@
+@com_google_googleapis//google/cloud/backupdr/logging/v1:eventlog.proto
+@com_google_googleapis//google/cloud/backupdr/logging/v1:reportlog.proto
 @com_google_googleapis//google/cloud/backupdr/v1:backupdr.proto

--- a/external/googleapis/update_libraries.sh
+++ b/external/googleapis/update_libraries.sh
@@ -49,8 +49,8 @@ declare -A -r LIBRARIES=(
   ["automl"]="@com_google_googleapis//google/cloud/automl/v1:automl_cc_grpc"
   ["backupdr"]="$(
     printf ",%s" \
-      "@com_google_googleapis//google/cloud/backupdr/v1:backupdr_cc_grpc"
-    "@com_google_googleapis//google/cloud/backupdr/logging/v1:logging_cc_grpc"
+      "@com_google_googleapis//google/cloud/backupdr/v1:backupdr_cc_grpc" \
+      "@com_google_googleapis//google/cloud/backupdr/logging/v1:logging_cc_grpc"
   )"
   ["baremetalsolution"]="@com_google_googleapis//google/cloud/baremetalsolution/v2:baremetalsolution_cc_grpc"
   ["batch"]="@com_google_googleapis//google/cloud/batch/v1:batch_cc_grpc"


### PR DESCRIPTION
This makes the backupdr logging protos available in `google-cloud-cpp::backupdr-protos`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14662)
<!-- Reviewable:end -->
