### PR TITLE
chore: clean up last reference to cloud-storage-dpe

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 * @googleapis/cloud-cxx-owners
 
 # These libraries are also owned by the GCS clients team.
-/google/cloud/storage/ @googleapis/cloud-storage-dpe @googleapis/cloud-cxx-owners
+/google/cloud/storage/ @googleapis/gcs-sdk-team @googleapis/cloud-cxx-owners
 /google/cloud/storagecontrol/ @googleapis/gcs-sdk-team @googleapis/cloud-cxx-owners
 /google/cloud/storageinsights/ @googleapis/gcs-sdk-team @googleapis/cloud-cxx-owners
 /google/cloud/storagetransfer/ @googleapis/gcs-sdk-team @googleapis/cloud-cxx-owners


### PR DESCRIPTION
Missed this in https://github.com/googleapis/google-cloud-cpp/pull/15000