### PR TITLE
fix: make googletest a regular dependency

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -34,7 +34,7 @@ bazel_dep(name = "rules_proto", version = "7.1.0")
 bazel_dep(name = "rules_python", version = "1.4.1")
 bazel_dep(name = "rules_apple", version = "3.16.0")
 
-bazel_dep(name = "googletest", version = "1.15.2", dev_dependency = True, repo_name = "com_google_googletest")
+bazel_dep(name = "googletest", version = "1.15.2", repo_name = "com_google_googletest")
 bazel_dep(name = "google_benchmark", version = "1.9.2", dev_dependency = True, repo_name = "com_google_benchmark")
 bazel_dep(name = "yaml-cpp", version = "0.8.0", dev_dependency = True, repo_name = "com_github_jbeder_yaml_cpp")
 bazel_dep(name = "pugixml", version = "1.15", dev_dependency = True, repo_name = "com_github_zeux_pugixml")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -33,8 +33,8 @@ bazel_dep(name = "opentelemetry-cpp", version = "1.19.0", repo_name = "io_opente
 bazel_dep(name = "rules_proto", version = "7.1.0")
 bazel_dep(name = "rules_python", version = "1.4.1")
 bazel_dep(name = "rules_apple", version = "3.16.0")
-
 bazel_dep(name = "googletest", version = "1.15.2", repo_name = "com_google_googletest")
+
 bazel_dep(name = "google_benchmark", version = "1.9.2", dev_dependency = True, repo_name = "com_google_benchmark")
 bazel_dep(name = "yaml-cpp", version = "0.8.0", dev_dependency = True, repo_name = "com_github_jbeder_yaml_cpp")
 bazel_dep(name = "pugixml", version = "1.15", dev_dependency = True, repo_name = "com_github_zeux_pugixml")


### PR DESCRIPTION
The googletest dependency was previously marked as a dev_dependency, which prevented it from being propagated to downstream users. This caused build failures for users of our mock libraries, which have a public dependency on googletest (e.g. https://github.com/googleapis/google-cloud-cpp/blob/229f9c24d483e45cb9169843626277604d790a37/google/cloud/storage/BUILD.bazel#L102-L115).

This change removes dev_dependency to make the mock libraries usable for consumers of our Bzlmod module.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15337)
<!-- Reviewable:end -->
