### PR TITLE
feat(storage): Add check for writeHandle before reansforming write_object_spec to append_object_spec

### DIFF
--- a/google/cloud/storage/internal/async/connection_impl.cc
+++ b/google/cloud/storage/internal/async/connection_impl.cc
@@ -360,9 +360,11 @@ AsyncConnectionImpl::AppendableObjectUploadImpl(AppendableUploadParams p) {
             open.reset();
             auto response = f.get();
             if (!response) {
-              EnsureFirstMessageAppendObjectSpec(request);
+              google::rpc::Status grpc_status =
+                  ExtractGrpcStatus(response.status());
+              EnsureFirstMessageAppendObjectSpec(request, grpc_status);
               ApplyWriteRedirectErrors(*request.mutable_append_object_spec(),
-                                       ExtractGrpcStatus(response.status()));
+                                       grpc_status);
             }
             return response;
           });

--- a/google/cloud/storage/internal/async/handle_redirect_error.cc
+++ b/google/cloud/storage/internal/async/handle_redirect_error.cc
@@ -23,10 +23,10 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 void EnsureFirstMessageAppendObjectSpec(
     google::storage::v2::BidiWriteObjectRequest& request,
     google::rpc::Status const& rpc_status) {
-  for (auto const& any : rpc_status.details()) {
+  for (auto const& rpc_status_detail : rpc_status.details()) {
     google::storage::v2::BidiWriteObjectRedirectedError error =
         google::storage::v2::BidiWriteObjectRedirectedError{};
-    if (!any.UnpackTo(&error)) continue;
+    if (!rpc_status_detail.UnpackTo(&error)) continue;
     if (!error.has_write_handle()) continue;
     if (request.has_write_object_spec()) {
       auto spec = request.write_object_spec();

--- a/google/cloud/storage/internal/async/handle_redirect_error.h
+++ b/google/cloud/storage/internal/async/handle_redirect_error.h
@@ -26,7 +26,8 @@ namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 void EnsureFirstMessageAppendObjectSpec(
-    google::storage::v2::BidiWriteObjectRequest& request, google::rpc::Status const& rpc_status);
+    google::storage::v2::BidiWriteObjectRequest& request,
+    google::rpc::Status const& rpc_status);
 
 google::rpc::Status ExtractGrpcStatus(Status const& status);
 

--- a/google/cloud/storage/internal/async/handle_redirect_error.h
+++ b/google/cloud/storage/internal/async/handle_redirect_error.h
@@ -26,7 +26,7 @@ namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 void EnsureFirstMessageAppendObjectSpec(
-    google::storage::v2::BidiWriteObjectRequest& request);
+    google::storage::v2::BidiWriteObjectRequest& request, google::rpc::Status const& rpc_status);
 
 google::rpc::Status ExtractGrpcStatus(Status const& status);
 

--- a/google/cloud/storage/internal/async/handle_redirect_error_test.cc
+++ b/google/cloud/storage/internal/async/handle_redirect_error_test.cc
@@ -75,7 +75,7 @@ TEST(EnsureFirstMessageAppendObjectSpec, Success) {
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
       R"pb(
         write_object_spec {
-          resource { bucket: "projects/_/buckets/b", name: "o"  }
+          resource { bucket: "projects/_/buckets/b", name: "o" }
           if_metageneration_match: 1
           if_metageneration_not_match: 1
         }
@@ -123,8 +123,6 @@ TEST(EnsureFirstMessageAppendObjectSpec, WriteHandleIsNotSet) {
   EXPECT_TRUE(request.has_write_object_spec());
   EXPECT_FALSE(request.has_append_object_spec());
 }
-
-
 
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/async/handle_redirect_error_test.cc
+++ b/google/cloud/storage/internal/async/handle_redirect_error_test.cc
@@ -70,6 +70,62 @@ TEST(ApplyRedirectErrors, NoRedirect) {
   EXPECT_TRUE(spec.routing_token().empty());
 }
 
+TEST(EnsureFirstMessageAppendObjectSpec, Success) {
+  google::storage::v2::BidiWriteObjectRequest request;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      R"pb(
+        write_object_spec {
+          resource { bucket: "projects/_/buckets/b", name: "o"  }
+          if_metageneration_match: 1
+          if_metageneration_not_match: 1
+        }
+      )pb",
+      &request));
+
+  google::rpc::Status rpc_status;
+  google::storage::v2::BidiWriteObjectRedirectedError redirect;
+  redirect.mutable_write_handle();
+  rpc_status.add_details()->PackFrom(redirect);
+
+  EnsureFirstMessageAppendObjectSpec(request, rpc_status);
+
+  EXPECT_FALSE(request.has_write_object_spec());
+  EXPECT_TRUE(request.has_append_object_spec());
+
+  auto const& append_spec = request.append_object_spec();
+  EXPECT_EQ(append_spec.bucket(), "projects/_/buckets/b");
+  EXPECT_EQ(append_spec.object(), "o");
+
+  EXPECT_FALSE(append_spec.has_write_handle());
+  EXPECT_TRUE(append_spec.routing_token().empty());
+  EXPECT_EQ(append_spec.if_metageneration_match(), 1);
+  EXPECT_EQ(append_spec.if_metageneration_not_match(), 1);
+  EXPECT_EQ(append_spec.generation(), 0);
+}
+
+TEST(EnsureFirstMessageAppendObjectSpec, WriteHandleIsNotSet) {
+  google::storage::v2::BidiWriteObjectRequest request;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      R"pb(
+        write_object_spec {
+          resource { bucket: "projects/_/buckets/b", name: "o" }
+        }
+      )pb",
+      &request));
+
+  google::rpc::Status rpc_status;
+  google::storage::v2::BidiWriteObjectRedirectedError redirect;
+  redirect.set_generation(1234);
+  rpc_status.add_details()->PackFrom(redirect);
+
+  EnsureFirstMessageAppendObjectSpec(request, rpc_status);
+
+  EXPECT_TRUE(request.has_write_object_spec());
+  EXPECT_FALSE(request.has_append_object_spec());
+}
+
+
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage_internal

--- a/google/cloud/storage/internal/async/writer_connection_impl.cc
+++ b/google/cloud/storage/internal/async/writer_connection_impl.cc
@@ -234,8 +234,7 @@ future<StatusOr<std::int64_t>> AsyncWriterConnectionImpl::OnQuery(
             "Expected error in Finish() after non-ok Read()"))
         .then([this](auto g) {
           auto result = g.get();
-          google::rpc::Status grpc_status =
-                  ExtractGrpcStatus(result);
+          google::rpc::Status grpc_status = ExtractGrpcStatus(result);
           EnsureFirstMessageAppendObjectSpec(request_, grpc_status);
           ApplyWriteRedirectErrors(*request_.mutable_append_object_spec(),
                                    grpc_status);

--- a/google/cloud/storage/internal/async/writer_connection_impl.cc
+++ b/google/cloud/storage/internal/async/writer_connection_impl.cc
@@ -234,9 +234,11 @@ future<StatusOr<std::int64_t>> AsyncWriterConnectionImpl::OnQuery(
             "Expected error in Finish() after non-ok Read()"))
         .then([this](auto g) {
           auto result = g.get();
-          EnsureFirstMessageAppendObjectSpec(request_);
+          google::rpc::Status grpc_status =
+                  ExtractGrpcStatus(result);
+          EnsureFirstMessageAppendObjectSpec(request_, grpc_status);
           ApplyWriteRedirectErrors(*request_.mutable_append_object_spec(),
-                                   ExtractGrpcStatus(result));
+                                   grpc_status);
           return StatusOr<std::int64_t>(std::move(result));
         });
   }


### PR DESCRIPTION
This change will only allow transformation from write_obejct_spec to append_object_spec when error has write handle, because the failure without write handle needs write_object_spec as input for retry.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15224)
<!-- Reviewable:end -->
