### PR TITLE
ci: disable external account integration test

### DIFF
--- a/.github/workflows/macos-bazel.yml
+++ b/.github/workflows/macos-bazel.yml
@@ -25,7 +25,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: 'read'
-      id-token: 'write'
     strategy:
       # Continue other builds even if one fails
       fail-fast: false

--- a/.github/workflows/macos-cmake.yml
+++ b/.github/workflows/macos-cmake.yml
@@ -33,7 +33,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: 'read'
-      id-token: 'write'
     strategy:
       # Continue other builds even if one fails
       fail-fast: false

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -75,13 +75,6 @@ jobs:
   # in separate files to keep the size of this file under control. Note how
   # the additional jobs inherit any secrets needed to use the remote caches and
   # receive what version to checkout as an input.
-  external-account-integration:
-    name: External Account Integration
-    needs: [pre-flight]
-    uses: ./.github/workflows/external-account-integration.yml
-    with:
-      checkout-ref: ${{ needs.pre-flight.outputs.checkout-sha }}
-    secrets: inherit
   macos-bazel:
     # Build the full matrix only on push events to the default branch, or
     # when PR gets the has a `gha:full-build` label, or when it had the
@@ -160,7 +153,6 @@ jobs:
     name: Notify-Google-Chat
     # Wait until all the other jobs have completed.
     needs:
-      - external-account-integration
       - macos-bazel
       - macos-cmake
       - windows-bazel

--- a/.github/workflows/windows-bazel.yml
+++ b/.github/workflows/windows-bazel.yml
@@ -25,7 +25,6 @@ jobs:
     runs-on: windows-2022
     permissions:
       contents: 'read'
-      id-token: 'write'
     strategy:
       # Continue other builds even if one fails
       fail-fast: false

--- a/.github/workflows/windows-cmake.yml
+++ b/.github/workflows/windows-cmake.yml
@@ -33,7 +33,6 @@ jobs:
     runs-on: windows-2022
     permissions:
       contents: 'read'
-      id-token: 'write'
     strategy:
       # Continue other builds even if one fails
       fail-fast: false


### PR DESCRIPTION
Due to recent security changes, we need to disable the external account integration test until we figure out a way to get it working again.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15004)
<!-- Reviewable:end -->
