### PR TITLE
chore: allow commit SHA override in renovate.sh

### DIFF
--- a/doc/contributor/howto-guide-update-googleapis-sha.md
+++ b/doc/contributor/howto-guide-update-googleapis-sha.md
@@ -29,6 +29,9 @@ git checkout -b chore-update-googleapis-sha-circa-$(date +%Y-%m-%d)
 
 ## Run the "renovate.sh" script
 
+By default `renovate.sh` uses the most recent commit SHA and the current date.
+To override these values use environment variables `COMMIT` and `COMMIT_DATE`.
+
 ```shell
 external/googleapis/renovate.sh
 ```

--- a/release/README.md
+++ b/release/README.md
@@ -15,7 +15,8 @@ the project itself, [git][git-docs], [GitHub][github-guides], and
 In order to ensure that our released version includes a SHA of the service proto
 definitions that is both current and stable ([googleapis-sha-update-policy]),
 aim for a commit SHA from 5-7 days ago (TODO(#13062): automate this update
-process).
+process). Specifying `COMMIT` and `COMMIT_DATE` when running `renovate.sh` can
+be used to achieve this.
 
 ## 1. Preparing for a release
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14682)
<!-- Reviewable:end -->
