### PR TITLE
ci: fix spanner samples integration tests

### DIFF
--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -5492,6 +5492,8 @@ void RunAllSlowInstanceTests(
       backup_dst.project_id = project_id;
       backup_dst.instance_id = crud_instance_id;
       backup_dst.backup_id = backup_id;
+      version_time = DatabaseNow(
+          MakeSampleClient(project_id, crud_instance_id, database_id));
       CreateBackupWithMRCMEK(database_admin_client, backup_dst, database_id,
                              expire_time, version_time, encryption_keys);
 


### PR DESCRIPTION
We got error `Unable to create a backup of ... with version_time earlier than the creation time of the database`, it is introduced by tests in #14674.

In this test, we are trying to use a `version_time` that is initialized before the current database is created, it was used for a database backup creation which was already dropped.

My changes might impact the original intent of this test case. If so, we could have suggestions from the author @aman-19 .

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14883)
<!-- Reviewable:end -->
