### PR TITLE
chore: set gcs-sdk-team as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,6 @@
 
 # These libraries are also owned by the GCS clients team.
 /google/cloud/storage/ @googleapis/cloud-storage-dpe @googleapis/cloud-cxx-owners
-/google/cloud/storagecontrol/ @googleapis/cloud-storage-dpe @googleapis/cloud-cxx-owners
-/google/cloud/storageinsights/ @googleapis/cloud-storage-dpe @googleapis/cloud-cxx-owners
-/google/cloud/storagetransfer/ @googleapis/cloud-storage-dpe @googleapis/cloud-cxx-owners
+/google/cloud/storagecontrol/ @googleapis/gcs-sdk-team @googleapis/cloud-cxx-owners
+/google/cloud/storageinsights/ @googleapis/gcs-sdk-team @googleapis/cloud-cxx-owners
+/google/cloud/storagetransfer/ @googleapis/gcs-sdk-team @googleapis/cloud-cxx-owners


### PR DESCRIPTION
Replace outdated GCS codeowners name to gcs-sdk-team

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15000)
<!-- Reviewable:end -->
