### PR TITLE
feat(otel): copy service labels into GCM Metric

### DIFF
--- a/google/cloud/opentelemetry/internal/time_series.h
+++ b/google/cloud/opentelemetry/internal/time_series.h
@@ -21,6 +21,7 @@
 #include <google/api/monitored_resource.pb.h>
 #include <google/monitoring/v3/metric_service.pb.h>
 #include <opentelemetry/sdk/metrics/metric_reader.h>
+#include <opentelemetry/sdk/resource/resource.h>
 #include <functional>
 #include <string>
 
@@ -37,6 +38,7 @@ auto constexpr kMaxTimeSeriesPerRequest = 200;
 google::api::Metric ToMetric(
     opentelemetry::sdk::metrics::MetricData const& metric_data,
     opentelemetry::sdk::metrics::PointAttributes const& attributes,
+    opentelemetry::sdk::resource::Resource const* resource,
     std::function<std::string(std::string)> const& metrics_name_formatter);
 
 google::monitoring::v3::TimeSeries ToTimeSeries(

--- a/google/cloud/opentelemetry/internal/time_series_test.cc
+++ b/google/cloud/opentelemetry/internal/time_series_test.cc
@@ -32,6 +32,8 @@ namespace otel_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+namespace sc = opentelemetry::sdk::resource::SemanticConventions;
+
 using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::protobuf::TextFormat;
 using ::testing::_;
@@ -133,7 +135,6 @@ auto Interval(std::chrono::system_clock::time_point start,
 }
 
 auto TestResource() {
-  namespace sc = opentelemetry::sdk::resource::SemanticConventions;
   return opentelemetry::sdk::resource::Resource::Create({
       {sc::kCloudProvider, "gcp"},
       {sc::kCloudPlatform, "gcp_compute_engine"},
@@ -247,13 +248,13 @@ TEST(ToMetric, Simple) {
   opentelemetry::sdk::metrics::PointAttributes attributes = {
       {"key1", "value1"}, {"_key2", "value2"}};
 
-  auto metric = ToMetric(md, attributes, PrefixWithWorkload);
+  auto metric = ToMetric(md, attributes, {}, PrefixWithWorkload);
 
   EXPECT_EQ(metric.type(), "workload.googleapis.com/test");
   EXPECT_THAT(metric.labels(), UnorderedElementsAre(Pair("key1", "value1"),
                                                     Pair("_key2", "value2")));
 
-  metric = ToMetric(md, {}, [](std::string s) {
+  metric = ToMetric(md, {}, {}, [](std::string s) {
     std::replace(s.begin(), s.end(), 't', 'T');
     return "custom.googleapis.com/" + std::move(s);
   });
@@ -266,7 +267,7 @@ TEST(ToMetric, BadLabelNames) {
   opentelemetry::sdk::metrics::PointAttributes attributes = {
       {"99", "dropped"}, {"a key-with.bad/characters", "value"}};
 
-  auto metric = ToMetric({}, attributes, PrefixWithWorkload);
+  auto metric = ToMetric({}, attributes, {}, PrefixWithWorkload);
 
   EXPECT_THAT(metric.labels(),
               UnorderedElementsAre(Pair("a_key_with_bad_characters", "value")));
@@ -274,6 +275,53 @@ TEST(ToMetric, BadLabelNames) {
   EXPECT_THAT(
       log.ExtractLines(),
       Contains(AllOf(HasSubstr("Dropping metric label"), HasSubstr("99"))));
+}
+
+TEST(ToMetric, IncludesServiceLabelsFromResource) {
+  opentelemetry::sdk::metrics::MetricData md;
+  md.instrument_descriptor.name_ = "test";
+
+  opentelemetry::sdk::resource::ResourceAttributes resource_attributes = {
+      {"unused", "unused"},
+      {sc::kServiceName, "test-name"},
+      {sc::kServiceNamespace, "test-namespace"},
+      {sc::kServiceInstanceId, "test-instance"},
+  };
+  auto resource =
+      opentelemetry::sdk::resource::Resource::Create(resource_attributes);
+
+  auto metric = ToMetric(md, {}, &resource, PrefixWithWorkload);
+  EXPECT_THAT(
+      metric.labels(),
+      UnorderedElementsAre(Pair("service_name", "test-name"),
+                           Pair("service_namespace", "test-namespace"),
+                           Pair("service_instance_id", "test-instance")));
+}
+
+TEST(ToMetric, PointAttributesOverServiceResourceAttributes) {
+  opentelemetry::sdk::metrics::MetricData md;
+  md.instrument_descriptor.name_ = "test";
+
+  opentelemetry::sdk::metrics::PointAttributes point_attributes = {
+      {"service_name", "point-name"},
+      {"service_namespace", "point-namespace"},
+      {"service_instance_id", "point-instance"},
+  };
+
+  opentelemetry::sdk::resource::ResourceAttributes resource_attributes = {
+      {sc::kServiceName, "resource-name"},
+      {sc::kServiceNamespace, "resource-namespace"},
+      {sc::kServiceInstanceId, "resource-instance"},
+  };
+  auto resource =
+      opentelemetry::sdk::resource::Resource::Create(resource_attributes);
+
+  auto metric = ToMetric(md, point_attributes, &resource, PrefixWithWorkload);
+  EXPECT_THAT(
+      metric.labels(),
+      UnorderedElementsAre(Pair("service_name", "point-name"),
+                           Pair("service_namespace", "point-namespace"),
+                           Pair("service_instance_id", "point-instance")));
 }
 
 TEST(SumPointData, Simple) {

--- a/google/cloud/opentelemetry/internal/time_series_test.cc
+++ b/google/cloud/opentelemetry/internal/time_series_test.cc
@@ -580,6 +580,7 @@ TEST(ToTimeSeries, Sum) {
 
   opentelemetry::sdk::metrics::ResourceMetrics rm;
   rm.scope_metric_data_.push_back(std::move(sm));
+  rm.resource_ = nullptr;
 
   auto tss = ToTimeSeries(rm, PrefixWithWorkload);
   EXPECT_THAT(tss, ElementsAre(SumTimeSeries(), SumTimeSeries()));
@@ -604,6 +605,7 @@ TEST(ToTimeSeries, Gauge) {
 
   opentelemetry::sdk::metrics::ResourceMetrics rm;
   rm.scope_metric_data_.push_back(std::move(sm));
+  rm.resource_ = nullptr;
 
   auto tss = ToTimeSeries(rm, PrefixWithWorkload);
   EXPECT_THAT(tss, ElementsAre(GaugeTimeSeries(), GaugeTimeSeries()));
@@ -628,6 +630,7 @@ TEST(ToTimeSeries, Histogram) {
 
   opentelemetry::sdk::metrics::ResourceMetrics rm;
   rm.scope_metric_data_.push_back(std::move(sm));
+  rm.resource_ = nullptr;
 
   auto tss = ToTimeSeries(rm, PrefixWithWorkload);
   EXPECT_THAT(tss, ElementsAre(HistogramTimeSeries(), HistogramTimeSeries()));
@@ -652,6 +655,7 @@ TEST(ToTimeSeries, DropIgnored) {
 
   opentelemetry::sdk::metrics::ResourceMetrics rm;
   rm.scope_metric_data_.push_back(std::move(sm));
+  rm.resource_ = nullptr;
 
   auto tss = ToTimeSeries(rm, PrefixWithWorkload);
   EXPECT_THAT(tss, IsEmpty());
@@ -682,6 +686,7 @@ TEST(ToTimeSeries, Combined) {
 
   opentelemetry::sdk::metrics::ResourceMetrics rm;
   rm.scope_metric_data_.push_back(std::move(sm));
+  rm.resource_ = nullptr;
 
   auto tss = ToTimeSeries(
       rm, [](std::string const& s) { return "custom.googleapis.com/" + s; });


### PR DESCRIPTION
Fixes #14823 

Credit to @icysteam for raising the issue, and offering a fix for it in #14825. I also stole their tests. :smile: 

---

Copy several well-known service labels from the resource into the metric, if they exist.

This avoids duplicate timeseries when multiple instances of a service are running on a single monitored resource, for example running multiple service processes on a single GCE VM.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14930)
<!-- Reviewable:end -->
