### PR TITLE
impl(spanner): support multiplexed session transaction priority

### DIFF
--- a/google/cloud/spanner/internal/transaction_impl.cc
+++ b/google/cloud/spanner/internal/transaction_impl.cc
@@ -21,6 +21,45 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 TransactionImpl::~TransactionImpl() = default;
 
+TransactionImpl::TransactionImpl(
+    google::spanner::v1::TransactionSelector selector, bool route_to_leader,
+    std::string tag)
+    : TransactionImpl(/*session=*/{}, std::move(selector), route_to_leader,
+                      std::move(tag), absl::nullopt) {}
+
+TransactionImpl::TransactionImpl(
+    TransactionImpl const& impl,
+    google::spanner::v1::TransactionSelector selector, bool route_to_leader,
+    std::string tag)
+    : TransactionImpl(impl.session_, std::move(selector), route_to_leader,
+                      std::move(tag),
+                      (impl.session_ && impl.session_->is_multiplexed() &&
+                       impl.selector_->has_id())
+                          ? absl::optional<std::string>(impl.selector_->id())
+                          : absl::nullopt) {}
+
+TransactionImpl::TransactionImpl(
+    SessionHolder session, google::spanner::v1::TransactionSelector selector,
+    bool route_to_leader, std::string tag,
+    absl::optional<std::string> multiplexed_session_previous_transaction_id)
+    : session_(std::move(session)),
+      selector_(std::move(selector)),
+      route_to_leader_(route_to_leader),
+      tag_(std::move(tag)),
+      seqno_(0) {
+  state_ = selector_->has_begin() ? State::kBegin : State::kDone;
+  // If we're attempting to retry an aborted ReadWrite transaction on a
+  // multiplexed session, then propagate the aborted transaction id.
+  if (session_ && session_->is_multiplexed() && selector_.ok() &&
+      selector_->has_begin() && selector_->begin().has_read_write() &&
+      multiplexed_session_previous_transaction_id.has_value()) {
+    selector_->mutable_begin()
+        ->mutable_read_write()
+        ->set_multiplexed_session_previous_transaction_id(
+            *multiplexed_session_previous_transaction_id);
+  }
+}
+
 void TransactionImpl::UpdatePrecommitToken(
     std::unique_lock<std::mutex> const&,
     absl::optional<google::spanner::v1::MultiplexedSessionPrecommitToken>

--- a/google/cloud/spanner/internal/transaction_impl.h
+++ b/google/cloud/spanner/internal/transaction_impl.h
@@ -52,26 +52,16 @@ using VisitInvokeResult = ::google::cloud::internal::invoke_result_t<
 class TransactionImpl {
  public:
   TransactionImpl(google::spanner::v1::TransactionSelector selector,
-                  bool route_to_leader, std::string tag)
-      : TransactionImpl(/*session=*/{}, std::move(selector), route_to_leader,
-                        std::move(tag)) {}
+                  bool route_to_leader, std::string tag);
 
   TransactionImpl(TransactionImpl const& impl,
                   google::spanner::v1::TransactionSelector selector,
-                  bool route_to_leader, std::string tag)
-      : TransactionImpl(impl.session_, std::move(selector), route_to_leader,
-                        std::move(tag)) {}
+                  bool route_to_leader, std::string tag);
 
-  TransactionImpl(SessionHolder session,
-                  google::spanner::v1::TransactionSelector selector,
-                  bool route_to_leader, std::string tag)
-      : session_(std::move(session)),
-        selector_(std::move(selector)),
-        route_to_leader_(route_to_leader),
-        tag_(std::move(tag)),
-        seqno_(0) {
-    state_ = selector_->has_begin() ? State::kBegin : State::kDone;
-  }
+  TransactionImpl(
+      SessionHolder session, google::spanner::v1::TransactionSelector selector,
+      bool route_to_leader, std::string tag,
+      absl::optional<std::string> multiplexed_session_previous_transaction_id);
 
   ~TransactionImpl();
 
@@ -148,6 +138,13 @@ class TransactionImpl {
       throw;
     }
 #endif
+  }
+
+  absl::optional<std::string> id() const {
+    if (selector_.ok() && selector_->has_id()) {
+      return selector_->id();
+    }
+    return absl::nullopt;
   }
 
  private:

--- a/google/cloud/spanner/internal/transaction_impl.h
+++ b/google/cloud/spanner/internal/transaction_impl.h
@@ -140,13 +140,6 @@ class TransactionImpl {
 #endif
   }
 
-  absl::optional<std::string> id() const {
-    if (selector_.ok() && selector_->has_id()) {
-      return selector_->id();
-    }
-    return absl::nullopt;
-  }
-
  private:
   void UpdatePrecommitToken(
       std::unique_lock<std::mutex> const&,

--- a/google/cloud/spanner/transaction.cc
+++ b/google/cloud/spanner/transaction.cc
@@ -144,7 +144,8 @@ Transaction::Transaction(std::string session_id, std::string transaction_id,
   selector.set_id(std::move(transaction_id));
   impl_ = std::make_shared<spanner_internal::TransactionImpl>(
       spanner_internal::MakeDissociatedSessionHolder(std::move(session_id)),
-      std::move(selector), route_to_leader, std::move(transaction_tag));
+      std::move(selector), route_to_leader, std::move(transaction_tag),
+      absl::nullopt);
 }
 
 Transaction::~Transaction() = default;


### PR DESCRIPTION
When retrying an aborted read-write transaction on multiplexed sessions, the aborted transaction id needs to be included when creating the new transaction.

fixes #15222

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15361)
<!-- Reviewable:end -->
