### PR TITLE
fix(gha): Update CMake installation for macOS

### DIFF
--- a/.github/workflows/macos-cmake.yml
+++ b/.github/workflows/macos-cmake.yml
@@ -263,9 +263,30 @@ jobs:
       run: |
         # Remove the older CMake version
         brew unlink cmake
+
+        # Create a temporary local tap
+        cd "${{runner.temp}}"
+        mkdir -p user/homebrew-tap/Formula
+        cd user/homebrew-tap
+        git init
+
         # Download the Homebrew formula for CMake==3.27.2
-        curl -fsSL -o cmake.rb https://raw.githubusercontent.com/Homebrew/homebrew-core/fd21fcf239bcd0231c9fed5719403ec128151af4/Formula/cmake.rb
-        brew install cmake.rb
+        curl -fsSL -o cmake.rb https://raw.githubusercontent.com/Homebrew/homebrew-core/fd21fcf239bcd0231c9fed5719403ec128151af4/Formula/c/cmake.rb
+        mv cmake.rb ./Formula/
+
+        git add .
+        git commit -m "Add CMake formula"
+
+        # Tap the local repository
+        brew tap user/homebrew-tap "${{runner.temp}}/user/homebrew-tap"
+
+        # Install CMake from the local tap
+        brew install --build-from-source user/homebrew-tap/cmake
+
+        # Clean up the tap
+        brew untap user/homebrew-tap
+        cd "${{runner.temp}}"
+        rm -rf user
     - name: Download and Install sccache
       if: ${{ inputs.sccache-mode != 'DISABLED' }}
       working-directory: "${{runner.temp}}"


### PR DESCRIPTION
- Use a local tap to install a specific CMake version to work around Homebrew environment issues on runners.

[gha: macOS & Windows / macOS-CMake / cmake + macos-14 + Core2 (pull_request_target)](https://github.com/googleapis/google-cloud-cpp/actions/runs/17333450720/job/49214631350?pr=15439) passes with this PR.

Fixes https://github.com/googleapis/google-cloud-cpp/issues/15440.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15439)
<!-- Reviewable:end -->
