### PR TITLE
impl(bigtable): update BulkMutator to support new OperationContext

### DIFF
--- a/google/cloud/bigtable/internal/bulk_mutator.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator.cc
@@ -190,8 +190,10 @@ std::vector<bigtable::FailedMutation> BulkMutatorState::OnRetryDone() && {
 BulkMutator::BulkMutator(std::string const& app_profile_id,
                          std::string const& table_name,
                          bigtable::IdempotentMutationPolicy& idempotent_policy,
-                         bigtable::BulkMutation mut)
-    : state_(app_profile_id, table_name, idempotent_policy, std::move(mut)) {}
+                         bigtable::BulkMutation mut,
+                         std::shared_ptr<OperationContext> operation_context)
+    : state_(app_profile_id, table_name, idempotent_policy, std::move(mut)),
+      operation_context_(std::move(operation_context)) {}
 
 grpc::Status BulkMutator::MakeOneRequest(bigtable::DataClient& client,
                                          grpc::ClientContext& client_context) {
@@ -215,10 +217,10 @@ Status BulkMutator::MakeOneRequest(BigtableStub& stub,
   // Send the request to the server.
   auto const& mutations = state_.BeforeStart();
 
-  // Configure the context
-  auto context = std::make_shared<grpc::ClientContext>();
-  google::cloud::internal::ConfigureContext(*context, options);
-  operation_context_.PreCall(*context);
+  // Configure the client_context
+  auto client_context = std::make_shared<grpc::ClientContext>();
+  google::cloud::internal::ConfigureContext(*client_context, options);
+  operation_context_->PreCall(*client_context);
   bool enable_server_retries = options.get<EnableServerRetriesOption>();
 
   struct UnpackVariant {
@@ -241,11 +243,11 @@ Status BulkMutator::MakeOneRequest(BigtableStub& stub,
   limiter.Acquire();
 
   // Read the stream of responses.
-  auto stream = stub.MutateRows(context, options, mutations);
+  auto stream = stub.MutateRows(client_context, options, mutations);
   while (absl::visit(UnpackVariant{state_, limiter, enable_server_retries},
                      stream->Read())) {
   }
-  operation_context_.PostCall(*context, {});
+  operation_context_->PostCall(*client_context, state_.last_status());
   return state_.last_status();
 }
 

--- a/google/cloud/bigtable/internal/bulk_mutator.h
+++ b/google/cloud/bigtable/internal/bulk_mutator.h
@@ -117,7 +117,8 @@ class BulkMutator {
  public:
   BulkMutator(std::string const& app_profile_id, std::string const& table_name,
               bigtable::IdempotentMutationPolicy& idempotent_policy,
-              bigtable::BulkMutation mut);
+              bigtable::BulkMutation mut,
+              std::shared_ptr<OperationContext> operation_context);
 
   /// Return true if there are pending mutations in the mutator
   bool HasPendingMutations() const { return state_.HasPendingMutations(); }
@@ -135,7 +136,7 @@ class BulkMutator {
 
  protected:
   BulkMutatorState state_;
-  OperationContext operation_context_;
+  std::shared_ptr<OperationContext> operation_context_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/internal/legacy_bulk_mutator_test.cc
+++ b/google/cloud/bigtable/internal/legacy_bulk_mutator_test.cc
@@ -76,8 +76,9 @@ TEST(MultipleRowsMutatorTest, Simple) {
       .WillOnce(reader.release()->MakeMockReturner());
 
   auto policy = DefaultIdempotentMutationPolicy();
-  bigtable_internal::BulkMutator mutator("", kTableName, *policy,
-                                         std::move(mut));
+  bigtable_internal::BulkMutator mutator(
+      "", kTableName, *policy, std::move(mut),
+      std::make_shared<bigtable_internal::OperationContext>());
 
   EXPECT_TRUE(mutator.HasPendingMutations());
   auto context = TestContext();
@@ -130,8 +131,9 @@ TEST(MultipleRowsMutatorTest, BulkApplyAppProfileId) {
       });
 
   auto policy = DefaultIdempotentMutationPolicy();
-  bigtable_internal::BulkMutator mutator("test-id", kTableName, *policy,
-                                         std::move(mut));
+  bigtable_internal::BulkMutator mutator(
+      "test-id", kTableName, *policy, std::move(mut),
+      std::make_shared<bigtable_internal::OperationContext>());
 
   EXPECT_TRUE(mutator.HasPendingMutations());
   auto context = TestContext("test-id");
@@ -197,8 +199,9 @@ TEST(MultipleRowsMutatorTest, RetryPartialFailure) {
           });
 
   auto policy = DefaultIdempotentMutationPolicy();
-  bigtable_internal::BulkMutator mutator("", kTableName, *policy,
-                                         std::move(mut));
+  bigtable_internal::BulkMutator mutator(
+      "", kTableName, *policy, std::move(mut),
+      std::make_shared<bigtable_internal::OperationContext>());
 
   // This work will be in BulkApply(), but this is the test for BulkMutator in
   // isolation, so call MakeOneRequest() twice, for the r1, and the r2 cases.
@@ -261,8 +264,9 @@ TEST(MultipleRowsMutatorTest, PermanentFailure) {
       .WillOnce(r2.release()->MakeMockReturner());
 
   auto policy = DefaultIdempotentMutationPolicy();
-  bigtable_internal::BulkMutator mutator("", kTableName, *policy,
-                                         std::move(mut));
+  bigtable_internal::BulkMutator mutator(
+      "", kTableName, *policy, std::move(mut),
+      std::make_shared<bigtable_internal::OperationContext>());
 
   // This work will be in BulkApply(), but this is the test for BulkMutator in
   // isolation, so call MakeOneRequest() twice, for the r1, and the r2 cases.
@@ -325,8 +329,9 @@ TEST(MultipleRowsMutatorTest, PartialStream) {
       .WillOnce(r2.release()->MakeMockReturner());
 
   auto policy = DefaultIdempotentMutationPolicy();
-  bigtable_internal::BulkMutator mutator("", kTableName, *policy,
-                                         std::move(mut));
+  bigtable_internal::BulkMutator mutator(
+      "", kTableName, *policy, std::move(mut),
+      std::make_shared<bigtable_internal::OperationContext>());
 
   // This work will be in BulkApply(), but this is the test for BulkMutator in
   // isolation, so call MakeOneRequest() twice: for the r1 and r2 cases.
@@ -404,8 +409,9 @@ TEST(MultipleRowsMutatorTest, RetryOnlyIdempotent) {
       });
 
   auto policy = DefaultIdempotentMutationPolicy();
-  bigtable_internal::BulkMutator mutator("", kTableName, *policy,
-                                         std::move(mut));
+  bigtable_internal::BulkMutator mutator(
+      "", kTableName, *policy, std::move(mut),
+      std::make_shared<bigtable_internal::OperationContext>());
 
   // This work will be in BulkApply(), but this is the test for BulkMutator in
   // isolation, so call MakeOneRequest() twice, for the r1, and the r2 cases.
@@ -466,8 +472,9 @@ TEST(MultipleRowsMutatorTest, UnconfirmedAreFailed) {
       });
 
   auto policy = DefaultIdempotentMutationPolicy();
-  bigtable_internal::BulkMutator mutator("", kTableName, *policy,
-                                         std::move(mut));
+  bigtable_internal::BulkMutator mutator(
+      "", kTableName, *policy, std::move(mut),
+      std::make_shared<bigtable_internal::OperationContext>());
 
   EXPECT_TRUE(mutator.HasPendingMutations());
   auto context = TestContext();

--- a/google/cloud/bigtable/table.cc
+++ b/google/cloud/bigtable/table.cc
@@ -175,8 +175,9 @@ std::vector<FailedMutation> Table::BulkApply(BulkMutation mut, Options opts) {
   auto retry_policy = clone_rpc_retry_policy();
   auto idempotent_policy = clone_idempotent_mutation_policy();
 
-  bigtable_internal::BulkMutator mutator(app_profile_id(), table_name_,
-                                         *idempotent_policy, std::move(mut));
+  bigtable_internal::BulkMutator mutator(
+      app_profile_id(), table_name_, *idempotent_policy, std::move(mut),
+      std::make_shared<bigtable_internal::OperationContext>());
   while (true) {
     grpc::ClientContext client_context;
     backoff_policy->Setup(client_context);


### PR DESCRIPTION
This PR adjusts the location where PostCall is called and adds calls to OnDone (to the caller). The OperationContext is default constructed for the time being.

BulkMutator requires some different handling than the previous Async* types. First, it's a legacy type that can be used with either the deprecated DataClient or the current DataConnection. Metrics are only supported using DataConnection. Second, the retry logic is external to BulkMutator, so the OnDone hook has to be called form the scope that creates and uses BulkMutator (DataConnectionImpl) as opposed to being called from some member method of BulkMutator.