### PR TITLE
ci: fix spanner samples

### DIFF
--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -1331,6 +1331,9 @@ void CopyBackupWithMRCMEK(
   request.set_source_backup(source.FullName());
   *request.mutable_expire_time() =
       expire_time.get<google::protobuf::Timestamp>().value();
+  request.mutable_encryption_config()->set_encryption_type(
+      google::spanner::admin::database::v1::CopyBackupEncryptionConfig::
+          CUSTOMER_MANAGED_ENCRYPTION);
   for (google::cloud::KmsKeyName const& encryption_key : encryption_keys) {
     request.mutable_encryption_config()->add_kms_key_names(
         encryption_key.FullName());


### PR DESCRIPTION
After the fix #14883 is merged, there is new error in `integration-daily`

```
Running spanner_copy_backup_with_MR_CMEK sample
status=INVALID_ARGUMENT: Invalid CopyBackup request. + google.rpc.BadRequest {
Step #2:   field_violations {
Step #2:     field: "encryption_config.encryption_type"
Step #2:     description: "No value provided for required field."
Step #2:   }
Step #2: } (google/cloud/internal/log_wrapper.cc:29)
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14885)
<!-- Reviewable:end -->
