### PR TITLE
refactor(spanner): do not expose PrecommitToken in public interface

### DIFF
--- a/google/cloud/spanner/connection.cc
+++ b/google/cloud/spanner/connection.cc
@@ -35,10 +35,6 @@ class StatusOnlyResultSetSource : public ResultSourceInterface {
   absl::optional<google::spanner::v1::ResultSetStats> Stats() const override {
     return {};
   }
-  absl::optional<google::spanner::v1::MultiplexedSessionPrecommitToken>
-  PrecommitToken() const override {
-    return absl::nullopt;
-  }
 
  private:
   Status status_;

--- a/google/cloud/spanner/internal/connection_impl.h
+++ b/google/cloud/spanner/internal/connection_impl.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/spanner/connection.h"
 #include "google/cloud/spanner/database.h"
+#include "google/cloud/spanner/internal/partial_result_set_source.h"
 #include "google/cloud/spanner/internal/session.h"
 #include "google/cloud/spanner/internal/session_pool.h"
 #include "google/cloud/spanner/internal/spanner_stub.h"
@@ -152,7 +153,7 @@ class ConnectionImpl : public spanner::Connection {
       StatusOr<google::spanner::v1::TransactionSelector>& selector,
       TransactionContext& ctx, SqlParams params,
       google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode,
-      std::function<StatusOr<std::unique_ptr<spanner::ResultSourceInterface>>(
+      std::function<StatusOr<std::unique_ptr<PartialResultSourceInterface>>(
           google::spanner::v1::ExecuteSqlRequest& request)> const&
           retry_resume_fn);
 

--- a/google/cloud/spanner/internal/partial_result_set_resume_test.cc
+++ b/google/cloud/spanner/internal/partial_result_set_resume_test.cc
@@ -68,7 +68,7 @@ std::unique_ptr<PartialResultSetReader> MakeTestResume(
           .clone());
 }
 
-StatusOr<std::unique_ptr<spanner::ResultSourceInterface>>
+StatusOr<std::unique_ptr<PartialResultSourceInterface>>
 CreatePartialResultSetSource(std::unique_ptr<PartialResultSetReader> reader,
                              Options opts = {}) {
   internal::OptionsSpan span(

--- a/google/cloud/spanner/internal/partial_result_set_source.cc
+++ b/google/cloud/spanner/internal/partial_result_set_source.cc
@@ -56,7 +56,7 @@ void ExtractSubrangeAndAppend(Values& src, int start, Values& dst) {
 
 }  // namespace
 
-StatusOr<std::unique_ptr<spanner::ResultSourceInterface>>
+StatusOr<std::unique_ptr<PartialResultSourceInterface>>
 PartialResultSetSource::Create(std::unique_ptr<PartialResultSetReader> reader) {
   std::unique_ptr<PartialResultSetSource> source(
       new PartialResultSetSource(std::move(reader)));

--- a/google/cloud/spanner/internal/partial_result_set_source.h
+++ b/google/cloud/spanner/internal/partial_result_set_source.h
@@ -37,15 +37,32 @@ namespace cloud {
 namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+class PrecommitInterface {
+ public:
+  /**
+   * A precommit token is included if the read-write transaction is on
+   * a multiplexed session. The precommit token with the highest sequence
+   * number from this transaction attempt is added to the Commit request for
+   * this transaction by the library.
+   */
+  virtual absl::optional<google::spanner::v1::MultiplexedSessionPrecommitToken>
+  PrecommitToken() const {
+    return absl::nullopt;
+  }
+};
+
+class PartialResultSourceInterface : public spanner::ResultSourceInterface,
+                                     public PrecommitInterface {};
+
 /**
  * This class serves as a bridge between the gRPC `PartialResultSet` streaming
  * reader and the spanner `ResultSet`, and is used to iterate over the rows
  * returned from a read operation.
  */
-class PartialResultSetSource : public spanner::ResultSourceInterface {
+class PartialResultSetSource : public PartialResultSourceInterface {
  public:
   /// Factory method to create a PartialResultSetSource.
-  static StatusOr<std::unique_ptr<spanner::ResultSourceInterface>> Create(
+  static StatusOr<std::unique_ptr<PartialResultSourceInterface>> Create(
       std::unique_ptr<PartialResultSetReader> reader);
 
   ~PartialResultSetSource() override;

--- a/google/cloud/spanner/internal/partial_result_set_source_test.cc
+++ b/google/cloud/spanner/internal/partial_result_set_source_test.cc
@@ -52,7 +52,7 @@ struct StringOption {
 // Create the `PartialResultSetSource` within an `OptionsSpan` that has its
 // `StringOption` set to the current test name, so that we might check that
 // all `PartialResultSetReader` calls happen within a matching span.
-StatusOr<std::unique_ptr<spanner::ResultSourceInterface>>
+StatusOr<std::unique_ptr<PartialResultSourceInterface>>
 CreatePartialResultSetSource(std::unique_ptr<PartialResultSetReader> reader,
                              Options opts = {}) {
   internal::OptionsSpan span(internal::MergeOptions(

--- a/google/cloud/spanner/results.h
+++ b/google/cloud/spanner/results.h
@@ -70,17 +70,6 @@ class ResultSourceInterface {
    *     for more information.
    */
   virtual absl::optional<google::spanner::v1::ResultSetStats> Stats() const = 0;
-
-  /**
-   * A precommit token is included if the read-write transaction is on
-   * a multiplexed session. The precommit token with the highest sequence
-   * number from this transaction attempt is added to the Commit request for
-   * this transaction by the library.
-   */
-  virtual absl::optional<google::spanner::v1::MultiplexedSessionPrecommitToken>
-  PrecommitToken() const {
-    return absl::nullopt;
-  }
 };
 
 /**


### PR DESCRIPTION
The PrecommitToken method is only needed internally, so let's not add it to the public API.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15368)
<!-- Reviewable:end -->
