### PR TITLE
cleanup: disable modernize-type-traits in .clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -26,6 +26,9 @@
 #      avoiding C arrays often makes the code less readable, and std::array is
 #      not a drop-in replacement because it doesn't deduce the size.
 #
+#  -modernize-type-traits: clang-tidy recommands using c++17 style variable
+#      templates. We will enable this check after we moved to c++17.
+#
 #  -performance-move-const-arg: This warning requires the developer to
 #      know/care more about the implementation details of types/functions than
 #      should be necessary. For example, `A a; F(std::move(a));` will trigger a
@@ -89,6 +92,7 @@ Checks: >
   -modernize-concat-nested-namespaces,
   -modernize-use-nodiscard,
   -modernize-avoid-c-arrays,
+  -modernize-type-traits,
   -performance-move-const-arg,
   -performance-avoid-endl,
   -performance-enum-size,


### PR DESCRIPTION
Created #14972 to re-enable it with C++17.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14973)
<!-- Reviewable:end -->
