### PR TITLE
chore(otel): prepare for otel-cpp 1.19

### DIFF
--- a/google/cloud/opentelemetry/trace_exporter.cc
+++ b/google/cloud/opentelemetry/trace_exporter.cc
@@ -74,6 +74,7 @@ class TraceExporter final : public opentelemetry::sdk::trace::SpanExporter {
     return opentelemetry::sdk::common::ExportResult::kFailure;
   }
 
+  bool ForceFlush(std::chrono::microseconds) noexcept override { return true; }
   bool Shutdown(std::chrono::microseconds) noexcept override { return true; }
 
  private:


### PR DESCRIPTION
They made this thing pure virtual in v1.19.0, so we have to override it.

https://github.com/open-telemetry/opentelemetry-cpp/commit/762b73d8510b24c577043a75f6373ebbc4f6765f#r151638892