### PR TITLE
feat(storage): add diagnostic about deprecated storage gRPC option.

### DIFF
--- a/cmake/GoogleCloudCppFeatures.cmake
+++ b/cmake/GoogleCloudCppFeatures.cmake
@@ -515,7 +515,10 @@ function (google_cloud_cpp_define_dependent_legacy_feature_options)
 
     # Emit a warning if the deprecated option is explicitly set
     if (GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
-        message(WARNING "GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC is deprecated. Please use -DGOOGLE_CLOUD_CPP_ENABLE=storage_grpc instead.")
+        message(
+            WARNING
+                "GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC is deprecated. Please use -DGOOGLE_CLOUD_CPP_ENABLE=storage_grpc instead."
+        )
     endif ()
 
     option(

--- a/cmake/GoogleCloudCppFeatures.cmake
+++ b/cmake/GoogleCloudCppFeatures.cmake
@@ -512,6 +512,12 @@ function (google_cloud_cpp_define_dependent_legacy_feature_options)
         OR (experimental-storage_grpc IN_LIST GOOGLE_CLOUD_CPP_ENABLE))
         set(GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC_DEFAULT ON)
     endif ()
+
+    # Emit a warning if the deprecated option is explicitly set
+    if (GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
+        message(WARNING "GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC is deprecated. Please use -DGOOGLE_CLOUD_CPP_ENABLE=storage_grpc instead.")
+    endif ()
+
     option(
         GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC
         "Enable compilation for the GCS gRPC plugin (EXPERIMENTAL).  Deprecated, prefer GOOGLE_CLOUD_CPP_ENABLE."


### PR DESCRIPTION
With this change, a diagnostic indicating that GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC has been deprecated and that DGOOGLE_CLOUD_CPP_ENABLE=storage_grpc should be used instead, is being emitted when the option GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC is used.

fixes:  #15046

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15144)
<!-- Reviewable:end -->
