### PR TITLE
refactor(spanner): remove unnecessary interface class

### DIFF
--- a/google/cloud/spanner/internal/partial_result_set_source.h
+++ b/google/cloud/spanner/internal/partial_result_set_source.h
@@ -37,7 +37,7 @@ namespace cloud {
 namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-class PrecommitInterface {
+class PartialResultSourceInterface : public spanner::ResultSourceInterface {
  public:
   /**
    * A precommit token is included if the read-write transaction is on
@@ -50,9 +50,6 @@ class PrecommitInterface {
     return absl::nullopt;
   }
 };
-
-class PartialResultSourceInterface : public spanner::ResultSourceInterface,
-                                     public PrecommitInterface {};
 
 /**
  * This class serves as a bridge between the gRPC `PartialResultSet` streaming


### PR DESCRIPTION
I originally thought having a separate Interface class for the PrecommitToken would be useful. It isn't.