### PR TITLE
impl(bigtable): update OperationContext to support metrics

### DIFF
--- a/google/cloud/bigtable/BUILD.bazel
+++ b/google/cloud/bigtable/BUILD.bazel
@@ -113,6 +113,10 @@ cc_library(
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
+    local_defines = select({
+        ":metrics_enabled": ["GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS"],
+        "//conditions:default": [],
+    }),
     deps = [
         ":bigtable_client_testing",
         ":google_cloud_cpp_bigtable",

--- a/google/cloud/bigtable/internal/async_bulk_apply.cc
+++ b/google/cloud/bigtable/internal/async_bulk_apply.cc
@@ -105,7 +105,7 @@ void AsyncBulkApplier::OnFinish(Status const& status) {
     return;
   }
 
-  operation_context_->PostCall(*context_);
+  operation_context_->PostCall(*context_, {});
   context_.reset();
   auto self = this->shared_from_this();
   internal::TracedAsyncBackoff(cq_, *call_context_.options, *delay,

--- a/google/cloud/bigtable/internal/async_row_reader.cc
+++ b/google/cloud/bigtable/internal/async_row_reader.cc
@@ -220,7 +220,7 @@ void AsyncRowReader::OnStreamFinished(Status status) {
     TryGiveRowToUser();
     return;
   }
-  operation_context_->PostCall(*context_);
+  operation_context_->PostCall(*context_, {});
   context_.reset();
   auto self = this->shared_from_this();
   internal::TracedAsyncBackoff(cq_, *call_context_.options, *delay,

--- a/google/cloud/bigtable/internal/async_row_sampler.cc
+++ b/google/cloud/bigtable/internal/async_row_sampler.cc
@@ -96,7 +96,7 @@ void AsyncRowSampler::OnFinish(Status const& status) {
     return;
   }
 
-  operation_context_->PostCall(*context_);
+  operation_context_->PostCall(*context_, {});
   context_.reset();
   samples_.clear();
   auto self = this->shared_from_this();

--- a/google/cloud/bigtable/internal/bulk_mutator.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator.cc
@@ -245,7 +245,7 @@ Status BulkMutator::MakeOneRequest(BigtableStub& stub,
   while (absl::visit(UnpackVariant{state_, limiter, enable_server_retries},
                      stream->Read())) {
   }
-  operation_context_.PostCall(*context);
+  operation_context_.PostCall(*context, {});
   return state_.last_status();
 }
 

--- a/google/cloud/bigtable/internal/data_connection_impl.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl.cc
@@ -114,7 +114,7 @@ Status DataConnectionImpl::Apply(std::string const& table_name,
           google::bigtable::v2::MutateRowRequest const& request) {
         operation_context.PreCall(context);
         auto s = stub_->MutateRow(context, options, request);
-        operation_context.PostCall(context);
+        operation_context.PostCall(context, s.status());
         return s;
       },
       *current, request, __func__);
@@ -156,7 +156,7 @@ future<Status> DataConnectionImpl::AsyncApply(std::string const& table_name,
                return f.then(
                    [operation_context, context = std::move(context)](auto f) {
                      auto s = f.get();
-                     operation_context->PostCall(*context);
+                     operation_context->PostCall(*context, s.status());
                      return s;
                    });
              },
@@ -264,7 +264,7 @@ StatusOr<bigtable::MutationBranch> DataConnectionImpl::CheckAndMutateRow(
           google::bigtable::v2::CheckAndMutateRowRequest const& request) {
         operation_context.PreCall(context);
         auto s = stub_->CheckAndMutateRow(context, options, request);
-        operation_context.PostCall(context);
+        operation_context.PostCall(context, s.status());
         return s;
       },
       *current, request, __func__);
@@ -314,7 +314,7 @@ DataConnectionImpl::AsyncCheckAndMutateRow(
                return f.then(
                    [operation_context, context = std::move(context)](auto f) {
                      auto s = f.get();
-                     operation_context->PostCall(*context);
+                     operation_context->PostCall(*context, s.status());
                      return s;
                    });
              },
@@ -374,7 +374,7 @@ StatusOr<std::vector<bigtable::RowKeySample>> DataConnectionImpl::SampleRows(
                                    Idempotency::kIdempotent,
                                    enable_server_retries(*current));
     if (!delay) return std::move(delay).status();
-    operation_context.PostCall(*context);
+    operation_context.PostCall(*context, status);
     // A new stream invalidates previously returned samples.
     samples.clear();
     std::this_thread::sleep_for(*delay);

--- a/google/cloud/bigtable/internal/default_row_reader.cc
+++ b/google/cloud/bigtable/internal/default_row_reader.cc
@@ -79,7 +79,7 @@ bool DefaultRowReader::NextChunk() {
     if (absl::holds_alternative<Status>(v)) {
       last_status_ = absl::get<Status>(std::move(v));
       response_ = {};
-      operation_context_.PostCall(*context_);
+      operation_context_.PostCall(*context_, {});
       context_.reset();
       return false;
     }

--- a/google/cloud/bigtable/internal/operation_context.cc
+++ b/google/cloud/bigtable/internal/operation_context.cc
@@ -122,9 +122,8 @@ void OperationContext::ElementDelivery(grpc::ClientContext const&) {
 
 OperationContext::OperationContext(
     ResourceLabels const&, DataLabels const&,
-    std::vector<std::shared_ptr<Metric const>> const&,
-    std::shared_ptr<Clock> clock)
-    : clock_(std::move(clock)) {}
+    std::vector<std::shared_ptr<Metric const>> const&, std::shared_ptr<Clock>) {
+}
 
 void OperationContext::PreCall(grpc::ClientContext& client_context) {
   for (auto const& h : cookies_) {

--- a/google/cloud/bigtable/internal/operation_context.cc
+++ b/google/cloud/bigtable/internal/operation_context.cc
@@ -13,24 +13,32 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/internal/operation_context.h"
+#include "google/cloud/bigtable/internal/metrics.h"
 #include "absl/strings/match.h"
+#include "absl/strings/str_split.h"
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+#include <opentelemetry/context/runtime_context.h>
+#endif
 
 namespace google {
 namespace cloud {
 namespace bigtable_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-void OperationContext::PreCall(grpc::ClientContext& context) {
-  for (auto const& h : cookies_) {
-    context.AddMetadata(h.first, h.second);
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+namespace {
+std::vector<std::shared_ptr<Metric>> CloneMetrics(
+    ResourceLabels const& resource_labels, DataLabels const& data_labels,
+    std::vector<std::shared_ptr<Metric const>> const& metrics) {
+  std::vector<std::shared_ptr<Metric>> v;
+  v.reserve(metrics.size());
+  for (auto const& m : metrics) {
+    v.emplace_back(m->clone(resource_labels, data_labels));
   }
-  context.AddMetadata("bigtable-attempt", std::to_string(attempt_number_++));
+  return v;
 }
-
-void OperationContext::PostCall(grpc::ClientContext const& context) {
-  ProcessMetadata(context.GetServerInitialMetadata());
-  ProcessMetadata(context.GetServerTrailingMetadata());
-}
+}  // namespace
+#endif
 
 void OperationContext::ProcessMetadata(
     std::multimap<grpc::string_ref, grpc::string_ref> const& metadata) {
@@ -42,6 +50,103 @@ void OperationContext::ProcessMetadata(
     }
   }
 }
+
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+
+OperationContext::OperationContext(
+    ResourceLabels const& resource_labels, DataLabels const& data_labels,
+    std::vector<std::shared_ptr<Metric const>> const& metrics,
+    std::shared_ptr<Clock> clock)
+    : cloned_metrics_(CloneMetrics(resource_labels, data_labels, metrics)),
+      clock_(std::move(clock)) {}
+
+void OperationContext::PreCall(grpc::ClientContext& client_context) {
+  auto otel_context = opentelemetry::context::RuntimeContext::GetCurrent();
+  auto attempt_start = clock_->Now();
+  if (attempt_number_ == 0) {
+    operation_start_ = attempt_start;
+  }
+  for (auto& m : cloned_metrics_) {
+    m->PreCall(otel_context,
+               PreCallParams{attempt_start, attempt_number_ == 0});
+  }
+
+  for (auto const& h : cookies_) {
+    client_context.AddMetadata(h.first, h.second);
+  }
+  client_context.AddMetadata("bigtable-attempt",
+                             std::to_string(attempt_number_++));
+}
+
+void OperationContext::PostCall(grpc::ClientContext const& client_context,
+                                google::cloud::Status const& status) {
+  ProcessMetadata(client_context.GetServerInitialMetadata());
+  ProcessMetadata(client_context.GetServerTrailingMetadata());
+  auto attempt_end = clock_->Now();
+  auto otel_context = opentelemetry::context::RuntimeContext::GetCurrent();
+  for (auto& m : cloned_metrics_) {
+    m->PostCall(otel_context, client_context,
+                PostCallParams{attempt_end, status});
+  }
+}
+
+void OperationContext::OnDone(Status const& s) {
+  auto operation_end = clock_->Now();
+  auto otel_context = opentelemetry::context::RuntimeContext::GetCurrent();
+  for (auto& m : cloned_metrics_) {
+    m->OnDone(otel_context, OnDoneParams{operation_end, s});
+  }
+}
+
+void OperationContext::ElementRequest(grpc::ClientContext const&) {
+  auto element_request = clock_->Now();
+  auto otel_context = opentelemetry::context::RuntimeContext::GetCurrent();
+  for (auto& m : cloned_metrics_) {
+    m->ElementRequest(otel_context, ElementRequestParams{element_request});
+  }
+}
+
+void OperationContext::ElementDelivery(grpc::ClientContext const&) {
+  auto otel_context = opentelemetry::context::RuntimeContext::GetCurrent();
+  auto first_response = clock_->Now();
+  for (auto& m : cloned_metrics_) {
+    m->ElementDelivery(otel_context,
+                       ElementDeliveryParams{first_response, first_response_});
+  }
+  if (first_response_) {
+    first_response_ = false;
+  }
+}
+
+#else  // GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+
+OperationContext::OperationContext(
+    ResourceLabels const&, DataLabels const&,
+    std::vector<std::shared_ptr<Metric const>> const&,
+    std::shared_ptr<Clock> clock)
+    : clock_(std::move(clock)) {}
+
+void OperationContext::PreCall(grpc::ClientContext& client_context) {
+  for (auto const& h : cookies_) {
+    client_context.AddMetadata(h.first, h.second);
+  }
+  client_context.AddMetadata("bigtable-attempt",
+                             std::to_string(attempt_number_++));
+}
+
+void OperationContext::PostCall(grpc::ClientContext const& client_context,
+                                google::cloud::Status const&) {
+  ProcessMetadata(client_context.GetServerInitialMetadata());
+  ProcessMetadata(client_context.GetServerTrailingMetadata());
+}
+
+void OperationContext::OnDone(Status const&) {}
+
+void OperationContext::ElementRequest(grpc::ClientContext const&) {}
+
+void OperationContext::ElementDelivery(grpc::ClientContext const&) {}
+
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable_internal

--- a/google/cloud/bigtable/internal/operation_context.h
+++ b/google/cloud/bigtable/internal/operation_context.h
@@ -61,9 +61,9 @@ class OperationContext {
  public:
   using Clock = ::google::cloud::internal::SteadyClock;
 
-  // The default constructor is used by the SimpleOperationContextFactory.
+  // The default constructor is used when metric support is unavailable or
+  // disabled.
   OperationContext() = default;
-
   OperationContext(ResourceLabels const& resource_labels,
                    DataLabels const& data_labels,
                    std::vector<std::shared_ptr<Metric const>> const& metrics,
@@ -87,11 +87,13 @@ class OperationContext {
 
   std::unordered_map<std::string, std::string> cookies_;
   int attempt_number_ = 0;
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
   std::vector<std::shared_ptr<Metric>> cloned_metrics_;
   std::shared_ptr<Clock> clock_ = std::make_shared<Clock>();
   Clock::time_point operation_start_;
   Clock::time_point attempt_start_;
   bool first_response_ = true;
+#endif  //  GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/internal/operation_context.h
+++ b/google/cloud/bigtable/internal/operation_context.h
@@ -17,15 +17,22 @@
 
 #include "google/cloud/bigtable/version.h"
 #include "google/cloud/internal/clock.h"
+#include "google/cloud/status.h"
 #include <grpcpp/grpcpp.h>
 #include <map>
+#include <memory>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 namespace google {
 namespace cloud {
 namespace bigtable_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+struct DataLabels;
+struct ResourceLabels;
+class Metric;
 
 /**
  * A Bigtable-specific context that persists across retries in an operation.
@@ -54,18 +61,37 @@ class OperationContext {
  public:
   using Clock = ::google::cloud::internal::SteadyClock;
 
-  // Adds stored bigtable cookies as client metadata.
-  void PreCall(grpc::ClientContext& context);
-  // Stores bigtable cookies returned as server metadata.
-  void PostCall(grpc::ClientContext const& context);
+  // The default constructor is used by the SimpleOperationContextFactory.
+  OperationContext() = default;
+
+  OperationContext(ResourceLabels const& resource_labels,
+                   DataLabels const& data_labels,
+                   std::vector<std::shared_ptr<Metric const>> const& metrics,
+                   std::shared_ptr<Clock> clock);
+
+  // Called before each RPC attempt.
+  void PreCall(grpc::ClientContext& client_context);
+  // Called after receiving RPC attempt response.
+  void PostCall(grpc::ClientContext const& client_context,
+                google::cloud::Status const& status);
+  // A hook that executes at the end of a client operation.
+  void OnDone(Status const& status);
+  // Called during operations that allow the user to iterate over data
+  // synchronously or asynchronously.
+  void ElementRequest(grpc::ClientContext const& client_context);
+  void ElementDelivery(grpc::ClientContext const& client_context);
 
  private:
-  // Adds cookies that start with "x-goog-cbt-cookie" to the cookie jar.
   void ProcessMetadata(
       std::multimap<grpc::string_ref, grpc::string_ref> const& metadata);
 
   std::unordered_map<std::string, std::string> cookies_;
   int attempt_number_ = 0;
+  std::vector<std::shared_ptr<Metric>> cloned_metrics_;
+  std::shared_ptr<Clock> clock_ = std::make_shared<Clock>();
+  Clock::time_point operation_start_;
+  Clock::time_point attempt_start_;
+  bool first_response_ = true;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/internal/operation_context_test.cc
+++ b/google/cloud/bigtable/internal/operation_context_test.cc
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/internal/operation_context.h"
+#include "google/cloud/bigtable/internal/metrics.h"
+#include "google/cloud/testing_util/fake_clock.h"
 #include "google/cloud/testing_util/validate_metadata.h"
 #include <gmock/gmock.h>
 
@@ -22,6 +24,9 @@ namespace bigtable_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+using ::google::cloud::testing_util::FakeSteadyClock;
+
+using ::testing::Eq;
 using ::testing::Pair;
 using ::testing::UnorderedElementsAre;
 
@@ -47,7 +52,7 @@ class OperationContextTest : public ::testing::Test {
       RpcMetadata const& server_metadata = {}) {
     grpc::ClientContext c1;
     metadata_fixture_.SetServerMetadata(c1, server_metadata);
-    operation_context.PostCall(c1);
+    operation_context.PostCall(c1, {});
 
     // Return the headers set by the client.
     grpc::ClientContext c2;
@@ -112,6 +117,168 @@ TEST_F(OperationContextTest, Retries) {
                            Pair("x-goog-cbt-cookie-routing", "request-2"),
                            Pair("bigtable-attempt", "2")));
 }
+
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+
+class MockMetric : public Metric {
+ public:
+  MOCK_METHOD(void, PreCall,
+              (opentelemetry::context::Context const&, PreCallParams const&),
+              (override));
+  MOCK_METHOD(void, PostCall,
+              (opentelemetry::context::Context const&,
+               grpc::ClientContext const&, PostCallParams const&),
+              (override));
+  MOCK_METHOD(void, OnDone,
+              (opentelemetry::context::Context const&, OnDoneParams const&),
+              (override));
+  MOCK_METHOD(void, ElementRequest,
+              (opentelemetry::context::Context const&,
+               ElementRequestParams const&),
+              (override));
+  MOCK_METHOD(void, ElementDelivery,
+              (opentelemetry::context::Context const&,
+               ElementDeliveryParams const&),
+              (override));
+  MOCK_METHOD(std::unique_ptr<Metric>, clone,
+              (ResourceLabels resource_labels, DataLabels data_labels),
+              (const, override));
+};
+
+// This class is a vehicle to get a MockMetric into the OperationContext object.
+class CloningMetric : public Metric {
+ public:
+  explicit CloningMetric(std::unique_ptr<MockMetric> metric)
+      : metric_(std::move(metric)) {}
+  std::unique_ptr<Metric> clone(ResourceLabels, DataLabels) const override {
+    return std::move(metric_);
+  }
+
+ private:
+  mutable std::unique_ptr<MockMetric> metric_;
+};
+
+TEST(OperationContextMetricTest, MetricPreCall) {
+  auto first_attempt = std::chrono::steady_clock::now();
+  auto mock_metric = std::make_unique<MockMetric>();
+
+  EXPECT_CALL(*mock_metric, PreCall)
+      .WillOnce(
+          [&](opentelemetry::context::Context const&, PreCallParams const& p) {
+            EXPECT_THAT(p.attempt_start, Eq(first_attempt));
+            EXPECT_TRUE(p.first_attempt);
+          })
+      .WillOnce(
+          [&](opentelemetry::context::Context const&, PreCallParams const& p) {
+            EXPECT_THAT(p.attempt_start,
+                        Eq(first_attempt + std::chrono::milliseconds(5)));
+            EXPECT_FALSE(p.first_attempt);
+          });
+
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<FakeSteadyClock>();
+  OperationContext operation_context({}, {}, {fake_metric}, clock);
+  grpc::ClientContext client_context;
+
+  clock->SetTime(first_attempt);
+  operation_context.PreCall(client_context);
+  clock->AdvanceTime(std::chrono::milliseconds(5));
+  operation_context.PreCall(client_context);
+}
+
+TEST(OperationContextMetricTest, MetricPostCall) {
+  auto attempt_end = std::chrono::steady_clock::now();
+  Status status{StatusCode::kUnavailable, "unavailable"};
+  auto mock_metric = std::make_unique<MockMetric>();
+
+  EXPECT_CALL(*mock_metric, PostCall)
+      .WillOnce([&](opentelemetry::context::Context const&,
+                    grpc::ClientContext const&, PostCallParams const& p) {
+        EXPECT_THAT(p.attempt_end, Eq(attempt_end));
+        EXPECT_THAT(p.attempt_status, Eq(status));
+      });
+
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<FakeSteadyClock>();
+  OperationContext operation_context({}, {}, {fake_metric}, clock);
+
+  testing_util::ValidateMetadataFixture metadata_fixture;
+  grpc::ClientContext client_context;
+  RpcMetadata server_metadata;
+  metadata_fixture.SetServerMetadata(client_context, server_metadata);
+
+  clock->SetTime(attempt_end);
+  operation_context.PostCall(client_context, status);
+}
+
+TEST(OperationContextMetricTest, MetricOnDone) {
+  auto operation_end = std::chrono::steady_clock::now();
+  Status status{StatusCode::kUnavailable, "unavailable"};
+  auto mock_metric = std::make_unique<MockMetric>();
+
+  EXPECT_CALL(*mock_metric, OnDone)
+      .WillOnce(
+          [&](opentelemetry::context::Context const&, OnDoneParams const& p) {
+            EXPECT_THAT(p.operation_end, Eq(operation_end));
+            EXPECT_THAT(p.operation_status, Eq(status));
+          });
+
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<FakeSteadyClock>();
+  OperationContext operation_context({}, {}, {fake_metric}, clock);
+
+  clock->SetTime(operation_end);
+  operation_context.OnDone(status);
+}
+
+TEST(OperationContextMetricTest, MetricElementRequest) {
+  auto element_request = std::chrono::steady_clock::now();
+  auto mock_metric = std::make_unique<MockMetric>();
+
+  EXPECT_CALL(*mock_metric, ElementRequest)
+      .WillOnce([&](opentelemetry::context::Context const&,
+                    ElementRequestParams const& p) {
+        EXPECT_THAT(p.element_request, Eq(element_request));
+      });
+
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<FakeSteadyClock>();
+  OperationContext operation_context({}, {}, {fake_metric}, clock);
+  grpc::ClientContext client_context;
+
+  clock->SetTime(element_request);
+  operation_context.ElementRequest(client_context);
+}
+
+TEST(OperationContextMetricTest, MetricElementDelivery) {
+  auto element_delivery = std::chrono::steady_clock::now();
+  auto mock_metric = std::make_unique<MockMetric>();
+
+  EXPECT_CALL(*mock_metric, ElementDelivery)
+      .WillOnce([&](opentelemetry::context::Context const&,
+                    ElementDeliveryParams const& p) {
+        EXPECT_THAT(p.element_delivery, Eq(element_delivery));
+        EXPECT_TRUE(p.first_response);
+      })
+      .WillOnce([&](opentelemetry::context::Context const&,
+                    ElementDeliveryParams const& p) {
+        EXPECT_THAT(p.element_delivery,
+                    Eq(element_delivery + std::chrono::milliseconds(5)));
+        EXPECT_FALSE(p.first_response);
+      });
+
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<FakeSteadyClock>();
+  OperationContext operation_context({}, {}, {fake_metric}, clock);
+  grpc::ClientContext client_context;
+
+  clock->SetTime(element_delivery);
+  operation_context.ElementDelivery(client_context);
+  clock->AdvanceTime(std::chrono::milliseconds(5));
+  operation_context.ElementDelivery(client_context);
+}
+
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
 
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
As an additional `Status` parameter was added to `OperationContext::PostCall`, I added a default constructed `Status` at the call sites that were non-trivial. Later tasks will address populating the correct value in those calls and potentially relocating where `OperationContext::PostCall` is invoked in the execution flow.

Whatever value for status used currently is immaterial as the Metric vectors are empty.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15280)
<!-- Reviewable:end -->
