### PR TITLE
doc(release): update instructions for creating patch release to preserve existing cloudbuild triggers

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -354,6 +354,12 @@ In your development fork:
   ```
 - If this is the first patch release for that branch, you need to update the GCB
   triggers.
+  - Update convert-to-branch-triggers.sh from HEAD/main as previous releases
+    likely contain a bug that preserves the trigger `id` and will overwrite the
+    `main` CI triggers instead of creating new triggers on `${BRANCH}`.
+    ```shell
+    git checkout main -- ci/cloudbuild/convert-to-branch-triggers.sh
+    ```
   - Update the Google Cloud Build trigger definitions to compile this branch:
     ```shell
     ci/cloudbuild/convert-to-branch-triggers.sh --branch "${BRANCH}"


### PR DESCRIPTION
Part of creating a patch release requires creating CI builds on the branch to be released. While a bug in `ci/cloudbuild/convert-to-branch-triggers.sh` has been fixed, that fix is not present in branches that predate the fix (#14627). It's necessary to backport that fix in order to avoid overwriting the existing cloudbuild triggers and pointing them from main to the patch release branch.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15033)
<!-- Reviewable:end -->
