### PR TITLE
chore: remove redundant cmake add_subdirs for samples

### DIFF
--- a/google/cloud/aiplatform/CMakeLists.txt
+++ b/google/cloud/aiplatform/CMakeLists.txt
@@ -33,5 +33,3 @@ if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     set_tests_properties(aiplatform_quickstart
                          PROPERTIES LABELS "integration-test;quickstart")
 endif ()
-
-add_subdirectory(samples)

--- a/google/cloud/generativelanguage/CMakeLists.txt
+++ b/google/cloud/generativelanguage/CMakeLists.txt
@@ -33,5 +33,3 @@ if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
         PROPERTIES LABELS "integration-test;quickstart" PASS_REGULAR_EXPRESSION
                    "Request had insufficient authentication scopes")
 endif ()
-
-add_subdirectory(samples)


### PR DESCRIPTION
Adding these sample dirs is taken care of by:

https://github.com/googleapis/google-cloud-cpp/blob/00ff87b59b9ef7b3ed62a3a174321f968c86101f/cmake/GoogleCloudCppFeatures.cmake#L447

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14717)
<!-- Reviewable:end -->
