### PR TITLE
fix: Bypass proxy for GCE metadata server requests

### DIFF
--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -370,16 +370,8 @@ Status CurlImpl::MakeRequest(HttpMethod method, RestContext& context,
     if (!status.ok()) return OnTransferError(context, std::move(status));
   }
 
-  if (absl::StartsWithIgnoreCase(this->url_,
-                                 "http://metadata.google.internal") ||
-      absl::StartsWithIgnoreCase(this->url_,
-                                 "https://metadata.google.internal")) {
-    status = handle_.SetOption(CURLOPT_NOPROXY, "metadata.google.internal");
-    if (!status.ok()) return OnTransferError(context, std::move(status));
-    GCP_LOG(INFO) << "Request to metadata server (" << this->url_
-                  << ") detected. Explicitly setting NOPROXY for "
-                     "'metadata.google.internal'.";
-  }
+  status = handle_.SetOption(CURLOPT_NOPROXY, "metadata.google.internal");
+  if (!status.ok()) return OnTransferError(context, std::move(status));
 
   if (interface_) {
     status = handle_.SetOption(CURLOPT_INTERFACE, interface_->c_str());

--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -369,6 +369,18 @@ Status CurlImpl::MakeRequest(HttpMethod method, RestContext& context,
     status = handle_.SetOption(CURLOPT_PROXYPASSWORD, proxy_password_->c_str());
     if (!status.ok()) return OnTransferError(context, std::move(status));
   }
+
+  if (absl::StartsWithIgnoreCase(this->url_,
+                                 "http://metadata.google.internal") ||
+      absl::StartsWithIgnoreCase(this->url_,
+                                 "https://metadata.google.internal")) {
+    status = handle_.SetOption(CURLOPT_NOPROXY, "metadata.google.internal");
+    if (!status.ok()) return OnTransferError(context, std::move(status));
+    GCP_LOG(INFO) << "Request to metadata server (" << this->url_
+                  << ") detected. Explicitly setting NOPROXY for "
+                     "'metadata.google.internal'.";
+  }
+
   if (interface_) {
     status = handle_.SetOption(CURLOPT_INTERFACE, interface_->c_str());
     if (!status.ok()) return OnTransferError(context, std::move(status));

--- a/google/cloud/internal/curl_impl_test.cc
+++ b/google/cloud/internal/curl_impl_test.cc
@@ -14,10 +14,7 @@
 
 #include "google/cloud/internal/curl_impl.h"
 #include "google/cloud/common_options.h"
-#include "google/cloud/log.h"
 #include "google/cloud/rest_options.h"
-#include "google/cloud/testing_util/scoped_log.h"
-#include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <vector>
 

--- a/google/cloud/internal/curl_impl_test.cc
+++ b/google/cloud/internal/curl_impl_test.cc
@@ -424,18 +424,11 @@ TEST_F(CurlImplTest, MakeRequestDoesNotLogNoProxyForNonMetadataUrl) {
 
   RestContext rest_context;
   (void)impl.MakeRequest(CurlImpl::HttpMethod::kGet, rest_context, {});
-
   std::vector<std::string> log_lines = log_capture.ExtractLines();
-
-  bool found_specific_noproxy_log = false;
-  for (auto const& line : log_lines) {
-    if (line.find("Explicitly setting NOPROXY") != std::string::npos &&
-        line.find("metadata.google.internal") != std::string::npos) {
-      found_specific_noproxy_log = true;
-      break;
-    }
-  }
-  EXPECT_FALSE(found_specific_noproxy_log);
+  EXPECT_THAT(
+      log_lines,
+      Not(Contains(HasSubstr(
+          "Explicitly setting NOPROXY for 'metadata.google.internal'"))));
 }
 
 }  // namespace

--- a/google/cloud/internal/curl_impl_test.cc
+++ b/google/cloud/internal/curl_impl_test.cc
@@ -397,40 +397,6 @@ TEST_F(CurlImplTest, MergeAndWriteHeadersDoNotMergeContentLength) {
   EXPECT_THAT(headers_written, ElementsAre(std::string(expected)));
 }
 
-TEST_F(CurlImplTest, MakeRequestSetsNoProxyAndLogsForMetadataUrl) {
-  testing_util::ScopedLog log_capture;
-  CurlImpl impl(std::move(handle_), factory_, Options{});
-  RestRequest request;
-  std::string metadata_url =
-      "http://metadata.google.internal/computeMetadata/v1/token";
-  impl.SetUrl(metadata_url, request, {});
-  RestContext rest_context;
-  Status request_status =
-      impl.MakeRequest(CurlImpl::HttpMethod::kGet, rest_context, {});
-  std::vector<std::string> log_lines = log_capture.ExtractLines();
-  EXPECT_THAT(
-      log_lines,
-      Contains(HasSubstr(
-          "Explicitly setting NOPROXY for 'metadata.google.internal'")));
-  EXPECT_THAT(log_lines, Contains(HasSubstr(metadata_url)));
-}
-
-TEST_F(CurlImplTest, MakeRequestDoesNotLogNoProxyForNonMetadataUrl) {
-  testing_util::ScopedLog log_capture;
-  CurlImpl impl(std::move(handle_), factory_, Options{});
-  RestRequest request;
-  std::string non_metadata_url = "https://example.com/api/v1/data";
-  impl.SetUrl(non_metadata_url, request, {});
-
-  RestContext rest_context;
-  (void)impl.MakeRequest(CurlImpl::HttpMethod::kGet, rest_context, {});
-  std::vector<std::string> log_lines = log_capture.ExtractLines();
-  EXPECT_THAT(
-      log_lines,
-      Not(Contains(HasSubstr(
-          "Explicitly setting NOPROXY for 'metadata.google.internal'"))));
-}
-
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace rest_internal

--- a/google/cloud/internal/curl_impl_test.cc
+++ b/google/cloud/internal/curl_impl_test.cc
@@ -27,10 +27,8 @@ namespace rest_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-using ::testing::Contains;
 using ::testing::ElementsAre;
 using ::testing::Eq;
-using ::testing::HasSubstr;
 
 TEST(SpillBuffer, InitialState) {
   SpillBuffer sb;


### PR DESCRIPTION
This resolves an issue where requests to the GCE metadata server (metadata.google.internal) could fail on GCE VMs if an HTTP/HTTPS proxy was configured

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15145)
<!-- Reviewable:end -->
