### PR TITLE
feat: prepare for breaking change in Protobuf C++ API.

### DIFF
--- a/google/cloud/spanner/internal/status_utils.cc
+++ b/google/cloud/spanner/internal/status_utils.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/grpc_error_delegate.h"
 #include "google/cloud/internal/status_payload_keys.h"
 #include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
 #include <google/rpc/error_details.pb.h>
 #include <google/rpc/status.pb.h>
 #include <google/spanner/v1/spanner.pb.h>
@@ -38,7 +39,7 @@ bool IsSessionNotFound(google::cloud::Status const& status) {
     for (google::protobuf::Any const& any : proto.details()) {
       if (any.UnpackTo(&resource_info)) {
         google::spanner::v1::Session session;
-        auto session_url = "type.googleapis.com/" + session.GetTypeName();
+        auto session_url = absl::StrCat("type.googleapis.com/", session.GetTypeName());
         return resource_info.resource_type() == session_url;
       }
     }

--- a/google/cloud/spanner/internal/status_utils.cc
+++ b/google/cloud/spanner/internal/status_utils.cc
@@ -39,7 +39,8 @@ bool IsSessionNotFound(google::cloud::Status const& status) {
     for (google::protobuf::Any const& any : proto.details()) {
       if (any.UnpackTo(&resource_info)) {
         google::spanner::v1::Session session;
-        auto session_url = absl::StrCat("type.googleapis.com/", session.GetTypeName());
+        auto session_url =
+            absl::StrCat("type.googleapis.com/", session.GetTypeName());
         return resource_info.resource_type() == session_url;
       }
     }

--- a/google/cloud/spanner/internal/status_utils.cc
+++ b/google/cloud/spanner/internal/status_utils.cc
@@ -14,9 +14,9 @@
 
 #include "google/cloud/spanner/internal/status_utils.h"
 #include "google/cloud/grpc_error_delegate.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/status_payload_keys.h"
 #include "absl/strings/match.h"
-#include "absl/strings/str_cat.h"
 #include <google/rpc/error_details.pb.h>
 #include <google/rpc/status.pb.h>
 #include <google/spanner/v1/spanner.pb.h>

--- a/google/cloud/spanner/proto_enum.h
+++ b/google/cloud/spanner/proto_enum.h
@@ -58,8 +58,8 @@ class ProtoEnum {
 
   /// The fully-qualified name of the enum type, scope delimited by periods.
   static std::string const& TypeName() {
-    static std::string const name(Descriptor()->full_name());
-    return name;
+    static std::string const kName(Descriptor()->full_name());
+    return kName;
   }
 
   /// @name Relational operators

--- a/google/cloud/spanner/proto_enum.h
+++ b/google/cloud/spanner/proto_enum.h
@@ -16,7 +16,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_PROTO_ENUM_H
 
 #include "google/cloud/version.h"
-#include "absl/strings/string_view.h"
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/generated_enum_reflection.h>
 #include <ostream>
@@ -58,7 +57,10 @@ class ProtoEnum {
   explicit operator enum_type() const { return v_; }
 
   /// The fully-qualified name of the enum type, scope delimited by periods.
-  static absl::string_view TypeName() { return Descriptor()->full_name(); }
+  static std::string const& TypeName() {
+    static std::string const name(Descriptor()->full_name());
+    return name;
+  }
 
   /// @name Relational operators
   ///@{

--- a/google/cloud/spanner/proto_enum.h
+++ b/google/cloud/spanner/proto_enum.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_PROTO_ENUM_H
 
 #include "google/cloud/version.h"
+#include "absl/strings/string_view.h"
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/generated_enum_reflection.h>
 #include <ostream>
@@ -57,7 +58,7 @@ class ProtoEnum {
   explicit operator enum_type() const { return v_; }
 
   /// The fully-qualified name of the enum type, scope delimited by periods.
-  static std::string const& TypeName() { return Descriptor()->full_name(); }
+  static absl::string_view TypeName() { return Descriptor()->full_name(); }
 
   /// @name Relational operators
   ///@{

--- a/google/cloud/spanner/proto_message.h
+++ b/google/cloud/spanner/proto_message.h
@@ -74,8 +74,8 @@ class ProtoMessage {
 
   /// The fully-qualified name of the message type, scope delimited by periods.
   static std::string const& TypeName() {
-    static std::string const name(message_type::GetDescriptor()->full_name());
-    return name;
+    static std::string const kName(message_type::GetDescriptor()->full_name());
+    return kName;
   }
 
   /// @name Relational operators

--- a/google/cloud/spanner/proto_message.h
+++ b/google/cloud/spanner/proto_message.h
@@ -17,7 +17,6 @@
 
 #include "google/cloud/internal/debug_string_protobuf.h"
 #include "google/cloud/version.h"
-#include "absl/strings/string_view.h"
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/message.h>
 #include <google/protobuf/util/message_differencer.h>
@@ -74,8 +73,9 @@ class ProtoMessage {
   explicit operator std::string() const { return serialized_message_; }
 
   /// The fully-qualified name of the message type, scope delimited by periods.
-  static absl::string_view TypeName() {
-    return message_type::GetDescriptor()->full_name();
+  static std::string const& TypeName() {
+    static std::string const name(message_type::GetDescriptor()->full_name());
+    return name;
   }
 
   /// @name Relational operators

--- a/google/cloud/spanner/proto_message.h
+++ b/google/cloud/spanner/proto_message.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/internal/debug_string_protobuf.h"
 #include "google/cloud/version.h"
+#include "absl/strings/string_view.h"
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/message.h>
 #include <google/protobuf/util/message_differencer.h>
@@ -73,7 +74,7 @@ class ProtoMessage {
   explicit operator std::string() const { return serialized_message_; }
 
   /// The fully-qualified name of the message type, scope delimited by periods.
-  static std::string const& TypeName() {
+  static absl::string_view TypeName() {
     return message_type::GetDescriptor()->full_name();
   }
 

--- a/google/cloud/spanner/testing/status_utils.cc
+++ b/google/cloud/spanner/testing/status_utils.cc
@@ -26,7 +26,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 grpc::Status SessionNotFoundRpcError(std::string name) {
   google::spanner::v1::Session session;
-  auto session_url = absl::StrCat("type.googleapis.com/", session.GetTypeName());
+  auto session_url =
+      absl::StrCat("type.googleapis.com/", session.GetTypeName());
 
   google::rpc::ResourceInfo resource_info;
   resource_info.set_resource_type(session_url);

--- a/google/cloud/spanner/testing/status_utils.cc
+++ b/google/cloud/spanner/testing/status_utils.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/spanner/testing/status_utils.h"
 #include "google/cloud/grpc_error_delegate.h"
+#include "absl/strings/str_cat.h"
 #include <google/rpc/error_details.pb.h>
 #include <google/rpc/status.pb.h>
 #include <google/spanner/v1/spanner.pb.h>
@@ -25,7 +26,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 grpc::Status SessionNotFoundRpcError(std::string name) {
   google::spanner::v1::Session session;
-  auto session_url = "type.googleapis.com/" + session.GetTypeName();
+  auto session_url = absl::StrCat("type.googleapis.com/", session.GetTypeName());
 
   google::rpc::ResourceInfo resource_info;
   resource_info.set_resource_type(session_url);

--- a/google/cloud/spanner/testing/status_utils.cc
+++ b/google/cloud/spanner/testing/status_utils.cc
@@ -14,7 +14,7 @@
 
 #include "google/cloud/spanner/testing/status_utils.h"
 #include "google/cloud/grpc_error_delegate.h"
-#include "absl/strings/str_cat.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include <google/rpc/error_details.pb.h>
 #include <google/rpc/status.pb.h>
 #include <google/spanner/v1/spanner.pb.h>


### PR DESCRIPTION
Protobuf 6.30.0 will change the return types of Descriptor::name() and other methods to absl::string_view. This makes the code work both before and after such a change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14828)
<!-- Reviewable:end -->
