### PR TITLE
fix: respect `GOOGLE_CLOUD_QUOTA_PROJECT`

### DIFF
--- a/google/cloud/internal/populate_common_options.cc
+++ b/google/cloud/internal/populate_common_options.cc
@@ -63,6 +63,7 @@ Options PopulateCommonOptions(Options opts, std::string const& endpoint_env_var,
   }
 
   e = GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+  if (!e || e->empty()) e = GetEnv("GOOGLE_CLOUD_QUOTA_PROJECT");
   if (e && !e->empty()) {
     opts.set<UserProjectOption>(*std::move(e));
   }

--- a/google/cloud/internal/populate_common_options_test.cc
+++ b/google/cloud/internal/populate_common_options_test.cc
@@ -222,7 +222,8 @@ TEST(PopulateCommonOptions, UserProject) {
 }
 
 TEST(PopulateCommonOptions, QuotaProjectEnvVar) {
-  ScopedEnvironment projects("GOOGLE_CLOUD_QUOTA_PROJECT", "env");
+  ScopedEnvironment e1("GOOGLE_CLOUD_CPP_USER_PROJECT", absl::nullopt);
+  ScopedEnvironment e2("GOOGLE_CLOUD_QUOTA_PROJECT", "env");
 
   auto opts = Options{}.set<UserProjectOption>("option");
   opts = PopulateCommonOptions(std::move(opts), {}, {}, {},

--- a/google/cloud/internal/populate_common_options_test.cc
+++ b/google/cloud/internal/populate_common_options_test.cc
@@ -221,6 +221,15 @@ TEST(PopulateCommonOptions, UserProject) {
   }
 }
 
+TEST(PopulateCommonOptions, QuotaProjectEnvVar) {
+  ScopedEnvironment projects("GOOGLE_CLOUD_QUOTA_PROJECT", "env");
+
+  auto opts = Options{}.set<UserProjectOption>("option");
+  opts = PopulateCommonOptions(std::move(opts), {}, {}, {},
+                               "default.googleapis.com");
+  EXPECT_EQ(opts.get<UserProjectOption>(), "env");
+}
+
 TEST(PopulateCommonOptions, OpenTelemetryTracing) {
   struct TestCase {
     absl::optional<std::string> env;


### PR DESCRIPTION
https://google.aip.dev/auth/4110 says we should have used the env var `GOOGLE_CLOUD_QUOTA_PROJECT` instead of making up our own `GOOGLE_CLOUD_CPP_USER_PROJECT`.

So we will respect both.

Note that this is separate from our `QuotaUserOption` which sets the `x-goog-quota-user` header. Confusing stuff.

I do not think we need to publicize the new form of the env var.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14684)
<!-- Reviewable:end -->
