### PR TITLE
test: add unit test to confirm absence of pageToken param

### DIFF
--- a/google/cloud/storage/internal/rest/stub_test.cc
+++ b/google/cloud/storage/internal/rest/stub_test.cc
@@ -180,6 +180,25 @@ TEST(RestStubTest, ListBuckets) {
               StatusIs(PermanentError().code(), PermanentError().message()));
 }
 
+TEST(RestStubTest, ListBucketsIncludesPageToken) {
+  auto mock = std::make_shared<MockRestClient>();
+  std::string expected_token = "test-page-token";
+  ListBucketsRequest request("test-project-id");
+  request.set_page_token(expected_token);
+
+  EXPECT_CALL(*mock,
+              Get(ExpectedContext(),
+                  ResultOf(
+                      "request includes pageToken query parameter",
+                      [](RestRequest const& r) { return r.parameters(); },
+                      Contains(Pair("pageToken", expected_token)))))
+      .WillOnce(Return(PermanentError()));
+
+  auto tested = std::make_unique<RestStub>(Options{}, mock, mock);
+  auto context = TestContext();
+  tested->ListBuckets(context, TestOptions(), request);
+}
+
 TEST(RestStubTest, CreateBucket) {
   auto mock = std::make_shared<MockRestClient>();
   EXPECT_CALL(*mock,


### PR DESCRIPTION
Added a unit test to confirm absence of `pageToken` param in `ListBuckets` request, which causes the 1000+ buckets infinite pagination loop.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15126)
<!-- Reviewable:end -->
