### PR TITLE
fix(rest): promote buffer curl reads from to member variable

### DIFF
--- a/google/cloud/internal/curl_impl.h
+++ b/google/cloud/internal/curl_impl.h
@@ -18,6 +18,7 @@
 #include "google/cloud/internal/curl_handle.h"
 #include "google/cloud/internal/curl_handle_factory.h"
 #include "google/cloud/internal/curl_wrappers.h"
+#include "google/cloud/internal/curl_writev.h"
 #include "google/cloud/internal/rest_context.h"
 #include "google/cloud/internal/rest_request.h"
 #include "google/cloud/internal/rest_response.h"
@@ -170,6 +171,10 @@ class CurlImpl {
 
   // Track when status and headers from the response are received.
   bool all_headers_received_ = false;
+
+  // writev_ is a member variable in order to ensure that its lifetime remains
+  // valid even if libcurl is interrupted when trying to send data.
+  WriteVector writev_;
 
   // Track the unused portion of the output buffer provided to Read().
   absl::Span<char> avail_;

--- a/google/cloud/internal/curl_writev.h
+++ b/google/cloud/internal/curl_writev.h
@@ -28,6 +28,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 // Vector of data chunks to satisfy requests from libcurl.
 class WriteVector {
  public:
+  WriteVector() = default;
   explicit WriteVector(std::vector<absl::Span<char const>> v)
       : original_(std::move(v)), writev_(original_.begin(), original_.end()) {}
 


### PR DESCRIPTION
As a member variable, writev_ will remain in scope until the request is complete.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14732)
<!-- Reviewable:end -->
