### PR TITLE
feat(storage): Do not move while creating current variable

### DIFF
--- a/google/cloud/storage/internal/async/connection_impl.cc
+++ b/google/cloud/storage/internal/async/connection_impl.cc
@@ -195,8 +195,8 @@ future<
     StatusOr<std::shared_ptr<storage_experimental::ObjectDescriptorConnection>>>
 AsyncConnectionImpl::Open(OpenParams p) {
   auto initial_request = google::storage::v2::BidiReadObjectRequest{};
-  *initial_request.mutable_read_object_spec() = std::move(p.read_spec);
-  auto current = internal::MakeImmutableOptions(std::move(p.options));
+  *initial_request.mutable_read_object_spec() = p.read_spec;
+  auto current = internal::MakeImmutableOptions(p.options);
   // Get the policy factory and immediately create a policy.
   auto resume_policy =
       current->get<storage_experimental::ResumePolicyOption>()();


### PR DESCRIPTION
The p.options is moved two times in this function, which is causing empty option at later stage.