### PR TITLE
cleanup(generator): generalize return type strings followup

### DIFF
--- a/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_logging_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_thing_admin_rest_logging_decorator.cc
@@ -364,10 +364,10 @@ GoldenThingAdminRestLogging::AsyncGetDatabase(
 
 future<Status>
 GoldenThingAdminRestLogging::AsyncDropDatabase(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<rest_internal::RestContext> rest_context,
-      google::cloud::internal::ImmutableOptions options,
-      google::test::admin::database::v1::DropDatabaseRequest const& request) {
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<rest_internal::RestContext> rest_context,
+    google::cloud::internal::ImmutableOptions options,
+    google::test::admin::database::v1::DropDatabaseRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](CompletionQueue& cq,
              std::unique_ptr<rest_internal::RestContext> rest_context,

--- a/generator/internal/connection_generator.cc
+++ b/generator/internal/connection_generator.cc
@@ -238,10 +238,8 @@ class $connection_class_name$ {
         method,
         {MethodPattern(
              {
-                 {IsResponseTypeEmpty,
-                  // clang-format off
-    "\n  virtual Status\n",
-    "\n  virtual StatusOr<$response_type$>\n"},
+                 {"\n  virtual $return_type$\n"},
+                 // clang-format off
    {"  $method_name$($request_type$ const& request);\n"}
                  // clang-format on
              },
@@ -298,10 +296,8 @@ class $connection_class_name$ {
         method,
         {MethodPattern(
             {
-                {IsResponseTypeEmpty,
-                 // clang-format off
-    "\n  virtual future<Status>\n",
-    "\n  virtual future<StatusOr<$response_type$>>\n"},
+                {"\n  virtual future<$return_type$>\n"},
+                // clang-format off
    {"  Async$method_name$($request_type$ const& request);\n"}
                 // clang-format on
             },
@@ -375,10 +371,8 @@ $connection_class_name$::Async$method_name$() {
         method,
         {MethodPattern(
              {
-                 {IsResponseTypeEmpty,
-                  // clang-format off
-    "\nStatus\n",
-    "\nStatusOr<$response_type$>\n"},
+                 {"\n$return_type$\n"},
+                 // clang-format off
    {"$connection_class_name$::$method_name$(\n"
     "    $request_type$ const&) {\n"
     "  return Status(StatusCode::kUnimplemented, \"not implemented\");\n"

--- a/generator/internal/connection_impl_generator.cc
+++ b/generator/internal/connection_impl_generator.cc
@@ -528,9 +528,9 @@ $connection_class_name$Impl::$method_name$(
                         await_function);
   }
 
-  auto const* return_fragment = R"""($return_type$)""";
   if (HasRequestId(method)) {
-    return absl::StrCat("\n", return_fragment, R"""(
+    return R"""(
+$return_type$
 $connection_class_name$Impl::$method_name$($request_type$ const& request) {
   auto current = google::cloud::internal::SaveCurrentOptions();
   auto request_copy = request;
@@ -546,11 +546,11 @@ $connection_class_name$Impl::$method_name$($request_type$ const& request) {
       },
       *current, request_copy, __func__);
 }
-)""");
+)""";
   }
 
-  return absl::StrCat("\n", return_fragment,
-                      R"""(
+  return R"""(
+$return_type$
 $connection_class_name$Impl::$method_name$($request_type$ const& request) {
   auto current = google::cloud::internal::SaveCurrentOptions();
   return google::cloud::internal::RetryLoop(
@@ -562,12 +562,11 @@ $connection_class_name$Impl::$method_name$($request_type$ const& request) {
       },
       *current, request, __func__);
 }
-)""");
+)""";
 }
 
 std::string ConnectionImplGenerator::AsyncMethodDefinition(
     google::protobuf::MethodDescriptor const& method) {
-  auto const* return_fragment = R"""(future<$return_type$>)""";
   auto const* request_id_fragment = HasRequestId(method) ?
                                                          R"""(
   if (request_copy.$request_id_field_name$().empty()) {
@@ -575,8 +574,8 @@ std::string ConnectionImplGenerator::AsyncMethodDefinition(
   })"""
                                                          : "";
 
-  return absl::StrCat("\n", return_fragment,
-                      R"""(
+  return absl::StrCat(R"""(
+future<$return_type$>
 $connection_class_name$Impl::Async$method_name$($request_type$ const& request) {
   auto current = google::cloud::internal::SaveCurrentOptions();
   auto request_copy = request;)""",

--- a/generator/internal/connection_impl_generator.cc
+++ b/generator/internal/connection_impl_generator.cc
@@ -305,29 +305,16 @@ std::string ConnectionImplGenerator::MethodDeclaration(
 )""";
   }
 
-  if (IsResponseTypeEmpty(method)) {
-    return R"""(
-  Status
-  $method_name$($request_type$ const& request) override;
-)""";
-  }
   return R"""(
-  StatusOr<$response_type$>
+  $return_type$
   $method_name$($request_type$ const& request) override;
 )""";
 }
 
 std::string ConnectionImplGenerator::AsyncMethodDeclaration(
     google::protobuf::MethodDescriptor const& method) {
-  if (IsResponseTypeEmpty(method)) {
-    return R"""(
-  future<Status>
-  Async$method_name$($request_type$ const& request) override;
-)""";
-  }
-
   return R"""(
-  future<StatusOr<$response_type$>>
+  future<$return_type$>
   Async$method_name$($request_type$ const& request) override;
 )""";
 }
@@ -543,9 +530,7 @@ $connection_class_name$Impl::$method_name$(
                         await_function);
   }
 
-  auto const* return_fragment = IsResponseTypeEmpty(method)
-                                    ? R"""(Status)"""
-                                    : R"""(StatusOr<$response_type$>)""";
+  auto const* return_fragment = R"""($return_type$)""";
   if (HasRequestId(method)) {
     return absl::StrCat("\n", return_fragment, R"""(
 $connection_class_name$Impl::$method_name$($request_type$ const& request) {
@@ -584,9 +569,7 @@ $connection_class_name$Impl::$method_name$($request_type$ const& request) {
 
 std::string ConnectionImplGenerator::AsyncMethodDefinition(
     google::protobuf::MethodDescriptor const& method) {
-  auto const* return_fragment =
-      IsResponseTypeEmpty(method) ? R"""(future<Status>)"""
-                                  : R"""(future<StatusOr<$response_type$>>)""";
+  auto const* return_fragment = R"""(future<$return_type$>)""";
   auto const* request_id_fragment = HasRequestId(method) ?
                                                          R"""(
   if (request_copy.$request_id_field_name$().empty()) {

--- a/generator/internal/connection_impl_generator.cc
+++ b/generator/internal/connection_impl_generator.cc
@@ -115,8 +115,7 @@ class $connection_class_name$Impl
   for (auto const& method : async_methods()) {
     if (IsStreamingRead(method)) continue;
     if (IsStreamingWrite(method)) continue;
-    HeaderPrintMethod(method, __FILE__, __LINE__,
-                      AsyncMethodDeclaration(method));
+    HeaderPrintMethod(method, __FILE__, __LINE__, AsyncMethodDeclaration());
   }
 
   HeaderPrint(R"""(
@@ -311,8 +310,7 @@ std::string ConnectionImplGenerator::MethodDeclaration(
 )""";
 }
 
-std::string ConnectionImplGenerator::AsyncMethodDeclaration(
-    google::protobuf::MethodDescriptor const& method) {
+std::string ConnectionImplGenerator::AsyncMethodDeclaration() {
   return R"""(
   future<$return_type$>
   Async$method_name$($request_type$ const& request) override;

--- a/generator/internal/connection_impl_generator.h
+++ b/generator/internal/connection_impl_generator.h
@@ -48,8 +48,7 @@ class ConnectionImplGenerator : public ServiceCodeGenerator {
 
   static std::string MethodDeclaration(
       google::protobuf::MethodDescriptor const& method);
-  static std::string AsyncMethodDeclaration(
-      google::protobuf::MethodDescriptor const& method);
+  static std::string AsyncMethodDeclaration();
   std::string MethodDefinition(
       google::protobuf::MethodDescriptor const& method);
   std::string AsyncMethodDefinition(

--- a/generator/internal/connection_impl_rest_generator.cc
+++ b/generator/internal/connection_impl_rest_generator.cc
@@ -236,29 +236,16 @@ std::string ConnectionImplRestGenerator::MethodDeclaration(
 )""");
   }
 
-  if (IsResponseTypeEmpty(method)) {
-    return R"""(
-  Status
-  $method_name$($request_type$ const& request) override;
-)""";
-  }
   return R"""(
-  StatusOr<$response_type$>
+  $return_type$
   $method_name$($request_type$ const& request) override;
 )""";
 }
 
 std::string ConnectionImplRestGenerator::AsyncMethodDeclaration(
     google::protobuf::MethodDescriptor const& method) {
-  if (IsResponseTypeEmpty(method)) {
-    return R"""(
-  future<Status>
-  Async$method_name$($request_type$ const& request) override;
-)""";
-  }
-
   return R"""(
-  future<StatusOr<$response_type$>>
+  future<$return_type$>
   Async$method_name$($request_type$ const& request) override;
 )""";
 }
@@ -512,11 +499,8 @@ $connection_impl_rest_class_name$::$method_name$(
                         await_function);
   }
 
-  return absl::StrCat(IsResponseTypeEmpty(method) ? R"""(
-Status)"""
-                                                  : R"""(
-StatusOr<$response_type$>)""",
-                      R"""(
+  return R"""(
+$return_type$
 $connection_impl_rest_class_name$::$method_name$($request_type$ const& request) {
   auto current = google::cloud::internal::SaveCurrentOptions();
   return google::cloud::rest_internal::RestRetryLoop(
@@ -528,16 +512,13 @@ $connection_impl_rest_class_name$::$method_name$($request_type$ const& request) 
       },
       *current, request, __func__);
 }
-)""");
+)""";
 }
 
 std::string ConnectionImplRestGenerator::AsyncMethodDefinition(
     google::protobuf::MethodDescriptor const& method) {
-  return absl::StrCat(IsResponseTypeEmpty(method) ? R"""(
-future<Status>)"""
-                                                  : R"""(
-future<StatusOr<$response_type$>>)""",
-                      R"""(
+  return R"""(
+future<$return_type$>
 $connection_impl_rest_class_name$::Async$method_name$($request_type$ const& request) {
   auto current = google::cloud::internal::SaveCurrentOptions();
   auto retry = retry_policy(*current);
@@ -554,7 +535,7 @@ $connection_impl_rest_class_name$::Async$method_name$($request_type$ const& requ
       },
       std::move(current), request, __func__);
 }
-)""");
+)""";
 }
 
 }  // namespace generator_internal

--- a/generator/internal/connection_impl_rest_generator.cc
+++ b/generator/internal/connection_impl_rest_generator.cc
@@ -87,8 +87,7 @@ class $connection_impl_rest_class_name$
   for (auto const& method : async_methods()) {
     if (IsStreaming(method)) continue;
     if (!HasHttpAnnotation(method)) continue;
-    HeaderPrintMethod(method, __FILE__, __LINE__,
-                      AsyncMethodDeclaration(method));
+    HeaderPrintMethod(method, __FILE__, __LINE__, AsyncMethodDeclaration());
   }
 
   // `CurrentOptions()` may not have the service default options because we
@@ -190,7 +189,7 @@ $connection_impl_rest_class_name$::$connection_impl_rest_class_name$(
   for (auto const& method : async_methods()) {
     if (IsStreaming(method)) continue;
     if (!HasHttpAnnotation(method)) continue;
-    CcPrintMethod(method, __FILE__, __LINE__, AsyncMethodDefinition(method));
+    CcPrintMethod(method, __FILE__, __LINE__, AsyncMethodDefinition());
   }
 
   CcCloseNamespaces();
@@ -242,8 +241,7 @@ std::string ConnectionImplRestGenerator::MethodDeclaration(
 )""";
 }
 
-std::string ConnectionImplRestGenerator::AsyncMethodDeclaration(
-    google::protobuf::MethodDescriptor const& method) {
+std::string ConnectionImplRestGenerator::AsyncMethodDeclaration() {
   return R"""(
   future<$return_type$>
   Async$method_name$($request_type$ const& request) override;
@@ -515,8 +513,7 @@ $connection_impl_rest_class_name$::$method_name$($request_type$ const& request) 
 )""";
 }
 
-std::string ConnectionImplRestGenerator::AsyncMethodDefinition(
-    google::protobuf::MethodDescriptor const& method) {
+std::string ConnectionImplRestGenerator::AsyncMethodDefinition() {
   return R"""(
 future<$return_type$>
 $connection_impl_rest_class_name$::Async$method_name$($request_type$ const& request) {

--- a/generator/internal/connection_impl_rest_generator.h
+++ b/generator/internal/connection_impl_rest_generator.h
@@ -50,10 +50,8 @@ class ConnectionImplRestGenerator : public ServiceCodeGenerator {
       google::protobuf::MethodDescriptor const& method);
   static std::string MethodDefinition(
       google::protobuf::MethodDescriptor const& method);
-  static std::string AsyncMethodDeclaration(
-      google::protobuf::MethodDescriptor const& method);
-  static std::string AsyncMethodDefinition(
-      google::protobuf::MethodDescriptor const& method);
+  static std::string AsyncMethodDeclaration();
+  static std::string AsyncMethodDefinition();
 };
 
 }  // namespace generator_internal

--- a/generator/internal/logging_decorator_generator.cc
+++ b/generator/internal/logging_decorator_generator.cc
@@ -270,9 +270,7 @@ $logging_class_name$::$method_name$(
 )""");
       continue;
     }
-    CcPrintMethod(method, __FILE__, __LINE__,
-                  IsResponseTypeEmpty(method) ? "\nStatus"
-                                              : "\nStatusOr<$response_type$>");
+    CcPrintMethod(method, __FILE__, __LINE__, "\n$return_type$");
     CcPrintMethod(method, __FILE__, __LINE__,
                   R"""(
 $logging_class_name$::$method_name$(
@@ -346,10 +344,7 @@ $logging_class_name$::Async$method_name$(
       CcPrintMethod(method, __FILE__, __LINE__, kDefinition);
       continue;
     }
-    CcPrintMethod(method, __FILE__, __LINE__,
-                  IsResponseTypeEmpty(method)
-                      ? "\nfuture<Status>"
-                      : "\nfuture<StatusOr<$response_type$>>");
+    CcPrintMethod(method, __FILE__, __LINE__, "\nfuture<$return_type$>");
     CcPrintMethod(method, __FILE__, __LINE__, R"""(
 $logging_class_name$::Async$method_name$(
       google::cloud::CompletionQueue& cq,

--- a/generator/internal/logging_decorator_rest_generator.cc
+++ b/generator/internal/logging_decorator_rest_generator.cc
@@ -87,19 +87,11 @@ class $logging_rest_class_name$ : public $stub_rest_class_name$ {
       Options const& options, $request_type$ const& request) override;
 )""");
     } else {
-      if (IsResponseTypeEmpty(method)) {
-        HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
-  Status $method_name$(
+      HeaderPrintMethod(method, __FILE__, __LINE__, absl::StrCat(R"""(
+  $return_type$ $method_name$(
       google::cloud::rest_internal::RestContext& rest_context,
       Options const& options, $request_type$ const& request) override;
-)""");
-      } else {
-        HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
-  StatusOr<$response_type$> $method_name$(
-      google::cloud::rest_internal::RestContext& rest_context,
-      Options const& options, $request_type$ const& request) override;
-)""");
-      }
+)"""));
     }
   }
 
@@ -107,23 +99,13 @@ class $logging_rest_class_name$ : public $stub_rest_class_name$ {
     // Nothing to do, these are always asynchronous.
     if (IsBidirStreaming(method) || IsLongrunningOperation(method)) continue;
     if (!HasHttpAnnotation(method)) continue;
-    if (IsResponseTypeEmpty(method)) {
-      HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
-  future<Status> Async$method_name$(
+    HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
+  future<$return_type$> Async$method_name$(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::cloud::internal::ImmutableOptions options,
       $request_type$ const& request) override;
 )""");
-    } else {
-      HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
-  future<StatusOr<$response_type$>> Async$method_name$(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
-      google::cloud::internal::ImmutableOptions options,
-      $request_type$ const& request) override;
-)""");
-    }
   }
 
   if (HasLongrunningMethod()) {
@@ -226,9 +208,8 @@ $logging_rest_class_name$::$method_name$(
 )""");
 
     } else {
-      if (IsResponseTypeEmpty(method)) {
-        CcPrintMethod(method, __FILE__, __LINE__, R"""(
-Status
+      CcPrintMethod(method, __FILE__, __LINE__, R"""(
+$return_type$
 $logging_rest_class_name$::$method_name$(
     rest_internal::RestContext& rest_context,
     Options const& options,
@@ -242,23 +223,6 @@ $logging_rest_class_name$::$method_name$(
       rest_context, options, request, __func__, tracing_options_);
 }
 )""");
-      } else {
-        CcPrintMethod(method, __FILE__, __LINE__, R"""(
-StatusOr<$response_type$>
-$logging_rest_class_name$::$method_name$(
-    rest_internal::RestContext& rest_context,
-    Options const& options,
-    $request_type$ const& request) {
-  return google::cloud::internal::LogWrapper(
-      [this](rest_internal::RestContext& rest_context,
-             Options const& options,
-             $request_type$ const& request) {
-        return child_->$method_name$(rest_context, options, request);
-      },
-      rest_context, options, request, __func__, tracing_options_);
-}
-)""");
-      }
     }
   }
 
@@ -266,29 +230,8 @@ $logging_rest_class_name$::$method_name$(
     // No streaming RPCs for REST, and Longrunning is already taken care of.
     if (IsStreaming(method) || IsLongrunningOperation(method)) continue;
     if (!HasHttpAnnotation(method)) continue;
-    if (IsResponseTypeEmpty(method)) {
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
-future<Status>
-$logging_rest_class_name$::Async$method_name$(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<rest_internal::RestContext> rest_context,
-      google::cloud::internal::ImmutableOptions options,
-      $request_type$ const& request) {
-  return google::cloud::internal::LogWrapper(
-      [this](CompletionQueue& cq,
-             std::unique_ptr<rest_internal::RestContext> rest_context,
-             google::cloud::internal::ImmutableOptions options,
-             $request_type$ const& request) {
-        return child_->Async$method_name$(
-            cq, std::move(rest_context), std::move(options), request);
-      },
-      cq, std::move(rest_context), std::move(options), request, __func__,
-      tracing_options_);
-}
-)""");
-    } else {
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
-future<StatusOr<$response_type$>>
+    CcPrintMethod(method, __FILE__, __LINE__, R"""(
+future<$return_type$>
 $logging_rest_class_name$::Async$method_name$(
     google::cloud::CompletionQueue& cq,
     std::unique_ptr<rest_internal::RestContext> rest_context,
@@ -306,7 +249,6 @@ $logging_rest_class_name$::Async$method_name$(
       tracing_options_);
 }
 )""");
-    }
   }
 
   if (HasLongrunningMethod()) {

--- a/generator/internal/metadata_decorator_generator.cc
+++ b/generator/internal/metadata_decorator_generator.cc
@@ -293,9 +293,7 @@ $metadata_class_name$::$method_name$(
 )""");
       continue;
     }
-    CcPrintMethod(method, __FILE__, __LINE__,
-                  IsResponseTypeEmpty(method) ? "\nStatus"
-                                              : "\nStatusOr<$response_type$>");
+    CcPrintMethod(method, __FILE__, __LINE__, "\n$return_type$");
     CcPrintMethod(method, __FILE__, __LINE__, R"""(
 $metadata_class_name$::$method_name$(
     grpc::ClientContext& context,
@@ -353,10 +351,7 @@ $metadata_class_name$::Async$method_name$(
       CcPrintMethod(method, __FILE__, __LINE__, definition);
       continue;
     }
-    CcPrintMethod(method, __FILE__, __LINE__,
-                  IsResponseTypeEmpty(method)
-                      ? "\nfuture<Status>"
-                      : "\nfuture<StatusOr<$response_type$>>");
+    CcPrintMethod(method, __FILE__, __LINE__, "\nfuture<$return_type$>");
     CcPrintMethod(method, __FILE__, __LINE__, R"""(
 $metadata_class_name$::Async$method_name$(
       google::cloud::CompletionQueue& cq,

--- a/generator/internal/metadata_decorator_rest_generator.cc
+++ b/generator/internal/metadata_decorator_rest_generator.cc
@@ -153,19 +153,11 @@ class $metadata_rest_class_name$ : public $stub_rest_class_name$ {
       Options const& options, $request_type$ const& request) override;
 )""");
     } else {
-      if (IsResponseTypeEmpty(method)) {
-        HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
-  Status $method_name$(
+      HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
+  $return_type$ $method_name$(
       google::cloud::rest_internal::RestContext& rest_context,
       Options const& options, $request_type$ const& request) override;
 )""");
-      } else {
-        HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
-  StatusOr<$response_type$> $method_name$(
-      google::cloud::rest_internal::RestContext& rest_context,
-      Options const& options, $request_type$ const& request) override;
-)""");
-      }
     }
   }
 
@@ -173,23 +165,13 @@ class $metadata_rest_class_name$ : public $stub_rest_class_name$ {
     // No streaming RPCs for REST, and Longrunning is already taken care of.
     if (IsStreaming(method) || IsLongrunningOperation(method)) continue;
     if (!HasHttpAnnotation(method)) continue;
-    if (IsResponseTypeEmpty(method)) {
-      HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
-  google::cloud::future<Status> Async$method_name$(
+    HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
+  google::cloud::future<$return_type$> Async$method_name$(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::cloud::internal::ImmutableOptions options,
       $request_type$ const& request) override;
 )""");
-    } else {
-      HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
-  google::cloud::future<StatusOr<$response_type$>> Async$method_name$(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
-      google::cloud::internal::ImmutableOptions options,
-      $request_type$ const& request) override;
-)""");
-    }
   }
 
   if (HasLongrunningMethod()) {
@@ -295,33 +277,18 @@ $metadata_rest_class_name$::$method_name$(
 )""");
 
     } else {
-      if (IsResponseTypeEmpty(method)) {
-        CcPrintMethod(method, __FILE__, __LINE__, R"""(
-Status
+      CcPrintMethod(method, __FILE__, __LINE__, R"""(
+$return_type$
 $metadata_rest_class_name$::$method_name$(
     rest_internal::RestContext& rest_context,
     Options const& options, $request_type$ const& request) {
 )""");
-        CcPrintMethod(method, __FILE__, __LINE__,
-                      SetMetadataText(method, kReference, "options"));
-        CcPrintMethod(method, __FILE__, __LINE__, R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    SetMetadataText(method, kReference, "options"));
+      CcPrintMethod(method, __FILE__, __LINE__, R"""(
   return child_->$method_name$(rest_context, options, request);
 }
 )""");
-      } else {
-        CcPrintMethod(method, __FILE__, __LINE__, R"""(
-StatusOr<$response_type$>
-$metadata_rest_class_name$::$method_name$(
-    rest_internal::RestContext& rest_context,
-    Options const& options, $request_type$ const& request) {
-)""");
-        CcPrintMethod(method, __FILE__, __LINE__,
-                      SetMetadataText(method, kReference, "options"));
-        CcPrintMethod(method, __FILE__, __LINE__, R"""(
-  return child_->$method_name$(rest_context, options, request);
-}
-)""");
-      }
     }
   }
 
@@ -329,39 +296,21 @@ $metadata_rest_class_name$::$method_name$(
     // No streaming RPCs for REST, and Longrunning is already taken care of.
     if (IsStreaming(method) || IsLongrunningOperation(method)) continue;
     if (!HasHttpAnnotation(method)) continue;
-    if (IsResponseTypeEmpty(method)) {
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
-future<Status>
+    CcPrintMethod(method, __FILE__, __LINE__, R"""(
+future<$return_type$>
 $metadata_rest_class_name$::Async$method_name$(
     google::cloud::CompletionQueue& cq,
     std::unique_ptr<rest_internal::RestContext> rest_context,
     google::cloud::internal::ImmutableOptions options,
     $request_type$ const& request) {
 )""");
-      CcPrintMethod(method, __FILE__, __LINE__,
-                    SetMetadataText(method, kPointer, "*options"));
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
+    CcPrintMethod(method, __FILE__, __LINE__,
+                  SetMetadataText(method, kPointer, "*options"));
+    CcPrintMethod(method, __FILE__, __LINE__, R"""(
   return child_->Async$method_name$(
       cq, std::move(rest_context), std::move(options), request);
 }
 )""");
-    } else {
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
-future<StatusOr<$response_type$>>
-$metadata_rest_class_name$::Async$method_name$(
-    google::cloud::CompletionQueue& cq,
-    std::unique_ptr<rest_internal::RestContext> rest_context,
-    google::cloud::internal::ImmutableOptions options,
-    $request_type$ const& request) {
-)""");
-      CcPrintMethod(method, __FILE__, __LINE__,
-                    SetMetadataText(method, kPointer, "*options"));
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
-  return child_->Async$method_name$(
-      cq, std::move(rest_context), std::move(options), request);
-}
-)""");
-    }
   }
 
   if (HasLongrunningMethod()) {

--- a/generator/internal/mock_connection_generator.cc
+++ b/generator/internal/mock_connection_generator.cc
@@ -91,10 +91,8 @@ class $mock_connection_class_name$ : public $product_namespace$::$connection_cla
         method,
         {MethodPattern(
              {
-                 {IsResponseTypeEmpty,
-                  // clang-format off
-    "\n  MOCK_METHOD(Status,\n",
-    "\n  MOCK_METHOD(StatusOr<$response_type$>,\n"},
+                 {"\n  MOCK_METHOD($return_type$,\n"},
+                 // clang-format off
    {"  $method_name$,\n"
     "  ($request_type$ const& request), (override));\n",}
                  // clang-format on
@@ -179,10 +177,8 @@ class $mock_connection_class_name$ : public $product_namespace$::$connection_cla
         method,
         {MethodPattern(
             {
-                {IsResponseTypeEmpty,
-                 // clang-format off
-    "\n  MOCK_METHOD(future<Status>,\n",
-    "\n  MOCK_METHOD(future<StatusOr<$response_type$>>,\n"},
+                {"\n  MOCK_METHOD(future<$return_type$>,\n"},
+                // clang-format off
    {"  Async$method_name$,\n"
     "  ($request_type$ const& request), (override));\n",}
                 // clang-format on

--- a/generator/internal/round_robin_decorator_generator.cc
+++ b/generator/internal/round_robin_decorator_generator.cc
@@ -173,19 +173,8 @@ $round_robin_class_name$::$method_name$(
 
       continue;
     }
-    if (IsResponseTypeEmpty(method)) {
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
-Status $round_robin_class_name$::$method_name$(
-    grpc::ClientContext& context,
-    Options const& options,
-    $request_type$ const& request) {
-  return Child()->$method_name$(context, options, request);
-}
-)""");
-      continue;
-    }
     CcPrintMethod(method, __FILE__, __LINE__, R"""(
-StatusOr<$response_type$> $round_robin_class_name$::$method_name$(
+$return_type$ $round_robin_class_name$::$method_name$(
     grpc::ClientContext& context,
     Options const& options,
     $request_type$ const& request) {
@@ -227,10 +216,7 @@ $round_robin_class_name$::Async$method_name$(
 )""");
       continue;
     }
-    CcPrintMethod(method, __FILE__, __LINE__,
-                  IsResponseTypeEmpty(method)
-                      ? "\nfuture<Status>"
-                      : "\nfuture<StatusOr<$response_type$>>");
+    CcPrintMethod(method, __FILE__, __LINE__, "\nfuture<$return_type$>");
     CcPrintMethod(method, __FILE__, __LINE__, R"""(
 $round_robin_class_name$::Async$method_name$(
     google::cloud::CompletionQueue& cq,

--- a/generator/internal/stub_generator.cc
+++ b/generator/internal/stub_generator.cc
@@ -140,17 +140,8 @@ Status StubGenerator::GenerateHeader() {
 )""");
       continue;
     }
-    if (IsResponseTypeEmpty(method)) {
-      HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
-  virtual Status $method_name$(
-      grpc::ClientContext& context,
-      Options const& options,
-      $request_type$ const& request) = 0;
-)""");
-      continue;
-    }
     HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
-  virtual StatusOr<$response_type$> $method_name$(
+  virtual $return_type$ $method_name$(
       grpc::ClientContext& context,
       Options const& options,
       $request_type$ const& request) = 0;
@@ -185,19 +176,8 @@ Status StubGenerator::GenerateHeader() {
       HeaderPrintMethod(method, __FILE__, __LINE__, kDeclaration);
       continue;
     }
-    if (IsResponseTypeEmpty(method)) {
-      HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
-  virtual future<Status>
-  Async$method_name$(
-    google::cloud::CompletionQueue& cq,
-    std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options,
-    $request_type$ const& request) = 0;
-)""");
-      continue;
-    }
     HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
-  virtual future<StatusOr<$response_type$>>
+  virtual future<$return_type$>
   Async$method_name$(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,

--- a/generator/internal/stub_generator_base.cc
+++ b/generator/internal/stub_generator_base.cc
@@ -82,17 +82,8 @@ void StubGeneratorBase::HeaderPrintPublicMethods() {
 )""");
       continue;
     }
-    if (IsResponseTypeEmpty(method)) {
-      HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
-  Status $method_name$(
-      grpc::ClientContext& context,
-      Options const& options,
-      $request_type$ const& request) override;
-)""");
-      continue;
-    }
     HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
-  StatusOr<$response_type$> $method_name$(
+  $return_type$ $method_name$(
       grpc::ClientContext& context,
       Options const& options,
       $request_type$ const& request) override;
@@ -127,18 +118,8 @@ void StubGeneratorBase::HeaderPrintPublicMethods() {
       HeaderPrintMethod(method, __FILE__, __LINE__, kDeclaration);
       continue;
     }
-    if (IsResponseTypeEmpty(method)) {
-      HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
-  future<Status> Async$method_name$(
-      google::cloud::CompletionQueue& cq,
-      std::shared_ptr<grpc::ClientContext> context,
-      google::cloud::internal::ImmutableOptions options,
-      $request_type$ const& request) override;
-)""");
-      continue;
-    }
     HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
-  future<StatusOr<$response_type$>> Async$method_name$(
+  future<$return_type$> Async$method_name$(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,

--- a/generator/internal/stub_rest_generator.cc
+++ b/generator/internal/stub_rest_generator.cc
@@ -87,19 +87,11 @@ class $stub_rest_class_name$ {
 )""");
 
     } else {
-      if (IsResponseTypeEmpty(method)) {
-        HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
-  virtual Status $method_name$(
+      HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
+  virtual $return_type$ $method_name$(
       google::cloud::rest_internal::RestContext& rest_context,
       Options const& options, $request_type$ const& request) = 0;
 )""");
-      } else {
-        HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
-  virtual StatusOr<$response_type$> $method_name$(
-      google::cloud::rest_internal::RestContext& rest_context,
-      Options const& options, $request_type$ const& request) = 0;
-)""");
-      }
     }
   }
 
@@ -107,23 +99,13 @@ class $stub_rest_class_name$ {
     // No streaming RPCs for REST, and Longrunning is already taken care of.
     if (IsStreaming(method) || IsLongrunningOperation(method)) continue;
     if (!HasHttpAnnotation(method)) continue;
-    if (IsResponseTypeEmpty(method)) {
-      HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
-  virtual future<Status> Async$method_name$(
+    HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
+  virtual future<$return_type$> Async$method_name$(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::cloud::internal::ImmutableOptions options,
       $request_type$ const& request) = 0;
 )""");
-    } else {
-      HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
-  virtual future<StatusOr<$response_type$>> Async$method_name$(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
-      google::cloud::internal::ImmutableOptions options,
-      $request_type$ const& request) = 0;
-)""");
-    }
   }
 
   if (HasLongrunningMethod()) {
@@ -199,19 +181,11 @@ class Default$stub_rest_class_name$ : public $stub_rest_class_name$ {
 )""");
 
       } else {
-        if (IsResponseTypeEmpty(method)) {
-          HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
-  Status $method_name$(
+        HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
+  $return_type$ $method_name$(
       google::cloud::rest_internal::RestContext& rest_context,
       Options const& options, $request_type$ const& request) override;
 )""");
-        } else {
-          HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
-  StatusOr<$response_type$> $method_name$(
-      google::cloud::rest_internal::RestContext& rest_context,
-      Options const& options, $request_type$ const& request) override;
-)""");
-        }
       }
     }
   }
@@ -219,23 +193,13 @@ class Default$stub_rest_class_name$ : public $stub_rest_class_name$ {
   for (auto const& method : async_methods()) {
     // No streaming RPCs for REST, and Longrunning is already taken care of.
     if (IsStreaming(method) || IsLongrunningOperation(method)) continue;
-    if (IsResponseTypeEmpty(method)) {
-      HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
-  future<Status> Async$method_name$(
+    HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
+  future<$return_type$> Async$method_name$(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
       google::cloud::internal::ImmutableOptions options,
       $request_type$ const& request) override;
 )""");
-    } else {
-      HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
-  future<StatusOr<$response_type$>> Async$method_name$(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<google::cloud::rest_internal::RestContext> rest_context,
-      google::cloud::internal::ImmutableOptions options,
-      $request_type$ const& request) override;
-)""");
-    }
   }
 
   if (HasLongrunningMethod()) {

--- a/generator/internal/tracing_connection_generator.cc
+++ b/generator/internal/tracing_connection_generator.cc
@@ -78,8 +78,7 @@ class $tracing_connection_class_name$
   for (auto const& method : async_methods()) {
     if (IsStreamingRead(method)) continue;
     if (IsStreamingWrite(method)) continue;
-    HeaderPrintMethod(method, __FILE__, __LINE__,
-                      AsyncMethodDeclaration(method));
+    HeaderPrintMethod(method, __FILE__, __LINE__, AsyncMethodDeclaration());
   }
 
   HeaderPrint(R"""(
@@ -144,7 +143,7 @@ $tracing_connection_class_name$::$tracing_connection_class_name$(
   for (auto const& method : async_methods()) {
     if (IsStreamingRead(method)) continue;
     if (IsStreamingWrite(method)) continue;
-    CcPrintMethod(method, __FILE__, __LINE__, AsyncMethodDefinition(method));
+    CcPrintMethod(method, __FILE__, __LINE__, AsyncMethodDefinition());
   }
 
   CcPrint(R"""(
@@ -231,8 +230,7 @@ std::string TracingConnectionGenerator::MethodDeclaration(
 )""";
 }
 
-std::string TracingConnectionGenerator::AsyncMethodDeclaration(
-    google::protobuf::MethodDescriptor const& method) {
+std::string TracingConnectionGenerator::AsyncMethodDeclaration() {
   return R"""(
   future<$return_type$>
   Async$method_name$($request_type$ const& request) override;
@@ -341,8 +339,7 @@ $tracing_connection_class_name$::$method_name$($request_type$ const& request) {
 )""";
 }
 
-std::string TracingConnectionGenerator::AsyncMethodDefinition(
-    google::protobuf::MethodDescriptor const& method) {
+std::string TracingConnectionGenerator::AsyncMethodDefinition() {
   return R"""(
 future<$return_type$>
 $tracing_connection_class_name$::Async$method_name$($request_type$ const& request) {

--- a/generator/internal/tracing_connection_generator.h
+++ b/generator/internal/tracing_connection_generator.h
@@ -48,12 +48,10 @@ class TracingConnectionGenerator : public ServiceCodeGenerator {
 
   static std::string MethodDeclaration(
       google::protobuf::MethodDescriptor const& method);
-  static std::string AsyncMethodDeclaration(
-      google::protobuf::MethodDescriptor const& method);
+  static std::string AsyncMethodDeclaration();
   static std::string MethodDefinition(
       google::protobuf::MethodDescriptor const& method);
-  static std::string AsyncMethodDefinition(
-      google::protobuf::MethodDescriptor const& method);
+  static std::string AsyncMethodDefinition();
 };
 
 }  // namespace generator_internal

--- a/generator/internal/tracing_stub_generator.cc
+++ b/generator/internal/tracing_stub_generator.cc
@@ -227,9 +227,7 @@ $tracing_stub_class_name$::$method_name$(
 )""");
       continue;
     }
-    CcPrintMethod(method, __FILE__, __LINE__,
-                  IsResponseTypeEmpty(method) ? "\nStatus"
-                                              : "\nStatusOr<$response_type$>");
+    CcPrintMethod(method, __FILE__, __LINE__, "\n$return_type$");
     CcPrintMethod(method, __FILE__, __LINE__,
                   R"""( $tracing_stub_class_name$::$method_name$(
     grpc::ClientContext& context,
@@ -293,10 +291,7 @@ $tracing_stub_class_name$::Async$method_name$(
       CcPrintMethod(method, __FILE__, __LINE__, kDefinition);
       continue;
     }
-    CcPrintMethod(method, __FILE__, __LINE__,
-                  IsResponseTypeEmpty(method)
-                      ? "\nfuture<Status>"
-                      : "\nfuture<StatusOr<$response_type$>>");
+    CcPrintMethod(method, __FILE__, __LINE__, "\nfuture<$return_type$>");
     CcPrintMethod(method, __FILE__, __LINE__, R"""(
 $tracing_stub_class_name$::Async$method_name$(
       google::cloud::CompletionQueue& cq,


### PR DESCRIPTION
A followup cleanup of #14657.

Generalize return type strings of the non-lro methods in generator.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14669)
<!-- Reviewable:end -->
