### PR TITLE
cleanup(mixin): refactor mixin utils to use HttpRule

### DIFF
--- a/generator/BUILD.bazel
+++ b/generator/BUILD.bazel
@@ -77,6 +77,7 @@ cc_library(
     deps = [
         ":google_cloud_cpp_generator",
         ":google_cloud_cpp_generator_testing",
+        "//google/cloud/testing_util:google_cloud_cpp_testing_grpc_private",
         "@com_google_googletest//:gtest",
     ],
 ) for test in google_cloud_cpp_generator_unit_tests]

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -35,6 +35,7 @@
 #include "absl/strings/str_split.h"
 #include "absl/strings/strip.h"
 #include "absl/types/variant.h"
+#include <google/api/annotations.pb.h>
 #include <google/api/routing.pb.h>
 #include <google/longrunning/operations.pb.h>
 #include <google/protobuf/compiler/code_generator.h>
@@ -842,7 +843,11 @@ std::map<std::string, VarsDictionary> CreateMethodVars(
     SetLongrunningOperationMethodVars(method, method_vars);
     AssignPaginationMethodVars(method, method_vars);
     SetMethodSignatureMethodVars(service, method, omitted_rpcs, method_vars);
-    auto parsed_http_info = ParseHttpExtension(method);
+    HttpExtensionInfo parsed_http_info;
+    if (method.options().HasExtension(google::api::http)) {
+      parsed_http_info =
+          ParseHttpExtension(method.options().GetExtension(google::api::http));
+    }
     method_vars["request_resource"] =
         FormatRequestResource(*method.input_type(), parsed_http_info);
     SetHttpDerivedMethodVars(parsed_http_info, method, method_vars);

--- a/generator/internal/http_option_utils.cc
+++ b/generator/internal/http_option_utils.cc
@@ -263,7 +263,7 @@ void SetHttpQueryParameters(HttpExtensionInfo const& info,
       FormatQueryParameterCode(method, std::move(param_field_names));
 }
 
-HttpExtensionInfo ParseHttpExtension(google::api::HttpRule http_rule) {
+HttpExtensionInfo ParseHttpExtension(google::api::HttpRule const& http_rule) {
   HttpExtensionInfo info;
   switch (http_rule.pattern_case()) {
     case google::api::HttpRule::kGet:

--- a/generator/internal/http_option_utils.h
+++ b/generator/internal/http_option_utils.h
@@ -42,12 +42,8 @@ struct HttpExtensionInfo {
  * Parses the http extension providing resource routing info, if present,
  * for the provided method per AIP-4222. Output is also used for gRPC/HTTP
  * transcoding and REST transport.
- * Mixin method should use the target service's package and file names instead
- * of its own.
- * Mixin method' url, verb and body are overridden by the definition in target
- * service's YAML.
  */
-HttpExtensionInfo ParseHttpExtension(google::api::HttpRule http_rule);
+HttpExtensionInfo ParseHttpExtension(google::api::HttpRule const& http_rule);
 
 /**
  * Sets the following method_vars based on the provided parsed_http_info:

--- a/generator/internal/http_option_utils.h
+++ b/generator/internal/http_option_utils.h
@@ -19,6 +19,7 @@
 #include "generator/internal/mixin_utils.h"
 #include "generator/internal/printer.h"
 #include "absl/types/optional.h"
+#include <google/api/http.pb.h>
 #include <google/protobuf/descriptor.h>
 #include <string>
 
@@ -46,9 +47,7 @@ struct HttpExtensionInfo {
  * Mixin method' url, verb and body are overridden by the definition in target
  * service's YAML.
  */
-HttpExtensionInfo ParseHttpExtension(
-    google::protobuf::MethodDescriptor const& method,
-    absl::optional<MixinMethodOverride> method_override = absl::nullopt);
+HttpExtensionInfo ParseHttpExtension(google::api::HttpRule http_rule);
 
 /**
  * Sets the following method_vars based on the provided parsed_http_info:

--- a/generator/internal/mixin_utils.cc
+++ b/generator/internal/mixin_utils.cc
@@ -21,6 +21,7 @@
 #include "absl/types/optional.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <yaml-cpp/yaml.h>
+#include <google/api/http.pb.h>
 #include <iostream>
 #include <string>
 #include <unordered_map>
@@ -61,49 +62,78 @@ std::unordered_map<std::string, std::string> const& GetHttpVerbs() {
   return *kHttpVerbs;
 }
 
+void ParseHttpRule(std::string const& selector, YAML::detail::iterator_value const& rule, google::api::HttpRule& http_rule) {
+  http_rule.set_selector(selector);
+  if (rule["body"]) {
+    http_rule.set_body(rule["body"].as<std::string>());
+  }
+
+  for (auto const& kv : rule) {
+    if (kv.first.Type() != YAML::NodeType::Scalar ||
+        kv.second.Type() != YAML::NodeType::Scalar)
+      continue;
+
+    std::string const rule_key =
+          absl::AsciiStrToLower(kv.first.as<std::string>());
+    std::string const rule_value = kv.second.as<std::string>();
+
+    if (rule_key == "get") {
+        http_rule.set_get(rule_value);
+    } else if (rule_key == "post") {
+        http_rule.set_post(rule_value);
+    } else if (rule_key == "put") {
+        http_rule.set_put(rule_value);
+    } else if (rule_key == "patch") {
+        http_rule.set_patch(rule_value);
+    } else if (rule_key == "delete") {
+        http_rule.set_delete_(rule_value);
+    }
+  }
+}
+
 /**
  * Extract Mixin methods from the YAML file, together with the overwritten http
  * info.
  */
-std::unordered_map<std::string, MixinMethodOverride> GetMixinMethodOverrides(
+std::unordered_map<std::string, google::api::HttpRule> GetMixinHttpOverrides(
     YAML::Node const& service_config) {
-  std::unordered_map<std::string, MixinMethodOverride> mixin_method_overrides;
+  std::unordered_map<std::string, google::api::HttpRule> http_rules;
+
   if (service_config.Type() != YAML::NodeType::Map)
-    return mixin_method_overrides;
-  if (!service_config["http"]) return mixin_method_overrides;
+    return http_rules;
+  if (!service_config["http"]) return http_rules;
+
   auto const& http = service_config["http"];
-  if (http.Type() != YAML::NodeType::Map) return mixin_method_overrides;
+  if (http.Type() != YAML::NodeType::Map) return http_rules;
+
   auto const& rules = http["rules"];
-  if (rules.Type() != YAML::NodeType::Sequence) return mixin_method_overrides;
+  if (rules.Type() != YAML::NodeType::Sequence) return http_rules;
+
   for (auto const& rule : rules) {
     if (rule.Type() != YAML::NodeType::Map) continue;
 
     auto const& selector = rule["selector"];
     if (selector.Type() != YAML::NodeType::Scalar) continue;
+
     std::string const method_full_name = selector.as<std::string>();
+    google::api::HttpRule http_rule;
+    ParseHttpRule(method_full_name, rule, http_rule);
 
-    for (auto const& kv : rule) {
-      if (kv.first.Type() != YAML::NodeType::Scalar ||
-          kv.second.Type() != YAML::NodeType::Scalar)
-        continue;
-
-      std::string const http_verb_lower =
-          absl::AsciiStrToLower(kv.first.as<std::string>());
-      auto const& http_verbs = GetHttpVerbs();
-      auto const it = http_verbs.find(http_verb_lower);
-      if (it == http_verbs.end()) continue;
-      std::string const& http_verb = it->second;
-      std::string const http_path = kv.second.as<std::string>();
-      absl::optional<std::string> http_body;
-      if (rule["body"]) {
-        http_body = rule["body"].as<std::string>();
+    if (rule["additional_bindings"]) {
+      google::api::HttpRule& additional_http_rule = *http_rule.add_additional_bindings();
+      auto const& additional_bindings = rule["additional_bindings"];
+      if (additional_bindings.Type() == YAML::NodeType::Sequence) {
+        for (auto const& additional_binding : additional_bindings) {
+          if (additional_binding.Type() != YAML::NodeType::Map) continue;
+          ParseHttpRule(method_full_name, additional_binding, additional_http_rule);
+        }
       }
-
-      mixin_method_overrides[method_full_name] =
-          MixinMethodOverride{http_verb, http_path, http_body};
     }
+
+    // std::cout << http_rule.DebugString() << std::endl;
+    http_rules[method_full_name] = std::move(http_rule);
   }
-  return mixin_method_overrides;
+  return http_rules;
 }
 
 /**
@@ -155,7 +185,7 @@ std::vector<MixinMethod> GetMixinMethods(YAML::Node const& service_config,
   }
   std::unordered_set<std::string> const method_names = GetMethodNames(service);
   auto const mixin_proto_paths = GetMixinProtoPaths(service_config);
-  auto const mixin_method_overrides = GetMixinMethodOverrides(service_config);
+  auto const mixin_http_overrides = GetMixinHttpOverrides(service_config);
 
   for (auto const& mixin_proto_path : mixin_proto_paths) {
     FileDescriptor const* mixin_file = pool->FindFileByName(mixin_proto_path);
@@ -170,8 +200,8 @@ std::vector<MixinMethod> GetMixinMethods(YAML::Node const& service_config,
       for (int j = 0; j < mixin_service->method_count(); ++j) {
         MethodDescriptor const* mixin_method = mixin_service->method(j);
         auto mixin_method_full_name = mixin_method->full_name();
-        auto const it = mixin_method_overrides.find(mixin_method_full_name);
-        if (it == mixin_method_overrides.end()) continue;
+        auto const it = mixin_http_overrides.find(mixin_method_full_name);
+        if (it == mixin_http_overrides.end()) continue;
 
         // if the mixin method name required from YAML appears in the original
         // service proto, ignore the mixin.

--- a/generator/internal/mixin_utils.cc
+++ b/generator/internal/mixin_utils.cc
@@ -120,7 +120,6 @@ std::unordered_map<std::string, google::api::HttpRule> GetMixinHttpOverrides(
       }
     }
 
-    // std::cout << http_rule.DebugString() << std::endl;
     http_rules[method_full_name] = std::move(http_rule);
   }
   return http_rules;

--- a/generator/internal/mixin_utils.cc
+++ b/generator/internal/mixin_utils.cc
@@ -21,7 +21,6 @@
 #include "absl/types/optional.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <yaml-cpp/yaml.h>
-#include <google/api/http.pb.h>
 #include <iostream>
 #include <string>
 #include <unordered_map>
@@ -50,19 +49,9 @@ std::unordered_map<std::string, std::string> const& GetMixinProtoPathMap() {
   return *kMixinProtoPathMap;
 }
 
-std::unordered_map<std::string, std::string> const& GetHttpVerbs() {
-  static absl::NoDestructor<std::unordered_map<std::string, std::string>> const
-      kHttpVerbs{{
-          {"get", "Get"},
-          {"post", "Post"},
-          {"put", "Put"},
-          {"patch", "Patch"},
-          {"delete", "Delete"},
-      }};
-  return *kHttpVerbs;
-}
-
-void ParseHttpRule(std::string const& selector, YAML::detail::iterator_value const& rule, google::api::HttpRule& http_rule) {
+void ParseHttpRule(std::string const& selector,
+                   YAML::detail::iterator_value const& rule,
+                   google::api::HttpRule& http_rule) {
   http_rule.set_selector(selector);
   if (rule["body"]) {
     http_rule.set_body(rule["body"].as<std::string>());
@@ -74,19 +63,19 @@ void ParseHttpRule(std::string const& selector, YAML::detail::iterator_value con
       continue;
 
     std::string const rule_key =
-          absl::AsciiStrToLower(kv.first.as<std::string>());
+        absl::AsciiStrToLower(kv.first.as<std::string>());
     std::string const rule_value = kv.second.as<std::string>();
 
     if (rule_key == "get") {
-        http_rule.set_get(rule_value);
+      http_rule.set_get(rule_value);
     } else if (rule_key == "post") {
-        http_rule.set_post(rule_value);
+      http_rule.set_post(rule_value);
     } else if (rule_key == "put") {
-        http_rule.set_put(rule_value);
+      http_rule.set_put(rule_value);
     } else if (rule_key == "patch") {
-        http_rule.set_patch(rule_value);
+      http_rule.set_patch(rule_value);
     } else if (rule_key == "delete") {
-        http_rule.set_delete_(rule_value);
+      http_rule.set_delete_(rule_value);
     }
   }
 }
@@ -99,8 +88,7 @@ std::unordered_map<std::string, google::api::HttpRule> GetMixinHttpOverrides(
     YAML::Node const& service_config) {
   std::unordered_map<std::string, google::api::HttpRule> http_rules;
 
-  if (service_config.Type() != YAML::NodeType::Map)
-    return http_rules;
+  if (service_config.Type() != YAML::NodeType::Map) return http_rules;
   if (!service_config["http"]) return http_rules;
 
   auto const& http = service_config["http"];
@@ -120,12 +108,14 @@ std::unordered_map<std::string, google::api::HttpRule> GetMixinHttpOverrides(
     ParseHttpRule(method_full_name, rule, http_rule);
 
     if (rule["additional_bindings"]) {
-      google::api::HttpRule& additional_http_rule = *http_rule.add_additional_bindings();
       auto const& additional_bindings = rule["additional_bindings"];
       if (additional_bindings.Type() == YAML::NodeType::Sequence) {
         for (auto const& additional_binding : additional_bindings) {
+          google::api::HttpRule& additional_http_rule =
+              *http_rule.add_additional_bindings();
           if (additional_binding.Type() != YAML::NodeType::Map) continue;
-          ParseHttpRule(method_full_name, additional_binding, additional_http_rule);
+          ParseHttpRule(method_full_name, additional_binding,
+                        additional_http_rule);
         }
       }
     }

--- a/generator/internal/mixin_utils.cc
+++ b/generator/internal/mixin_utils.cc
@@ -51,8 +51,13 @@ std::unordered_map<std::string, std::string> const& GetMixinProtoPathMap() {
 
 google::api::HttpRule ParseHttpRule(YAML::detail::iterator_value const& rule) {
   google::api::HttpRule http_rule;
-  if (rule["body"]) {
-    http_rule.set_body(rule["body"].as<std::string>());
+  auto const& body = rule["body"];
+  if (body) {
+    http_rule.set_body(body.as<std::string>());
+  }
+  auto const& selector = rule["selector"];
+  if (selector) {
+    http_rule.set_selector(selector.as<std::string>());
   }
 
   for (auto const& kv : rule) {

--- a/generator/internal/mixin_utils.cc
+++ b/generator/internal/mixin_utils.cc
@@ -189,10 +189,11 @@ std::vector<MixinMethod> GetMixinMethods(YAML::Node const& service_config,
       for (int j = 0; j < mixin_service->method_count(); ++j) {
         MethodDescriptor const* mixin_method = mixin_service->method(j);
         auto mixin_method_full_name = mixin_method->full_name();
+        // Add the mixin method only if it appears in the http field of YAML
         auto const it = mixin_http_overrides.find(mixin_method_full_name);
         if (it == mixin_http_overrides.end()) continue;
 
-        // if the mixin method name required from YAML appears in the original
+        // If the mixin method name required from YAML appears in the original
         // service proto, ignore the mixin.
         if (method_names.find(mixin_method->name()) != method_names.end())
           continue;

--- a/generator/internal/mixin_utils.h
+++ b/generator/internal/mixin_utils.h
@@ -19,20 +19,12 @@
 #include <google/protobuf/compiler/code_generator.h>
 #include <yaml-cpp/yaml.h>
 #include <string>
+#include <google/api/http.pb.h>
 #include <vector>
 
 namespace google {
 namespace cloud {
 namespace generator_internal {
-
-/**
- * Override of http info of a mixin method.
- */
-struct MixinMethodOverride {
-  std::string http_verb;
-  std::string http_path;
-  absl::optional<std::string> http_body;
-};
 
 /**
  * All required info for a mixin method
@@ -43,7 +35,7 @@ struct MixinMethod {
   std::string grpc_stub_name;
   std::string grpc_stub_fqn;
   std::reference_wrapper<google::protobuf::MethodDescriptor const> method;
-  MixinMethodOverride method_override;
+  google::api::HttpRule http_override;
 };
 
 /**

--- a/generator/internal/mixin_utils.h
+++ b/generator/internal/mixin_utils.h
@@ -16,10 +16,10 @@
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_MIXIN_UTILS_H
 
 #include "absl/types/optional.h"
+#include <google/api/http.pb.h>
 #include <google/protobuf/compiler/code_generator.h>
 #include <yaml-cpp/yaml.h>
 #include <string>
-#include <google/api/http.pb.h>
 #include <vector>
 
 namespace google {

--- a/generator/internal/mixin_utils_test.cc
+++ b/generator/internal/mixin_utils_test.cc
@@ -24,6 +24,7 @@ namespace cloud {
 namespace generator_internal {
 namespace {
 
+using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::protobuf::FileDescriptor;
 using ::google::protobuf::ServiceDescriptor;
 using ::testing::AllOf;
@@ -35,18 +36,6 @@ using ::testing::NotNull;
 
 MATCHER_P(HasMethod, expected, "has method full name") {
   return arg.get().full_name() == expected;
-}
-
-MATCHER_P3(HasHttpRuleBinding, body, path, pattern_case,
-           "has http rule binding") {
-  return is_http_rule_expected(arg, body, path, pattern_case);
-}
-
-MATCHER_P4(HasAdditionalBinding, idx, body, path, pattern_case,
-           "has additional binding") {
-  if (idx >= arg.additional_bindings().size()) return false;
-  return is_http_rule_expected(arg.additional_bindings(idx), body, path,
-                               pattern_case);
 }
 
 auto constexpr kServiceConfigYaml = R"""(
@@ -272,8 +261,7 @@ TEST_F(MixinUtilsTest, GetMixinMethods) {
     return AllOf(Field(&MixinMethod::method, HasMethod(full_name)),
                  Field(&MixinMethod::grpc_stub_name, Eq(stub_name)),
                  Field(&MixinMethod::grpc_stub_fqn, Eq(stub_fqn)),
-                 Field(&MixinMethod::http_override,
-                       google::cloud::testing_util::IsProtoEqual(http_rule)));
+                 Field(&MixinMethod::http_override, IsProtoEqual(http_rule)));
   };
 
   EXPECT_THAT(

--- a/generator/internal/mixin_utils_test.cc
+++ b/generator/internal/mixin_utils_test.cc
@@ -26,9 +26,7 @@ using ::google::protobuf::FileDescriptor;
 using ::google::protobuf::ServiceDescriptor;
 using ::testing::AllOf;
 using ::testing::Contains;
-using ::testing::Eq;
 using ::testing::NotNull;
-using ::testing::Optional;
 
 auto constexpr kServiceConfigYaml = R"""(
 apis:


### PR DESCRIPTION
Refactor mixin utils to use HttpRule as http overrides.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14723)
<!-- Reviewable:end -->
