### PR TITLE
Remove grpc shims

### DIFF
--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
@@ -270,16 +270,6 @@ create_bazel_config(google_cloud_cpp_storage_grpc)
 
 add_library(google-cloud-cpp::storage_grpc ALIAS google_cloud_cpp_storage_grpc)
 
-# TODO(#13857) - remove the backwards compatibility shims
-add_library(google_cloud_cpp_experimental_storage_grpc INTERFACE)
-set_target_properties(
-    google_cloud_cpp_experimental_storage_grpc
-    PROPERTIES EXPORT_NAME "google-cloud-cpp::experimental-storage_grpc")
-target_link_libraries(google_cloud_cpp_experimental_storage_grpc
-                      INTERFACE google-cloud-cpp::storage_grpc)
-add_library(google-cloud-cpp::experimental-storage_grpc ALIAS
-            google_cloud_cpp_experimental_storage_grpc)
-
 google_cloud_cpp_add_pkgconfig(
     storage_grpc
     "The GCS (Google Cloud Storage) gRPC plugin"
@@ -316,8 +306,6 @@ install(
 
 install(
     TARGETS google_cloud_cpp_storage_grpc google_cloud_cpp_storage_protos
-            # TODO(#13857) - remove the backwards compatibility shims
-            google_cloud_cpp_experimental_storage_grpc
     EXPORT storage_grpc-targets
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
             COMPONENT google_cloud_cpp_runtime
@@ -360,13 +348,6 @@ if (GOOGLE_CLOUD_CPP_WITH_MOCKS)
     add_library(google-cloud-cpp::storage_grpc_mocks ALIAS
                 google_cloud_cpp_storage_grpc_mocks)
 
-    # TODO(#13857) - remove backwards compatibility shims
-    add_library(google_cloud_cpp_experimental_storage_grpc_mocks INTERFACE)
-    target_link_libraries(google_cloud_cpp_experimental_storage_grpc_mocks
-                          INTERFACE google-cloud-cpp::storage_grpc_mocks)
-    add_library(google-cloud-cpp::experimental-storage_grpc_mocks ALIAS
-                google_cloud_cpp_experimental_storage_grpc_mocks)
-
     install(
         FILES ${google_cloud_cpp_storage_grpc_mocks_hdrs}
         DESTINATION "include/google/cloud/storage/mocks"
@@ -380,8 +361,6 @@ if (GOOGLE_CLOUD_CPP_WITH_MOCKS)
 
     install(
         TARGETS google_cloud_cpp_storage_grpc_mocks
-                # TODO(#13857) - remove backwards compatibility shims
-                google_cloud_cpp_experimental_storage_grpc_mocks
         EXPORT storage_grpc_mocks-targets
         COMPONENT google_cloud_cpp_development)
 

--- a/google/cloud/storage/grpc_plugin.cc
+++ b/google/cloud/storage/grpc_plugin.cc
@@ -14,11 +14,9 @@
 
 #include "google/cloud/storage/grpc_plugin.h"
 #include "google/cloud/storage/internal/connection_factory.h"
-#include "google/cloud/storage/internal/generic_stub_factory.h"
 #include "google/cloud/storage/internal/grpc/default_options.h"
 #include "google/cloud/storage/internal/grpc/enable_metrics.h"
 #include "google/cloud/storage/internal/grpc/stub.h"
-#include "google/cloud/internal/getenv.h"
 #include <memory>
 #include <utility>
 
@@ -26,23 +24,9 @@ namespace google {
 namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace {
 
-// TODO(#13857) - stop using storage_experimental::GrpcPluginOption
-#include "google/cloud/internal/disable_deprecation_warnings.inc"
-bool UseRest(Options const& options) {
-  using ::google::cloud::internal::GetEnv;
-  auto const config =
-      GetEnv("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG")
-          .value_or(options.get<storage_experimental::GrpcPluginOption>());
-  return config == "none";
-}
-#include "google/cloud/internal/diagnostics_pop.inc"
-
-}  // namespace
 
 google::cloud::storage::Client MakeGrpcClient(Options opts) {
-  if (UseRest(opts)) return google::cloud::storage::Client(std::move(opts));
   opts = google::cloud::storage_internal::DefaultOptionsGrpc(std::move(opts));
   storage_internal::EnableGrpcMetrics(opts);
   auto stub = std::make_unique<storage_internal::GrpcStub>(opts);
@@ -52,16 +36,6 @@ google::cloud::storage::Client MakeGrpcClient(Options opts) {
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
-
-namespace storage_experimental {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-
-google::cloud::storage::Client DefaultGrpcClient(Options opts) {
-  return google::cloud::storage::MakeGrpcClient(std::move(opts));
-}
-
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage_experimental
 
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/grpc_plugin.h
+++ b/google/cloud/storage/grpc_plugin.h
@@ -16,8 +16,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_GRPC_PLUGIN_H
 
 #include "google/cloud/storage/client.h"
-#include "google/cloud/storage/version.h"
-#include "google/cloud/status_or.h"
 
 namespace google {
 namespace cloud {
@@ -40,29 +38,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 // TODO(#13857) - remove the backwards compatibility shims.
 namespace storage_experimental {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-
-/**
- * Configure the GCS+gRPC plugin.
- *
- * @deprecated use `google::cloud::storage::Client()` to create JSON-based
- *     clients and `google::cloud::storage::DefaultGrpcClient()` to create
- *     gRPC-based clients. If you need to pick one dynamically a simple
- *     `if()` statement or ternary expression can do the job.
- */
-struct [[deprecated(
-    "use storage::Client() or storage::MakeGrpcClient()")]] GrpcPluginOption {
-  using Type = std::string;
-};
-
-/**
- * Create a `google::cloud::storage::Client` object configured to use gRPC.
- *
- * @deprecated Please use `google::cloud::storage::MakeGrpcClient`.
- */
-[[deprecated(
-    "use ::google::cloud::storage::MakeGrpcClient() instead")]] google::cloud::
-    storage::Client
-    DefaultGrpcClient(Options opts = {});
 
 /**
  * Enable gRPC telemetry for GCS RPCs.

--- a/google/cloud/storage/quickstart/BUILD.bazel
+++ b/google/cloud/storage/quickstart/BUILD.bazel
@@ -32,8 +32,7 @@ cc_binary(
         "quickstart_grpc.cc",
     ],
     deps = [
-        # TODO(#13857) - remove backwards compatibility shims
-        "@google_cloud_cpp//:experimental-storage_grpc",
+        "@google_cloud_cpp//:storage_grpc",
     ],
 )
 


### PR DESCRIPTION
Since gRPC is now GA, removing the backwards compatibility shims for gRPC.

- `storage_experimental` namespace is still present in grpc_plugin.h as it has the members related gRPC metrics like `EnableGrpcMetricsOption` and `GrpcMetricsPeriodOption`. I'm not sure whether these are completely implemented.
- Simplify MakeGrpcClient(): drop the `UseRest()` branch and ENV-var fallback so it unconditionally returns a gRPC-backed Client. Previously MakeGrpcClient() could return JSON client by comparing the ENV variable. Now it is removed so that we've a clear separation of gRPC and JSON clients.
- Refactored unit tests as per the new behavior.