### PR TITLE
feat: API key authentication

### DIFF
--- a/examples/api_key.cc
+++ b/examples/api_key.cc
@@ -21,8 +21,7 @@
 // [END apikeys_create_api_key]
 // [START apikeys_authenticate_api_key]
 #include "google/cloud/language/v1/language_client.h"
-#include "google/cloud/common_options.h"
-#include "google/cloud/grpc_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/options.h"
 
 // [END apikeys_authenticate_api_key]
@@ -83,10 +82,8 @@ void AuthenticateWithApiKey(std::vector<std::string> const& argv) {
         "authenticate-with-api-key <project-id> <api-key>"};
   }
   namespace gc = ::google::cloud;
-  auto options =
-      gc::Options{}
-          .set<gc::GrpcCredentialOption>(grpc::SslCredentials({}))
-          .set<gc::CustomHeadersOption>({{"x-goog-api-key", argv[1]}});
+  auto options = gc::Options{}.set<gc::UnifiedCredentialsOption>(
+      gc::MakeApiKeyCredentials(argv[1]));
   auto client = gc::language_v1::LanguageServiceClient(
       gc::language_v1::MakeLanguageServiceConnection(options));
 

--- a/google/cloud/credentials.cc
+++ b/google/cloud/credentials.cc
@@ -57,6 +57,12 @@ std::shared_ptr<Credentials> MakeExternalAccountCredentials(
       std::move(json_object), std::move(opts));
 }
 
+std::shared_ptr<Credentials> MakeApiKeyCredentials(std::string api_key,
+                                                   Options opts) {
+  return std::make_shared<internal::ApiKeyConfig>(std::move(api_key),
+                                                  std::move(opts));
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/credentials.h
+++ b/google/cloud/credentials.h
@@ -277,6 +277,27 @@ std::shared_ptr<Credentials> MakeExternalAccountCredentials(
     std::string json_object, Options opts = {});
 
 /**
+ * Create credentials that authenticate using an [API key].
+ *
+ * API keys are convenient because no [principal] is needed. The API key
+ * associates the request with a Google Cloud project for billing and quota
+ * purposes.
+ *
+ * @note Most Cloud APIs do not support API keys, instead requiring full
+ * credentials.
+ *
+ * @note This authentication scheme does not involve access tokens. The returned
+ * `Credentials` are incompatible with an `oauth2::AccessTokenGenerator`.
+ *
+ * @ingroup guac
+ *
+ * [API key]: https://cloud.google.com/docs/authentication/api-keys-use
+ * [principal]: https://cloud.google.com/docs/authentication#principal
+ */
+std::shared_ptr<Credentials> MakeApiKeyCredentials(std::string api_key,
+                                                   Options opts = {});
+
+/**
  * Configure the delegates for `MakeImpersonateServiceAccountCredentials()`
  *
  * @ingroup options

--- a/google/cloud/internal/credentials_impl_test.cc
+++ b/google/cloud/internal/credentials_impl_test.cc
@@ -30,7 +30,7 @@ using ::testing::IsNull;
 TEST(Credentials, ErrorCredentials) {
   TestCredentialsVisitor visitor;
 
-  auto credentials = internal::MakeErrorCredentials({});
+  auto credentials = MakeErrorCredentials({});
   CredentialsVisitor::dispatch(*credentials, visitor);
   EXPECT_EQ("ErrorCredentialsConfig", visitor.name);
 }
@@ -111,6 +111,15 @@ TEST(Credentials, ExternalAccount) {
   EXPECT_EQ("test-only-invalid", visitor.json_object);
   EXPECT_THAT(visitor.options.get<ScopesOption>(),
               ElementsAre("scope1", "scope2"));
+}
+
+TEST(Credentials, ApiKeyCredentials) {
+  TestCredentialsVisitor visitor;
+
+  auto credentials = MakeApiKeyCredentials("api-key");
+  CredentialsVisitor::dispatch(*credentials, visitor);
+  EXPECT_EQ("ApiKeyConfig", visitor.name);
+  EXPECT_EQ("api-key", visitor.api_key);
 }
 
 }  // namespace


### PR DESCRIPTION
Part of the work for #14759 

Introduce a dedicated API for authenticating with API keys.

Update the sample because it doubles as an integration test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14779)
<!-- Reviewable:end -->
