### PR TITLE
impl(bigtable): update DataConnectionImpl to create and call OperationContext hooks

### DIFF
--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -456,6 +456,7 @@ if (BUILD_TESTING)
         internal/logging_data_client_test.cc
         internal/metrics_test.cc
         internal/mutate_rows_limiter_test.cc
+        internal/operation_context_factory_test.cc
         internal/operation_context_test.cc
         internal/prefix_range_end_test.cc
         internal/rate_limiter_test.cc

--- a/google/cloud/bigtable/bigtable_client_unit_tests.bzl
+++ b/google/cloud/bigtable/bigtable_client_unit_tests.bzl
@@ -61,6 +61,7 @@ bigtable_client_unit_tests = [
     "internal/logging_data_client_test.cc",
     "internal/metrics_test.cc",
     "internal/mutate_rows_limiter_test.cc",
+    "internal/operation_context_factory_test.cc",
     "internal/operation_context_test.cc",
     "internal/prefix_range_end_test.cc",
     "internal/rate_limiter_test.cc",

--- a/google/cloud/bigtable/internal/data_connection_impl.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl.cc
@@ -128,6 +128,18 @@ DataConnectionImpl::DataConnectionImpl(
 #endif
 }
 
+DataConnectionImpl::DataConnectionImpl(
+    std::unique_ptr<BackgroundThreads> background,
+    std::shared_ptr<BigtableStub> stub,
+    std::unique_ptr<OperationContextFactory> operation_context_factory,
+    std::shared_ptr<MutateRowsLimiter> limiter, Options options)
+    : background_(std::move(background)),
+      stub_(std::move(stub)),
+      operation_context_factory_(std::move(operation_context_factory)),
+      limiter_(std::move(limiter)),
+      options_(internal::MergeOptions(std::move(options),
+                                      DataConnection::options())) {}
+
 Status DataConnectionImpl::Apply(std::string const& table_name,
                                  bigtable::SingleRowMutation mut) {
   auto current = google::cloud::internal::SaveCurrentOptions();
@@ -143,19 +155,21 @@ Status DataConnectionImpl::Apply(std::string const& table_name,
         return idempotent_policy->is_idempotent(m);
       });
 
-  OperationContext operation_context;
+  auto operation_context = operation_context_factory_->MutateRow(
+      table_name, app_profile_id(*current));
   auto sor = google::cloud::internal::RetryLoop(
       retry_policy(*current), backoff_policy(*current),
       is_idempotent ? Idempotency::kIdempotent : Idempotency::kNonIdempotent,
       [this, &operation_context](
           grpc::ClientContext& context, Options const& options,
           google::bigtable::v2::MutateRowRequest const& request) {
-        operation_context.PreCall(context);
+        operation_context->PreCall(context);
         auto s = stub_->MutateRow(context, options, request);
-        operation_context.PostCall(context, s.status());
+        operation_context->PostCall(context, s.status());
         return s;
       },
       *current, request, __func__);
+  operation_context->OnDone(sor.status());
   if (!sor) return std::move(sor).status();
   return Status{};
 }
@@ -175,6 +189,8 @@ future<Status> DataConnectionImpl::AsyncApply(std::string const& table_name,
         return idempotent_policy->is_idempotent(m);
       });
 
+  auto operation_context = operation_context_factory_->MutateRow(
+      table_name, app_profile_id(*current));
   auto retry = retry_policy(*current);
   auto backoff = backoff_policy(*current);
   return google::cloud::internal::AsyncRetryLoop(
@@ -182,8 +198,7 @@ future<Status> DataConnectionImpl::AsyncApply(std::string const& table_name,
              is_idempotent ? Idempotency::kIdempotent
                            : Idempotency::kNonIdempotent,
              background_->cq(),
-             [stub = stub_,
-              operation_context = std::make_shared<OperationContext>()](
+             [stub = stub_, operation_context](
                  CompletionQueue& cq,
                  std::shared_ptr<grpc::ClientContext> context,
                  google::cloud::internal::ImmutableOptions options,
@@ -199,8 +214,10 @@ future<Status> DataConnectionImpl::AsyncApply(std::string const& table_name,
                    });
              },
              std::move(current), request, __func__)
-      .then([](future<StatusOr<google::bigtable::v2::MutateRowResponse>> f) {
+      .then([operation_context](
+                future<StatusOr<google::bigtable::v2::MutateRowResponse>> f) {
         auto sor = f.get();
+        operation_context->OnDone(sor.status());
         if (!sor) return std::move(sor).status();
         return Status{};
       });
@@ -210,7 +227,8 @@ std::vector<bigtable::FailedMutation> DataConnectionImpl::BulkApply(
     std::string const& table_name, bigtable::BulkMutation mut) {
   auto current = google::cloud::internal::SaveCurrentOptions();
   if (mut.empty()) return {};
-  auto operation_context = std::make_shared<OperationContext>();
+  auto operation_context = operation_context_factory_->MutateRows(
+      table_name, app_profile_id(*current));
   BulkMutator mutator(app_profile_id(*current), table_name,
                       *idempotency_policy(*current), std::move(mut),
                       operation_context);
@@ -238,7 +256,8 @@ future<std::vector<bigtable::FailedMutation>>
 DataConnectionImpl::AsyncBulkApply(std::string const& table_name,
                                    bigtable::BulkMutation mut) {
   auto current = google::cloud::internal::SaveCurrentOptions();
-  auto operation_context = std::make_shared<OperationContext>();
+  auto operation_context = operation_context_factory_->MutateRows(
+      table_name, app_profile_id(*current));
   return AsyncBulkApplier::Create(
       background_->cq(), stub_, limiter_, retry_policy(*current),
       backoff_policy(*current), enable_server_retries(*current),
@@ -249,7 +268,8 @@ DataConnectionImpl::AsyncBulkApply(std::string const& table_name,
 bigtable::RowReader DataConnectionImpl::ReadRowsFull(
     bigtable::ReadRowsParams params) {
   auto current = google::cloud::internal::SaveCurrentOptions();
-  auto operation_context = std::make_shared<OperationContext>();
+  auto operation_context = operation_context_factory_->ReadRows(
+      params.table_name, params.app_profile_id);
   return ReadRowsHelper(stub_, current, std::move(params),
                         std::move(operation_context));
 }
@@ -263,7 +283,8 @@ StatusOr<std::pair<bool, bigtable::Row>> DataConnectionImpl::ReadRow(
   // TODO(sdhart): ensure OperationContext::OnDone is called correctly.
   // TODO(sdhart): add ReadRow tests once we call
   //  OperationContextFactory::ReadRow to create the operation_context.
-  auto operation_context = std::make_shared<OperationContext>();
+  auto operation_context =
+      operation_context_factory_->ReadRow(table_name, app_profile_id(*current));
   auto reader =
       ReadRowsHelper(stub_, current,
                      bigtable::ReadRowsParams{
@@ -303,18 +324,20 @@ StatusOr<bigtable::MutationBranch> DataConnectionImpl::CheckAndMutateRow(
   auto const idempotency = idempotency_policy(*current)->is_idempotent(request)
                                ? Idempotency::kIdempotent
                                : Idempotency::kNonIdempotent;
-  OperationContext operation_context;
+  auto operation_context = operation_context_factory_->CheckAndMutateRow(
+      table_name, app_profile_id(*current));
   auto sor = google::cloud::internal::RetryLoop(
       retry_policy(*current), backoff_policy(*current), idempotency,
       [this, &operation_context](
           grpc::ClientContext& context, Options const& options,
           google::bigtable::v2::CheckAndMutateRowRequest const& request) {
-        operation_context.PreCall(context);
+        operation_context->PreCall(context);
         auto s = stub_->CheckAndMutateRow(context, options, request);
-        operation_context.PostCall(context, s.status());
+        operation_context->PostCall(context, s.status());
         return s;
       },
       *current, request, __func__);
+  operation_context->OnDone(sor.status());
   if (!sor) return std::move(sor).status();
   auto response = *std::move(sor);
   return response.predicate_matched()
@@ -345,11 +368,12 @@ DataConnectionImpl::AsyncCheckAndMutateRow(
 
   auto retry = retry_policy(*current);
   auto backoff = backoff_policy(*current);
+  auto operation_context = operation_context_factory_->CheckAndMutateRow(
+      table_name, app_profile_id(*current));
   return google::cloud::internal::AsyncRetryLoop(
              std::move(retry), std::move(backoff), idempotency,
              background_->cq(),
-             [stub = stub_,
-              operation_context = std::make_shared<OperationContext>()](
+             [stub = stub_, operation_context](
                  CompletionQueue& cq,
                  std::shared_ptr<grpc::ClientContext> context,
                  google::cloud::internal::ImmutableOptions options,
@@ -366,15 +390,18 @@ DataConnectionImpl::AsyncCheckAndMutateRow(
                    });
              },
              std::move(current), request, __func__)
-      .then([](future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
-                   f) -> StatusOr<bigtable::MutationBranch> {
-        auto sor = f.get();
-        if (!sor) return std::move(sor).status();
-        auto response = *std::move(sor);
-        return response.predicate_matched()
-                   ? bigtable::MutationBranch::kPredicateMatched
-                   : bigtable::MutationBranch::kPredicateNotMatched;
-      });
+      .then(
+          [operation_context](
+              future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
+                  f) -> StatusOr<bigtable::MutationBranch> {
+            auto sor = f.get();
+            operation_context->OnDone(sor.status());
+            if (!sor) return std::move(sor).status();
+            auto response = *std::move(sor);
+            return response.predicate_matched()
+                       ? bigtable::MutationBranch::kPredicateMatched
+                       : bigtable::MutationBranch::kPredicateNotMatched;
+          });
 }
 
 StatusOr<std::vector<bigtable::RowKeySample>> DataConnectionImpl::SampleRows(
@@ -388,11 +415,12 @@ StatusOr<std::vector<bigtable::RowKeySample>> DataConnectionImpl::SampleRows(
   std::vector<bigtable::RowKeySample> samples;
   std::unique_ptr<bigtable::DataRetryPolicy> retry;
   std::unique_ptr<BackoffPolicy> backoff;
-  OperationContext operation_context;
+  auto operation_context = operation_context_factory_->SampleRowKeys(
+      table_name, app_profile_id(*current));
   while (true) {
     auto context = std::make_shared<grpc::ClientContext>();
     internal::ConfigureContext(*context, internal::CurrentOptions());
-    operation_context.PreCall(*context);
+    operation_context->PreCall(*context);
     auto stream = stub_->SampleRowKeys(context, Options{}, request);
 
     struct UnpackVariant {
@@ -412,6 +440,7 @@ StatusOr<std::vector<bigtable::RowKeySample>> DataConnectionImpl::SampleRows(
     };
     while (absl::visit(UnpackVariant{status, samples}, stream->Read())) {
     }
+    operation_context->PostCall(*context, status);
     if (status.ok()) break;
     // We wait to allocate the policies until they are needed as a
     // micro-optimization.
@@ -420,19 +449,23 @@ StatusOr<std::vector<bigtable::RowKeySample>> DataConnectionImpl::SampleRows(
     auto delay = internal::Backoff(status, "SampleRows", *retry, *backoff,
                                    Idempotency::kIdempotent,
                                    enable_server_retries(*current));
-    if (!delay) return std::move(delay).status();
-    operation_context.PostCall(*context, status);
+    if (!delay) {
+      operation_context->OnDone(delay.status());
+      return std::move(delay).status();
+    }
     // A new stream invalidates previously returned samples.
     samples.clear();
     std::this_thread::sleep_for(*delay);
   }
+  operation_context->OnDone({});
   return samples;
 }
 
 future<StatusOr<std::vector<bigtable::RowKeySample>>>
 DataConnectionImpl::AsyncSampleRows(std::string const& table_name) {
   auto current = google::cloud::internal::SaveCurrentOptions();
-  auto operation_context = std::make_shared<OperationContext>();
+  auto operation_context = operation_context_factory_->SampleRowKeys(
+      table_name, app_profile_id(*current));
   return AsyncRowSampler::Create(
       background_->cq(), stub_, retry_policy(*current),
       backoff_policy(*current), enable_server_retries(*current),
@@ -442,14 +475,21 @@ DataConnectionImpl::AsyncSampleRows(std::string const& table_name) {
 StatusOr<bigtable::Row> DataConnectionImpl::ReadModifyWriteRow(
     google::bigtable::v2::ReadModifyWriteRowRequest request) {
   auto current = google::cloud::internal::SaveCurrentOptions();
+  auto operation_context = operation_context_factory_->ReadModifyWriteRow(
+      request.table_name(), app_profile_id(*current));
   auto sor = google::cloud::internal::RetryLoop(
       retry_policy(*current), backoff_policy(*current),
       Idempotency::kNonIdempotent,
-      [this](grpc::ClientContext& context, Options const& options,
-             google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
-        return stub_->ReadModifyWriteRow(context, options, request);
+      [this, operation_context](
+          grpc::ClientContext& context, Options const& options,
+          google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
+        operation_context->PreCall(context);
+        auto result = stub_->ReadModifyWriteRow(context, options, request);
+        operation_context->PostCall(context, result.status());
+        return result;
       },
       *current, request, __func__);
+  operation_context->OnDone(sor.status());
   if (!sor) return std::move(sor).status();
   return TransformReadModifyWriteRowResponse(*std::move(sor));
 }
@@ -457,28 +497,55 @@ StatusOr<bigtable::Row> DataConnectionImpl::ReadModifyWriteRow(
 future<StatusOr<bigtable::Row>> DataConnectionImpl::AsyncReadModifyWriteRow(
     google::bigtable::v2::ReadModifyWriteRowRequest request) {
   auto current = google::cloud::internal::SaveCurrentOptions();
+  auto operation_context = operation_context_factory_->ReadModifyWriteRow(
+      request.table_name(), app_profile_id(*current));
   auto retry = retry_policy(*current);
   auto backoff = backoff_policy(*current);
   return google::cloud::internal::AsyncRetryLoop(
              std::move(retry), std::move(backoff), Idempotency::kNonIdempotent,
              background_->cq(),
-             [stub = stub_](
+             [stub = stub_, operation_context](
                  CompletionQueue& cq,
                  std::shared_ptr<grpc::ClientContext> context,
                  google::cloud::internal::ImmutableOptions options,
                  google::bigtable::v2::ReadModifyWriteRowRequest const&
                      request) {
-               return stub->AsyncReadModifyWriteRow(
-                   cq, std::move(context), std::move(options), request);
+               operation_context->PreCall(*context);
+               auto f = stub->AsyncReadModifyWriteRow(
+                   cq, context, std::move(options), request);
+               return f.then(
+                   [operation_context, context = std::move(context)](auto f) {
+                     auto s = f.get();
+                     operation_context->PostCall(*context, s.status());
+                     return s;
+                   });
              },
              std::move(current), request, __func__)
       .then(
-          [](future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>
-                 f) -> StatusOr<bigtable::Row> {
+          [operation_context](
+              future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>
+                  f) -> StatusOr<bigtable::Row> {
             auto sor = f.get();
+            operation_context->OnDone(sor.status());
             if (!sor) return std::move(sor).status();
             return TransformReadModifyWriteRowResponse(*std::move(sor));
           });
+}
+
+void DataConnectionImpl::AsyncReadRowsHelper(
+    std::string const& table_name,
+    std::function<future<bool>(bigtable::Row)> on_row,
+    std::function<void(Status)> on_finish, bigtable::RowSet row_set,
+    std::int64_t rows_limit, bigtable::Filter filter,
+    internal::ImmutableOptions const& current,
+    std::shared_ptr<OperationContext> operation_context) {
+  auto reverse = internal::CurrentOptions().get<bigtable::ReverseScanOption>();
+  bigtable_internal::AsyncRowReader::Create(
+      background_->cq(), stub_, app_profile_id(*current), table_name,
+      std::move(on_row), std::move(on_finish), std::move(row_set), rows_limit,
+      std::move(filter), reverse, retry_policy(*current),
+      backoff_policy(*current), enable_server_retries(*current),
+      std::move(operation_context));
 }
 
 void DataConnectionImpl::AsyncReadRows(
@@ -487,14 +554,11 @@ void DataConnectionImpl::AsyncReadRows(
     std::function<void(Status)> on_finish, bigtable::RowSet row_set,
     std::int64_t rows_limit, bigtable::Filter filter) {
   auto current = google::cloud::internal::SaveCurrentOptions();
-  auto reverse = internal::CurrentOptions().get<bigtable::ReverseScanOption>();
-  auto operation_context = std::make_shared<OperationContext>();
-  bigtable_internal::AsyncRowReader::Create(
-      background_->cq(), stub_, app_profile_id(*current), table_name,
-      std::move(on_row), std::move(on_finish), std::move(row_set), rows_limit,
-      std::move(filter), reverse, retry_policy(*current),
-      backoff_policy(*current), enable_server_retries(*current),
-      std::move(operation_context));
+  auto operation_context = operation_context_factory_->ReadRows(
+      table_name, app_profile_id(*current));
+  AsyncReadRowsHelper(table_name, std::move(on_row), std::move(on_finish),
+                      std::move(row_set), rows_limit, std::move(filter),
+                      current, std::move(operation_context));
 }
 
 future<StatusOr<std::pair<bool, bigtable::Row>>>
@@ -541,16 +605,21 @@ DataConnectionImpl::AsyncReadRow(std::string const& table_name,
     promise<StatusOr<std::pair<bool, bigtable::Row>>> row_promise_;
   };
 
+  auto current = google::cloud::internal::SaveCurrentOptions();
+  auto operation_context =
+      operation_context_factory_->ReadRow(table_name, app_profile_id(*current));
+
   bigtable::RowSet row_set(std::move(row_key));
   std::int64_t const rows_limit = 1;
   auto handler = std::make_shared<AsyncReadRowHandler>();
-  AsyncReadRows(
+  AsyncReadRowsHelper(
       table_name,
       [handler](bigtable::Row row) { return handler->OnRow(std::move(row)); },
       [handler](Status status) {
         handler->OnStreamFinished(std::move(status));
       },
-      std::move(row_set), rows_limit, std::move(filter));
+      std::move(row_set), rows_limit, std::move(filter), current,
+      std::move(operation_context));
   return handler->GetFuture();
 }
 

--- a/google/cloud/bigtable/internal/data_connection_impl.h
+++ b/google/cloud/bigtable/internal/data_connection_impl.h
@@ -42,6 +42,13 @@ class DataConnectionImpl : public bigtable::DataConnection {
                      std::shared_ptr<MutateRowsLimiter> limiter,
                      Options options);
 
+  // This constructor is used for testing.
+  DataConnectionImpl(
+      std::unique_ptr<BackgroundThreads> background,
+      std::shared_ptr<BigtableStub> stub,
+      std::unique_ptr<OperationContextFactory> operation_context_factory,
+      std::shared_ptr<MutateRowsLimiter> limiter, Options options);
+
   Options options() override { return options_; }
 
   Status Apply(std::string const& table_name,
@@ -95,9 +102,17 @@ class DataConnectionImpl : public bigtable::DataConnection {
       bigtable::Filter filter) override;
 
  private:
-  std::unique_ptr<OperationContextFactory> operation_context_factory_;
+  void AsyncReadRowsHelper(std::string const& table_name,
+                           std::function<future<bool>(bigtable::Row)> on_row,
+                           std::function<void(Status)> on_finish,
+                           bigtable::RowSet row_set, std::int64_t rows_limit,
+                           bigtable::Filter filter,
+                           internal::ImmutableOptions const& current,
+                           std::shared_ptr<OperationContext> operation_context);
+
   std::unique_ptr<BackgroundThreads> background_;
   std::shared_ptr<BigtableStub> stub_;
+  std::unique_ptr<OperationContextFactory> operation_context_factory_;
   std::shared_ptr<MutateRowsLimiter> limiter_;
   Options options_;
 };

--- a/google/cloud/bigtable/internal/data_connection_impl_test.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl_test.cc
@@ -15,6 +15,10 @@
 #include "google/cloud/bigtable/internal/data_connection_impl.h"
 #include "google/cloud/bigtable/data_connection.h"
 #include "google/cloud/bigtable/internal/defaults.h"
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+#include "google/cloud/bigtable/internal/metrics.h"
+#include "google/cloud/testing_util/fake_clock.h"
+#endif
 #include "google/cloud/bigtable/options.h"
 #include "google/cloud/bigtable/testing/mock_bigtable_stub.h"
 #include "google/cloud/bigtable/testing/mock_mutate_rows_limiter.h"
@@ -210,6 +214,17 @@ std::shared_ptr<DataConnectionImpl> TestConnection(
       std::move(background), std::move(stub), std::move(limiter), Options{});
 }
 
+std::shared_ptr<DataConnectionImpl> TestConnection(
+    std::shared_ptr<BigtableStub> stub,
+    std::unique_ptr<OperationContextFactory> operation_context_factory,
+    std::shared_ptr<MutateRowsLimiter> limiter =
+        std::make_shared<NoopMutateRowsLimiter>()) {
+  auto background = internal::MakeBackgroundThreadsFactory()();
+  return std::make_shared<DataConnectionImpl>(
+      std::move(background), std::move(stub),
+      std::move(operation_context_factory), std::move(limiter), Options{});
+}
+
 TEST(TransformReadModifyWriteRowResponse, Basic) {
   v2::ReadModifyWriteRowResponse response;
   auto constexpr kText = R"pb(
@@ -248,6 +263,111 @@ TEST(TransformReadModifyWriteRowResponse, Basic) {
                                        MatchCell(c3), MatchCell(c4)));
 }
 
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+
+class MockMetric : public Metric {
+ public:
+  MOCK_METHOD(void, PreCall,
+              (opentelemetry::context::Context const&, PreCallParams const&),
+              (override));
+  MOCK_METHOD(void, PostCall,
+              (opentelemetry::context::Context const&,
+               grpc::ClientContext const&, PostCallParams const&),
+              (override));
+  MOCK_METHOD(void, OnDone,
+              (opentelemetry::context::Context const&, OnDoneParams const&),
+              (override));
+  MOCK_METHOD(void, ElementRequest,
+              (opentelemetry::context::Context const&,
+               ElementRequestParams const&),
+              (override));
+  MOCK_METHOD(void, ElementDelivery,
+              (opentelemetry::context::Context const&,
+               ElementDeliveryParams const&),
+              (override));
+  MOCK_METHOD(std::unique_ptr<Metric>, clone,
+              (ResourceLabels resource_labels, DataLabels data_labels),
+              (const, override));
+};
+
+// This class is a vehicle to get a MockMetric into the OperationContext object.
+class CloningMetric : public Metric {
+ public:
+  explicit CloningMetric(std::unique_ptr<MockMetric> metric) {
+    metrics_.push_back(std::move(metric));
+  }
+  explicit CloningMetric(std::vector<std::unique_ptr<MockMetric>> metrics)
+      : metrics_(std::move(metrics)) {
+    std::reverse(metrics_.begin(), metrics_.end());
+  }
+
+  std::unique_ptr<Metric> clone(ResourceLabels, DataLabels) const override {
+    auto m = std::move(metrics_.back());
+    metrics_.pop_back();
+    return m;
+  }
+
+ private:
+  mutable std::vector<std::unique_ptr<MockMetric>> metrics_;
+};
+
+class FakeOperationContextFactory : public OperationContextFactory {
+ public:
+  FakeOperationContextFactory(ResourceLabels r, DataLabels d,
+                              std::shared_ptr<Metric> metric,
+                              std::shared_ptr<OperationContext::Clock> clock)
+      : resource_labels_(std::move(r)),
+        data_labels_(std::move(d)),
+        clock_(std::move(clock)) {
+    metrics_.push_back(std::move(metric));
+  }
+
+  std::shared_ptr<OperationContext> ReadRow(
+      std::string const& name, std::string const& app_profile) override {
+    return Helper(name, app_profile);
+  }
+  std::shared_ptr<OperationContext> ReadRows(
+      std::string const& name, std::string const& app_profile) override {
+    return Helper(name, app_profile);
+  }
+  std::shared_ptr<OperationContext> MutateRow(
+      std::string const& name, std::string const& app_profile) override {
+    return Helper(name, app_profile);
+  }
+  std::shared_ptr<OperationContext> MutateRows(
+      std::string const& name, std::string const& app_profile) override {
+    return Helper(name, app_profile);
+  }
+  std::shared_ptr<OperationContext> CheckAndMutateRow(
+      std::string const& name, std::string const& app_profile) override {
+    return Helper(name, app_profile);
+  }
+  std::shared_ptr<OperationContext> SampleRowKeys(
+      std::string const& name, std::string const& app_profile) override {
+    return Helper(name, app_profile);
+  }
+  std::shared_ptr<OperationContext> ReadModifyWriteRow(
+      std::string const& name, std::string const& app_profile) override {
+    return Helper(name, app_profile);
+  }
+
+ private:
+  std::shared_ptr<OperationContext> Helper(std::string const& name,
+                                           std::string const& app_profile) {
+    resource_labels_.table = name;
+    data_labels_.app_profile = app_profile;
+    return std::make_shared<OperationContext>(resource_labels_, data_labels_,
+                                              metrics_, clock_);
+  }
+
+  ResourceLabels resource_labels_;
+  DataLabels data_labels_;
+  std::vector<std::shared_ptr<Metric const>> metrics_;
+  std::shared_ptr<OperationContext::Clock> clock_;
+};
+
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+
 class DataConnectionTest : public ::testing::Test {
  protected:
   Options CallOptions() {
@@ -265,6 +385,21 @@ class DataConnectionTest : public ::testing::Test {
 };
 
 TEST_F(DataConnectionTest, ApplySuccess) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(1);
+  EXPECT_CALL(*mock_metric, PostCall).Times(1);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRow)
       .WillOnce([](grpc::ClientContext&, Options const&,
@@ -275,13 +410,28 @@ TEST_F(DataConnectionTest, ApplySuccess) {
         return v2::MutateRowResponse{};
       });
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(CallOptions());
   auto status = conn->Apply(kTableName, IdempotentMutation("row"));
   ASSERT_STATUS_OK(status);
 }
 
 TEST_F(DataConnectionTest, ApplyPermanentFailure) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(1);
+  EXPECT_CALL(*mock_metric, PostCall).Times(1);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRow)
       .WillOnce([](grpc::ClientContext&, Options const&,
@@ -292,13 +442,28 @@ TEST_F(DataConnectionTest, ApplyPermanentFailure) {
         return PermanentError();
       });
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(CallOptions());
   auto status = conn->Apply(kTableName, IdempotentMutation("row"));
   EXPECT_THAT(status, StatusIs(StatusCode::kPermissionDenied));
 }
 
 TEST_F(DataConnectionTest, ApplyRetryThenSuccess) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(2);
+  EXPECT_CALL(*mock_metric, PostCall).Times(2);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRow)
       .WillOnce([](grpc::ClientContext&, Options const&,
@@ -316,13 +481,28 @@ TEST_F(DataConnectionTest, ApplyRetryThenSuccess) {
         return v2::MutateRowResponse{};
       });
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(CallOptions());
   auto status = conn->Apply(kTableName, IdempotentMutation("row"));
   ASSERT_STATUS_OK(status);
 }
 
 TEST_F(DataConnectionTest, ApplyRetryExhausted) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(kNumRetries + 1);
+  EXPECT_CALL(*mock_metric, PostCall).Times(kNumRetries + 1);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRow)
       .Times(kNumRetries + 1)
@@ -341,7 +521,7 @@ TEST_F(DataConnectionTest, ApplyRetryExhausted) {
     return clone;
   });
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(
       CallOptions().set<DataBackoffPolicyOption>(std::move(mock_b)));
   auto status = conn->Apply(kTableName, IdempotentMutation("row"));
@@ -375,6 +555,21 @@ TEST_F(DataConnectionTest, ApplyRetryIdempotency) {
 }
 
 TEST_F(DataConnectionTest, ApplyBigtableCookie) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(2);
+  EXPECT_CALL(*mock_metric, PostCall).Times(2);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRow)
       .WillOnce([this](grpc::ClientContext& context, Options const&,
@@ -401,7 +596,7 @@ TEST_F(DataConnectionTest, ApplyBigtableCookie) {
     return clone;
   });
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(
       CallOptionsWithoutClientContextSetup().set<DataBackoffPolicyOption>(
           std::move(mock_b)));
@@ -410,6 +605,21 @@ TEST_F(DataConnectionTest, ApplyBigtableCookie) {
 }
 
 TEST_F(DataConnectionTest, AsyncApplySuccess) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(1);
+  EXPECT_CALL(*mock_metric, PostCall).Times(1);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRow)
       .WillOnce([](google::cloud::CompletionQueue&, auto, auto,
@@ -420,7 +630,7 @@ TEST_F(DataConnectionTest, AsyncApplySuccess) {
         return make_ready_future(make_status_or(v2::MutateRowResponse{}));
       });
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(CallOptions());
   auto status = conn->AsyncApply(kTableName, IdempotentMutation("row"));
   ASSERT_STATUS_OK(status.get());
@@ -445,6 +655,21 @@ TEST_F(DataConnectionTest, AsyncApplyPermanentFailure) {
 }
 
 TEST_F(DataConnectionTest, AsyncApplyRetryExhausted) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(kNumRetries + 1);
+  EXPECT_CALL(*mock_metric, PostCall).Times(kNumRetries + 1);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRow)
       .Times(kNumRetries + 1)
@@ -464,7 +689,7 @@ TEST_F(DataConnectionTest, AsyncApplyRetryExhausted) {
     return clone;
   });
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(
       CallOptions().set<DataBackoffPolicyOption>(std::move(mock_b)));
   auto status = conn->AsyncApply(kTableName, IdempotentMutation("row"));
@@ -537,13 +762,43 @@ TEST_F(DataConnectionTest, AsyncApplyBigtableCookie) {
 }
 
 TEST_F(DataConnectionTest, BulkApplyEmpty) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(0);
+  EXPECT_CALL(*mock_metric, PostCall).Times(0);
+  EXPECT_CALL(*mock_metric, OnDone).Times(0);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   auto mock = std::make_shared<MockBigtableStub>();
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   auto actual = conn->BulkApply(kTableName, bigtable::BulkMutation());
   CheckFailedMutations(actual, {});
 }
 
 TEST_F(DataConnectionTest, BulkApplySuccess) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(1);
+  EXPECT_CALL(*mock_metric, PostCall).Times(1);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   bigtable::BulkMutation mut(IdempotentMutation("r0"),
                              IdempotentMutation("r1"));
 
@@ -562,13 +817,28 @@ TEST_F(DataConnectionTest, BulkApplySuccess) {
         return stream;
       });
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(CallOptions());
   auto actual = conn->BulkApply(kTableName, std::move(mut));
   CheckFailedMutations(actual, {});
 }
 
 TEST_F(DataConnectionTest, BulkApplyRetryMutationPolicy) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(2);
+  EXPECT_CALL(*mock_metric, PostCall).Times(2);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   std::vector<bigtable::FailedMutation> expected = {{PermanentError(), 2},
                                                     {TransientError(), 3}};
   bigtable::BulkMutation mut(
@@ -607,13 +877,28 @@ TEST_F(DataConnectionTest, BulkApplyRetryMutationPolicy) {
         return stream;
       });
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(CallOptions());
   auto actual = conn->BulkApply(kTableName, std::move(mut));
   CheckFailedMutations(actual, expected);
 }
 
 TEST_F(DataConnectionTest, BulkApplyIncompleteStreamRetried) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(2);
+  EXPECT_CALL(*mock_metric, PostCall).Times(2);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   bigtable::BulkMutation mut(IdempotentMutation("returned"),
                              IdempotentMutation("forgotten"));
 
@@ -643,13 +928,27 @@ TEST_F(DataConnectionTest, BulkApplyIncompleteStreamRetried) {
         return stream;
       });
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(CallOptions());
   auto actual = conn->BulkApply(kTableName, std::move(mut));
   CheckFailedMutations(actual, {});
 }
 
 TEST_F(DataConnectionTest, BulkApplyStreamRetryExhausted) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(kNumRetries + 1);
+  EXPECT_CALL(*mock_metric, PostCall).Times(kNumRetries + 1);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
   std::vector<bigtable::FailedMutation> expected = {{TransientError(), 0}};
   bigtable::BulkMutation mut(IdempotentMutation("row"));
 
@@ -673,7 +972,7 @@ TEST_F(DataConnectionTest, BulkApplyStreamRetryExhausted) {
     return clone;
   });
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(
       CallOptions().set<DataBackoffPolicyOption>(std::move(mock_b)));
   auto actual = conn->BulkApply(kTableName, std::move(mut));
@@ -681,6 +980,21 @@ TEST_F(DataConnectionTest, BulkApplyStreamRetryExhausted) {
 }
 
 TEST_F(DataConnectionTest, BulkApplyStreamPermanentError) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(1);
+  EXPECT_CALL(*mock_metric, PostCall).Times(1);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   std::vector<bigtable::FailedMutation> expected = {{PermanentError(), 0}};
   bigtable::BulkMutation mut(IdempotentMutation("row"));
 
@@ -695,7 +1009,7 @@ TEST_F(DataConnectionTest, BulkApplyStreamPermanentError) {
         return stream;
       });
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(CallOptions());
   auto actual = conn->BulkApply(kTableName, std::move(mut));
   CheckFailedMutations(actual, expected);
@@ -984,6 +1298,21 @@ TEST_F(DataConnectionTest, ReadRowsRetryInfoIgnored) {
 }
 
 TEST_F(DataConnectionTest, ReadRowEmpty) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(1);
+  EXPECT_CALL(*mock_metric, PostCall).Times(1);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
       .WillOnce([](auto, auto const&,
@@ -999,7 +1328,7 @@ TEST_F(DataConnectionTest, ReadRowEmpty) {
         return stream;
       });
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(CallOptions());
   auto resp = conn->ReadRow(kTableName, "row", TestFilter());
   ASSERT_STATUS_OK(resp);
@@ -1007,6 +1336,21 @@ TEST_F(DataConnectionTest, ReadRowEmpty) {
 }
 
 TEST_F(DataConnectionTest, ReadRowSuccess) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(1);
+  EXPECT_CALL(*mock_metric, PostCall).Times(1);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(1);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(1);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
       .WillOnce([](auto, auto const&,
@@ -1032,7 +1376,7 @@ TEST_F(DataConnectionTest, ReadRowSuccess) {
         return stream;
       });
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(CallOptions());
   auto resp = conn->ReadRow(kTableName, "row", TestFilter());
   ASSERT_STATUS_OK(resp);
@@ -1041,6 +1385,21 @@ TEST_F(DataConnectionTest, ReadRowSuccess) {
 }
 
 TEST_F(DataConnectionTest, ReadRowFailure) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(1);
+  EXPECT_CALL(*mock_metric, PostCall).Times(1);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
       .WillOnce([](auto, auto const&,
@@ -1056,13 +1415,36 @@ TEST_F(DataConnectionTest, ReadRowFailure) {
         return stream;
       });
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(CallOptions());
   auto resp = conn->ReadRow(kTableName, "row", TestFilter());
   EXPECT_THAT(resp, StatusIs(StatusCode::kPermissionDenied));
 }
 
 TEST_F(DataConnectionTest, CheckAndMutateRowSuccess) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric1 = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric1, PreCall).Times(1);
+  EXPECT_CALL(*mock_metric1, PostCall).Times(1);
+  EXPECT_CALL(*mock_metric1, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric1, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric1, ElementDelivery).Times(0);
+  auto mock_metric2 = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric2, PreCall).Times(1);
+  EXPECT_CALL(*mock_metric2, PostCall).Times(1);
+  EXPECT_CALL(*mock_metric2, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric2, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric2, ElementDelivery).Times(0);
+  std::vector<std::unique_ptr<MockMetric>> v;
+  v.push_back(std::move(mock_metric1));
+  v.push_back(std::move(mock_metric2));
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(v));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
   auto t1 = bigtable::SetCell("f1", "c1", ms(0), "true1");
   auto t2 = bigtable::SetCell("f2", "c2", ms(0), "true2");
   auto f1 = bigtable::SetCell("f1", "c1", ms(0), "false1");
@@ -1101,7 +1483,7 @@ TEST_F(DataConnectionTest, CheckAndMutateRowSuccess) {
         return resp;
       });
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(CallOptions());
   auto predicate = conn->CheckAndMutateRow(kTableName, "row", TestFilter(),
                                            {t1, t2}, {f1, f2});
@@ -1153,6 +1535,21 @@ TEST_F(DataConnectionTest, CheckAndMutateRowIdempotency) {
 }
 
 TEST_F(DataConnectionTest, CheckAndMutateRowPermanentError) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(1);
+  EXPECT_CALL(*mock_metric, PostCall).Times(1);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   auto t1 = bigtable::SetCell("f1", "c1", ms(0), "true1");
   auto t2 = bigtable::SetCell("f2", "c2", ms(0), "true2");
   auto f1 = bigtable::SetCell("f1", "c1", ms(0), "false1");
@@ -1173,7 +1570,7 @@ TEST_F(DataConnectionTest, CheckAndMutateRowPermanentError) {
         return PermanentError();
       });
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(CallOptions());
   auto status = conn->CheckAndMutateRow(kTableName, "row", TestFilter(),
                                         {t1, t2}, {f1, f2});
@@ -1181,6 +1578,21 @@ TEST_F(DataConnectionTest, CheckAndMutateRowPermanentError) {
 }
 
 TEST_F(DataConnectionTest, CheckAndMutateRowRetryExhausted) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(kNumRetries + 1);
+  EXPECT_CALL(*mock_metric, PostCall).Times(kNumRetries + 1);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   auto t1 = bigtable::SetCell("f1", "c1", ms(0), "true1");
   auto t2 = bigtable::SetCell("f2", "c2", ms(0), "true2");
   auto f1 = bigtable::SetCell("f1", "c1", ms(0), "false1");
@@ -1209,7 +1621,7 @@ TEST_F(DataConnectionTest, CheckAndMutateRowRetryExhausted) {
     return clone;
   });
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(
       CallOptions()
           .set<DataBackoffPolicyOption>(std::move(mock_b))
@@ -1263,6 +1675,30 @@ TEST_F(DataConnectionTest, CheckAndMutateRowBigtableCookie) {
 }
 
 TEST_F(DataConnectionTest, AsyncCheckAndMutateRowSuccess) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric1 = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric1, PreCall).Times(1);
+  EXPECT_CALL(*mock_metric1, PostCall).Times(1);
+  EXPECT_CALL(*mock_metric1, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric1, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric1, ElementDelivery).Times(0);
+  auto mock_metric2 = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric2, PreCall).Times(1);
+  EXPECT_CALL(*mock_metric2, PostCall).Times(1);
+  EXPECT_CALL(*mock_metric2, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric2, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric2, ElementDelivery).Times(0);
+  std::vector<std::unique_ptr<MockMetric>> v;
+  v.push_back(std::move(mock_metric1));
+  v.push_back(std::move(mock_metric2));
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(v));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   auto t1 = bigtable::SetCell("f1", "c1", ms(0), "true1");
   auto t2 = bigtable::SetCell("f2", "c2", ms(0), "true2");
   auto f1 = bigtable::SetCell("f1", "c1", ms(0), "false1");
@@ -1301,7 +1737,7 @@ TEST_F(DataConnectionTest, AsyncCheckAndMutateRowSuccess) {
         return make_ready_future(make_status_or(resp));
       });
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(CallOptions());
   auto predicate = conn->AsyncCheckAndMutateRow(kTableName, "row", TestFilter(),
                                                 {t1, t2}, {f1, f2})
@@ -1356,6 +1792,21 @@ TEST_F(DataConnectionTest, AsyncCheckAndMutateRowIdempotency) {
 }
 
 TEST_F(DataConnectionTest, AsyncCheckAndMutateRowPermanentError) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(1);
+  EXPECT_CALL(*mock_metric, PostCall).Times(1);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   auto t1 = bigtable::SetCell("f1", "c1", ms(0), "true1");
   auto t2 = bigtable::SetCell("f2", "c2", ms(0), "true2");
   auto f1 = bigtable::SetCell("f1", "c1", ms(0), "false1");
@@ -1377,7 +1828,7 @@ TEST_F(DataConnectionTest, AsyncCheckAndMutateRowPermanentError) {
             PermanentError());
       });
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(CallOptions());
   auto status = conn->AsyncCheckAndMutateRow(kTableName, "row", TestFilter(),
                                              {t1, t2}, {f1, f2});
@@ -1385,6 +1836,21 @@ TEST_F(DataConnectionTest, AsyncCheckAndMutateRowPermanentError) {
 }
 
 TEST_F(DataConnectionTest, AsyncCheckAndMutateRowRetryExhausted) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(kNumRetries + 1);
+  EXPECT_CALL(*mock_metric, PostCall).Times(kNumRetries + 1);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   auto t1 = bigtable::SetCell("f1", "c1", ms(0), "true1");
   auto t2 = bigtable::SetCell("f2", "c2", ms(0), "true2");
   auto f1 = bigtable::SetCell("f1", "c1", ms(0), "false1");
@@ -1414,7 +1880,7 @@ TEST_F(DataConnectionTest, AsyncCheckAndMutateRowRetryExhausted) {
     return clone;
   });
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(
       CallOptions()
           .set<DataBackoffPolicyOption>(std::move(mock_b))
@@ -1472,9 +1938,26 @@ TEST_F(DataConnectionTest, AsyncCheckAndMutateRowBigtableCookie) {
 }
 
 TEST_F(DataConnectionTest, SampleRowsSuccess) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(1);
+  EXPECT_CALL(*mock_metric, PostCall).Times(1);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, SampleRowKeys)
-      .WillOnce([](auto, auto const&, v2::SampleRowKeysRequest const& request) {
+      .WillOnce([this](auto client_context, auto const&,
+                       v2::SampleRowKeysRequest const& request) {
+        metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         auto stream = std::make_unique<MockSampleRowKeysStream>();
@@ -1488,7 +1971,7 @@ TEST_F(DataConnectionTest, SampleRowsSuccess) {
   MockFunction<void(grpc::ClientContext&)> mock_setup;
   EXPECT_CALL(mock_setup, Call).Times(1);
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(
       CallOptions().set<internal::GrpcSetupOption>(mock_setup.AsStdFunction()));
   auto samples = conn->SampleRows(kTableName);
@@ -1499,6 +1982,21 @@ TEST_F(DataConnectionTest, SampleRowsSuccess) {
 }
 
 TEST_F(DataConnectionTest, SampleRowsRetryResetsSamples) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(2);
+  EXPECT_CALL(*mock_metric, PostCall).Times(2);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, SampleRowKeys)
       .WillOnce([](auto, auto const&, v2::SampleRowKeysRequest const& request) {
@@ -1520,7 +2018,7 @@ TEST_F(DataConnectionTest, SampleRowsRetryResetsSamples) {
         return stream;
       });
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(CallOptions());
   auto samples = conn->SampleRows(kTableName);
   ASSERT_STATUS_OK(samples);
@@ -1530,6 +2028,21 @@ TEST_F(DataConnectionTest, SampleRowsRetryResetsSamples) {
 }
 
 TEST_F(DataConnectionTest, SampleRowsRetryExhausted) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(kNumRetries + 1);
+  EXPECT_CALL(*mock_metric, PostCall).Times(kNumRetries + 1);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, SampleRowKeys)
       .Times(kNumRetries + 1)
@@ -1552,7 +2065,7 @@ TEST_F(DataConnectionTest, SampleRowsRetryExhausted) {
   MockFunction<void(grpc::ClientContext&)> mock_setup;
   EXPECT_CALL(mock_setup, Call).Times(kNumRetries + 1);
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(
       CallOptions()
           .set<DataBackoffPolicyOption>(std::move(mock_b))
@@ -1562,9 +2075,26 @@ TEST_F(DataConnectionTest, SampleRowsRetryExhausted) {
 }
 
 TEST_F(DataConnectionTest, SampleRowsPermanentError) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(1);
+  EXPECT_CALL(*mock_metric, PostCall).Times(1);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, SampleRowKeys)
-      .WillOnce([](auto, auto const&, v2::SampleRowKeysRequest const& request) {
+      .WillOnce([this](auto client_context, auto const&,
+                       v2::SampleRowKeysRequest const& request) {
+        metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         auto stream = std::make_unique<MockSampleRowKeysStream>();
@@ -1575,7 +2105,7 @@ TEST_F(DataConnectionTest, SampleRowsPermanentError) {
   MockFunction<void(grpc::ClientContext&)> mock_setup;
   EXPECT_CALL(mock_setup, Call).Times(1);
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(
       CallOptions().set<internal::GrpcSetupOption>(mock_setup.AsStdFunction()));
   auto samples = conn->SampleRows(kTableName);
@@ -1683,6 +2213,21 @@ TEST_F(DataConnectionTest, AsyncSampleRows) {
 }
 
 TEST_F(DataConnectionTest, ReadModifyWriteRowSuccess) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(1);
+  EXPECT_CALL(*mock_metric, PostCall).Times(1);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   v2::ReadModifyWriteRowResponse response;
   auto constexpr kText = R"pb(
     row {
@@ -1712,7 +2257,7 @@ TEST_F(DataConnectionTest, ReadModifyWriteRowSuccess) {
   req.set_table_name(kTableName);
   req.set_row_key("row");
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(CallOptions());
   auto row = conn->ReadModifyWriteRow(req);
   ASSERT_STATUS_OK(row);
@@ -1723,6 +2268,21 @@ TEST_F(DataConnectionTest, ReadModifyWriteRowSuccess) {
 }
 
 TEST_F(DataConnectionTest, ReadModifyWriteRowPermanentError) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(1);
+  EXPECT_CALL(*mock_metric, PostCall).Times(1);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadModifyWriteRow)
       .WillOnce([](grpc::ClientContext&, Options const&,
@@ -1738,13 +2298,28 @@ TEST_F(DataConnectionTest, ReadModifyWriteRowPermanentError) {
   req.set_table_name(kTableName);
   req.set_row_key("row");
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(CallOptions());
   auto row = conn->ReadModifyWriteRow(req);
   EXPECT_THAT(row, StatusIs(StatusCode::kPermissionDenied));
 }
 
 TEST_F(DataConnectionTest, ReadModifyWriteRowTransientErrorNotRetried) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(1);
+  EXPECT_CALL(*mock_metric, PostCall).Times(1);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadModifyWriteRow)
       .WillOnce([](grpc::ClientContext&, Options const&,
@@ -1767,7 +2342,7 @@ TEST_F(DataConnectionTest, ReadModifyWriteRowTransientErrorNotRetried) {
     return clone;
   });
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(
       CallOptions().set<DataBackoffPolicyOption>(std::move(mock_b)));
   auto row = conn->ReadModifyWriteRow(req);
@@ -1775,6 +2350,21 @@ TEST_F(DataConnectionTest, ReadModifyWriteRowTransientErrorNotRetried) {
 }
 
 TEST_F(DataConnectionTest, AsyncReadModifyWriteRowSuccess) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(1);
+  EXPECT_CALL(*mock_metric, PostCall).Times(1);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   v2::ReadModifyWriteRowResponse response;
   auto constexpr kText = R"pb(
     row {
@@ -1791,8 +2381,10 @@ TEST_F(DataConnectionTest, AsyncReadModifyWriteRowSuccess) {
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadModifyWriteRow)
-      .WillOnce([&response](google::cloud::CompletionQueue&, auto, auto,
-                            v2::ReadModifyWriteRowRequest const& request) {
+      .WillOnce([&response, this](
+                    google::cloud::CompletionQueue&, auto client_context, auto,
+                    v2::ReadModifyWriteRowRequest const& request) {
+        metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ("row", request.row_key());
@@ -1804,8 +2396,12 @@ TEST_F(DataConnectionTest, AsyncReadModifyWriteRowSuccess) {
   req.set_table_name(kTableName);
   req.set_row_key("row");
 
-  auto conn = TestConnection(std::move(mock));
-  internal::OptionsSpan span(CallOptions());
+  MockFunction<void(grpc::ClientContext&)> mock_setup;
+  EXPECT_CALL(mock_setup, Call).Times(1);
+
+  auto conn = TestConnection(std::move(mock), std::move(factory));
+  internal::OptionsSpan span(
+      CallOptions().set<internal::GrpcSetupOption>(mock_setup.AsStdFunction()));
   auto row = conn->AsyncReadModifyWriteRow(req).get();
   ASSERT_STATUS_OK(row);
   EXPECT_EQ("row", row->row_key());
@@ -1815,10 +2411,26 @@ TEST_F(DataConnectionTest, AsyncReadModifyWriteRowSuccess) {
 }
 
 TEST_F(DataConnectionTest, AsyncReadModifyWriteRowPermanentError) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(1);
+  EXPECT_CALL(*mock_metric, PostCall).Times(1);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadModifyWriteRow)
-      .WillOnce([](google::cloud::CompletionQueue&, auto, auto,
-                   v2::ReadModifyWriteRowRequest const& request) {
+      .WillOnce([this](google::cloud::CompletionQueue&, auto client_context,
+                       auto, v2::ReadModifyWriteRowRequest const& request) {
+        metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ("row", request.row_key());
@@ -1831,8 +2443,12 @@ TEST_F(DataConnectionTest, AsyncReadModifyWriteRowPermanentError) {
   req.set_table_name(kTableName);
   req.set_row_key("row");
 
-  auto conn = TestConnection(std::move(mock));
-  internal::OptionsSpan span(CallOptions());
+  MockFunction<void(grpc::ClientContext&)> mock_setup;
+  EXPECT_CALL(mock_setup, Call).Times(1);
+
+  auto conn = TestConnection(std::move(mock), std::move(factory));
+  internal::OptionsSpan span(
+      CallOptions().set<internal::GrpcSetupOption>(mock_setup.AsStdFunction()));
   auto row = conn->AsyncReadModifyWriteRow(req).get();
   EXPECT_THAT(row, StatusIs(StatusCode::kPermissionDenied));
 }
@@ -1840,8 +2456,9 @@ TEST_F(DataConnectionTest, AsyncReadModifyWriteRowPermanentError) {
 TEST_F(DataConnectionTest, AsyncReadModifyWriteRowTransientErrorNotRetried) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadModifyWriteRow)
-      .WillOnce([](google::cloud::CompletionQueue&, auto, auto,
-                   v2::ReadModifyWriteRowRequest const& request) {
+      .WillOnce([this](google::cloud::CompletionQueue&, auto client_context,
+                       auto, v2::ReadModifyWriteRowRequest const& request) {
+        metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ("row", request.row_key());
@@ -1861,9 +2478,14 @@ TEST_F(DataConnectionTest, AsyncReadModifyWriteRowTransientErrorNotRetried) {
     return clone;
   });
 
+  MockFunction<void(grpc::ClientContext&)> mock_setup;
+  EXPECT_CALL(mock_setup, Call).Times(1);
+
   auto conn = TestConnection(std::move(mock));
   internal::OptionsSpan span(
-      CallOptions().set<DataBackoffPolicyOption>(std::move(mock_b)));
+      CallOptions()
+          .set<internal::GrpcSetupOption>(mock_setup.AsStdFunction())
+          .set<DataBackoffPolicyOption>(std::move(mock_b)));
   auto row = conn->AsyncReadModifyWriteRow(req).get();
   EXPECT_THAT(row, StatusIs(StatusCode::kUnavailable));
 }
@@ -1927,6 +2549,21 @@ TEST_F(DataConnectionTest, AsyncReadRowsReverseScan) {
 }
 
 TEST_F(DataConnectionTest, AsyncReadRowEmpty) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(1);
+  EXPECT_CALL(*mock_metric, PostCall).Times(1);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadRows)
       .WillOnce([](CompletionQueue const&, auto, auto,
@@ -1950,7 +2587,7 @@ TEST_F(DataConnectionTest, AsyncReadRowEmpty) {
         return stream;
       });
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(CallOptions());
   auto resp = conn->AsyncReadRow(kTableName, "row", TestFilter()).get();
   ASSERT_STATUS_OK(resp);
@@ -1958,6 +2595,21 @@ TEST_F(DataConnectionTest, AsyncReadRowEmpty) {
 }
 
 TEST_F(DataConnectionTest, AsyncReadRowSuccess) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(1);
+  EXPECT_CALL(*mock_metric, PostCall).Times(1);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(1);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadRows)
       .WillOnce([](CompletionQueue const&, auto, auto,
@@ -1992,7 +2644,7 @@ TEST_F(DataConnectionTest, AsyncReadRowSuccess) {
         return stream;
       });
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(CallOptions());
   auto resp = conn->AsyncReadRow(kTableName, "row", TestFilter()).get();
   ASSERT_STATUS_OK(resp);
@@ -2001,6 +2653,21 @@ TEST_F(DataConnectionTest, AsyncReadRowSuccess) {
 }
 
 TEST_F(DataConnectionTest, AsyncReadRowFailure) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(1);
+  EXPECT_CALL(*mock_metric, PostCall).Times(1);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadRows)
       .WillOnce([](CompletionQueue const&, auto, auto,
@@ -2016,7 +2683,7 @@ TEST_F(DataConnectionTest, AsyncReadRowFailure) {
         return std::make_unique<ErrorStream>(PermanentError());
       });
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(CallOptions());
   auto resp = conn->AsyncReadRow(kTableName, "row", TestFilter()).get();
   EXPECT_THAT(resp, StatusIs(StatusCode::kPermissionDenied));

--- a/google/cloud/bigtable/internal/operation_context_factory.h
+++ b/google/cloud/bigtable/internal/operation_context_factory.h
@@ -19,6 +19,7 @@
 #include "google/cloud/bigtable/version.h"
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
 #include "google/cloud/monitoring/v3/metric_connection.h"
+#include "absl/base/call_once.h"
 #include <opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader_factory.h>
 #include <opentelemetry/sdk/metrics/meter_provider_factory.h>
 #endif  // GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
@@ -125,13 +126,17 @@ class MetricsOperationContextFactory : public OperationContextFactory {
 
   // These vectors are initialized exactly once and the initialization is
   // delayed until the first time the corresponding method is called.
-  std::vector<std::shared_ptr<Metric const>> read_row_metrics_;
-  std::vector<std::shared_ptr<Metric const>> read_rows_metrics_;
-  std::vector<std::shared_ptr<Metric const>> mutate_row_metrics_;
-  std::vector<std::shared_ptr<Metric const>> mutate_rows_metrics_;
-  std::vector<std::shared_ptr<Metric const>> check_and_mutate_row_metrics_;
-  std::vector<std::shared_ptr<Metric const>> sample_row_keys_metrics_;
-  std::vector<std::shared_ptr<Metric const>> read_modify_write_row_metrics_;
+  struct MetricHolder {
+    absl::once_flag once;
+    std::vector<std::shared_ptr<Metric const>> metrics;
+  };
+  MetricHolder read_row_metrics_;
+  MetricHolder read_rows_metrics_;
+  MetricHolder mutate_row_metrics_;
+  MetricHolder mutate_rows_metrics_;
+  MetricHolder check_and_mutate_row_metrics_;
+  MetricHolder sample_row_keys_metrics_;
+  MetricHolder read_modify_write_row_metrics_;
 };
 
 #endif  // GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS

--- a/google/cloud/bigtable/internal/operation_context_factory.h
+++ b/google/cloud/bigtable/internal/operation_context_factory.h
@@ -84,7 +84,15 @@ class MetricsOperationContextFactory : public OperationContextFactory {
   MetricsOperationContextFactory(
       std::string client_uid,
       std::shared_ptr<monitoring_v3::MetricServiceConnection> conn,
+      std::shared_ptr<OperationContext::Clock> clock =
+          std::make_shared<OperationContext::Clock>(),
       Options options = {});
+
+  // This constructs an instance only suitable for testing. The provided metric
+  // is copied into every RPC metric vector, preventing normal Metric
+  // initialization and skipping OpenTelemetry provider initialization.
+  MetricsOperationContextFactory(std::string client_uid,
+                                 std::shared_ptr<Metric const> const& metric);
 
   std::shared_ptr<OperationContext> ReadRow(
       std::string const& table_name, std::string const& app_profile) override;
@@ -107,7 +115,12 @@ class MetricsOperationContextFactory : public OperationContextFactory {
       std::string const& table_name, std::string const& app_profile) override;
 
  private:
+  void InitializeProvider(
+      std::shared_ptr<monitoring_v3::MetricServiceConnection> conn,
+      Options options);
+
   std::string client_uid_;
+  std::shared_ptr<OperationContext::Clock> clock_;
   std::shared_ptr<opentelemetry::metrics::MeterProvider> provider_;
 
   // These vectors are initialized exactly once and the initialization is

--- a/google/cloud/bigtable/internal/operation_context_factory_test.cc
+++ b/google/cloud/bigtable/internal/operation_context_factory_test.cc
@@ -1,0 +1,174 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+
+#include "google/cloud/bigtable/internal/operation_context_factory.h"
+#include "google/cloud/bigtable/internal/metrics.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace bigtable_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+using ::testing::Eq;
+using ::testing::IsEmpty;
+
+class MockMetric : public Metric {
+ public:
+  MOCK_METHOD(std::unique_ptr<Metric>, clone, (ResourceLabels, DataLabels),
+              (const, override));
+};
+
+TEST(MetricsOperationContextFactoryTest, ReadRow) {
+  std::string app_profile = "my-app-profile";
+  std::string table_full_name =
+      "projects/my-project/instances/my-instance/tables/my-table";
+
+  auto mock_metric = std::make_shared<MockMetric const>();
+  EXPECT_CALL(*mock_metric, clone)
+      .WillOnce([&](ResourceLabels const& resource_labels,
+                    DataLabels const& data_labels) {
+        EXPECT_THAT(resource_labels.project_id, Eq("my-project"));
+        EXPECT_THAT(resource_labels.instance, Eq("my-instance"));
+        EXPECT_THAT(resource_labels.table, Eq("my-table"));
+        EXPECT_THAT(resource_labels.cluster, IsEmpty());
+        EXPECT_THAT(resource_labels.zone, IsEmpty());
+        EXPECT_THAT(data_labels.method, Eq("ReadRow"));
+        EXPECT_THAT(data_labels.streaming, Eq("true"));
+        EXPECT_THAT(data_labels.client_name,
+                    Eq("cpp.Bigtable/" + version_string()));
+        EXPECT_THAT(data_labels.client_uid, Eq("my-client-uid"));
+        EXPECT_THAT(data_labels.app_profile, Eq(app_profile));
+        EXPECT_THAT(data_labels.status, IsEmpty());
+        return std::make_unique<MockMetric>();
+      });
+
+  MetricsOperationContextFactory factory("my-client-uid", mock_metric);
+  auto operation_context = factory.ReadRow(table_full_name, app_profile);
+}
+
+TEST(MetricsOperationContextFactoryTest, ReadRows) {
+  std::string app_profile = "my-app-profile";
+  std::string table_full_name =
+      "projects/my-project/instances/my-instance/tables/my-table";
+
+  auto mock_metric = std::make_shared<MockMetric const>();
+  EXPECT_CALL(*mock_metric, clone)
+      .WillOnce([&](ResourceLabels const&, DataLabels const& data_labels) {
+        EXPECT_THAT(data_labels.method, Eq("ReadRows"));
+        EXPECT_THAT(data_labels.streaming, Eq("true"));
+        return std::make_unique<MockMetric>();
+      });
+
+  MetricsOperationContextFactory factory({}, mock_metric);
+  auto operation_context = factory.ReadRows(table_full_name, app_profile);
+}
+
+TEST(MetricsOperationContextFactoryTest, MutateRow) {
+  std::string app_profile = "my-app-profile";
+  std::string table_full_name =
+      "projects/my-project/instances/my-instance/tables/my-table";
+
+  auto mock_metric = std::make_shared<MockMetric const>();
+  EXPECT_CALL(*mock_metric, clone)
+      .WillOnce([&](ResourceLabels const&, DataLabels const& data_labels) {
+        EXPECT_THAT(data_labels.method, Eq("MutateRow"));
+        EXPECT_THAT(data_labels.streaming, Eq("false"));
+        return std::make_unique<MockMetric>();
+      });
+
+  MetricsOperationContextFactory factory({}, mock_metric);
+  auto operation_context = factory.MutateRow(table_full_name, app_profile);
+}
+
+TEST(MetricsOperationContextFactoryTest, MutateRows) {
+  std::string app_profile = "my-app-profile";
+  std::string table_full_name =
+      "projects/my-project/instances/my-instance/tables/my-table";
+
+  auto mock_metric = std::make_shared<MockMetric const>();
+  EXPECT_CALL(*mock_metric, clone)
+      .WillOnce([&](ResourceLabels const&, DataLabels const& data_labels) {
+        EXPECT_THAT(data_labels.method, Eq("MutateRows"));
+        EXPECT_THAT(data_labels.streaming, Eq("true"));
+        return std::make_unique<MockMetric>();
+      });
+
+  MetricsOperationContextFactory factory({}, mock_metric);
+  auto operation_context = factory.MutateRows(table_full_name, app_profile);
+}
+
+TEST(MetricsOperationContextFactoryTest, CheckAndMutateRow) {
+  std::string app_profile = "my-app-profile";
+  std::string table_full_name =
+      "projects/my-project/instances/my-instance/tables/my-table";
+
+  auto mock_metric = std::make_shared<MockMetric const>();
+  EXPECT_CALL(*mock_metric, clone)
+      .WillOnce([&](ResourceLabels const&, DataLabels const& data_labels) {
+        EXPECT_THAT(data_labels.method, Eq("CheckAndMutateRow"));
+        EXPECT_THAT(data_labels.streaming, Eq("false"));
+        return std::make_unique<MockMetric>();
+      });
+
+  MetricsOperationContextFactory factory({}, mock_metric);
+  auto operation_context =
+      factory.CheckAndMutateRow(table_full_name, app_profile);
+}
+
+TEST(MetricsOperationContextFactoryTest, SampleRowKeys) {
+  std::string app_profile = "my-app-profile";
+  std::string table_full_name =
+      "projects/my-project/instances/my-instance/tables/my-table";
+
+  auto mock_metric = std::make_shared<MockMetric const>();
+  EXPECT_CALL(*mock_metric, clone)
+      .WillOnce([&](ResourceLabels const&, DataLabels const& data_labels) {
+        EXPECT_THAT(data_labels.method, Eq("SampleRowKeys"));
+        EXPECT_THAT(data_labels.streaming, Eq("true"));
+        return std::make_unique<MockMetric>();
+      });
+
+  MetricsOperationContextFactory factory({}, mock_metric);
+  auto operation_context = factory.SampleRowKeys(table_full_name, app_profile);
+}
+
+TEST(MetricsOperationContextFactoryTest, ReadModifyWriteRow) {
+  std::string app_profile = "my-app-profile";
+  std::string table_full_name =
+      "projects/my-project/instances/my-instance/tables/my-table";
+
+  auto mock_metric = std::make_shared<MockMetric const>();
+  EXPECT_CALL(*mock_metric, clone)
+      .WillOnce([&](ResourceLabels const&, DataLabels const& data_labels) {
+        EXPECT_THAT(data_labels.method, Eq("ReadModifyWriteRow"));
+        EXPECT_THAT(data_labels.streaming, Eq("false"));
+        return std::make_unique<MockMetric>();
+      });
+
+  MetricsOperationContextFactory factory({}, mock_metric);
+  auto operation_context =
+      factory.ReadModifyWriteRow(table_full_name, app_profile);
+}
+
+}  // namespace
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable_internal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS


### PR DESCRIPTION
This PR adds the remaining OperationContext hooks to DataConnectionImpl. 
Updates the OperationContext initialization in DataConnectionImpl to use the OperationContextFactory
Implements the OperationContextFactory methods with placeholder Metrics.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15320)
<!-- Reviewable:end -->
