### PR TITLE
feat: add support for API keys

### DIFF
--- a/google/cloud/common_options.h
+++ b/google/cloud/common_options.h
@@ -281,6 +281,30 @@ struct CustomHeadersOption {
 };
 
 /**
+ * An option to authenticate using an [API key].
+ *
+ * API keys are convenient because no [principal] is needed. The API key
+ * associates the request with a Google Cloud project for billing and quota
+ * purposes.
+ *
+ * @note Most Cloud APIs do not support API keys, instead requiring full
+ * credentials.
+ *
+ * @note Using API keys is mutually exclusive with providing credentials. The
+ * client library will error out if both `ApiKeyOption` and
+ * `UnifiedCredentialsOption` are set.
+ *
+ * @ingroup guac
+ * @ingroup options
+ *
+ * [API key]: https://cloud.google.com/docs/authentication/api-keys-use
+ * [principal]: https://cloud.google.com/docs/authentication#principal
+ */
+struct ApiKeyOption {
+  using Type = std::string;
+};
+
+/**
  * Configure server-side filtering.
  *
  * Google services can filter the fields in a response using the

--- a/google/cloud/doc/guac.dox
+++ b/google/cloud/doc/guac.dox
@@ -58,6 +58,10 @@ The client libraries automatically refresh access tokens, that is, create new
 tokens before they expire. The only exception is `MakeAccessTokenCredentials()`,
 where the application provides the access token.
 
+The client libraries also support authentication without a principal via API
+keys. Note that while the client libraries support sending the API key, not all
+Google Cloud Platform services support this method of authentication.
+
 ## Development Workstations
 
 We find that developers typically use Application Default Credentials to test

--- a/google/cloud/grpc_options.cc
+++ b/google/cloud/grpc_options.cc
@@ -45,6 +45,9 @@ void SetMetadata(grpc::ClientContext& context, Options const& options,
   if (options.has<QuotaUserOption>()) {
     context.AddMetadata("x-goog-quota-user", options.get<QuotaUserOption>());
   }
+  if (options.has<ApiKeyOption>()) {
+    context.AddMetadata("x-goog-api-key", options.get<ApiKeyOption>());
+  }
   if (options.has<FieldMaskOption>()) {
     context.AddMetadata("x-goog-fieldmask", options.get<FieldMaskOption>());
   }

--- a/google/cloud/grpc_options_test.cc
+++ b/google/cloud/grpc_options_test.cc
@@ -329,6 +329,7 @@ TEST(GrpcSetMetadata, Full) {
       Options{}
           .set<UserProjectOption>("user-project")
           .set<QuotaUserOption>("quota-user")
+          .set<ApiKeyOption>("api-key")
           .set<AuthorityOption>("authority.googleapis.com")
           .set<CustomHeadersOption>(
               {{"custom-header-1", "v1"}, {"custom-header-2", "v2"}}),
@@ -340,6 +341,7 @@ TEST(GrpcSetMetadata, Full) {
               UnorderedElementsAre(
                   Pair("x-goog-user-project", "user-project"),
                   Pair("x-goog-quota-user", "quota-user"),
+                  Pair("x-goog-api-key", "api-key"),
                   Pair("fixed-header-1", "v1"), Pair("fixed-header-2", "v2"),
                   Pair("custom-header-1", "v1"), Pair("custom-header-2", "v2"),
                   Pair("x-goog-api-client", "api-client-header")));

--- a/google/cloud/internal/populate_grpc_options.cc
+++ b/google/cloud/internal/populate_grpc_options.cc
@@ -15,6 +15,8 @@
 #include "google/cloud/internal/populate_grpc_options.h"
 #include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
+#include "google/cloud/internal/credentials_impl.h"
+#include "google/cloud/internal/make_status.h"
 #include "google/cloud/internal/populate_common_options.h"
 
 namespace google {
@@ -23,6 +25,15 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 
 Options PopulateGrpcOptions(Options opts) {
+  if (opts.has<ApiKeyOption>()) {
+    if (opts.has<UnifiedCredentialsOption>()) {
+      opts.set<UnifiedCredentialsOption>(
+          internal::MakeErrorCredentials(internal::InvalidArgumentError(
+              "API Keys and Credentials are mutually exclusive authentication "
+              "methods and cannot be used together.")));
+    }
+    opts.set<GrpcCredentialOption>(grpc::SslCredentials({}));
+  }
   if (!opts.has<GrpcCredentialOption>() &&
       !opts.has<UnifiedCredentialsOption>()) {
     opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials());

--- a/google/cloud/internal/populate_grpc_options_test.cc
+++ b/google/cloud/internal/populate_grpc_options_test.cc
@@ -63,6 +63,24 @@ TEST(PopulateGrpcOptions, GrpcCredentialOptionBackCompat) {
   EXPECT_EQ(creds, actual.get<GrpcCredentialOption>());
 }
 
+TEST(PopulateGrpcOptions, ApiKey) {
+  auto actual = PopulateGrpcOptions(Options{}.set<ApiKeyOption>("api-key"));
+  EXPECT_TRUE(actual.has<GrpcCredentialOption>());
+  EXPECT_FALSE(actual.has<UnifiedCredentialsOption>());
+}
+
+TEST(PopulateGrpcOptions, ApiKeyWithCredentialsErrors) {
+  auto actual = PopulateGrpcOptions(
+      Options{}.set<ApiKeyOption>("api-key").set<UnifiedCredentialsOption>(
+          MakeGoogleDefaultCredentials()));
+
+  EXPECT_TRUE(actual.has<UnifiedCredentialsOption>());
+  auto const& creds = actual.get<UnifiedCredentialsOption>();
+  TestCredentialsVisitor v;
+  CredentialsVisitor::dispatch(*creds, v);
+  EXPECT_EQ(v.name, "ErrorCredentialsConfig");
+}
+
 TEST(PopulateGrpcOptions, TracingOptions) {
   ScopedEnvironment env("GOOGLE_CLOUD_CPP_TRACING_OPTIONS",
                         "truncate_string_field_longer_than=42");


### PR DESCRIPTION
Part of the work for #14733 

Start with gRPC support only, because that is all I have had time to test.

My follow up PR will add the sample, which doubles as an integration test. It is involved enough to warrant its own PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14737)
<!-- Reviewable:end -->
