### PR TITLE
fix(deps): Remove dev_dependency = True for rules_proto and rules_python.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -31,8 +31,9 @@ bazel_dep(name = "nlohmann_json", version = "3.11.3", repo_name = "com_github_nl
 bazel_dep(name = "curl", version = "8.8.0.bcr.1", repo_name = "com_github_curl_curl")
 bazel_dep(name = "crc32c", version = "1.1.0", repo_name = "com_github_google_crc32c")
 bazel_dep(name = "opentelemetry-cpp", version = "1.16.0", repo_name = "io_opentelemetry_cpp")
+bazel_dep(name = "rules_proto", version = "6.0.2")
+bazel_dep(name = "rules_python", version = "0.35.0")
 
-bazel_dep(name = "rules_proto", version = "6.0.2", dev_dependency = True)
 bazel_dep(name = "googletest", version = "1.15.2", dev_dependency = True, repo_name = "com_google_googletest")
 bazel_dep(name = "google_benchmark", version = "1.8.5", dev_dependency = True, repo_name = "com_google_benchmark")
 bazel_dep(name = "yaml-cpp", version = "0.8.0", dev_dependency = True, repo_name = "com_github_jbeder_yaml_cpp")
@@ -41,10 +42,6 @@ bazel_dep(name = "pugixml", version = "1.14.bcr.1", dev_dependency = True, repo_
 # Our `curl.BUILD` file uses these.
 bazel_dep(name = "zlib", version = "1.3.1.bcr.3")
 bazel_dep(name = "c-ares", version = "1.16.1", repo_name = "com_github_cares_cares")
-
-# `google-cloud-cpp` uses this indirectly in the coverage build. And we need
-# to configure it for our CI builds.
-bazel_dep(name = "rules_python", version = "0.35.0", dev_dependency = True)
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(


### PR DESCRIPTION
rules_proto is used in protos/google/cloud/compute/BUILD.bazel whereas rules_python is used immediately below with the python extension.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14696)
<!-- Reviewable:end -->
