### PR TITLE
impl(bigtable): implement application blocking latencies metrics

### DIFF
--- a/google/cloud/bigtable/internal/metrics.h
+++ b/google/cloud/bigtable/internal/metrics.h
@@ -235,6 +235,8 @@ class ApplicationBlockingLatency : public Metric {
                        ElementDeliveryParams const&) override;
   void ElementRequest(opentelemetry::context::Context const&,
                       ElementRequestParams const&) override;
+  void OnDone(opentelemetry::context::Context const& context,
+              OnDoneParams const&) override;
 
   std::unique_ptr<Metric> clone(ResourceLabels resource_labels,
                                 DataLabels data_labels) const override;
@@ -245,7 +247,7 @@ class ApplicationBlockingLatency : public Metric {
   opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Histogram<double>>
       application_blocking_latencies_;
   OperationContext::Clock::time_point element_delivery_time_;
-  absl::optional<LatencyDuration> application_blocking_latency_;
+  std::vector<LatencyDuration> pending_latencies_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/internal/metrics.h
+++ b/google/cloud/bigtable/internal/metrics.h
@@ -222,6 +222,32 @@ class ServerLatency : public Metric {
       server_latencies_;
 };
 
+class ApplicationBlockingLatency : public Metric {
+ public:
+  ApplicationBlockingLatency(
+      std::string const& instrumentation_scope,
+      opentelemetry::nostd::shared_ptr<
+          opentelemetry::metrics::MeterProvider> const& provider);
+  void PostCall(opentelemetry::context::Context const& context,
+                grpc::ClientContext const& client_context,
+                PostCallParams const& p) override;
+  void ElementDelivery(opentelemetry::context::Context const&,
+                       ElementDeliveryParams const&) override;
+  void ElementRequest(opentelemetry::context::Context const&,
+                      ElementRequestParams const&) override;
+
+  std::unique_ptr<Metric> clone(ResourceLabels resource_labels,
+                                DataLabels data_labels) const override;
+
+ private:
+  ResourceLabels resource_labels_;
+  DataLabels data_labels_;
+  opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Histogram<double>>
+      application_blocking_latencies_;
+  OperationContext::Clock::time_point element_delivery_time_;
+  absl::optional<LatencyDuration> application_blocking_latency_;
+};
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable_internal
 }  // namespace cloud

--- a/google/cloud/bigtable/internal/metrics_test.cc
+++ b/google/cloud/bigtable/internal/metrics_test.cc
@@ -1574,6 +1574,167 @@ TEST(ServerLatency, NoServerTiming) {
                   {clock->Now(), Status{StatusCode::kOk, "ok"}});
 }
 
+TEST(ApplicationBlockingLatency, Success) {
+  auto mock_histogram = std::make_unique<MockHistogram<double>>();
+  EXPECT_CALL(
+      *mock_histogram,
+      Record(A<double>(), A<opentelemetry::common::KeyValueIterable const&>(),
+             A<opentelemetry::context::Context const&>()))
+      .WillOnce([](double value,
+                   opentelemetry::common::KeyValueIterable const& attributes,
+                   opentelemetry::context::Context const&) {
+        EXPECT_THAT(value, Eq(1.234));
+        EXPECT_THAT(
+            MakeAttributesMap(attributes),
+            UnorderedElementsAre(
+                Pair("project_id", "my-project-id"),
+                Pair("instance", "my-instance"), Pair("cluster", "my-cluster"),
+                Pair("table", "my-table"), Pair("zone", "my-zone"),
+                Pair("method", "my-method"),
+                Pair("client_name", "my-client-name"),
+                Pair("client_uid", "my-client-uid"),
+                Pair("app_profile", "my-app-profile")));
+      });
+
+  opentelemetry::nostd::shared_ptr<MockMeter> mock_meter =
+      std::make_shared<MockMeter>();
+  EXPECT_CALL(*mock_meter, CreateDoubleHistogram)
+      .WillOnce([mock = std::move(mock_histogram)](
+                    opentelemetry::nostd::string_view name,
+                    opentelemetry::nostd::string_view,
+                    opentelemetry::nostd::string_view) mutable {
+        EXPECT_THAT(name, Eq("application_latencies"));
+        return std::move(mock);
+      });
+
+  opentelemetry::nostd::shared_ptr<MockMeterProvider> mock_provider =
+      std::make_shared<MockMeterProvider>();
+  EXPECT_CALL(*mock_provider, GetMeter)
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+      .WillOnce([&](opentelemetry::nostd::string_view scope,
+                    opentelemetry::nostd::string_view scope_version,
+                    opentelemetry::nostd::string_view,
+                    opentelemetry::common::KeyValueIterable const*) mutable {
+#else
+      .WillOnce([&](opentelemetry::nostd::string_view scope,
+                    opentelemetry::nostd::string_view scope_version,
+                    opentelemetry::nostd::string_view) mutable {
+#endif
+        EXPECT_THAT(scope, Eq("my-instrument-scope"));
+        EXPECT_THAT(scope_version, Eq("v1"));
+        return mock_meter;
+      });
+
+  ApplicationBlockingLatency application_blocking_latency("my-instrument-scope",
+                                                          mock_provider);
+  ResourceLabels resource_labels{"my-project-id", "my-instance", "my-table", "",
+                                 ""};
+  DataLabels data_labels{"my-method",     "my-streaming",   "my-client-name",
+                         "my-client-uid", "my-app-profile", ""};
+  auto clone = application_blocking_latency.clone(resource_labels, data_labels);
+
+  grpc::ClientContext client_context;
+  SetClusterZone(client_context, "my-cluster", "my-zone");
+  auto otel_context = opentelemetry::context::RuntimeContext::GetCurrent();
+  auto clock = std::make_shared<FakeSteadyClock>();
+
+  clock->SetTime(std::chrono::steady_clock::now());
+  clone->ElementDelivery(otel_context, {clock->Now(), true});
+  clock->AdvanceTime(std::chrono::microseconds(1234));
+  clone->ElementRequest(otel_context, {clock->Now()});
+  clone->PostCall(otel_context, client_context, {clock->Now(), Status{}});
+}
+TEST(ApplicationBlockingLatency, TwoCalls) {
+  auto mock_histogram = std::make_unique<MockHistogram<double>>();
+  EXPECT_CALL(
+      *mock_histogram,
+      Record(A<double>(), A<opentelemetry::common::KeyValueIterable const&>(),
+             A<opentelemetry::context::Context const&>()))
+      .WillOnce([](double value,
+                   opentelemetry::common::KeyValueIterable const& attributes,
+                   opentelemetry::context::Context const&) {
+        EXPECT_THAT(value, Eq(1.234));
+        EXPECT_THAT(
+            MakeAttributesMap(attributes),
+            UnorderedElementsAre(
+                Pair("project_id", "my-project-id"),
+                Pair("instance", "my-instance"), Pair("cluster", "my-cluster"),
+                Pair("table", "my-table"), Pair("zone", "my-zone"),
+                Pair("method", "my-method"),
+                Pair("client_name", "my-client-name"),
+                Pair("client_uid", "my-client-uid"),
+                Pair("app_profile", "my-app-profile")));
+      })
+      .WillOnce([](double value,
+                   opentelemetry::common::KeyValueIterable const& attributes,
+                   opentelemetry::context::Context const&) {
+        EXPECT_THAT(value, Eq(5.0));
+        EXPECT_THAT(
+            MakeAttributesMap(attributes),
+            UnorderedElementsAre(
+                Pair("project_id", "my-project-id"),
+                Pair("instance", "my-instance"), Pair("cluster", "my-cluster"),
+                Pair("table", "my-table"), Pair("zone", "my-zone"),
+                Pair("method", "my-method"),
+                Pair("client_name", "my-client-name"),
+                Pair("client_uid", "my-client-uid"),
+                Pair("app_profile", "my-app-profile")));
+      });
+
+  opentelemetry::nostd::shared_ptr<MockMeter> mock_meter =
+      std::make_shared<MockMeter>();
+  EXPECT_CALL(*mock_meter, CreateDoubleHistogram)
+      .WillOnce([mock = std::move(mock_histogram)](
+                    opentelemetry::nostd::string_view name,
+                    opentelemetry::nostd::string_view,
+                    opentelemetry::nostd::string_view) mutable {
+        EXPECT_THAT(name, Eq("application_latencies"));
+        return std::move(mock);
+      });
+
+  opentelemetry::nostd::shared_ptr<MockMeterProvider> mock_provider =
+      std::make_shared<MockMeterProvider>();
+  EXPECT_CALL(*mock_provider, GetMeter)
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+      .WillOnce([&](opentelemetry::nostd::string_view scope,
+                    opentelemetry::nostd::string_view scope_version,
+                    opentelemetry::nostd::string_view,
+                    opentelemetry::common::KeyValueIterable const*) mutable {
+#else
+      .WillOnce([&](opentelemetry::nostd::string_view scope,
+                    opentelemetry::nostd::string_view scope_version,
+                    opentelemetry::nostd::string_view) mutable {
+#endif
+        EXPECT_THAT(scope, Eq("my-instrument-scope"));
+        EXPECT_THAT(scope_version, Eq("v1"));
+        return mock_meter;
+      });
+
+  ApplicationBlockingLatency application_blocking_latency("my-instrument-scope",
+                                                          mock_provider);
+  ResourceLabels resource_labels{"my-project-id", "my-instance", "my-table", "",
+                                 ""};
+  DataLabels data_labels{"my-method",     "my-streaming",   "my-client-name",
+                         "my-client-uid", "my-app-profile", ""};
+  auto clone = application_blocking_latency.clone(resource_labels, data_labels);
+
+  grpc::ClientContext client_context;
+  SetClusterZone(client_context, "my-cluster", "my-zone");
+  auto otel_context = opentelemetry::context::RuntimeContext::GetCurrent();
+  auto clock = std::make_shared<FakeSteadyClock>();
+
+  clock->SetTime(std::chrono::steady_clock::now());
+  clone->ElementDelivery(otel_context, {clock->Now(), true});
+  clock->AdvanceTime(std::chrono::microseconds(1234));
+  clone->ElementRequest(otel_context, {clock->Now()});
+  clone->PostCall(otel_context, client_context, {clock->Now(), Status{}});
+  clock->AdvanceTime(std::chrono::milliseconds(100));
+  clone->ElementDelivery(otel_context, {clock->Now(), true});
+  clock->AdvanceTime(std::chrono::milliseconds(5));
+  clone->ElementRequest(otel_context, {clock->Now()});
+  clone->PostCall(otel_context, client_context, {clock->Now(), Status{}});
+
+}
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable_internal

--- a/google/cloud/bigtable/internal/metrics_test.cc
+++ b/google/cloud/bigtable/internal/metrics_test.cc
@@ -1644,6 +1644,7 @@ TEST(ApplicationBlockingLatency, Success) {
   clone->ElementRequest(otel_context, {clock->Now()});
   clone->PostCall(otel_context, client_context, {clock->Now(), Status{}});
 }
+
 TEST(ApplicationBlockingLatency, TwoCalls) {
   auto mock_histogram = std::make_unique<MockHistogram<double>>();
   EXPECT_CALL(
@@ -1733,7 +1734,6 @@ TEST(ApplicationBlockingLatency, TwoCalls) {
   clock->AdvanceTime(std::chrono::milliseconds(5));
   clone->ElementRequest(otel_context, {clock->Now()});
   clone->PostCall(otel_context, client_context, {clock->Now(), Status{}});
-
 }
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/internal/metrics_test.cc
+++ b/google/cloud/bigtable/internal/metrics_test.cc
@@ -1643,9 +1643,10 @@ TEST(ApplicationBlockingLatency, Success) {
   clock->AdvanceTime(std::chrono::microseconds(1234));
   clone->ElementRequest(otel_context, {clock->Now()});
   clone->PostCall(otel_context, client_context, {clock->Now(), Status{}});
+  clone->OnDone(otel_context, {clock->Now(), Status{}});
 }
 
-TEST(ApplicationBlockingLatency, TwoCalls) {
+TEST(ApplicationBlockingLatency, StreamingData) {
   auto mock_histogram = std::make_unique<MockHistogram<double>>();
   EXPECT_CALL(
       *mock_histogram,
@@ -1654,7 +1655,7 @@ TEST(ApplicationBlockingLatency, TwoCalls) {
       .WillOnce([](double value,
                    opentelemetry::common::KeyValueIterable const& attributes,
                    opentelemetry::context::Context const&) {
-        EXPECT_THAT(value, Eq(1.234));
+        EXPECT_THAT(value, Eq(1.0));
         EXPECT_THAT(
             MakeAttributesMap(attributes),
             UnorderedElementsAre(
@@ -1726,14 +1727,14 @@ TEST(ApplicationBlockingLatency, TwoCalls) {
 
   clock->SetTime(std::chrono::steady_clock::now());
   clone->ElementDelivery(otel_context, {clock->Now(), true});
-  clock->AdvanceTime(std::chrono::microseconds(1234));
+  clock->AdvanceTime(std::chrono::milliseconds(1));
   clone->ElementRequest(otel_context, {clock->Now()});
-  clone->PostCall(otel_context, client_context, {clock->Now(), Status{}});
-  clock->AdvanceTime(std::chrono::milliseconds(100));
+  clock->AdvanceTime(std::chrono::milliseconds(10));
   clone->ElementDelivery(otel_context, {clock->Now(), true});
   clock->AdvanceTime(std::chrono::milliseconds(5));
   clone->ElementRequest(otel_context, {clock->Now()});
   clone->PostCall(otel_context, client_context, {clock->Now(), Status{}});
+  clone->OnDone(otel_context, {clock->Now(), Status{}});
 }
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/internal/operation_context_factory.cc
+++ b/google/cloud/bigtable/internal/operation_context_factory.cc
@@ -323,8 +323,8 @@ std::shared_ptr<OperationContext> MetricsOperationContextFactory::MutateRows(
     v.emplace_back(std::make_shared<OperationLatency>(kRpc, provider_));
     v.emplace_back(std::make_shared<AttemptLatency>(kRpc, provider_));
     v.emplace_back(std::make_shared<RetryCount>(kRpc, provider_));
-    v.emplace_back(std::make_shared<ApplicationBlockingLatency>(kRpc,
-    provider_));
+    v.emplace_back(
+        std::make_shared<ApplicationBlockingLatency>(kRpc, provider_));
     v.emplace_back(std::make_shared<ServerLatency>(kRpc, provider_));
     // v.emplace_back(std::make_shared<ConnectivityErrorCount>(kRpc,
     // provider_));
@@ -352,8 +352,8 @@ MetricsOperationContextFactory::CheckAndMutateRow(
     v.emplace_back(std::make_shared<OperationLatency>(kRpc, provider_));
     v.emplace_back(std::make_shared<AttemptLatency>(kRpc, provider_));
     v.emplace_back(std::make_shared<RetryCount>(kRpc, provider_));
-    v.emplace_back(std::make_shared<ApplicationBlockingLatency>(kRpc,
-    provider_));
+    v.emplace_back(
+        std::make_shared<ApplicationBlockingLatency>(kRpc, provider_));
     v.emplace_back(std::make_shared<ServerLatency>(kRpc, provider_));
     // v.emplace_back(std::make_shared<ConnectivityErrorCount>(kRpc,
     // provider_));

--- a/google/cloud/bigtable/internal/operation_context_factory.cc
+++ b/google/cloud/bigtable/internal/operation_context_factory.cc
@@ -238,8 +238,8 @@ std::shared_ptr<OperationContext> MetricsOperationContextFactory::ReadRow(
     v.emplace_back(std::make_shared<OperationLatency>(kRpc, provider_));
     v.emplace_back(std::make_shared<AttemptLatency>(kRpc, provider_));
     v.emplace_back(std::make_shared<RetryCount>(kRpc, provider_));
-    // v.emplace_back(std::make_shared<ApplicationBlockingLatency>(kRpc,
-    // provider_));
+    v.emplace_back(
+        std::make_shared<ApplicationBlockingLatency>(kRpc, provider_));
     v.emplace_back(std::make_shared<ServerLatency>(kRpc, provider_));
     // v.emplace_back(std::make_shared<ConnectivityErrorCount>(kRpc,
     // provider_));
@@ -267,8 +267,8 @@ std::shared_ptr<OperationContext> MetricsOperationContextFactory::ReadRows(
     v.emplace_back(std::make_shared<AttemptLatency>(kRpc, provider_));
     v.emplace_back(std::make_shared<RetryCount>(kRpc, provider_));
     v.emplace_back(std::make_shared<FirstResponseLatency>(kRpc, provider_));
-    // v.emplace_back(std::make_shared<ApplicationBlockingLatency>(kRpc,
-    // provider_));
+    v.emplace_back(
+        std::make_shared<ApplicationBlockingLatency>(kRpc, provider_));
     v.emplace_back(std::make_shared<ServerLatency>(kRpc, provider_));
     // v.emplace_back(std::make_shared<ConnectivityErrorCount>(kRpc,
     // provider_));
@@ -295,8 +295,8 @@ std::shared_ptr<OperationContext> MetricsOperationContextFactory::MutateRow(
     v.emplace_back(std::make_shared<OperationLatency>(kRpc, provider_));
     v.emplace_back(std::make_shared<AttemptLatency>(kRpc, provider_));
     v.emplace_back(std::make_shared<RetryCount>(kRpc, provider_));
-    // v.emplace_back(std::make_shared<ApplicationBlockingLatency>(kRpc,
-    // provider_));
+    v.emplace_back(
+        std::make_shared<ApplicationBlockingLatency>(kRpc, provider_));
     v.emplace_back(std::make_shared<ServerLatency>(kRpc, provider_));
     // v.emplace_back(std::make_shared<ConnectivityErrorCount>(kRpc,
     // provider_));
@@ -323,8 +323,8 @@ std::shared_ptr<OperationContext> MetricsOperationContextFactory::MutateRows(
     v.emplace_back(std::make_shared<OperationLatency>(kRpc, provider_));
     v.emplace_back(std::make_shared<AttemptLatency>(kRpc, provider_));
     v.emplace_back(std::make_shared<RetryCount>(kRpc, provider_));
-    // v.emplace_back(std::make_shared<ApplicationBlockingLatency>(kRpc,
-    // provider_));
+    v.emplace_back(std::make_shared<ApplicationBlockingLatency>(kRpc,
+    provider_));
     v.emplace_back(std::make_shared<ServerLatency>(kRpc, provider_));
     // v.emplace_back(std::make_shared<ConnectivityErrorCount>(kRpc,
     // provider_));
@@ -352,8 +352,8 @@ MetricsOperationContextFactory::CheckAndMutateRow(
     v.emplace_back(std::make_shared<OperationLatency>(kRpc, provider_));
     v.emplace_back(std::make_shared<AttemptLatency>(kRpc, provider_));
     v.emplace_back(std::make_shared<RetryCount>(kRpc, provider_));
-    // v.emplace_back(std::make_shared<ApplicationBlockingLatency>(kRpc,
-    // provider_));
+    v.emplace_back(std::make_shared<ApplicationBlockingLatency>(kRpc,
+    provider_));
     v.emplace_back(std::make_shared<ServerLatency>(kRpc, provider_));
     // v.emplace_back(std::make_shared<ConnectivityErrorCount>(kRpc,
     // provider_));
@@ -381,8 +381,8 @@ std::shared_ptr<OperationContext> MetricsOperationContextFactory::SampleRowKeys(
     v.emplace_back(std::make_shared<OperationLatency>(kRpc, provider_));
     v.emplace_back(std::make_shared<AttemptLatency>(kRpc, provider_));
     v.emplace_back(std::make_shared<RetryCount>(kRpc, provider_));
-    // v.emplace_back(std::make_shared<ApplicationBlockingLatency>(kRpc,
-    // provider_));
+    v.emplace_back(
+        std::make_shared<ApplicationBlockingLatency>(kRpc, provider_));
     v.emplace_back(std::make_shared<ServerLatency>(kRpc, provider_));
     // v.emplace_back(std::make_shared<ConnectivityErrorCount>(kRpc,
     // provider_));
@@ -410,8 +410,8 @@ MetricsOperationContextFactory::ReadModifyWriteRow(
     v.emplace_back(std::make_shared<OperationLatency>(kRpc, provider_));
     v.emplace_back(std::make_shared<AttemptLatency>(kRpc, provider_));
     v.emplace_back(std::make_shared<RetryCount>(kRpc, provider_));
-    // v.emplace_back(std::make_shared<ApplicationBlockingLatency>(kRpc,
-    // provider_));
+    v.emplace_back(
+        std::make_shared<ApplicationBlockingLatency>(kRpc, provider_));
     v.emplace_back(std::make_shared<ServerLatency>(kRpc, provider_));
     // v.emplace_back(std::make_shared<ConnectivityErrorCount>(kRpc,
     // provider_));


### PR DESCRIPTION
Notable Changes:
- Using `application_blocking_latencies` as the metric type was resulting in the following error:
```
2025-08-12T03:28:05.329599122Z [WARNING] <139799742625472> Cloud Monitoring Export failed with status=INVALID_ARGUMENT: Error in non-idempotent operation: One or more TimeSeries could not be written: timeSeries[1] (metric.type="bigtable.googleapis.com/internal/client/application_blocking_latencies", metric.labels={"status": "OK", "app_profile": "default", "method": "ReadRow", "client_name": "cpp.Bigtable/v2.41.0-rc", "client_uid": "<uid>"}): unknown metric type;
``` 
Using `application_latencies` as per https://github.com/googleapis/java-bigtable/blob/d8055c1fb75a616cda1503b92d7cddb9da47d42b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsConstants.java#L69

To handle the case where we can have streaming data or multiple calls of ElementRequest and ElementDelivery per attempt (PostCall), moved recording of the metric to OnDone.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15373)
<!-- Reviewable:end -->
