### PR TITLE
cleanup: revert `ApiKeyOption` changes

### DIFF
--- a/google/cloud/common_options.h
+++ b/google/cloud/common_options.h
@@ -281,30 +281,6 @@ struct CustomHeadersOption {
 };
 
 /**
- * An option to authenticate using an [API key].
- *
- * API keys are convenient because no [principal] is needed. The API key
- * associates the request with a Google Cloud project for billing and quota
- * purposes.
- *
- * @note Most Cloud APIs do not support API keys, instead requiring full
- * credentials.
- *
- * @note Using API keys is mutually exclusive with providing credentials. The
- * client library will error out if both `ApiKeyOption` and
- * `UnifiedCredentialsOption` are set.
- *
- * @ingroup guac
- * @ingroup options
- *
- * [API key]: https://cloud.google.com/docs/authentication/api-keys-use
- * [principal]: https://cloud.google.com/docs/authentication#principal
- */
-struct ApiKeyOption {
-  using Type = std::string;
-};
-
-/**
  * Configure server-side filtering.
  *
  * Google services can filter the fields in a response using the

--- a/google/cloud/grpc_options.cc
+++ b/google/cloud/grpc_options.cc
@@ -45,9 +45,6 @@ void SetMetadata(grpc::ClientContext& context, Options const& options,
   if (options.has<QuotaUserOption>()) {
     context.AddMetadata("x-goog-quota-user", options.get<QuotaUserOption>());
   }
-  if (options.has<ApiKeyOption>()) {
-    context.AddMetadata("x-goog-api-key", options.get<ApiKeyOption>());
-  }
   if (options.has<FieldMaskOption>()) {
     context.AddMetadata("x-goog-fieldmask", options.get<FieldMaskOption>());
   }

--- a/google/cloud/grpc_options_test.cc
+++ b/google/cloud/grpc_options_test.cc
@@ -329,7 +329,6 @@ TEST(GrpcSetMetadata, Full) {
       Options{}
           .set<UserProjectOption>("user-project")
           .set<QuotaUserOption>("quota-user")
-          .set<ApiKeyOption>("api-key")
           .set<AuthorityOption>("authority.googleapis.com")
           .set<CustomHeadersOption>(
               {{"custom-header-1", "v1"}, {"custom-header-2", "v2"}}),
@@ -341,7 +340,6 @@ TEST(GrpcSetMetadata, Full) {
               UnorderedElementsAre(
                   Pair("x-goog-user-project", "user-project"),
                   Pair("x-goog-quota-user", "quota-user"),
-                  Pair("x-goog-api-key", "api-key"),
                   Pair("fixed-header-1", "v1"), Pair("fixed-header-2", "v2"),
                   Pair("custom-header-1", "v1"), Pair("custom-header-2", "v2"),
                   Pair("x-goog-api-client", "api-client-header")));

--- a/google/cloud/internal/populate_grpc_options.cc
+++ b/google/cloud/internal/populate_grpc_options.cc
@@ -25,15 +25,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 
 Options PopulateGrpcOptions(Options opts) {
-  if (opts.has<ApiKeyOption>()) {
-    if (opts.has<UnifiedCredentialsOption>()) {
-      opts.set<UnifiedCredentialsOption>(
-          internal::MakeErrorCredentials(internal::InvalidArgumentError(
-              "API Keys and Credentials are mutually exclusive authentication "
-              "methods and cannot be used together.")));
-    }
-    opts.set<GrpcCredentialOption>(grpc::SslCredentials({}));
-  }
   if (!opts.has<GrpcCredentialOption>() &&
       !opts.has<UnifiedCredentialsOption>()) {
     opts.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials());

--- a/google/cloud/internal/populate_grpc_options_test.cc
+++ b/google/cloud/internal/populate_grpc_options_test.cc
@@ -63,24 +63,6 @@ TEST(PopulateGrpcOptions, GrpcCredentialOptionBackCompat) {
   EXPECT_EQ(creds, actual.get<GrpcCredentialOption>());
 }
 
-TEST(PopulateGrpcOptions, ApiKey) {
-  auto actual = PopulateGrpcOptions(Options{}.set<ApiKeyOption>("api-key"));
-  EXPECT_TRUE(actual.has<GrpcCredentialOption>());
-  EXPECT_FALSE(actual.has<UnifiedCredentialsOption>());
-}
-
-TEST(PopulateGrpcOptions, ApiKeyWithCredentialsErrors) {
-  auto actual = PopulateGrpcOptions(
-      Options{}.set<ApiKeyOption>("api-key").set<UnifiedCredentialsOption>(
-          MakeGoogleDefaultCredentials()));
-
-  EXPECT_TRUE(actual.has<UnifiedCredentialsOption>());
-  auto const& creds = actual.get<UnifiedCredentialsOption>();
-  TestCredentialsVisitor v;
-  CredentialsVisitor::dispatch(*creds, v);
-  EXPECT_EQ(v.name, "ErrorCredentialsConfig");
-}
-
 TEST(PopulateGrpcOptions, TracingOptions) {
   ScopedEnvironment env("GOOGLE_CLOUD_CPP_TRACING_OPTIONS",
                         "truncate_string_field_longer_than=42");

--- a/google/cloud/internal/populate_rest_options.cc
+++ b/google/cloud/internal/populate_rest_options.cc
@@ -29,13 +29,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 
 Options PopulateRestOptions(Options opts) {
-  if (opts.has<ApiKeyOption>() && opts.has<UnifiedCredentialsOption>()) {
-    opts.set<UnifiedCredentialsOption>(
-        internal::MakeErrorCredentials(internal::InvalidArgumentError(
-            "API Keys and Credentials are mutually exclusive authentication "
-            "methods and cannot be used together.")));
-  }
-  if (!opts.has<UnifiedCredentialsOption>() && !opts.has<ApiKeyOption>()) {
+  if (!opts.has<UnifiedCredentialsOption>()) {
     opts.set<UnifiedCredentialsOption>(
         MakeGoogleDefaultCredentials(internal::MakeAuthOptions(opts)));
   }

--- a/google/cloud/internal/populate_rest_options_test.cc
+++ b/google/cloud/internal/populate_rest_options_test.cc
@@ -103,23 +103,6 @@ TEST(PopulateRestOptions, TracingOptions) {
   EXPECT_EQ(tracing.truncate_string_field_longer_than(), 42);
 }
 
-TEST(PopulateRestOptions, ApiKey) {
-  auto actual = PopulateRestOptions(Options{}.set<ApiKeyOption>("api-key"));
-  EXPECT_FALSE(actual.has<UnifiedCredentialsOption>());
-}
-
-TEST(PopulateRestOptions, ApiKeyWithCredentialsErrors) {
-  auto actual = PopulateRestOptions(
-      Options{}.set<ApiKeyOption>("api-key").set<UnifiedCredentialsOption>(
-          MakeGoogleDefaultCredentials()));
-
-  EXPECT_TRUE(actual.has<UnifiedCredentialsOption>());
-  auto const& creds = actual.get<UnifiedCredentialsOption>();
-  TestCredentialsVisitor v;
-  CredentialsVisitor::dispatch(*creds, v);
-  EXPECT_EQ(v.name, "ErrorCredentialsConfig");
-}
-
 }  // namespace
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/rest_set_metadata.cc
+++ b/google/cloud/internal/rest_set_metadata.cc
@@ -38,9 +38,6 @@ void SetMetadata(RestContext& context, Options const& options,
   if (options.has<QuotaUserOption>()) {
     context.AddHeader("x-goog-quota-user", options.get<QuotaUserOption>());
   }
-  if (options.has<ApiKeyOption>()) {
-    context.AddHeader("x-goog-api-key", options.get<ApiKeyOption>());
-  }
   if (options.has<FieldMaskOption>()) {
     context.AddHeader("x-goog-fieldmask", options.get<FieldMaskOption>());
   }

--- a/google/cloud/internal/rest_set_metadata_test.cc
+++ b/google/cloud/internal/rest_set_metadata_test.cc
@@ -53,7 +53,6 @@ TEST(RestContextTest, SetMetadataFull) {
               Options{}
                   .set<UserProjectOption>("user-project")
                   .set<QuotaUserOption>("quota-user")
-                  .set<ApiKeyOption>("api-key")
                   .set<FieldMaskOption>("items.name,token")
                   .set<ServerTimeoutOption>(std::chrono::milliseconds(1050))
                   .set<CustomHeadersOption>(
@@ -65,19 +64,10 @@ TEST(RestContextTest, SetMetadataFull) {
                   Pair("x-goog-request-params", ElementsAre("p1=v1&p2=v2")),
                   Pair("x-goog-user-project", ElementsAre("user-project")),
                   Pair("x-goog-quota-user", ElementsAre("quota-user")),
-                  Pair("x-goog-api-key", ElementsAre("api-key")),
                   Pair("x-goog-fieldmask", ElementsAre("items.name,token")),
                   Pair("x-server-timeout", ElementsAre("1.050")),
                   Pair("custom-header-1", ElementsAre("v1")),
                   Pair("custom-header-2", ElementsAre("v2"))));
-}
-
-TEST(RestContextTest, Regression14745) {
-  RestContext lhs;
-  SetMetadata(lhs, Options{}.set<ApiKeyOption>("api-key"), {},
-              "api-client-header");
-  EXPECT_THAT(lhs.headers(),
-              Contains(Pair("x-goog-api-key", ElementsAre("api-key"))));
 }
 
 }  // namespace

--- a/google/cloud/internal/rest_set_metadata_test.cc
+++ b/google/cloud/internal/rest_set_metadata_test.cc
@@ -25,7 +25,6 @@ namespace rest_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-using ::testing::Contains;
 using ::testing::ElementsAre;
 using ::testing::Pair;
 using ::testing::UnorderedElementsAre;


### PR DESCRIPTION
Part of the work for #14759 

This is breaking at HEAD, but note that `ApiKeyOption` has not been released yet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14761)
<!-- Reviewable:end -->
