### PR TITLE
feat(mixin): add mixin support in descriptor utils

### DIFF
--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -550,7 +550,7 @@ void GetMethodVarsByMethod(
   auto parsed_http_info =
       method_override
           ? ParseHttpExtension(method, service.file()->package(),
-                               service.file()->name(), *method_override)
+                               service.file()->name(), method_override)
           : ParseHttpExtension(method);
   method_vars["request_resource"] =
       FormatRequestResource(*method.input_type(), parsed_http_info);

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -547,11 +547,7 @@ void GetMethodVarsByMethod(
   SetLongrunningOperationMethodVars(method, method_vars);
   AssignPaginationMethodVars(method, method_vars);
   SetMethodSignatureMethodVars(service, method, omitted_rpcs, method_vars);
-  auto parsed_http_info =
-      method_override
-          ? ParseHttpExtension(method, service.file()->package(),
-                               service.file()->name(), method_override)
-          : ParseHttpExtension(method);
+  auto parsed_http_info = ParseHttpExtension(method, method_override);
   method_vars["request_resource"] =
       FormatRequestResource(*method.input_type(), parsed_http_info);
   SetHttpDerivedMethodVars(parsed_http_info, method, method_vars);

--- a/generator/internal/descriptor_utils.h
+++ b/generator/internal/descriptor_utils.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_DESCRIPTOR_UTILS_H
 
 #include "generator/internal/generator_interface.h"
+#include "generator/internal/mixin_utils.h"
 #include "generator/internal/predicate_utils.h"
 #include "generator/internal/printer.h"
 #include "absl/types/variant.h"
@@ -38,14 +39,16 @@ namespace generator_internal {
  */
 VarsDictionary CreateServiceVars(
     google::protobuf::ServiceDescriptor const& descriptor,
-    std::vector<std::pair<std::string, std::string>> const& initial_values);
+    std::vector<std::pair<std::string, std::string>> const& initial_values,
+    std::vector<MixinMethod> const& mixin_methods = std::vector<MixinMethod>());
 
 /**
  * Extracts method specific substitution data for each method in the service.
  */
 std::map<std::string, VarsDictionary> CreateMethodVars(
     google::protobuf::ServiceDescriptor const& service,
-    YAML::Node const& service_config, VarsDictionary const& service_vars);
+    YAML::Node const& service_config, VarsDictionary const& service_vars,
+    std::vector<MixinMethod> const& mixin_methods = std::vector<MixinMethod>());
 
 /**
  * Determines which `MethodPattern` to use from patterns for the given method

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -1301,7 +1301,7 @@ TEST_F(CreateMethodVarsTest, CreateMixinMethodsVars) {
       {"",
        "",
        *mixin_file->service(0)->method(1),
-       {"Put", "/v2/{name=projects/*/locations}", "*"}}};
+       {"Put", "/{name=projects/*/locations}", "*"}}};
 
   service_vars_ = CreateServiceVars(
       *service_file_descriptor->service(0),
@@ -1354,11 +1354,9 @@ TEST_F(CreateMethodVarsTest, CreateMixinMethodsVars) {
   EXPECT_EQ(list_locations->second["method_request_params"],
             "\"name=\", internal::UrlEncode(request.name())");
   EXPECT_EQ(list_locations->second["method_rest_path"],
-            "absl::StrCat(\"/\", rest_internal::DetermineApiVersion(\"v2\", "
-            "options), \"/\", request.name())");
+            "absl::StrCat(\"/\", request.name())");
   EXPECT_EQ(list_locations->second["method_rest_path_async"],
-            "absl::StrCat(\"/\", rest_internal::DetermineApiVersion(\"v2\", "
-            "*options), \"/\", request.name())");
+            "absl::StrCat(\"/\", request.name())");
   EXPECT_EQ(list_locations->second["request_resource"], "request");
   EXPECT_EQ(list_locations->second["request_type"],
             "google::cloud::location::Request");


### PR DESCRIPTION
Add mixin support in descriptor utils.

Next step: use `HttpRule` to replace `MixinMethodOverride` as discussed.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14716)
<!-- Reviewable:end -->
