### PR TITLE
ci: remove vc toolset 14.40 workaround

### DIFF
--- a/.github/workflows/windows-bazel.yml
+++ b/.github/workflows/windows-bazel.yml
@@ -66,30 +66,6 @@ jobs:
           # From Compute
           - -//google/cloud/compute/...
     steps:
-    # TODO(14314) - remove this VC Toolset workaround
-    - name: Select VC Toolset
-      id: vctoolset
-      shell: bash
-      run: |
-        # upb does not compile with the compiler that comes with the 14.40.33807
-        # VC toolset. To workaround this, we list the available toolset
-        # versions, then pick the latest one that is not 14.40.*. If 14.40.* is
-        # the only compiler version, we use that.
-        #
-        # See https://github.com/protocolbuffers/protobuf/issues/17032 for more
-        # details.
-        toolset_versions=($(ls "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Tools\\MSVC"))
-        echo "Available VC toolsets: ${toolset_versions[@]}"
-        toolset_version=""
-        for v in "${toolset_versions[@]}"; do
-          if [ -z "${toolset_version}" ]; then
-            toolset_version=${v}
-          elif ! echo ${v} | grep -q "^14\.40\."; then
-            toolset_version=${v}
-          fi
-        done
-        echo "Using VC toolset: ${toolset_version}"
-        echo "toolset_version=${toolset_version}" >> "${GITHUB_OUTPUT}"
     - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.checkout-ref }}
@@ -105,9 +81,6 @@ jobs:
     # Note that in other runners the publisher is GitHub. If we trust GitHub
     # to run the VM, we should trust their runners.
     - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # @v1.13.0
-      # TODO(14314) - remove this VC Toolset workaround
-      with:
-        toolset: ${{ steps.vctoolset.outputs.toolset_version }}
     - name: Build google-cloud-cpp
       shell: bash
       run: |
@@ -117,8 +90,6 @@ jobs:
         # Using a short name like this avoids the problem in most cases.
         mkdir -p 'c:\b' || true
         export BAZEL_ROOT='c:\b'
-        # TODO(14314) - remove this VC Toolset workaround
-        export BAZEL_VC_FULL_VERSION=${{ steps.vctoolset.outputs.toolset_version }}
         export BAZEL_REMOTE_CACHE_RW_MODE=${{ inputs.bazel-cache-mode }}
         export EXECUTE_INTEGRATION_TESTS=${{ inputs.execute-integration-tests }}
         ci/gha/builds/windows-bazel.sh ${{ matrix.compilation_mode }} ${{ join(matrix.targets, ' ') }}

--- a/.github/workflows/windows-cmake.yml
+++ b/.github/workflows/windows-cmake.yml
@@ -74,30 +74,6 @@ jobs:
     - uses: google-github-actions/setup-gcloud@v2
       env:
         CLOUDSDK_PYTHON: ${{ steps.py311.outputs.python-path }}
-    # TODO(14314) - remove this VC Toolset workaround
-    - name: Select VC Toolset
-      id: vctoolset
-      shell: bash
-      run: |
-        # upb does not compile with the compiler that comes with the 14.40.33807
-        # VC toolset. To workaround this, we list the available toolset
-        # versions, then pick the latest one that is not 14.40.*. If 14.40.* is
-        # the only compiler version, we use that.
-        #
-        # See https://github.com/protocolbuffers/protobuf/issues/17032 for more
-        # details.
-        toolset_versions=($(ls "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Tools\\MSVC"))
-        echo "Available VC toolsets: ${toolset_versions[@]}"
-        toolset_version=""
-        for v in "${toolset_versions[@]}"; do
-          if [ -z "${toolset_version}" ]; then
-            toolset_version=${v}
-          elif ! echo ${v} | grep -q "^14\.40\."; then
-            toolset_version=${v}
-          fi
-        done
-        echo "Using VC toolset: ${toolset_version}"
-        echo "toolset_version=${toolset_version}" >> "${GITHUB_OUTPUT}"
     - name: Dynamic Configuration
       id: dynamic
       shell: bash
@@ -246,9 +222,6 @@ jobs:
         curl -fsSL "https://github.com/microsoft/vcpkg/archive/${{ steps.dynamic.outputs.vcpkg-version }}.tar.gz" |
             tar -C .build/vcpkg --strip-components=1 -zxf -
         .build/vcpkg/bootstrap-vcpkg.sh -disableMetrics
-        # TODO(14314) - remove this VC Toolset workaround
-        echo "set(VCPKG_PLATFORM_TOOLSET_VERSION ${{ steps.vctoolset.outputs.toolset_version }})" >> .build/vcpkg/triplets/x64-windows.cmake
-        echo "set(VCPKG_PLATFORM_TOOLSET_VERSION ${{ steps.vctoolset.outputs.toolset_version }})" >> .build/vcpkg/triplets/x86-windows.cmake
     # go/github-actions#gha-bestpractices explains why we use a SHA instead of
     # a named version for this runner. We could avoid using this runner with the
     # ideas from:
@@ -258,8 +231,6 @@ jobs:
     - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # @v1.13.0
       with:
         arch: ${{ matrix.arch }}
-        # TODO(14314) - remove this VC Toolset workaround
-        toolset: ${{ steps.vctoolset.outputs.toolset_version }}
     - name: Build google-cloud-cpp
       shell: bash
       run: |


### PR DESCRIPTION
Fixes #14314 

The machines now come with VC Toolset `14.41.*` which successfully build `upb`.

Tested: https://github.com/googleapis/google-cloud-cpp/actions/runs/10779264515. Note that the failures are due to running out of disk space, not in building `upb` with `vcpkg`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14694)
<!-- Reviewable:end -->
