### PR TITLE
feat(storage): Fix the bucket name not found error

### DIFF
--- a/google/cloud/storage/internal/async/connection_impl.cc
+++ b/google/cloud/storage/internal/async/connection_impl.cc
@@ -306,7 +306,7 @@ AsyncConnectionImpl::ResumeAppendableObjectUpload(AppendableUploadParams p) {
 
 future<StatusOr<std::unique_ptr<storage_experimental::AsyncWriterConnection>>>
 AsyncConnectionImpl::AppendableObjectUploadImpl(AppendableUploadParams p) {
-  auto current = internal::MakeImmutableOptions(p.options);
+  auto current = internal::MakeImmutableOptions(std::move(p.options));
   auto request = p.request;
   std::int64_t persisted_size = 0;
   std::shared_ptr<storage::internal::HashFunction> hash_function =

--- a/google/cloud/storage/internal/async/connection_impl.cc
+++ b/google/cloud/storage/internal/async/connection_impl.cc
@@ -306,8 +306,8 @@ AsyncConnectionImpl::ResumeAppendableObjectUpload(AppendableUploadParams p) {
 
 future<StatusOr<std::unique_ptr<storage_experimental::AsyncWriterConnection>>>
 AsyncConnectionImpl::AppendableObjectUploadImpl(AppendableUploadParams p) {
-  auto current = internal::MakeImmutableOptions(std::move(p.options));
-  auto request = std::move(p.request);
+  auto current = internal::MakeImmutableOptions(p.options);
+  auto request = p.request;
   std::int64_t persisted_size = 0;
   std::shared_ptr<storage::internal::HashFunction> hash_function =
       CreateHashFunction(*current);


### PR DESCRIPTION
We are getting the bucket not found error on finalization of ResumeAppendableObject because we are using the variable after moving them.
<img width="2105" height="635" alt="Screenshot 2025-07-10 at 7 26 41 PM" src="https://github.com/user-attachments/assets/b585b636-5001-44db-ad25-b10688d16e65" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15274)
<!-- Reviewable:end -->
