### PR TITLE
impl: prevent logging options from being overwritten

### DIFF
--- a/google/cloud/internal/credentials_impl.cc
+++ b/google/cloud/internal/credentials_impl.cc
@@ -42,8 +42,8 @@ Options PopulateAuthOptions(Options options) {
                        .set<AccessTokenLifetimeOption>(kDefaultTokenLifetime));
   // Then apply any overrides.
   return MergeOptions(
-      Options{}.set<LoggingComponentsOption>(DefaultTracingComponents()),
-      std::move(options));
+      std::move(options),
+      Options{}.set<LoggingComponentsOption>(DefaultTracingComponents()));
 }
 
 void CredentialsVisitor::dispatch(Credentials const& credentials,

--- a/google/cloud/internal/populate_common_options.cc
+++ b/google/cloud/internal/populate_common_options.cc
@@ -94,11 +94,16 @@ TracingOptions DefaultTracingOptions() {
   return TracingOptions{}.SetOptions(*tracing_options);
 }
 
+// TODO(#15089): Determine if this function needs to preserve more (or all) of
+// the options passed in.
 Options MakeAuthOptions(Options const& options) {
   Options opts;
   if (options.has<OpenTelemetryTracingOption>()) {
     opts.set<OpenTelemetryTracingOption>(
         options.get<OpenTelemetryTracingOption>());
+  }
+  if (options.has<LoggingComponentsOption>()) {
+    opts.set<LoggingComponentsOption>(options.get<LoggingComponentsOption>());
   }
   return opts;
 }

--- a/google/cloud/internal/populate_common_options_test.cc
+++ b/google/cloud/internal/populate_common_options_test.cc
@@ -299,6 +299,23 @@ TEST(MakeAuthOptions, WithTracing) {
   EXPECT_TRUE(auth_options.get<OpenTelemetryTracingOption>());
 }
 
+TEST(MakeAuthOptions, WithoutLoggingComponents) {
+  auto options = Options{}.set<EndpointOption>("endpoint_option");
+  auto auth_options = MakeAuthOptions(options);
+  EXPECT_FALSE(auth_options.has<EndpointOption>());
+  EXPECT_FALSE(auth_options.has<LoggingComponentsOption>());
+}
+
+TEST(MakeAuthOptions, WitLoggingComponents) {
+  auto options = Options{}
+                     .set<EndpointOption>("endpoint_option")
+                     .set<LoggingComponentsOption>({"logging_component"});
+  auto auth_options = MakeAuthOptions(options);
+  EXPECT_FALSE(auth_options.has<EndpointOption>());
+  EXPECT_THAT(auth_options.get<LoggingComponentsOption>(),
+              ElementsAre("logging_component"));
+}
+
 }  // namespace
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
When trying to specify a LoggingComponent option for logging the auth rpc flow, I discovered that the value I provided was being overwritten with the default values. This makes debugging hard. Adjusting the options flow to preserve user specified values for logging.