### PR TITLE
ci: fix `bazel/deps-cache.py`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -43,6 +43,9 @@ bazel_dep(name = "pugixml", version = "1.14.bcr.1", dev_dependency = True, repo_
 bazel_dep(name = "zlib", version = "1.3.1.bcr.4")
 bazel_dep(name = "c-ares", version = "1.16.1", repo_name = "com_github_cares_cares")
 
+# Pin this to fix a break in bazel/deps-cache.py
+bazel_dep(name = "protoc-gen-validate", version = "1.0.4.bcr.2", dev_dependency = True, repo_name = "com_envoyproxy_protoc_gen_validate")
+
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(
     ignore_root_user_error = True,


### PR DESCRIPTION
`bazel/deps-cache.py` is broken. It calls `bazelisk mod deps --output json google_cloud_cpp`. This fails because of issues in `protoc-gen-validate` v1.0.4. We do not use this mod directly, but one of our dependents does.

We can avoid problems by explicitly pinning to a newer version of this module.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14912)
<!-- Reviewable:end -->
