### PR TITLE
impl: add ApiKeyConfig, implement in gRPC

### DIFF
--- a/google/cloud/internal/credentials_impl.cc
+++ b/google/cloud/internal/credentials_impl.cc
@@ -97,6 +97,10 @@ ExternalAccountConfig::ExternalAccountConfig(std::string json_object,
     : json_object_(std::move(json_object)),
       options_(PopulateAuthOptions(std::move(options))) {}
 
+ApiKeyConfig::ApiKeyConfig(std::string api_key, Options opts)
+    : api_key_(std::move(api_key)),
+      options_(PopulateAuthOptions(std::move(opts))) {}
+
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud

--- a/google/cloud/internal/credentials_impl.h
+++ b/google/cloud/internal/credentials_impl.h
@@ -39,6 +39,7 @@ class AccessTokenConfig;
 class ImpersonateServiceAccountConfig;
 class ServiceAccountConfig;
 class ExternalAccountConfig;
+class ApiKeyConfig;
 
 std::shared_ptr<Credentials> MakeErrorCredentials(Status error_status);
 
@@ -52,6 +53,7 @@ class CredentialsVisitor {
   virtual void visit(ImpersonateServiceAccountConfig const&) = 0;
   virtual void visit(ServiceAccountConfig const&) = 0;
   virtual void visit(ExternalAccountConfig const&) = 0;
+  virtual void visit(ApiKeyConfig const&) = 0;
 
   static void dispatch(Credentials const& credentials,
                        CredentialsVisitor& visitor);
@@ -163,6 +165,21 @@ class ExternalAccountConfig : public Credentials {
   void dispatch(CredentialsVisitor& v) const override { v.visit(*this); }
 
   std::string json_object_;
+  Options options_;
+};
+
+class ApiKeyConfig : public Credentials {
+ public:
+  ApiKeyConfig(std::string api_key, Options opts);
+  ~ApiKeyConfig() override = default;
+
+  std::string const& api_key() const { return api_key_; }
+  Options const& options() const { return options_; }
+
+ private:
+  void dispatch(CredentialsVisitor& v) const override { v.visit(*this); }
+
+  std::string api_key_;
   Options options_;
 };
 

--- a/google/cloud/internal/grpc_api_key_authentication_test.cc
+++ b/google/cloud/internal/grpc_api_key_authentication_test.cc
@@ -25,6 +25,7 @@ namespace {
 
 using ::google::cloud::testing_util::ValidateMetadataFixture;
 using ::testing::Contains;
+using ::testing::IsNull;
 using ::testing::NotNull;
 using ::testing::Pair;
 
@@ -40,6 +41,7 @@ TEST(GrpcApiKeyAuthenticationTest, ConfigureContext) {
 
   grpc::ClientContext context;
   EXPECT_STATUS_OK(auth.ConfigureContext(context));
+  EXPECT_THAT(context.credentials(), IsNull());
 
   ValidateMetadataFixture fixture;
   auto headers = fixture.GetMetadata(context);

--- a/google/cloud/internal/unified_grpc_credentials.cc
+++ b/google/cloud/internal/unified_grpc_credentials.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/grpc_error_delegate.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/grpc_access_token_authentication.h"
+#include "google/cloud/internal/grpc_api_key_authentication.h"
 #include "google/cloud/internal/grpc_channel_credentials_authentication.h"
 #include "google/cloud/internal/grpc_impersonate_service_account.h"
 #include "google/cloud/internal/grpc_service_account_authentication.h"
@@ -124,6 +125,9 @@ std::shared_ptr<GrpcAuthenticationStrategy> CreateAuthenticationStrategy(
           grpc::CompositeChannelCredentials(
               grpc::SslCredentials(ssl_options),
               GrpcExternalAccountCredentials(cfg)));
+    }
+    void visit(ApiKeyConfig const& cfg) override {
+      result = std::make_unique<GrpcApiKeyAuthentication>(cfg.api_key());
     }
   } visitor(std::move(cq), std::move(options));
 

--- a/google/cloud/internal/unified_rest_credentials.cc
+++ b/google/cloud/internal/unified_rest_credentials.cc
@@ -31,6 +31,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::google::cloud::internal::AccessTokenConfig;
+using ::google::cloud::internal::ApiKeyConfig;
 using ::google::cloud::internal::CredentialsVisitor;
 using ::google::cloud::internal::ErrorCredentialsConfig;
 using ::google::cloud::internal::ExternalAccountConfig;
@@ -134,6 +135,11 @@ std::shared_ptr<oauth2_internal::Credentials> MapCredentials(
           std::make_shared<oauth2_internal::ExternalAccountCredentials>(
               *std::move(info), std::move(client_factory_), cfg.options()),
           cfg.options());
+    }
+
+    void visit(ApiKeyConfig const&) override {
+      // TODO(#14759) - Support API key authentication over REST
+      result = std::make_shared<oauth2_internal::AnonymousCredentials>();
     }
 
    private:

--- a/google/cloud/storage/internal/unified_rest_credentials.cc
+++ b/google/cloud/storage/internal/unified_rest_credentials.cc
@@ -37,6 +37,7 @@ namespace internal {
 namespace {
 
 using ::google::cloud::internal::AccessTokenConfig;
+using ::google::cloud::internal::ApiKeyConfig;
 using ::google::cloud::internal::CredentialsVisitor;
 using ::google::cloud::internal::ErrorCredentialsConfig;
 using ::google::cloud::internal::ExternalAccountConfig;
@@ -133,6 +134,10 @@ std::shared_ptr<oauth2::Credentials> MapCredentials(
           *info, std::move(client_factory_), cfg.options());
       result = std::make_shared<WrapRestCredentials>(
           Decorate(std::move(impl), cfg.options()));
+    }
+    void visit(internal::ApiKeyConfig const&) override {
+      // TODO(#14759) - Support API key authentication over REST
+      result = google::cloud::storage::oauth2::CreateAnonymousCredentials();
     }
 
    private:

--- a/google/cloud/testing_util/credentials.h
+++ b/google/cloud/testing_util/credentials.h
@@ -30,6 +30,7 @@ struct TestCredentialsVisitor : public internal::CredentialsVisitor {
   AccessToken access_token;
   internal::ImpersonateServiceAccountConfig const* impersonate = nullptr;
   std::string json_object;
+  std::string api_key;
   Options options;
 
   void visit(internal::ErrorCredentialsConfig const&) override {
@@ -58,6 +59,10 @@ struct TestCredentialsVisitor : public internal::CredentialsVisitor {
     name = "ExternalAccountConfig";
     json_object = cfg.json_object();
     options = cfg.options();
+  }
+  void visit(internal::ApiKeyConfig const& cfg) override {
+    name = "ApiKeyConfig";
+    api_key = cfg.api_key();
   }
 };
 


### PR DESCRIPTION
Part of the work for #14759 

We implement the gRPC half only.

We short-circuit the REST half because
- None of the services for which we use REST transport support API keys.
- The REST half requires some refactoring to `oauth2_internal::Credentials`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14778)
<!-- Reviewable:end -->
