### PR TITLE
cleanup(mixin): deduplicate mixin pb headers

### DIFF
--- a/generator/internal/stub_generator.cc
+++ b/generator/internal/stub_generator.cc
@@ -77,9 +77,14 @@ Status StubGenerator::GenerateHeader() {
   std::vector<std::string> mixin_headers =
       absl::StrSplit(vars("mixin_proto_grpc_header_paths"), ',');
   HeaderSystemIncludes(mixin_headers);
+  bool include_lro_header =
+      HasLongrunningMethod() &&
+      std::find(mixin_headers.begin(), mixin_headers.end(),
+                "google/longrunning/operations.grpc.pb.h") ==
+          mixin_headers.end();
   HeaderSystemIncludes(
       {vars("proto_grpc_header_path"),
-       HasLongrunningMethod() ? "google/longrunning/operations.grpc.pb.h" : "",
+       include_lro_header ? "google/longrunning/operations.grpc.pb.h" : "",
        "memory", "utility"});
 
   auto result = HeaderOpenNamespaces(NamespaceType::kInternal);

--- a/generator/internal/stub_rest_generator.cc
+++ b/generator/internal/stub_rest_generator.cc
@@ -58,11 +58,15 @@ Status StubRestGenerator::GenerateHeader() {
   std::vector<std::string> mixin_headers =
       absl::StrSplit(vars("mixin_proto_header_paths"), ',');
   HeaderSystemIncludes(mixin_headers);
-  HeaderSystemIncludes({vars("proto_header_path"),
-                        HasLongrunningMethod()
-                            ? vars("longrunning_operation_include_header")
-                            : "",
-                        "memory"});
+  bool include_lro_header =
+      HasLongrunningMethod() &&
+      std::find(mixin_headers.begin(), mixin_headers.end(),
+                vars("longrunning_operation_include_header")) ==
+          mixin_headers.end();
+  HeaderSystemIncludes(
+      {vars("proto_header_path"),
+       include_lro_header ? vars("longrunning_operation_include_header") : "",
+       "memory"});
 
   auto result = HeaderOpenNamespaces(NamespaceType::kInternal);
   if (!result.ok()) return result;


### PR DESCRIPTION
Prevent `pb` headers introduced by Mixin from being included twice.

This cleanup won't affect existing generated code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14819)
<!-- Reviewable:end -->
