### PR TITLE
ci: add otel overlay to use STL

### DIFF
--- a/ci/gha/builds/lib/cmake.sh
+++ b/ci/gha/builds/lib/cmake.sh
@@ -58,7 +58,7 @@ function cmake::common_args() {
   if [[ -n "${VCPKG_TRIPLET:-}" ]]; then
     args+=("-DVCPKG_TARGET_TRIPLET=${VCPKG_TRIPLET}")
   fi
-  args+=("-DVCPKG_OVERLAY_PORTS=../vcpkg-overlays")
+  args+=("-DVCPKG_OVERLAY_PORTS=ci/gha/builds/vcpkg-overlays")
   printf "%s\n" "${args[@]}"
 }
 

--- a/ci/gha/builds/lib/cmake.sh
+++ b/ci/gha/builds/lib/cmake.sh
@@ -58,6 +58,7 @@ function cmake::common_args() {
   if [[ -n "${VCPKG_TRIPLET:-}" ]]; then
     args+=("-DVCPKG_TARGET_TRIPLET=${VCPKG_TRIPLET}")
   fi
+  args+=("-DVCPKG_OVERLAY_PORTS=../vcpkg-overlays")
   printf "%s\n" "${args[@]}"
 }
 

--- a/ci/gha/builds/vcpkg-overlays/opentelemetry-cpp/portfile.cmake
+++ b/ci/gha/builds/vcpkg-overlays/opentelemetry-cpp/portfile.cmake
@@ -1,91 +1,125 @@
-if(VCPKG_TARGET_IS_WINDOWS)
+if (VCPKG_TARGET_IS_WINDOWS)
     vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-endif()
+endif ()
 
 vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO open-telemetry/opentelemetry-cpp
-    REF "v${VERSION}"
-    SHA512 c93005c9b24b358a9998141f6c7fd9675778731775dacaad18f0e81117fd00aaabff371c04cf96688a9c86117727181052a141d961d4db28fc457b454351c570
-    HEAD_REF main
+    OUT_SOURCE_PATH
+    SOURCE_PATH
+    REPO
+    open-telemetry/opentelemetry-cpp
+    REF
+    "v${VERSION}"
+    SHA512
+    c93005c9b24b358a9998141f6c7fd9675778731775dacaad18f0e81117fd00aaabff371c04cf96688a9c86117727181052a141d961d4db28fc457b454351c570
+    HEAD_REF
+    main
     PATCHES
-        # Missing find_dependency for Abseil
-        add-missing-find-dependency.patch
-)
+    # Missing find_dependency for Abseil
+    add-missing-find-dependency.patch)
 
-vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS
+    FEATURE_OPTIONS
     FEATURES
-        etw WITH_ETW
-        zipkin WITH_ZIPKIN
-        prometheus WITH_PROMETHEUS
-        elasticsearch WITH_ELASTICSEARCH
-        otlp-http WITH_OTLP_HTTP
-        otlp-grpc WITH_OTLP_GRPC
-        geneva WITH_GENEVA
-        user-events WITH_USER_EVENTS
+    etw
+    WITH_ETW
+    zipkin
+    WITH_ZIPKIN
+    prometheus
+    WITH_PROMETHEUS
+    elasticsearch
+    WITH_ELASTICSEARCH
+    otlp-http
+    WITH_OTLP_HTTP
+    otlp-grpc
+    WITH_OTLP_GRPC
+    geneva
+    WITH_GENEVA
+    user-events
+    WITH_USER_EVENTS
     INVERTED_FEATURES
-        user-events BUILD_TRACEPOINTS
-)
+    user-events
+    BUILD_TRACEPOINTS)
 
-# opentelemetry-proto is a third party submodule and opentelemetry-cpp release did not pack it.
-if(WITH_OTLP_GRPC OR WITH_OTLP_HTTP)
+# opentelemetry-proto is a third party submodule and opentelemetry-cpp release
+# did not pack it.
+if (WITH_OTLP_GRPC OR WITH_OTLP_HTTP)
     set(OTEL_PROTO_VERSION "1.3.1")
-    vcpkg_download_distfile(ARCHIVE
-        URLS "https://github.com/open-telemetry/opentelemetry-proto/archive/v${OTEL_PROTO_VERSION}.tar.gz"
-        FILENAME "opentelemetry-proto-${OTEL_PROTO_VERSION}.tar.gz"
-        SHA512 8c75e4ff79c4b5b251e0ec8ece92ec901d70ec601644505ffdd137fb728daac91fd9203e1f448500124906737d91d80f10b694977688c655418b94f61c828d06
+    vcpkg_download_distfile(
+        ARCHIVE
+        URLS
+        "https://github.com/open-telemetry/opentelemetry-proto/archive/v${OTEL_PROTO_VERSION}.tar.gz"
+        FILENAME
+        "opentelemetry-proto-${OTEL_PROTO_VERSION}.tar.gz"
+        SHA512
+        8c75e4ff79c4b5b251e0ec8ece92ec901d70ec601644505ffdd137fb728daac91fd9203e1f448500124906737d91d80f10b694977688c655418b94f61c828d06
     )
 
     vcpkg_extract_source_archive(src ARCHIVE "${ARCHIVE}")
     file(REMOVE_RECURSE "${SOURCE_PATH}/third_party/opentelemetry-proto")
-    file(COPY "${src}/." DESTINATION "${SOURCE_PATH}/third_party/opentelemetry-proto")
-    # Create empty .git directory to prevent opentelemetry from cloning it during build time
+    file(COPY "${src}/."
+         DESTINATION "${SOURCE_PATH}/third_party/opentelemetry-proto")
+    # Create empty .git directory to prevent opentelemetry from cloning it
+    # during build time
     file(MAKE_DIRECTORY "${SOURCE_PATH}/third_party/opentelemetry-proto/.git")
     list(APPEND FEATURE_OPTIONS -DCMAKE_CXX_STANDARD=14)
-    list(APPEND FEATURE_OPTIONS "-DgRPC_CPP_PLUGIN_EXECUTABLE=${CURRENT_HOST_INSTALLED_DIR}/tools/grpc/grpc_cpp_plugin${VCPKG_HOST_EXECUTABLE_SUFFIX}")
-endif()
+    list(
+        APPEND
+        FEATURE_OPTIONS
+        "-DgRPC_CPP_PLUGIN_EXECUTABLE=${CURRENT_HOST_INSTALLED_DIR}/tools/grpc/grpc_cpp_plugin${VCPKG_HOST_EXECUTABLE_SUFFIX}"
+    )
+endif ()
 
 set(OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS "OFF")
 
-if(WITH_GENEVA OR WITH_USER_EVENTS)
-    # Geneva and user events exporters from opentelemetry-cpp-contrib are tightly coupled with opentelemetry-cpp repo,
-    # so they should be ported as a feature under opentelemetry-cpp.
+if (WITH_GENEVA OR WITH_USER_EVENTS)
+    # Geneva and user events exporters from opentelemetry-cpp-contrib are
+    # tightly coupled with opentelemetry-cpp repo, so they should be ported as a
+    # feature under opentelemetry-cpp.
     clone_opentelemetry_cpp_contrib(CONTRIB_SOURCE_PATH)
 
-    if(WITH_GENEVA)
-        set(OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS "${CONTRIB_SOURCE_PATH}/exporters/geneva")
-        if(VCPKG_TARGET_IS_WINDOWS)
-            set(OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS "${OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS}\;${CONTRIB_SOURCE_PATH}/exporters/geneva-trace")
-        else()
-            set(OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS "${OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS}\;${CONTRIB_SOURCE_PATH}/exporters/fluentd")
-        endif()
-    endif()
+    if (WITH_GENEVA)
+        set(OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS
+            "${CONTRIB_SOURCE_PATH}/exporters/geneva")
+        if (VCPKG_TARGET_IS_WINDOWS)
+            set(OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS
+                "${OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS}\;${CONTRIB_SOURCE_PATH}/exporters/geneva-trace"
+            )
+        else ()
+            set(OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS
+                "${OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS}\;${CONTRIB_SOURCE_PATH}/exporters/fluentd"
+            )
+        endif ()
+    endif ()
 
-    if(WITH_USER_EVENTS)
-        if(WITH_GENEVA)
-            set(OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS "${OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS}\;${CONTRIB_SOURCE_PATH}/exporters/user_events")
-        else()
-            set(OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS "${CONTRIB_SOURCE_PATH}/exporters/user_events")
-        endif()
-    endif()
-endif()
+    if (WITH_USER_EVENTS)
+        if (WITH_GENEVA)
+            set(OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS
+                "${OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS}\;${CONTRIB_SOURCE_PATH}/exporters/user_events"
+            )
+        else ()
+            set(OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS
+                "${CONTRIB_SOURCE_PATH}/exporters/user_events")
+        endif ()
+    endif ()
+endif ()
 
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}"
+    SOURCE_PATH
+    "${SOURCE_PATH}"
     OPTIONS
-        -DBUILD_TESTING=OFF
-        -DWITH_EXAMPLES=OFF
-        -DOPENTELEMETRY_INSTALL=ON
-        -DWITH_STL=CXX14
-        -DWITH_ABSEIL=ON
-        -DWITH_BENCHMARK=OFF
-        -DOPENTELEMETRY_EXTERNAL_COMPONENT_PATH=${OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS}
-        ${FEATURE_OPTIONS}
+    -DBUILD_TESTING=OFF
+    -DWITH_EXAMPLES=OFF
+    -DOPENTELEMETRY_INSTALL=ON
+    -DWITH_STL=CXX14
+    -DWITH_ABSEIL=ON
+    -DWITH_BENCHMARK=OFF
+    -DOPENTELEMETRY_EXTERNAL_COMPONENT_PATH=${OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS}
+    ${FEATURE_OPTIONS}
     MAYBE_UNUSED_VARIABLES
-        WITH_GENEVA
-        WITH_USER_EVENTS
-        BUILD_TRACEPOINTS
-)
+    WITH_GENEVA
+    WITH_USER_EVENTS
+    BUILD_TRACEPOINTS)
 
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")

--- a/ci/gha/builds/vcpkg-overlays/opentelemetry-cpp/portfile.cmake
+++ b/ci/gha/builds/vcpkg-overlays/opentelemetry-cpp/portfile.cmake
@@ -1,0 +1,96 @@
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO open-telemetry/opentelemetry-cpp
+    REF "v${VERSION}"
+    SHA512 c93005c9b24b358a9998141f6c7fd9675778731775dacaad18f0e81117fd00aaabff371c04cf96688a9c86117727181052a141d961d4db28fc457b454351c570
+    HEAD_REF main
+    PATCHES
+        # Missing find_dependency for Abseil
+        add-missing-find-dependency.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        etw WITH_ETW
+        zipkin WITH_ZIPKIN
+        prometheus WITH_PROMETHEUS
+        elasticsearch WITH_ELASTICSEARCH
+        otlp-http WITH_OTLP_HTTP
+        otlp-grpc WITH_OTLP_GRPC
+        geneva WITH_GENEVA
+        user-events WITH_USER_EVENTS
+    INVERTED_FEATURES
+        user-events BUILD_TRACEPOINTS
+)
+
+# opentelemetry-proto is a third party submodule and opentelemetry-cpp release did not pack it.
+if(WITH_OTLP_GRPC OR WITH_OTLP_HTTP)
+    set(OTEL_PROTO_VERSION "1.3.1")
+    vcpkg_download_distfile(ARCHIVE
+        URLS "https://github.com/open-telemetry/opentelemetry-proto/archive/v${OTEL_PROTO_VERSION}.tar.gz"
+        FILENAME "opentelemetry-proto-${OTEL_PROTO_VERSION}.tar.gz"
+        SHA512 8c75e4ff79c4b5b251e0ec8ece92ec901d70ec601644505ffdd137fb728daac91fd9203e1f448500124906737d91d80f10b694977688c655418b94f61c828d06
+    )
+
+    vcpkg_extract_source_archive(src ARCHIVE "${ARCHIVE}")
+    file(REMOVE_RECURSE "${SOURCE_PATH}/third_party/opentelemetry-proto")
+    file(COPY "${src}/." DESTINATION "${SOURCE_PATH}/third_party/opentelemetry-proto")
+    # Create empty .git directory to prevent opentelemetry from cloning it during build time
+    file(MAKE_DIRECTORY "${SOURCE_PATH}/third_party/opentelemetry-proto/.git")
+    list(APPEND FEATURE_OPTIONS -DCMAKE_CXX_STANDARD=14)
+    list(APPEND FEATURE_OPTIONS "-DgRPC_CPP_PLUGIN_EXECUTABLE=${CURRENT_HOST_INSTALLED_DIR}/tools/grpc/grpc_cpp_plugin${VCPKG_HOST_EXECUTABLE_SUFFIX}")
+endif()
+
+set(OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS "OFF")
+
+if(WITH_GENEVA OR WITH_USER_EVENTS)
+    # Geneva and user events exporters from opentelemetry-cpp-contrib are tightly coupled with opentelemetry-cpp repo,
+    # so they should be ported as a feature under opentelemetry-cpp.
+    clone_opentelemetry_cpp_contrib(CONTRIB_SOURCE_PATH)
+
+    if(WITH_GENEVA)
+        set(OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS "${CONTRIB_SOURCE_PATH}/exporters/geneva")
+        if(VCPKG_TARGET_IS_WINDOWS)
+            set(OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS "${OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS}\;${CONTRIB_SOURCE_PATH}/exporters/geneva-trace")
+        else()
+            set(OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS "${OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS}\;${CONTRIB_SOURCE_PATH}/exporters/fluentd")
+        endif()
+    endif()
+
+    if(WITH_USER_EVENTS)
+        if(WITH_GENEVA)
+            set(OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS "${OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS}\;${CONTRIB_SOURCE_PATH}/exporters/user_events")
+        else()
+            set(OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS "${CONTRIB_SOURCE_PATH}/exporters/user_events")
+        endif()
+    endif()
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+        -DWITH_EXAMPLES=OFF
+        -DOPENTELEMETRY_INSTALL=ON
+        -DWITH_STL=CXX14
+        -DWITH_ABSEIL=ON
+        -DWITH_BENCHMARK=OFF
+        -DOPENTELEMETRY_EXTERNAL_COMPONENT_PATH=${OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS}
+        ${FEATURE_OPTIONS}
+    MAYBE_UNUSED_VARIABLES
+        WITH_GENEVA
+        WITH_USER_EVENTS
+        BUILD_TRACEPOINTS
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")


### PR DESCRIPTION
This instructs the GHA builds using vcpkg to build opentelemetry with support for the C++14 STL.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15335)
<!-- Reviewable:end -->
