### PR TITLE
ci(optimization): pass quickstart if service is unavailable

### DIFF
--- a/google/cloud/optimization/CMakeLists.txt
+++ b/google/cloud/optimization/CMakeLists.txt
@@ -30,6 +30,12 @@ if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
             cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
             $<TARGET_FILE:optimization_quickstart> GOOGLE_CLOUD_PROJECT
             GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME)
-    set_tests_properties(optimization_quickstart
-                         PROPERTIES LABELS "integration-test;quickstart")
+    set_tests_properties(
+        optimization_quickstart
+        PROPERTIES
+            LABELS
+            "integration-test;quickstart"
+            PASS_REGULAR_EXPRESSION
+            "The service is currently unavailable.*gcloud-cpp.retry.function=BatchOptimizeTours"
+    )
 endif ()


### PR DESCRIPTION
The optimization service is currently returning `UNAVAILABLE`. Until the service comes back online, update the quickstart to pass. If/when the service is back online, we'll likely need to revert this PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14955)
<!-- Reviewable:end -->
