### PR TITLE
impl: do not attempt to include openSSL headers in windows

### DIFF
--- a/google/cloud/internal/curl_handle_factory.cc
+++ b/google/cloud/internal/curl_handle_factory.cc
@@ -44,7 +44,8 @@ struct X509InfoPtrCleanup {
 };
 
 using X509InfoPtr = std::unique_ptr<STACK_OF(X509_INFO), X509InfoPtrCleanup>;
-
+#else
+using SSL_CTX = void;
 #endif
 
 Status SetCurlCAInMemory(CurlHandleFactory const& factory, SSL_CTX* ssl_ctx) {

--- a/google/cloud/internal/curl_handle_factory.cc
+++ b/google/cloud/internal/curl_handle_factory.cc
@@ -17,8 +17,10 @@
 #include "google/cloud/internal/curl_options.h"
 #include "google/cloud/internal/make_status.h"
 #include "google/cloud/log.h"
+#ifndef _WIN32
 #include <openssl/err.h>
 #include <openssl/ssl.h>
+#endif
 #include <algorithm>
 #include <iterator>
 


### PR DESCRIPTION
Currently we have some experimental OpenSSL features that do not yet work with Windows. We need to ensure that we don't attempt to include those OpenSSL headers, as they may not be available, nor use any types defined in those headers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15087)
<!-- Reviewable:end -->
