### PR TITLE
feat: remove dev_dependency for googletest module

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -33,8 +33,8 @@ bazel_dep(name = "opentelemetry-cpp", version = "1.19.0", repo_name = "io_opente
 bazel_dep(name = "rules_proto", version = "7.1.0")
 bazel_dep(name = "rules_python", version = "1.4.1")
 bazel_dep(name = "rules_apple", version = "3.16.0")
+bazel_dep(name = "googletest", version = "1.15.2", repo_name = "com_google_googletest")
 
-bazel_dep(name = "googletest", version = "1.15.2", dev_dependency = True, repo_name = "com_google_googletest")
 bazel_dep(name = "google_benchmark", version = "1.9.2", dev_dependency = True, repo_name = "com_google_benchmark")
 bazel_dep(name = "yaml-cpp", version = "0.8.0", dev_dependency = True, repo_name = "com_github_jbeder_yaml_cpp")
 bazel_dep(name = "pugixml", version = "1.15", dev_dependency = True, repo_name = "com_github_zeux_pugixml")


### PR DESCRIPTION
google/cloud/storage:storage_client_testing, which is available publically, depends on googletest.
https://github.com/googleapis/google-cloud-cpp/blob/855ac8994aa69817fc0c5c376162df1858d5f932/google/cloud/storage/BUILD.bazel#L184-L200

When clients take dependency on google/cloud/storage:storage_client_testing, the build fails if dev_dependency is set to True for googletest.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15342)
<!-- Reviewable:end -->
