### PR TITLE
Improve compatibility with googleapis from BCR

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -63,6 +63,8 @@ archive_override(
         "https://github.com/googleapis/googleapis/archive/f9d6fe4a6ad9ed89dfc315f284124d2104377940.tar.gz",
     ],
 )
+bazel_dep(name = "googleapis-cc", version = "1.0.0")
+bazel_dep(name = "googleapis-grpc-cc", version = "1.0.0")
 
 switched_rules = use_extension("@com_google_googleapis//:extensions.bzl", "switched_rules")
 switched_rules.use_languages(

--- a/bazel/googleapis.modules.patch
+++ b/bazel/googleapis.modules.patch
@@ -1,67 +1,29 @@
-diff --git a/BUILD.bazel b/BUILD.bazel
-index 026553f5c7..f3c6b6925c 100644
---- a/BUILD.bazel
-+++ b/BUILD.bazel
-@@ -1,11 +1,13 @@
-+package(default_visibility = ["//visibility:public"])
-+
-+licenses(["notice"])  # Apache 2.0
-+
- genrule(
--    name = "build_gen",
--    srcs = glob(
--        ["run_build_gen.sh"],
--        allow_empty = True,
--    ),
--    outs = ["build_gen.sh"],
--    cmd = """
-+  name = "build_gen",
-+  outs = ["build_gen.sh"],
-+  executable = True,
-+  srcs = glob(["run_build_gen.sh"], allow_empty=True),
-+  cmd = """
-     if test -z \"$(SRCS)\"; then
-       cat <<EOD > $@
- #!/bin/sh
-@@ -17,5 +19,17 @@ EOD
-       cp $(SRCS) $@
-     fi
-   """,
--    executable = True,
- )
-+
-+# This build file overlays on top of the BUILD files for the googleapis repo,
-+# and it adds a target that lets us include their header files using
-+# angle-brackets, thus treating their headers as system includes. This allows
-+# us to dial-up the warnings in our own code, without seeing compiler warnings
-+# from their headers, which we do not own.
-+#cc_library(
-+#    name = "googleapis_system_includes",
-+#    includes = [
-+#        ".",
-+#    ],
-+#)
-+
+
 diff --git a/MODULE.bazel b/MODULE.bazel
 new file mode 100644
 index 000000000..169133e43
 --- /dev/null
 +++ b/MODULE.bazel
-@@ -0,0 +1,14 @@
+@@ -0,0 +1,19 @@
 +module(
 +    name = "googleapis",
-+    version = "0.0.0-20240326-1c8d509c5",
++    version = "0.0.0",
 +    repo_name = "com_google_googleapis",
++    bazel_compatibility = [">=7.2.1"],
 +)
 +
-+bazel_dep(name = "grpc", version = "1.63.1.bcr.1", repo_name = "com_github_grpc_grpc")
 +bazel_dep(name = "protobuf", version = "21.7", repo_name = "com_google_protobuf")
++
 +bazel_dep(name = "rules_proto", version = "5.3.0-21.7")
 +
-+switched_rules = use_extension("//:extensions.bzl", "switched_rules")
++bazel_dep(name = "googleapis-rules-registry", version = "1.0.0")
 +
-+switched_rules.use_languages()
-+use_repo(switched_rules, "com_google_googleapis_imports")
++rules_registry = use_extension("@googleapis-rules-registry//private/extensions:rules_registry.bzl", "rules_registry")
++use_repo(
++    rules_registry,
++    "com_google_googleapis_imports",
++    "io_bazel_rules_go",
++)
 diff --git a/WORKSPACE.bzlmod b/WORKSPACE.bzlmod
 new file mode 100644
 index 000000000..8cf3fe396
@@ -70,68 +32,3 @@ index 000000000..8cf3fe396
 @@ -0,0 +1,2 @@
 +workspace(name = "com_google_googleapis")
 +
-diff --git a/extensions.bzl b/extensions.bzl
-new file mode 100644
-index 000000000..9aa161841
---- /dev/null
-+++ b/extensions.bzl
-@@ -0,0 +1,59 @@
-+load(":repository_rules.bzl", "switched_rules_by_language")
-+
-+_use_languages_tag = tag_class(
-+    attrs = {
-+        "cc": attr.bool(default = False),
-+        "csharp": attr.bool(default = False),
-+        "gapic": attr.bool(default = False),
-+        "go": attr.bool(default = False),
-+        "go_test": attr.bool(default = False),
-+        "grpc": attr.bool(default = False),
-+        "java": attr.bool(default = False),
-+        "nodejs": attr.bool(default = False),
-+        "php": attr.bool(default = False),
-+        "python": attr.bool(default = False),
-+        "ruby": attr.bool(default = False),
-+    },
-+)
-+
-+def _switched_rules_impl(ctx):
-+    attrs = {}
-+    for module in ctx.modules:
-+        if not module.is_root:
-+            continue
-+
-+        is_tag_set = False
-+        set_tag_name = ""
-+
-+        for t in module.tags.use_languages:
-+            if is_tag_set:
-+                fail("Multiple use_language tags are set in the root module: '{}' and '{}'. Only one is allowed.".format(set_tag_name, module.name))
-+
-+            is_tag_set = True
-+            set_tag_name = module.name
-+
-+            attrs = {
-+                "cc": t.cc,
-+                "csharp": t.csharp,
-+                "gapic": t.gapic,
-+                "go": t.go,
-+                "go_test": t.go_test,
-+                "grpc": t.grpc,
-+                "java": t.java,
-+                "nodejs": t.nodejs,
-+                "php": t.php,
-+                "python": t.python,
-+                "ruby": t.ruby,
-+            }
-+
-+    switched_rules_by_language(
-+        name = "com_google_googleapis_imports",
-+        **attrs
-+    )
-+
-+switched_rules = module_extension(
-+    implementation = _switched_rules_impl,
-+    tag_classes = {
-+        "use_languages": _use_languages_tag,
-+    },
-+)


### PR DESCRIPTION
Googleapis on BCR changed the way they enable language bindings in bazelbuild/bazel-central-registry#3472. This makes google-cloud-cpp compatible with these changes.

This is an intermediate step towards using googleapis from BCR. See #14803 for additional context.

Requires #15264

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15251)
<!-- Reviewable:end -->
