### PR TITLE
cleanup: changes following clang-tidy suggestions

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -29,6 +29,10 @@
 #  -modernize-type-traits: clang-tidy recommands using c++17 style variable
 #      templates. We will enable this check after we moved to c++17.
 #
+#  -modernize-unary-static-assert: clang-tidy asks removing empty string in
+#      static_assert(), the check is only applicable for c++17 and later code.
+#      We will enable this check after we moved to c++17.
+#
 #  -performance-move-const-arg: This warning requires the developer to
 #      know/care more about the implementation details of types/functions than
 #      should be necessary. For example, `A a; F(std::move(a));` will trigger a
@@ -93,6 +97,7 @@ Checks: >
   -modernize-use-nodiscard,
   -modernize-avoid-c-arrays,
   -modernize-type-traits,
+  -modernize-unary-static-assert,
   -performance-move-const-arg,
   -performance-avoid-endl,
   -performance-enum-size,

--- a/generator/internal/mixin_utils.cc
+++ b/generator/internal/mixin_utils.cc
@@ -65,9 +65,8 @@ google::api::HttpRule ParseHttpRule(YAML::detail::iterator_value const& rule) {
         kv.second.Type() != YAML::NodeType::Scalar)
       continue;
 
-    std::string const rule_key =
-        absl::AsciiStrToLower(kv.first.as<std::string>());
-    std::string const rule_value = kv.second.as<std::string>();
+    auto const rule_key = absl::AsciiStrToLower(kv.first.as<std::string>());
+    auto const rule_value = kv.second.as<std::string>();
 
     if (rule_key == "get") {
       http_rule.set_get(rule_value);
@@ -107,7 +106,7 @@ std::unordered_map<std::string, google::api::HttpRule> GetMixinHttpOverrides(
     auto const& selector = rule["selector"];
     if (selector.Type() != YAML::NodeType::Scalar) continue;
 
-    std::string const method_full_name = selector.as<std::string>();
+    auto const method_full_name = selector.as<std::string>();
     google::api::HttpRule http_rule = ParseHttpRule(rule);
 
     if (rule["additional_bindings"]) {
@@ -150,7 +149,7 @@ std::vector<std::string> GetMixinProtoPaths(YAML::Node const& service_config) {
     if (api.Type() != YAML::NodeType::Map) continue;
     auto const& name = api["name"];
     if (name.Type() != YAML::NodeType::Scalar) continue;
-    std::string const package_path = name.as<std::string>();
+    auto const package_path = name.as<std::string>();
     auto const& mixin_proto_path_map = GetMixinProtoPathMap();
     auto const it = mixin_proto_path_map.find(package_path);
     if (it == mixin_proto_path_map.end()) continue;

--- a/google/cloud/bigtable/row_reader.h
+++ b/google/cloud/bigtable/row_reader.h
@@ -81,7 +81,8 @@ class RowReader {
             MetadataUpdatePolicy metadata_update_policy,
             std::unique_ptr<internal::ReadRowsParserFactory> parser_factory);
 
-  RowReader(RowReader&&) noexcept = default;
+  // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+  RowReader(RowReader&&) = default;
 
   ~RowReader() = default;
 

--- a/google/cloud/bigtable/row_reader.h
+++ b/google/cloud/bigtable/row_reader.h
@@ -81,7 +81,7 @@ class RowReader {
             MetadataUpdatePolicy metadata_update_policy,
             std::unique_ptr<internal::ReadRowsParserFactory> parser_factory);
 
-  RowReader(RowReader&&) = default;
+  RowReader(RowReader&&) noexcept = default;
 
   ~RowReader() = default;
 

--- a/google/cloud/storage/async/reader.cc
+++ b/google/cloud/storage/async/reader.cc
@@ -55,6 +55,7 @@ class Discard : public std::enable_shared_from_this<Discard> {
 
 }  // namespace
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
 AsyncReader::~AsyncReader() {
   if (!impl_ || finished_) return;
   impl_->Cancel();

--- a/google/cloud/storage/async/reader.h
+++ b/google/cloud/storage/async/reader.h
@@ -62,7 +62,7 @@ class AsyncReader {
    * does **not** block waiting for the download to cancel. This may delay the
    * termination of the associated completion queue.
    */
-  ~AsyncReader() noexcept(false);
+  ~AsyncReader();
 
   /**
    * Retrieves more data from the object.

--- a/google/cloud/storage/async/reader.h
+++ b/google/cloud/storage/async/reader.h
@@ -62,7 +62,7 @@ class AsyncReader {
    * does **not** block waiting for the download to cancel. This may delay the
    * termination of the associated completion queue.
    */
-  ~AsyncReader();
+  ~AsyncReader() noexcept(false);
 
   /**
    * Retrieves more data from the object.


### PR DESCRIPTION
For merging #14957, fix the following:
[modernize-unary-static-assert](modernize-unary-static-assert): Disabled, it is only for c++17, and added it to #14972 
[modernize-use-auto]: changes `std::string` to `auto`
[performance-noexcept-move-constructor]: Disabled because adding `nonexcept` to move constructor will cause error.
[bugprone-exception-escape]: Disabled, because adding `noexcept(false)` to destructor will cause error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14976)
<!-- Reviewable:end -->
