### PR TITLE
feat(storage): Add samples for AppendableObject and OpenObject

### DIFF
--- a/google/cloud/storage/examples/storage_async_samples.cc
+++ b/google/cloud/storage/examples/storage_async_samples.cc
@@ -200,7 +200,7 @@ void OpenObjectSingleRangedRead(google::cloud::storage_experimental::AsyncClient
 
 void OpenObjectMultipleRangedRead(google::cloud::storage_experimental::AsyncClient& client,
                 std::vector<std::string> const& argv) {
-  //! [open-object-mulitple-ranged-read]
+  //! [open-object-multiple-ranged-read]
   namespace gcs_ex = google::cloud::storage_experimental;
   // Helper coroutine, count lines returned by a AsyncReader
   auto count_newlines =
@@ -233,7 +233,7 @@ void OpenObjectMultipleRangedRead(google::cloud::storage_experimental::AsyncClie
     auto c2 = count_newlines(std::move(r2), std::move(t2));
     co_return (co_await std::move(c1)) + (co_await std::move(c2));
   };
-  //! [open-object-mulitple-ranged-read]
+  //! [open-object-multiple-ranged-read]
   // The example is easier to test and run if we call the coroutine and block
   // until it completes.
   auto const count = coro(client, argv.at(0), argv.at(1)).get();

--- a/google/cloud/storage/examples/storage_async_samples.cc
+++ b/google/cloud/storage/examples/storage_async_samples.cc
@@ -156,9 +156,51 @@ void InsertObjectVectorVectors(
 }
 
 #if GOOGLE_CLOUD_CPP_HAVE_COROUTINES
-void OpenObject(google::cloud::storage_experimental::AsyncClient& client,
+void OpenObjectSingleRangedRead(google::cloud::storage_experimental::AsyncClient& client,
                 std::vector<std::string> const& argv) {
-  //! [open-object]
+  //! [open-object-single-ranged-read]
+  namespace gcs_ex = google::cloud::storage_experimental;
+
+  // Helper coroutine to count newlines returned by an AsyncReader.
+  // This helps consume the data from the read operation.
+  auto count_newlines =
+      [](gcs_ex::AsyncReader reader,
+         gcs_ex::AsyncToken token) -> google::cloud::future<std::uint64_t> {
+    std::uint64_t count = 0;
+    while (token.valid()) {
+      auto [payload, t] = (co_await reader.Read(std::move(token))).value();
+      token = std::move(t);
+      for (auto const& buffer : payload.contents()) {
+        count += std::count(buffer.begin(), buffer.end(), '\n');
+      }
+    }
+    co_return count;
+  };
+
+  auto coro =
+      [&count_newlines](
+          gcs_ex::AsyncClient& client, std::string bucket_name,
+          std::string object_name) -> google::cloud::future<std::uint64_t> {
+    auto descriptor =
+        (co_await client.Open(gcs_ex::BucketName(std::move(bucket_name)),
+                              std::move(object_name)))
+            .value();
+
+    auto [reader, token] = descriptor.Read(0, 1024);
+
+    co_return co_await count_newlines(std::move(reader), std::move(token));
+  };
+  //! [open-object-single-ranged-read]
+
+  // The example is easier to test if we call the coroutine and block
+  // until it completes.
+  auto const count = coro(client, argv.at(0), argv.at(1)).get();
+  std::cout << "The range contains " << count << " newlines\n";
+}
+
+void OpenObjectMultipleRangedRead(google::cloud::storage_experimental::AsyncClient& client,
+                std::vector<std::string> const& argv) {
+  //! [open-object-mulitple-ranged-read]
   namespace gcs_ex = google::cloud::storage_experimental;
   // Helper coroutine, count lines returned by a AsyncReader
   auto count_newlines =
@@ -191,11 +233,53 @@ void OpenObject(google::cloud::storage_experimental::AsyncClient& client,
     auto c2 = count_newlines(std::move(r2), std::move(t2));
     co_return (co_await std::move(c1)) + (co_await std::move(c2));
   };
-  //! [open-object]
+  //! [open-object-mulitple-ranged-read]
   // The example is easier to test and run if we call the coroutine and block
   // until it completes.
   auto const count = coro(client, argv.at(0), argv.at(1)).get();
   std::cout << "The ranges contain " << count << " newlines\n";
+}
+
+void OpenObjectReadFullObject(google::cloud::storage_experimental::AsyncClient& client,
+                std::vector<std::string> const& argv) {
+  //! [open-object-read-full-object]
+  namespace gcs_ex = google::cloud::storage_experimental;
+
+  // Helper coroutine to count newlines returned by an AsyncReader.
+  // This helps consume the data from the read operation.
+  auto count_newlines =
+      [](gcs_ex::AsyncReader reader,
+         gcs_ex::AsyncToken token) -> google::cloud::future<std::uint64_t> {
+    std::uint64_t count = 0;
+    while (token.valid()) {
+      auto [payload, t] = (co_await reader.Read(std::move(token))).value();
+      token = std::move(t);
+      for (auto const& buffer : payload.contents()) {
+        count += std::count(buffer.begin(), buffer.end(), '\n');
+      }
+    }
+    co_return count;
+  };
+
+  auto coro =
+      [&count_newlines](
+          gcs_ex::AsyncClient& client, std::string bucket_name,
+          std::string object_name) -> google::cloud::future<std::uint64_t> {
+    auto descriptor =
+        (co_await client.Open(gcs_ex::BucketName(std::move(bucket_name)),
+                              std::move(object_name)))
+            .value();
+
+    auto [reader, token] = descriptor.ReadFromOffset(0);
+
+    co_return co_await count_newlines(std::move(reader), std::move(token));
+  };
+  //! [open-object-read-full-object]
+
+  // The example is easier to test if we call the coroutine and block
+  // until it completes.
+  auto const count = coro(client, argv.at(0), argv.at(1)).get();
+  std::cout << "The range contains " << count << " newlines\n";
 }
 
 void ReadObject(google::cloud::storage_experimental::AsyncClient& client,
@@ -564,6 +648,71 @@ void StartAppendableObjectUpload(
   std::cout << "File successfully uploaded " << object.DebugString() << "\n";
 }
 
+void ResumeAppendableObjectUpload(
+    google::cloud::storage_experimental::AsyncClient& client,
+    std::vector<std::string> const& argv) {
+  //! [resume-appendable-object-upload]
+  namespace gcs = google::cloud::storage;
+  namespace gcs_ex = google::cloud::storage_experimental;
+  auto coro = [](gcs_ex::AsyncClient& client, std::string bucket_name,
+                 std::string object_name)
+      -> google::cloud::future<google::storage::v2::Object> {
+    // Start an appendable upload and write some data.
+    auto [writer, token] =
+        (co_await client.StartAppendableObjectUpload(
+             gcs_ex::BucketName(bucket_name), object_name))
+            .value();
+    for (int i = 0; i != 5; ++i) {
+      auto line = gcs_ex::WritePayload(std::vector<std::string>{
+          std::string("line number "), std::to_string(i), std::string("\n")});
+      token =
+          (co_await writer.Write(std::move(token), std::move(line))).value();
+    }
+    // The writer is closed, but the upload is not finalized. The object remains
+    // appendable.
+    auto close_status = co_await writer.Close();
+    if (!close_status.ok()) {
+      throw std::runtime_error(close_status.message());
+    }
+
+    // To resume the upload we need the object's generation. We can use the
+    // regular GCS client to get the latest metadata.
+    auto regular_client = gcs::Client();
+    auto metadata =
+        regular_client.GetObjectMetadata(bucket_name, object_name).value();
+
+    // Now resume the upload from the beginning.
+    std::tie(writer, token) =
+        (co_await client.ResumeAppendableObjectUpload(
+             gcs_ex::BucketName(bucket_name), object_name,
+             metadata.generation()))
+            .value();
+
+    // The writer returns the persisted size, which can be used to understand
+    // where to resume from.
+    auto persisted_size = absl::get<std::int64_t>(writer.PersistedState());
+    std::cout << "Upload resumed at offset " << persisted_size << "\n";
+
+    // Append the rest of the data.
+    for (int i = 5; i != 10; ++i) {
+      auto line = gcs_ex::WritePayload(std::vector<std::string>{
+          std::string("line number "), std::to_string(i), std::string("\n")});
+      token =
+          (co_await writer.Write(std::move(token), std::move(line))).value();
+    }
+
+    // Finalize the upload and return the object metadata.
+    co_return (co_await writer.Finalize(std::move(token))).value();
+  };
+  //! [resume-appendable-object-upload]
+
+  // The example is easier to test and run if we call the coroutine and block
+  // until it completes.
+  auto const object = coro(client, argv.at(0), argv.at(1)).get();
+  std::cout << "File successfully uploaded and finalized "
+            << object.DebugString() << "\n";
+}
+
 void RewriteObject(google::cloud::storage_experimental::AsyncClient& client,
                    std::vector<std::string> const& argv) {
   //! [rewrite-object]
@@ -653,7 +802,17 @@ void ResumeRewrite(google::cloud::storage_experimental::AsyncClient& client,
 }
 
 #else
-void OpenObject(google::cloud::storage_experimental::AsyncClient&,
+void OpenObjectSingleRangedRead(google::cloud::storage_experimental::AsyncClient&,
+                std::vector<std::string> const&) {
+  std::cerr << "AsyncClient::Open() example requires coroutines\n";
+}
+
+void OpenObjectMultipleRangedRead(google::cloud::storage_experimental::AsyncClient&,
+                std::vector<std::string> const&) {
+  std::cerr << "AsyncClient::Open() example requires coroutines\n";
+}
+
+void OpenObjectReadFullObject(google::cloud::storage_experimental::AsyncClient&,
                 std::vector<std::string> const&) {
   std::cerr << "AsyncClient::Open() example requires coroutines\n";
 }
@@ -723,6 +882,13 @@ void StartAppendableObjectUpload(
     google::cloud::storage_experimental::AsyncClient&,
     std::vector<std::string> const&) {
   std::cerr << "AsyncClient::StartAppendableObjectUpload() example requires "
+               "coroutines\n";
+}
+
+void ResumeAppendableObjectUpload(
+    google::cloud::storage_experimental::AsyncClient&,
+    std::vector<std::string> const&) {
+  std::cerr << "AsyncClient::ResumeAppendableObjectUpload() example requires "
                "coroutines\n";
 }
 
@@ -901,8 +1067,14 @@ void AutoRun(std::vector<std::string> const& argv) {
   scheduled_for_delete.push_back(std::move(object_name));
   object_name = examples::MakeRandomObjectName(generator, "object-");
 
-  std::cout << "Running the OpenObject() example" << std::endl;
-  OpenObject(client, {bucket_name, composed_name});
+  std::cout << "Running the OpenObjectSingleRangedRead() example" << std::endl;
+  OpenObjectSingleRangedRead(client, {bucket_name, composed_name});
+
+  std::cout << "Running the OpenObjectMultipleRangedRead() example" << std::endl;
+  OpenObjectMultipleRangedRead(client, {bucket_name, composed_name});
+
+  std::cout << "Running the OpenObjectReadFullObject() example" << std::endl;
+  OpenObjectReadFullObject(client, {bucket_name, composed_name});
 
   std::cout << "Running the ReadObject() example" << std::endl;
   ReadObject(client, {bucket_name, composed_name});
@@ -1064,7 +1236,9 @@ int main(int argc, char* argv[]) try {
       make_entry("insert-object-vector", {}, InsertObjectVector),
       make_entry("insert-object-vector-strings", {}, InsertObjectVectorStrings),
       make_entry("insert-object-vector-vectors", {}, InsertObjectVectorVectors),
-      make_entry("open-object", {}, OpenObject),
+      make_entry("open-object-single-ranged-read", {}, OpenObjectSingleRangedRead),
+      make_entry("open-object-multiple-ranged-read", {}, OpenObjectMultipleRangedRead),
+      make_entry("open-object-read-full-object", {}, OpenObjectReadFullObject),
       make_entry("read-object", {}, ReadObject),
       make_entry("read-all", {}, ReadAll),
       make_entry("read-object-range", {}, ReadObjectRange),
@@ -1086,6 +1260,8 @@ int main(int argc, char* argv[]) try {
 
       make_entry("start-appendable-object-upload", {},
                  StartAppendableObjectUpload),
+      make_entry("resume-appendable-object-upload", {},
+                 ResumeAppendableObjectUpload),
 
       make_entry("rewrite-object", {"<destination>"}, RewriteObject),
       make_entry("resume-rewrite-object", {"<destination>"}, ResumeRewrite),

--- a/google/cloud/storage/examples/storage_async_samples.cc
+++ b/google/cloud/storage/examples/storage_async_samples.cc
@@ -156,8 +156,9 @@ void InsertObjectVectorVectors(
 }
 
 #if GOOGLE_CLOUD_CPP_HAVE_COROUTINES
-void OpenObjectSingleRangedRead(google::cloud::storage_experimental::AsyncClient& client,
-                std::vector<std::string> const& argv) {
+void OpenObjectSingleRangedRead(
+    google::cloud::storage_experimental::AsyncClient& client,
+    std::vector<std::string> const& argv) {
   //! [open-object-single-ranged-read]
   namespace gcs_ex = google::cloud::storage_experimental;
 
@@ -198,8 +199,9 @@ void OpenObjectSingleRangedRead(google::cloud::storage_experimental::AsyncClient
   std::cout << "The range contains " << count << " newlines\n";
 }
 
-void OpenObjectMultipleRangedRead(google::cloud::storage_experimental::AsyncClient& client,
-                std::vector<std::string> const& argv) {
+void OpenObjectMultipleRangedRead(
+    google::cloud::storage_experimental::AsyncClient& client,
+    std::vector<std::string> const& argv) {
   //! [open-object-multiple-ranged-read]
   namespace gcs_ex = google::cloud::storage_experimental;
   // Helper coroutine, count lines returned by a AsyncReader
@@ -240,8 +242,9 @@ void OpenObjectMultipleRangedRead(google::cloud::storage_experimental::AsyncClie
   std::cout << "The ranges contain " << count << " newlines\n";
 }
 
-void OpenObjectReadFullObject(google::cloud::storage_experimental::AsyncClient& client,
-                std::vector<std::string> const& argv) {
+void OpenObjectReadFullObject(
+    google::cloud::storage_experimental::AsyncClient& client,
+    std::vector<std::string> const& argv) {
   //! [open-object-read-full-object]
   namespace gcs_ex = google::cloud::storage_experimental;
 
@@ -658,10 +661,9 @@ void ResumeAppendableObjectUpload(
                  std::string object_name)
       -> google::cloud::future<google::storage::v2::Object> {
     // Start an appendable upload and write some data.
-    auto [writer, token] =
-        (co_await client.StartAppendableObjectUpload(
-             gcs_ex::BucketName(bucket_name), object_name))
-            .value();
+    auto [writer, token] = (co_await client.StartAppendableObjectUpload(
+                                gcs_ex::BucketName(bucket_name), object_name))
+                               .value();
     for (int i = 0; i != 5; ++i) {
       auto line = gcs_ex::WritePayload(std::vector<std::string>{
           std::string("line number "), std::to_string(i), std::string("\n")});
@@ -682,11 +684,10 @@ void ResumeAppendableObjectUpload(
         regular_client.GetObjectMetadata(bucket_name, object_name).value();
 
     // Now resume the upload from the beginning.
-    std::tie(writer, token) =
-        (co_await client.ResumeAppendableObjectUpload(
-             gcs_ex::BucketName(bucket_name), object_name,
-             metadata.generation()))
-            .value();
+    std::tie(writer, token) = (co_await client.ResumeAppendableObjectUpload(
+                                   gcs_ex::BucketName(bucket_name), object_name,
+                                   metadata.generation()))
+                                  .value();
 
     // The writer returns the persisted size, which can be used to understand
     // where to resume from.
@@ -802,18 +803,20 @@ void ResumeRewrite(google::cloud::storage_experimental::AsyncClient& client,
 }
 
 #else
-void OpenObjectSingleRangedRead(google::cloud::storage_experimental::AsyncClient&,
-                std::vector<std::string> const&) {
+void OpenObjectSingleRangedRead(
+    google::cloud::storage_experimental::AsyncClient&,
+    std::vector<std::string> const&) {
   std::cerr << "AsyncClient::Open() example requires coroutines\n";
 }
 
-void OpenObjectMultipleRangedRead(google::cloud::storage_experimental::AsyncClient&,
-                std::vector<std::string> const&) {
+void OpenObjectMultipleRangedRead(
+    google::cloud::storage_experimental::AsyncClient&,
+    std::vector<std::string> const&) {
   std::cerr << "AsyncClient::Open() example requires coroutines\n";
 }
 
 void OpenObjectReadFullObject(google::cloud::storage_experimental::AsyncClient&,
-                std::vector<std::string> const&) {
+                              std::vector<std::string> const&) {
   std::cerr << "AsyncClient::Open() example requires coroutines\n";
 }
 
@@ -1070,7 +1073,8 @@ void AutoRun(std::vector<std::string> const& argv) {
   std::cout << "Running the OpenObjectSingleRangedRead() example" << std::endl;
   OpenObjectSingleRangedRead(client, {bucket_name, composed_name});
 
-  std::cout << "Running the OpenObjectMultipleRangedRead() example" << std::endl;
+  std::cout << "Running the OpenObjectMultipleRangedRead() example"
+            << std::endl;
   OpenObjectMultipleRangedRead(client, {bucket_name, composed_name});
 
   std::cout << "Running the OpenObjectReadFullObject() example" << std::endl;
@@ -1236,8 +1240,10 @@ int main(int argc, char* argv[]) try {
       make_entry("insert-object-vector", {}, InsertObjectVector),
       make_entry("insert-object-vector-strings", {}, InsertObjectVectorStrings),
       make_entry("insert-object-vector-vectors", {}, InsertObjectVectorVectors),
-      make_entry("open-object-single-ranged-read", {}, OpenObjectSingleRangedRead),
-      make_entry("open-object-multiple-ranged-read", {}, OpenObjectMultipleRangedRead),
+      make_entry("open-object-single-ranged-read", {},
+                 OpenObjectSingleRangedRead),
+      make_entry("open-object-multiple-ranged-read", {},
+                 OpenObjectMultipleRangedRead),
       make_entry("open-object-read-full-object", {}, OpenObjectReadFullObject),
       make_entry("read-object", {}, ReadObject),
       make_entry("read-all", {}, ReadAll),


### PR DESCRIPTION
Added samples for the following operations, also added screenshot for all the sample working:

Creating appendable object (It was already there)
<img width="1248" height="345" alt="Screenshot 2025-08-11 at 2 15 57 PM" src="https://github.com/user-attachments/assets/0afd6fb2-ac37-41a7-ade4-227361eaa030" />

Resume appendable object
<img width="1270" height="359" alt="Screenshot 2025-08-11 at 2 16 32 PM" src="https://github.com/user-attachments/assets/3dd238c3-7579-4083-94cb-dcddd5c9822a" />

Performing single ranged read
<img width="1212" height="32" alt="Screenshot 2025-08-11 at 2 17 16 PM" src="https://github.com/user-attachments/assets/b554e1f9-62ca-4a16-86df-cd8c965f30ad" />

Reading multiple ranges (It was already there, just renamed it, this screenshot reads two ranges the first one is succeeded but the second one is expectedly giving OUT OF RANGE error)
<img width="1327" height="39" alt="Screenshot 2025-08-11 at 2 17 41 PM" src="https://github.com/user-attachments/assets/15792952-9dbc-499e-8495-0d81fdb621a8" />

Reading entire object
<img width="1226" height="27" alt="Screenshot 2025-08-11 at 2 18 13 PM" src="https://github.com/user-attachments/assets/cbfc9c61-481b-49a4-9029-f76367c6e733" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15365)
<!-- Reviewable:end -->
