### PR TITLE
feat(spanner): add ISO8601 duration support to spanner::Interval

### DIFF
--- a/google/cloud/spanner/interval.cc
+++ b/google/cloud/spanner/interval.cc
@@ -115,7 +115,7 @@ std::string SerializeInterval(std::int32_t months, std::int32_t days,
     if (years == 0 && months == 0 && days == 0) ss << "0D";
   } else {
     ss << 'T';
-    auto* sign = "";
+    auto const* sign = "";
     nanoseconds::rep nanosecond_carry = 0;
     if (offset < nanoseconds::zero()) {
       sign = "-";
@@ -208,7 +208,7 @@ bool ParseInteger(absl::string_view& s, T& n, bool allow_sign) {
 Status SyntaxError(absl::string_view str, absl::string_view suf,
                    internal::ErrorInfoBuilder eib) {
   return internal::InvalidArgumentError(
-      absl::StrFormat("\"%s\": Syntax error at \"%s\" (position %d)",  //
+      absl::StrFormat(R"("%s": Syntax error at "%s" (position %d))",  //
                       str, suf.substr(0, 5), suf.data() - str.data()),
       std::move(eib));
 }
@@ -256,8 +256,8 @@ StatusOr<Interval> ParseISO8601Interval(absl::string_view str) {
   Interval intvl;
   absl::string_view s = str;
 
-  auto units = std::begin(kISO8601DateUnitFactories);
-  auto units_end = std::end(kISO8601DateUnitFactories);
+  auto const* units = std::begin(kISO8601DateUnitFactories);
+  auto const* units_end = std::end(kISO8601DateUnitFactories);
   enum { kValue, kUnit, kNothing } expecting = kValue;
   bool negated = false;
 

--- a/google/cloud/spanner/interval.cc
+++ b/google/cloud/spanner/interval.cc
@@ -13,19 +13,22 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/interval.h"
-#include "google/cloud/internal/absl_str_cat_quiet.h"
+#include "google/cloud/internal/absl_str_replace_quiet.h"
 #include "google/cloud/internal/make_status.h"
 #include "google/cloud/internal/time_utils.h"
 #include "absl/strings/ascii.h"
 #include "absl/strings/match.h"
 #include "absl/strings/numbers.h"
+#include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 #include "absl/strings/strip.h"
 #include "absl/time/time.h"
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <functional>
 #include <iomanip>
+#include <iterator>
 #include <ostream>
 #include <sstream>
 #include <string>
@@ -47,30 +50,14 @@ using std::chrono::minutes;
 using std::chrono::nanoseconds;
 using std::chrono::seconds;
 
-// Interval factories for quantity units.
-struct {
-  absl::string_view name;  // de-pluralized forms
-  std::function<Interval(std::int32_t)> factory;
-} const kUnitFactories[] = {
-    // "day" is first so that it is chosen when unit is empty.
-    {"day", [](auto n) { return Interval(0, 0, n); }},
-
-    // "minute" comes before other "m"s so it is chosen for, say, "6m".
-    {"minute", [](auto n) { return Interval{minutes(n)}; }},
-
-    {"microsecond", [](auto n) { return Interval{microseconds(n)}; }},
-    {"millisecond", [](auto n) { return Interval{milliseconds(n)}; }},
-    {"second", [](auto n) { return Interval{seconds(n)}; }},
-    {"hour", [](auto n) { return Interval{hours(n)}; }},
-    {"week", [](auto n) { return Interval(0, 0, n * 7); }},
-    {"month", [](auto n) { return Interval(0, n, 0); }},
-    {"year", [](auto n) { return Interval(n, 0, 0); }},
-    {"decade", [](auto n) { return Interval(n * 10, 0, 0); }},
-    {"century", [](auto n) { return Interval(n * 100, 0, 0); }},
-    {"centurie", [](auto n) { return Interval(n * 100, 0, 0); }},
-    {"millennium", [](auto n) { return Interval(n * 1000, 0, 0); }},
-    {"millennia", [](auto n) { return Interval(n * 1000, 0, 0); }},
-};
+StatusOr<absl::TimeZone> LoadTimeZone(absl::string_view name) {
+  absl::TimeZone tz;
+  if (!absl::LoadTimeZone(name, &tz)) {
+    return internal::InvalidArgumentError(
+        absl::StrFormat("%s: Invalid time zone", name), GCP_ERROR_INFO());
+  }
+  return tz;
+}
 
 // Round d to a microsecond boundary (to even in halfway cases).
 microseconds Round(nanoseconds d) {
@@ -114,33 +101,24 @@ bool Cmp(std::int64_t a_months, std::int64_t a_days, nanoseconds a_offset,
   return C<microseconds>()(rounded_a_offset, rounded_b_offset);
 }
 
-// "y years m months d days H:M:S.F"
+// ISO8601 duration format.
 std::string SerializeInterval(std::int32_t months, std::int32_t days,
                               nanoseconds offset) {
   std::ostringstream ss;
   std::int32_t years = months / 12;
   months %= 12;
-  auto plural = [](std::int32_t v) { return std::abs(v) == 1 ? "" : "s"; };
-  char const* sep = "";
-  if (years != 0) {
-    ss << sep << years << " year" << plural(years);
-    sep = " ";
-  }
-  if (months != 0) {
-    ss << sep << months << " month" << plural(months);
-    sep = " ";
-  }
-  if (days != 0) {
-    ss << sep << days << " day" << plural(days);
-    sep = " ";
-  }
+  ss << 'P';
+  if (years != 0) ss << years << 'Y';
+  if (months != 0) ss << months << 'M';
+  if (days != 0) ss << days << 'D';
   if (offset == nanoseconds::zero()) {
-    if (*sep == '\0') ss << "0 days";
+    if (years == 0 && months == 0 && days == 0) ss << "0D";
   } else {
-    ss << sep;
+    ss << 'T';
+    auto* sign = "";
     nanoseconds::rep nanosecond_carry = 0;
     if (offset < nanoseconds::zero()) {
-      ss << "-";
+      sign = "-";
       if (offset == nanoseconds::min()) {
         // Handle the inability to negate the most negative value.
         // This works because no power of 2 is a multiple of 10,
@@ -156,18 +134,22 @@ std::string SerializeInterval(std::int32_t months, std::int32_t days,
     offset -= min;
     auto sec = duration_cast<seconds>(offset);
     offset -= sec;
-    ss << std::setfill('0') << std::setw(2) << hour.count();
-    ss << ':' << std::setfill('0') << std::setw(2) << min.count();
-    ss << ':' << std::setfill('0') << std::setw(2) << sec.count();
-    if (auto ns = offset.count() + nanosecond_carry) {
-      ss << '.' << std::setfill('0');
-      if (ns % 1000000 == 0) {
-        ss << std::setw(3) << ns / 1000000;
-      } else if (ns % 1000 == 0) {
-        ss << std::setw(6) << ns / 1000;
-      } else {
-        ss << std::setw(9) << ns;
+    if (hour.count() != 0) ss << sign << hour.count() << 'H';
+    if (min.count() != 0) ss << sign << min.count() << 'M';
+    auto ns = offset.count() + nanosecond_carry;
+    if (sec.count() != 0 || ns != 0) {
+      ss << sign << sec.count();
+      if (ns != 0) {
+        ss << '.';
+        if (ns % 1000000 == 0) {
+          ss << std::setw(3) << ns / 1000000;
+        } else if (ns % 1000 == 0) {
+          ss << std::setw(6) << ns / 1000;
+        } else {
+          ss << std::setw(9) << ns;
+        }
       }
+      ss << 'S';
     }
   }
   return std::move(ss).str();
@@ -193,14 +175,21 @@ absl::string_view ConsumeWord(absl::string_view& s) {
   return t.substr(0, t.size() - s.size());
 }
 
-bool ParseDouble(absl::string_view& s, double& d, bool allow_sign) {
+bool ParseDouble(absl::string_view& s, double& d, bool allow_sign,
+                 bool allow_comma) {
   auto t = s;
   if (allow_sign) ConsumeSign(t);
   ConsumeInteger(t);
-  if (!absl::ConsumePrefix(&t, ".")) return false;
+  bool has_comma = allow_comma && absl::ConsumePrefix(&t, ",");
+  if (!has_comma && !absl::ConsumePrefix(&t, ".")) return false;
   ConsumeInteger(t);
   auto len = s.size() - t.size();
-  if (!absl::SimpleAtod(s.substr(0, len), &d)) return false;
+  if (has_comma) {
+    auto cs = absl::StrReplaceAll(s.substr(0, len), {{",", "."}});
+    if (!absl::SimpleAtod(cs, &d)) return false;
+  } else {
+    if (!absl::SimpleAtod(s.substr(0, len), &d)) return false;
+  }
   s.remove_prefix(len);
   return true;
 }
@@ -215,6 +204,149 @@ bool ParseInteger(absl::string_view& s, T& n, bool allow_sign) {
   s.remove_prefix(len);
   return true;
 }
+
+Status SyntaxError(absl::string_view str, absl::string_view suf,
+                   internal::ErrorInfoBuilder eib) {
+  return internal::InvalidArgumentError(
+      absl::StrFormat("\"%s\": Syntax error at \"%s\" (position %d)",  //
+                      str, suf.substr(0, 5), suf.data() - str.data()),
+      std::move(eib));
+}
+
+/**
+ * https://www.iso.org/standard/70907.html
+ * https://www.iso.org/standard/70908.html
+ *
+ * [-+]P[n]Y[n]M[n]W[n]DT[n]H[n]M[n]S
+ *
+ * where "P" indicates a period, "Y", "M", "W", and "D" represent years,
+ * months, weeks, and days respectively, separated by a "T" from "H",
+ * "M", and "S" that represent hours, minutes, and seconds respectively.
+ * "[n]" gives the value of the following unit. A leading "-" negates all
+ * of the unit values.
+ *
+ * Units may be omitted if their value is zero, however, at least one
+ * unit must be present. The smallest unit given may have a decimal
+ * fractional value, with the decimal point being either a period or a
+ * comma. Otherwise the values are integers.
+ */
+
+// Interval factories for ISO8601 date/time quantity units.
+struct ISO8601UnitFactory {
+  char name;
+  std::function<Interval(std::int32_t)> factory;
+};
+ISO8601UnitFactory const kISO8601DateUnitFactories[] = {
+    {'Y', [](auto n) { return Interval(n, 0, 0); }},
+    {'M', [](auto n) { return Interval(0, n, 0); }},
+    {'W', [](auto n) { return Interval(0, 0, n * 7); }},
+    {'D', [](auto n) { return Interval(0, 0, n); }},
+};
+ISO8601UnitFactory const kISO8601TimeUnitFactories[] = {
+    {'H', [](auto n) { return Interval{hours(n)}; }},
+    {'M', [](auto n) { return Interval{minutes(n)}; }},
+    {'S', [](auto n) { return Interval{seconds(n)}; }},
+};
+
+auto NameIs(char name) {
+  return [name](ISO8601UnitFactory const& u) { return u.name == name; };
+}
+
+StatusOr<Interval> ParseISO8601Interval(absl::string_view str) {
+  Interval intvl;
+  absl::string_view s = str;
+
+  auto units = std::begin(kISO8601DateUnitFactories);
+  auto units_end = std::end(kISO8601DateUnitFactories);
+  enum { kValue, kUnit, kNothing } expecting = kValue;
+  bool negated = false;
+
+  for (;;) {
+    if (units == std::begin(kISO8601DateUnitFactories)) {
+      negated = !absl::ConsumePrefix(&s, "+") && absl::ConsumePrefix(&s, "-");
+      if (!absl::ConsumePrefix(&s, "P")) break;
+    }
+    if (units_end == std::end(kISO8601DateUnitFactories)) {
+      if (absl::ConsumePrefix(&s, "T")) {
+        units = std::begin(kISO8601TimeUnitFactories);
+        units_end = std::end(kISO8601TimeUnitFactories);
+        expecting = kValue;
+      }
+    }
+    if (units == units_end) break;
+    double vf;
+    if (ParseDouble(s, vf, true, true)) {
+      expecting = kUnit;
+      if (s.empty()) break;
+      units = std::find_if(units, units_end, NameIs(s.front()));
+      if (units == units_end) break;
+      intvl += units++->factory(1) * vf;
+      expecting = kNothing;
+      s.remove_prefix(1);
+      break;  // must be last unit
+    }
+    std::int32_t vn;
+    if (!ParseInteger(s, vn, true)) break;
+    expecting = kUnit;
+    if (s.empty()) break;
+    units = std::find_if(units, units_end, NameIs(s.front()));
+    if (units == units_end) break;
+    intvl += units++->factory(vn);
+    expecting = kNothing;
+    s.remove_prefix(1);
+  }
+
+  if (!s.empty() || expecting != kNothing) {
+    return SyntaxError(str, s, GCP_ERROR_INFO());
+  }
+  return negated ? -intvl : intvl;
+}
+
+/**
+ * https://www.postgresql.org/docs/current/datatype-datetime.html
+ *
+ * [@] quantity unit [quantity unit...] [direction]
+ *
+ * where quantity is a number (possibly signed); unit is microsecond,
+ * millisecond, second, minute, hour, day, week, month, year, decade,
+ * century, millennium, or abbreviations or plurals of these units;
+ * direction can be ago or empty. The at sign (@) is optional noise.
+ *
+ * The amounts of the different units are implicitly added with
+ * appropriate sign accounting. ago negates all the fields.
+ *
+ * Quantities of days, hours, minutes, and seconds can be specified
+ * without explicit unit markings. For example, '1 12:59:10' is read
+ * the same as '1 day 12 hours 59 min 10 sec'.
+ *
+ * Also, a combination of years and months can be specified with a
+ * dash; for example '200-10' is read the same as '200 years 10 months'.
+ */
+
+// Interval factories for PostgreSql quantity units.
+struct {
+  absl::string_view name;  // de-pluralized forms
+  std::function<Interval(std::int32_t)> factory;
+} const kPostgreSqlUnitFactories[] = {
+    // "day" is first so that it is chosen when unit is empty.
+    {"day", [](auto n) { return Interval(0, 0, n); }},
+
+    // "minute" comes before other "m"s so it is chosen for, say, "6m".
+    {"minute", [](auto n) { return Interval{minutes(n)}; }},
+
+    {"microsecond", [](auto n) { return Interval{microseconds(n)}; }},
+    {"millisecond", [](auto n) { return Interval{milliseconds(n)}; }},
+    {"second", [](auto n) { return Interval{seconds(n)}; }},
+    {"hour", [](auto n) { return Interval{hours(n)}; }},
+    {"week", [](auto n) { return Interval(0, 0, n * 7); }},
+    {"month", [](auto n) { return Interval(0, n, 0); }},
+    {"year", [](auto n) { return Interval(n, 0, 0); }},
+    {"decade", [](auto n) { return Interval(n * 10, 0, 0); }},
+    {"century", [](auto n) { return Interval(n * 100, 0, 0); }},
+    {"centurie", [](auto n) { return Interval(n * 100, 0, 0); }},
+    {"millennium", [](auto n) { return Interval(n * 1000, 0, 0); }},
+    {"millennia", [](auto n) { return Interval(n * 1000, 0, 0); }},
+};
 
 bool ParseYearMonth(absl::string_view& s, Interval& intvl) {
   auto t = s;
@@ -241,7 +373,7 @@ bool ParseHourMinuteSecond(absl::string_view& s, Interval& intvl) {
   d += minutes(minute);
   if (!absl::ConsumePrefix(&t, ":")) return false;
   double second;
-  if (ParseDouble(t, second, false)) {
+  if (ParseDouble(t, second, false, false)) {
     d += duration_cast<nanoseconds>(duration<double>(second));
   } else {
     std::int64_t second;
@@ -253,11 +385,11 @@ bool ParseHourMinuteSecond(absl::string_view& s, Interval& intvl) {
   return true;
 }
 
-Interval Unit(absl::string_view& s, std::int32_t n) {
+Interval PostgreSqlUnit(absl::string_view& s, std::int32_t n) {
   auto t = s;
   auto unit = ConsumeWord(t);
   if (unit.size() > 1) absl::ConsumeSuffix(&unit, "s");  // de-pluralize
-  for (auto const& factory : kUnitFactories) {
+  for (auto const& factory : kPostgreSqlUnitFactories) {
     if (absl::StartsWith(factory.name, unit)) {
       s.remove_prefix(s.size() - t.size());
       return factory.factory(n);
@@ -266,27 +398,7 @@ Interval Unit(absl::string_view& s, std::int32_t n) {
   return Interval(0, 0, n);  // default to days without removing unit
 }
 
-/**
- * https://www.postgresql.org/docs/current/datatype-datetime.html
- *
- * [@] quantity unit [quantity unit...] [direction]
- *
- * where quantity is a number (possibly signed); unit is microsecond,
- * millisecond, second, minute, hour, day, week, month, year, decade,
- * century, millennium, or abbreviations or plurals of these units;
- * direction can be ago or empty. The at sign (@) is optional noise.
- *
- * The amounts of the different units are implicitly added with
- * appropriate sign accounting. ago negates all the fields.
- *
- * Quantities of days, hours, minutes, and seconds can be specified
- * without explicit unit markings. For example, '1 12:59:10' is read
- * the same as '1 day 12 hours 59 min 10 sec'.
- *
- * Also, a combination of years and months can be specified with a
- * dash; for example '200-10' is read the same as '200 years 10 months'.
- */
-StatusOr<Interval> ParseInterval(std::string const& str) {
+StatusOr<Interval> ParsePostgreSqlInterval(absl::string_view str) {
   Interval intvl;
   absl::string_view s = str;
 
@@ -306,15 +418,15 @@ StatusOr<Interval> ParseInterval(std::string const& str) {
       continue;
     }
     double vf;
-    if (ParseDouble(s, vf, true)) {
+    if (ParseDouble(s, vf, true, false)) {
       ConsumeSpaces(s);
-      intvl += Unit(s, 1) * vf;
+      intvl += PostgreSqlUnit(s, 1) * vf;
       continue;
     }
     std::int32_t vn;
     if (ParseInteger(s, vn, true)) {
       ConsumeSpaces(s);
-      intvl += Unit(s, vn);
+      intvl += PostgreSqlUnit(s, vn);
       continue;
     }
     break;  // no match
@@ -325,21 +437,8 @@ StatusOr<Interval> ParseInterval(std::string const& str) {
     intvl = -intvl;
   }
 
-  if (!s.empty()) {
-    return internal::InvalidArgumentError(
-        absl::StrCat("\"", str, "\": Syntax error at \"", s.substr(0, 5), "\""),
-        GCP_ERROR_INFO());
-  }
+  if (!s.empty()) return SyntaxError(str, s, GCP_ERROR_INFO());
   return intvl;
-}
-
-StatusOr<absl::TimeZone> LoadTimeZone(absl::string_view name) {
-  absl::TimeZone tz;
-  if (!absl::LoadTimeZone(name, &tz)) {
-    return internal::InvalidArgumentError(
-        absl::StrCat(name, ": Invalid time zone"), GCP_ERROR_INFO());
-  }
-  return tz;
 }
 
 }  // namespace
@@ -392,7 +491,20 @@ Interval::operator std::string() const {
 }
 
 StatusOr<Interval> MakeInterval(absl::string_view s) {
-  return ParseInterval(absl::AsciiStrToLower(s));
+  auto interval = ParseISO8601Interval(s);
+  if (interval.ok()) return interval;
+
+  auto pg_interval = ParsePostgreSqlInterval(absl::AsciiStrToLower(s));
+  if (pg_interval.ok()) return pg_interval;
+
+  // We failed to parse the argument using either syntax. The most
+  // informative thing to do is return a sequence of Status values,
+  // but until Status supports such an operation we have to glue
+  // something together.
+  return Status(interval.status().code(),
+                absl::StrFormat("%s; %s", interval.status().message(),
+                                pg_interval.status().message()),
+                interval.status().error_info());
 }
 
 Interval JustifyDays(Interval intvl) {

--- a/google/cloud/spanner/interval.h
+++ b/google/cloud/spanner/interval.h
@@ -97,7 +97,7 @@ class Interval {
   }
   ///@}
 
-  /// @name Conversion to a string using "intervalstyle == postgres".
+  /// @name Conversion to a string using ISO8601 duration format.
   explicit operator std::string() const;
 
   /// @name Output streaming


### PR DESCRIPTION
In the pre-release specification for `TypeCode::INTERVAL`, the wire encoding was given as a string in "intervalstyle == postgres" format, and `spanner::Interval` was implemented accordingly.

By the time the feature was released in the backend, this encoding changed to be a string in ISO8601 duration format.

So:
- Change `Interval::operator std::string()` to return a ISO8601 duration string.
- Extend `MakeInterval(absl::string_view)` to recognize ISO8601 duration format.
- Update and extend the test cases accordingly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15077)
<!-- Reviewable:end -->
