### PR TITLE
Change StreamingReadRpc::Read interface to take ResponseType

### DIFF
--- a/google/cloud/aiplatform/v1/internal/featurestore_online_serving_connection_impl.cc
+++ b/google/cloud/aiplatform/v1/internal/featurestore_online_serving_connection_impl.cc
@@ -108,10 +108,16 @@ FeaturestoreOnlineServingServiceConnectionImpl::StreamingReadFeatureValues(
       retry_policy(*current), backoff_policy(*current), factory,
       FeaturestoreOnlineServingServiceStreamingReadFeatureValuesStreamingUpdater,
       request);
-  return internal::MakeStreamRange(
-      internal::StreamReader<
-          google::cloud::aiplatform::v1::ReadFeatureValuesResponse>(
-          [resumable] { return resumable->Read(); }));
+  return internal::MakeStreamRange<
+      google::cloud::aiplatform::v1::ReadFeatureValuesResponse>(
+      [resumable = std::move(resumable)]()
+          -> absl::variant<Status, google::cloud::aiplatform::v1::
+                                       ReadFeatureValuesResponse> {
+        google::cloud::aiplatform::v1::ReadFeatureValuesResponse response;
+        auto status = resumable->Read(&response);
+        if (status.has_value()) return *status;
+        return response;
+      });
 }
 
 StatusOr<google::cloud::aiplatform::v1::WriteFeatureValuesResponse>

--- a/google/cloud/aiplatform/v1/internal/prediction_connection_impl.cc
+++ b/google/cloud/aiplatform/v1/internal/prediction_connection_impl.cc
@@ -118,9 +118,14 @@ PredictionServiceConnectionImpl::StreamRawPredict(
       google::cloud::aiplatform::v1::StreamRawPredictRequest>(
       retry_policy(*current), backoff_policy(*current), factory,
       PredictionServiceStreamRawPredictStreamingUpdater, request);
-  return internal::MakeStreamRange(
-      internal::StreamReader<google::api::HttpBody>(
-          [resumable] { return resumable->Read(); }));
+  return internal::MakeStreamRange<google::api::HttpBody>(
+      [resumable = std::move(resumable)]()
+          -> absl::variant<Status, google::api::HttpBody> {
+        google::api::HttpBody response;
+        auto status = resumable->Read(&response);
+        if (status.has_value()) return *status;
+        return response;
+      });
 }
 
 StatusOr<google::cloud::aiplatform::v1::DirectPredictResponse>
@@ -196,10 +201,16 @@ PredictionServiceConnectionImpl::ServerStreamingPredict(
       google::cloud::aiplatform::v1::StreamingPredictRequest>(
       retry_policy(*current), backoff_policy(*current), factory,
       PredictionServiceServerStreamingPredictStreamingUpdater, request);
-  return internal::MakeStreamRange(
-      internal::StreamReader<
-          google::cloud::aiplatform::v1::StreamingPredictResponse>(
-          [resumable] { return resumable->Read(); }));
+  return internal::MakeStreamRange<
+      google::cloud::aiplatform::v1::StreamingPredictResponse>(
+      [resumable = std::move(resumable)]()
+          -> absl::variant<
+              Status, google::cloud::aiplatform::v1::StreamingPredictResponse> {
+        google::cloud::aiplatform::v1::StreamingPredictResponse response;
+        auto status = resumable->Read(&response);
+        if (status.has_value()) return *status;
+        return response;
+      });
 }
 
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
@@ -256,10 +267,16 @@ PredictionServiceConnectionImpl::StreamGenerateContent(
       google::cloud::aiplatform::v1::GenerateContentRequest>(
       retry_policy(*current), backoff_policy(*current), factory,
       PredictionServiceStreamGenerateContentStreamingUpdater, request);
-  return internal::MakeStreamRange(
-      internal::StreamReader<
-          google::cloud::aiplatform::v1::GenerateContentResponse>(
-          [resumable] { return resumable->Read(); }));
+  return internal::MakeStreamRange<
+      google::cloud::aiplatform::v1::GenerateContentResponse>(
+      [resumable = std::move(resumable)]()
+          -> absl::variant<
+              Status, google::cloud::aiplatform::v1::GenerateContentResponse> {
+        google::cloud::aiplatform::v1::GenerateContentResponse response;
+        auto status = resumable->Read(&response);
+        if (status.has_value()) return *status;
+        return response;
+      });
 }
 
 StreamRange<google::cloud::location::Location>

--- a/google/cloud/bigtable/internal/bulk_mutator_test.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator_test.cc
@@ -160,8 +160,11 @@ TEST_F(BulkMutatorTest, Simple) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
         EXPECT_CALL(*stream, Read)
-            .WillOnce(Return(MakeResponse(
-                {{0, grpc::StatusCode::OK}, {1, grpc::StatusCode::OK}})))
+            .WillOnce([](google::bigtable::v2::MutateRowsResponse* r) {
+              *r = MakeResponse(
+                  {{0, grpc::StatusCode::OK}, {1, grpc::StatusCode::OK}});
+              return absl::nullopt;
+            })
             .WillOnce(Return(Status()));
         return stream;
       });
@@ -211,8 +214,11 @@ TEST_F(BulkMutatorTest, RetryPartialFailure) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
         EXPECT_CALL(*stream, Read)
-            .WillOnce(Return(MakeResponse({{0, grpc::StatusCode::UNAVAILABLE},
-                                           {1, grpc::StatusCode::OK}})))
+            .WillOnce([](google::bigtable::v2::MutateRowsResponse* r) {
+              *r = MakeResponse({{0, grpc::StatusCode::UNAVAILABLE},
+                                 {1, grpc::StatusCode::OK}});
+              return absl::nullopt;
+            })
             .WillOnce(Return(Status()));
         return stream;
       })
@@ -224,7 +230,10 @@ TEST_F(BulkMutatorTest, RetryPartialFailure) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
         EXPECT_CALL(*stream, Read)
-            .WillOnce(Return(MakeResponse({{0, grpc::StatusCode::OK}})))
+            .WillOnce([](google::bigtable::v2::MutateRowsResponse* r) {
+              *r = MakeResponse({{0, grpc::StatusCode::OK}});
+              return absl::nullopt;
+            })
             .WillOnce(Return(Status()));
         return stream;
       });
@@ -277,9 +286,11 @@ TEST_F(BulkMutatorTest, PermanentFailure) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
         EXPECT_CALL(*stream, Read)
-            .WillOnce(
-                Return(MakeResponse({{0, grpc::StatusCode::UNAVAILABLE},
-                                     {1, grpc::StatusCode::OUT_OF_RANGE}})))
+            .WillOnce([](google::bigtable::v2::MutateRowsResponse* r) {
+              *r = MakeResponse({{0, grpc::StatusCode::UNAVAILABLE},
+                                 {1, grpc::StatusCode::OUT_OF_RANGE}});
+              return absl::nullopt;
+            })
             .WillOnce(Return(Status()));
         return stream;
       })
@@ -291,7 +302,10 @@ TEST_F(BulkMutatorTest, PermanentFailure) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
         EXPECT_CALL(*stream, Read)
-            .WillOnce(Return(MakeResponse({{0, grpc::StatusCode::OK}})))
+            .WillOnce([](google::bigtable::v2::MutateRowsResponse* r) {
+              *r = MakeResponse({{0, grpc::StatusCode::OK}});
+              return absl::nullopt;
+            })
             .WillOnce(Return(Status()));
         return stream;
       });
@@ -347,7 +361,10 @@ TEST_F(BulkMutatorTest, PartialStream) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
         EXPECT_CALL(*stream, Read)
-            .WillOnce(Return(MakeResponse({{0, grpc::StatusCode::OK}})))
+            .WillOnce([](google::bigtable::v2::MutateRowsResponse* r) {
+              *r = MakeResponse({{0, grpc::StatusCode::OK}});
+              return absl::nullopt;
+            })
             .WillOnce(Return(Status()));
         return stream;
       })
@@ -360,7 +377,10 @@ TEST_F(BulkMutatorTest, PartialStream) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
         EXPECT_CALL(*stream, Read)
-            .WillOnce(Return(MakeResponse({{0, grpc::StatusCode::OK}})))
+            .WillOnce([](google::bigtable::v2::MutateRowsResponse* r) {
+              *r = MakeResponse({{0, grpc::StatusCode::OK}});
+              return absl::nullopt;
+            })
             .WillOnce(Return(Status()));
         return stream;
       });
@@ -407,9 +427,11 @@ TEST_F(BulkMutatorTest, RetryOnlyIdempotent) {
         EXPECT_EQ(2, request.entries_size());
         auto stream = std::make_unique<MockMutateRowsStream>();
         EXPECT_CALL(*stream, Read)
-            .WillOnce(
-                Return(MakeResponse({{0, grpc::StatusCode::UNAVAILABLE},
-                                     {1, grpc::StatusCode::UNAVAILABLE}})))
+            .WillOnce([](google::bigtable::v2::MutateRowsResponse* r) {
+              *r = MakeResponse({{0, grpc::StatusCode::UNAVAILABLE},
+                                 {1, grpc::StatusCode::UNAVAILABLE}});
+              return absl::nullopt;
+            })
             .WillOnce(Return(Status()));
         return stream;
       })
@@ -423,7 +445,10 @@ TEST_F(BulkMutatorTest, RetryOnlyIdempotent) {
         expect_r2(request);
         auto stream = std::make_unique<MockMutateRowsStream>();
         EXPECT_CALL(*stream, Read)
-            .WillOnce(Return(MakeResponse({{0, grpc::StatusCode::OK}})))
+            .WillOnce([](google::bigtable::v2::MutateRowsResponse* r) {
+              *r = MakeResponse({{0, grpc::StatusCode::OK}});
+              return absl::nullopt;
+            })
             .WillOnce(Return(Status()));
         return stream;
       });
@@ -477,7 +502,10 @@ TEST_F(BulkMutatorTest, RetryInfoHeeded) {
         EXPECT_THAT(row_keys, ElementsAre("row"));
         auto stream = std::make_unique<MockMutateRowsStream>();
         EXPECT_CALL(*stream, Read)
-            .WillOnce(Return(MakeResponse({{0, grpc::StatusCode::OK}})))
+            .WillOnce([](google::bigtable::v2::MutateRowsResponse* r) {
+              *r = MakeResponse({{0, grpc::StatusCode::OK}});
+              return absl::nullopt;
+            })
             .WillOnce(Return(Status()));
         return stream;
       });
@@ -548,8 +576,11 @@ TEST_F(BulkMutatorTest, UnconfirmedAreFailed) {
         EXPECT_EQ(3, request.entries_size());
         auto stream = std::make_unique<MockMutateRowsStream>();
         EXPECT_CALL(*stream, Read)
-            .WillOnce(Return(MakeResponse(
-                {{0, grpc::StatusCode::OK}, {2, grpc::StatusCode::OK}})))
+            .WillOnce([](google::bigtable::v2::MutateRowsResponse* r) {
+              *r = MakeResponse(
+                  {{0, grpc::StatusCode::OK}, {2, grpc::StatusCode::OK}});
+              return absl::nullopt;
+            })
             .WillOnce(Return(Status(StatusCode::kPermissionDenied, "fail")));
         return stream;
       });
@@ -612,8 +643,10 @@ TEST_F(BulkMutatorTest, MutationStatusReportedOnOkStream) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
         EXPECT_CALL(*stream, Read)
-            .WillOnce(
-                Return(MakeResponse({{0, grpc::StatusCode::UNAVAILABLE}})))
+            .WillOnce([](google::bigtable::v2::MutateRowsResponse* r) {
+              *r = MakeResponse({{0, grpc::StatusCode::UNAVAILABLE}});
+              return absl::nullopt;
+            })
             .WillOnce(Return(Status()));
         return stream;
       });
@@ -650,8 +683,10 @@ TEST_F(BulkMutatorTest, ReportEitherRetryableMutationFailOrStreamFail) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
         EXPECT_CALL(*stream, Read)
-            .WillOnce(
-                Return(MakeResponse({{0, grpc::StatusCode::UNAVAILABLE}})))
+            .WillOnce([](google::bigtable::v2::MutateRowsResponse* r) {
+              *r = MakeResponse({{0, grpc::StatusCode::UNAVAILABLE}});
+              return absl::nullopt;
+            })
             .WillOnce(Return(Status(StatusCode::kDataLoss, "stream fail")));
         return stream;
       });
@@ -690,7 +725,10 @@ TEST_F(BulkMutatorTest, ReportOnlyLatestMutationStatus) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
         EXPECT_CALL(*stream, Read)
-            .WillOnce(Return(MakeResponse({{0, grpc::StatusCode::ABORTED}})))
+            .WillOnce([](google::bigtable::v2::MutateRowsResponse* r) {
+              *r = MakeResponse({{0, grpc::StatusCode::ABORTED}});
+              return absl::nullopt;
+            })
             .WillOnce(Return(Status(StatusCode::kUnavailable, "try again")));
         return stream;
       })
@@ -739,8 +777,14 @@ TEST_F(BulkMutatorTest, Throttling) {
               EXPECT_THAT(request, HasCorrectResourceNames());
               auto stream = std::make_unique<MockMutateRowsStream>();
               EXPECT_CALL(*stream, Read)
-                  .WillOnce(Return(MakeResponse({{0, grpc::StatusCode::OK}})))
-                  .WillOnce(Return(MakeResponse({{1, grpc::StatusCode::OK}})))
+                  .WillOnce([](google::bigtable::v2::MutateRowsResponse* r) {
+                    *r = MakeResponse({{0, grpc::StatusCode::OK}});
+                    return absl::nullopt;
+                  })
+                  .WillOnce([](google::bigtable::v2::MutateRowsResponse* r) {
+                    *r = MakeResponse({{1, grpc::StatusCode::OK}});
+                    return absl::nullopt;
+                  })
                   .WillOnce(Return(Status()));
               return stream;
             });

--- a/google/cloud/bigtable/internal/data_connection_impl.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl.cc
@@ -362,7 +362,6 @@ StatusOr<std::vector<bigtable::RowKeySample>> DataConnectionImpl::SampleRows(
   request.set_app_profile_id(app_profile_id(*current));
   request.set_table_name(table_name);
 
-  Status status;
   std::vector<bigtable::RowKeySample> samples;
   std::unique_ptr<bigtable::DataRetryPolicy> retry;
   std::unique_ptr<BackoffPolicy> backoff;
@@ -373,33 +372,28 @@ StatusOr<std::vector<bigtable::RowKeySample>> DataConnectionImpl::SampleRows(
     operation_context.PreCall(*context);
     auto stream = stub_->SampleRowKeys(context, Options{}, request);
 
-    struct UnpackVariant {
-      Status& status;
-      std::vector<bigtable::RowKeySample>& samples;
-      bool operator()(Status s) {
-        status = std::move(s);
-        return false;
+    absl::optional<Status> status;
+    while (true) {
+      google::bigtable::v2::SampleRowKeysResponse r;
+      status = stream->Read(&r);
+      if (status.has_value()) {
+        break;
       }
-      bool operator()(google::bigtable::v2::SampleRowKeysResponse r) {
-        bigtable::RowKeySample row_sample;
-        row_sample.offset_bytes = r.offset_bytes();
-        row_sample.row_key = std::move(*r.mutable_row_key());
-        samples.emplace_back(std::move(row_sample));
-        return true;
-      }
-    };
-    while (absl::visit(UnpackVariant{status, samples}, stream->Read())) {
+      bigtable::RowKeySample row_sample;
+      row_sample.offset_bytes = r.offset_bytes();
+      row_sample.row_key = std::move(*r.mutable_row_key());
+      samples.emplace_back(std::move(row_sample));
     }
-    if (status.ok()) break;
+    if (status->ok()) break;
     // We wait to allocate the policies until they are needed as a
     // micro-optimization.
     if (!retry) retry = retry_policy(*current);
     if (!backoff) backoff = backoff_policy(*current);
-    auto delay = internal::Backoff(status, "SampleRows", *retry, *backoff,
+    auto delay = internal::Backoff(*status, "SampleRows", *retry, *backoff,
                                    Idempotency::kIdempotent,
                                    enable_server_retries(*current));
     if (!delay) return std::move(delay).status();
-    operation_context.PostCall(*context, status);
+    operation_context.PostCall(*context, *status);
     // A new stream invalidates previously returned samples.
     samples.clear();
     std::this_thread::sleep_for(*delay);

--- a/google/cloud/bigtable/testing/mock_bigtable_stub.h
+++ b/google/cloud/bigtable/testing/mock_bigtable_stub.h
@@ -124,9 +124,8 @@ class MockMutateRowsStream : public google::cloud::internal::StreamingReadRpc<
                                  google::bigtable::v2::MutateRowsResponse> {
  public:
   MOCK_METHOD(void, Cancel, (), (override));
-  using MutateRowsResultType =
-      absl::variant<Status, google::bigtable::v2::MutateRowsResponse>;
-  MOCK_METHOD(MutateRowsResultType, Read, (), (override));
+  MOCK_METHOD(absl::optional<Status>, Read,
+              (google::bigtable::v2::MutateRowsResponse*), (override));
   MOCK_METHOD(google::cloud::RpcMetadata, GetRequestMetadata, (),
               (const, override));
 };
@@ -135,9 +134,8 @@ class MockReadRowsStream : public google::cloud::internal::StreamingReadRpc<
                                google::bigtable::v2::ReadRowsResponse> {
  public:
   MOCK_METHOD(void, Cancel, (), (override));
-  using ReadRowsResultType =
-      absl::variant<Status, google::bigtable::v2::ReadRowsResponse>;
-  MOCK_METHOD(ReadRowsResultType, Read, (), (override));
+  MOCK_METHOD(absl::optional<Status>, Read,
+              (google::bigtable::v2::ReadRowsResponse*), (override));
   MOCK_METHOD(google::cloud::RpcMetadata, GetRequestMetadata, (),
               (const, override));
 };
@@ -147,9 +145,8 @@ class MockSampleRowKeysStream
           google::bigtable::v2::SampleRowKeysResponse> {
  public:
   MOCK_METHOD(void, Cancel, (), (override));
-  using SampleRowKeysResultType =
-      absl::variant<Status, google::bigtable::v2::SampleRowKeysResponse>;
-  MOCK_METHOD(SampleRowKeysResultType, Read, (), (override));
+  MOCK_METHOD(absl::optional<Status>, Read,
+              (google::bigtable::v2::SampleRowKeysResponse*), (override));
   MOCK_METHOD(google::cloud::RpcMetadata, GetRequestMetadata, (),
               (const, override));
 };

--- a/google/cloud/internal/streaming_read_rpc_test.cc
+++ b/google/cloud/internal/streaming_read_rpc_test.cc
@@ -70,13 +70,13 @@ TEST(StreamingReadRpcImpl, SuccessfulStream) {
       std::make_shared<grpc::ClientContext>(), std::move(mock));
   std::vector<std::string> values;
   for (;;) {
-    auto v = impl.Read();
-    if (absl::holds_alternative<FakeResponse>(v)) {
-      values.push_back(absl::get<FakeResponse>(std::move(v)).value);
-      continue;
+    FakeResponse response;
+    auto status = impl.Read(&response);
+    if (status.has_value()) {
+      EXPECT_THAT(*status, IsOk());
+      break;
     }
-    EXPECT_THAT(absl::get<Status>(std::move(v)), IsOk());
-    break;
+    values.push_back(response.value);
   }
   EXPECT_THAT(values, ElementsAre("value-0", "value-1", "value-2"));
 }
@@ -88,7 +88,10 @@ TEST(StreamingReadRpcImpl, EmptyStream) {
 
   StreamingReadRpcImpl<FakeResponse> impl(
       std::make_shared<grpc::ClientContext>(), std::move(mock));
-  EXPECT_THAT(impl.Read(), VariantWith<Status>(IsOk()));
+  FakeResponse response;
+  auto status = impl.Read(&response);
+  ASSERT_TRUE(status.has_value());
+  EXPECT_THAT(*status, IsOk());
 }
 
 TEST(StreamingReadRpcImpl, EmptyWithError) {
@@ -100,8 +103,10 @@ TEST(StreamingReadRpcImpl, EmptyWithError) {
 
   StreamingReadRpcImpl<FakeResponse> impl(
       std::make_shared<grpc::ClientContext>(), std::move(mock));
-  EXPECT_THAT(impl.Read(), VariantWith<Status>(StatusIs(
-                               StatusCode::kPermissionDenied, "uh-oh")));
+  FakeResponse response;
+  auto status = impl.Read(&response);
+  ASSERT_TRUE(status.has_value());
+  EXPECT_THAT(*status, StatusIs(StatusCode::kPermissionDenied, "uh-oh"));
 }
 
 TEST(StreamingReadRpcImpl, ErrorAfterData) {
@@ -120,14 +125,13 @@ TEST(StreamingReadRpcImpl, ErrorAfterData) {
       std::make_shared<grpc::ClientContext>(), std::move(mock));
   std::vector<std::string> values;
   for (;;) {
-    auto v = impl.Read();
-    if (absl::holds_alternative<FakeResponse>(v)) {
-      values.push_back(absl::get<FakeResponse>(std::move(v)).value);
-      continue;
+    FakeResponse response;
+    auto status = impl.Read(&response);
+    if (status.has_value()) {
+      EXPECT_THAT(*status, StatusIs(StatusCode::kPermissionDenied, "uh-oh"));
+      break;
     }
-    EXPECT_THAT(absl::get<Status>(std::move(v)),
-                StatusIs(StatusCode::kPermissionDenied, "uh-oh"));
-    break;
+    values.push_back(response.value);
   }
   EXPECT_THAT(values, ElementsAre("test-value-0"));
 }
@@ -153,8 +157,11 @@ TEST(StreamingReadRpcImpl, HandleUnfinished) {
     StreamingReadRpcImpl<FakeResponse> impl(
         std::make_shared<grpc::ClientContext>(), std::move(mock));
     std::vector<std::string> values;
-    values.push_back(absl::get<FakeResponse>(impl.Read()).value);
-    values.push_back(absl::get<FakeResponse>(impl.Read()).value);
+    FakeResponse response;
+    EXPECT_FALSE(impl.Read(&response).has_value());
+    values.push_back(response.value);
+    EXPECT_FALSE(impl.Read(&response).has_value());
+    values.push_back(response.value);
     EXPECT_THAT(values, ElementsAre("value-0", "value-1"));
   }
   EXPECT_THAT(log.ExtractLines(),
@@ -181,8 +188,11 @@ TEST(StreamingReadRpcImpl, HandleUnfinishedExpected) {
       StreamingReadRpcImpl<FakeResponse> impl(
           std::make_shared<grpc::ClientContext>(), std::move(mock));
       std::vector<std::string> values;
-      values.push_back(absl::get<FakeResponse>(impl.Read()).value);
-      values.push_back(absl::get<FakeResponse>(impl.Read()).value);
+      FakeResponse response;
+      EXPECT_FALSE(impl.Read(&response).has_value());
+      values.push_back(response.value);
+      EXPECT_FALSE(impl.Read(&response).has_value());
+      values.push_back(response.value);
       EXPECT_THAT(values, ElementsAre("value-0", "value-1"));
     }
     EXPECT_THAT(log.ExtractLines(),
@@ -194,8 +204,10 @@ TEST(StreamingReadRpcImpl, ErrorStream) {
   auto under_test = StreamingReadRpcError<FakeResponse>(
       Status(StatusCode::kPermissionDenied, "uh-oh"));
   under_test.Cancel();  // just a smoke test
-  EXPECT_THAT(under_test.Read(), VariantWith<Status>(StatusIs(
-                                     StatusCode::kPermissionDenied, "uh-oh")));
+  FakeResponse response;
+  auto status = under_test.Read(&response);
+  ASSERT_TRUE(status.has_value());
+  EXPECT_THAT(*status, StatusIs(StatusCode::kPermissionDenied, "uh-oh"));
 }
 
 }  // namespace

--- a/google/cloud/internal/streaming_read_rpc_tracing.h
+++ b/google/cloud/internal/streaming_read_rpc_tracing.h
@@ -47,10 +47,10 @@ class StreamingReadRpcTracing : public StreamingReadRpc<ResponseType> {
     impl_->Cancel();
   }
 
-  absl::variant<Status, ResponseType> Read() override {
-    auto result = impl_->Read();
-    if (absl::holds_alternative<Status>(result)) {
-      return End(absl::get<Status>(result));
+  absl::optional<Status> Read(ResponseType* response) override {
+    auto result = impl_->Read(response);
+    if (result.has_value()) {
+      return End(*result);
     }
     span_->AddEvent("message", {{"message.type", "RECEIVED"},
                                 {"message.id", ++read_count_}});

--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -594,17 +594,15 @@ class ReadExperiment : public BasicExperiment<Traits> {
       auto stream = stub->StreamingRead(std::make_shared<grpc::ClientContext>(),
                                         google::cloud::Options{}, request);
       for (;;) {
-        auto read = stream->Read();
-        if (absl::holds_alternative<Status>(read)) {
-          auto status = absl::get<Status>(std::move(read));
+        google::spanner::v1::PartialResultSet result;
+        auto status = stream->Read(&result);
+        if (status.has_value()) {
           auto const usage = timer.Sample();
           samples.push_back(RowCpuSample{channel_count, thread_count, true,
                                          row_count, usage.elapsed_time,
-                                         usage.cpu_time, std::move(status)});
+                                         usage.cpu_time, *std::move(status)});
           break;
         }
-        auto result =
-            absl::get<google::spanner::v1::PartialResultSet>(std::move(read));
         if (result.chunked_value()) {
           // We do not handle chunked values in the benchmark.
           continue;
@@ -745,17 +743,15 @@ class SelectExperiment : public BasicExperiment<Traits> {
           stub->ExecuteStreamingSql(std::make_shared<grpc::ClientContext>(),
                                     google::cloud::Options{}, request);
       for (;;) {
-        auto read = stream->Read();
-        if (absl::holds_alternative<Status>(read)) {
-          auto status = absl::get<Status>(std::move(read));
+        google::spanner::v1::PartialResultSet result;
+        auto status = stream->Read(&result);
+        if (status.has_value()) {
           auto const usage = timer.Sample();
           samples.push_back(RowCpuSample{channel_count, thread_count, true,
                                          row_count, usage.elapsed_time,
-                                         usage.cpu_time, std::move(status)});
+                                         usage.cpu_time, *std::move(status)});
           break;
         }
-        auto result =
-            absl::get<google::spanner::v1::PartialResultSet>(std::move(read));
         if (result.chunked_value()) {
           // We do not handle chunked values in the benchmark.
           continue;

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -76,6 +76,7 @@ using ::testing::_;
 using ::testing::AllOf;
 using ::testing::AtLeast;
 using ::testing::ByMove;
+using ::testing::DoAll;
 using ::testing::ElementsAre;
 using ::testing::Eq;
 using ::testing::Field;
@@ -88,6 +89,7 @@ using ::testing::Pair;
 using ::testing::Property;
 using ::testing::Return;
 using ::testing::Sequence;
+using ::testing::SetArgPointee;
 using ::testing::StartsWith;
 using ::testing::StrictMock;
 using ::testing::UnorderedElementsAre;
@@ -324,7 +326,7 @@ template <typename ResponseType>
 class MockStreamingReadRpc : public internal::StreamingReadRpc<ResponseType> {
  public:
   MOCK_METHOD(void, Cancel, (), (override));
-  MOCK_METHOD((absl::variant<Status, ResponseType>), Read, (), (override));
+  MOCK_METHOD(absl::optional<Status>, Read, (ResponseType*), (override));
   MOCK_METHOD(RpcMetadata, GetRequestMetadata, (), (const, override));
 };
 
@@ -338,7 +340,8 @@ std::unique_ptr<MockStreamingReadRpc<ResponseType>> MakeReader(
   for (auto& response : responses) {
     EXPECT_CALL(*reader, Read)
         .InSequence(s)
-        .WillOnce(Return(std::move(response)));
+        .WillOnce(DoAll(SetArgPointee<0>(std::move(response)),
+                        Return(absl::nullopt)));
   }
   EXPECT_CALL(*reader, Read).InSequence(s).WillOnce(Return(std::move(status)));
   return reader;
@@ -1359,7 +1362,8 @@ TEST(ConnectionImplTest, QueryOptions) {
     )pb";
     PartialResultSet response;
     ASSERT_TRUE(TextFormat::ParseFromString(kResponseText, &response));
-    EXPECT_CALL(*stream, Read).WillOnce(Return(response));
+    EXPECT_CALL(*stream, Read)
+        .WillOnce(DoAll(SetArgPointee<0>(response), Return(absl::nullopt)));
     {
       InSequence seq;
 

--- a/google/cloud/storage/internal/storage_stub_factory_test.cc
+++ b/google/cloud/storage/internal/storage_stub_factory_test.cc
@@ -135,8 +135,10 @@ TEST_F(StorageStubFactory, ReadObject) {
       stub->ReadObject(std::make_shared<grpc::ClientContext>(),
                        Options{}.set<UserAgentProductsOption>({"test-only/1"}),
                        google::storage::v2::ReadObjectRequest{});
-  EXPECT_THAT(stream->Read(),
-              VariantWith<Status>(StatusIs(StatusCode::kUnavailable)));
+  google::storage::v2::ReadObjectResponse response;
+  auto status = stream->Read(&response);
+  EXPECT_TRUE(status.has_value());
+  EXPECT_THAT(*status, StatusIs(StatusCode::kUnavailable));
   EXPECT_THAT(log.ExtractLines(), Contains(HasSubstr("ReadObject")));
 }
 

--- a/google/cloud/storage/testing/mock_storage_stub.h
+++ b/google/cloud/storage/testing/mock_storage_stub.h
@@ -214,8 +214,8 @@ class MockObjectMediaStream : public google::cloud::internal::StreamingReadRpc<
                                   google::storage::v2::ReadObjectResponse> {
  public:
   MOCK_METHOD(void, Cancel, (), (override));
-  MOCK_METHOD((absl::variant<Status, google::storage::v2::ReadObjectResponse>),
-              Read, (), (override));
+  MOCK_METHOD(absl::optional<Status>, Read,
+              (google::storage::v2::ReadObjectResponse*), (override));
   MOCK_METHOD(google::cloud::RpcMetadata, GetRequestMetadata, (),
               (const, override));
 };


### PR DESCRIPTION
This allows the caller to allocate the ResponseType on an arena and better matches the underlying GRPC interface

TESTED=bazel test //google/... --test_tag_filters=-integration-test,-benchmark,-sample