### PR TITLE
cleanup(generator): check extension existence in IsGRPCLongrunningOperation

### DIFF
--- a/generator/internal/longrunning_test.cc
+++ b/generator/internal/longrunning_test.cc
@@ -46,12 +46,20 @@ TEST(LongrunningTest, IsGRPCLongrunningOperation) {
     service {
       name: "Service"
       method {
-        name: "Lro"
+        name: "GrpcLro"
+        input_type: "google.longrunning.Bar"
+        output_type: "google.longrunning.Operation"
+        options {
+          [google.longrunning.operation_info] {}
+        }
+      }
+      method {
+        name: "NonLro1"
         input_type: "google.longrunning.Bar"
         output_type: "google.longrunning.Operation"
       }
       method {
-        name: "NonLro"
+        name: "NonLro2"
         input_type: "google.longrunning.Bar"
         output_type: "google.longrunning.Bar"
       }
@@ -61,14 +69,20 @@ TEST(LongrunningTest, IsGRPCLongrunningOperation) {
   ASSERT_TRUE(TextFormat::ParseFromString(kServiceText, &service_file));
   DescriptorPool pool;
   FileDescriptor const* service_file_descriptor = pool.BuildFile(service_file);
-  EXPECT_TRUE(
-      IsLongrunningOperation(*service_file_descriptor->service(0)->method(0)));
   EXPECT_TRUE(IsGRPCLongrunningOperation(
       *service_file_descriptor->service(0)->method(0)));
   EXPECT_FALSE(IsHttpLongrunningOperation(
       *service_file_descriptor->service(0)->method(0)));
+  EXPECT_FALSE(IsGRPCLongrunningOperation(
+      *service_file_descriptor->service(0)->method(1)));
+  EXPECT_FALSE(IsGRPCLongrunningOperation(
+      *service_file_descriptor->service(0)->method(2)));
+  EXPECT_TRUE(
+      IsLongrunningOperation(*service_file_descriptor->service(0)->method(0)));
   EXPECT_FALSE(
       IsLongrunningOperation(*service_file_descriptor->service(0)->method(1)));
+  EXPECT_FALSE(
+      IsLongrunningOperation(*service_file_descriptor->service(0)->method(2)));
 }
 
 TEST(LongrunningTest, IsLongrunningMetadataTypeUsedAsResponseEmptyResponse) {

--- a/generator/internal/service_code_generator_test.cc
+++ b/generator/internal/service_code_generator_test.cc
@@ -171,6 +171,9 @@ TEST(PredicateUtilsTest, HasLongRunningMethodOne) {
         name: "One"
         input_type: "google.protobuf.Bar"
         output_type: "google.longrunning.Operation"
+        options {
+          [google.longrunning.operation_info] {}
+        }
       }
       method {
         name: "Two"
@@ -224,11 +227,17 @@ TEST(PredicateUtilsTest, HasLongRunningMethodMoreThanOne) {
         name: "Two"
         input_type: "google.protobuf.Bar"
         output_type: "google.longrunning.Operation"
+        options {
+          [google.longrunning.operation_info] {}
+        }
       }
       method {
         name: "Three"
         input_type: "google.protobuf.Bar"
         output_type: "google.longrunning.Operation"
+        options {
+          [google.longrunning.operation_info] {}
+        }
       }
     }
   )pb";


### PR DESCRIPTION
If a method is grpc longrunning operation, it should also define `google.longrunning.operation_info` extension.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14675)
<!-- Reviewable:end -->
