### PR TITLE
impl(generator): add toggle for how proto includes are generated

### DIFF
--- a/generator/internal/auth_decorator_generator.cc
+++ b/generator/internal/auth_decorator_generator.cc
@@ -51,9 +51,10 @@ Status AuthDecoratorGenerator::GenerateHeader() {
   HeaderLocalIncludes({vars("stub_header_path"),
                        "google/cloud/internal/unified_grpc_credentials.h",
                        "google/cloud/version.h"});
-  HeaderSystemIncludes(
-      {HasLongrunningMethod() ? "google/longrunning/operations.grpc.pb.h" : "",
-       "memory", "set", "string"});
+  HeaderProtobufGenCodeIncludes({HasLongrunningMethod()
+                                     ? "google/longrunning/operations.grpc.pb.h"
+                                     : ""});
+  HeaderSystemIncludes({"memory", "set", "string"});
 
   auto result = HeaderOpenNamespaces(NamespaceType::kInternal);
   if (!result.ok()) return result;
@@ -110,7 +111,8 @@ Status AuthDecoratorGenerator::GenerateCc() {
           ? "google/cloud/internal/streaming_write_rpc_impl.h"
           : "",
   });
-  CcSystemIncludes({vars("proto_grpc_header_path"), "memory", "utility"});
+  CcProtobufGenCodeIncludes({vars("proto_grpc_header_path")});
+  CcSystemIncludes({"memory", "utility"});
 
   auto result = CcOpenNamespaces(NamespaceType::kInternal);
   if (!result.ok()) return result;

--- a/generator/internal/client_generator.cc
+++ b/generator/internal/client_generator.cc
@@ -88,11 +88,12 @@ Status ClientGenerator::GenerateHeader() {
   if (get_iam_policy_extension_ && set_iam_policy_extension_) {
     HeaderLocalIncludes({"google/cloud/iam_updater.h"});
   }
-  HeaderSystemIncludes(MethodSignatureWellKnownProtobufTypeIncludes());
+  HeaderProtobufGenCodeIncludes(MethodSignatureWellKnownProtobufTypeIncludes());
+  HeaderProtobufGenCodeIncludes({HasGRPCLongrunningOperation()
+                                     ? "google/longrunning/operations.grpc.pb.h"
+                                     : ""});
   HeaderSystemIncludes(
-      {HasGRPCLongrunningOperation() ? "google/longrunning/operations.grpc.pb.h"
-                                     : "",
-       HasMessageWithMapField() ? "map" : "", "memory", "string"});
+      {HasMessageWithMapField() ? "map" : "", "memory", "string"});
 
   auto result = HeaderOpenNamespaces();
   if (!result.ok()) return result;

--- a/generator/internal/connection_generator.cc
+++ b/generator/internal/connection_generator.cc
@@ -73,12 +73,12 @@ Status ConnectionGenerator::GenerateHeader() {
        "google/cloud/version.h"});
   std::vector<std::string> const additional_pb_header_paths =
       absl::StrSplit(vars("additional_pb_header_paths"), absl::ByChar(','));
-  HeaderSystemIncludes(additional_pb_header_paths);
-  HeaderSystemIncludes({vars("proto_header_path"),
-                        HasGRPCLongrunningOperation()
-                            ? "google/longrunning/operations.grpc.pb.h"
-                            : "",
-                        "memory"});
+  HeaderProtobufGenCodeIncludes(additional_pb_header_paths);
+  HeaderProtobufGenCodeIncludes({vars("proto_header_path")});
+  HeaderProtobufGenCodeIncludes({HasGRPCLongrunningOperation()
+                                     ? "google/longrunning/operations.grpc.pb.h"
+                                     : ""});
+  HeaderSystemIncludes({"memory"});
   switch (endpoint_location_style) {
     case ServiceConfiguration::LOCATION_DEPENDENT:
     case ServiceConfiguration::LOCATION_DEPENDENT_COMPAT:

--- a/generator/internal/connection_impl_generator.cc
+++ b/generator/internal/connection_impl_generator.cc
@@ -75,9 +75,10 @@ Status ConnectionImplGenerator::GenerateHeader() {
            ? "google/cloud/stream_range.h"
            : "",
        "google/cloud/version.h"});
-  HeaderSystemIncludes(
-      {HasLongrunningMethod() ? "google/longrunning/operations.grpc.pb.h" : "",
-       "memory"});
+  HeaderProtobufGenCodeIncludes({HasLongrunningMethod()
+                                     ? "google/longrunning/operations.grpc.pb.h"
+                                     : ""});
+  HeaderSystemIncludes({"memory"});
 
   auto result = HeaderOpenNamespaces(NamespaceType::kInternal);
   if (!result.ok()) return result;

--- a/generator/internal/connection_impl_rest_generator.cc
+++ b/generator/internal/connection_impl_rest_generator.cc
@@ -57,10 +57,10 @@ Status ConnectionImplRestGenerator::GenerateHeader() {
        "google/cloud/status_or.h",
        HasPaginatedMethod() ? "google/cloud/stream_range.h" : "",
        "google/cloud/version.h"});
-  HeaderSystemIncludes({HasLongrunningMethod()
-                            ? vars("longrunning_operation_include_header")
-                            : "",
-                        "memory"});
+  HeaderProtobufGenCodeIncludes(
+      {HasLongrunningMethod() ? vars("longrunning_operation_include_header")
+                              : ""});
+  HeaderSystemIncludes({"memory"});
 
   auto result = HeaderOpenNamespaces(NamespaceType::kInternal);
   if (!result.ok()) return result;

--- a/generator/internal/idempotency_policy_generator.cc
+++ b/generator/internal/idempotency_policy_generator.cc
@@ -54,8 +54,9 @@ Status IdempotencyPolicyGenerator::GenerateHeader() {
   HeaderLocalIncludes({"google/cloud/idempotency.h", "google/cloud/version.h"});
 
   auto headers = GetMixinPbIncludeByTransport();
-  headers.insert(headers.end(), {GetPbIncludeByTransport(), "memory"});
-  HeaderSystemIncludes(headers);
+  headers.insert(headers.end(), {GetPbIncludeByTransport()});
+  HeaderProtobufGenCodeIncludes(headers);
+  HeaderSystemIncludes({"memory"});
 
   auto result = HeaderOpenNamespaces();
   if (!result.ok()) return result;

--- a/generator/internal/logging_decorator_generator.cc
+++ b/generator/internal/logging_decorator_generator.cc
@@ -59,9 +59,10 @@ Status LoggingDecoratorGenerator::GenerateHeader() {
   HeaderLocalIncludes({vars("stub_header_path"),
                        "google/cloud/tracing_options.h",
                        "google/cloud/version.h"});
-  HeaderSystemIncludes(
-      {HasLongrunningMethod() ? "google/longrunning/operations.grpc.pb.h" : "",
-       "memory", "set", "string"});
+  HeaderProtobufGenCodeIncludes({HasLongrunningMethod()
+                                     ? "google/longrunning/operations.grpc.pb.h"
+                                     : ""});
+  HeaderSystemIncludes({"memory", "set", "string"});
 
   auto result = HeaderOpenNamespaces(NamespaceType::kInternal);
   if (!result.ok()) return result;
@@ -124,8 +125,8 @@ Status LoggingDecoratorGenerator::GenerateCc() {
            ? "google/cloud/internal/async_streaming_write_rpc_logging.h"
            : "",
        "google/cloud/status_or.h"});
-  CcSystemIncludes(
-      {vars("proto_grpc_header_path"), "memory", "set", "string", "utility"});
+  CcProtobufGenCodeIncludes({vars("proto_grpc_header_path")});
+  CcSystemIncludes({"memory", "set", "string", "utility"});
 
   auto result = CcOpenNamespaces(NamespaceType::kInternal);
   if (!result.ok()) return result;

--- a/generator/internal/logging_decorator_rest_generator.cc
+++ b/generator/internal/logging_decorator_rest_generator.cc
@@ -53,11 +53,11 @@ Status LoggingDecoratorRestGenerator::GenerateHeader() {
       {vars("stub_rest_header_path"), "google/cloud/internal/rest_context.h",
        "google/cloud/future.h", "google/cloud/tracing_options.h",
        "google/cloud/version.h"});
-  HeaderSystemIncludes({vars("proto_header_path"),
-                        HasLongrunningMethod()
-                            ? vars("longrunning_operation_include_header")
-                            : "",
-                        "memory", "set", "string"});
+  HeaderProtobufGenCodeIncludes(
+      {vars("proto_header_path"),
+       HasLongrunningMethod() ? vars("longrunning_operation_include_header")
+                              : ""});
+  HeaderSystemIncludes({"memory", "set", "string"});
 
   auto result = HeaderOpenNamespaces(NamespaceType::kInternal);
   if (!result.ok()) return result;

--- a/generator/internal/metadata_decorator_generator.cc
+++ b/generator/internal/metadata_decorator_generator.cc
@@ -129,9 +129,10 @@ Status MetadataDecoratorGenerator::GenerateHeader() {
   HeaderPrint("\n");
   HeaderLocalIncludes({vars("stub_header_path"), "google/cloud/options.h",
                        "google/cloud/version.h"});
-  HeaderSystemIncludes(
-      {HasLongrunningMethod() ? "google/longrunning/operations.grpc.pb.h" : "",
-       "map", "memory", "string"});
+  HeaderProtobufGenCodeIncludes({HasLongrunningMethod()
+                                     ? "google/longrunning/operations.grpc.pb.h"
+                                     : ""});
+  HeaderSystemIncludes({"map", "memory", "string"});
 
   auto result = HeaderOpenNamespaces(NamespaceType::kInternal);
   if (!result.ok()) return result;
@@ -190,8 +191,8 @@ Status MetadataDecoratorGenerator::GenerateCc() {
        HasExplicitRoutingMethod() ? "google/cloud/internal/routing_matcher.h"
                                   : "",
        "google/cloud/status_or.h", "google/cloud/internal/url_encode.h"});
-  CcSystemIncludes({vars("proto_grpc_header_path"), "memory", "string",
-                    "utility", "vector"});
+  CcProtobufGenCodeIncludes({vars("proto_grpc_header_path")});
+  CcSystemIncludes({"memory", "string", "utility", "vector"});
 
   auto result = CcOpenNamespaces(NamespaceType::kInternal);
   if (!result.ok()) return result;

--- a/generator/internal/metadata_decorator_rest_generator.cc
+++ b/generator/internal/metadata_decorator_rest_generator.cc
@@ -118,11 +118,11 @@ Status MetadataDecoratorRestGenerator::GenerateHeader() {
   HeaderLocalIncludes({vars("stub_rest_header_path"), "google/cloud/future.h",
                        "google/cloud/rest_options.h",
                        "google/cloud/version.h"});
-  HeaderSystemIncludes({vars("proto_header_path"),
-                        HasLongrunningMethod()
-                            ? vars("longrunning_operation_include_header")
-                            : "",
-                        "memory", "string"});
+  HeaderProtobufGenCodeIncludes(
+      {vars("proto_header_path"),
+       HasLongrunningMethod() ? vars("longrunning_operation_include_header")
+                              : ""});
+  HeaderSystemIncludes({"memory", "string"});
 
   auto result = HeaderOpenNamespaces(NamespaceType::kInternal);
   if (!result.ok()) return result;

--- a/generator/internal/service_code_generator.cc
+++ b/generator/internal/service_code_generator.cc
@@ -406,6 +406,24 @@ void ServiceCodeGenerator::GenerateSystemIncludes(
   }
 }
 
+void ServiceCodeGenerator::HeaderProtobufGenCodeIncludes(
+    std::vector<std::string> const& pb_h_includes) {
+  if (pb_h_system_includes_) {
+    HeaderSystemIncludes(pb_h_includes);
+  } else {
+    HeaderLocalIncludes(pb_h_includes);
+  }
+}
+
+void ServiceCodeGenerator::CcProtobufGenCodeIncludes(
+    std::vector<std::string> const& pb_h_includes) {
+  if (pb_h_system_includes_) {
+    CcSystemIncludes(pb_h_includes);
+  } else {
+    CcLocalIncludes(pb_h_includes);
+  }
+}
+
 Status ServiceCodeGenerator::OpenNamespaces(
     Printer& p, NamespaceType ns_type, std::string const& product_path_var,
     std::string const& ns_documentation) {

--- a/generator/internal/service_code_generator.h
+++ b/generator/internal/service_code_generator.h
@@ -77,6 +77,10 @@ class ServiceCodeGenerator : public GeneratorInterface {
   void HeaderSystemIncludes(std::vector<std::string> const& system_includes);
   void CcSystemIncludes(std::vector<std::string> const& system_includes);
 
+  void HeaderProtobufGenCodeIncludes(
+      std::vector<std::string> const& pb_h_includes);
+  void CcProtobufGenCodeIncludes(std::vector<std::string> const& pb_h_includes);
+
   Status HeaderOpenNamespaces(NamespaceType ns_type = NamespaceType::kNormal);
   Status HeaderOpenForwardingNamespaces(
       NamespaceType ns_type = NamespaceType::kNormal,
@@ -263,6 +267,7 @@ class ServiceCodeGenerator : public GeneratorInterface {
   std::map<std::string, VarsDictionary> service_method_vars_;
   std::string namespace_;
   bool define_backwards_compatibility_namespace_alias_ = false;
+  bool pb_h_system_includes_ = true;
   MethodDescriptorList methods_;
   MethodDescriptorList async_methods_;
   Printer header_;

--- a/generator/internal/stub_factory_generator.cc
+++ b/generator/internal/stub_factory_generator.cc
@@ -90,9 +90,9 @@ Status StubFactoryGenerator::GenerateCc() {
 
   std::vector<std::string> headers =
       absl::StrSplit(vars("mixin_proto_grpc_header_paths"), ',');
-  headers.insert(headers.end(),
-                 {vars("proto_grpc_header_path"), "memory", "utility"});
-  CcSystemIncludes(headers);
+  headers.insert(headers.end(), {vars("proto_grpc_header_path")});
+  CcProtobufGenCodeIncludes(headers);
+  CcSystemIncludes({"memory", "utility"});
 
   auto result = CcOpenNamespaces(NamespaceType::kInternal);
   if (!result.ok()) return result;

--- a/generator/internal/stub_generator.cc
+++ b/generator/internal/stub_generator.cc
@@ -73,19 +73,19 @@ Status StubGenerator::GenerateHeader() {
        "google/cloud/version.h"});
   std::vector<std::string> additional_pb_header_paths =
       absl::StrSplit(vars("additional_pb_header_paths"), absl::ByChar(','));
-  HeaderSystemIncludes(additional_pb_header_paths);
+  HeaderProtobufGenCodeIncludes(additional_pb_header_paths);
   std::vector<std::string> mixin_headers =
       absl::StrSplit(vars("mixin_proto_grpc_header_paths"), ',');
-  HeaderSystemIncludes(mixin_headers);
+  HeaderProtobufGenCodeIncludes(mixin_headers);
   bool include_lro_header =
       HasLongrunningMethod() &&
       std::find(mixin_headers.begin(), mixin_headers.end(),
                 "google/longrunning/operations.grpc.pb.h") ==
           mixin_headers.end();
-  HeaderSystemIncludes(
+  HeaderProtobufGenCodeIncludes(
       {vars("proto_grpc_header_path"),
-       include_lro_header ? "google/longrunning/operations.grpc.pb.h" : "",
-       "memory", "utility"});
+       include_lro_header ? "google/longrunning/operations.grpc.pb.h" : ""});
+  HeaderSystemIncludes({"memory", "utility"});
 
   auto result = HeaderOpenNamespaces(NamespaceType::kInternal);
   if (!result.ok()) return result;
@@ -321,10 +321,11 @@ Status StubGenerator::GenerateCc() {
            ? "google/cloud/internal/streaming_write_rpc_impl.h"
            : "",
        "google/cloud/grpc_error_delegate.h", "google/cloud/status_or.h"});
-  CcSystemIncludes(
-      {vars("proto_grpc_header_path"),
-       HasLongrunningMethod() ? "google/longrunning/operations.grpc.pb.h" : "",
-       "memory", "utility"});
+  CcProtobufGenCodeIncludes({vars("proto_grpc_header_path"),
+                             HasLongrunningMethod()
+                                 ? "google/longrunning/operations.grpc.pb.h"
+                                 : ""});
+  CcSystemIncludes({"memory", "utility"});
 
   auto result = CcOpenNamespaces(NamespaceType::kInternal);
   if (!result.ok()) return result;

--- a/generator/internal/stub_rest_generator.cc
+++ b/generator/internal/stub_rest_generator.cc
@@ -54,19 +54,19 @@ Status StubRestGenerator::GenerateHeader() {
                        "google/cloud/status_or.h", "google/cloud/version.h"});
   std::vector<std::string> additional_pb_header_paths =
       absl::StrSplit(vars("additional_pb_header_paths"), absl::ByChar(','));
-  HeaderSystemIncludes(additional_pb_header_paths);
+  HeaderProtobufGenCodeIncludes(additional_pb_header_paths);
   std::vector<std::string> mixin_headers =
       absl::StrSplit(vars("mixin_proto_header_paths"), ',');
-  HeaderSystemIncludes(mixin_headers);
+  HeaderProtobufGenCodeIncludes(mixin_headers);
   bool include_lro_header =
       HasLongrunningMethod() &&
       std::find(mixin_headers.begin(), mixin_headers.end(),
                 vars("longrunning_operation_include_header")) ==
           mixin_headers.end();
-  HeaderSystemIncludes(
+  HeaderProtobufGenCodeIncludes(
       {vars("proto_header_path"),
-       include_lro_header ? vars("longrunning_operation_include_header") : "",
-       "memory"});
+       include_lro_header ? vars("longrunning_operation_include_header") : ""});
+  HeaderSystemIncludes({"memory"});
 
   auto result = HeaderOpenNamespaces(NamespaceType::kInternal);
   if (!result.ok()) return result;
@@ -261,11 +261,11 @@ Status StubRestGenerator::GenerateCc() {
                    "google/cloud/internal/absl_str_cat_quiet.h",
                    "google/cloud/internal/rest_stub_helpers.h",
                    "google/cloud/status_or.h"});
-  CcSystemIncludes({vars("proto_header_path"),
-                    HasLongrunningMethod()
-                        ? vars("longrunning_operation_include_header")
-                        : "",
-                    "memory", "utility"});
+  CcProtobufGenCodeIncludes({vars("proto_header_path"),
+                             HasLongrunningMethod()
+                                 ? vars("longrunning_operation_include_header")
+                                 : ""});
+  CcSystemIncludes({"memory", "utility"});
 
   auto result = CcOpenNamespaces(NamespaceType::kInternal);
   if (!result.ok()) return result;


### PR DESCRIPTION
Adds a third category of includes that the generator emits for protobuf generated headers, i.e. "pb.h" files. This PR preserves the current behavior of treating them as system includes (using <>), but prepares us for eventually switching to local includes (using "").

This PR should not result any any changes to generated code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15116)
<!-- Reviewable:end -->
