### PR TITLE
feat: don't require crc32c with recent Abseil

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -31,7 +31,14 @@ google_cloud_cpp_doxygen_targets("storage" DEPENDS cloud-docs
 include(GoogleCloudCppCommon)
 
 include(IncludeNlohmannJson)
-find_package(Crc32c)
+if (BUILD_TESTING OR absl_VERSION VERSION_LESS "20230125")
+    set(NEED_CRC32C TRUE)
+else ()
+    set(NEED_CRC32C FALSE)
+endif ()
+if (NEED_CRC32C)
+    find_package(Crc32c REQUIRED)
+endif()
 
 # Export the version information for Bazel.
 include(CreateBazelConfig)

--- a/google/cloud/storage/google_cloud_cpp_storage.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage.cmake
@@ -273,9 +273,11 @@ target_link_libraries(
            google-cloud-cpp::common
            google-cloud-cpp::rest_internal
            nlohmann_json::nlohmann_json
-           Crc32c::crc32c
            CURL::libcurl
            Threads::Threads)
+if (NEED_CRC32C)
+    target_link_libraries(google_cloud_cpp_storage PUBLIC Crc32c::crc32c)
+endif()
 if (WIN32)
     target_compile_definitions(google_cloud_cpp_storage
                                PRIVATE WIN32_LEAN_AND_MEAN)
@@ -333,6 +335,11 @@ install(
 google_cloud_cpp_install_headers(google_cloud_cpp_storage
                                  include/google/cloud/storage)
 
+set(PKGCONFIG_LIBS)
+if (NEED_CRC32C)
+    list(APPEND PKGCONFIG_LIBS crc32c)
+endif()
+
 google_cloud_cpp_add_pkgconfig(
     "storage"
     "The Google Cloud Storage C++ Client Library"
@@ -348,7 +355,7 @@ google_cloud_cpp_add_pkgconfig(
     NON_WIN32_REQUIRES
     openssl
     LIBS
-    crc32c
+    ${PKGCONFIG_LIBS}
     WIN32_LIBS
     ws2_32
     bcrypt)

--- a/google/cloud/storage/internal/crc32c.cc
+++ b/google/cloud/storage/internal/crc32c.cc
@@ -18,19 +18,14 @@
 #include "absl/crc/crc32c.h"
 #define GOOGLE_CLOUD_CPP_USE_ABSL_CRC32C 1
 #else
+#include <crc32c/crc32c.h>
 #define GOOGLE_CLOUD_CPP_USE_ABSL_CRC32C 0
 #endif  // ABSL_LTS_RELEASE_VERSION
-#include <crc32c/crc32c.h>
 
 namespace google {
 namespace cloud {
 namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-
-std::uint32_t ExtendCrc32c(std::uint32_t crc, absl::string_view data) {
-  return crc32c::Extend(crc, reinterpret_cast<uint8_t const*>(data.data()),
-                        data.size());
-}
 
 std::uint32_t ExtendCrc32c(std::uint32_t crc,
                            storage::internal::ConstBufferSequence const& data) {
@@ -48,6 +43,10 @@ std::uint32_t ExtendCrc32c(std::uint32_t crc, absl::Cord const& data) {
 }
 
 #if GOOGLE_CLOUD_CPP_USE_ABSL_CRC32C
+
+std::uint32_t ExtendCrc32c(std::uint32_t crc, absl::string_view data) {
+  return static_cast<std::uint32_t>(absl::ExtendCrc32c(absl::crc32c_t{crc}, data));
+}
 
 std::uint32_t ExtendCrc32c(std::uint32_t crc, absl::string_view data,
                            std::uint32_t data_crc) {
@@ -70,6 +69,11 @@ std::uint32_t ExtendCrc32c(std::uint32_t crc, absl::Cord const& data,
 }
 
 #else
+
+std::uint32_t ExtendCrc32c(std::uint32_t crc, absl::string_view data) {
+  return crc32c::Extend(crc, reinterpret_cast<uint8_t const*>(data.data()),
+                        data.size());
+}
 
 std::uint32_t ExtendCrc32c(std::uint32_t crc, absl::string_view data,
                            std::uint32_t /*data_crc*/) {


### PR DESCRIPTION
cc2a5641e88a589d40551143401f21ea3659aed2 (#11061) introduced Abseil based CRC32C implementation. So we don't require crc32c when we use recent Abseil.

If we don't require crc32c with recent Abseil, downstream users such as Apache Arrow don't need to bundle crc32c. It reduces maintenance cost.

See also: https://github.com/apache/arrow/issues/45989

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15402)
<!-- Reviewable:end -->
