### PR TITLE
impl(bigtable): Add support for inserting tags into InstanceConfig

### DIFF
--- a/google/cloud/bigtable/instance_config.h
+++ b/google/cloud/bigtable/instance_config.h
@@ -67,6 +67,11 @@ class InstanceConfig {
     return *this;
   }
 
+  InstanceConfig& insert_tag(std::string const& key, std::string const& value) {
+    (*proto_.mutable_instance()->mutable_tags())[key] = value;
+    return *this;
+  }
+
   // NOLINT: accessors can (and should) be snake_case.
   google::bigtable::admin::v2::CreateInstanceRequest const& as_proto() const& {
     return proto_;

--- a/google/cloud/bigtable/instance_config_test.cc
+++ b/google/cloud/bigtable/instance_config_test.cc
@@ -75,6 +75,23 @@ TEST(InstanceConfigTest, SetLabels) {
   EXPECT_EQ("qux", proto.instance().labels().at("baz"));
 }
 
+TEST(InstanceConfigTest, InsertTags) {
+  InstanceConfig config("my-instance", "pretty name",
+                        {
+                            {"cluster-1", {"somewhere", 7, ClusterConfig::SSD}},
+                        });
+
+  config.insert_tag("tag_key", "tag_value");
+
+  auto proto = config.as_proto();
+  EXPECT_EQ("my-instance", proto.instance_id());
+  EXPECT_EQ("pretty name", proto.instance().display_name());
+  ASSERT_EQ(1, proto.clusters_size());
+
+  ASSERT_EQ(1, proto.instance().tags_size());
+  EXPECT_EQ("tag_value", proto.instance().tags().at("tag_key"));
+}
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable


### PR DESCRIPTION
This PR adds the `insert_tag()` helper function to `InstanceConfig`.