### PR TITLE
cleanup(quickstart): disable speech_quickstart_global

### DIFF
--- a/google/cloud/speech/CMakeLists.txt
+++ b/google/cloud/speech/CMakeLists.txt
@@ -25,8 +25,9 @@ if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(speech_quickstart "quickstart/quickstart.cc")
     target_link_libraries(speech_quickstart PRIVATE google-cloud-cpp::speech)
     google_cloud_cpp_add_common_options(speech_quickstart)
-    # TODO(#14841): add this back when the test on CI is recovered. add_test(
-    # NAME speech_quickstart_global COMMAND cmake -P
+    # TODO(#14841): add this back when the test on CI is recovered.
+
+    # add_test( NAME speech_quickstart_global COMMAND cmake -P
     # "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
     # $<TARGET_FILE:speech_quickstart> GOOGLE_CLOUD_PROJECT
     # GOOGLE_CLOUD_CPP_TEST_GLOBAL)

--- a/google/cloud/speech/CMakeLists.txt
+++ b/google/cloud/speech/CMakeLists.txt
@@ -25,14 +25,13 @@ if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(speech_quickstart "quickstart/quickstart.cc")
     target_link_libraries(speech_quickstart PRIVATE google-cloud-cpp::speech)
     google_cloud_cpp_add_common_options(speech_quickstart)
-    add_test(
-        NAME speech_quickstart_global
-        COMMAND
-            cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
-            $<TARGET_FILE:speech_quickstart> GOOGLE_CLOUD_PROJECT
-            GOOGLE_CLOUD_CPP_TEST_GLOBAL)
-    set_tests_properties(speech_quickstart_global
-                         PROPERTIES LABELS "integration-test;quickstart")
+    # TODO(#14841): add this back when the test on CI is recovered. add_test(
+    # NAME speech_quickstart_global COMMAND cmake -P
+    # "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+    # $<TARGET_FILE:speech_quickstart> GOOGLE_CLOUD_PROJECT
+    # GOOGLE_CLOUD_CPP_TEST_GLOBAL)
+    # set_tests_properties(speech_quickstart_global PROPERTIES LABELS
+    # "integration-test;quickstart")
     add_test(
         NAME speech_quickstart_regional
         COMMAND


### PR DESCRIPTION
Our ci failed in running quickstart-production-pr, although we can succeed locally. See #14841.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14842)
<!-- Reviewable:end -->
