### PR TITLE
impl: censor API key header in traces

### DIFF
--- a/google/cloud/internal/tracing_rest_client.cc
+++ b/google/cloud/internal/tracing_rest_client.cc
@@ -68,6 +68,10 @@ StatusOr<std::unique_ptr<RestResponse>> EndResponseSpan(
       span->SetAttribute(name, kv.second.front().substr(0, 32));
       continue;
     }
+    if (absl::EqualsIgnoreCase(kv.first, "x-goog-api-key")) {
+      span->SetAttribute(name, kv.second.front().substr(0, 16) + "...");
+      continue;
+    }
     span->SetAttribute(name, kv.second.front());
   }
   if (!request_result || !(*request_result)) {

--- a/google/cloud/internal/tracing_rest_client.cc
+++ b/google/cloud/internal/tracing_rest_client.cc
@@ -34,6 +34,19 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 /**
+ * The number of characters to print in an [API key].
+ *
+ * API keys are 39 characters in length. The value is a secret, so we do not
+ * want to include the entire key in our telemetry.
+ *
+ * Providing some number of characters allows applications to confirm the
+ * correct API key is in use, given that the full API key is known.
+ *
+ * [API key]: https://cloud.google.com/docs/authentication/api-keys-use
+ */
+auto constexpr kApiKeyHintLength = 12;
+
+/**
  * Extracts information from @p value, and adds it to a span.
  *
  * The span is ended. The original value is returned, for the sake of
@@ -69,7 +82,8 @@ StatusOr<std::unique_ptr<RestResponse>> EndResponseSpan(
       continue;
     }
     if (absl::EqualsIgnoreCase(kv.first, "x-goog-api-key")) {
-      span->SetAttribute(name, kv.second.front().substr(0, 16) + "...");
+      span->SetAttribute(
+          name, kv.second.front().substr(0, kApiKeyHintLength) + "...");
       continue;
     }
     span->SetAttribute(name, kv.second.front());

--- a/google/cloud/internal/tracing_rest_client_test.cc
+++ b/google/cloud/internal/tracing_rest_client_test.cc
@@ -317,7 +317,7 @@ TEST(TracingRestClient, CensorsAuthFields) {
           OTelAttribute<std::string>("http.request.header.authorization",
                                      "bearer: ABCDEFGHIJKLMNOPQRSTUVWX"),
           OTelAttribute<std::string>("http.request.header.x-goog-api-key",
-                                     "ABCDEFGHIJKLMNOP..."))));
+                                     "ABCDEFGHIJKL..."))));
 }
 
 TEST(TracingRestClient, CachedConnection) {


### PR DESCRIPTION
Part of the work for #14733

Truncate any API keys in our traces. While we're here, test that we truncate OAuth2 tokens as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14755)
<!-- Reviewable:end -->
