### PR TITLE
Fix: Bypass proxy for metadata based on libcurl version

### DIFF
--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -370,8 +370,10 @@ Status CurlImpl::MakeRequest(HttpMethod method, RestContext& context,
     if (!status.ok()) return OnTransferError(context, std::move(status));
   }
 
+#if CURL_AT_LEAST_VERSION(7, 19, 4)
   status = handle_.SetOption(CURLOPT_NOPROXY, "metadata.google.internal");
   if (!status.ok()) return OnTransferError(context, std::move(status));
+#endif
 
   if (interface_) {
     status = handle_.SetOption(CURLOPT_INTERFACE, interface_->c_str());


### PR DESCRIPTION
Implemented conditional proxy bypass for `metadata.google.internal` using `libcurl` version check. Only version 7.19.4 or later support `CURLOPT_NOPROXY`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15155)
<!-- Reviewable:end -->
