### PR TITLE
cleanup(pubsub): samples

### DIFF
--- a/google/cloud/pubsub/samples/iam_samples.cc
+++ b/google/cloud/pubsub/samples/iam_samples.cc
@@ -233,9 +233,8 @@ void AutoRun(std::vector<std::string> const& argv) {
   auto subscription =
       subscription_admin_client
           .CreateSubscription(
-              pubsub::Topic(project_id, topic_id).FullName(),
-              pubsub::Subscription(project_id, subscription_id).FullName(), {},
-              {})
+              pubsub::Subscription(project_id, subscription_id).FullName(),
+              pubsub::Topic(project_id, topic_id).FullName(), {}, {})
           .value();
 
   std::cout << "\nRunning GetTopicPolicy() sample" << std::endl;

--- a/google/cloud/pubsub/samples/samples.cc
+++ b/google/cloud/pubsub/samples/samples.cc
@@ -1034,8 +1034,8 @@ void OptimisticSubscribe(std::vector<std::string> const& argv) {
   namespace pubsub_admin = ::google::cloud::pubsub_admin;
   namespace pubsub = ::google::cloud::pubsub;
   namespace gc = ::google::cloud;
-  [](std::string project_id, std::string topic_id,
-     std::string subscription_id) {
+  [](std::string const& project_id, std::string topic_id,
+     std::string const& subscription_id) {
     // Do not retry the attempts to consume messages.
     auto subscriber = pubsub::Subscriber(
         pubsub::MakeSubscriberConnection(

--- a/google/cloud/pubsub/samples/topic_admin_samples.cc
+++ b/google/cloud/pubsub/samples/topic_admin_samples.cc
@@ -219,9 +219,9 @@ void CreateTopicWithCloudStorageIngestion(
   namespace pubsub = ::google::cloud::pubsub;
   namespace pubsub_admin = ::google::cloud::pubsub_admin;
   [](pubsub_admin::TopicAdminClient client, std::string project_id,
-     std::string topic_id, std::string bucket, std::string input_format,
+     std::string topic_id, std::string bucket, std::string const& input_format,
      std::string text_delimiter, std::string match_glob,
-     std::string minimum_object_create_time) {
+     std::string const& minimum_object_create_time) {
     google::pubsub::v1::Topic request;
     request.set_name(
         pubsub::Topic(std::move(project_id), std::move(topic_id)).FullName());

--- a/google/cloud/pubsub/samples/topic_admin_samples.cc
+++ b/google/cloud/pubsub/samples/topic_admin_samples.cc
@@ -225,15 +225,16 @@ void CreateTopicWithCloudStorageIngestion(
     google::pubsub::v1::Topic request;
     request.set_name(
         pubsub::Topic(std::move(project_id), std::move(topic_id)).FullName());
-    auto* cloud_storage = request.mutable_ingestion_data_source_settings()
-                              ->mutable_cloud_storage();
-    cloud_storage->set_bucket(bucket);
+    auto& cloud_storage = *request.mutable_ingestion_data_source_settings()
+                               ->mutable_cloud_storage();
+    cloud_storage.set_bucket(std::move(bucket));
     if (input_format == "text") {
-      cloud_storage->mutable_text_format()->set_delimiter(text_delimiter);
+      cloud_storage.mutable_text_format()->set_delimiter(
+          std::move(text_delimiter));
     } else if (input_format == "avro") {
-      cloud_storage->mutable_avro_format();
+      cloud_storage.mutable_avro_format();
     } else if (input_format == "pubsub_avro") {
-      cloud_storage->mutable_pubsub_avro_format();
+      cloud_storage.mutable_pubsub_avro_format();
     } else {
       std::cout << "input_format must be in ('text', 'avro', 'pubsub_avro'); "
                    "got value: "
@@ -242,14 +243,14 @@ void CreateTopicWithCloudStorageIngestion(
     }
 
     if (!match_glob.empty()) {
-      cloud_storage->set_match_glob(match_glob);
+      cloud_storage.set_match_glob(std::move(match_glob));
     }
 
     if (!minimum_object_create_time.empty()) {
       google::protobuf::Timestamp timestamp;
       if (!google::protobuf::util::TimeUtil::FromString(
               minimum_object_create_time,
-              cloud_storage->mutable_minimum_object_create_time())) {
+              cloud_storage.mutable_minimum_object_create_time())) {
         std::cout << "Invalid minimum object create time: "
                   << minimum_object_create_time << std::endl;
       }


### PR DESCRIPTION
Use the preferred admin client, and quash some `clang-tidy` errors. No I do not know how the `clang-tidy` errors got through our CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14758)
<!-- Reviewable:end -->
