### PR TITLE
ci: enable pedantic in clang-tidy builds

### DIFF
--- a/cmake/GoogleCloudCppCommonOptions.cmake
+++ b/cmake/GoogleCloudCppCommonOptions.cmake
@@ -34,6 +34,7 @@ check_cxx_compiler_flag(-Wno-sign-conversion
 check_cxx_compiler_flag(-Werror GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WERROR)
 check_cxx_compiler_flag(-fclang-abi-compat=17
                         GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_CLANG_ABI_COMPAT_17)
+check_cxx_compiler_flag(-pedantic GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_PEDANTIC)
 
 #[=======================================================================[.rst:
 google_cloud_cpp_add_common_options(target [NO_WARNINGS])
@@ -108,5 +109,8 @@ function (google_cloud_cpp_add_common_options target)
         target_compile_options(${target} PRIVATE "-Werror")
         target_compile_options(${target}
                                PRIVATE "-Wno-error=deprecated-declarations")
+    endif ()
+    if (CMAKE_CXX_CLANG_TIDY AND GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_PEDANTIC)
+        target_compile_options(${target} PRIVATE "-pedantic")
     endif ()
 endfunction ()

--- a/generator/internal/pagination_test.cc
+++ b/generator/internal/pagination_test.cc
@@ -683,27 +683,18 @@ TEST_P(BigQueryTestFixture, DetermineBigQueryPagination) {
             params.items_field_type_message_name);
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    BigQueryTests, BigQueryTestFixture,
-    ValuesIn<BigQueryTestParams>(
-        {{.max_results_field_type_message_name = "google.protobuf.Int32Value",
-          .items_field_name = "jobs",
-          .items_field_type_message_name =
-              "google.cloud.bigquery.v2.ListFormatJob"},
-         {.max_results_field_type_message_name = "google.protobuf.UInt32Value",
-          .items_field_name = "rows",
-          .items_field_type_message_name = "google.protobuf.Struct"},
-         {.max_results_field_type_message_name = "google.protobuf.UInt32Value",
-          .items_field_name = "tables",
-          .items_field_type_message_name =
-              "google.cloud.bigquery.v2.ListFormatTable"},
-         {.max_results_field_type_message_name = "google.protobuf.UInt32Value",
-          .items_field_name = "datasets",
-          .items_field_type_message_name =
-              "google.cloud.bigquery.v2.ListFormatDataset"},
-         {.max_results_field_type_message_name = "google.protobuf.UInt32Value",
-          .items_field_name = "models",
-          .items_field_type_message_name = "google.cloud.bigquery.v2.Model"}}));
+INSTANTIATE_TEST_SUITE_P(BigQueryTests, BigQueryTestFixture,
+                         ValuesIn<BigQueryTestParams>(
+                             {{"google.protobuf.Int32Value", "jobs",
+                               "google.cloud.bigquery.v2.ListFormatJob"},
+                              {"google.protobuf.UInt32Value", "rows",
+                               "google.protobuf.Struct"},
+                              {"google.protobuf.UInt32Value", "tables",
+                               "google.cloud.bigquery.v2.ListFormatTable"},
+                              {"google.protobuf.UInt32Value", "datasets",
+                               "google.cloud.bigquery.v2.ListFormatDataset"},
+                              {"google.protobuf.UInt32Value", "models",
+                               "google.cloud.bigquery.v2.Model"}}));
 
 TEST(PaginationTest, PaginationBigQuerySpecialCaseSuccess) {
   FileDescriptorProto service_file;

--- a/google/cloud/internal/log_wrapper_test.cc
+++ b/google/cloud/internal/log_wrapper_test.cc
@@ -63,7 +63,7 @@ using TestVariations = ::testing::Types<
     std::tuple<StatusOr<Response>, std::shared_ptr<grpc::ClientContext>>  //
     >;
 
-TYPED_TEST_SUITE(LogWrapperTest, TestVariations);
+TYPED_TEST_SUITE(LogWrapperTest, TestVariations, );
 
 // These helper functions make it easier to write the tests.
 Request MakeRequest() {

--- a/google/cloud/internal/pagination_range_test.cc
+++ b/google/cloud/internal/pagination_range_test.cc
@@ -92,7 +92,7 @@ class MockRpcExplicit {
 template <typename T>
 class PaginationRangeTest : public testing::Test {};
 using ResponseTypes = ::testing::Types<ProtoResponse, StructResponse>;
-TYPED_TEST_SUITE(PaginationRangeTest, ResponseTypes);
+TYPED_TEST_SUITE(PaginationRangeTest, ResponseTypes, );
 
 TYPED_TEST(PaginationRangeTest, SinglePageImplicit) {
   using ResponseType = TypeParam;

--- a/google/cloud/storage/internal/grpc/make_cord_test.cc
+++ b/google/cloud/storage/internal/grpc/make_cord_test.cc
@@ -70,7 +70,7 @@ using TestVariations = ::testing::Types<
     std::string, std::vector<char>, std::vector<signed char>,
     std::vector<unsigned char>, std::vector<std::uint8_t> >;
 
-TYPED_TEST_SUITE(MakeCordFromVector, TestVariations);
+TYPED_TEST_SUITE(MakeCordFromVector, TestVariations, );
 
 TYPED_TEST(MakeCordFromVector, MakeCord) {
   using Collection = typename TestFixture::TestType;


### PR DESCRIPTION
Because macros are bad, in order to turn on `-pedantic` we had to apply https://github.com/google/googletest/issues/2271 to all usages of `TYPED_TEST_SUITE`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15107)
<!-- Reviewable:end -->
