### PR TITLE
fix(otel): Exporter creating Monitored Resource with task_id for Cloud Run

### DIFF
--- a/google/cloud/opentelemetry/internal/monitored_resource.cc
+++ b/google/cloud/opentelemetry/internal/monitored_resource.cc
@@ -52,7 +52,7 @@ struct AsStringVisitor {
 
 struct OTelKeyMatch {
   std::vector<std::string> otel_keys;
-  absl::optional<std::string> fallback = absl::nullopt;
+  std::string fallback = {};
 };
 
 class MonitoredResourceProvider {
@@ -72,8 +72,8 @@ class MonitoredResourceProvider {
           [](auto const& key, auto const& attr) { return key == attr.first; });
       if (found != oks.end()) {
         mr.labels[kv.first] = AsString(attributes.at(*found));
-      } else if (kv.second.fallback) {
-        mr.labels[kv.first] = *kv.second.fallback;
+      } else {
+        mr.labels[kv.first] = kv.second.fallback;
       }
     }
     return mr;
@@ -162,8 +162,8 @@ MonitoredResourceProvider GenericTask() {
           {"location",
            {{sc::kCloudAvailabilityZone, sc::kCloudRegion}, "global"}},
           {"namespace", {{sc::kServiceNamespace}}},
-          {"job", {{sc::kServiceName}}},
-          {"task_id", {{sc::kServiceInstanceId}}},
+          {"job", {{sc::kServiceName, sc::kFaasName}}},
+          {"task_id", {{sc::kServiceInstanceId, sc::kFaasInstance}}},
       });
 }
 
@@ -174,7 +174,7 @@ MonitoredResourceProvider GenericNode() {
           {"location",
            {{sc::kCloudAvailabilityZone, sc::kCloudRegion}, "global"}},
           {"namespace", {{sc::kServiceNamespace}}},
-          {"node_id", {{sc::kHostId}}},
+          {"node_id", {{sc::kHostId, sc::kHostName}}},
       });
 }
 

--- a/google/cloud/opentelemetry/internal/monitored_resource.cc
+++ b/google/cloud/opentelemetry/internal/monitored_resource.cc
@@ -52,6 +52,7 @@ struct AsStringVisitor {
 
 struct OTelKeyMatch {
   std::vector<std::string> otel_keys;
+  // NOLINTNEXTLINE(readability-redundant-member-init)
   std::string fallback = {};
 };
 

--- a/google/cloud/opentelemetry/internal/monitored_resource_test.cc
+++ b/google/cloud/opentelemetry/internal/monitored_resource_test.cc
@@ -283,8 +283,11 @@ TEST(MonitoredResource, GenericTaskFaas) {
 
     auto mr = ToMonitoredResource(attributes);
     EXPECT_EQ(mr.type, "generic_task");
-    EXPECT_THAT(mr.labels,
-                UnorderedElementsAre(Pair("location", test.expected_location)));
+    EXPECT_THAT(mr.labels, UnorderedElementsAre(
+                               Pair("location", test.expected_location),
+                               // Verify fallback to empty string.
+                               Pair("namespace", ""), Pair("job", "faas-name"),
+                               Pair("task_id", "faas-instance")));
   }
 }
 
@@ -320,18 +323,18 @@ TEST(MonitoredResource, GenericTaskService) {
 }
 
 TEST(MonitoredResource, GenericNode) {
-  struct TestCase {
+  struct LocationTestCase {
     absl::optional<std::string> zone;
     absl::optional<std::string> region;
     std::string expected_location;
   };
-  auto tests = std::vector<TestCase>{
+  auto location_tests = std::vector<LocationTestCase>{
       {"us-central1-a", "us-central1", "us-central1-a"},
       {"us-central1-a", absl::nullopt, "us-central1-a"},
       {absl::nullopt, "us-central1", "us-central1"},
       {absl::nullopt, absl::nullopt, "global"},
   };
-  for (auto const& test : tests) {
+  for (auto const& test : location_tests) {
     auto attributes = opentelemetry::sdk::resource::ResourceAttributes{
         {sc::kServiceNamespace, "test-namespace"},
         {sc::kHostId, "test-instance"},
@@ -345,6 +348,31 @@ TEST(MonitoredResource, GenericNode) {
                 UnorderedElementsAre(Pair("location", test.expected_location),
                                      Pair("namespace", "test-namespace"),
                                      Pair("node_id", "test-instance")));
+  }
+
+  struct NodeIDTestCase {
+    absl::optional<std::string> host_id;
+    std::string expected_node_id;
+  };
+  auto node_id_tests = std::vector<NodeIDTestCase>{
+      {"test-instance", "test-instance"},
+      {absl::nullopt, "test-name"},
+  };
+  for (auto const& test : node_id_tests) {
+    auto attributes = opentelemetry::sdk::resource::ResourceAttributes{
+        {sc::kCloudAvailabilityZone, "us-central1-a"},
+        {sc::kCloudRegion, "us-central1"},
+        {sc::kServiceNamespace, "test-namespace"},
+        {sc::kHostName, "test-name"},
+    };
+    if (test.host_id) attributes[sc::kHostId] = *test.host_id;
+
+    auto mr = ToMonitoredResource(attributes);
+    EXPECT_EQ(mr.type, "generic_node");
+    EXPECT_THAT(mr.labels,
+                UnorderedElementsAre(Pair("location", "us-central1-a"),
+                                     Pair("namespace", "test-namespace"),
+                                     Pair("node_id", test.expected_node_id)));
   }
 }
 


### PR DESCRIPTION
Fixes #14925

When inside a Cloud Run environment, the [`MonitoredResource`](https://cloud.google.com/monitoring/api/ref_v3/rpc/google.monitoring.v3#google.monitoring.v3.TimeSeries) in a [`CreateTimeSeriesRequest`](https://cloud.google.com/monitoring/api/ref_v3/rpc/google.monitoring.v3#google.monitoring.v3.CreateTimeSeriesRequest) to the Cloud Monitoring API does not include the necessary fields for the [`generic_task`](https://cloud.google.com/monitoring/api/resources#tag_generic_task) resource type, and is rejected.

Also updating the GenericNode mapping to match Golang.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14923)
<!-- Reviewable:end -->
