### PR TITLE
docs: add code formatting to `msbuild`

### DIFF
--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -64,7 +64,7 @@ As is often the case, the CMake build can be configured using a number of
 options and command-line flags. A full treatment of these options is outside the
 scope of this document, but here are a few highlights:
 
-- Consider using `-GNinja` to switch the generator from `make` (or msbuild on
+- Consider using `-GNinja` to switch the generator from `make` (or `msbuild` on
   Windows) to [`ninja`][ninja-build]. In our experience `ninja` takes better
   advantage of multicore machines. Be aware that `ninja` is often not installed
   in development workstations, but it is available through most package


### PR DESCRIPTION
I think `msbuild` is very similar to the `make` tool just mentioned a few words before. Thus, adding a similar style.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14962)
<!-- Reviewable:end -->
