### PR TITLE
feat(storage): Create OTel tracing decorator for `client:: WriteObject()`

### DIFF
--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -97,9 +97,7 @@ ObjectWriteStream Client::WriteObjectImpl(
     error_stream.Close();
     return error_stream;
   }
-  auto const& current = google::cloud::internal::CurrentOptions();
-  auto const buffer_size = request.GetOption<UploadBufferSize>().value_or(
-      current.get<UploadBufferSizeOption>());
+  std::size_t const buffer_size = *connection_->WriteObjectBufferSize(request).value();
   return ObjectWriteStream(std::make_unique<internal::ObjectWriteStreambuf>(
       connection_, request, std::move(response->upload_id),
       response->committed_size, std::move(response->metadata), buffer_size,

--- a/google/cloud/storage/internal/connection_impl.cc
+++ b/google/cloud/storage/internal/connection_impl.cc
@@ -769,9 +769,9 @@ StatusOr<std::unique_ptr<std::string>> StorageConnectionImpl::UploadFileSimple(
     return google::cloud::internal::InvalidArgumentError(std::move(os).str(),
                                                          GCP_ERROR_INFO());
   }
-  auto upload_size = (std::min)(
-      request.GetOption<UploadLimit>().value_or(file_size - upload_offset),
-      file_size - upload_offset);
+  auto upload_size = (std::min)(request.GetOption<UploadLimit>().value_or(
+                                    file_size - upload_offset),
+                                file_size - upload_offset);
 
   std::ifstream is(file_name, std::ios::binary);
   if (!is.is_open()) {
@@ -835,9 +835,9 @@ integrity checks using the DisableMD5Hash() and DisableCrc32cChecksum() options.
                                                            GCP_ERROR_INFO());
     }
 
-    auto upload_size = (std::min)(
-        request.GetOption<UploadLimit>().value_or(file_size - upload_offset),
-        file_size - upload_offset);
+    auto upload_size = (std::min)(request.GetOption<UploadLimit>().value_or(
+                                      file_size - upload_offset),
+                                  file_size - upload_offset);
     request.set_option(UploadContentLength(upload_size));
   }
   auto source = std::make_unique<std::ifstream>(file_name, std::ios::binary);
@@ -852,6 +852,16 @@ integrity checks using the DisableMD5Hash() and DisableCrc32cChecksum() options.
   // need to compute `UploadFromOffset` again.
   source->seekg(upload_offset, std::ios::beg);
   return std::unique_ptr<std::istream>(std::move(source));
+}
+
+StatusOr<std::unique_ptr<std::size_t>>
+StorageConnectionImpl::WriteObjectBufferSize(
+    ResumableUploadRequest const& request) {
+  auto const& current = google::cloud::internal::CurrentOptions();
+  std::size_t const buffer_size =
+      request.GetOption<UploadBufferSize>().value_or(
+          current.get<UploadBufferSizeOption>());
+  return std::make_unique<std::size_t>(buffer_size);
 }
 
 StatusOr<ListBucketAclResponse> StorageConnectionImpl::ListBucketAcl(

--- a/google/cloud/storage/internal/connection_impl.h
+++ b/google/cloud/storage/internal/connection_impl.h
@@ -104,6 +104,8 @@ class StorageConnectionImpl
       InsertObjectMediaRequest& request) override;
   StatusOr<std::unique_ptr<std::istream>> UploadFileResumable(
       std::string const& file_name, ResumableUploadRequest& request) override;
+  StatusOr<std::unique_ptr<std::size_t>> WriteObjectBufferSize(
+      ResumableUploadRequest const& request) override;
 
   StatusOr<ListBucketAclResponse> ListBucketAcl(
       ListBucketAclRequest const& request) override;

--- a/google/cloud/storage/internal/storage_connection.h
+++ b/google/cloud/storage/internal/storage_connection.h
@@ -118,6 +118,10 @@ class StorageConnection {
       std::string const&, ResumableUploadRequest&) {
     return Status(StatusCode::kUnimplemented, "unimplemented");
   }
+  virtual StatusOr<std::unique_ptr<std::size_t>> WriteObjectBufferSize(
+      ResumableUploadRequest const&) {
+    return Status(StatusCode::kUnimplemented, "unimplemented");
+  }
   ///@}
 
   ///@{

--- a/google/cloud/storage/internal/storage_connection_test.cc
+++ b/google/cloud/storage/internal/storage_connection_test.cc
@@ -160,6 +160,13 @@ TEST(StorageConnectionTest, UploadFileResumableUnimplemented) {
   EXPECT_THAT(response, StatusIs(StatusCode::kUnimplemented));
 }
 
+TEST(StorageConnectionTest, WriteObjectBufferSizeUnimplemented) {
+  TestStorageConnection connection;
+  ResumableUploadRequest request;
+  auto response = connection.WriteObjectBufferSize(request);
+  EXPECT_THAT(response, StatusIs(StatusCode::kUnimplemented));
+}
+
 }  // namespace
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/tracing_connection.cc
+++ b/google/cloud/storage/internal/tracing_connection.cc
@@ -255,6 +255,14 @@ StatusOr<std::unique_ptr<std::istream>> TracingConnection::UploadFileResumable(
                            impl_->UploadFileResumable(file_name, request));
 }
 
+StatusOr<std::unique_ptr<std::size_t>> TracingConnection::WriteObjectBufferSize(
+    storage::internal::ResumableUploadRequest const& request) {
+  auto span =
+      internal::MakeSpan("storage::Client::WriteObject/WriteObjectBufferSize");
+  auto scope = opentelemetry::trace::Scope(span);
+  return internal::EndSpan(*span, impl_->WriteObjectBufferSize(request));
+}
+
 StatusOr<storage::internal::ListBucketAclResponse>
 TracingConnection::ListBucketAcl(
     storage::internal::ListBucketAclRequest const& request) {

--- a/google/cloud/storage/internal/tracing_connection.h
+++ b/google/cloud/storage/internal/tracing_connection.h
@@ -104,6 +104,8 @@ class TracingConnection : public storage::internal::StorageConnection {
   StatusOr<std::unique_ptr<std::istream>> UploadFileResumable(
       std::string const& file_name,
       storage::internal::ResumableUploadRequest& request) override;
+  StatusOr<std::unique_ptr<std::size_t>> WriteObjectBufferSize(
+      storage::internal::ResumableUploadRequest const&) override;
 
   StatusOr<storage::internal::ListBucketAclResponse> ListBucketAcl(
       storage::internal::ListBucketAclRequest const& request) override;

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -108,6 +108,8 @@ class MockClient : public google::cloud::storage::internal::StorageConnection {
   MOCK_METHOD(StatusOr<std::unique_ptr<std::istream>>, UploadFileResumable,
               (std::string const&, storage::internal::ResumableUploadRequest&),
               (override));
+  MOCK_METHOD(StatusOr<std::unique_ptr<std::size_t>>, WriteObjectBufferSize,
+              (storage::internal::ResumableUploadRequest const&), (override));
 
   MOCK_METHOD(StatusOr<internal::ListBucketAclResponse>, ListBucketAcl,
               (internal::ListBucketAclRequest const&), (override));


### PR DESCRIPTION
Moving some implementation logic of the method WriteObjectImpl from [client.cc](https://github.com/googleapis/google-cloud-cpp/blob/93275969fd151e939f64bc32562ff9b7a1edcb82/google/cloud/storage/client.cc#L89) file to [connection_impl.cc](https://github.com/googleapis/google-cloud-cpp/blob/93275969fd151e939f64bc32562ff9b7a1edcb82/google/cloud/storage/internal/connection_impl.cc#L856) file, so that complate tracing of client:: WriteObject can be enabled (#11394).

Trace screenshot: https://screenshot.googleplex.com/3FS8Z5pR67ZNx3i