### PR TITLE
impl(bigquery): Fixed jobs and tables response for empty use case

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
@@ -126,6 +126,20 @@ TEST(GetJobResponseTest, InvalidJob) {
                                      HasSubstr("Not a valid Json Job object")));
 }
 
+TEST(ListJobsResponseTest, NoJobs) {
+  BigQueryHttpResponse http_response;
+  http_response.payload =
+      R"({"kind": "kind-1",
+          "etag": "tag-1"})";
+  auto const list_jobs_response =
+      ListJobsResponse::BuildFromHttpResponse(http_response);
+
+  ASSERT_STATUS_OK(list_jobs_response);
+  EXPECT_FALSE(list_jobs_response->http_response.payload.empty());
+  EXPECT_EQ(list_jobs_response->kind, "kind-1");
+  EXPECT_EQ(list_jobs_response->etag, "tag-1");
+}
+
 TEST(ListJobsResponseTest, SuccessMultiplePages) {
   BigQueryHttpResponse http_response;
   http_response.payload =
@@ -223,16 +237,6 @@ TEST(ListJobsResponseTest, InvalidJson) {
   EXPECT_THAT(response,
               StatusIs(StatusCode::kInternal,
                        HasSubstr("Error parsing Json from response payload")));
-}
-
-TEST(ListJobsResponseTest, InvalidJobList) {
-  BigQueryHttpResponse http_response;
-  http_response.payload =
-      R"({"kind": "jkind",
-          "etag": "jtag"})";
-  auto const response = ListJobsResponse::BuildFromHttpResponse(http_response);
-  EXPECT_THAT(response, StatusIs(StatusCode::kInternal,
-                                 HasSubstr("Not a valid Json JobList object")));
 }
 
 TEST(ListJobsResponseTest, InvalidListFormatJob) {

--- a/google/cloud/bigquery/v2/minimal/internal/table_response.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/table_response.cc
@@ -36,7 +36,7 @@ bool valid_list_format_table(nlohmann::json const& j) {
 }
 
 bool valid_tables_list(nlohmann::json const& j) {
-  return (j.contains("kind") && j.contains("etag") && j.contains("tables"));
+  return (j.contains("kind") && j.contains("etag"));
 }
 
 StatusOr<nlohmann::json> parse_json(std::string const& payload) {
@@ -87,6 +87,11 @@ StatusOr<ListTablesResponse> ListTablesResponse::BuildFromHttpResponse(
   result.etag = json->value("etag", "");
   result.next_page_token = json->value("nextPageToken", "");
   result.total_items = json->value("totalItems", 0);
+
+  if (result.total_items == 0) {
+    // If the dataset is empty, server does not return the "tables" key.
+    return result;
+  }
 
   for (auto const& kv : json->at("tables").items()) {
     auto const& json_list_format_table_obj = kv.value();

--- a/google/cloud/bigquery/v2/minimal/internal/table_response_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/table_response_test.cc
@@ -64,6 +64,20 @@ TEST(GetTableResponseTest, InvalidTable) {
                                  HasSubstr("Not a valid Json Table object")));
 }
 
+TEST(ListTablesResponseTest, EmptyDatasetNoTables) {
+  BigQueryHttpResponse http_response;
+  http_response.payload =
+      R"({"kind":"kind-1", "etag":"tag-1", "totalItems":0})";
+  auto const list_tables_response =
+      ListTablesResponse::BuildFromHttpResponse(http_response);
+  ASSERT_STATUS_OK(list_tables_response);
+  EXPECT_FALSE(list_tables_response->http_response.payload.empty());
+  EXPECT_EQ(list_tables_response->kind, "kind-1");
+  EXPECT_EQ(list_tables_response->etag, "tag-1");
+  EXPECT_EQ(list_tables_response->total_items, 0);
+  EXPECT_THAT(list_tables_response->next_page_token, "");
+}
+
 TEST(ListTablesResponseTest, SuccessMultiplePages) {
   BigQueryHttpResponse http_response;
   auto tables_json_txt =
@@ -131,18 +145,6 @@ TEST(ListTablesResponseTest, InvalidJson) {
   EXPECT_THAT(response,
               StatusIs(StatusCode::kInternal,
                        HasSubstr("Error parsing Json from response payload")));
-}
-
-TEST(ListTablesResponseTest, InvalidTableList) {
-  BigQueryHttpResponse http_response;
-  http_response.payload =
-      R"({"kind": "dkind",
-          "etag": "dtag"})";
-  auto const response =
-      ListTablesResponse::BuildFromHttpResponse(http_response);
-  EXPECT_THAT(response,
-              StatusIs(StatusCode::kInternal,
-                       HasSubstr("Not a valid Json TableList object")));
 }
 
 TEST(ListTablesResponseTest, InvalidListFormatTable) {


### PR DESCRIPTION
This PR fixes the jobs and tables response for the usecase when no jobs or tables returned from the server for the calling account.

Before the fix, the API response for `jobs.list` and `tables.list`assumed that the "jobs" and "tables" json keys will always be provided by the server. From our testing this was not the case.

This PR fixes the above and adds unit test cases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14938)
<!-- Reviewable:end -->
