### PR TITLE
impl(bigquery): Json parsing changes for custom BigQuery library

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/json_utils_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/json_utils_test.cc
@@ -315,6 +315,8 @@ TEST(JsonUtilsTest, SafeGetToWithNullableStringAsFloat) {
 
 TEST(JsonUtilsTest, SafeGetToWithNullableStringAsArray) {
   auto const* const key = "v";
+  auto constexpr kExpectedJsonText =
+      R"([{"v":"1"},{"v":"2"},{"v":"3"},{"v":"4"},{"v":"5"}])";
   auto constexpr kJsonText =
       R"({"v":[{"v":"1"},{"v":"2"},{"v":"3"},{"v":"4"},{"v":"5"}]})";
   auto json = nlohmann::json::parse(kJsonText, nullptr, false);
@@ -323,9 +325,7 @@ TEST(JsonUtilsTest, SafeGetToWithNullableStringAsArray) {
   std::string val;
   bool is_null;
   EXPECT_TRUE(SafeGetToWithNullable(val, is_null, json, key));
-  auto constexpr expected_json_text =
-      R"([{"v":"1"},{"v":"2"},{"v":"3"},{"v":"4"},{"v":"5"}])";
-  EXPECT_EQ(val, expected_json_text);
+  EXPECT_EQ(val, kExpectedJsonText);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/v2/minimal/internal/json_utils_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/json_utils_test.cc
@@ -277,6 +277,57 @@ TEST(JsonUtilsTest, SafeGetToWithNullableNonNull) {
   EXPECT_FALSE(is_null);
 }
 
+TEST(JsonUtilsTest, SafeGetToWithNullableString) {
+  auto const* const key = "v";
+  auto constexpr kJsonText = R"({"v":"Apple"})";
+  auto json = nlohmann::json::parse(kJsonText, nullptr, false);
+  EXPECT_TRUE(json.is_object());
+
+  std::string val;
+  bool is_null;
+  EXPECT_TRUE(SafeGetToWithNullable(val, is_null, json, key));
+  EXPECT_EQ(val, "Apple");
+}
+
+TEST(JsonUtilsTest, SafeGetToWithNullableStringAsNumber) {
+  auto const* const key = "v";
+  auto constexpr kJsonText = R"({"v":"123"})";
+  auto json = nlohmann::json::parse(kJsonText, nullptr, false);
+  EXPECT_TRUE(json.is_object());
+
+  std::string val;
+  bool is_null;
+  EXPECT_TRUE(SafeGetToWithNullable(val, is_null, json, key));
+  EXPECT_EQ(val, "123");
+}
+
+TEST(JsonUtilsTest, SafeGetToWithNullableStringAsFloat) {
+  auto const* const key = "v";
+  auto constexpr kJsonText = R"({"v":"123.123"})";
+  auto json = nlohmann::json::parse(kJsonText, nullptr, false);
+  EXPECT_TRUE(json.is_object());
+
+  std::string val;
+  bool is_null;
+  EXPECT_TRUE(SafeGetToWithNullable(val, is_null, json, key));
+  EXPECT_EQ(val, "123.123");
+}
+
+TEST(JsonUtilsTest, SafeGetToWithNullableStringAsArray) {
+  auto const* const key = "v";
+  auto constexpr kJsonText =
+      R"({"v":[{"v":"1"},{"v":"2"},{"v":"3"},{"v":"4"},{"v":"5"}]})";
+  auto json = nlohmann::json::parse(kJsonText, nullptr, false);
+  EXPECT_TRUE(json.is_object());
+
+  std::string val;
+  bool is_null;
+  EXPECT_TRUE(SafeGetToWithNullable(val, is_null, json, key));
+  auto constexpr expected_json_text =
+      R"([{"v":"1"},{"v":"2"},{"v":"3"},{"v":"4"},{"v":"5"}])";
+  EXPECT_EQ(val, expected_json_text);
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_v2_minimal_internal
 }  // namespace cloud


### PR DESCRIPTION
This PR modifies the `SafeGetToNullable` method based on the calling use case. The Json value field can hold any values and it is best parsed on the calling layer based on column schema and the row data that is provided to the caller.

The function is being modified to consistently return a string value. What that string value means is decided and parsed by by the calling layer as it has the most information to parse the value. It is not feasible to do this parsing at the Client LIbrary layer for our usecase.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14918)
<!-- Reviewable:end -->
