### PR TITLE
feat: API key support over REST transport

### DIFF
--- a/google/cloud/internal/populate_rest_options.cc
+++ b/google/cloud/internal/populate_rest_options.cc
@@ -15,6 +15,8 @@
 #include "google/cloud/internal/populate_rest_options.h"
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
+#include "google/cloud/internal/credentials_impl.h"
+#include "google/cloud/internal/make_status.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/rest_options.h"
@@ -27,7 +29,13 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 
 Options PopulateRestOptions(Options opts) {
-  if (!opts.has<UnifiedCredentialsOption>()) {
+  if (opts.has<ApiKeyOption>() && opts.has<UnifiedCredentialsOption>()) {
+    opts.set<UnifiedCredentialsOption>(
+        internal::MakeErrorCredentials(internal::InvalidArgumentError(
+            "API Keys and Credentials are mutually exclusive authentication "
+            "methods and cannot be used together.")));
+  }
+  if (!opts.has<UnifiedCredentialsOption>() && !opts.has<ApiKeyOption>()) {
     opts.set<UnifiedCredentialsOption>(
         MakeGoogleDefaultCredentials(internal::MakeAuthOptions(opts)));
   }

--- a/google/cloud/internal/populate_rest_options_test.cc
+++ b/google/cloud/internal/populate_rest_options_test.cc
@@ -103,6 +103,23 @@ TEST(PopulateRestOptions, TracingOptions) {
   EXPECT_EQ(tracing.truncate_string_field_longer_than(), 42);
 }
 
+TEST(PopulateRestOptions, ApiKey) {
+  auto actual = PopulateRestOptions(Options{}.set<ApiKeyOption>("api-key"));
+  EXPECT_FALSE(actual.has<UnifiedCredentialsOption>());
+}
+
+TEST(PopulateRestOptions, ApiKeyWithCredentialsErrors) {
+  auto actual = PopulateRestOptions(
+      Options{}.set<ApiKeyOption>("api-key").set<UnifiedCredentialsOption>(
+          MakeGoogleDefaultCredentials()));
+
+  EXPECT_TRUE(actual.has<UnifiedCredentialsOption>());
+  auto const& creds = actual.get<UnifiedCredentialsOption>();
+  TestCredentialsVisitor v;
+  CredentialsVisitor::dispatch(*creds, v);
+  EXPECT_EQ(v.name, "ErrorCredentialsConfig");
+}
+
 }  // namespace
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/rest_set_metadata.cc
+++ b/google/cloud/internal/rest_set_metadata.cc
@@ -38,6 +38,9 @@ void SetMetadata(RestContext& context, Options const& options,
   if (options.has<QuotaUserOption>()) {
     context.AddHeader("x-goog-quota-user", options.get<QuotaUserOption>());
   }
+  if (options.has<UserProjectOption>()) {
+    context.AddHeader("x-goog-api-key", options.get<ApiKeyOption>());
+  }
   if (options.has<FieldMaskOption>()) {
     context.AddHeader("x-goog-fieldmask", options.get<FieldMaskOption>());
   }

--- a/google/cloud/internal/rest_set_metadata_test.cc
+++ b/google/cloud/internal/rest_set_metadata_test.cc
@@ -52,6 +52,7 @@ TEST(RestContextTest, SetMetadataFull) {
               Options{}
                   .set<UserProjectOption>("user-project")
                   .set<QuotaUserOption>("quota-user")
+                  .set<ApiKeyOption>("api-key")
                   .set<FieldMaskOption>("items.name,token")
                   .set<ServerTimeoutOption>(std::chrono::milliseconds(1050))
                   .set<CustomHeadersOption>(
@@ -63,6 +64,7 @@ TEST(RestContextTest, SetMetadataFull) {
                   Pair("x-goog-request-params", ElementsAre("p1=v1&p2=v2")),
                   Pair("x-goog-user-project", ElementsAre("user-project")),
                   Pair("x-goog-quota-user", ElementsAre("quota-user")),
+                  Pair("x-goog-api-key", ElementsAre("api-key")),
                   Pair("x-goog-fieldmask", ElementsAre("items.name,token")),
                   Pair("x-server-timeout", ElementsAre("1.050")),
                   Pair("custom-header-1", ElementsAre("v1")),


### PR DESCRIPTION
Part of the work for #14733 

Note that none of the services for which we have a REST transport layer (`bigquery`, `compute`, `sql`) support authentication via API keys. So there is no useful integration test for us to write at this time.

This PR is still worth having.  We want to be ready if:
- Any of these services start supporting API keys.
- We generate REST transport layers (using gRPC transcoding) for a service that does support API keys.

---

Just to verify the spec, I ran:

```sh
$ API_KEY=...

$ curl -X POST \
  -H "Content-Type: application/json" \
  -H "x-goog-api-key: ${API_KEY}" \
  -d '{"document":{"content":"I finally figured out how to make a request using curl. This is the best day of my life!","type":"PLAIN_TEXT"}}' \
  https://content-language.googleapis.com/v1/documents:analyzeSentiment?alt=json

{
  "documentSentiment": {
    "magnitude": 1.3,
    "score": 0.6
  },
  "language": "en",
  "sentences": [
    {
      "text": {
        "content": "I finally figured out how to make a request using curl.",
        "beginOffset": -1
      },
      "sentiment": {
        "magnitude": 0.3,
        "score": 0.3
      }
    },
    {
      "text": {
        "content": "This is the best day of my life!",
        "beginOffset": -1
      },
      "sentiment": {
        "magnitude": 0.9,
        "score": 0.9
      }
    }
  ]
}

```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14745)
<!-- Reviewable:end -->
