### PR TITLE
chore(spanner): add integration testing for lock hint in spanner

### DIFF
--- a/google/cloud/spanner/integration_tests/client_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/client_integration_test.cc
@@ -872,7 +872,7 @@ TEST_F(ClientIntegrationTest, ReadWithLockHint) {
   auto commit_result = client_->Commit(
       [&client](google::cloud::spanner::Transaction const& txn)
           -> google::cloud::StatusOr<google::cloud::spanner::Mutations> {
-        // Read SingerId 1 and apply LockHint to the  Read operation
+        // Read row 1 and apply LockHint to the Read operation
         auto rows = client.Read(
             txn, "Singers",
             google::cloud::spanner::KeySet().AddKey(
@@ -889,7 +889,7 @@ TEST_F(ClientIntegrationTest, ReadWithLockHint) {
         EXPECT_EQ(std::get<1>(*row), "test-fname-1");
         EXPECT_EQ(std::get<2>(*row), "test-lname-1");
 
-        // Update row 1 (same row as read).
+        // Update same row as read.
         auto update_result = client.ExecuteDml(
             txn, google::cloud::spanner::SqlStatement(
                      "UPDATE Singers SET LastName = @new_lname "

--- a/google/cloud/spanner/integration_tests/client_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/client_integration_test.cc
@@ -863,6 +863,63 @@ TEST_F(ClientIntegrationTest, ReadWithOrderByPrimaryKey) {
   EXPECT_THAT(actual_singer_ids, ::testing::ElementsAre(1, 2, 3));
 }
 
+TEST_F(ClientIntegrationTest, ReadWithLockHint) {
+  // Insert initial data: SingerId 1 and 2.
+  ASSERT_NO_FATAL_FAILURE(InsertTwoSingers());
+
+  auto& client = *client_;
+
+  auto commit_result = client_->Commit(
+      [&client](google::cloud::spanner::Transaction const& txn)
+          -> google::cloud::StatusOr<google::cloud::spanner::Mutations> {
+        // Read SingerId 1 and apply LockHint to the  Read operation
+        auto rows = client.Read(
+            txn, "Singers",
+            google::cloud::spanner::KeySet().AddKey(
+                google::cloud::spanner::MakeKey(1)),
+            {"SingerId", "FirstName", "LastName"},
+            Options{}.set<LockHintOption>(LockHint::kLockHintExclusive));
+
+        using RowType = std::tuple<std::int64_t, std::string, std::string>;
+        auto row = GetSingularRow(StreamOf<RowType>(rows));
+        if (!row) {
+          return std::move(row).status();
+        }
+        EXPECT_EQ(std::get<0>(*row), 1);
+        EXPECT_EQ(std::get<1>(*row), "test-fname-1");
+        EXPECT_EQ(std::get<2>(*row), "test-lname-1");
+
+        // Update row 1 (same row as read).
+        auto update_result = client.ExecuteDml(
+            txn, google::cloud::spanner::SqlStatement(
+                     "UPDATE Singers SET LastName = @new_lname "
+                     "WHERE SingerId = @id",
+                     {{"new_lname",
+                       google::cloud::spanner::Value("Updated-lname-1")},
+                      {"id", google::cloud::spanner::Value(1)}}));
+        if (!update_result) {
+          return std::move(update_result).status();
+        }
+        return google::cloud::spanner::Mutations{};
+      });
+
+  // Verify that the transaction successfully committed.
+  EXPECT_STATUS_OK(commit_result);
+
+  // After the commit, read the data directly to verify the update.
+  auto rows_after_commit =
+      client_->Read("Singers",
+                    google::cloud::spanner::KeySet().AddKey(
+                        google::cloud::spanner::MakeKey(1)),
+                    {"SingerId", "FirstName", "LastName"});
+  using RowType = std::tuple<std::int64_t, std::string, std::string>;
+  auto updated_row = GetSingularRow(StreamOf<RowType>(rows_after_commit));
+  ASSERT_STATUS_OK(updated_row);
+  EXPECT_EQ(std::get<0>(*updated_row), 1);
+  EXPECT_EQ(std::get<1>(*updated_row), "test-fname-1");
+  EXPECT_EQ(std::get<2>(*updated_row), "Updated-lname-1");
+}
+
 StatusOr<std::vector<std::vector<Value>>> AddSingerDataToTable(Client client) {
   std::vector<std::vector<Value>> expected_rows;
   auto commit = client.Commit(


### PR DESCRIPTION
Adding a happy path IT (single transaction read write) to verify that setting LockHint in the read request is not resulting in unexpected (i.e. "unimplemented") errors from the server. Also verified that the read request does indeed set the lock hint feature via `export GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc,rpc-streams` and `cmake-out/google/cloud/spanner/integration_tests/client_integration_test --gtest_filter=ClientIntegrationTest.ReadLockHint`:

```
2025-07-17T14:49:12.909746269Z [DEBUG] <140185177004288> Commit() >> response=google.spanner.v1.CommitResponse { commit_timestamp { "2025-07-17T14:49:12.817295Z" } } (/usr/local/google/home/mpeddada/IdeaProjects/google-cloud-cpp/google/cloud/internal/log_wrapper.h:76)
2025-07-17T14:49:12.911172338Z [DEBUG] <140185177004288> StreamingRead() << google.spanner.v1.ReadRequest { session: "projects/mpeddada-test/instances/<redacted-instance>/databases/<redacted-database>" transaction { begin { read_write { } } } table: "Singers" columns: "SingerId" columns: "FirstName" columns: "LastName" key_set { keys { values { string_value: "1" } } } request_options { } lock_hint: LOCK_HINT_EXCLUSIVE }
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15275)
<!-- Reviewable:end -->
