### PR TITLE
impl(storage): explicitly cast span data to supported common::AttributeValue type

### DIFF
--- a/google/cloud/storage/internal/async/object_descriptor_reader_tracing.cc
+++ b/google/cloud/storage/internal/async/object_descriptor_reader_tracing.cc
@@ -57,7 +57,7 @@ class ObjectDescriptorReaderTracing : public ObjectDescriptorReader {
                 "gl-cpp.read-range",
                 {{/*sc::kRpcMessageType=*/"rpc.message.type", "RECEIVED"},
                  {sc::kThreadId, internal::CurrentThreadId()},
-                 {"message.size", payload.size()}});
+                 {"message.size", static_cast<std::uint32_t>(payload.size())}});
           } else {
             span->AddEvent(
                 "gl-cpp.read-range",

--- a/google/cloud/storage/internal/async/object_descriptor_reader_tracing_test.cc
+++ b/google/cloud/storage/internal/async/object_descriptor_reader_tracing_test.cc
@@ -60,15 +60,16 @@ TEST(ObjectDescriptorReaderTracing, Read) {
 
   auto actual = reader->Read().get();
   auto spans = span_catcher->GetSpans();
-  EXPECT_THAT(spans, ElementsAre(AllOf(
-                         SpanNamed("storage::AsyncConnection::ReadObjectRange"),
-                         SpanHasEvents(AllOf(
-                             EventNamed("gl-cpp.read-range"),
-                             SpanEventAttributesAre(
-                                 OTelAttribute<std::size_t>("message.size", 10),
-                                 OTelAttribute<std::string>(sc::kThreadId, _),
-                                 OTelAttribute<std::string>("rpc.message.type",
-                                                            "RECEIVED")))))));
+  EXPECT_THAT(
+      spans, ElementsAre(
+                 AllOf(SpanNamed("storage::AsyncConnection::ReadObjectRange"),
+                       SpanHasEvents(AllOf(
+                           EventNamed("gl-cpp.read-range"),
+                           SpanEventAttributesAre(
+                               OTelAttribute<std::uint32_t>("message.size", 10),
+                               OTelAttribute<std::string>(sc::kThreadId, _),
+                               OTelAttribute<std::string>("rpc.message.type",
+                                                          "RECEIVED")))))));
 }
 
 TEST(ObjectDescriptorReaderTracing, ReadError) {


### PR DESCRIPTION
`std::size_t` on some platforms didn't always translate to a type contained in Otel's `AttributeValue` type:

```
using AttributeValue =
    nostd::variant<bool,
                   int32_t,
                   int64_t,
                   uint32_t,
                   double,
                   const char *,
                   nostd::string_view,
                   nostd::span<const bool>,
                   nostd::span<const int32_t>,
                   nostd::span<const int64_t>,
                   nostd::span<const uint32_t>,
                   nostd::span<const double>,
                   nostd::span<const nostd::string_view>,
                   // Not currently supported by the specification, but reserved for future use.
                   // Added to provide support for all primitive C++ types.
                   uint64_t,
                   // Not currently supported by the specification, but reserved for future use.
                   // Added to provide support for all primitive C++ types.
                   nostd::span<const uint64_t>,
                   // Not currently supported by the specification, but reserved for future use.
                   // See https://github.com/open-telemetry/opentelemetry-specification/issues/780
                   nostd::span<const uint8_t>>;
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15119)
<!-- Reviewable:end -->
