### PR TITLE
impl: warn but do not error on deprecated proto types

### DIFF
--- a/cmake/GoogleCloudCppCommonOptions.cmake
+++ b/cmake/GoogleCloudCppCommonOptions.cmake
@@ -105,5 +105,6 @@ function (google_cloud_cpp_add_common_options target)
     if (GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WERROR
         AND GOOGLE_CLOUD_CPP_ENABLE_WERROR)
         target_compile_options(${target} PRIVATE "-Werror")
+        target_compile_options(${target} PRIVATE "-Wno-error=deprecated-declarations")
     endif ()
 endfunction ()

--- a/cmake/GoogleCloudCppCommonOptions.cmake
+++ b/cmake/GoogleCloudCppCommonOptions.cmake
@@ -105,6 +105,7 @@ function (google_cloud_cpp_add_common_options target)
     if (GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WERROR
         AND GOOGLE_CLOUD_CPP_ENABLE_WERROR)
         target_compile_options(${target} PRIVATE "-Werror")
-        target_compile_options(${target} PRIVATE "-Wno-error=deprecated-declarations")
+        target_compile_options(${target}
+                               PRIVATE "-Wno-error=deprecated-declarations")
     endif ()
 endfunction ()


### PR DESCRIPTION
We need our CI builds to not error on deprecated services and rpc that we still need to support.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14855)
<!-- Reviewable:end -->
