### PR TITLE
cleanup: changes following clang-tidy suggestions

### DIFF
--- a/google/cloud/storage/benchmarks/storage_parallel_uploads_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_parallel_uploads_benchmark.cc
@@ -107,8 +107,8 @@ StatusOr<std::string> CreateTempFile(
     std::string const& directory,
     google::cloud::internal::DefaultPRNG& generator, std::uintmax_t size_left) {
   std::size_t const single_buf_size = 4 * 1024 * 1024;
-  auto const file_name = directory + (directory.empty() ? "" : "/") +
-                         gcs_bm::MakeRandomFileName(generator);
+  auto file_name = directory + (directory.empty() ? "" : "/") +
+                   gcs_bm::MakeRandomFileName(generator);
 
   std::string random_data = gcs_bm::MakeRandomData(generator, single_buf_size);
 

--- a/google/cloud/storagecontrol/v2/samples/storage_control_folder_samples.cc
+++ b/google/cloud/storagecontrol/v2/samples/storage_control_folder_samples.cc
@@ -180,7 +180,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 
 }  // namespace
 
-int main(int argc, char* argv[]) {
+int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   using google::cloud::testing_util::Example;
   namespace storagecontrol = google::cloud::storagecontrol_v2;
   using ClientCommand = std::function<void(storagecontrol::StorageControlClient,

--- a/google/cloud/storagecontrol/v2/samples/storage_control_managed_folder_samples.cc
+++ b/google/cloud/storagecontrol/v2/samples/storage_control_managed_folder_samples.cc
@@ -158,7 +158,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 
 }  // namespace
 
-int main(int argc, char* argv[]) {
+int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   using google::cloud::testing_util::Example;
   namespace storagecontrol = google::cloud::storagecontrol_v2;
   using ClientCommand = std::function<void(storagecontrol::StorageControlClient,


### PR DESCRIPTION
For merging #14957,

[performance-no-automatic-move] - removed const.

[bugprone-exception-escape] - mark as no linting.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/14977)
<!-- Reviewable:end -->
