### PR TITLE
feat(resourcemanager): add Connection factory function for regional endpoints

### DIFF
--- a/ci/generate-markdown/update-library-landing-dox.sh
+++ b/ci/generate-markdown/update-library-landing-dox.sh
@@ -64,8 +64,10 @@ while IFS= read -r -d $'\0' option_defaults_cc; do
   variable=$(grep -om1 "${variable_re}" "${option_defaults_cc}")
   endpoint_re='"[^"]*?\.googleapis\.com"'
   endpoint=$(grep -Pom1 "${endpoint_re}" "${option_defaults_cc}")
-  if grep -q 'location,' "${option_defaults_cc}"; then
-    endpoint="\"<location>-${endpoint:1:-1}\""
+  if ! grep -q 'optional location tag' "${option_defaults_cc}"; then
+    if grep -q 'location,' "${option_defaults_cc}"; then
+      endpoint="\"<location>-${endpoint:1:-1}\""
+    fi
   fi
   make_connection_re='Make.*?Connection()'
   make_connection=$(grep -Pom1 "${make_connection_re}" "${connection_h}")

--- a/generator/generator_config.textproto
+++ b/generator/generator_config.textproto
@@ -3302,6 +3302,7 @@ service {
   forwarding_product_path: "google/cloud/resourcemanager"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_OPTIONALLY_DEPENDENT
 }
 
 service {
@@ -3310,6 +3311,7 @@ service {
   forwarding_product_path: "google/cloud/resourcemanager"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_OPTIONALLY_DEPENDENT
 }
 
 service {
@@ -3318,6 +3320,7 @@ service {
   forwarding_product_path: "google/cloud/resourcemanager"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_OPTIONALLY_DEPENDENT
 }
 
 service {
@@ -3325,6 +3328,7 @@ service {
   product_path: "google/cloud/resourcemanager/v3"
   initial_copyright_year: "2023"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_OPTIONALLY_DEPENDENT
 }
 
 service {
@@ -3332,6 +3336,7 @@ service {
   product_path: "google/cloud/resourcemanager/v3"
   initial_copyright_year: "2023"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_OPTIONALLY_DEPENDENT
 }
 
 service {
@@ -3339,6 +3344,7 @@ service {
   product_path: "google/cloud/resourcemanager/v3"
   initial_copyright_year: "2023"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_OPTIONALLY_DEPENDENT
 }
 
 service {
@@ -3346,6 +3352,7 @@ service {
   product_path: "google/cloud/resourcemanager/v3"
   initial_copyright_year: "2023"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_OPTIONALLY_DEPENDENT
 }
 
 # Retail

--- a/generator/integration_tests/golden/v1/internal/golden_rest_only_option_defaults.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_rest_only_option_defaults.cc
@@ -38,6 +38,7 @@ Options GoldenRestOnlyDefaultOptions(std::string const& location, Options option
   options = internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_GOLDEN_REST_ONLY_ENDPOINT",
       "", "GOOGLE_CLOUD_CPP_GOLDEN_REST_ONLY_AUTHORITY",
+      // optional location tag for generating docs
       absl::StrCat(location, location.empty() ? "" : "-", "goldenrestonly.googleapis.com"));
   options = internal::PopulateGrpcOptions(std::move(options));
   if (!options.has<golden_v1::GoldenRestOnlyRetryPolicyOption>()) {

--- a/generator/internal/option_defaults_generator.cc
+++ b/generator/internal/option_defaults_generator.cc
@@ -141,8 +141,13 @@ auto constexpr kBackoffScaling = 2.0;
           R"""(      absl::StrCat(location, "-", "$service_endpoint$"));)""");
       break;
     case ServiceConfiguration::LOCATION_DEPENDENT_COMPAT:
-    case ServiceConfiguration::LOCATION_OPTIONALLY_DEPENDENT:
       CcPrint(R"""(      absl::StrCat(location, )"""
+              R"""(location.empty() ? "" : "-", "$service_endpoint$"));)""");
+      break;
+    case ServiceConfiguration::LOCATION_OPTIONALLY_DEPENDENT:
+      CcPrint(R"""(      // optional location tag for generating docs
+)"""
+              R"""(      absl::StrCat(location, )"""
               R"""(location.empty() ? "" : "-", "$service_endpoint$"));)""");
       break;
     default:

--- a/google/cloud/resourcemanager/v3/folders_connection.cc
+++ b/google/cloud/resourcemanager/v3/folders_connection.cc
@@ -190,12 +190,13 @@ StatusOr<google::longrunning::Operation> FoldersConnection::GetOperation(
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-std::shared_ptr<FoldersConnection> MakeFoldersConnection(Options options) {
+std::shared_ptr<FoldersConnection> MakeFoldersConnection(
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  UnifiedCredentialsOptionList,
                                  FoldersPolicyOptionList>(options, __func__);
-  options =
-      resourcemanager_v3_internal::FoldersDefaultOptions(std::move(options));
+  options = resourcemanager_v3_internal::FoldersDefaultOptions(
+      location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto auth = internal::CreateAuthenticationStrategy(background->cq(), options);
   auto stub = resourcemanager_v3_internal::CreateDefaultFoldersStub(
@@ -203,6 +204,10 @@ std::shared_ptr<FoldersConnection> MakeFoldersConnection(Options options) {
   return resourcemanager_v3_internal::MakeFoldersTracingConnection(
       std::make_shared<resourcemanager_v3_internal::FoldersConnectionImpl>(
           std::move(background), std::move(stub), std::move(options)));
+}
+
+std::shared_ptr<FoldersConnection> MakeFoldersConnection(Options options) {
+  return MakeFoldersConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/resourcemanager/v3/folders_connection.h
+++ b/google/cloud/resourcemanager/v3/folders_connection.h
@@ -33,6 +33,7 @@
 #include <google/cloud/resourcemanager/v3/folders.pb.h>
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -278,8 +279,18 @@ class FoldersConnection {
  * @note Unexpected options will be ignored. To log unexpected options instead,
  *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `FoldersConnection` created by
  * this function.
+ */
+std::shared_ptr<FoldersConnection> MakeFoldersConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A factory function to construct an object of type `FoldersConnection`.
+ *
+ * This overload of `MakeFoldersConnection` does not require a location
+ * argument, creating a connection to the global service endpoint.
  */
 std::shared_ptr<FoldersConnection> MakeFoldersConnection(Options options = {});
 

--- a/google/cloud/resourcemanager/v3/internal/folders_option_defaults.cc
+++ b/google/cloud/resourcemanager/v3/internal/folders_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/resourcemanager/v3/internal/folders_option_defaults.h"
 #include "google/cloud/resourcemanager/v3/folders_connection.h"
 #include "google/cloud/resourcemanager/v3/folders_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -33,11 +34,13 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options FoldersDefaultOptions(Options options) {
+Options FoldersDefaultOptions(std::string const& location, Options options) {
   options = internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_FOLDERS_ENDPOINT", "",
       "GOOGLE_CLOUD_CPP_FOLDERS_AUTHORITY",
-      "cloudresourcemanager.googleapis.com");
+      // optional location tag for generating docs
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "cloudresourcemanager.googleapis.com"));
   options = internal::PopulateGrpcOptions(std::move(options));
   if (!options.has<resourcemanager_v3::FoldersRetryPolicyOption>()) {
     options.set<resourcemanager_v3::FoldersRetryPolicyOption>(

--- a/google/cloud/resourcemanager/v3/internal/folders_option_defaults.h
+++ b/google/cloud/resourcemanager/v3/internal/folders_option_defaults.h
@@ -21,13 +21,14 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace resourcemanager_v3_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options FoldersDefaultOptions(Options options);
+Options FoldersDefaultOptions(std::string const& location, Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcemanager_v3_internal

--- a/google/cloud/resourcemanager/v3/internal/organizations_option_defaults.cc
+++ b/google/cloud/resourcemanager/v3/internal/organizations_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/resourcemanager/v3/internal/organizations_option_defaults.h"
 #include "google/cloud/resourcemanager/v3/organizations_connection.h"
 #include "google/cloud/resourcemanager/v3/organizations_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -33,11 +34,14 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options OrganizationsDefaultOptions(Options options) {
+Options OrganizationsDefaultOptions(std::string const& location,
+                                    Options options) {
   options = internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_ORGANIZATIONS_ENDPOINT", "",
       "GOOGLE_CLOUD_CPP_ORGANIZATIONS_AUTHORITY",
-      "cloudresourcemanager.googleapis.com");
+      // optional location tag for generating docs
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "cloudresourcemanager.googleapis.com"));
   options = internal::PopulateGrpcOptions(std::move(options));
   if (!options.has<resourcemanager_v3::OrganizationsRetryPolicyOption>()) {
     options.set<resourcemanager_v3::OrganizationsRetryPolicyOption>(

--- a/google/cloud/resourcemanager/v3/internal/organizations_option_defaults.h
+++ b/google/cloud/resourcemanager/v3/internal/organizations_option_defaults.h
@@ -21,13 +21,15 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace resourcemanager_v3_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options OrganizationsDefaultOptions(Options options);
+Options OrganizationsDefaultOptions(std::string const& location,
+                                    Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcemanager_v3_internal

--- a/google/cloud/resourcemanager/v3/internal/projects_option_defaults.cc
+++ b/google/cloud/resourcemanager/v3/internal/projects_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/resourcemanager/v3/internal/projects_option_defaults.h"
 #include "google/cloud/resourcemanager/v3/projects_connection.h"
 #include "google/cloud/resourcemanager/v3/projects_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -33,11 +34,13 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options ProjectsDefaultOptions(Options options) {
+Options ProjectsDefaultOptions(std::string const& location, Options options) {
   options = internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_PROJECTS_ENDPOINT", "",
       "GOOGLE_CLOUD_CPP_PROJECTS_AUTHORITY",
-      "cloudresourcemanager.googleapis.com");
+      // optional location tag for generating docs
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "cloudresourcemanager.googleapis.com"));
   options = internal::PopulateGrpcOptions(std::move(options));
   if (!options.has<resourcemanager_v3::ProjectsRetryPolicyOption>()) {
     options.set<resourcemanager_v3::ProjectsRetryPolicyOption>(

--- a/google/cloud/resourcemanager/v3/internal/projects_option_defaults.h
+++ b/google/cloud/resourcemanager/v3/internal/projects_option_defaults.h
@@ -21,13 +21,14 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace resourcemanager_v3_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options ProjectsDefaultOptions(Options options);
+Options ProjectsDefaultOptions(std::string const& location, Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcemanager_v3_internal

--- a/google/cloud/resourcemanager/v3/internal/tag_bindings_option_defaults.cc
+++ b/google/cloud/resourcemanager/v3/internal/tag_bindings_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/resourcemanager/v3/internal/tag_bindings_option_defaults.h"
 #include "google/cloud/resourcemanager/v3/tag_bindings_connection.h"
 #include "google/cloud/resourcemanager/v3/tag_bindings_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -33,11 +34,14 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options TagBindingsDefaultOptions(Options options) {
+Options TagBindingsDefaultOptions(std::string const& location,
+                                  Options options) {
   options = internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_TAG_BINDINGS_ENDPOINT", "",
       "GOOGLE_CLOUD_CPP_TAG_BINDINGS_AUTHORITY",
-      "cloudresourcemanager.googleapis.com");
+      // optional location tag for generating docs
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "cloudresourcemanager.googleapis.com"));
   options = internal::PopulateGrpcOptions(std::move(options));
   if (!options.has<resourcemanager_v3::TagBindingsRetryPolicyOption>()) {
     options.set<resourcemanager_v3::TagBindingsRetryPolicyOption>(

--- a/google/cloud/resourcemanager/v3/internal/tag_bindings_option_defaults.h
+++ b/google/cloud/resourcemanager/v3/internal/tag_bindings_option_defaults.h
@@ -21,13 +21,14 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace resourcemanager_v3_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options TagBindingsDefaultOptions(Options options);
+Options TagBindingsDefaultOptions(std::string const& location, Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcemanager_v3_internal

--- a/google/cloud/resourcemanager/v3/internal/tag_holds_option_defaults.cc
+++ b/google/cloud/resourcemanager/v3/internal/tag_holds_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/resourcemanager/v3/internal/tag_holds_option_defaults.h"
 #include "google/cloud/resourcemanager/v3/tag_holds_connection.h"
 #include "google/cloud/resourcemanager/v3/tag_holds_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -33,11 +34,13 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options TagHoldsDefaultOptions(Options options) {
+Options TagHoldsDefaultOptions(std::string const& location, Options options) {
   options = internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_TAG_HOLDS_ENDPOINT", "",
       "GOOGLE_CLOUD_CPP_TAG_HOLDS_AUTHORITY",
-      "cloudresourcemanager.googleapis.com");
+      // optional location tag for generating docs
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "cloudresourcemanager.googleapis.com"));
   options = internal::PopulateGrpcOptions(std::move(options));
   if (!options.has<resourcemanager_v3::TagHoldsRetryPolicyOption>()) {
     options.set<resourcemanager_v3::TagHoldsRetryPolicyOption>(

--- a/google/cloud/resourcemanager/v3/internal/tag_holds_option_defaults.h
+++ b/google/cloud/resourcemanager/v3/internal/tag_holds_option_defaults.h
@@ -21,13 +21,14 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace resourcemanager_v3_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options TagHoldsDefaultOptions(Options options);
+Options TagHoldsDefaultOptions(std::string const& location, Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcemanager_v3_internal

--- a/google/cloud/resourcemanager/v3/internal/tag_keys_option_defaults.cc
+++ b/google/cloud/resourcemanager/v3/internal/tag_keys_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/resourcemanager/v3/internal/tag_keys_option_defaults.h"
 #include "google/cloud/resourcemanager/v3/tag_keys_connection.h"
 #include "google/cloud/resourcemanager/v3/tag_keys_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -33,11 +34,13 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options TagKeysDefaultOptions(Options options) {
+Options TagKeysDefaultOptions(std::string const& location, Options options) {
   options = internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_TAG_KEYS_ENDPOINT", "",
       "GOOGLE_CLOUD_CPP_TAG_KEYS_AUTHORITY",
-      "cloudresourcemanager.googleapis.com");
+      // optional location tag for generating docs
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "cloudresourcemanager.googleapis.com"));
   options = internal::PopulateGrpcOptions(std::move(options));
   if (!options.has<resourcemanager_v3::TagKeysRetryPolicyOption>()) {
     options.set<resourcemanager_v3::TagKeysRetryPolicyOption>(

--- a/google/cloud/resourcemanager/v3/internal/tag_keys_option_defaults.h
+++ b/google/cloud/resourcemanager/v3/internal/tag_keys_option_defaults.h
@@ -21,13 +21,14 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace resourcemanager_v3_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options TagKeysDefaultOptions(Options options);
+Options TagKeysDefaultOptions(std::string const& location, Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcemanager_v3_internal

--- a/google/cloud/resourcemanager/v3/internal/tag_values_option_defaults.cc
+++ b/google/cloud/resourcemanager/v3/internal/tag_values_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/resourcemanager/v3/internal/tag_values_option_defaults.h"
 #include "google/cloud/resourcemanager/v3/tag_values_connection.h"
 #include "google/cloud/resourcemanager/v3/tag_values_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -33,11 +34,13 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options TagValuesDefaultOptions(Options options) {
+Options TagValuesDefaultOptions(std::string const& location, Options options) {
   options = internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_TAG_VALUES_ENDPOINT", "",
       "GOOGLE_CLOUD_CPP_TAG_VALUES_AUTHORITY",
-      "cloudresourcemanager.googleapis.com");
+      // optional location tag for generating docs
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "cloudresourcemanager.googleapis.com"));
   options = internal::PopulateGrpcOptions(std::move(options));
   if (!options.has<resourcemanager_v3::TagValuesRetryPolicyOption>()) {
     options.set<resourcemanager_v3::TagValuesRetryPolicyOption>(

--- a/google/cloud/resourcemanager/v3/internal/tag_values_option_defaults.h
+++ b/google/cloud/resourcemanager/v3/internal/tag_values_option_defaults.h
@@ -21,13 +21,14 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace resourcemanager_v3_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options TagValuesDefaultOptions(Options options);
+Options TagValuesDefaultOptions(std::string const& location, Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace resourcemanager_v3_internal

--- a/google/cloud/resourcemanager/v3/organizations_connection.cc
+++ b/google/cloud/resourcemanager/v3/organizations_connection.cc
@@ -74,13 +74,13 @@ StatusOr<google::longrunning::Operation> OrganizationsConnection::GetOperation(
 }
 
 std::shared_ptr<OrganizationsConnection> MakeOrganizationsConnection(
-    Options options) {
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  UnifiedCredentialsOptionList,
                                  OrganizationsPolicyOptionList>(options,
                                                                 __func__);
   options = resourcemanager_v3_internal::OrganizationsDefaultOptions(
-      std::move(options));
+      location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto auth = internal::CreateAuthenticationStrategy(background->cq(), options);
   auto stub = resourcemanager_v3_internal::CreateDefaultOrganizationsStub(
@@ -89,6 +89,11 @@ std::shared_ptr<OrganizationsConnection> MakeOrganizationsConnection(
       std::make_shared<
           resourcemanager_v3_internal::OrganizationsConnectionImpl>(
           std::move(background), std::move(stub), std::move(options)));
+}
+
+std::shared_ptr<OrganizationsConnection> MakeOrganizationsConnection(
+    Options options) {
+  return MakeOrganizationsConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/resourcemanager/v3/organizations_connection.h
+++ b/google/cloud/resourcemanager/v3/organizations_connection.h
@@ -29,6 +29,7 @@
 #include "google/cloud/version.h"
 #include <google/cloud/resourcemanager/v3/organizations.pb.h>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -222,8 +223,18 @@ class OrganizationsConnection {
  * @note Unexpected options will be ignored. To log unexpected options instead,
  *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `OrganizationsConnection` created by
  * this function.
+ */
+std::shared_ptr<OrganizationsConnection> MakeOrganizationsConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A factory function to construct an object of type `OrganizationsConnection`.
+ *
+ * This overload of `MakeOrganizationsConnection` does not require a location
+ * argument, creating a connection to the global service endpoint.
  */
 std::shared_ptr<OrganizationsConnection> MakeOrganizationsConnection(
     Options options = {});

--- a/google/cloud/resourcemanager/v3/projects_connection.cc
+++ b/google/cloud/resourcemanager/v3/projects_connection.cc
@@ -190,12 +190,13 @@ StatusOr<google::longrunning::Operation> ProjectsConnection::GetOperation(
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-std::shared_ptr<ProjectsConnection> MakeProjectsConnection(Options options) {
+std::shared_ptr<ProjectsConnection> MakeProjectsConnection(
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  UnifiedCredentialsOptionList,
                                  ProjectsPolicyOptionList>(options, __func__);
-  options =
-      resourcemanager_v3_internal::ProjectsDefaultOptions(std::move(options));
+  options = resourcemanager_v3_internal::ProjectsDefaultOptions(
+      location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto auth = internal::CreateAuthenticationStrategy(background->cq(), options);
   auto stub = resourcemanager_v3_internal::CreateDefaultProjectsStub(
@@ -203,6 +204,10 @@ std::shared_ptr<ProjectsConnection> MakeProjectsConnection(Options options) {
   return resourcemanager_v3_internal::MakeProjectsTracingConnection(
       std::make_shared<resourcemanager_v3_internal::ProjectsConnectionImpl>(
           std::move(background), std::move(stub), std::move(options)));
+}
+
+std::shared_ptr<ProjectsConnection> MakeProjectsConnection(Options options) {
+  return MakeProjectsConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/resourcemanager/v3/projects_connection.h
+++ b/google/cloud/resourcemanager/v3/projects_connection.h
@@ -33,6 +33,7 @@
 #include <google/cloud/resourcemanager/v3/projects.pb.h>
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -281,8 +282,18 @@ class ProjectsConnection {
  * @note Unexpected options will be ignored. To log unexpected options instead,
  *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `ProjectsConnection` created by
  * this function.
+ */
+std::shared_ptr<ProjectsConnection> MakeProjectsConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A factory function to construct an object of type `ProjectsConnection`.
+ *
+ * This overload of `MakeProjectsConnection` does not require a location
+ * argument, creating a connection to the global service endpoint.
  */
 std::shared_ptr<ProjectsConnection> MakeProjectsConnection(
     Options options = {});

--- a/google/cloud/resourcemanager/v3/samples/folders_client_samples.cc
+++ b/google/cloud/resourcemanager/v3/samples/folders_client_samples.cc
@@ -40,6 +40,14 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
     throw google::cloud::testing_util::Usage{"set-client-endpoint"};
   }
   //! [set-client-endpoint]
+  // This service supports specifying a regional or locational endpoint prefix
+  // when creating the FoldersConnection.
+  // For example, to connect to
+  // "europe-central2-cloudresourcemanager.googleapis.com":
+  auto client = google::cloud::resourcemanager_v3::FoldersClient(
+      google::cloud::resourcemanager_v3::MakeFoldersConnection(
+          "europe-central2"));
+
   // This configuration is common with Private Google Access:
   //     https://cloud.google.com/vpc/docs/private-google-access
   auto options = google::cloud::Options{}.set<google::cloud::EndpointOption>(

--- a/google/cloud/resourcemanager/v3/samples/organizations_client_samples.cc
+++ b/google/cloud/resourcemanager/v3/samples/organizations_client_samples.cc
@@ -38,6 +38,14 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
     throw google::cloud::testing_util::Usage{"set-client-endpoint"};
   }
   //! [set-client-endpoint]
+  // This service supports specifying a regional or locational endpoint prefix
+  // when creating the OrganizationsConnection.
+  // For example, to connect to
+  // "europe-central2-cloudresourcemanager.googleapis.com":
+  auto client = google::cloud::resourcemanager_v3::OrganizationsClient(
+      google::cloud::resourcemanager_v3::MakeOrganizationsConnection(
+          "europe-central2"));
+
   // This configuration is common with Private Google Access:
   //     https://cloud.google.com/vpc/docs/private-google-access
   auto options = google::cloud::Options{}.set<google::cloud::EndpointOption>(

--- a/google/cloud/resourcemanager/v3/samples/projects_client_samples.cc
+++ b/google/cloud/resourcemanager/v3/samples/projects_client_samples.cc
@@ -40,6 +40,14 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
     throw google::cloud::testing_util::Usage{"set-client-endpoint"};
   }
   //! [set-client-endpoint]
+  // This service supports specifying a regional or locational endpoint prefix
+  // when creating the ProjectsConnection.
+  // For example, to connect to
+  // "europe-central2-cloudresourcemanager.googleapis.com":
+  auto client = google::cloud::resourcemanager_v3::ProjectsClient(
+      google::cloud::resourcemanager_v3::MakeProjectsConnection(
+          "europe-central2"));
+
   // This configuration is common with Private Google Access:
   //     https://cloud.google.com/vpc/docs/private-google-access
   auto options = google::cloud::Options{}.set<google::cloud::EndpointOption>(

--- a/google/cloud/resourcemanager/v3/samples/tag_bindings_client_samples.cc
+++ b/google/cloud/resourcemanager/v3/samples/tag_bindings_client_samples.cc
@@ -40,6 +40,14 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
     throw google::cloud::testing_util::Usage{"set-client-endpoint"};
   }
   //! [set-client-endpoint]
+  // This service supports specifying a regional or locational endpoint prefix
+  // when creating the TagBindingsConnection.
+  // For example, to connect to
+  // "europe-central2-cloudresourcemanager.googleapis.com":
+  auto client = google::cloud::resourcemanager_v3::TagBindingsClient(
+      google::cloud::resourcemanager_v3::MakeTagBindingsConnection(
+          "europe-central2"));
+
   // This configuration is common with Private Google Access:
   //     https://cloud.google.com/vpc/docs/private-google-access
   auto options = google::cloud::Options{}.set<google::cloud::EndpointOption>(

--- a/google/cloud/resourcemanager/v3/samples/tag_holds_client_samples.cc
+++ b/google/cloud/resourcemanager/v3/samples/tag_holds_client_samples.cc
@@ -40,6 +40,14 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
     throw google::cloud::testing_util::Usage{"set-client-endpoint"};
   }
   //! [set-client-endpoint]
+  // This service supports specifying a regional or locational endpoint prefix
+  // when creating the TagHoldsConnection.
+  // For example, to connect to
+  // "europe-central2-cloudresourcemanager.googleapis.com":
+  auto client = google::cloud::resourcemanager_v3::TagHoldsClient(
+      google::cloud::resourcemanager_v3::MakeTagHoldsConnection(
+          "europe-central2"));
+
   // This configuration is common with Private Google Access:
   //     https://cloud.google.com/vpc/docs/private-google-access
   auto options = google::cloud::Options{}.set<google::cloud::EndpointOption>(

--- a/google/cloud/resourcemanager/v3/samples/tag_keys_client_samples.cc
+++ b/google/cloud/resourcemanager/v3/samples/tag_keys_client_samples.cc
@@ -40,6 +40,14 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
     throw google::cloud::testing_util::Usage{"set-client-endpoint"};
   }
   //! [set-client-endpoint]
+  // This service supports specifying a regional or locational endpoint prefix
+  // when creating the TagKeysConnection.
+  // For example, to connect to
+  // "europe-central2-cloudresourcemanager.googleapis.com":
+  auto client = google::cloud::resourcemanager_v3::TagKeysClient(
+      google::cloud::resourcemanager_v3::MakeTagKeysConnection(
+          "europe-central2"));
+
   // This configuration is common with Private Google Access:
   //     https://cloud.google.com/vpc/docs/private-google-access
   auto options = google::cloud::Options{}.set<google::cloud::EndpointOption>(

--- a/google/cloud/resourcemanager/v3/samples/tag_values_client_samples.cc
+++ b/google/cloud/resourcemanager/v3/samples/tag_values_client_samples.cc
@@ -40,6 +40,14 @@ void SetClientEndpoint(std::vector<std::string> const& argv) {
     throw google::cloud::testing_util::Usage{"set-client-endpoint"};
   }
   //! [set-client-endpoint]
+  // This service supports specifying a regional or locational endpoint prefix
+  // when creating the TagValuesConnection.
+  // For example, to connect to
+  // "europe-central2-cloudresourcemanager.googleapis.com":
+  auto client = google::cloud::resourcemanager_v3::TagValuesClient(
+      google::cloud::resourcemanager_v3::MakeTagValuesConnection(
+          "europe-central2"));
+
   // This configuration is common with Private Google Access:
   //     https://cloud.google.com/vpc/docs/private-google-access
   auto options = google::cloud::Options{}.set<google::cloud::EndpointOption>(

--- a/google/cloud/resourcemanager/v3/tag_bindings_connection.cc
+++ b/google/cloud/resourcemanager/v3/tag_bindings_connection.cc
@@ -106,13 +106,13 @@ StatusOr<google::longrunning::Operation> TagBindingsConnection::GetOperation(
 }
 
 std::shared_ptr<TagBindingsConnection> MakeTagBindingsConnection(
-    Options options) {
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  UnifiedCredentialsOptionList,
                                  TagBindingsPolicyOptionList>(options,
                                                               __func__);
   options = resourcemanager_v3_internal::TagBindingsDefaultOptions(
-      std::move(options));
+      location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto auth = internal::CreateAuthenticationStrategy(background->cq(), options);
   auto stub = resourcemanager_v3_internal::CreateDefaultTagBindingsStub(
@@ -120,6 +120,11 @@ std::shared_ptr<TagBindingsConnection> MakeTagBindingsConnection(
   return resourcemanager_v3_internal::MakeTagBindingsTracingConnection(
       std::make_shared<resourcemanager_v3_internal::TagBindingsConnectionImpl>(
           std::move(background), std::move(stub), std::move(options)));
+}
+
+std::shared_ptr<TagBindingsConnection> MakeTagBindingsConnection(
+    Options options) {
+  return MakeTagBindingsConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/resourcemanager/v3/tag_bindings_connection.h
+++ b/google/cloud/resourcemanager/v3/tag_bindings_connection.h
@@ -33,6 +33,7 @@
 #include <google/cloud/resourcemanager/v3/tag_bindings.pb.h>
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -243,8 +244,18 @@ class TagBindingsConnection {
  * @note Unexpected options will be ignored. To log unexpected options instead,
  *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `TagBindingsConnection` created by
  * this function.
+ */
+std::shared_ptr<TagBindingsConnection> MakeTagBindingsConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A factory function to construct an object of type `TagBindingsConnection`.
+ *
+ * This overload of `MakeTagBindingsConnection` does not require a location
+ * argument, creating a connection to the global service endpoint.
  */
 std::shared_ptr<TagBindingsConnection> MakeTagBindingsConnection(
     Options options = {});

--- a/google/cloud/resourcemanager/v3/tag_holds_connection.cc
+++ b/google/cloud/resourcemanager/v3/tag_holds_connection.cc
@@ -95,12 +95,13 @@ StatusOr<google::longrunning::Operation> TagHoldsConnection::GetOperation(
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-std::shared_ptr<TagHoldsConnection> MakeTagHoldsConnection(Options options) {
+std::shared_ptr<TagHoldsConnection> MakeTagHoldsConnection(
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  UnifiedCredentialsOptionList,
                                  TagHoldsPolicyOptionList>(options, __func__);
-  options =
-      resourcemanager_v3_internal::TagHoldsDefaultOptions(std::move(options));
+  options = resourcemanager_v3_internal::TagHoldsDefaultOptions(
+      location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto auth = internal::CreateAuthenticationStrategy(background->cq(), options);
   auto stub = resourcemanager_v3_internal::CreateDefaultTagHoldsStub(
@@ -108,6 +109,10 @@ std::shared_ptr<TagHoldsConnection> MakeTagHoldsConnection(Options options) {
   return resourcemanager_v3_internal::MakeTagHoldsTracingConnection(
       std::make_shared<resourcemanager_v3_internal::TagHoldsConnectionImpl>(
           std::move(background), std::move(stub), std::move(options)));
+}
+
+std::shared_ptr<TagHoldsConnection> MakeTagHoldsConnection(Options options) {
+  return MakeTagHoldsConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/resourcemanager/v3/tag_holds_connection.h
+++ b/google/cloud/resourcemanager/v3/tag_holds_connection.h
@@ -33,6 +33,7 @@
 #include <google/cloud/resourcemanager/v3/tag_holds.pb.h>
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -232,8 +233,18 @@ class TagHoldsConnection {
  * @note Unexpected options will be ignored. To log unexpected options instead,
  *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `TagHoldsConnection` created by
  * this function.
+ */
+std::shared_ptr<TagHoldsConnection> MakeTagHoldsConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A factory function to construct an object of type `TagHoldsConnection`.
+ *
+ * This overload of `MakeTagHoldsConnection` does not require a location
+ * argument, creating a connection to the global service endpoint.
  */
 std::shared_ptr<TagHoldsConnection> MakeTagHoldsConnection(
     Options options = {});

--- a/google/cloud/resourcemanager/v3/tag_keys_connection.cc
+++ b/google/cloud/resourcemanager/v3/tag_keys_connection.cc
@@ -145,12 +145,13 @@ StatusOr<google::longrunning::Operation> TagKeysConnection::GetOperation(
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-std::shared_ptr<TagKeysConnection> MakeTagKeysConnection(Options options) {
+std::shared_ptr<TagKeysConnection> MakeTagKeysConnection(
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  UnifiedCredentialsOptionList,
                                  TagKeysPolicyOptionList>(options, __func__);
-  options =
-      resourcemanager_v3_internal::TagKeysDefaultOptions(std::move(options));
+  options = resourcemanager_v3_internal::TagKeysDefaultOptions(
+      location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto auth = internal::CreateAuthenticationStrategy(background->cq(), options);
   auto stub = resourcemanager_v3_internal::CreateDefaultTagKeysStub(
@@ -158,6 +159,10 @@ std::shared_ptr<TagKeysConnection> MakeTagKeysConnection(Options options) {
   return resourcemanager_v3_internal::MakeTagKeysTracingConnection(
       std::make_shared<resourcemanager_v3_internal::TagKeysConnectionImpl>(
           std::move(background), std::move(stub), std::move(options)));
+}
+
+std::shared_ptr<TagKeysConnection> MakeTagKeysConnection(Options options) {
+  return MakeTagKeysConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/resourcemanager/v3/tag_keys_connection.h
+++ b/google/cloud/resourcemanager/v3/tag_keys_connection.h
@@ -33,6 +33,7 @@
 #include <google/cloud/resourcemanager/v3/tag_keys.pb.h>
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -258,8 +259,18 @@ class TagKeysConnection {
  * @note Unexpected options will be ignored. To log unexpected options instead,
  *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `TagKeysConnection` created by
  * this function.
+ */
+std::shared_ptr<TagKeysConnection> MakeTagKeysConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A factory function to construct an object of type `TagKeysConnection`.
+ *
+ * This overload of `MakeTagKeysConnection` does not require a location
+ * argument, creating a connection to the global service endpoint.
  */
 std::shared_ptr<TagKeysConnection> MakeTagKeysConnection(Options options = {});
 

--- a/google/cloud/resourcemanager/v3/tag_values_connection.cc
+++ b/google/cloud/resourcemanager/v3/tag_values_connection.cc
@@ -145,12 +145,13 @@ StatusOr<google::longrunning::Operation> TagValuesConnection::GetOperation(
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-std::shared_ptr<TagValuesConnection> MakeTagValuesConnection(Options options) {
+std::shared_ptr<TagValuesConnection> MakeTagValuesConnection(
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  UnifiedCredentialsOptionList,
                                  TagValuesPolicyOptionList>(options, __func__);
-  options =
-      resourcemanager_v3_internal::TagValuesDefaultOptions(std::move(options));
+  options = resourcemanager_v3_internal::TagValuesDefaultOptions(
+      location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto auth = internal::CreateAuthenticationStrategy(background->cq(), options);
   auto stub = resourcemanager_v3_internal::CreateDefaultTagValuesStub(
@@ -158,6 +159,10 @@ std::shared_ptr<TagValuesConnection> MakeTagValuesConnection(Options options) {
   return resourcemanager_v3_internal::MakeTagValuesTracingConnection(
       std::make_shared<resourcemanager_v3_internal::TagValuesConnectionImpl>(
           std::move(background), std::move(stub), std::move(options)));
+}
+
+std::shared_ptr<TagValuesConnection> MakeTagValuesConnection(Options options) {
+  return MakeTagValuesConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/resourcemanager/v3/tag_values_connection.h
+++ b/google/cloud/resourcemanager/v3/tag_values_connection.h
@@ -33,6 +33,7 @@
 #include <google/cloud/resourcemanager/v3/tag_values.pb.h>
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -261,8 +262,18 @@ class TagValuesConnection {
  * @note Unexpected options will be ignored. To log unexpected options instead,
  *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `TagValuesConnection` created by
  * this function.
+ */
+std::shared_ptr<TagValuesConnection> MakeTagValuesConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A factory function to construct an object of type `TagValuesConnection`.
+ *
+ * This overload of `MakeTagValuesConnection` does not require a location
+ * argument, creating a connection to the global service endpoint.
  */
 std::shared_ptr<TagValuesConnection> MakeTagValuesConnection(
     Options options = {});


### PR DESCRIPTION
part of the work for #15161 

I had to also update the generator to spit out a comment tag to direct the markdown generator to recognize the difference between services that require a location and services that optionally allow a location.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15189)
<!-- Reviewable:end -->
