### PR TITLE
cleanup(storage): Mark google::cloud::storage::oauth2 as deprecated

### DIFF
--- a/google/cloud/storage/oauth2/anonymous_credentials.h
+++ b/google/cloud/storage/oauth2/anonymous_credentials.h
@@ -36,7 +36,8 @@ namespace oauth2 {
  *
  * @deprecated Prefer using the unified credentials documented in @ref guac
  */
-class AnonymousCredentials : public Credentials {
+class GOOGLE_CLOUD_CPP_DEPRECATED(
+    "This class will be removed shortly") AnonymousCredentials : public Credentials {
  public:
   AnonymousCredentials() = default;
 

--- a/google/cloud/storage/oauth2/authorized_user_credentials.h
+++ b/google/cloud/storage/oauth2/authorized_user_credentials.h
@@ -106,7 +106,8 @@ class AuthorizedUserCredentials;
 
 /// @copydoc AuthorizedUserCredentials
 template <>
-class AuthorizedUserCredentials<storage::internal::CurlRequestBuilder,
+class GOOGLE_CLOUD_CPP_DEPRECATED(
+    "This class will be removed shortly") AuthorizedUserCredentials<storage::internal::CurlRequestBuilder,
                                 std::chrono::system_clock>
     : public Credentials {
  public:
@@ -138,7 +139,8 @@ class AuthorizedUserCredentials<storage::internal::CurlRequestBuilder,
 
 /// @copydoc AuthorizedUserCredentials
 template <typename HttpRequestBuilderType, typename ClockType>
-class AuthorizedUserCredentials : public Credentials {
+class GOOGLE_CLOUD_CPP_DEPRECATED(
+    "This class will be removed shortly") AuthorizedUserCredentials : public Credentials {
  public:
   explicit AuthorizedUserCredentials(AuthorizedUserCredentialsInfo info,
                                      ChannelOptions const& channel_options = {})

--- a/google/cloud/storage/oauth2/compute_engine_credentials.h
+++ b/google/cloud/storage/oauth2/compute_engine_credentials.h
@@ -104,7 +104,9 @@ class ComputeEngineCredentials;
 
 /// @copydoc ComputeEngineCredentials
 template <>
-class ComputeEngineCredentials<storage::internal::CurlRequestBuilder,
+class GOOGLE_CLOUD_CPP_DEPRECATED(
+    "This class will be removed shortly. Prefer using the unified credentials "
+    "documented in @ref guac") ComputeEngineCredentials<storage::internal::CurlRequestBuilder,
                                std::chrono::system_clock> : public Credentials {
  public:
   explicit ComputeEngineCredentials() : ComputeEngineCredentials("default") {}
@@ -152,7 +154,9 @@ class ComputeEngineCredentials<storage::internal::CurlRequestBuilder,
 
 /// @copydoc ComputeEngineCredentials
 template <typename HttpRequestBuilderType, typename ClockType>
-class ComputeEngineCredentials : public Credentials {
+class GOOGLE_CLOUD_CPP_DEPRECATED(
+    "This class will be removed shortly. Prefer using the unified credentials "
+    "documented in @ref guac") ComputeEngineCredentials : public Credentials {
  public:
   explicit ComputeEngineCredentials() : ComputeEngineCredentials("default") {}
 

--- a/google/cloud/storage/oauth2/credentials.h
+++ b/google/cloud/storage/oauth2/credentials.h
@@ -44,7 +44,9 @@ namespace oauth2 {
  *
  * @deprecated Prefer using the unified credentials documented in @ref guac
  */
-class Credentials {
+class  GOOGLE_CLOUD_CPP_DEPRECATED(
+    "This class will be removed shortly. Prefer using the unified credentials "
+    "documented in @ref guac") Credentials {
  public:
   virtual ~Credentials() = default;
 

--- a/google/cloud/storage/oauth2/google_application_default_credentials_file.h
+++ b/google/cloud/storage/oauth2/google_application_default_credentials_file.h
@@ -32,6 +32,7 @@ namespace oauth2 {
  *
  * @deprecated Prefer using the unified credentials documented in @ref guac
  */
+GOOGLE_CLOUD_CPP_DEPRECATED("This function will be removed shortly. Prefer using the unified credentials documented in @ref guac")
 char const* GoogleAdcEnvVar();
 
 /**
@@ -43,6 +44,7 @@ char const* GoogleAdcEnvVar();
  *
  * @deprecated Prefer using the unified credentials documented in @ref guac
  */
+GOOGLE_CLOUD_CPP_DEPRECATED("This function will be removed shortly. Prefer using the unified credentials documented in @ref guac")
 std::string GoogleAdcFilePathFromEnvVarOrEmpty();
 
 /**
@@ -54,6 +56,7 @@ std::string GoogleAdcFilePathFromEnvVarOrEmpty();
  *
  * @deprecated Prefer using the unified credentials documented in @ref guac
  */
+GOOGLE_CLOUD_CPP_DEPRECATED("This function will be removed shortly. Prefer using the unified credentials documented in @ref guac")
 std::string GoogleAdcFilePathFromWellKnownPathOrEmpty();
 
 /**
@@ -64,6 +67,7 @@ std::string GoogleAdcFilePathFromWellKnownPathOrEmpty();
  *
  * @deprecated Prefer using the unified credentials documented in @ref guac
  */
+GOOGLE_CLOUD_CPP_DEPRECATED("This function will be removed shortly. Prefer using the unified credentials documented in @ref guac")
 char const* GoogleGcloudAdcFileEnvVar();
 
 /**
@@ -76,6 +80,7 @@ char const* GoogleGcloudAdcFileEnvVar();
  *
  * @deprecated Prefer using the unified credentials documented in @ref guac
  */
+GOOGLE_CLOUD_CPP_DEPRECATED("This function will be removed shortly. Prefer using the unified credentials documented in @ref guac")
 char const* GoogleAdcHomeEnvVar();
 
 }  // namespace oauth2

--- a/google/cloud/storage/oauth2/google_credentials.h
+++ b/google/cloud/storage/oauth2/google_credentials.h
@@ -44,6 +44,7 @@ namespace oauth2 {
  *
  * @deprecated Prefer using the unified credentials documented in @ref guac
  */
+GOOGLE_CLOUD_CPP_DEPRECATED("This function will be removed. Prefer using the unified credentials documented in @ref guac")
 StatusOr<std::shared_ptr<Credentials>> GoogleDefaultCredentials(
     ChannelOptions const& options = {});
 
@@ -59,6 +60,7 @@ StatusOr<std::shared_ptr<Credentials>> GoogleDefaultCredentials(
  *
  * @deprecated Prefer using the unified credentials documented in @ref guac
  */
+GOOGLE_CLOUD_CPP_DEPRECATED("This function will be removed. Prefer using the unified credentials documented in @ref guac")
 std::shared_ptr<Credentials> CreateAnonymousCredentials();
 
 /**
@@ -69,6 +71,7 @@ std::shared_ptr<Credentials> CreateAnonymousCredentials();
  *
  * @deprecated Prefer using the unified credentials documented in @ref guac
  */
+GOOGLE_CLOUD_CPP_DEPRECATED("This function will be removed. Prefer using the unified credentials documented in @ref guac")
 StatusOr<std::shared_ptr<Credentials>>
 CreateAuthorizedUserCredentialsFromJsonFilePath(std::string const& path);
 
@@ -80,6 +83,7 @@ CreateAuthorizedUserCredentialsFromJsonFilePath(std::string const& path);
  *
  * @deprecated Prefer using the unified credentials documented in @ref guac
  */
+GOOGLE_CLOUD_CPP_DEPRECATED("This function will be removed. Prefer using the unified credentials documented in @ref guac")
 StatusOr<std::shared_ptr<Credentials>>
 CreateAuthorizedUserCredentialsFromJsonContents(
     std::string const& contents, ChannelOptions const& options = {});
@@ -105,6 +109,7 @@ CreateAuthorizedUserCredentialsFromJsonContents(
  *
  * @deprecated Prefer using the unified credentials documented in @ref guac
  */
+GOOGLE_CLOUD_CPP_DEPRECATED("This function will be removed. Prefer using the unified credentials documented in @ref guac")
 StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromFilePath(std::string const& path);
 
@@ -132,6 +137,7 @@ CreateServiceAccountCredentialsFromFilePath(std::string const& path);
  *
  * @deprecated Prefer using the unified credentials documented in @ref guac
  */
+GOOGLE_CLOUD_CPP_DEPRECATED("This function will be removed. Prefer using the unified credentials documented in @ref guac")
 StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromFilePath(
     std::string const& path, absl::optional<std::set<std::string>> scopes,
@@ -146,6 +152,7 @@ CreateServiceAccountCredentialsFromFilePath(
  *
  * @deprecated Prefer using the unified credentials documented in @ref guac
  */
+GOOGLE_CLOUD_CPP_DEPRECATED("This function will be removed. Prefer using the unified credentials documented in @ref guac")
 StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromJsonFilePath(std::string const& path);
 
@@ -170,6 +177,7 @@ CreateServiceAccountCredentialsFromJsonFilePath(std::string const& path);
  *
  * @deprecated Prefer using the unified credentials documented in @ref guac
  */
+GOOGLE_CLOUD_CPP_DEPRECATED("This function will be removed. Prefer using the unified credentials documented in @ref guac")
 StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromJsonFilePath(
     std::string const& path, absl::optional<std::set<std::string>> scopes,
@@ -184,6 +192,7 @@ CreateServiceAccountCredentialsFromJsonFilePath(
  *
  * @deprecated Prefer using the unified credentials documented in @ref guac
  */
+GOOGLE_CLOUD_CPP_DEPRECATED("This function will be removed. Prefer using the unified credentials documented in @ref guac")
 StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromP12FilePath(std::string const& path);
 
@@ -208,6 +217,7 @@ CreateServiceAccountCredentialsFromP12FilePath(std::string const& path);
  *
  * @deprecated Prefer using the unified credentials documented in @ref guac
  */
+GOOGLE_CLOUD_CPP_DEPRECATED("This function will be removed. Prefer using the unified credentials documented in @ref guac")
 StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromP12FilePath(
     std::string const& path, absl::optional<std::set<std::string>> scopes,
@@ -231,6 +241,7 @@ CreateServiceAccountCredentialsFromP12FilePath(
  *
  * @deprecated Prefer using the unified credentials documented in @ref guac
  */
+GOOGLE_CLOUD_CPP_DEPRECATED("This function will be removed. Prefer using the unified credentials documented in @ref guac")
 StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromDefaultPaths(
     ChannelOptions const& options = {});
@@ -261,6 +272,7 @@ CreateServiceAccountCredentialsFromDefaultPaths(
  *
  * @deprecated Prefer using the unified credentials documented in @ref guac
  */
+GOOGLE_CLOUD_CPP_DEPRECATED("This function will be removed. Prefer using the unified credentials documented in @ref guac")
 StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromDefaultPaths(
     absl::optional<std::set<std::string>> scopes,
@@ -275,6 +287,7 @@ CreateServiceAccountCredentialsFromDefaultPaths(
  *
  * @deprecated Prefer using the unified credentials documented in @ref guac
  */
+GOOGLE_CLOUD_CPP_DEPRECATED("This function will be removed. Prefer using the unified credentials documented in @ref guac")
 StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromJsonContents(
     std::string const& contents, ChannelOptions const& options = {});
@@ -301,6 +314,7 @@ CreateServiceAccountCredentialsFromJsonContents(
  *
  * @deprecated Prefer using the unified credentials documented in @ref guac
  */
+GOOGLE_CLOUD_CPP_DEPRECATED("This function will be removed. Prefer using the unified credentials documented in @ref guac")
 StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromJsonContents(
     std::string const& contents, absl::optional<std::set<std::string>> scopes,
@@ -311,6 +325,7 @@ CreateServiceAccountCredentialsFromJsonContents(
  *
  * @deprecated Prefer using the unified credentials documented in @ref guac
  */
+GOOGLE_CLOUD_CPP_DEPRECATED("This function will be removed. Prefer using the unified credentials documented in @ref guac")
 std::shared_ptr<Credentials> CreateComputeEngineCredentials();
 
 /**
@@ -318,6 +333,7 @@ std::shared_ptr<Credentials> CreateComputeEngineCredentials();
  *
  * @deprecated Prefer using the unified credentials documented in @ref guac
  */
+GOOGLE_CLOUD_CPP_DEPRECATED("This function will be removed. Prefer using the unified credentials documented in @ref guac")
 std::shared_ptr<Credentials> CreateComputeEngineCredentials(
     std::string const& service_account_email);
 

--- a/google/cloud/storage/oauth2/refreshing_credentials_wrapper.h
+++ b/google/cloud/storage/oauth2/refreshing_credentials_wrapper.h
@@ -35,11 +35,15 @@ namespace oauth2 {
  *
  * @deprecated Prefer using the unified credentials documented in @ref guac
  */
-class RefreshingCredentialsWrapper {
+class GOOGLE_CLOUD_CPP_DEPRECATED(
+    "This class will be removed shortly. Prefer using the unified credentials "
+    "documented in @ref guac") RefreshingCredentialsWrapper {
  public:
   RefreshingCredentialsWrapper();
 
-  struct TemporaryToken {
+  struct GOOGLE_CLOUD_CPP_DEPRECATED(
+      "This struct will be removed shortly. Prefer using the unified credentials "
+      "documented in @ref guac") TemporaryToken {
     std::string token;
     std::chrono::system_clock::time_point expiration_time;
   };

--- a/google/cloud/storage/oauth2/service_account_credentials.h
+++ b/google/cloud/storage/oauth2/service_account_credentials.h
@@ -211,7 +211,8 @@ class ServiceAccountCredentials;
 
 /// @copydoc ServiceAccountCredentials
 template <>
-class ServiceAccountCredentials<storage::internal::CurlRequestBuilder,
+class GOOGLE_CLOUD_CPP_DEPRECATED(
+    "This class will be removed shortly") ServiceAccountCredentials<storage::internal::CurlRequestBuilder,
                                 std::chrono::system_clock>
     : public Credentials {
  public:


### PR DESCRIPTION
Marking it deprecated since, the unified credentials documented in @ref guac is recommended now.