### PR TITLE
fix: `ApiKeyOption` without `UserProjectOption` over REST

### DIFF
--- a/google/cloud/internal/rest_set_metadata.cc
+++ b/google/cloud/internal/rest_set_metadata.cc
@@ -38,7 +38,7 @@ void SetMetadata(RestContext& context, Options const& options,
   if (options.has<QuotaUserOption>()) {
     context.AddHeader("x-goog-quota-user", options.get<QuotaUserOption>());
   }
-  if (options.has<UserProjectOption>()) {
+  if (options.has<ApiKeyOption>()) {
     context.AddHeader("x-goog-api-key", options.get<ApiKeyOption>());
   }
   if (options.has<FieldMaskOption>()) {

--- a/google/cloud/internal/rest_set_metadata_test.cc
+++ b/google/cloud/internal/rest_set_metadata_test.cc
@@ -25,6 +25,7 @@ namespace rest_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+using ::testing::Contains;
 using ::testing::ElementsAre;
 using ::testing::Pair;
 using ::testing::UnorderedElementsAre;
@@ -69,6 +70,14 @@ TEST(RestContextTest, SetMetadataFull) {
                   Pair("x-server-timeout", ElementsAre("1.050")),
                   Pair("custom-header-1", ElementsAre("v1")),
                   Pair("custom-header-2", ElementsAre("v2"))));
+}
+
+TEST(RestContextTest, Regression14745) {
+  RestContext lhs;
+  SetMetadata(lhs, Options{}.set<ApiKeyOption>("api-key"), {},
+              "api-client-header");
+  EXPECT_THAT(lhs.headers(),
+              Contains(Pair("x-goog-api-key", ElementsAre("api-key"))));
 }
 
 }  // namespace


### PR DESCRIPTION
Thank you @devbww for noticing.

I added a unit test out of shame.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14748)
<!-- Reviewable:end -->
