### PR TITLE
impl(rest): support LRO operation types without name method

### DIFF
--- a/google/cloud/internal/async_rest_long_running_operation_custom.h
+++ b/google/cloud/internal/async_rest_long_running_operation_custom.h
@@ -71,6 +71,44 @@ future<StatusOr<ReturnType>> AsyncRestLongRunningOperation(
       });
 }
 
+template <typename ReturnType, typename OperationType,
+          typename GetOperationRequestType, typename CancelOperationRequestType,
+          typename RequestType, typename StartFunctor, typename RetryPolicyType,
+          typename CompletionQueue>
+future<StatusOr<ReturnType>> AsyncRestLongRunningOperation(
+    CompletionQueue cq, internal::ImmutableOptions options,
+    RequestType&& request, StartFunctor&& start,
+    AsyncRestPollLongRunningOperation<OperationType, GetOperationRequestType>
+        poll,
+    AsyncRestCancelLongRunningOperation<CancelOperationRequestType> cancel,
+    LongRunningOperationValueExtractor<ReturnType, OperationType>
+        value_extractor,
+    std::unique_ptr<RetryPolicyType> retry_policy,
+    std::unique_ptr<BackoffPolicy> backoff_policy, Idempotency idempotent,
+    std::unique_ptr<PollingPolicy> polling_policy, char const* location,
+    std::function<bool(OperationType const&)> is_operation_done,
+    std::function<void(std::string const&, GetOperationRequestType&)>
+        get_request_set_operation_name,
+    std::function<void(std::string const&, CancelOperationRequestType&)>
+        cancel_request_set_operation_name,
+    std::function<std::string(StatusOr<OperationType> const&)> operation_name) {
+  auto operation =
+      AsyncRestRetryLoop(std::move(retry_policy), std::move(backoff_policy),
+                         idempotent, cq, std::forward<StartFunctor>(start),
+                         options, std::forward<RequestType>(request), location);
+  auto loc = std::string{location};
+  return AsyncRestPollingLoop<OperationType, GetOperationRequestType,
+                              CancelOperationRequestType>(
+             std::move(cq), std::move(options), std::move(operation),
+             std::move(poll), std::move(cancel), std::move(polling_policy),
+             std::move(location), is_operation_done,
+             get_request_set_operation_name, cancel_request_set_operation_name,
+             operation_name)
+      .then([value_extractor, loc](future<StatusOr<OperationType>> g) {
+        return value_extractor(g.get(), loc);
+      });
+}
+
 /*
  * AsyncAwaitRestLongRunningOperation for services that do not conform to
  * AIP-151.
@@ -100,6 +138,38 @@ future<StatusOr<ReturnType>> AsyncRestAwaitLongRunningOperation(
              std::move(poll), std::move(cancel), std::move(polling_policy),
              std::move(location), is_operation_done,
              get_request_set_operation_name, cancel_request_set_operation_name)
+      .then([value_extractor, loc](future<StatusOr<OperationType>> g) {
+        return value_extractor(g.get(), loc);
+      });
+}
+
+template <typename ReturnType, typename OperationType,
+          typename GetOperationRequestType, typename CancelOperationRequestType,
+          typename CompletionQueue>
+future<StatusOr<ReturnType>> AsyncRestAwaitLongRunningOperation(
+    CompletionQueue cq, internal::ImmutableOptions options,
+    OperationType operation,
+    AsyncRestPollLongRunningOperation<OperationType, GetOperationRequestType>
+        poll,
+    AsyncRestCancelLongRunningOperation<CancelOperationRequestType> cancel,
+    LongRunningOperationValueExtractor<ReturnType, OperationType>
+        value_extractor,
+    std::unique_ptr<PollingPolicy> polling_policy, char const* location,
+    std::function<bool(OperationType const&)> is_operation_done,
+    std::function<void(std::string const&, GetOperationRequestType&)>
+        get_request_set_operation_name,
+    std::function<void(std::string const&, CancelOperationRequestType&)>
+        cancel_request_set_operation_name,
+    std::function<std::string(StatusOr<OperationType> const&)> operation_name) {
+  auto loc = std::string{location};
+  return AsyncRestPollingLoop<OperationType, GetOperationRequestType,
+                              CancelOperationRequestType>(
+             std::move(cq), std::move(options),
+             make_ready_future(StatusOr<OperationType>(operation)),
+             std::move(poll), std::move(cancel), std::move(polling_policy),
+             std::move(location), is_operation_done,
+             get_request_set_operation_name, cancel_request_set_operation_name,
+             operation_name)
       .then([value_extractor, loc](future<StatusOr<OperationType>> g) {
         return value_extractor(g.get(), loc);
       });

--- a/google/cloud/internal/async_rest_polling_loop_custom.h
+++ b/google/cloud/internal/async_rest_polling_loop_custom.h
@@ -64,6 +64,30 @@ future<StatusOr<OperationType>> AsyncRestPollingLoop(
   return loop->Start(std::move(op));
 }
 
+template <typename OperationType, typename GetOperationRequestType,
+          typename CancelOperationRequestType>
+future<StatusOr<OperationType>> AsyncRestPollingLoop(
+    google::cloud::CompletionQueue cq, internal::ImmutableOptions options,
+    future<StatusOr<OperationType>> op,
+    AsyncRestPollLongRunningOperation<OperationType, GetOperationRequestType>
+        poll,
+    AsyncRestCancelLongRunningOperation<CancelOperationRequestType> cancel,
+    std::unique_ptr<PollingPolicy> polling_policy, std::string location,
+    std::function<bool(OperationType const&)> is_operation_done,
+    std::function<void(std::string const&, GetOperationRequestType&)>
+        get_request_set_operation_name,
+    std::function<void(std::string const&, CancelOperationRequestType&)>
+        cancel_request_set_operation_name,
+    std::function<std::string(StatusOr<OperationType> const&)> operation_name) {
+  auto loop = std::make_shared<AsyncRestPollingLoopImpl<
+      OperationType, GetOperationRequestType, CancelOperationRequestType>>(
+      std::move(cq), options, std::move(poll), std::move(cancel),
+      std::move(polling_policy), std::move(location), is_operation_done,
+      get_request_set_operation_name, cancel_request_set_operation_name,
+      operation_name);
+  return loop->Start(std::move(op));
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace rest_internal
 }  // namespace cloud

--- a/google/cloud/internal/async_rest_polling_loop_custom_test.cc
+++ b/google/cloud/internal/async_rest_polling_loop_custom_test.cc
@@ -81,6 +81,22 @@ class BespokeOperationType {
   std::string name_;
 };
 
+class BespokeOperationTypeNoNameMethod {
+ public:
+  bool is_done() const { return is_done_; }
+  void set_is_done(bool is_done) { is_done_ = is_done; }
+  std::string const& pseudo_name_function() const { return name_; }
+  void set_name(std::string name) { name_ = std::move(name); }
+  std::string* mutable_name() { return &name_; }
+  bool operator==(BespokeOperationTypeNoNameMethod const& other) const {
+    return is_done_ == other.is_done_ && name_ == other.name_;
+  }
+
+ private:
+  bool is_done_;
+  std::string name_;
+};
+
 class BespokeGetOperationRequestType {
  public:
   std::string const& name() const { return name_; }
@@ -172,6 +188,87 @@ TEST(AsyncRestPollingLoopTest, PollThenSuccessWithBespokeOperationTypes) {
           });
   internal::OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
   StatusOr<BespokeOperationType> actual = pending.get();
+  ASSERT_THAT(actual, IsOk());
+  EXPECT_THAT(*actual, Eq(expected));
+}
+
+class MockBespokeOperationNoNameMethodStub {
+ public:
+  MOCK_METHOD(future<StatusOr<BespokeOperationTypeNoNameMethod>>,
+              AsyncGetOperation,
+              (CompletionQueue&, std::unique_ptr<RestContext>, ImmutableOptions,
+               BespokeGetOperationRequestType const&),
+              ());
+
+  MOCK_METHOD(future<Status>, AsyncCancelOperation,
+              (CompletionQueue&, std::unique_ptr<RestContext>, ImmutableOptions,
+               BespokeCancelOperationRequestType const&),
+              ());
+};
+
+TEST(AsyncRestPollingLoopTest,
+     PollThenSuccessWithBespokeOperationTypeNoNameMethod) {
+  Response response;
+  response.set_seconds(123456);
+  BespokeOperationTypeNoNameMethod starting_op;
+  starting_op.set_name("test-op-name");
+  starting_op.set_is_done(false);
+  BespokeOperationTypeNoNameMethod expected = starting_op;
+  expected.set_is_done(true);
+
+  auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
+  EXPECT_CALL(*mock_cq, MakeRelativeTimer)
+      .WillOnce([](std::chrono::nanoseconds) {
+        return make_ready_future(
+            make_status_or(std::chrono::system_clock::now()));
+      });
+  CompletionQueue cq(mock_cq);
+
+  auto mock = std::make_shared<MockBespokeOperationNoNameMethodStub>();
+  EXPECT_CALL(*mock, AsyncGetOperation)
+      .WillOnce([&](CompletionQueue&, std::unique_ptr<RestContext>,
+                    ImmutableOptions const& options,
+                    BespokeGetOperationRequestType const&) {
+        EXPECT_EQ(options->get<StringOption>(), CurrentTestName());
+        return make_ready_future(make_status_or(expected));
+      });
+  auto policy = std::make_unique<MockPollingPolicy>();
+  EXPECT_CALL(*policy, clone()).Times(0);
+  EXPECT_CALL(*policy, OnFailure).Times(0);
+  EXPECT_CALL(*policy, WaitPeriod)
+      .WillRepeatedly(Return(std::chrono::milliseconds(1)));
+
+  auto current = internal::MakeImmutableOptions(
+      Options{}.set<StringOption>(CurrentTestName()));
+  auto pending = AsyncRestPollingLoop<BespokeOperationTypeNoNameMethod,
+                                      BespokeGetOperationRequestType,
+                                      BespokeCancelOperationRequestType>(
+      std::move(cq), current, make_ready_future(make_status_or(starting_op)),
+      [mock](CompletionQueue& cq, std::unique_ptr<RestContext> context,
+             ImmutableOptions options,
+             BespokeGetOperationRequestType const& request) {
+        return mock->AsyncGetOperation(cq, std::move(context),
+                                       std::move(options), request);
+      },
+      [mock](CompletionQueue& cq, std::unique_ptr<RestContext> context,
+             ImmutableOptions options,
+             BespokeCancelOperationRequestType const& request) {
+        return mock->AsyncCancelOperation(cq, std::move(context),
+                                          std::move(options), request);
+      },
+      std::move(policy), "test-function",
+      [](BespokeOperationTypeNoNameMethod const& op) { return op.is_done(); },
+      [](std::string const& s, BespokeGetOperationRequestType& op) {
+        op.set_name(s);
+      },
+      [](std::string const& s, BespokeCancelOperationRequestType& op) {
+        op.set_name(s);
+      },
+      [](StatusOr<BespokeOperationTypeNoNameMethod> const& op) {
+        return op->pseudo_name_function();
+      });
+  internal::OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
+  StatusOr<BespokeOperationTypeNoNameMethod> actual = pending.get();
   ASSERT_THAT(actual, IsOk());
   EXPECT_THAT(*actual, Eq(expected));
 }


### PR DESCRIPTION
Unlike Compute, BigQuery LRO Operation types don't have a `name` method. This PR adds a mechanism to provide a function to get the name from the Operation.