### PR TITLE
impl(generator): push and pop deprecated pragma when needed

### DIFF
--- a/generator/integration_tests/golden/golden_kitchen_sink_client.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_GOLDEN_KITCHEN_SINK_CLIENT_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_GOLDEN_KITCHEN_SINK_CLIENT_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/golden_kitchen_sink_connection.h"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_client.h"
 
@@ -37,5 +38,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_GOLDEN_KITCHEN_SINK_CLIENT_H

--- a/generator/integration_tests/golden/golden_kitchen_sink_connection.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_GOLDEN_KITCHEN_SINK_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_GOLDEN_KITCHEN_SINK_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/golden_kitchen_sink_connection_idempotency_policy.h"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_connection.h"
 
@@ -46,5 +47,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_GOLDEN_KITCHEN_SINK_CONNECTION_H

--- a/generator/integration_tests/golden/golden_kitchen_sink_connection_idempotency_policy.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection_idempotency_policy.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_GOLDEN_KITCHEN_SINK_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_GOLDEN_KITCHEN_SINK_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_connection_idempotency_policy.h"
 
 namespace google {
@@ -36,5 +37,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_GOLDEN_KITCHEN_SINK_CONNECTION_IDEMPOTENCY_POLICY_H

--- a/generator/integration_tests/golden/golden_kitchen_sink_options.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_options.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_GOLDEN_KITCHEN_SINK_OPTIONS_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_GOLDEN_KITCHEN_SINK_OPTIONS_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/golden_kitchen_sink_connection.h"
 #include "generator/integration_tests/golden/golden_kitchen_sink_connection_idempotency_policy.h"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_options.h"
@@ -44,5 +45,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_GOLDEN_KITCHEN_SINK_OPTIONS_H

--- a/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_connection.h
+++ b/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_MOCKS_MOCK_GOLDEN_KITCHEN_SINK_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_MOCKS_MOCK_GOLDEN_KITCHEN_SINK_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/golden_kitchen_sink_connection.h"
 #include "generator/integration_tests/golden/v1/mocks/mock_golden_kitchen_sink_connection.h"
 
@@ -37,5 +38,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_mocks
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_MOCKS_MOCK_GOLDEN_KITCHEN_SINK_CONNECTION_H

--- a/generator/integration_tests/golden/v1/deprecated_client.cc
+++ b/generator/integration_tests/golden/v1/deprecated_client.cc
@@ -43,3 +43,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/deprecated_client.h
+++ b/generator/integration_tests/golden/v1/deprecated_client.h
@@ -123,5 +123,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_DEPRECATED_CLIENT_H

--- a/generator/integration_tests/golden/v1/deprecated_connection.cc
+++ b/generator/integration_tests/golden/v1/deprecated_connection.cc
@@ -64,3 +64,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/deprecated_connection.h
+++ b/generator/integration_tests/golden/v1/deprecated_connection.h
@@ -207,5 +207,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_DEPRECATED_CONNECTION_H

--- a/generator/integration_tests/golden/v1/deprecated_connection_idempotency_policy.cc
+++ b/generator/integration_tests/golden/v1/deprecated_connection_idempotency_policy.cc
@@ -47,3 +47,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/deprecated_connection_idempotency_policy.h
+++ b/generator/integration_tests/golden/v1/deprecated_connection_idempotency_policy.h
@@ -48,5 +48,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_DEPRECATED_CONNECTION_IDEMPOTENCY_POLICY_H

--- a/generator/integration_tests/golden/v1/deprecated_options.h
+++ b/generator/integration_tests/golden/v1/deprecated_options.h
@@ -73,5 +73,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_DEPRECATED_OPTIONS_H

--- a/generator/integration_tests/golden/v1/deprecated_rest_connection.cc
+++ b/generator/integration_tests/golden/v1/deprecated_rest_connection.cc
@@ -56,3 +56,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/deprecated_rest_connection.h
+++ b/generator/integration_tests/golden/v1/deprecated_rest_connection.h
@@ -61,5 +61,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_DEPRECATED_REST_CONNECTION_H

--- a/generator/integration_tests/golden/v1/golden_kitchen_sink_client.cc
+++ b/generator/integration_tests/golden/v1/golden_kitchen_sink_client.cc
@@ -17,6 +17,8 @@
 // source: generator/integration_tests/test.proto
 
 #include "google/cloud/internal/disable_deprecation_warnings.inc"
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_client.h"
 #include <memory>
 #include <utility>
@@ -212,3 +214,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/golden_kitchen_sink_client.h
+++ b/generator/integration_tests/golden/v1/golden_kitchen_sink_client.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_GOLDEN_KITCHEN_SINK_CLIENT_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_GOLDEN_KITCHEN_SINK_CLIENT_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_connection.h"
 #include "google/cloud/future.h"
 #include "google/cloud/options.h"
@@ -909,5 +910,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_GOLDEN_KITCHEN_SINK_CLIENT_H

--- a/generator/integration_tests/golden/v1/golden_kitchen_sink_connection.cc
+++ b/generator/integration_tests/golden/v1/golden_kitchen_sink_connection.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: generator/integration_tests/test.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_connection.h"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_options.h"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_connection_impl.h"
@@ -151,3 +152,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/golden_kitchen_sink_connection.h
+++ b/generator/integration_tests/golden/v1/golden_kitchen_sink_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_GOLDEN_KITCHEN_SINK_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_GOLDEN_KITCHEN_SINK_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_connection_idempotency_policy.h"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_retry_traits.h"
 #include "google/cloud/backoff_policy.h"
@@ -253,5 +254,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_GOLDEN_KITCHEN_SINK_CONNECTION_H

--- a/generator/integration_tests/golden/v1/golden_kitchen_sink_connection_idempotency_policy.cc
+++ b/generator/integration_tests/golden/v1/golden_kitchen_sink_connection_idempotency_policy.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: generator/integration_tests/test.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_connection_idempotency_policy.h"
 #include <memory>
 
@@ -90,3 +91,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/golden_kitchen_sink_connection_idempotency_policy.h
+++ b/generator/integration_tests/golden/v1/golden_kitchen_sink_connection_idempotency_policy.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_GOLDEN_KITCHEN_SINK_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_GOLDEN_KITCHEN_SINK_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/idempotency.h"
 #include "google/cloud/version.h"
 #include <generator/integration_tests/test.grpc.pb.h>
@@ -83,5 +84,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_GOLDEN_KITCHEN_SINK_CONNECTION_IDEMPOTENCY_POLICY_H

--- a/generator/integration_tests/golden/v1/golden_kitchen_sink_options.h
+++ b/generator/integration_tests/golden/v1/golden_kitchen_sink_options.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_GOLDEN_KITCHEN_SINK_OPTIONS_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_GOLDEN_KITCHEN_SINK_OPTIONS_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_connection.h"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_connection_idempotency_policy.h"
 #include "google/cloud/backoff_policy.h"
@@ -72,5 +73,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_GOLDEN_KITCHEN_SINK_OPTIONS_H

--- a/generator/integration_tests/golden/v1/golden_kitchen_sink_rest_connection.cc
+++ b/generator/integration_tests/golden/v1/golden_kitchen_sink_rest_connection.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: generator/integration_tests/test.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_rest_connection.h"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_options.h"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_option_defaults.h"
@@ -55,3 +56,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/golden_kitchen_sink_rest_connection.h
+++ b/generator/integration_tests/golden/v1/golden_kitchen_sink_rest_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_GOLDEN_KITCHEN_SINK_REST_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_GOLDEN_KITCHEN_SINK_REST_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_connection.h"
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
@@ -60,5 +61,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_GOLDEN_KITCHEN_SINK_REST_CONNECTION_H

--- a/generator/integration_tests/golden/v1/internal/deprecated_auth_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/deprecated_auth_decorator.cc
@@ -45,3 +45,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/internal/deprecated_auth_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/deprecated_auth_decorator.h
@@ -53,5 +53,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_DEPRECATED_AUTH_DECORATOR_H

--- a/generator/integration_tests/golden/v1/internal/deprecated_connection_impl.cc
+++ b/generator/integration_tests/golden/v1/internal/deprecated_connection_impl.cc
@@ -75,3 +75,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/internal/deprecated_connection_impl.h
+++ b/generator/integration_tests/golden/v1/internal/deprecated_connection_impl.h
@@ -62,5 +62,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_DEPRECATED_CONNECTION_IMPL_H

--- a/generator/integration_tests/golden/v1/internal/deprecated_logging_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/deprecated_logging_decorator.cc
@@ -56,3 +56,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/internal/deprecated_logging_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/deprecated_logging_decorator.h
@@ -53,5 +53,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_DEPRECATED_LOGGING_DECORATOR_H

--- a/generator/integration_tests/golden/v1/internal/deprecated_metadata_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/deprecated_metadata_decorator.cc
@@ -71,3 +71,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/internal/deprecated_metadata_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/deprecated_metadata_decorator.h
@@ -60,5 +60,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_DEPRECATED_METADATA_DECORATOR_H

--- a/generator/integration_tests/golden/v1/internal/deprecated_option_defaults.cc
+++ b/generator/integration_tests/golden/v1/internal/deprecated_option_defaults.cc
@@ -62,3 +62,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/internal/deprecated_option_defaults.h
+++ b/generator/integration_tests/golden/v1/internal/deprecated_option_defaults.h
@@ -34,5 +34,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_DEPRECATED_OPTION_DEFAULTS_H

--- a/generator/integration_tests/golden/v1/internal/deprecated_rest_connection_impl.cc
+++ b/generator/integration_tests/golden/v1/internal/deprecated_rest_connection_impl.cc
@@ -57,3 +57,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/internal/deprecated_rest_connection_impl.h
+++ b/generator/integration_tests/golden/v1/internal/deprecated_rest_connection_impl.h
@@ -76,5 +76,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_DEPRECATED_REST_CONNECTION_IMPL_H

--- a/generator/integration_tests/golden/v1/internal/deprecated_rest_logging_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/deprecated_rest_logging_decorator.cc
@@ -53,3 +53,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/internal/deprecated_rest_logging_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/deprecated_rest_logging_decorator.h
@@ -56,5 +56,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_DEPRECATED_REST_LOGGING_DECORATOR_H

--- a/generator/integration_tests/golden/v1/internal/deprecated_rest_metadata_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/deprecated_rest_metadata_decorator.cc
@@ -59,3 +59,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/internal/deprecated_rest_metadata_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/deprecated_rest_metadata_decorator.h
@@ -57,5 +57,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_DEPRECATED_REST_METADATA_DECORATOR_H

--- a/generator/integration_tests/golden/v1/internal/deprecated_rest_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/deprecated_rest_stub.cc
@@ -56,3 +56,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/internal/deprecated_rest_stub.h
+++ b/generator/integration_tests/golden/v1/internal/deprecated_rest_stub.h
@@ -64,5 +64,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_DEPRECATED_REST_STUB_H

--- a/generator/integration_tests/golden/v1/internal/deprecated_rest_stub_factory.cc
+++ b/generator/integration_tests/golden/v1/internal/deprecated_rest_stub_factory.cc
@@ -57,3 +57,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/internal/deprecated_rest_stub_factory.h
+++ b/generator/integration_tests/golden/v1/internal/deprecated_rest_stub_factory.h
@@ -37,5 +37,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_DEPRECATED_REST_STUB_FACTORY_H

--- a/generator/integration_tests/golden/v1/internal/deprecated_retry_traits.h
+++ b/generator/integration_tests/golden/v1/internal/deprecated_retry_traits.h
@@ -39,5 +39,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_DEPRECATED_RETRY_TRAITS_H

--- a/generator/integration_tests/golden/v1/internal/deprecated_sources.cc
+++ b/generator/integration_tests/golden/v1/internal/deprecated_sources.cc
@@ -36,4 +36,5 @@
 #include "generator/integration_tests/golden/v1/internal/deprecated_stub_factory.cc"
 #include "generator/integration_tests/golden/v1/internal/deprecated_tracing_connection.cc"
 #include "generator/integration_tests/golden/v1/internal/deprecated_tracing_stub.cc"
+#include "google/cloud/internal/diagnostics_pop.inc"
 // NOLINTEND(bugprone-suspicious-include)

--- a/generator/integration_tests/golden/v1/internal/deprecated_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/deprecated_stub.cc
@@ -48,3 +48,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/internal/deprecated_stub.h
+++ b/generator/integration_tests/golden/v1/internal/deprecated_stub.h
@@ -61,5 +61,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_DEPRECATED_STUB_H

--- a/generator/integration_tests/golden/v1/internal/deprecated_stub_factory.cc
+++ b/generator/integration_tests/golden/v1/internal/deprecated_stub_factory.cc
@@ -72,3 +72,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/internal/deprecated_stub_factory.h
+++ b/generator/integration_tests/golden/v1/internal/deprecated_stub_factory.h
@@ -39,5 +39,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_DEPRECATED_STUB_FACTORY_H

--- a/generator/integration_tests/golden/v1/internal/deprecated_tracing_connection.cc
+++ b/generator/integration_tests/golden/v1/internal/deprecated_tracing_connection.cc
@@ -57,3 +57,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/internal/deprecated_tracing_connection.h
+++ b/generator/integration_tests/golden/v1/internal/deprecated_tracing_connection.h
@@ -64,5 +64,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_DEPRECATED_TRACING_CONNECTION_H

--- a/generator/integration_tests/golden/v1/internal/deprecated_tracing_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/deprecated_tracing_stub.cc
@@ -59,3 +59,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/internal/deprecated_tracing_stub.h
+++ b/generator/integration_tests/golden/v1/internal/deprecated_tracing_stub.h
@@ -64,5 +64,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_DEPRECATED_TRACING_STUB_H

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_auth_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_auth_decorator.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: generator/integration_tests/test.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_auth_decorator.h"
 #include "google/cloud/internal/async_read_write_stream_auth.h"
 #include "google/cloud/internal/async_streaming_read_rpc_auth.h"
@@ -225,3 +226,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_auth_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_auth_decorator.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_AUTH_DECORATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_AUTH_DECORATOR_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"
 #include "google/cloud/version.h"
@@ -143,5 +144,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_AUTH_DECORATOR_H

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_connection_impl.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_connection_impl.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: generator/integration_tests/test.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_connection_impl.h"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_option_defaults.h"
 #include "google/cloud/background_threads.h"
@@ -279,3 +280,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_connection_impl.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_connection_impl.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_CONNECTION_IMPL_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_CONNECTION_IMPL_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_connection.h"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_connection_idempotency_policy.h"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_options.h"
@@ -108,5 +109,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_CONNECTION_IMPL_H

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_logging_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_logging_decorator.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: generator/integration_tests/test.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_logging_decorator.h"
 #include "google/cloud/internal/async_read_write_stream_logging.h"
 #include "google/cloud/internal/async_streaming_read_rpc_logging.h"
@@ -323,3 +324,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_logging_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_logging_decorator.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_LOGGING_DECORATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_LOGGING_DECORATOR_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.h"
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
@@ -144,5 +145,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_LOGGING_DECORATOR_H

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: generator/integration_tests/test.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
@@ -284,3 +285,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_METADATA_DECORATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_METADATA_DECORATOR_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.h"
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
@@ -150,5 +151,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_METADATA_DECORATOR_H

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_option_defaults.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_option_defaults.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: generator/integration_tests/test.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_option_defaults.h"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_connection.h"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_options.h"
@@ -61,3 +62,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_option_defaults.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_option_defaults.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_OPTION_DEFAULTS_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_OPTION_DEFAULTS_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
 
@@ -33,5 +34,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_OPTION_DEFAULTS_H

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_connection_impl.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_connection_impl.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: generator/integration_tests/test.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_connection_impl.h"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_stub_factory.h"
 #include "google/cloud/common_options.h"
@@ -220,3 +221,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_connection_impl.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_connection_impl.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_REST_CONNECTION_IMPL_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_REST_CONNECTION_IMPL_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_connection.h"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_connection_idempotency_policy.h"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_options.h"
@@ -106,5 +107,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_REST_CONNECTION_IMPL_H

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_logging_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_logging_decorator.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: generator/integration_tests/test.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_logging_decorator.h"
 #include "google/cloud/internal/log_wrapper.h"
 #include "google/cloud/status_or.h"
@@ -192,3 +193,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_logging_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_logging_decorator.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_REST_LOGGING_DECORATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_REST_LOGGING_DECORATOR_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_stub.h"
 #include "google/cloud/future.h"
 #include "google/cloud/internal/rest_context.h"
@@ -95,5 +96,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_REST_LOGGING_DECORATOR_H

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_metadata_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_metadata_decorator.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: generator/integration_tests/test.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_metadata_decorator.h"
 #include "absl/strings/str_format.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
@@ -194,3 +195,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_metadata_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_metadata_decorator.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_REST_METADATA_DECORATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_REST_METADATA_DECORATOR_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_stub.h"
 #include "google/cloud/future.h"
 #include "google/cloud/rest_options.h"
@@ -96,5 +97,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_REST_METADATA_DECORATOR_H

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_stub.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: generator/integration_tests/test.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_stub.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
@@ -170,3 +171,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_stub.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_stub.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_REST_STUB_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_REST_STUB_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/internal/rest_client.h"
 #include "google/cloud/internal/rest_context.h"
@@ -147,5 +148,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_REST_STUB_H

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_stub_factory.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_stub_factory.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: generator/integration_tests/test.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_stub_factory.h"
 #include "absl/strings/match.h"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_logging_decorator.h"
@@ -56,3 +57,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_stub_factory.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_stub_factory.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_REST_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_REST_STUB_FACTORY_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_stub.h"
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
@@ -36,5 +37,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_REST_STUB_FACTORY_H

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_retry_traits.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_retry_traits.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_RETRY_TRAITS_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_RETRY_TRAITS_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/status.h"
 #include "google/cloud/version.h"
 
@@ -38,5 +39,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_RETRY_TRAITS_H

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_round_robin_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_round_robin_decorator.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: generator/integration_tests/test.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_round_robin_decorator.h"
 #include <memory>
 #include <mutex>
@@ -176,3 +177,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_round_robin_decorator.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_round_robin_decorator.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_ROUND_ROBIN_DECORATOR_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_ROUND_ROBIN_DECORATOR_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.h"
 #include "google/cloud/version.h"
 #include <memory>
@@ -144,5 +145,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_ROUND_ROBIN_DECORATOR_H

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_sources.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_sources.cc
@@ -17,6 +17,7 @@
 // source: generator/integration_tests/test.proto
 
 // NOLINTBEGIN(bugprone-suspicious-include)
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_client.cc"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_connection.cc"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_connection_idempotency_policy.cc"
@@ -36,4 +37,5 @@
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub_factory.cc"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_connection.cc"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_stub.cc"
+#include "google/cloud/internal/diagnostics_pop.inc"
 // NOLINTEND(bugprone-suspicious-include)

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: generator/integration_tests/test.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.h"
 #include "google/cloud/grpc_error_delegate.h"
 #include "google/cloud/internal/async_read_write_stream_impl.h"
@@ -259,3 +260,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_STUB_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_STUB_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/async_streaming_read_write_rpc.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/future.h"
@@ -265,5 +266,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_STUB_H

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub_factory.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub_factory.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: generator/integration_tests/test.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub_factory.h"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_auth_decorator.h"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_logging_decorator.h"
@@ -77,3 +78,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub_factory.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub_factory.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_STUB_FACTORY_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"
 #include "google/cloud/options.h"
@@ -38,5 +39,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_STUB_FACTORY_H

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_connection.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_connection.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: generator/integration_tests/test.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_connection.h"
 #include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/internal/traced_stream_range.h"
@@ -153,3 +154,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_connection.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_TRACING_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_TRACING_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_connection.h"
 #include "google/cloud/version.h"
 #include <memory>
@@ -104,5 +105,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_TRACING_CONNECTION_H

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_stub.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_stub.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: generator/integration_tests/test.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_stub.h"
 #include "google/cloud/internal/async_read_write_stream_tracing.h"
 #include "google/cloud/internal/async_streaming_read_rpc_tracing.h"
@@ -257,3 +258,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_stub.h
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_tracing_stub.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_TRACING_STUB_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_TRACING_STUB_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/internal/golden_kitchen_sink_stub.h"
 #include "google/cloud/internal/trace_propagator.h"
 #include "google/cloud/options.h"
@@ -154,5 +155,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_INTERNAL_GOLDEN_KITCHEN_SINK_TRACING_STUB_H

--- a/generator/integration_tests/golden/v1/mocks/mock_deprecated_connection.h
+++ b/generator/integration_tests/golden/v1/mocks/mock_deprecated_connection.h
@@ -56,5 +56,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_mocks
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_MOCKS_MOCK_DEPRECATED_CONNECTION_H

--- a/generator/integration_tests/golden/v1/mocks/mock_golden_kitchen_sink_connection.h
+++ b/generator/integration_tests/golden/v1/mocks/mock_golden_kitchen_sink_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_MOCKS_MOCK_GOLDEN_KITCHEN_SINK_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_MOCKS_MOCK_GOLDEN_KITCHEN_SINK_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_connection.h"
 #include <gmock/gmock.h>
 
@@ -108,5 +109,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_v1_mocks
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_V1_MOCKS_MOCK_GOLDEN_KITCHEN_SINK_CONNECTION_H

--- a/generator/integration_tests/golden/v1/samples/deprecated_client_samples.cc
+++ b/generator/integration_tests/golden/v1/samples/deprecated_client_samples.cc
@@ -144,3 +144,4 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   });
   return example.Run(argc, argv);
 }
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/integration_tests/golden/v1/samples/golden_kitchen_sink_client_samples.cc
+++ b/generator/integration_tests/golden/v1/samples/golden_kitchen_sink_client_samples.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: generator/integration_tests/test.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_client.h"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_connection_idempotency_policy.h"
 #include "generator/integration_tests/golden/v1/golden_kitchen_sink_options.h"
@@ -143,3 +144,4 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   });
   return example.Run(argc, argv);
 }
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/generator/internal/auth_decorator_generator.cc
+++ b/generator/internal/auth_decorator_generator.cc
@@ -79,6 +79,7 @@ class $auth_class_name$ : public $stub_class_name$ {
 )""");
 
   HeaderCloseNamespaces();
+  HeaderPrintDiagnosticsPop();
   // close header guard
   HeaderPrint("\n#endif  // $header_include_guard$\n");
   return {};
@@ -360,6 +361,7 @@ future<Status> $auth_class_name$::AsyncCancelOperation(
   }
 
   CcCloseNamespaces();
+  CcPrintDiagnosticsPop();
   return {};
 }
 

--- a/generator/internal/client_generator.cc
+++ b/generator/internal/client_generator.cc
@@ -392,6 +392,7 @@ R"""(  std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
   HeaderPrint("};\n");
 
   HeaderCloseNamespaces();
+  HeaderPrintDiagnosticsPop();
   // close header guard
   HeaderPrint("\n#endif  // $header_include_guard$\n");
   return {};
@@ -728,6 +729,7 @@ $client_class_name$::Async$method_name$(Options opts) {
   }
 
   CcCloseNamespaces();
+  CcPrintDiagnosticsPop();
   return {};
 }
 

--- a/generator/internal/connection_generator.cc
+++ b/generator/internal/connection_generator.cc
@@ -320,7 +320,7 @@ class $connection_class_name$ {
   }
 
   HeaderCloseNamespaces();
-
+  HeaderPrintDiagnosticsPop();
   // close header guard
   HeaderPrint("\n#endif  // $header_include_guard$\n");
   return {};
@@ -508,7 +508,7 @@ void BigQueryReadReadRowsStreamingUpdater(
 )""");
     CcCloseNamespaces();
   }
-
+  CcPrintDiagnosticsPop();
   return {};
 }
 

--- a/generator/internal/connection_impl_generator.cc
+++ b/generator/internal/connection_impl_generator.cc
@@ -136,7 +136,7 @@ class $connection_class_name$Impl
   HeaderPrint("\n};\n");
 
   HeaderCloseNamespaces();
-
+  HeaderPrintDiagnosticsPop();
   // close header guard
   HeaderPrint("\n#endif  // $header_include_guard$\n");
   return {};
@@ -242,6 +242,7 @@ $connection_class_name$Impl::$connection_class_name$Impl(
   }
 
   CcCloseNamespaces();
+  CcPrintDiagnosticsPop();
   return {};
 }
 

--- a/generator/internal/connection_impl_rest_generator.cc
+++ b/generator/internal/connection_impl_rest_generator.cc
@@ -127,6 +127,7 @@ class $connection_impl_rest_class_name$
 )""");
 
   HeaderCloseNamespaces();
+  HeaderPrintDiagnosticsPop();
   HeaderPrint("\n#endif  // $header_include_guard$\n");
   return {};
 }
@@ -194,6 +195,7 @@ $connection_impl_rest_class_name$::$connection_impl_rest_class_name$(
   }
 
   CcCloseNamespaces();
+  CcPrintDiagnosticsPop();
   return {};
 }
 

--- a/generator/internal/connection_rest_generator.cc
+++ b/generator/internal/connection_rest_generator.cc
@@ -120,6 +120,7 @@ std::shared_ptr<$connection_class_name$> Make$connection_class_name$Rest(
   }
 
   HeaderCloseNamespaces();
+  HeaderPrintDiagnosticsPop();
   // close header guard
   HeaderPrint("\n#endif  // $header_include_guard$\n");
   return {};
@@ -195,6 +196,7 @@ std::shared_ptr<$connection_class_name$> Make$connection_class_name$Rest(
   }
 
   CcCloseNamespaces();
+  CcPrintDiagnosticsPop();
   return {};
 }
 

--- a/generator/internal/forwarding_client_generator.cc
+++ b/generator/internal/forwarding_client_generator.cc
@@ -61,6 +61,7 @@ using ::google::cloud::$product_namespace$::$client_class_name$;
 )""");
 
   HeaderCloseNamespaces();
+  HeaderPrintDiagnosticsPop();
   // close header guard
   HeaderPrint(R"""(
 #endif  // $header_include_guard$

--- a/generator/internal/forwarding_connection_generator.cc
+++ b/generator/internal/forwarding_connection_generator.cc
@@ -92,6 +92,7 @@ using ::google::cloud::$product_namespace$::$retry_policy_name$;
   }
 
   HeaderCloseNamespaces();
+  HeaderPrintDiagnosticsPop();
   // close header guard
   HeaderPrint(R"""(
 #endif  // $header_include_guard$

--- a/generator/internal/forwarding_idempotency_policy_generator.cc
+++ b/generator/internal/forwarding_idempotency_policy_generator.cc
@@ -60,6 +60,7 @@ using ::google::cloud::$product_namespace$::$idempotency_class_name$;
 )""");
 
   HeaderCloseNamespaces();
+  HeaderPrintDiagnosticsPop();
   // close header guard
   HeaderPrint(R"""(
 #endif  // $header_include_guard$

--- a/generator/internal/forwarding_mock_connection_generator.cc
+++ b/generator/internal/forwarding_mock_connection_generator.cc
@@ -60,6 +60,7 @@ using ::google::cloud::$product_namespace$_mocks::$mock_connection_class_name$;
 )""");
 
   HeaderCloseNamespaces();
+  HeaderPrintDiagnosticsPop();
   // close header guard
   HeaderPrint(R"""(
 #endif  // $header_include_guard$

--- a/generator/internal/forwarding_options_generator.cc
+++ b/generator/internal/forwarding_options_generator.cc
@@ -73,6 +73,7 @@ using ::google::cloud::$product_namespace$::$service_name$RetryPolicyOption;
 )""");
 
   HeaderCloseNamespaces();
+  HeaderPrintDiagnosticsPop();
   // close header guard
   HeaderPrint(R"""(
 #endif  // $header_include_guard$

--- a/generator/internal/idempotency_policy_generator.cc
+++ b/generator/internal/idempotency_policy_generator.cc
@@ -111,6 +111,7 @@ Status IdempotencyPolicyGenerator::GenerateHeader() {
   // clang-format on
 
   HeaderCloseNamespaces();
+  HeaderPrintDiagnosticsPop();
   // close header guard
   HeaderPrint("\n#endif  // $header_include_guard$\n");
   return {};
@@ -213,6 +214,7 @@ Idempotency $idempotency_class_name$::$method_name$($request_type$ const&) {
   // clang-format on
 
   CcCloseNamespaces();
+  CcPrintDiagnosticsPop();
   return {};
 }
 

--- a/generator/internal/logging_decorator_generator.cc
+++ b/generator/internal/logging_decorator_generator.cc
@@ -91,6 +91,7 @@ Status LoggingDecoratorGenerator::GenerateHeader() {
   HeaderPrint("};  // $logging_class_name$\n");
 
   HeaderCloseNamespaces();
+  HeaderPrintDiagnosticsPop();
   HeaderPrint("\n#endif  // $header_include_guard$\n");
   return {};
 }
@@ -407,6 +408,7 @@ future<Status> $logging_class_name$::AsyncCancelOperation(
   }
 
   CcCloseNamespaces();
+  CcPrintDiagnosticsPop();
   return {};
 }
 

--- a/generator/internal/logging_decorator_rest_generator.cc
+++ b/generator/internal/logging_decorator_rest_generator.cc
@@ -136,6 +136,7 @@ class $logging_rest_class_name$ : public $stub_rest_class_name$ {
 )""");
 
   HeaderCloseNamespaces();
+  HeaderPrintDiagnosticsPop();
   HeaderPrint("\n#endif  // $header_include_guard$\n");
   return {};
 }
@@ -295,6 +296,7 @@ $logging_rest_class_name$::AsyncCancelOperation(
   }
 
   CcCloseNamespaces();
+  CcPrintDiagnosticsPop();
   return {};
 }
 

--- a/generator/internal/metadata_decorator_generator.cc
+++ b/generator/internal/metadata_decorator_generator.cc
@@ -163,6 +163,7 @@ class $metadata_class_name$ : public $stub_class_name$ {
 )""");
 
   HeaderCloseNamespaces();
+  HeaderPrintDiagnosticsPop();
   // close header guard
   HeaderPrint("\n#endif  // $header_include_guard$\n");
   return {};
@@ -420,6 +421,7 @@ void $metadata_class_name$::SetMetadata(grpc::ClientContext& context,
 )""");
 
   CcCloseNamespaces();
+  CcPrintDiagnosticsPop();
   return {};
 }
 

--- a/generator/internal/metadata_decorator_rest_generator.cc
+++ b/generator/internal/metadata_decorator_rest_generator.cc
@@ -205,6 +205,7 @@ class $metadata_rest_class_name$ : public $stub_rest_class_name$ {
 )""");
 
   HeaderCloseNamespaces();
+  HeaderPrintDiagnosticsPop();
   HeaderPrint("\n#endif  // $header_include_guard$\n");
   return {};
 }
@@ -362,6 +363,7 @@ void $metadata_rest_class_name$::SetMetadata(
 )""");
 
   CcCloseNamespaces();
+  CcPrintDiagnosticsPop();
   return {};
 }
 

--- a/generator/internal/mock_connection_generator.cc
+++ b/generator/internal/mock_connection_generator.cc
@@ -194,6 +194,7 @@ class $mock_connection_class_name$ : public $product_namespace$::$connection_cla
   HeaderPrint("};\n");
 
   HeaderCloseNamespaces();
+  HeaderPrintDiagnosticsPop();
   // close header guard
   HeaderPrint("\n#endif  // $header_include_guard$\n");
   return {};

--- a/generator/internal/option_defaults_generator.cc
+++ b/generator/internal/option_defaults_generator.cc
@@ -72,7 +72,7 @@ Status OptionDefaultsGenerator::GenerateHeader() {
   HeaderPrint("Options options);\n");
 
   HeaderCloseNamespaces();
-
+  HeaderPrintDiagnosticsPop();
   // close header guard
   HeaderPrint("\n#endif  // $header_include_guard$\n");
   return {};
@@ -188,6 +188,7 @@ auto constexpr kBackoffScaling = 2.0;
 )""");
 
   CcCloseNamespaces();
+  CcPrintDiagnosticsPop();
   return {};
 }
 

--- a/generator/internal/options_generator.cc
+++ b/generator/internal/options_generator.cc
@@ -124,6 +124,7 @@ using $service_name$PolicyOptionList =
   }
 
   HeaderCloseNamespaces();
+  HeaderPrintDiagnosticsPop();
   // close header guard
   HeaderPrint("\n#endif  // $header_include_guard$\n");
   return {};

--- a/generator/internal/retry_traits_generator.cc
+++ b/generator/internal/retry_traits_generator.cc
@@ -63,6 +63,7 @@ Status RetryTraitsGenerator::GenerateHeader() {
   );
 
   HeaderCloseNamespaces();
+  HeaderPrintDiagnosticsPop();
   // close header guard
   HeaderPrint("\n#endif  // $header_include_guard$\n");
   return {};

--- a/generator/internal/round_robin_decorator_generator.cc
+++ b/generator/internal/round_robin_decorator_generator.cc
@@ -78,6 +78,7 @@ class $round_robin_class_name$ : public $stub_class_name$ {
 )""");
 
   HeaderCloseNamespaces();
+  HeaderPrintDiagnosticsPop();
   // close header guard
   HeaderPrint("\n#endif  // $header_include_guard$\n");
   return {};
@@ -268,6 +269,7 @@ $round_robin_class_name$::Child() {
 )""");
 
   CcCloseNamespaces();
+  CcPrintDiagnosticsPop();
   return {};
 }
 

--- a/generator/internal/sample_generator.cc
+++ b/generator/internal/sample_generator.cc
@@ -332,6 +332,7 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
 }
 )""");
 
+  HeaderPrintDiagnosticsPop();
   return {};
 }
 

--- a/generator/internal/service_code_generator.h
+++ b/generator/internal/service_code_generator.h
@@ -242,6 +242,11 @@ class ServiceCodeGenerator : public GeneratorInterface {
    */
   bool IsDeprecated() const;
 
+  bool HasDeprecatedRpcs() const;
+
+  void HeaderPrintDiagnosticsPop();
+  void CcPrintDiagnosticsPop();
+
  private:
   void SetMethods();
 
@@ -263,6 +268,7 @@ class ServiceCodeGenerator : public GeneratorInterface {
   std::map<std::string, VarsDictionary> service_method_vars_;
   std::string namespace_;
   bool define_backwards_compatibility_namespace_alias_ = false;
+  bool needs_diagnostics_pop_ = false;
   MethodDescriptorList methods_;
   MethodDescriptorList async_methods_;
   Printer header_;

--- a/generator/internal/sources_generator.cc
+++ b/generator/internal/sources_generator.cc
@@ -55,6 +55,7 @@ Status SourcesGenerator::GenerateHeader() {
   HeaderPrint(R"""(// NOLINTBEGIN(bugprone-suspicious-include)
   )""");
   HeaderLocalIncludes(sources_);
+  HeaderPrintDiagnosticsPop();
   HeaderPrint(R"""(// NOLINTEND(bugprone-suspicious-include)
   )""");
   return Status();

--- a/generator/internal/stub_factory_generator.cc
+++ b/generator/internal/stub_factory_generator.cc
@@ -63,6 +63,7 @@ std::shared_ptr<$stub_class_name$> CreateDefault$stub_class_name$(
 )""");
 
   HeaderCloseNamespaces();
+  HeaderPrintDiagnosticsPop();
   // close header guard
   HeaderPrint("\n#endif  // $header_include_guard$\n");
   return {};
@@ -168,6 +169,7 @@ CreateDefault$stub_class_name$(
 )""");
 
   CcCloseNamespaces();
+  CcPrintDiagnosticsPop();
   return {};
 }
 

--- a/generator/internal/stub_factory_rest_generator.cc
+++ b/generator/internal/stub_factory_rest_generator.cc
@@ -58,6 +58,7 @@ std::shared_ptr<$stub_rest_class_name$> CreateDefault$stub_rest_class_name$(
 )""");
 
   HeaderCloseNamespaces();
+  HeaderPrintDiagnosticsPop();
   // close header guard
   HeaderPrint("\n#endif  // $header_include_guard$\n");
   return {};
@@ -106,6 +107,7 @@ CreateDefault$stub_rest_class_name$(Options const& options) {
 )""");
 
   CcCloseNamespaces();
+  CcPrintDiagnosticsPop();
   return {};
 }
 

--- a/generator/internal/stub_generator.cc
+++ b/generator/internal/stub_generator.cc
@@ -290,6 +290,7 @@ Status StubGenerator::GenerateHeader() {
   HeaderPrint("};\n");
 
   HeaderCloseNamespaces();
+  HeaderPrintDiagnosticsPop();
   // close header guard
   HeaderPrint("\n#endif  // $header_include_guard$\n");
   return {};
@@ -595,6 +596,7 @@ future<Status> Default$stub_class_name$::AsyncCancelOperation(
   }
 
   CcCloseNamespaces();
+  CcPrintDiagnosticsPop();
   return {};
 }
 

--- a/generator/internal/stub_rest_generator.cc
+++ b/generator/internal/stub_rest_generator.cc
@@ -242,6 +242,7 @@ class Default$stub_rest_class_name$ : public $stub_rest_class_name$ {
 )""");
 
   HeaderCloseNamespaces();
+  HeaderPrintDiagnosticsPop();
   // close header guard
   HeaderPrint("\n#endif  // $header_include_guard$\n");
   return {};
@@ -500,6 +501,7 @@ Default$stub_rest_class_name$::AsyncCancelOperation(
   }
 
   CcCloseNamespaces();
+  CcPrintDiagnosticsPop();
   return {};
 }
 

--- a/generator/internal/tracing_connection_generator.cc
+++ b/generator/internal/tracing_connection_generator.cc
@@ -101,7 +101,7 @@ Make$tracing_connection_class_name$(
 )""");
 
   HeaderCloseNamespaces();
-
+  HeaderPrintDiagnosticsPop();
   // close header guard
   HeaderPrint("\n#endif  // $header_include_guard$\n");
   return {};
@@ -162,6 +162,7 @@ Make$tracing_connection_class_name$(
 }
 )""");
   CcCloseNamespaces();
+  CcPrintDiagnosticsPop();
   return {};
 }
 

--- a/generator/internal/tracing_stub_generator.cc
+++ b/generator/internal/tracing_stub_generator.cc
@@ -87,6 +87,7 @@ std::shared_ptr<$stub_class_name$> Make$tracing_stub_class_name$(
 )""");
 
   HeaderCloseNamespaces();
+  HeaderPrintDiagnosticsPop();
   // close header guard
   HeaderPrint("\n#endif  // $header_include_guard$\n");
   return {};
@@ -358,6 +359,7 @@ std::shared_ptr<$stub_class_name$> Make$tracing_stub_class_name$(
 }
 )""");
   CcCloseNamespaces();
+  CcPrintDiagnosticsPop();
   return {};
 }
 

--- a/google/cloud/bigquery/data_transfer_client.h
+++ b/google/cloud/bigquery/data_transfer_client.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATA_TRANSFER_CLIENT_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATA_TRANSFER_CLIENT_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/data_transfer_connection.h"
 #include "google/cloud/bigquery/datatransfer/v1/data_transfer_client.h"
 
@@ -38,5 +39,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATA_TRANSFER_CLIENT_H

--- a/google/cloud/bigquery/data_transfer_connection.h
+++ b/google/cloud/bigquery/data_transfer_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATA_TRANSFER_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATA_TRANSFER_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/data_transfer_connection_idempotency_policy.h"
 #include "google/cloud/bigquery/datatransfer/v1/data_transfer_connection.h"
 
@@ -56,5 +57,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATA_TRANSFER_CONNECTION_H

--- a/google/cloud/bigquery/data_transfer_connection_idempotency_policy.h
+++ b/google/cloud/bigquery/data_transfer_connection_idempotency_policy.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATA_TRANSFER_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATA_TRANSFER_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/datatransfer/v1/data_transfer_connection_idempotency_policy.h"
 
 namespace google {
@@ -42,5 +43,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATA_TRANSFER_CONNECTION_IDEMPOTENCY_POLICY_H

--- a/google/cloud/bigquery/data_transfer_options.h
+++ b/google/cloud/bigquery/data_transfer_options.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATA_TRANSFER_OPTIONS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATA_TRANSFER_OPTIONS_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/data_transfer_connection.h"
 #include "google/cloud/bigquery/data_transfer_connection_idempotency_policy.h"
 #include "google/cloud/bigquery/datatransfer/v1/data_transfer_options.h"
@@ -53,5 +54,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATA_TRANSFER_OPTIONS_H

--- a/google/cloud/bigquery/datatransfer/v1/data_transfer_client.cc
+++ b/google/cloud/bigquery/datatransfer/v1/data_transfer_client.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/bigquery/datatransfer/v1/datatransfer.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/datatransfer/v1/data_transfer_client.h"
 #include <memory>
 #include <utility>
@@ -319,3 +320,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_datatransfer_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/bigquery/datatransfer/v1/data_transfer_client.h
+++ b/google/cloud/bigquery/datatransfer/v1/data_transfer_client.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_DATA_TRANSFER_CLIENT_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_DATA_TRANSFER_CLIENT_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/datatransfer/v1/data_transfer_connection.h"
 #include "google/cloud/future.h"
 #include "google/cloud/options.h"
@@ -1144,5 +1145,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_datatransfer_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_DATA_TRANSFER_CLIENT_H

--- a/google/cloud/bigquery/datatransfer/v1/data_transfer_connection.cc
+++ b/google/cloud/bigquery/datatransfer/v1/data_transfer_connection.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/bigquery/datatransfer/v1/datatransfer.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/datatransfer/v1/data_transfer_connection.h"
 #include "google/cloud/bigquery/datatransfer/v1/data_transfer_options.h"
 #include "google/cloud/bigquery/datatransfer/v1/internal/data_transfer_connection_impl.h"
@@ -188,3 +189,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_datatransfer_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/bigquery/datatransfer/v1/data_transfer_connection.h
+++ b/google/cloud/bigquery/datatransfer/v1/data_transfer_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_DATA_TRANSFER_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_DATA_TRANSFER_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/datatransfer/v1/data_transfer_connection_idempotency_policy.h"
 #include "google/cloud/bigquery/datatransfer/v1/internal/data_transfer_retry_traits.h"
 #include "google/cloud/backoff_policy.h"
@@ -300,5 +301,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_datatransfer_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_DATA_TRANSFER_CONNECTION_H

--- a/google/cloud/bigquery/datatransfer/v1/data_transfer_connection_idempotency_policy.cc
+++ b/google/cloud/bigquery/datatransfer/v1/data_transfer_connection_idempotency_policy.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/bigquery/datatransfer/v1/datatransfer.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/datatransfer/v1/data_transfer_connection_idempotency_policy.h"
 #include <memory>
 
@@ -152,3 +153,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_datatransfer_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/bigquery/datatransfer/v1/data_transfer_connection_idempotency_policy.h
+++ b/google/cloud/bigquery/datatransfer/v1/data_transfer_connection_idempotency_policy.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_DATA_TRANSFER_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_DATA_TRANSFER_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/idempotency.h"
 #include "google/cloud/version.h"
 #include <google/cloud/bigquery/datatransfer/v1/datatransfer.grpc.pb.h>
@@ -116,5 +117,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_datatransfer_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_DATA_TRANSFER_CONNECTION_IDEMPOTENCY_POLICY_H

--- a/google/cloud/bigquery/datatransfer/v1/data_transfer_options.h
+++ b/google/cloud/bigquery/datatransfer/v1/data_transfer_options.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_DATA_TRANSFER_OPTIONS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_DATA_TRANSFER_OPTIONS_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/datatransfer/v1/data_transfer_connection.h"
 #include "google/cloud/bigquery/datatransfer/v1/data_transfer_connection_idempotency_policy.h"
 #include "google/cloud/backoff_policy.h"
@@ -72,5 +73,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_datatransfer_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_DATA_TRANSFER_OPTIONS_H

--- a/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_auth_decorator.cc
+++ b/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_auth_decorator.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/bigquery/datatransfer/v1/datatransfer.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/datatransfer/v1/internal/data_transfer_auth_decorator.h"
 #include <google/cloud/bigquery/datatransfer/v1/datatransfer.grpc.pb.h>
 #include <memory>
@@ -211,3 +212,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_datatransfer_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_auth_decorator.h
+++ b/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_auth_decorator.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_INTERNAL_DATA_TRANSFER_AUTH_DECORATOR_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_INTERNAL_DATA_TRANSFER_AUTH_DECORATOR_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/datatransfer/v1/internal/data_transfer_stub.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"
 #include "google/cloud/version.h"
@@ -145,5 +146,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_datatransfer_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_INTERNAL_DATA_TRANSFER_AUTH_DECORATOR_H

--- a/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_connection_impl.cc
+++ b/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_connection_impl.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/bigquery/datatransfer/v1/datatransfer.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/datatransfer/v1/internal/data_transfer_connection_impl.h"
 #include "google/cloud/bigquery/datatransfer/v1/internal/data_transfer_option_defaults.h"
 #include "google/cloud/background_threads.h"
@@ -456,3 +457,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_datatransfer_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_connection_impl.h
+++ b/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_connection_impl.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_INTERNAL_DATA_TRANSFER_CONNECTION_IMPL_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_INTERNAL_DATA_TRANSFER_CONNECTION_IMPL_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/datatransfer/v1/data_transfer_connection.h"
 #include "google/cloud/bigquery/datatransfer/v1/data_transfer_connection_idempotency_policy.h"
 #include "google/cloud/bigquery/datatransfer/v1/data_transfer_options.h"
@@ -142,5 +143,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_datatransfer_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_INTERNAL_DATA_TRANSFER_CONNECTION_IMPL_H

--- a/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_logging_decorator.cc
+++ b/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_logging_decorator.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/bigquery/datatransfer/v1/datatransfer.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/datatransfer/v1/internal/data_transfer_logging_decorator.h"
 #include "google/cloud/internal/log_wrapper.h"
 #include "google/cloud/status_or.h"
@@ -286,3 +287,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_datatransfer_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_logging_decorator.h
+++ b/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_logging_decorator.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_INTERNAL_DATA_TRANSFER_LOGGING_DECORATOR_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_INTERNAL_DATA_TRANSFER_LOGGING_DECORATOR_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/datatransfer/v1/internal/data_transfer_stub.h"
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
@@ -145,5 +146,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_datatransfer_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_INTERNAL_DATA_TRANSFER_LOGGING_DECORATOR_H

--- a/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_metadata_decorator.cc
+++ b/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_metadata_decorator.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/bigquery/datatransfer/v1/datatransfer.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/datatransfer/v1/internal/data_transfer_metadata_decorator.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
@@ -239,3 +240,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_datatransfer_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_metadata_decorator.h
+++ b/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_metadata_decorator.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_INTERNAL_DATA_TRANSFER_METADATA_DECORATOR_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_INTERNAL_DATA_TRANSFER_METADATA_DECORATOR_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/datatransfer/v1/internal/data_transfer_stub.h"
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
@@ -151,5 +152,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_datatransfer_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_INTERNAL_DATA_TRANSFER_METADATA_DECORATOR_H

--- a/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_option_defaults.cc
+++ b/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_option_defaults.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/bigquery/datatransfer/v1/datatransfer.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/datatransfer/v1/internal/data_transfer_option_defaults.h"
 #include "google/cloud/bigquery/datatransfer/v1/data_transfer_connection.h"
 #include "google/cloud/bigquery/datatransfer/v1/data_transfer_options.h"
@@ -71,3 +72,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_datatransfer_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_option_defaults.h
+++ b/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_option_defaults.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_INTERNAL_DATA_TRANSFER_OPTION_DEFAULTS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_INTERNAL_DATA_TRANSFER_OPTION_DEFAULTS_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
 
@@ -33,5 +34,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_datatransfer_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_INTERNAL_DATA_TRANSFER_OPTION_DEFAULTS_H

--- a/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_retry_traits.h
+++ b/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_retry_traits.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_INTERNAL_DATA_TRANSFER_RETRY_TRAITS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_INTERNAL_DATA_TRANSFER_RETRY_TRAITS_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/status.h"
 #include "google/cloud/version.h"
 
@@ -39,5 +40,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_datatransfer_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_INTERNAL_DATA_TRANSFER_RETRY_TRAITS_H

--- a/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_sources.cc
+++ b/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_sources.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/bigquery/datatransfer/v1/datatransfer.proto
 
 // NOLINTBEGIN(bugprone-suspicious-include)
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/datatransfer/v1/data_transfer_client.cc"
 #include "google/cloud/bigquery/datatransfer/v1/data_transfer_connection.cc"
 #include "google/cloud/bigquery/datatransfer/v1/data_transfer_connection_idempotency_policy.cc"
@@ -29,4 +30,5 @@
 #include "google/cloud/bigquery/datatransfer/v1/internal/data_transfer_stub_factory.cc"
 #include "google/cloud/bigquery/datatransfer/v1/internal/data_transfer_tracing_connection.cc"
 #include "google/cloud/bigquery/datatransfer/v1/internal/data_transfer_tracing_stub.cc"
+#include "google/cloud/internal/diagnostics_pop.inc"
 // NOLINTEND(bugprone-suspicious-include)

--- a/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_stub.cc
+++ b/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_stub.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/bigquery/datatransfer/v1/datatransfer.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/datatransfer/v1/internal/data_transfer_stub.h"
 #include "google/cloud/grpc_error_delegate.h"
 #include "google/cloud/status_or.h"
@@ -268,3 +269,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_datatransfer_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_stub.h
+++ b/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_stub.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_INTERNAL_DATA_TRANSFER_STUB_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_INTERNAL_DATA_TRANSFER_STUB_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
@@ -262,5 +263,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_datatransfer_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_INTERNAL_DATA_TRANSFER_STUB_H

--- a/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_stub_factory.cc
+++ b/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_stub_factory.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/bigquery/datatransfer/v1/datatransfer.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/datatransfer/v1/internal/data_transfer_stub_factory.h"
 #include "google/cloud/bigquery/datatransfer/v1/internal/data_transfer_auth_decorator.h"
 #include "google/cloud/bigquery/datatransfer/v1/internal/data_transfer_logging_decorator.h"
@@ -74,3 +75,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_datatransfer_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_stub_factory.h
+++ b/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_stub_factory.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_INTERNAL_DATA_TRANSFER_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_INTERNAL_DATA_TRANSFER_STUB_FACTORY_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/datatransfer/v1/internal/data_transfer_stub.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"
 #include "google/cloud/options.h"
@@ -38,5 +39,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_datatransfer_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_INTERNAL_DATA_TRANSFER_STUB_FACTORY_H

--- a/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_tracing_connection.cc
+++ b/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_tracing_connection.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/bigquery/datatransfer/v1/datatransfer.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/datatransfer/v1/internal/data_transfer_tracing_connection.h"
 #include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/internal/traced_stream_range.h"
@@ -257,3 +258,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_datatransfer_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_tracing_connection.h
+++ b/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_tracing_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_INTERNAL_DATA_TRANSFER_TRACING_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_INTERNAL_DATA_TRANSFER_TRACING_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/datatransfer/v1/data_transfer_connection.h"
 #include "google/cloud/version.h"
 #include <memory>
@@ -143,5 +144,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_datatransfer_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_INTERNAL_DATA_TRANSFER_TRACING_CONNECTION_H

--- a/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_tracing_stub.cc
+++ b/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_tracing_stub.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/bigquery/datatransfer/v1/datatransfer.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/datatransfer/v1/internal/data_transfer_tracing_stub.h"
 #include "google/cloud/internal/grpc_opentelemetry.h"
 #include <memory>
@@ -296,3 +297,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_datatransfer_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_tracing_stub.h
+++ b/google/cloud/bigquery/datatransfer/v1/internal/data_transfer_tracing_stub.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_INTERNAL_DATA_TRANSFER_TRACING_STUB_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_INTERNAL_DATA_TRANSFER_TRACING_STUB_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/datatransfer/v1/internal/data_transfer_stub.h"
 #include "google/cloud/internal/trace_propagator.h"
 #include "google/cloud/options.h"
@@ -158,5 +159,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_datatransfer_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_INTERNAL_DATA_TRANSFER_TRACING_STUB_H

--- a/google/cloud/bigquery/datatransfer/v1/mocks/mock_data_transfer_connection.h
+++ b/google/cloud/bigquery/datatransfer/v1/mocks/mock_data_transfer_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_MOCKS_MOCK_DATA_TRANSFER_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_MOCKS_MOCK_DATA_TRANSFER_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/datatransfer/v1/data_transfer_connection.h"
 #include <gmock/gmock.h>
 
@@ -165,5 +166,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_datatransfer_v1_mocks
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_DATATRANSFER_V1_MOCKS_MOCK_DATA_TRANSFER_CONNECTION_H

--- a/google/cloud/bigquery/datatransfer/v1/samples/data_transfer_client_samples.cc
+++ b/google/cloud/bigquery/datatransfer/v1/samples/data_transfer_client_samples.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/bigquery/datatransfer/v1/datatransfer.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/datatransfer/v1/data_transfer_client.h"
 #include "google/cloud/bigquery/datatransfer/v1/data_transfer_connection_idempotency_policy.h"
 #include "google/cloud/bigquery/datatransfer/v1/data_transfer_options.h"
@@ -163,3 +164,4 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   });
   return example.Run(argc, argv);
 }
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/bigquery/mocks/mock_data_transfer_connection.h
+++ b/google/cloud/bigquery/mocks/mock_data_transfer_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_MOCKS_MOCK_DATA_TRANSFER_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_MOCKS_MOCK_DATA_TRANSFER_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/data_transfer_connection.h"
 #include "google/cloud/bigquery/datatransfer/v1/mocks/mock_data_transfer_connection.h"
 
@@ -39,5 +40,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_mocks
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_MOCKS_MOCK_DATA_TRANSFER_CONNECTION_H

--- a/google/cloud/bigquery/mocks/mock_reservation_connection.h
+++ b/google/cloud/bigquery/mocks/mock_reservation_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_MOCKS_MOCK_RESERVATION_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_MOCKS_MOCK_RESERVATION_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/reservation/v1/mocks/mock_reservation_connection.h"
 #include "google/cloud/bigquery/reservation_connection.h"
 
@@ -39,5 +40,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_mocks
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_MOCKS_MOCK_RESERVATION_CONNECTION_H

--- a/google/cloud/bigquery/reservation/v1/internal/reservation_auth_decorator.cc
+++ b/google/cloud/bigquery/reservation/v1/internal/reservation_auth_decorator.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/bigquery/reservation/v1/reservation.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/reservation/v1/internal/reservation_auth_decorator.h"
 #include <google/cloud/bigquery/reservation/v1/reservation.grpc.pb.h>
 #include <memory>
@@ -244,3 +245,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_reservation_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/bigquery/reservation/v1/internal/reservation_auth_decorator.h
+++ b/google/cloud/bigquery/reservation/v1/internal/reservation_auth_decorator.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_INTERNAL_RESERVATION_AUTH_DECORATOR_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_INTERNAL_RESERVATION_AUTH_DECORATOR_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/reservation/v1/internal/reservation_stub.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"
 #include "google/cloud/version.h"
@@ -170,5 +171,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_reservation_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_INTERNAL_RESERVATION_AUTH_DECORATOR_H

--- a/google/cloud/bigquery/reservation/v1/internal/reservation_connection_impl.cc
+++ b/google/cloud/bigquery/reservation/v1/internal/reservation_connection_impl.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/bigquery/reservation/v1/reservation.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/reservation/v1/internal/reservation_connection_impl.h"
 #include "google/cloud/bigquery/reservation/v1/internal/reservation_option_defaults.h"
 #include "google/cloud/background_threads.h"
@@ -510,3 +511,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_reservation_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/bigquery/reservation/v1/internal/reservation_connection_impl.h
+++ b/google/cloud/bigquery/reservation/v1/internal/reservation_connection_impl.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_INTERNAL_RESERVATION_CONNECTION_IMPL_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_INTERNAL_RESERVATION_CONNECTION_IMPL_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/reservation/v1/internal/reservation_retry_traits.h"
 #include "google/cloud/bigquery/reservation/v1/internal/reservation_stub.h"
 #include "google/cloud/bigquery/reservation/v1/reservation_connection.h"
@@ -162,5 +163,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_reservation_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_INTERNAL_RESERVATION_CONNECTION_IMPL_H

--- a/google/cloud/bigquery/reservation/v1/internal/reservation_logging_decorator.cc
+++ b/google/cloud/bigquery/reservation/v1/internal/reservation_logging_decorator.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/bigquery/reservation/v1/reservation.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/reservation/v1/internal/reservation_logging_decorator.h"
 #include "google/cloud/internal/log_wrapper.h"
 #include "google/cloud/status_or.h"
@@ -334,3 +335,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_reservation_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/bigquery/reservation/v1/internal/reservation_logging_decorator.h
+++ b/google/cloud/bigquery/reservation/v1/internal/reservation_logging_decorator.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_INTERNAL_RESERVATION_LOGGING_DECORATOR_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_INTERNAL_RESERVATION_LOGGING_DECORATOR_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/reservation/v1/internal/reservation_stub.h"
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
@@ -170,5 +171,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_reservation_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_INTERNAL_RESERVATION_LOGGING_DECORATOR_H

--- a/google/cloud/bigquery/reservation/v1/internal/reservation_metadata_decorator.cc
+++ b/google/cloud/bigquery/reservation/v1/internal/reservation_metadata_decorator.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/bigquery/reservation/v1/reservation.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/reservation/v1/internal/reservation_metadata_decorator.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
@@ -276,3 +277,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_reservation_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/bigquery/reservation/v1/internal/reservation_metadata_decorator.h
+++ b/google/cloud/bigquery/reservation/v1/internal/reservation_metadata_decorator.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_INTERNAL_RESERVATION_METADATA_DECORATOR_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_INTERNAL_RESERVATION_METADATA_DECORATOR_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/reservation/v1/internal/reservation_stub.h"
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
@@ -176,5 +177,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_reservation_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_INTERNAL_RESERVATION_METADATA_DECORATOR_H

--- a/google/cloud/bigquery/reservation/v1/internal/reservation_option_defaults.cc
+++ b/google/cloud/bigquery/reservation/v1/internal/reservation_option_defaults.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/bigquery/reservation/v1/reservation.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/reservation/v1/internal/reservation_option_defaults.h"
 #include "google/cloud/bigquery/reservation/v1/reservation_connection.h"
 #include "google/cloud/bigquery/reservation/v1/reservation_options.h"
@@ -69,3 +70,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_reservation_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/bigquery/reservation/v1/internal/reservation_option_defaults.h
+++ b/google/cloud/bigquery/reservation/v1/internal/reservation_option_defaults.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_INTERNAL_RESERVATION_OPTION_DEFAULTS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_INTERNAL_RESERVATION_OPTION_DEFAULTS_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
 
@@ -33,5 +34,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_reservation_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_INTERNAL_RESERVATION_OPTION_DEFAULTS_H

--- a/google/cloud/bigquery/reservation/v1/internal/reservation_retry_traits.h
+++ b/google/cloud/bigquery/reservation/v1/internal/reservation_retry_traits.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_INTERNAL_RESERVATION_RETRY_TRAITS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_INTERNAL_RESERVATION_RETRY_TRAITS_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/status.h"
 #include "google/cloud/version.h"
 
@@ -39,5 +40,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_reservation_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_INTERNAL_RESERVATION_RETRY_TRAITS_H

--- a/google/cloud/bigquery/reservation/v1/internal/reservation_sources.cc
+++ b/google/cloud/bigquery/reservation/v1/internal/reservation_sources.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/bigquery/reservation/v1/reservation.proto
 
 // NOLINTBEGIN(bugprone-suspicious-include)
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/reservation/v1/internal/reservation_auth_decorator.cc"
 #include "google/cloud/bigquery/reservation/v1/internal/reservation_connection_impl.cc"
 #include "google/cloud/bigquery/reservation/v1/internal/reservation_logging_decorator.cc"
@@ -29,4 +30,5 @@
 #include "google/cloud/bigquery/reservation/v1/reservation_client.cc"
 #include "google/cloud/bigquery/reservation/v1/reservation_connection.cc"
 #include "google/cloud/bigquery/reservation/v1/reservation_connection_idempotency_policy.cc"
+#include "google/cloud/internal/diagnostics_pop.inc"
 // NOLINTEND(bugprone-suspicious-include)

--- a/google/cloud/bigquery/reservation/v1/internal/reservation_stub.cc
+++ b/google/cloud/bigquery/reservation/v1/internal/reservation_stub.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/bigquery/reservation/v1/reservation.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/reservation/v1/internal/reservation_stub.h"
 #include "google/cloud/grpc_error_delegate.h"
 #include "google/cloud/status_or.h"
@@ -315,3 +316,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_reservation_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/bigquery/reservation/v1/internal/reservation_stub.h
+++ b/google/cloud/bigquery/reservation/v1/internal/reservation_stub.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_INTERNAL_RESERVATION_STUB_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_INTERNAL_RESERVATION_STUB_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
@@ -303,5 +304,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_reservation_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_INTERNAL_RESERVATION_STUB_H

--- a/google/cloud/bigquery/reservation/v1/internal/reservation_stub_factory.cc
+++ b/google/cloud/bigquery/reservation/v1/internal/reservation_stub_factory.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/bigquery/reservation/v1/reservation.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/reservation/v1/internal/reservation_stub_factory.h"
 #include "google/cloud/bigquery/reservation/v1/internal/reservation_auth_decorator.h"
 #include "google/cloud/bigquery/reservation/v1/internal/reservation_logging_decorator.h"
@@ -71,3 +72,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_reservation_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/bigquery/reservation/v1/internal/reservation_stub_factory.h
+++ b/google/cloud/bigquery/reservation/v1/internal/reservation_stub_factory.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_INTERNAL_RESERVATION_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_INTERNAL_RESERVATION_STUB_FACTORY_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/reservation/v1/internal/reservation_stub.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"
 #include "google/cloud/options.h"
@@ -38,5 +39,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_reservation_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_INTERNAL_RESERVATION_STUB_FACTORY_H

--- a/google/cloud/bigquery/reservation/v1/internal/reservation_tracing_connection.cc
+++ b/google/cloud/bigquery/reservation/v1/internal/reservation_tracing_connection.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/bigquery/reservation/v1/reservation.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/reservation/v1/internal/reservation_tracing_connection.h"
 #include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/internal/traced_stream_range.h"
@@ -292,3 +293,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_reservation_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/bigquery/reservation/v1/internal/reservation_tracing_connection.h
+++ b/google/cloud/bigquery/reservation/v1/internal/reservation_tracing_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_INTERNAL_RESERVATION_TRACING_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_INTERNAL_RESERVATION_TRACING_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/reservation/v1/reservation_connection.h"
 #include "google/cloud/version.h"
 #include <memory>
@@ -163,5 +164,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_reservation_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_INTERNAL_RESERVATION_TRACING_CONNECTION_H

--- a/google/cloud/bigquery/reservation/v1/internal/reservation_tracing_stub.cc
+++ b/google/cloud/bigquery/reservation/v1/internal/reservation_tracing_stub.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/bigquery/reservation/v1/reservation.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/reservation/v1/internal/reservation_tracing_stub.h"
 #include "google/cloud/internal/grpc_opentelemetry.h"
 #include <memory>
@@ -346,3 +347,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_reservation_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/bigquery/reservation/v1/internal/reservation_tracing_stub.h
+++ b/google/cloud/bigquery/reservation/v1/internal/reservation_tracing_stub.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_INTERNAL_RESERVATION_TRACING_STUB_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_INTERNAL_RESERVATION_TRACING_STUB_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/reservation/v1/internal/reservation_stub.h"
 #include "google/cloud/internal/trace_propagator.h"
 #include "google/cloud/options.h"
@@ -183,5 +184,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_reservation_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_INTERNAL_RESERVATION_TRACING_STUB_H

--- a/google/cloud/bigquery/reservation/v1/mocks/mock_reservation_connection.h
+++ b/google/cloud/bigquery/reservation/v1/mocks/mock_reservation_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_MOCKS_MOCK_RESERVATION_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_MOCKS_MOCK_RESERVATION_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/reservation/v1/reservation_connection.h"
 #include <gmock/gmock.h>
 
@@ -195,5 +196,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_reservation_v1_mocks
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_MOCKS_MOCK_RESERVATION_CONNECTION_H

--- a/google/cloud/bigquery/reservation/v1/reservation_client.cc
+++ b/google/cloud/bigquery/reservation/v1/reservation_client.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/bigquery/reservation/v1/reservation.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/reservation/v1/reservation_client.h"
 #include <memory>
 #include <utility>
@@ -446,3 +447,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_reservation_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/bigquery/reservation/v1/reservation_client.h
+++ b/google/cloud/bigquery/reservation/v1/reservation_client.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_RESERVATION_CLIENT_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_RESERVATION_CLIENT_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/reservation/v1/reservation_connection.h"
 #include "google/cloud/future.h"
 #include "google/cloud/options.h"
@@ -1767,5 +1768,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_reservation_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_RESERVATION_CLIENT_H

--- a/google/cloud/bigquery/reservation/v1/reservation_connection.cc
+++ b/google/cloud/bigquery/reservation/v1/reservation_connection.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/bigquery/reservation/v1/reservation.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/reservation/v1/reservation_connection.h"
 #include "google/cloud/bigquery/reservation/v1/internal/reservation_connection_impl.h"
 #include "google/cloud/bigquery/reservation/v1/internal/reservation_option_defaults.h"
@@ -203,3 +204,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_reservation_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/bigquery/reservation/v1/reservation_connection.h
+++ b/google/cloud/bigquery/reservation/v1/reservation_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_RESERVATION_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_RESERVATION_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/reservation/v1/internal/reservation_retry_traits.h"
 #include "google/cloud/bigquery/reservation/v1/reservation_connection_idempotency_policy.h"
 #include "google/cloud/backoff_policy.h"
@@ -315,5 +316,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_reservation_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_RESERVATION_CONNECTION_H

--- a/google/cloud/bigquery/reservation/v1/reservation_connection_idempotency_policy.cc
+++ b/google/cloud/bigquery/reservation/v1/reservation_connection_idempotency_policy.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/bigquery/reservation/v1/reservation.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/reservation/v1/reservation_connection_idempotency_policy.h"
 #include <memory>
 
@@ -167,3 +168,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_reservation_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/bigquery/reservation/v1/reservation_connection_idempotency_policy.h
+++ b/google/cloud/bigquery/reservation/v1/reservation_connection_idempotency_policy.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_RESERVATION_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_RESERVATION_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/idempotency.h"
 #include "google/cloud/version.h"
 #include <google/cloud/bigquery/reservation/v1/reservation.grpc.pb.h>
@@ -128,5 +129,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_reservation_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_RESERVATION_CONNECTION_IDEMPOTENCY_POLICY_H

--- a/google/cloud/bigquery/reservation/v1/reservation_options.h
+++ b/google/cloud/bigquery/reservation/v1/reservation_options.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_RESERVATION_OPTIONS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_RESERVATION_OPTIONS_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/reservation/v1/reservation_connection.h"
 #include "google/cloud/bigquery/reservation/v1/reservation_connection_idempotency_policy.h"
 #include "google/cloud/backoff_policy.h"
@@ -72,5 +73,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_reservation_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_V1_RESERVATION_OPTIONS_H

--- a/google/cloud/bigquery/reservation/v1/samples/reservation_client_samples.cc
+++ b/google/cloud/bigquery/reservation/v1/samples/reservation_client_samples.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/bigquery/reservation/v1/reservation.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/reservation/v1/reservation_client.h"
 #include "google/cloud/bigquery/reservation/v1/reservation_connection_idempotency_policy.h"
 #include "google/cloud/bigquery/reservation/v1/reservation_options.h"
@@ -164,3 +165,4 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   });
   return example.Run(argc, argv);
 }
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/bigquery/reservation_client.h
+++ b/google/cloud/bigquery/reservation_client.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_CLIENT_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_CLIENT_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/reservation/v1/reservation_client.h"
 #include "google/cloud/bigquery/reservation_connection.h"
 
@@ -37,5 +38,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_CLIENT_H

--- a/google/cloud/bigquery/reservation_connection.h
+++ b/google/cloud/bigquery/reservation_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/reservation/v1/reservation_connection.h"
 #include "google/cloud/bigquery/reservation_connection_idempotency_policy.h"
 
@@ -55,5 +56,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_CONNECTION_H

--- a/google/cloud/bigquery/reservation_connection_idempotency_policy.h
+++ b/google/cloud/bigquery/reservation_connection_idempotency_policy.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/reservation/v1/reservation_connection_idempotency_policy.h"
 
 namespace google {
@@ -42,5 +43,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_CONNECTION_IDEMPOTENCY_POLICY_H

--- a/google/cloud/bigquery/reservation_options.h
+++ b/google/cloud/bigquery/reservation_options.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_OPTIONS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_OPTIONS_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigquery/reservation/v1/reservation_options.h"
 #include "google/cloud/bigquery/reservation_connection.h"
 #include "google/cloud/bigquery/reservation_connection_idempotency_policy.h"
@@ -53,5 +54,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_RESERVATION_OPTIONS_H

--- a/google/cloud/channel/v1/cloud_channel_reports_client.cc
+++ b/google/cloud/channel/v1/cloud_channel_reports_client.cc
@@ -156,3 +156,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace channel_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/channel/v1/cloud_channel_reports_client.h
+++ b/google/cloud/channel/v1/cloud_channel_reports_client.h
@@ -684,5 +684,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace channel_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CHANNEL_V1_CLOUD_CHANNEL_REPORTS_CLIENT_H

--- a/google/cloud/channel/v1/cloud_channel_reports_connection.cc
+++ b/google/cloud/channel/v1/cloud_channel_reports_connection.cc
@@ -125,3 +125,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace channel_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/channel/v1/cloud_channel_reports_connection.h
+++ b/google/cloud/channel/v1/cloud_channel_reports_connection.h
@@ -264,5 +264,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace channel_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CHANNEL_V1_CLOUD_CHANNEL_REPORTS_CONNECTION_H

--- a/google/cloud/channel/v1/cloud_channel_reports_connection_idempotency_policy.cc
+++ b/google/cloud/channel/v1/cloud_channel_reports_connection_idempotency_policy.cc
@@ -85,3 +85,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace channel_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/channel/v1/cloud_channel_reports_connection_idempotency_policy.h
+++ b/google/cloud/channel/v1/cloud_channel_reports_connection_idempotency_policy.h
@@ -68,5 +68,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace channel_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CHANNEL_V1_CLOUD_CHANNEL_REPORTS_CONNECTION_IDEMPOTENCY_POLICY_H

--- a/google/cloud/channel/v1/cloud_channel_reports_options.h
+++ b/google/cloud/channel/v1/cloud_channel_reports_options.h
@@ -85,5 +85,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace channel_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CHANNEL_V1_CLOUD_CHANNEL_REPORTS_OPTIONS_H

--- a/google/cloud/channel/v1/internal/cloud_channel_reports_auth_decorator.cc
+++ b/google/cloud/channel/v1/internal/cloud_channel_reports_auth_decorator.cc
@@ -153,3 +153,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace channel_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/channel/v1/internal/cloud_channel_reports_auth_decorator.h
+++ b/google/cloud/channel/v1/internal/cloud_channel_reports_auth_decorator.h
@@ -97,5 +97,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace channel_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CHANNEL_V1_INTERNAL_CLOUD_CHANNEL_REPORTS_AUTH_DECORATOR_H

--- a/google/cloud/channel/v1/internal/cloud_channel_reports_connection_impl.cc
+++ b/google/cloud/channel/v1/internal/cloud_channel_reports_connection_impl.cc
@@ -313,3 +313,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace channel_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/channel/v1/internal/cloud_channel_reports_connection_impl.h
+++ b/google/cloud/channel/v1/internal/cloud_channel_reports_connection_impl.h
@@ -92,5 +92,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace channel_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CHANNEL_V1_INTERNAL_CLOUD_CHANNEL_REPORTS_CONNECTION_IMPL_H

--- a/google/cloud/channel/v1/internal/cloud_channel_reports_logging_decorator.cc
+++ b/google/cloud/channel/v1/internal/cloud_channel_reports_logging_decorator.cc
@@ -176,3 +176,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace channel_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/channel/v1/internal/cloud_channel_reports_logging_decorator.h
+++ b/google/cloud/channel/v1/internal/cloud_channel_reports_logging_decorator.h
@@ -98,5 +98,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace channel_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CHANNEL_V1_INTERNAL_CLOUD_CHANNEL_REPORTS_LOGGING_DECORATOR_H

--- a/google/cloud/channel/v1/internal/cloud_channel_reports_metadata_decorator.cc
+++ b/google/cloud/channel/v1/internal/cloud_channel_reports_metadata_decorator.cc
@@ -159,3 +159,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace channel_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/channel/v1/internal/cloud_channel_reports_metadata_decorator.h
+++ b/google/cloud/channel/v1/internal/cloud_channel_reports_metadata_decorator.h
@@ -104,5 +104,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace channel_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CHANNEL_V1_INTERNAL_CLOUD_CHANNEL_REPORTS_METADATA_DECORATOR_H

--- a/google/cloud/channel/v1/internal/cloud_channel_reports_option_defaults.cc
+++ b/google/cloud/channel/v1/internal/cloud_channel_reports_option_defaults.cc
@@ -86,3 +86,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace channel_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/channel/v1/internal/cloud_channel_reports_option_defaults.h
+++ b/google/cloud/channel/v1/internal/cloud_channel_reports_option_defaults.h
@@ -34,5 +34,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace channel_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CHANNEL_V1_INTERNAL_CLOUD_CHANNEL_REPORTS_OPTION_DEFAULTS_H

--- a/google/cloud/channel/v1/internal/cloud_channel_reports_retry_traits.h
+++ b/google/cloud/channel/v1/internal/cloud_channel_reports_retry_traits.h
@@ -40,5 +40,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace channel_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CHANNEL_V1_INTERNAL_CLOUD_CHANNEL_REPORTS_RETRY_TRAITS_H

--- a/google/cloud/channel/v1/internal/cloud_channel_reports_sources.cc
+++ b/google/cloud/channel/v1/internal/cloud_channel_reports_sources.cc
@@ -30,4 +30,5 @@
 #include "google/cloud/channel/v1/internal/cloud_channel_reports_stub_factory.cc"
 #include "google/cloud/channel/v1/internal/cloud_channel_reports_tracing_connection.cc"
 #include "google/cloud/channel/v1/internal/cloud_channel_reports_tracing_stub.cc"
+#include "google/cloud/internal/diagnostics_pop.inc"
 // NOLINTEND(bugprone-suspicious-include)

--- a/google/cloud/channel/v1/internal/cloud_channel_reports_stub.cc
+++ b/google/cloud/channel/v1/internal/cloud_channel_reports_stub.cc
@@ -175,3 +175,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace channel_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/channel/v1/internal/cloud_channel_reports_stub.h
+++ b/google/cloud/channel/v1/internal/cloud_channel_reports_stub.h
@@ -160,5 +160,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace channel_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CHANNEL_V1_INTERNAL_CLOUD_CHANNEL_REPORTS_STUB_H

--- a/google/cloud/channel/v1/internal/cloud_channel_reports_stub_factory.cc
+++ b/google/cloud/channel/v1/internal/cloud_channel_reports_stub_factory.cc
@@ -74,3 +74,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace channel_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/channel/v1/internal/cloud_channel_reports_stub_factory.h
+++ b/google/cloud/channel/v1/internal/cloud_channel_reports_stub_factory.h
@@ -40,5 +40,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace channel_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CHANNEL_V1_INTERNAL_CLOUD_CHANNEL_REPORTS_STUB_FACTORY_H

--- a/google/cloud/channel/v1/internal/cloud_channel_reports_tracing_connection.cc
+++ b/google/cloud/channel/v1/internal/cloud_channel_reports_tracing_connection.cc
@@ -139,3 +139,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace channel_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/channel/v1/internal/cloud_channel_reports_tracing_connection.h
+++ b/google/cloud/channel/v1/internal/cloud_channel_reports_tracing_connection.h
@@ -90,5 +90,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace channel_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CHANNEL_V1_INTERNAL_CLOUD_CHANNEL_REPORTS_TRACING_CONNECTION_H

--- a/google/cloud/channel/v1/internal/cloud_channel_reports_tracing_stub.cc
+++ b/google/cloud/channel/v1/internal/cloud_channel_reports_tracing_stub.cc
@@ -175,3 +175,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace channel_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/channel/v1/internal/cloud_channel_reports_tracing_stub.h
+++ b/google/cloud/channel/v1/internal/cloud_channel_reports_tracing_stub.h
@@ -111,5 +111,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace channel_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CHANNEL_V1_INTERNAL_CLOUD_CHANNEL_REPORTS_TRACING_STUB_H

--- a/google/cloud/channel/v1/mocks/mock_cloud_channel_reports_connection.h
+++ b/google/cloud/channel/v1/mocks/mock_cloud_channel_reports_connection.h
@@ -116,5 +116,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace channel_v1_mocks
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CHANNEL_V1_MOCKS_MOCK_CLOUD_CHANNEL_REPORTS_CONNECTION_H

--- a/google/cloud/channel/v1/samples/cloud_channel_reports_client_samples.cc
+++ b/google/cloud/channel/v1/samples/cloud_channel_reports_client_samples.cc
@@ -214,3 +214,4 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   });
   return example.Run(argc, argv);
 }
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_client.cc
+++ b/google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_client.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/cloudcontrolspartner/v1/core.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_client.h"
 #include <memory>
 #include <utility>
@@ -177,3 +178,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloudcontrolspartner_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_client.h
+++ b/google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_client.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_CLOUD_CONTROLS_PARTNER_CORE_CLIENT_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_CLOUD_CONTROLS_PARTNER_CORE_CLIENT_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_connection.h"
 #include "google/cloud/future.h"
 #include "google/cloud/options.h"
@@ -625,5 +626,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloudcontrolspartner_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_CLOUD_CONTROLS_PARTNER_CORE_CLIENT_H

--- a/google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_connection.cc
+++ b/google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_connection.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/cloudcontrolspartner/v1/core.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_connection.h"
 #include "google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_options.h"
 #include "google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_connection_impl.h"
@@ -118,3 +119,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloudcontrolspartner_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_connection.h
+++ b/google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_CLOUD_CONTROLS_PARTNER_CORE_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_CLOUD_CONTROLS_PARTNER_CORE_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_connection_idempotency_policy.h"
 #include "google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_retry_traits.h"
 #include "google/cloud/backoff_policy.h"
@@ -263,5 +264,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloudcontrolspartner_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_CLOUD_CONTROLS_PARTNER_CORE_CONNECTION_H

--- a/google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_connection_idempotency_policy.cc
+++ b/google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_connection_idempotency_policy.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/cloudcontrolspartner/v1/core.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_connection_idempotency_policy.h"
 #include <memory>
 
@@ -90,3 +91,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloudcontrolspartner_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_connection_idempotency_policy.h
+++ b/google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_connection_idempotency_policy.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_CLOUD_CONTROLS_PARTNER_CORE_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_CLOUD_CONTROLS_PARTNER_CORE_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/idempotency.h"
 #include "google/cloud/version.h"
 #include <google/cloud/cloudcontrolspartner/v1/core.grpc.pb.h>
@@ -75,5 +76,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloudcontrolspartner_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_CLOUD_CONTROLS_PARTNER_CORE_CONNECTION_IDEMPOTENCY_POLICY_H

--- a/google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_options.h
+++ b/google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_options.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_CLOUD_CONTROLS_PARTNER_CORE_OPTIONS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_CLOUD_CONTROLS_PARTNER_CORE_OPTIONS_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_connection.h"
 #include "google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_connection_idempotency_policy.h"
 #include "google/cloud/backoff_policy.h"
@@ -73,5 +74,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloudcontrolspartner_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_CLOUD_CONTROLS_PARTNER_CORE_OPTIONS_H

--- a/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_auth_decorator.cc
+++ b/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_auth_decorator.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/cloudcontrolspartner/v1/core.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_auth_decorator.h"
 #include <google/cloud/cloudcontrolspartner/v1/core.grpc.pb.h>
 #include <memory>
@@ -115,3 +116,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloudcontrolspartner_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_auth_decorator.h
+++ b/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_auth_decorator.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_INTERNAL_CLOUD_CONTROLS_PARTNER_CORE_AUTH_DECORATOR_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_INTERNAL_CLOUD_CONTROLS_PARTNER_CORE_AUTH_DECORATOR_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_stub.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"
 #include "google/cloud/version.h"
@@ -93,5 +94,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloudcontrolspartner_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_INTERNAL_CLOUD_CONTROLS_PARTNER_CORE_AUTH_DECORATOR_H

--- a/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_connection_impl.cc
+++ b/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_connection_impl.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/cloudcontrolspartner/v1/core.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_connection_impl.h"
 #include "google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_option_defaults.h"
 #include "google/cloud/background_threads.h"
@@ -264,3 +265,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloudcontrolspartner_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_connection_impl.h
+++ b/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_connection_impl.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_INTERNAL_CLOUD_CONTROLS_PARTNER_CORE_CONNECTION_IMPL_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_INTERNAL_CLOUD_CONTROLS_PARTNER_CORE_CONNECTION_IMPL_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_connection.h"
 #include "google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_connection_idempotency_policy.h"
 #include "google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_options.h"
@@ -98,5 +99,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloudcontrolspartner_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_INTERNAL_CLOUD_CONTROLS_PARTNER_CORE_CONNECTION_IMPL_H

--- a/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_logging_decorator.cc
+++ b/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_logging_decorator.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/cloudcontrolspartner/v1/core.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_logging_decorator.h"
 #include "google/cloud/internal/log_wrapper.h"
 #include "google/cloud/status_or.h"
@@ -153,3 +154,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloudcontrolspartner_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_logging_decorator.h
+++ b/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_logging_decorator.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_INTERNAL_CLOUD_CONTROLS_PARTNER_CORE_LOGGING_DECORATOR_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_INTERNAL_CLOUD_CONTROLS_PARTNER_CORE_LOGGING_DECORATOR_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_stub.h"
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
@@ -93,5 +94,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloudcontrolspartner_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_INTERNAL_CLOUD_CONTROLS_PARTNER_CORE_LOGGING_DECORATOR_H

--- a/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_metadata_decorator.cc
+++ b/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_metadata_decorator.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/cloudcontrolspartner/v1/core.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_metadata_decorator.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
@@ -141,3 +142,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloudcontrolspartner_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_metadata_decorator.h
+++ b/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_metadata_decorator.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_INTERNAL_CLOUD_CONTROLS_PARTNER_CORE_METADATA_DECORATOR_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_INTERNAL_CLOUD_CONTROLS_PARTNER_CORE_METADATA_DECORATOR_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_stub.h"
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
@@ -99,5 +100,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloudcontrolspartner_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_INTERNAL_CLOUD_CONTROLS_PARTNER_CORE_METADATA_DECORATOR_H

--- a/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_option_defaults.cc
+++ b/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_option_defaults.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/cloudcontrolspartner/v1/core.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_option_defaults.h"
 #include "google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_connection.h"
 #include "google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_options.h"
@@ -73,3 +74,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloudcontrolspartner_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_option_defaults.h
+++ b/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_option_defaults.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_INTERNAL_CLOUD_CONTROLS_PARTNER_CORE_OPTION_DEFAULTS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_INTERNAL_CLOUD_CONTROLS_PARTNER_CORE_OPTION_DEFAULTS_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
 
@@ -33,5 +34,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloudcontrolspartner_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_INTERNAL_CLOUD_CONTROLS_PARTNER_CORE_OPTION_DEFAULTS_H

--- a/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_retry_traits.h
+++ b/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_retry_traits.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_INTERNAL_CLOUD_CONTROLS_PARTNER_CORE_RETRY_TRAITS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_INTERNAL_CLOUD_CONTROLS_PARTNER_CORE_RETRY_TRAITS_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/status.h"
 #include "google/cloud/version.h"
 
@@ -39,5 +40,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloudcontrolspartner_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_INTERNAL_CLOUD_CONTROLS_PARTNER_CORE_RETRY_TRAITS_H

--- a/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_sources.cc
+++ b/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_sources.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/cloudcontrolspartner/v1/core.proto
 
 // NOLINTBEGIN(bugprone-suspicious-include)
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_client.cc"
 #include "google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_connection.cc"
 #include "google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_connection_idempotency_policy.cc"
@@ -29,4 +30,5 @@
 #include "google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_stub_factory.cc"
 #include "google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_tracing_connection.cc"
 #include "google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_tracing_stub.cc"
+#include "google/cloud/internal/diagnostics_pop.inc"
 // NOLINTEND(bugprone-suspicious-include)

--- a/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_stub.cc
+++ b/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_stub.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/cloudcontrolspartner/v1/core.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_stub.h"
 #include "google/cloud/grpc_error_delegate.h"
 #include "google/cloud/status_or.h"
@@ -140,3 +141,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloudcontrolspartner_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_stub.h
+++ b/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_stub.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_INTERNAL_CLOUD_CONTROLS_PARTNER_CORE_STUB_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_INTERNAL_CLOUD_CONTROLS_PARTNER_CORE_STUB_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
@@ -148,5 +149,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloudcontrolspartner_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_INTERNAL_CLOUD_CONTROLS_PARTNER_CORE_STUB_H

--- a/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_stub_factory.cc
+++ b/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_stub_factory.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/cloudcontrolspartner/v1/core.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_stub_factory.h"
 #include "google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_auth_decorator.h"
 #include "google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_logging_decorator.h"
@@ -71,3 +72,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloudcontrolspartner_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_stub_factory.h
+++ b/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_stub_factory.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_INTERNAL_CLOUD_CONTROLS_PARTNER_CORE_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_INTERNAL_CLOUD_CONTROLS_PARTNER_CORE_STUB_FACTORY_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_stub.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"
 #include "google/cloud/options.h"
@@ -39,5 +40,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloudcontrolspartner_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_INTERNAL_CLOUD_CONTROLS_PARTNER_CORE_STUB_FACTORY_H

--- a/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_tracing_connection.cc
+++ b/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_tracing_connection.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/cloudcontrolspartner/v1/core.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_tracing_connection.h"
 #include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/internal/traced_stream_range.h"
@@ -149,3 +150,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloudcontrolspartner_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_tracing_connection.h
+++ b/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_tracing_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_INTERNAL_CLOUD_CONTROLS_PARTNER_CORE_TRACING_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_INTERNAL_CLOUD_CONTROLS_PARTNER_CORE_TRACING_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_connection.h"
 #include "google/cloud/version.h"
 #include <memory>
@@ -99,5 +100,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloudcontrolspartner_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_INTERNAL_CLOUD_CONTROLS_PARTNER_CORE_TRACING_CONNECTION_H

--- a/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_tracing_stub.cc
+++ b/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_tracing_stub.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/cloudcontrolspartner/v1/core.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_tracing_stub.h"
 #include "google/cloud/internal/grpc_opentelemetry.h"
 #include <memory>
@@ -161,3 +162,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloudcontrolspartner_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_tracing_stub.h
+++ b/google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_tracing_stub.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_INTERNAL_CLOUD_CONTROLS_PARTNER_CORE_TRACING_STUB_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_INTERNAL_CLOUD_CONTROLS_PARTNER_CORE_TRACING_STUB_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/cloudcontrolspartner/v1/internal/cloud_controls_partner_core_stub.h"
 #include "google/cloud/internal/trace_propagator.h"
 #include "google/cloud/options.h"
@@ -108,5 +109,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloudcontrolspartner_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_INTERNAL_CLOUD_CONTROLS_PARTNER_CORE_TRACING_STUB_H

--- a/google/cloud/cloudcontrolspartner/v1/mocks/mock_cloud_controls_partner_core_connection.h
+++ b/google/cloud/cloudcontrolspartner/v1/mocks/mock_cloud_controls_partner_core_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_MOCKS_MOCK_CLOUD_CONTROLS_PARTNER_CORE_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_MOCKS_MOCK_CLOUD_CONTROLS_PARTNER_CORE_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_connection.h"
 #include <gmock/gmock.h>
 
@@ -104,5 +105,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloudcontrolspartner_v1_mocks
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDCONTROLSPARTNER_V1_MOCKS_MOCK_CLOUD_CONTROLS_PARTNER_CORE_CONNECTION_H

--- a/google/cloud/cloudcontrolspartner/v1/samples/cloud_controls_partner_core_client_samples.cc
+++ b/google/cloud/cloudcontrolspartner/v1/samples/cloud_controls_partner_core_client_samples.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/cloudcontrolspartner/v1/core.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_client.h"
 #include "google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_connection_idempotency_policy.h"
 #include "google/cloud/cloudcontrolspartner/v1/cloud_controls_partner_core_options.h"
@@ -168,3 +169,4 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   });
   return example.Run(argc, argv);
 }
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/container/cluster_manager_client.h
+++ b/google/cloud/container/cluster_manager_client.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_CLUSTER_MANAGER_CLIENT_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_CLUSTER_MANAGER_CLIENT_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/container/cluster_manager_connection.h"
 #include "google/cloud/container/v1/cluster_manager_client.h"
 
@@ -37,5 +38,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace container
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_CLUSTER_MANAGER_CLIENT_H

--- a/google/cloud/container/cluster_manager_connection.h
+++ b/google/cloud/container/cluster_manager_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_CLUSTER_MANAGER_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_CLUSTER_MANAGER_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/container/cluster_manager_connection_idempotency_policy.h"
 #include "google/cloud/container/v1/cluster_manager_connection.h"
 
@@ -47,5 +48,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace container
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_CLUSTER_MANAGER_CONNECTION_H

--- a/google/cloud/container/cluster_manager_connection_idempotency_policy.h
+++ b/google/cloud/container/cluster_manager_connection_idempotency_policy.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_CLUSTER_MANAGER_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_CLUSTER_MANAGER_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/container/v1/cluster_manager_connection_idempotency_policy.h"
 
 namespace google {
@@ -39,5 +40,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace container
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_CLUSTER_MANAGER_CONNECTION_IDEMPOTENCY_POLICY_H

--- a/google/cloud/container/cluster_manager_options.h
+++ b/google/cloud/container/cluster_manager_options.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_CLUSTER_MANAGER_OPTIONS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_CLUSTER_MANAGER_OPTIONS_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/container/cluster_manager_connection.h"
 #include "google/cloud/container/cluster_manager_connection_idempotency_policy.h"
 #include "google/cloud/container/v1/cluster_manager_options.h"
@@ -46,5 +47,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace container
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_CLUSTER_MANAGER_OPTIONS_H

--- a/google/cloud/container/mocks/mock_cluster_manager_connection.h
+++ b/google/cloud/container/mocks/mock_cluster_manager_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_MOCKS_MOCK_CLUSTER_MANAGER_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_MOCKS_MOCK_CLUSTER_MANAGER_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/container/cluster_manager_connection.h"
 #include "google/cloud/container/v1/mocks/mock_cluster_manager_connection.h"
 
@@ -37,5 +38,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace container_mocks
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_MOCKS_MOCK_CLUSTER_MANAGER_CONNECTION_H

--- a/google/cloud/container/v1/cluster_manager_client.cc
+++ b/google/cloud/container/v1/cluster_manager_client.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/container/v1/cluster_service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/container/v1/cluster_manager_client.h"
 #include <memory>
 #include <utility>
@@ -508,3 +509,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace container_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/container/v1/cluster_manager_client.h
+++ b/google/cloud/container/v1/cluster_manager_client.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_CLUSTER_MANAGER_CLIENT_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_CLUSTER_MANAGER_CLIENT_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/container/v1/cluster_manager_connection.h"
 #include "google/cloud/future.h"
 #include "google/cloud/options.h"
@@ -1943,5 +1944,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace container_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_CLUSTER_MANAGER_CLIENT_H

--- a/google/cloud/container/v1/cluster_manager_connection.cc
+++ b/google/cloud/container/v1/cluster_manager_connection.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/container/v1/cluster_service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/container/v1/cluster_manager_connection.h"
 #include "google/cloud/container/v1/cluster_manager_options.h"
 #include "google/cloud/container/v1/internal/cluster_manager_connection_impl.h"
@@ -260,3 +261,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace container_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/container/v1/cluster_manager_connection.h
+++ b/google/cloud/container/v1/cluster_manager_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_CLUSTER_MANAGER_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_CLUSTER_MANAGER_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/container/v1/cluster_manager_connection_idempotency_policy.h"
 #include "google/cloud/container/v1/internal/cluster_manager_retry_traits.h"
 #include "google/cloud/backoff_policy.h"
@@ -315,5 +316,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace container_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_CLUSTER_MANAGER_CONNECTION_H

--- a/google/cloud/container/v1/cluster_manager_connection_idempotency_policy.cc
+++ b/google/cloud/container/v1/cluster_manager_connection_idempotency_policy.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/container/v1/cluster_service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/container/v1/cluster_manager_connection_idempotency_policy.h"
 #include <memory>
 
@@ -214,3 +215,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace container_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/container/v1/cluster_manager_connection_idempotency_policy.h
+++ b/google/cloud/container/v1/cluster_manager_connection_idempotency_policy.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_CLUSTER_MANAGER_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_CLUSTER_MANAGER_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/idempotency.h"
 #include "google/cloud/version.h"
 #include <google/container/v1/cluster_service.grpc.pb.h>
@@ -147,5 +148,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace container_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_CLUSTER_MANAGER_CONNECTION_IDEMPOTENCY_POLICY_H

--- a/google/cloud/container/v1/cluster_manager_options.h
+++ b/google/cloud/container/v1/cluster_manager_options.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_CLUSTER_MANAGER_OPTIONS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_CLUSTER_MANAGER_OPTIONS_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/container/v1/cluster_manager_connection.h"
 #include "google/cloud/container/v1/cluster_manager_connection_idempotency_policy.h"
 #include "google/cloud/backoff_policy.h"
@@ -72,5 +73,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace container_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_CLUSTER_MANAGER_OPTIONS_H

--- a/google/cloud/container/v1/internal/cluster_manager_auth_decorator.cc
+++ b/google/cloud/container/v1/internal/cluster_manager_auth_decorator.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/container/v1/cluster_service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/container/v1/internal/cluster_manager_auth_decorator.h"
 #include <google/container/v1/cluster_service.grpc.pb.h>
 #include <memory>
@@ -321,3 +322,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace container_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/container/v1/internal/cluster_manager_auth_decorator.h
+++ b/google/cloud/container/v1/internal/cluster_manager_auth_decorator.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_INTERNAL_CLUSTER_MANAGER_AUTH_DECORATOR_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_INTERNAL_CLUSTER_MANAGER_AUTH_DECORATOR_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/container/v1/internal/cluster_manager_stub.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"
 #include "google/cloud/version.h"
@@ -193,5 +194,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace container_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_INTERNAL_CLUSTER_MANAGER_AUTH_DECORATOR_H

--- a/google/cloud/container/v1/internal/cluster_manager_connection_impl.cc
+++ b/google/cloud/container/v1/internal/cluster_manager_connection_impl.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/container/v1/cluster_service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/container/v1/internal/cluster_manager_connection_impl.h"
 #include "google/cloud/container/v1/internal/cluster_manager_option_defaults.h"
 #include "google/cloud/background_threads.h"
@@ -566,3 +567,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace container_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/container/v1/internal/cluster_manager_connection_impl.h
+++ b/google/cloud/container/v1/internal/cluster_manager_connection_impl.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_INTERNAL_CLUSTER_MANAGER_CONNECTION_IMPL_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_INTERNAL_CLUSTER_MANAGER_CONNECTION_IMPL_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/container/v1/cluster_manager_connection.h"
 #include "google/cloud/container/v1/cluster_manager_connection_idempotency_policy.h"
 #include "google/cloud/container/v1/cluster_manager_options.h"
@@ -169,5 +170,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace container_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_INTERNAL_CLUSTER_MANAGER_CONNECTION_IMPL_H

--- a/google/cloud/container/v1/internal/cluster_manager_logging_decorator.cc
+++ b/google/cloud/container/v1/internal/cluster_manager_logging_decorator.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/container/v1/cluster_service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/container/v1/internal/cluster_manager_logging_decorator.h"
 #include "google/cloud/internal/log_wrapper.h"
 #include "google/cloud/status_or.h"
@@ -442,3 +443,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace container_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/container/v1/internal/cluster_manager_logging_decorator.h
+++ b/google/cloud/container/v1/internal/cluster_manager_logging_decorator.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_INTERNAL_CLUSTER_MANAGER_LOGGING_DECORATOR_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_INTERNAL_CLUSTER_MANAGER_LOGGING_DECORATOR_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/container/v1/internal/cluster_manager_stub.h"
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
@@ -193,5 +194,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace container_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_INTERNAL_CLUSTER_MANAGER_LOGGING_DECORATOR_H

--- a/google/cloud/container/v1/internal/cluster_manager_metadata_decorator.cc
+++ b/google/cloud/container/v1/internal/cluster_manager_metadata_decorator.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/container/v1/cluster_service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/container/v1/internal/cluster_manager_metadata_decorator.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
@@ -359,3 +360,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace container_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/container/v1/internal/cluster_manager_metadata_decorator.h
+++ b/google/cloud/container/v1/internal/cluster_manager_metadata_decorator.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_INTERNAL_CLUSTER_MANAGER_METADATA_DECORATOR_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_INTERNAL_CLUSTER_MANAGER_METADATA_DECORATOR_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/container/v1/internal/cluster_manager_stub.h"
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
@@ -198,5 +199,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace container_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_INTERNAL_CLUSTER_MANAGER_METADATA_DECORATOR_H

--- a/google/cloud/container/v1/internal/cluster_manager_option_defaults.cc
+++ b/google/cloud/container/v1/internal/cluster_manager_option_defaults.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/container/v1/cluster_service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/container/v1/internal/cluster_manager_option_defaults.h"
 #include "google/cloud/container/v1/cluster_manager_connection.h"
 #include "google/cloud/container/v1/cluster_manager_options.h"
@@ -64,3 +65,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace container_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/container/v1/internal/cluster_manager_option_defaults.h
+++ b/google/cloud/container/v1/internal/cluster_manager_option_defaults.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_INTERNAL_CLUSTER_MANAGER_OPTION_DEFAULTS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_INTERNAL_CLUSTER_MANAGER_OPTION_DEFAULTS_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
 
@@ -33,5 +34,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace container_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_INTERNAL_CLUSTER_MANAGER_OPTION_DEFAULTS_H

--- a/google/cloud/container/v1/internal/cluster_manager_retry_traits.h
+++ b/google/cloud/container/v1/internal/cluster_manager_retry_traits.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_INTERNAL_CLUSTER_MANAGER_RETRY_TRAITS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_INTERNAL_CLUSTER_MANAGER_RETRY_TRAITS_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/status.h"
 #include "google/cloud/version.h"
 
@@ -39,5 +40,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace container_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_INTERNAL_CLUSTER_MANAGER_RETRY_TRAITS_H

--- a/google/cloud/container/v1/internal/cluster_manager_sources.cc
+++ b/google/cloud/container/v1/internal/cluster_manager_sources.cc
@@ -17,6 +17,7 @@
 // source: google/container/v1/cluster_service.proto
 
 // NOLINTBEGIN(bugprone-suspicious-include)
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/container/v1/cluster_manager_client.cc"
 #include "google/cloud/container/v1/cluster_manager_connection.cc"
 #include "google/cloud/container/v1/cluster_manager_connection_idempotency_policy.cc"
@@ -29,4 +30,5 @@
 #include "google/cloud/container/v1/internal/cluster_manager_stub_factory.cc"
 #include "google/cloud/container/v1/internal/cluster_manager_tracing_connection.cc"
 #include "google/cloud/container/v1/internal/cluster_manager_tracing_stub.cc"
+#include "google/cloud/internal/diagnostics_pop.inc"
 // NOLINTEND(bugprone-suspicious-include)

--- a/google/cloud/container/v1/internal/cluster_manager_stub.cc
+++ b/google/cloud/container/v1/internal/cluster_manager_stub.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/container/v1/cluster_service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/container/v1/internal/cluster_manager_stub.h"
 #include "google/cloud/grpc_error_delegate.h"
 #include "google/cloud/status_or.h"
@@ -442,3 +443,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace container_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/container/v1/internal/cluster_manager_stub.h
+++ b/google/cloud/container/v1/internal/cluster_manager_stub.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_INTERNAL_CLUSTER_MANAGER_STUB_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_INTERNAL_CLUSTER_MANAGER_STUB_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
@@ -339,5 +340,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace container_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_INTERNAL_CLUSTER_MANAGER_STUB_H

--- a/google/cloud/container/v1/internal/cluster_manager_stub_factory.cc
+++ b/google/cloud/container/v1/internal/cluster_manager_stub_factory.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/container/v1/cluster_service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/container/v1/internal/cluster_manager_stub_factory.h"
 #include "google/cloud/container/v1/internal/cluster_manager_auth_decorator.h"
 #include "google/cloud/container/v1/internal/cluster_manager_logging_decorator.h"
@@ -69,3 +70,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace container_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/container/v1/internal/cluster_manager_stub_factory.h
+++ b/google/cloud/container/v1/internal/cluster_manager_stub_factory.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_INTERNAL_CLUSTER_MANAGER_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_INTERNAL_CLUSTER_MANAGER_STUB_FACTORY_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/container/v1/internal/cluster_manager_stub.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"
 #include "google/cloud/options.h"
@@ -38,5 +39,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace container_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_INTERNAL_CLUSTER_MANAGER_STUB_FACTORY_H

--- a/google/cloud/container/v1/internal/cluster_manager_tracing_connection.cc
+++ b/google/cloud/container/v1/internal/cluster_manager_tracing_connection.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/container/v1/cluster_service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/container/v1/internal/cluster_manager_tracing_connection.h"
 #include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/internal/traced_stream_range.h"
@@ -356,3 +357,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace container_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/container/v1/internal/cluster_manager_tracing_connection.h
+++ b/google/cloud/container/v1/internal/cluster_manager_tracing_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_INTERNAL_CLUSTER_MANAGER_TRACING_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_INTERNAL_CLUSTER_MANAGER_TRACING_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/container/v1/cluster_manager_connection.h"
 #include "google/cloud/version.h"
 #include <memory>
@@ -170,5 +171,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace container_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_INTERNAL_CLUSTER_MANAGER_TRACING_CONNECTION_H

--- a/google/cloud/container/v1/internal/cluster_manager_tracing_stub.cc
+++ b/google/cloud/container/v1/internal/cluster_manager_tracing_stub.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/container/v1/cluster_service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/container/v1/internal/cluster_manager_tracing_stub.h"
 #include "google/cloud/internal/grpc_opentelemetry.h"
 #include <memory>
@@ -455,3 +456,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace container_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/container/v1/internal/cluster_manager_tracing_stub.h
+++ b/google/cloud/container/v1/internal/cluster_manager_tracing_stub.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_INTERNAL_CLUSTER_MANAGER_TRACING_STUB_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_INTERNAL_CLUSTER_MANAGER_TRACING_STUB_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/container/v1/internal/cluster_manager_stub.h"
 #include "google/cloud/internal/trace_propagator.h"
 #include "google/cloud/options.h"
@@ -205,5 +206,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace container_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_INTERNAL_CLUSTER_MANAGER_TRACING_STUB_H

--- a/google/cloud/container/v1/mocks/mock_cluster_manager_connection.h
+++ b/google/cloud/container/v1/mocks/mock_cluster_manager_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_MOCKS_MOCK_CLUSTER_MANAGER_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_MOCKS_MOCK_CLUSTER_MANAGER_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/container/v1/cluster_manager_connection.h"
 #include <gmock/gmock.h>
 
@@ -202,5 +203,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace container_v1_mocks
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONTAINER_V1_MOCKS_MOCK_CLUSTER_MANAGER_CONNECTION_H

--- a/google/cloud/container/v1/samples/cluster_manager_client_samples.cc
+++ b/google/cloud/container/v1/samples/cluster_manager_client_samples.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/container/v1/cluster_service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/container/v1/cluster_manager_client.h"
 #include "google/cloud/container/v1/cluster_manager_connection_idempotency_policy.h"
 #include "google/cloud/container/v1/cluster_manager_options.h"
@@ -154,3 +155,4 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   });
   return example.Run(argc, argv);
 }
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/edgenetwork/v1/edge_network_client.cc
+++ b/google/cloud/edgenetwork/v1/edge_network_client.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/edgenetwork/v1/service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/edgenetwork/v1/edge_network_client.h"
 #include <memory>
 #include <utility>
@@ -803,3 +804,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace edgenetwork_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/edgenetwork/v1/edge_network_client.h
+++ b/google/cloud/edgenetwork/v1/edge_network_client.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_EDGE_NETWORK_CLIENT_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_EDGE_NETWORK_CLIENT_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/edgenetwork/v1/edge_network_connection.h"
 #include "google/cloud/future.h"
 #include "google/cloud/no_await_tag.h"
@@ -2664,5 +2665,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace edgenetwork_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_EDGE_NETWORK_CLIENT_H

--- a/google/cloud/edgenetwork/v1/edge_network_connection.cc
+++ b/google/cloud/edgenetwork/v1/edge_network_connection.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/edgenetwork/v1/service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/edgenetwork/v1/edge_network_connection.h"
 #include "google/cloud/edgenetwork/v1/edge_network_options.h"
 #include "google/cloud/edgenetwork/v1/internal/edge_network_connection_impl.h"
@@ -420,3 +421,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace edgenetwork_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/edgenetwork/v1/edge_network_connection.h
+++ b/google/cloud/edgenetwork/v1/edge_network_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_EDGE_NETWORK_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_EDGE_NETWORK_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/edgenetwork/v1/edge_network_connection_idempotency_policy.h"
 #include "google/cloud/edgenetwork/v1/internal/edge_network_retry_traits.h"
 #include "google/cloud/backoff_policy.h"
@@ -403,5 +404,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace edgenetwork_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_EDGE_NETWORK_CONNECTION_H

--- a/google/cloud/edgenetwork/v1/edge_network_connection_idempotency_policy.cc
+++ b/google/cloud/edgenetwork/v1/edge_network_connection_idempotency_policy.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/edgenetwork/v1/service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/edgenetwork/v1/edge_network_connection_idempotency_policy.h"
 #include <memory>
 
@@ -208,3 +209,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace edgenetwork_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/edgenetwork/v1/edge_network_connection_idempotency_policy.h
+++ b/google/cloud/edgenetwork/v1/edge_network_connection_idempotency_policy.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_EDGE_NETWORK_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_EDGE_NETWORK_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/idempotency.h"
 #include "google/cloud/version.h"
 #include <google/cloud/edgenetwork/v1/service.grpc.pb.h>
@@ -147,5 +148,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace edgenetwork_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_EDGE_NETWORK_CONNECTION_IDEMPOTENCY_POLICY_H

--- a/google/cloud/edgenetwork/v1/edge_network_options.h
+++ b/google/cloud/edgenetwork/v1/edge_network_options.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_EDGE_NETWORK_OPTIONS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_EDGE_NETWORK_OPTIONS_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/edgenetwork/v1/edge_network_connection.h"
 #include "google/cloud/edgenetwork/v1/edge_network_connection_idempotency_policy.h"
 #include "google/cloud/backoff_policy.h"
@@ -82,5 +83,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace edgenetwork_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_EDGE_NETWORK_OPTIONS_H

--- a/google/cloud/edgenetwork/v1/internal/edge_network_auth_decorator.cc
+++ b/google/cloud/edgenetwork/v1/internal/edge_network_auth_decorator.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/edgenetwork/v1/service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/edgenetwork/v1/internal/edge_network_auth_decorator.h"
 #include <google/cloud/edgenetwork/v1/service.grpc.pb.h>
 #include <memory>
@@ -550,3 +551,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace edgenetwork_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/edgenetwork/v1/internal/edge_network_auth_decorator.h
+++ b/google/cloud/edgenetwork/v1/internal/edge_network_auth_decorator.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_INTERNAL_EDGE_NETWORK_AUTH_DECORATOR_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_INTERNAL_EDGE_NETWORK_AUTH_DECORATOR_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/edgenetwork/v1/internal/edge_network_stub.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"
 #include "google/cloud/version.h"
@@ -286,5 +287,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace edgenetwork_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_INTERNAL_EDGE_NETWORK_AUTH_DECORATOR_H

--- a/google/cloud/edgenetwork/v1/internal/edge_network_connection_impl.cc
+++ b/google/cloud/edgenetwork/v1/internal/edge_network_connection_impl.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/edgenetwork/v1/service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/edgenetwork/v1/internal/edge_network_connection_impl.h"
 #include "google/cloud/edgenetwork/v1/internal/edge_network_option_defaults.h"
 #include "google/cloud/background_threads.h"
@@ -1466,3 +1467,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace edgenetwork_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/edgenetwork/v1/internal/edge_network_connection_impl.h
+++ b/google/cloud/edgenetwork/v1/internal/edge_network_connection_impl.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_INTERNAL_EDGE_NETWORK_CONNECTION_IMPL_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_INTERNAL_EDGE_NETWORK_CONNECTION_IMPL_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/edgenetwork/v1/edge_network_connection.h"
 #include "google/cloud/edgenetwork/v1/edge_network_connection_idempotency_policy.h"
 #include "google/cloud/edgenetwork/v1/edge_network_options.h"
@@ -263,5 +264,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace edgenetwork_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_INTERNAL_EDGE_NETWORK_CONNECTION_IMPL_H

--- a/google/cloud/edgenetwork/v1/internal/edge_network_logging_decorator.cc
+++ b/google/cloud/edgenetwork/v1/internal/edge_network_logging_decorator.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/edgenetwork/v1/service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/edgenetwork/v1/internal/edge_network_logging_decorator.h"
 #include "google/cloud/internal/log_wrapper.h"
 #include "google/cloud/status_or.h"
@@ -661,3 +662,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace edgenetwork_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/edgenetwork/v1/internal/edge_network_logging_decorator.h
+++ b/google/cloud/edgenetwork/v1/internal/edge_network_logging_decorator.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_INTERNAL_EDGE_NETWORK_LOGGING_DECORATOR_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_INTERNAL_EDGE_NETWORK_LOGGING_DECORATOR_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/edgenetwork/v1/internal/edge_network_stub.h"
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
@@ -286,5 +287,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace edgenetwork_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_INTERNAL_EDGE_NETWORK_LOGGING_DECORATOR_H

--- a/google/cloud/edgenetwork/v1/internal/edge_network_metadata_decorator.cc
+++ b/google/cloud/edgenetwork/v1/internal/edge_network_metadata_decorator.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/edgenetwork/v1/service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/edgenetwork/v1/internal/edge_network_metadata_decorator.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
@@ -488,3 +489,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace edgenetwork_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/edgenetwork/v1/internal/edge_network_metadata_decorator.h
+++ b/google/cloud/edgenetwork/v1/internal/edge_network_metadata_decorator.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_INTERNAL_EDGE_NETWORK_METADATA_DECORATOR_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_INTERNAL_EDGE_NETWORK_METADATA_DECORATOR_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/edgenetwork/v1/internal/edge_network_stub.h"
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
@@ -291,5 +292,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace edgenetwork_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_INTERNAL_EDGE_NETWORK_METADATA_DECORATOR_H

--- a/google/cloud/edgenetwork/v1/internal/edge_network_option_defaults.cc
+++ b/google/cloud/edgenetwork/v1/internal/edge_network_option_defaults.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/edgenetwork/v1/service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/edgenetwork/v1/internal/edge_network_option_defaults.h"
 #include "google/cloud/edgenetwork/v1/edge_network_connection.h"
 #include "google/cloud/edgenetwork/v1/edge_network_options.h"
@@ -76,3 +77,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace edgenetwork_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/edgenetwork/v1/internal/edge_network_option_defaults.h
+++ b/google/cloud/edgenetwork/v1/internal/edge_network_option_defaults.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_INTERNAL_EDGE_NETWORK_OPTION_DEFAULTS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_INTERNAL_EDGE_NETWORK_OPTION_DEFAULTS_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
 
@@ -33,5 +34,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace edgenetwork_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_INTERNAL_EDGE_NETWORK_OPTION_DEFAULTS_H

--- a/google/cloud/edgenetwork/v1/internal/edge_network_retry_traits.h
+++ b/google/cloud/edgenetwork/v1/internal/edge_network_retry_traits.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_INTERNAL_EDGE_NETWORK_RETRY_TRAITS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_INTERNAL_EDGE_NETWORK_RETRY_TRAITS_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/status.h"
 #include "google/cloud/version.h"
 
@@ -39,5 +40,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace edgenetwork_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_INTERNAL_EDGE_NETWORK_RETRY_TRAITS_H

--- a/google/cloud/edgenetwork/v1/internal/edge_network_sources.cc
+++ b/google/cloud/edgenetwork/v1/internal/edge_network_sources.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/edgenetwork/v1/service.proto
 
 // NOLINTBEGIN(bugprone-suspicious-include)
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/edgenetwork/v1/edge_network_client.cc"
 #include "google/cloud/edgenetwork/v1/edge_network_connection.cc"
 #include "google/cloud/edgenetwork/v1/edge_network_connection_idempotency_policy.cc"
@@ -29,4 +30,5 @@
 #include "google/cloud/edgenetwork/v1/internal/edge_network_stub_factory.cc"
 #include "google/cloud/edgenetwork/v1/internal/edge_network_tracing_connection.cc"
 #include "google/cloud/edgenetwork/v1/internal/edge_network_tracing_stub.cc"
+#include "google/cloud/internal/diagnostics_pop.inc"
 // NOLINTEND(bugprone-suspicious-include)

--- a/google/cloud/edgenetwork/v1/internal/edge_network_stub.cc
+++ b/google/cloud/edgenetwork/v1/internal/edge_network_stub.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/edgenetwork/v1/service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/edgenetwork/v1/internal/edge_network_stub.h"
 #include "google/cloud/grpc_error_delegate.h"
 #include "google/cloud/status_or.h"
@@ -642,3 +643,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace edgenetwork_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/edgenetwork/v1/internal/edge_network_stub.h
+++ b/google/cloud/edgenetwork/v1/internal/edge_network_stub.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_INTERNAL_EDGE_NETWORK_STUB_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_INTERNAL_EDGE_NETWORK_STUB_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/future.h"
 #include "google/cloud/options.h"
@@ -528,5 +529,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace edgenetwork_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_INTERNAL_EDGE_NETWORK_STUB_H

--- a/google/cloud/edgenetwork/v1/internal/edge_network_stub_factory.cc
+++ b/google/cloud/edgenetwork/v1/internal/edge_network_stub_factory.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/edgenetwork/v1/service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/edgenetwork/v1/internal/edge_network_stub_factory.h"
 #include "google/cloud/edgenetwork/v1/internal/edge_network_auth_decorator.h"
 #include "google/cloud/edgenetwork/v1/internal/edge_network_logging_decorator.h"
@@ -74,3 +75,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace edgenetwork_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/edgenetwork/v1/internal/edge_network_stub_factory.h
+++ b/google/cloud/edgenetwork/v1/internal/edge_network_stub_factory.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_INTERNAL_EDGE_NETWORK_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_INTERNAL_EDGE_NETWORK_STUB_FACTORY_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/edgenetwork/v1/internal/edge_network_stub.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"
 #include "google/cloud/options.h"
@@ -38,5 +39,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace edgenetwork_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_INTERNAL_EDGE_NETWORK_STUB_FACTORY_H

--- a/google/cloud/edgenetwork/v1/internal/edge_network_tracing_connection.cc
+++ b/google/cloud/edgenetwork/v1/internal/edge_network_tracing_connection.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/edgenetwork/v1/service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/edgenetwork/v1/internal/edge_network_tracing_connection.h"
 #include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/internal/traced_stream_range.h"
@@ -557,3 +558,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace edgenetwork_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/edgenetwork/v1/internal/edge_network_tracing_connection.h
+++ b/google/cloud/edgenetwork/v1/internal/edge_network_tracing_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_INTERNAL_EDGE_NETWORK_TRACING_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_INTERNAL_EDGE_NETWORK_TRACING_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/edgenetwork/v1/edge_network_connection.h"
 #include "google/cloud/version.h"
 #include <memory>
@@ -262,5 +263,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace edgenetwork_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_INTERNAL_EDGE_NETWORK_TRACING_CONNECTION_H

--- a/google/cloud/edgenetwork/v1/internal/edge_network_tracing_stub.cc
+++ b/google/cloud/edgenetwork/v1/internal/edge_network_tracing_stub.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/edgenetwork/v1/service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/edgenetwork/v1/internal/edge_network_tracing_stub.h"
 #include "google/cloud/internal/grpc_opentelemetry.h"
 #include <memory>
@@ -599,3 +600,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace edgenetwork_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/edgenetwork/v1/internal/edge_network_tracing_stub.h
+++ b/google/cloud/edgenetwork/v1/internal/edge_network_tracing_stub.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_INTERNAL_EDGE_NETWORK_TRACING_STUB_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_INTERNAL_EDGE_NETWORK_TRACING_STUB_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/edgenetwork/v1/internal/edge_network_stub.h"
 #include "google/cloud/internal/trace_propagator.h"
 #include "google/cloud/options.h"
@@ -297,5 +298,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace edgenetwork_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_INTERNAL_EDGE_NETWORK_TRACING_STUB_H

--- a/google/cloud/edgenetwork/v1/mocks/mock_edge_network_connection.h
+++ b/google/cloud/edgenetwork/v1/mocks/mock_edge_network_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_MOCKS_MOCK_EDGE_NETWORK_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_MOCKS_MOCK_EDGE_NETWORK_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/edgenetwork/v1/edge_network_connection.h"
 #include <gmock/gmock.h>
 
@@ -556,5 +557,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace edgenetwork_v1_mocks
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EDGENETWORK_V1_MOCKS_MOCK_EDGE_NETWORK_CONNECTION_H

--- a/google/cloud/edgenetwork/v1/samples/edge_network_client_samples.cc
+++ b/google/cloud/edgenetwork/v1/samples/edge_network_client_samples.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/edgenetwork/v1/service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/edgenetwork/v1/edge_network_client.h"
 #include "google/cloud/edgenetwork/v1/edge_network_connection_idempotency_policy.h"
 #include "google/cloud/edgenetwork/v1/edge_network_options.h"
@@ -200,3 +201,4 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   });
   return example.Run(argc, argv);
 }
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/iam/admin/v1/iam_client.cc
+++ b/google/cloud/iam/admin/v1/iam_client.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/iam/admin/v1/iam.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/iam/admin/v1/iam_client.h"
 #include "google/cloud/iam/admin/v1/iam_options.h"
 #include <memory>
@@ -402,3 +403,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace iam_admin_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/iam/admin/v1/iam_client.h
+++ b/google/cloud/iam/admin/v1/iam_client.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_IAM_CLIENT_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_IAM_CLIENT_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/iam/admin/v1/iam_connection.h"
 #include "google/cloud/future.h"
 #include "google/cloud/iam_updater.h"
@@ -1654,5 +1655,6 @@ namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam_admin_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_IAM_CLIENT_H

--- a/google/cloud/iam/admin/v1/iam_connection.cc
+++ b/google/cloud/iam/admin/v1/iam_connection.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/iam/admin/v1/iam.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/iam/admin/v1/iam_connection.h"
 #include "google/cloud/iam/admin/v1/iam_options.h"
 #include "google/cloud/iam/admin/v1/internal/iam_connection_impl.h"
@@ -216,3 +217,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace iam_admin_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/iam/admin/v1/iam_connection.h
+++ b/google/cloud/iam/admin/v1/iam_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_IAM_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_IAM_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/iam/admin/v1/iam_connection_idempotency_policy.h"
 #include "google/cloud/iam/admin/v1/internal/iam_retry_traits.h"
 #include "google/cloud/backoff_policy.h"
@@ -299,5 +300,6 @@ namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam_admin_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_IAM_CONNECTION_H

--- a/google/cloud/iam/admin/v1/iam_connection_idempotency_policy.cc
+++ b/google/cloud/iam/admin/v1/iam_connection_idempotency_policy.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/iam/admin/v1/iam.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/iam/admin/v1/iam_connection_idempotency_policy.h"
 #include <memory>
 
@@ -183,3 +184,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace iam_admin_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/iam/admin/v1/iam_connection_idempotency_policy.h
+++ b/google/cloud/iam/admin/v1/iam_connection_idempotency_policy.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_IAM_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_IAM_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/idempotency.h"
 #include "google/cloud/version.h"
 #include <google/iam/admin/v1/iam.grpc.pb.h>
@@ -129,5 +130,6 @@ namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam_admin_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_IAM_CONNECTION_IDEMPOTENCY_POLICY_H

--- a/google/cloud/iam/admin/v1/iam_options.h
+++ b/google/cloud/iam/admin/v1/iam_options.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_IAM_OPTIONS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_IAM_OPTIONS_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/iam/admin/v1/iam_connection.h"
 #include "google/cloud/iam/admin/v1/iam_connection_idempotency_policy.h"
 #include "google/cloud/backoff_policy.h"
@@ -71,5 +72,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace iam_admin_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_IAM_OPTIONS_H

--- a/google/cloud/iam/admin/v1/internal/iam_auth_decorator.cc
+++ b/google/cloud/iam/admin/v1/internal/iam_auth_decorator.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/iam/admin/v1/iam.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/iam/admin/v1/internal/iam_auth_decorator.h"
 #include <google/iam/admin/v1/iam.grpc.pb.h>
 #include <memory>
@@ -269,3 +270,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace iam_admin_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/iam/admin/v1/internal/iam_auth_decorator.h
+++ b/google/cloud/iam/admin/v1/internal/iam_auth_decorator.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_INTERNAL_IAM_AUTH_DECORATOR_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_INTERNAL_IAM_AUTH_DECORATOR_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/iam/admin/v1/internal/iam_stub.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"
 #include "google/cloud/version.h"
@@ -181,5 +182,6 @@ namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam_admin_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_INTERNAL_IAM_AUTH_DECORATOR_H

--- a/google/cloud/iam/admin/v1/internal/iam_connection_impl.cc
+++ b/google/cloud/iam/admin/v1/internal/iam_connection_impl.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/iam/admin/v1/iam.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/iam/admin/v1/internal/iam_connection_impl.h"
 #include "google/cloud/iam/admin/v1/internal/iam_option_defaults.h"
 #include "google/cloud/background_threads.h"
@@ -532,3 +533,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace iam_admin_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/iam/admin/v1/internal/iam_connection_impl.h
+++ b/google/cloud/iam/admin/v1/internal/iam_connection_impl.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_INTERNAL_IAM_CONNECTION_IMPL_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_INTERNAL_IAM_CONNECTION_IMPL_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/iam/admin/v1/iam_connection.h"
 #include "google/cloud/iam/admin/v1/iam_connection_idempotency_policy.h"
 #include "google/cloud/iam/admin/v1/iam_options.h"
@@ -159,5 +160,6 @@ namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam_admin_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_INTERNAL_IAM_CONNECTION_IMPL_H

--- a/google/cloud/iam/admin/v1/internal/iam_logging_decorator.cc
+++ b/google/cloud/iam/admin/v1/internal/iam_logging_decorator.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/iam/admin/v1/iam.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/iam/admin/v1/internal/iam_logging_decorator.h"
 #include "google/cloud/internal/log_wrapper.h"
 #include "google/cloud/status_or.h"
@@ -376,3 +377,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace iam_admin_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/iam/admin/v1/internal/iam_logging_decorator.h
+++ b/google/cloud/iam/admin/v1/internal/iam_logging_decorator.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_INTERNAL_IAM_LOGGING_DECORATOR_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_INTERNAL_IAM_LOGGING_DECORATOR_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/iam/admin/v1/internal/iam_stub.h"
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
@@ -180,5 +181,6 @@ namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam_admin_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_INTERNAL_IAM_LOGGING_DECORATOR_H

--- a/google/cloud/iam/admin/v1/internal/iam_metadata_decorator.cc
+++ b/google/cloud/iam/admin/v1/internal/iam_metadata_decorator.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/iam/admin/v1/iam.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/iam/admin/v1/internal/iam_metadata_decorator.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
@@ -296,3 +297,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace iam_admin_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/iam/admin/v1/internal/iam_metadata_decorator.h
+++ b/google/cloud/iam/admin/v1/internal/iam_metadata_decorator.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_INTERNAL_IAM_METADATA_DECORATOR_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_INTERNAL_IAM_METADATA_DECORATOR_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/iam/admin/v1/internal/iam_stub.h"
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
@@ -186,5 +187,6 @@ namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam_admin_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_INTERNAL_IAM_METADATA_DECORATOR_H

--- a/google/cloud/iam/admin/v1/internal/iam_option_defaults.cc
+++ b/google/cloud/iam/admin/v1/internal/iam_option_defaults.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/iam/admin/v1/iam.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/iam/admin/v1/internal/iam_option_defaults.h"
 #include "google/cloud/iam/admin/v1/iam_connection.h"
 #include "google/cloud/iam/admin/v1/iam_options.h"
@@ -62,3 +63,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace iam_admin_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/iam/admin/v1/internal/iam_option_defaults.h
+++ b/google/cloud/iam/admin/v1/internal/iam_option_defaults.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_INTERNAL_IAM_OPTION_DEFAULTS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_INTERNAL_IAM_OPTION_DEFAULTS_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
 
@@ -34,5 +35,6 @@ namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam_admin_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_INTERNAL_IAM_OPTION_DEFAULTS_H

--- a/google/cloud/iam/admin/v1/internal/iam_retry_traits.h
+++ b/google/cloud/iam/admin/v1/internal/iam_retry_traits.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_INTERNAL_IAM_RETRY_TRAITS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_INTERNAL_IAM_RETRY_TRAITS_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/status.h"
 #include "google/cloud/version.h"
 
@@ -39,5 +40,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace iam_admin_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_INTERNAL_IAM_RETRY_TRAITS_H

--- a/google/cloud/iam/admin/v1/internal/iam_sources.cc
+++ b/google/cloud/iam/admin/v1/internal/iam_sources.cc
@@ -17,6 +17,7 @@
 // source: google/iam/admin/v1/iam.proto
 
 // NOLINTBEGIN(bugprone-suspicious-include)
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/iam/admin/v1/iam_client.cc"
 #include "google/cloud/iam/admin/v1/iam_connection.cc"
 #include "google/cloud/iam/admin/v1/iam_connection_idempotency_policy.cc"
@@ -29,4 +30,5 @@
 #include "google/cloud/iam/admin/v1/internal/iam_stub_factory.cc"
 #include "google/cloud/iam/admin/v1/internal/iam_tracing_connection.cc"
 #include "google/cloud/iam/admin/v1/internal/iam_tracing_stub.cc"
+#include "google/cloud/internal/diagnostics_pop.inc"
 // NOLINTEND(bugprone-suspicious-include)

--- a/google/cloud/iam/admin/v1/internal/iam_stub.cc
+++ b/google/cloud/iam/admin/v1/internal/iam_stub.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/iam/admin/v1/iam.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/iam/admin/v1/internal/iam_stub.h"
 #include "google/cloud/grpc_error_delegate.h"
 #include "google/cloud/status_or.h"
@@ -364,3 +365,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace iam_admin_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/iam/admin/v1/internal/iam_stub.h
+++ b/google/cloud/iam/admin/v1/internal/iam_stub.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_INTERNAL_IAM_STUB_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_INTERNAL_IAM_STUB_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
@@ -312,5 +313,6 @@ namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam_admin_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_INTERNAL_IAM_STUB_H

--- a/google/cloud/iam/admin/v1/internal/iam_stub_factory.cc
+++ b/google/cloud/iam/admin/v1/internal/iam_stub_factory.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/iam/admin/v1/iam.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/iam/admin/v1/internal/iam_stub_factory.h"
 #include "google/cloud/iam/admin/v1/internal/iam_auth_decorator.h"
 #include "google/cloud/iam/admin/v1/internal/iam_logging_decorator.h"
@@ -67,3 +68,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace iam_admin_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/iam/admin/v1/internal/iam_stub_factory.h
+++ b/google/cloud/iam/admin/v1/internal/iam_stub_factory.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_INTERNAL_IAM_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_INTERNAL_IAM_STUB_FACTORY_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/iam/admin/v1/internal/iam_stub.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"
 #include "google/cloud/options.h"
@@ -39,5 +40,6 @@ namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam_admin_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_INTERNAL_IAM_STUB_FACTORY_H

--- a/google/cloud/iam/admin/v1/internal/iam_tracing_connection.cc
+++ b/google/cloud/iam/admin/v1/internal/iam_tracing_connection.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/iam/admin/v1/iam.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/iam/admin/v1/internal/iam_tracing_connection.h"
 #include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/internal/traced_stream_range.h"
@@ -286,3 +287,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace iam_admin_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/iam/admin/v1/internal/iam_tracing_connection.h
+++ b/google/cloud/iam/admin/v1/internal/iam_tracing_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_INTERNAL_IAM_TRACING_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_INTERNAL_IAM_TRACING_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/iam/admin/v1/iam_connection.h"
 #include "google/cloud/version.h"
 #include <memory>
@@ -160,5 +161,6 @@ namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam_admin_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_INTERNAL_IAM_TRACING_CONNECTION_H

--- a/google/cloud/iam/admin/v1/internal/iam_tracing_stub.cc
+++ b/google/cloud/iam/admin/v1/internal/iam_tracing_stub.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/iam/admin/v1/iam.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/iam/admin/v1/internal/iam_tracing_stub.h"
 #include "google/cloud/internal/grpc_opentelemetry.h"
 #include <memory>
@@ -366,3 +367,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace iam_admin_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/iam/admin/v1/internal/iam_tracing_stub.h
+++ b/google/cloud/iam/admin/v1/internal/iam_tracing_stub.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_INTERNAL_IAM_TRACING_STUB_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_INTERNAL_IAM_TRACING_STUB_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/iam/admin/v1/internal/iam_stub.h"
 #include "google/cloud/internal/trace_propagator.h"
 #include "google/cloud/options.h"
@@ -192,5 +193,6 @@ namespace gcpcxxV1 = GOOGLE_CLOUD_CPP_NS;  // NOLINT(misc-unused-alias-decls)
 }  // namespace iam_admin_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_INTERNAL_IAM_TRACING_STUB_H

--- a/google/cloud/iam/admin/v1/mocks/mock_iam_connection.h
+++ b/google/cloud/iam/admin/v1/mocks/mock_iam_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_MOCKS_MOCK_IAM_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_MOCKS_MOCK_IAM_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/iam/admin/v1/iam_connection.h"
 #include <gmock/gmock.h>
 
@@ -185,5 +186,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace iam_admin_v1_mocks
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_ADMIN_V1_MOCKS_MOCK_IAM_CONNECTION_H

--- a/google/cloud/iam/admin/v1/samples/iam_client_samples.cc
+++ b/google/cloud/iam/admin/v1/samples/iam_client_samples.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/iam/admin/v1/iam.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/iam/admin/v1/iam_client.h"
 #include "google/cloud/iam/admin/v1/iam_connection_idempotency_policy.h"
 #include "google/cloud/iam/admin/v1/iam_options.h"
@@ -151,3 +152,4 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   });
   return example.Run(argc, argv);
 }
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/iam/iam_client.h
+++ b/google/cloud/iam/iam_client.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_IAM_CLIENT_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_IAM_CLIENT_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/iam/admin/v1/iam_client.h"
 #include "google/cloud/iam/iam_connection.h"
 
@@ -37,5 +38,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace iam
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_IAM_CLIENT_H

--- a/google/cloud/iam/iam_connection.h
+++ b/google/cloud/iam/iam_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_IAM_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_IAM_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/iam/admin/v1/iam_connection.h"
 #include "google/cloud/iam/iam_connection_idempotency_policy.h"
 
@@ -46,5 +47,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace iam
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_IAM_CONNECTION_H

--- a/google/cloud/iam/iam_connection_idempotency_policy.h
+++ b/google/cloud/iam/iam_connection_idempotency_policy.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_IAM_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_IAM_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/iam/admin/v1/iam_connection_idempotency_policy.h"
 
 namespace google {
@@ -37,5 +38,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace iam
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_IAM_CONNECTION_IDEMPOTENCY_POLICY_H

--- a/google/cloud/iam/iam_options.h
+++ b/google/cloud/iam/iam_options.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_IAM_OPTIONS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_IAM_OPTIONS_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/iam/admin/v1/iam_options.h"
 #include "google/cloud/iam/iam_connection.h"
 #include "google/cloud/iam/iam_connection_idempotency_policy.h"
@@ -44,5 +45,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace iam
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_IAM_OPTIONS_H

--- a/google/cloud/iam/mocks/mock_iam_connection.h
+++ b/google/cloud/iam/mocks/mock_iam_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_MOCKS_MOCK_IAM_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_MOCKS_MOCK_IAM_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/iam/admin/v1/mocks/mock_iam_connection.h"
 #include "google/cloud/iam/iam_connection.h"
 
@@ -37,5 +38,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace iam_mocks
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_MOCKS_MOCK_IAM_CONNECTION_H

--- a/google/cloud/resourcesettings/README.md
+++ b/google/cloud/resourcesettings/README.md
@@ -21,6 +21,7 @@ top-level [README](/README.md#building-and-installing).
 <!-- inject-quickstart-start -->
 
 ```cc
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/resourcesettings/v1/resource_settings_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
@@ -46,6 +47,7 @@ int main(int argc, char* argv[]) try {
   std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
+#include "google/cloud/internal/diagnostics_pop.inc"
 ```
 
 <!-- inject-quickstart-end -->

--- a/google/cloud/resourcesettings/mocks/mock_resource_settings_connection.h
+++ b/google/cloud/resourcesettings/mocks/mock_resource_settings_connection.h
@@ -40,5 +40,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcesettings_mocks
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RESOURCESETTINGS_MOCKS_MOCK_RESOURCE_SETTINGS_CONNECTION_H

--- a/google/cloud/resourcesettings/quickstart/quickstart.cc
+++ b/google/cloud/resourcesettings/quickstart/quickstart.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 //! [all]
 #include "google/cloud/resourcesettings/v1/resource_settings_client.h"
 #include "google/cloud/project.h"
@@ -39,3 +40,4 @@ int main(int argc, char* argv[]) try {
   return 1;
 }
 //! [all]
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/resourcesettings/resource_settings_client.h
+++ b/google/cloud/resourcesettings/resource_settings_client.h
@@ -38,5 +38,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcesettings
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RESOURCESETTINGS_RESOURCE_SETTINGS_CLIENT_H

--- a/google/cloud/resourcesettings/resource_settings_connection.h
+++ b/google/cloud/resourcesettings/resource_settings_connection.h
@@ -56,5 +56,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcesettings
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RESOURCESETTINGS_RESOURCE_SETTINGS_CONNECTION_H

--- a/google/cloud/resourcesettings/resource_settings_connection_idempotency_policy.h
+++ b/google/cloud/resourcesettings/resource_settings_connection_idempotency_policy.h
@@ -43,5 +43,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcesettings
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RESOURCESETTINGS_RESOURCE_SETTINGS_CONNECTION_IDEMPOTENCY_POLICY_H

--- a/google/cloud/resourcesettings/resource_settings_options.h
+++ b/google/cloud/resourcesettings/resource_settings_options.h
@@ -54,5 +54,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcesettings
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RESOURCESETTINGS_RESOURCE_SETTINGS_OPTIONS_H

--- a/google/cloud/resourcesettings/v1/internal/resource_settings_auth_decorator.cc
+++ b/google/cloud/resourcesettings/v1/internal/resource_settings_auth_decorator.cc
@@ -63,3 +63,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcesettings_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/resourcesettings/v1/internal/resource_settings_auth_decorator.h
+++ b/google/cloud/resourcesettings/v1/internal/resource_settings_auth_decorator.h
@@ -63,5 +63,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcesettings_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RESOURCESETTINGS_V1_INTERNAL_RESOURCE_SETTINGS_AUTH_DECORATOR_H

--- a/google/cloud/resourcesettings/v1/internal/resource_settings_connection_impl.cc
+++ b/google/cloud/resourcesettings/v1/internal/resource_settings_connection_impl.cc
@@ -137,3 +137,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcesettings_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/resourcesettings/v1/internal/resource_settings_connection_impl.h
+++ b/google/cloud/resourcesettings/v1/internal/resource_settings_connection_impl.h
@@ -74,5 +74,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcesettings_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RESOURCESETTINGS_V1_INTERNAL_RESOURCE_SETTINGS_CONNECTION_IMPL_H

--- a/google/cloud/resourcesettings/v1/internal/resource_settings_logging_decorator.cc
+++ b/google/cloud/resourcesettings/v1/internal/resource_settings_logging_decorator.cc
@@ -79,3 +79,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcesettings_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/resourcesettings/v1/internal/resource_settings_logging_decorator.h
+++ b/google/cloud/resourcesettings/v1/internal/resource_settings_logging_decorator.h
@@ -63,5 +63,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcesettings_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RESOURCESETTINGS_V1_INTERNAL_RESOURCE_SETTINGS_LOGGING_DECORATOR_H

--- a/google/cloud/resourcesettings/v1/internal/resource_settings_metadata_decorator.cc
+++ b/google/cloud/resourcesettings/v1/internal/resource_settings_metadata_decorator.cc
@@ -90,3 +90,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcesettings_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/resourcesettings/v1/internal/resource_settings_metadata_decorator.h
+++ b/google/cloud/resourcesettings/v1/internal/resource_settings_metadata_decorator.h
@@ -69,5 +69,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcesettings_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RESOURCESETTINGS_V1_INTERNAL_RESOURCE_SETTINGS_METADATA_DECORATOR_H

--- a/google/cloud/resourcesettings/v1/internal/resource_settings_option_defaults.cc
+++ b/google/cloud/resourcesettings/v1/internal/resource_settings_option_defaults.cc
@@ -72,3 +72,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcesettings_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/resourcesettings/v1/internal/resource_settings_option_defaults.h
+++ b/google/cloud/resourcesettings/v1/internal/resource_settings_option_defaults.h
@@ -34,5 +34,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcesettings_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RESOURCESETTINGS_V1_INTERNAL_RESOURCE_SETTINGS_OPTION_DEFAULTS_H

--- a/google/cloud/resourcesettings/v1/internal/resource_settings_retry_traits.h
+++ b/google/cloud/resourcesettings/v1/internal/resource_settings_retry_traits.h
@@ -40,5 +40,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcesettings_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RESOURCESETTINGS_V1_INTERNAL_RESOURCE_SETTINGS_RETRY_TRAITS_H

--- a/google/cloud/resourcesettings/v1/internal/resource_settings_sources.cc
+++ b/google/cloud/resourcesettings/v1/internal/resource_settings_sources.cc
@@ -30,4 +30,5 @@
 #include "google/cloud/resourcesettings/v1/resource_settings_client.cc"
 #include "google/cloud/resourcesettings/v1/resource_settings_connection.cc"
 #include "google/cloud/resourcesettings/v1/resource_settings_connection_idempotency_policy.cc"
+#include "google/cloud/internal/diagnostics_pop.inc"
 // NOLINTEND(bugprone-suspicious-include)

--- a/google/cloud/resourcesettings/v1/internal/resource_settings_stub.cc
+++ b/google/cloud/resourcesettings/v1/internal/resource_settings_stub.cc
@@ -71,3 +71,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcesettings_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/resourcesettings/v1/internal/resource_settings_stub.h
+++ b/google/cloud/resourcesettings/v1/internal/resource_settings_stub.h
@@ -85,5 +85,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcesettings_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RESOURCESETTINGS_V1_INTERNAL_RESOURCE_SETTINGS_STUB_H

--- a/google/cloud/resourcesettings/v1/internal/resource_settings_stub_factory.cc
+++ b/google/cloud/resourcesettings/v1/internal/resource_settings_stub_factory.cc
@@ -73,3 +73,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcesettings_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/resourcesettings/v1/internal/resource_settings_stub_factory.h
+++ b/google/cloud/resourcesettings/v1/internal/resource_settings_stub_factory.h
@@ -40,5 +40,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcesettings_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RESOURCESETTINGS_V1_INTERNAL_RESOURCE_SETTINGS_STUB_FACTORY_H

--- a/google/cloud/resourcesettings/v1/internal/resource_settings_tracing_connection.cc
+++ b/google/cloud/resourcesettings/v1/internal/resource_settings_tracing_connection.cc
@@ -85,3 +85,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcesettings_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/resourcesettings/v1/internal/resource_settings_tracing_connection.h
+++ b/google/cloud/resourcesettings/v1/internal/resource_settings_tracing_connection.h
@@ -76,5 +76,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcesettings_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RESOURCESETTINGS_V1_INTERNAL_RESOURCE_SETTINGS_TRACING_CONNECTION_H

--- a/google/cloud/resourcesettings/v1/internal/resource_settings_tracing_stub.cc
+++ b/google/cloud/resourcesettings/v1/internal/resource_settings_tracing_stub.cc
@@ -87,3 +87,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcesettings_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/resourcesettings/v1/internal/resource_settings_tracing_stub.h
+++ b/google/cloud/resourcesettings/v1/internal/resource_settings_tracing_stub.h
@@ -77,5 +77,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcesettings_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RESOURCESETTINGS_V1_INTERNAL_RESOURCE_SETTINGS_TRACING_STUB_H

--- a/google/cloud/resourcesettings/v1/mocks/mock_resource_settings_connection.h
+++ b/google/cloud/resourcesettings/v1/mocks/mock_resource_settings_connection.h
@@ -69,5 +69,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcesettings_v1_mocks
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RESOURCESETTINGS_V1_MOCKS_MOCK_RESOURCE_SETTINGS_CONNECTION_H

--- a/google/cloud/resourcesettings/v1/resource_settings_client.cc
+++ b/google/cloud/resourcesettings/v1/resource_settings_client.cc
@@ -79,3 +79,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcesettings_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/resourcesettings/v1/resource_settings_client.h
+++ b/google/cloud/resourcesettings/v1/resource_settings_client.h
@@ -304,5 +304,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcesettings_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RESOURCESETTINGS_V1_RESOURCE_SETTINGS_CLIENT_H

--- a/google/cloud/resourcesettings/v1/resource_settings_connection.cc
+++ b/google/cloud/resourcesettings/v1/resource_settings_connection.cc
@@ -84,3 +84,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcesettings_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/resourcesettings/v1/resource_settings_connection.h
+++ b/google/cloud/resourcesettings/v1/resource_settings_connection.h
@@ -233,5 +233,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcesettings_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RESOURCESETTINGS_V1_RESOURCE_SETTINGS_CONNECTION_H

--- a/google/cloud/resourcesettings/v1/resource_settings_connection_idempotency_policy.cc
+++ b/google/cloud/resourcesettings/v1/resource_settings_connection_idempotency_policy.cc
@@ -60,3 +60,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcesettings_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/resourcesettings/v1/resource_settings_connection_idempotency_policy.h
+++ b/google/cloud/resourcesettings/v1/resource_settings_connection_idempotency_policy.h
@@ -55,5 +55,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcesettings_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RESOURCESETTINGS_V1_RESOURCE_SETTINGS_CONNECTION_IDEMPOTENCY_POLICY_H

--- a/google/cloud/resourcesettings/v1/resource_settings_options.h
+++ b/google/cloud/resourcesettings/v1/resource_settings_options.h
@@ -74,5 +74,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcesettings_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RESOURCESETTINGS_V1_RESOURCE_SETTINGS_OPTIONS_H

--- a/google/cloud/resourcesettings/v1/samples/resource_settings_client_samples.cc
+++ b/google/cloud/resourcesettings/v1/samples/resource_settings_client_samples.cc
@@ -165,3 +165,4 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   });
   return example.Run(argc, argv);
 }
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/securitycenter/mocks/mock_security_center_connection.h
+++ b/google/cloud/securitycenter/mocks/mock_security_center_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_MOCKS_MOCK_SECURITY_CENTER_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_MOCKS_MOCK_SECURITY_CENTER_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/securitycenter/security_center_connection.h"
 #include "google/cloud/securitycenter/v1/mocks/mock_security_center_connection.h"
 
@@ -38,5 +39,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace securitycenter_mocks
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_MOCKS_MOCK_SECURITY_CENTER_CONNECTION_H

--- a/google/cloud/securitycenter/security_center_client.h
+++ b/google/cloud/securitycenter/security_center_client.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_SECURITY_CENTER_CLIENT_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_SECURITY_CENTER_CLIENT_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/securitycenter/security_center_connection.h"
 #include "google/cloud/securitycenter/v1/security_center_client.h"
 
@@ -37,5 +38,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace securitycenter
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_SECURITY_CENTER_CLIENT_H

--- a/google/cloud/securitycenter/security_center_connection.h
+++ b/google/cloud/securitycenter/security_center_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_SECURITY_CENTER_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_SECURITY_CENTER_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/securitycenter/security_center_connection_idempotency_policy.h"
 #include "google/cloud/securitycenter/v1/security_center_connection.h"
 
@@ -49,5 +50,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace securitycenter
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_SECURITY_CENTER_CONNECTION_H

--- a/google/cloud/securitycenter/security_center_connection_idempotency_policy.h
+++ b/google/cloud/securitycenter/security_center_connection_idempotency_policy.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_SECURITY_CENTER_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_SECURITY_CENTER_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/securitycenter/v1/security_center_connection_idempotency_policy.h"
 
 namespace google {
@@ -41,5 +42,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace securitycenter
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_SECURITY_CENTER_CONNECTION_IDEMPOTENCY_POLICY_H

--- a/google/cloud/securitycenter/security_center_options.h
+++ b/google/cloud/securitycenter/security_center_options.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_SECURITY_CENTER_OPTIONS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_SECURITY_CENTER_OPTIONS_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/securitycenter/security_center_connection.h"
 #include "google/cloud/securitycenter/security_center_connection_idempotency_policy.h"
 #include "google/cloud/securitycenter/v1/security_center_options.h"
@@ -51,5 +52,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace securitycenter
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_SECURITY_CENTER_OPTIONS_H

--- a/google/cloud/securitycenter/v1/internal/security_center_auth_decorator.cc
+++ b/google/cloud/securitycenter/v1/internal/security_center_auth_decorator.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/securitycenter/v1/securitycenter_service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/securitycenter/v1/internal/security_center_auth_decorator.h"
 #include <google/cloud/securitycenter/v1/securitycenter_service.grpc.pb.h>
 #include <memory>
@@ -772,3 +773,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace securitycenter_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/securitycenter/v1/internal/security_center_auth_decorator.h
+++ b/google/cloud/securitycenter/v1/internal/security_center_auth_decorator.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_INTERNAL_SECURITY_CENTER_AUTH_DECORATOR_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_INTERNAL_SECURITY_CENTER_AUTH_DECORATOR_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/securitycenter/v1/internal/security_center_stub.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"
 #include "google/cloud/version.h"
@@ -466,5 +467,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace securitycenter_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_INTERNAL_SECURITY_CENTER_AUTH_DECORATOR_H

--- a/google/cloud/securitycenter/v1/internal/security_center_connection_impl.cc
+++ b/google/cloud/securitycenter/v1/internal/security_center_connection_impl.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/securitycenter/v1/securitycenter_service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/securitycenter/v1/internal/security_center_connection_impl.h"
 #include "google/cloud/securitycenter/v1/internal/security_center_option_defaults.h"
 #include "google/cloud/background_threads.h"
@@ -1707,3 +1708,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace securitycenter_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/securitycenter/v1/internal/security_center_connection_impl.h
+++ b/google/cloud/securitycenter/v1/internal/security_center_connection_impl.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_INTERNAL_SECURITY_CENTER_CONNECTION_IMPL_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_INTERNAL_SECURITY_CENTER_CONNECTION_IMPL_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/securitycenter/v1/internal/security_center_retry_traits.h"
 #include "google/cloud/securitycenter/v1/internal/security_center_stub.h"
 #include "google/cloud/securitycenter/v1/security_center_connection.h"
@@ -401,5 +402,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace securitycenter_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_INTERNAL_SECURITY_CENTER_CONNECTION_IMPL_H

--- a/google/cloud/securitycenter/v1/internal/security_center_logging_decorator.cc
+++ b/google/cloud/securitycenter/v1/internal/security_center_logging_decorator.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/securitycenter/v1/securitycenter_service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/securitycenter/v1/internal/security_center_logging_decorator.h"
 #include "google/cloud/internal/log_wrapper.h"
 #include "google/cloud/status_or.h"
@@ -1058,3 +1059,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace securitycenter_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/securitycenter/v1/internal/security_center_logging_decorator.h
+++ b/google/cloud/securitycenter/v1/internal/security_center_logging_decorator.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_INTERNAL_SECURITY_CENTER_LOGGING_DECORATOR_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_INTERNAL_SECURITY_CENTER_LOGGING_DECORATOR_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/securitycenter/v1/internal/security_center_stub.h"
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
@@ -466,5 +467,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace securitycenter_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_INTERNAL_SECURITY_CENTER_LOGGING_DECORATOR_H

--- a/google/cloud/securitycenter/v1/internal/security_center_metadata_decorator.cc
+++ b/google/cloud/securitycenter/v1/internal/security_center_metadata_decorator.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/securitycenter/v1/securitycenter_service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/securitycenter/v1/internal/security_center_metadata_decorator.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
@@ -796,3 +797,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace securitycenter_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/securitycenter/v1/internal/security_center_metadata_decorator.h
+++ b/google/cloud/securitycenter/v1/internal/security_center_metadata_decorator.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_INTERNAL_SECURITY_CENTER_METADATA_DECORATOR_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_INTERNAL_SECURITY_CENTER_METADATA_DECORATOR_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/securitycenter/v1/internal/security_center_stub.h"
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
@@ -471,5 +472,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace securitycenter_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_INTERNAL_SECURITY_CENTER_METADATA_DECORATOR_H

--- a/google/cloud/securitycenter/v1/internal/security_center_option_defaults.cc
+++ b/google/cloud/securitycenter/v1/internal/security_center_option_defaults.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/securitycenter/v1/securitycenter_service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/securitycenter/v1/internal/security_center_option_defaults.h"
 #include "google/cloud/securitycenter/v1/security_center_connection.h"
 #include "google/cloud/securitycenter/v1/security_center_options.h"
@@ -79,3 +80,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace securitycenter_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/securitycenter/v1/internal/security_center_option_defaults.h
+++ b/google/cloud/securitycenter/v1/internal/security_center_option_defaults.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_INTERNAL_SECURITY_CENTER_OPTION_DEFAULTS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_INTERNAL_SECURITY_CENTER_OPTION_DEFAULTS_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
 
@@ -33,5 +34,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace securitycenter_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_INTERNAL_SECURITY_CENTER_OPTION_DEFAULTS_H

--- a/google/cloud/securitycenter/v1/internal/security_center_retry_traits.h
+++ b/google/cloud/securitycenter/v1/internal/security_center_retry_traits.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_INTERNAL_SECURITY_CENTER_RETRY_TRAITS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_INTERNAL_SECURITY_CENTER_RETRY_TRAITS_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/status.h"
 #include "google/cloud/version.h"
 
@@ -39,5 +40,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace securitycenter_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_INTERNAL_SECURITY_CENTER_RETRY_TRAITS_H

--- a/google/cloud/securitycenter/v1/internal/security_center_sources.cc
+++ b/google/cloud/securitycenter/v1/internal/security_center_sources.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/securitycenter/v1/securitycenter_service.proto
 
 // NOLINTBEGIN(bugprone-suspicious-include)
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/securitycenter/v1/internal/security_center_auth_decorator.cc"
 #include "google/cloud/securitycenter/v1/internal/security_center_connection_impl.cc"
 #include "google/cloud/securitycenter/v1/internal/security_center_logging_decorator.cc"
@@ -29,4 +30,5 @@
 #include "google/cloud/securitycenter/v1/security_center_client.cc"
 #include "google/cloud/securitycenter/v1/security_center_connection.cc"
 #include "google/cloud/securitycenter/v1/security_center_connection_idempotency_policy.cc"
+#include "google/cloud/internal/diagnostics_pop.inc"
 // NOLINTEND(bugprone-suspicious-include)

--- a/google/cloud/securitycenter/v1/internal/security_center_stub.cc
+++ b/google/cloud/securitycenter/v1/internal/security_center_stub.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/securitycenter/v1/securitycenter_service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/securitycenter/v1/internal/security_center_stub.h"
 #include "google/cloud/grpc_error_delegate.h"
 #include "google/cloud/status_or.h"
@@ -1003,3 +1004,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace securitycenter_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/securitycenter/v1/internal/security_center_stub.h
+++ b/google/cloud/securitycenter/v1/internal/security_center_stub.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_INTERNAL_SECURITY_CENTER_STUB_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_INTERNAL_SECURITY_CENTER_STUB_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/future.h"
 #include "google/cloud/options.h"
@@ -903,5 +904,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace securitycenter_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_INTERNAL_SECURITY_CENTER_STUB_H

--- a/google/cloud/securitycenter/v1/internal/security_center_stub_factory.cc
+++ b/google/cloud/securitycenter/v1/internal/security_center_stub_factory.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/securitycenter/v1/securitycenter_service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/securitycenter/v1/internal/security_center_stub_factory.h"
 #include "google/cloud/securitycenter/v1/internal/security_center_auth_decorator.h"
 #include "google/cloud/securitycenter/v1/internal/security_center_logging_decorator.h"
@@ -72,3 +73,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace securitycenter_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/securitycenter/v1/internal/security_center_stub_factory.h
+++ b/google/cloud/securitycenter/v1/internal/security_center_stub_factory.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_INTERNAL_SECURITY_CENTER_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_INTERNAL_SECURITY_CENTER_STUB_FACTORY_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/securitycenter/v1/internal/security_center_stub.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"
 #include "google/cloud/options.h"
@@ -38,5 +39,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace securitycenter_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_INTERNAL_SECURITY_CENTER_STUB_FACTORY_H

--- a/google/cloud/securitycenter/v1/internal/security_center_tracing_connection.cc
+++ b/google/cloud/securitycenter/v1/internal/security_center_tracing_connection.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/securitycenter/v1/securitycenter_service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/securitycenter/v1/internal/security_center_tracing_connection.h"
 #include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/internal/traced_stream_range.h"
@@ -833,3 +834,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace securitycenter_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/securitycenter/v1/internal/security_center_tracing_connection.h
+++ b/google/cloud/securitycenter/v1/internal/security_center_tracing_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_INTERNAL_SECURITY_CENTER_TRACING_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_INTERNAL_SECURITY_CENTER_TRACING_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/securitycenter/v1/security_center_connection.h"
 #include "google/cloud/version.h"
 #include <memory>
@@ -399,5 +400,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace securitycenter_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_INTERNAL_SECURITY_CENTER_TRACING_CONNECTION_H

--- a/google/cloud/securitycenter/v1/internal/security_center_tracing_stub.cc
+++ b/google/cloud/securitycenter/v1/internal/security_center_tracing_stub.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/securitycenter/v1/securitycenter_service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/securitycenter/v1/internal/security_center_tracing_stub.h"
 #include "google/cloud/internal/grpc_opentelemetry.h"
 #include <memory>
@@ -1016,3 +1017,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace securitycenter_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/securitycenter/v1/internal/security_center_tracing_stub.h
+++ b/google/cloud/securitycenter/v1/internal/security_center_tracing_stub.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_INTERNAL_SECURITY_CENTER_TRACING_STUB_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_INTERNAL_SECURITY_CENTER_TRACING_STUB_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/securitycenter/v1/internal/security_center_stub.h"
 #include "google/cloud/internal/trace_propagator.h"
 #include "google/cloud/options.h"
@@ -477,5 +478,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace securitycenter_v1_internal
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_INTERNAL_SECURITY_CENTER_TRACING_STUB_H

--- a/google/cloud/securitycenter/v1/mocks/mock_security_center_connection.h
+++ b/google/cloud/securitycenter/v1/mocks/mock_security_center_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_MOCKS_MOCK_SECURITY_CENTER_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_MOCKS_MOCK_SECURITY_CENTER_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/securitycenter/v1/security_center_connection.h"
 #include <gmock/gmock.h>
 
@@ -545,5 +546,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace securitycenter_v1_mocks
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_MOCKS_MOCK_SECURITY_CENTER_CONNECTION_H

--- a/google/cloud/securitycenter/v1/samples/security_center_client_samples.cc
+++ b/google/cloud/securitycenter/v1/samples/security_center_client_samples.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/securitycenter/v1/securitycenter_service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/securitycenter/v1/security_center_client.h"
 #include "google/cloud/securitycenter/v1/security_center_connection_idempotency_policy.h"
 #include "google/cloud/securitycenter/v1/security_center_options.h"
@@ -204,3 +205,4 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   });
   return example.Run(argc, argv);
 }
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/securitycenter/v1/security_center_client.cc
+++ b/google/cloud/securitycenter/v1/security_center_client.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/securitycenter/v1/securitycenter_service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/securitycenter/v1/security_center_client.h"
 #include "google/cloud/securitycenter/v1/security_center_options.h"
 #include <memory>
@@ -1376,3 +1377,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace securitycenter_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/securitycenter/v1/security_center_client.h
+++ b/google/cloud/securitycenter/v1/security_center_client.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_SECURITY_CENTER_CLIENT_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_SECURITY_CENTER_CLIENT_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/securitycenter/v1/security_center_connection.h"
 #include "google/cloud/future.h"
 #include "google/cloud/iam_updater.h"
@@ -4812,5 +4813,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace securitycenter_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_SECURITY_CENTER_CLIENT_H

--- a/google/cloud/securitycenter/v1/security_center_connection.cc
+++ b/google/cloud/securitycenter/v1/security_center_connection.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/securitycenter/v1/securitycenter_service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/securitycenter/v1/security_center_connection.h"
 #include "google/cloud/securitycenter/v1/internal/security_center_connection_impl.h"
 #include "google/cloud/securitycenter/v1/internal/security_center_option_defaults.h"
@@ -556,3 +557,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace securitycenter_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/securitycenter/v1/security_center_connection.h
+++ b/google/cloud/securitycenter/v1/security_center_connection.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_SECURITY_CENTER_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_SECURITY_CENTER_CONNECTION_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/securitycenter/v1/internal/security_center_retry_traits.h"
 #include "google/cloud/securitycenter/v1/security_center_connection_idempotency_policy.h"
 #include "google/cloud/backoff_policy.h"
@@ -539,5 +540,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace securitycenter_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_SECURITY_CENTER_CONNECTION_H

--- a/google/cloud/securitycenter/v1/security_center_connection_idempotency_policy.cc
+++ b/google/cloud/securitycenter/v1/security_center_connection_idempotency_policy.cc
@@ -16,6 +16,7 @@
 // If you make any local changes, they will be lost.
 // source: google/cloud/securitycenter/v1/securitycenter_service.proto
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/securitycenter/v1/security_center_connection_idempotency_policy.h"
 #include <memory>
 
@@ -425,3 +426,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace securitycenter_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/securitycenter/v1/security_center_connection_idempotency_policy.h
+++ b/google/cloud/securitycenter/v1/security_center_connection_idempotency_policy.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_SECURITY_CENTER_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_SECURITY_CENTER_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/idempotency.h"
 #include "google/cloud/version.h"
 #include <google/cloud/securitycenter/v1/securitycenter_service.grpc.pb.h>
@@ -297,5 +298,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace securitycenter_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_SECURITY_CENTER_CONNECTION_IDEMPOTENCY_POLICY_H

--- a/google/cloud/securitycenter/v1/security_center_options.h
+++ b/google/cloud/securitycenter/v1/security_center_options.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_SECURITY_CENTER_OPTIONS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_SECURITY_CENTER_OPTIONS_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/securitycenter/v1/security_center_connection.h"
 #include "google/cloud/securitycenter/v1/security_center_connection_idempotency_policy.h"
 #include "google/cloud/backoff_policy.h"
@@ -83,5 +84,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace securitycenter_v1
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECURITYCENTER_V1_SECURITY_CENTER_OPTIONS_H


### PR DESCRIPTION
In a previous PR, the disable_deprecations_warnings.inc was added to services that were deprecated. This PR also adds this include file when the service contains methods that are marked as deprecated. As the disable_deprecations_warnings.inc includes a pragma push, the corresponding pragma pop needed to be added, which this PR adds.

This was tested with both protobuf v28.3 and protobuf v29.0-rc3 and in both cases the `[[deprecated]]` present in the generated protobuf messages no longer results in a compilation error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14852)
<!-- Reviewable:end -->
