### PR TITLE
feat(oauth2): add support for external account workforce identity

### DIFF
--- a/google/cloud/internal/oauth2_external_account_credentials.cc
+++ b/google/cloud/internal/oauth2_external_account_credentials.cc
@@ -97,9 +97,9 @@ StatusOr<ExternalAccountInfo> ParseExternalAccountConfiguration(
   if (!source) return std::move(source).status();
 
   absl::optional<std::string> workforce_pool_user_project;
-  auto up_it = json.find("workforce_pool_user_project");
-  if (up_it != json.end()) {
-    workforce_pool_user_project = *up_it;
+  auto it = json.find("workforce_pool_user_project");
+  if (it != json.end()) {
+    workforce_pool_user_project = it->get<std::string>();
   }
 
   auto info = ExternalAccountInfo{*std::move(audience),
@@ -110,7 +110,7 @@ StatusOr<ExternalAccountInfo> ParseExternalAccountConfiguration(
                                   *std::move(universe_domain),
                                   std::move(workforce_pool_user_project)};
 
-  auto it = json.find("service_account_impersonation_url");
+  it = json.find("service_account_impersonation_url");
   if (it == json.end()) return info;
 
   auto constexpr kDefaultImpersonationTokenLifetime =
@@ -158,8 +158,9 @@ StatusOr<AccessToken> ExternalAccountCredentials::GetToken(
       {"subject_token", subject_token->token},
   };
 
-  // Workforce Identity is handled at org level, it requires userProject in
-  // header. Workload Identity is handled at project level, it doesn't require.
+  // Workforce Identity is handled at the org level and requires the userProject
+  // header. Workload Identity is handled at the project level and doesn't
+  // require the header.
   if (info_.workforce_pool_user_project) {
     form_data.emplace_back(
         "options", absl::StrCat(R"({"userProject": ")",

--- a/google/cloud/internal/oauth2_external_account_credentials.cc
+++ b/google/cloud/internal/oauth2_external_account_credentials.cc
@@ -24,7 +24,7 @@
 #include "google/cloud/internal/oauth2_universe_domain.h"
 #include "google/cloud/internal/parse_rfc3339.h"
 #include "google/cloud/internal/rest_client.h"
-#include "absl/strings/str_format.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include <nlohmann/json.hpp>
 
 namespace google {
@@ -163,8 +163,7 @@ StatusOr<AccessToken> ExternalAccountCredentials::GetToken(
   // header. Workload Identity is handled at project level, it doesn't require.
   if (info_.workforce_pool_user_project) {
     form_data.emplace_back("options",
-                           absl::StrFormat(R"({"userProject": "%s"})",
-                                           *info_.workforce_pool_user_project));
+                           absl::StrCat(R"({"userProject": ")", *info_.workforce_pool_user_project, R"("})"));
   }
 
   auto request =

--- a/google/cloud/internal/oauth2_external_account_credentials.cc
+++ b/google/cloud/internal/oauth2_external_account_credentials.cc
@@ -109,7 +109,7 @@ StatusOr<ExternalAccountInfo> ParseExternalAccountConfiguration(
                                   *std::move(source),
                                   absl::nullopt,
                                   *std::move(universe_domain),
-                                  workforce_pool_user_project};
+                                  std::move(workforce_pool_user_project)};
 
   auto it = json.find("service_account_impersonation_url");
   if (it == json.end()) return info;

--- a/google/cloud/internal/oauth2_external_account_credentials.cc
+++ b/google/cloud/internal/oauth2_external_account_credentials.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/internal/oauth2_universe_domain.h"
 #include "google/cloud/internal/parse_rfc3339.h"
 #include "google/cloud/internal/rest_client.h"
-#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include <nlohmann/json.hpp>
 
 namespace google {
@@ -162,8 +161,9 @@ StatusOr<AccessToken> ExternalAccountCredentials::GetToken(
   // Workforce Identity is handled at org level, it requires userProject in
   // header. Workload Identity is handled at project level, it doesn't require.
   if (info_.workforce_pool_user_project) {
-    form_data.emplace_back("options",
-                           absl::StrCat(R"({"userProject": ")", *info_.workforce_pool_user_project, R"("})"));
+    form_data.emplace_back(
+        "options", absl::StrCat(R"({"userProject": ")",
+                                *info_.workforce_pool_user_project, R"("})"));
   }
 
   auto request =

--- a/google/cloud/internal/oauth2_external_account_credentials.h
+++ b/google/cloud/internal/oauth2_external_account_credentials.h
@@ -68,6 +68,7 @@ struct ExternalAccountInfo {
   ExternalAccountTokenSource token_source;
   absl::optional<ExternalAccountImpersonationConfig> impersonation_config;
   std::string universe_domain;
+  absl::optional<std::string> workforce_pool_user_project;
 };
 
 /// Parse a JSON string with an external account configuration.


### PR DESCRIPTION
External account has two types of identities:

Workload Identity - 3rd party identities that represent a workload, the configs for this are all handled at a project level

Workforce Identity - 3rd party identities that represent a user, configs for this are handled at the org level

We already support Workload Identity. To support Workforce Identity, I added options `userProject` in the request header.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14800)
<!-- Reviewable:end -->
