### PR TITLE
perf(spanner): Use arenas to speed up queries that fetch many rows

### DIFF
--- a/google/cloud/spanner/internal/logging_result_set_reader.cc
+++ b/google/cloud/spanner/internal/logging_result_set_reader.cc
@@ -25,22 +25,23 @@ using ::google::cloud::internal::DebugString;
 
 void LoggingResultSetReader::TryCancel() { impl_->TryCancel(); }
 
-absl::optional<PartialResultSet> LoggingResultSetReader::Read(
-    absl::optional<std::string> const& resume_token) {
+bool LoggingResultSetReader::Read(
+    absl::optional<std::string> const& resume_token,
+    UnownedPartialResultSet& result) {
   if (resume_token) {
     GCP_LOG(DEBUG) << __func__ << "() << resume_token=\""
                    << DebugString(*resume_token, tracing_options_) << "\"";
   } else {
     GCP_LOG(DEBUG) << __func__ << "() << (unresumable)";
   }
-  auto result = impl_->Read(resume_token);
-  if (!result) {
-    GCP_LOG(DEBUG) << __func__ << "() >> (optional-with-no-value)";
+  bool success = impl_->Read(resume_token, result);
+  if (!success) {
+    GCP_LOG(DEBUG) << __func__ << "() >> (failed)";
   } else {
     GCP_LOG(DEBUG) << __func__ << "() >> resumption="
-                   << (result->resumption ? "true" : "false");
+                   << (result.resumption ? "true" : "false");
   }
-  return result;
+  return success;
 }
 
 Status LoggingResultSetReader::Finish() { return impl_->Finish(); }

--- a/google/cloud/spanner/internal/logging_result_set_reader.h
+++ b/google/cloud/spanner/internal/logging_result_set_reader.h
@@ -39,8 +39,8 @@ class LoggingResultSetReader : public PartialResultSetReader {
   ~LoggingResultSetReader() override = default;
 
   void TryCancel() override;
-  absl::optional<PartialResultSet> Read(
-      absl::optional<std::string> const& resume_token) override;
+  bool Read(absl::optional<std::string> const& resume_token,
+            UnownedPartialResultSet& result) override;
   Status Finish() override;
 
  private:

--- a/google/cloud/spanner/internal/logging_result_set_reader_test.cc
+++ b/google/cloud/spanner/internal/logging_result_set_reader_test.cc
@@ -50,7 +50,7 @@ TEST_F(LoggingResultSetReaderTest, TryCancel) {
 TEST_F(LoggingResultSetReaderTest, Read) {
   auto mock = std::make_unique<spanner_testing::MockPartialResultSetReader>();
   EXPECT_CALL(*mock, Read(_, _))
-      .WillOnce([](const absl::optional<std::string>& resume_token,
+      .WillOnce([](absl::optional<std::string> const& resume_token,
                    UnownedPartialResultSet& result) {
         result.resumption = false;
         result.result.set_resume_token("test-token");
@@ -59,8 +59,8 @@ TEST_F(LoggingResultSetReaderTest, Read) {
       .WillOnce([] { return false; });
   LoggingResultSetReader reader(std::move(mock), TracingOptions{});
   google::spanner::v1::PartialResultSet partial_result_set;
-  auto result = UnownedPartialResultSet::FromPartialResultSet(
-      partial_result_set);
+  auto result =
+      UnownedPartialResultSet::FromPartialResultSet(partial_result_set);
   ASSERT_TRUE(reader.Read("", result));
   EXPECT_EQ("test-token", result.result.resume_token());
 
@@ -74,7 +74,8 @@ TEST_F(LoggingResultSetReaderTest, Read) {
   log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, AllOf(Contains(StartsWith("Read()"))));
   EXPECT_THAT(log_lines, Contains(HasSubstr("resume_token=\"test-token\"")));
-  EXPECT_THAT(log_lines, Contains(HasSubstr("(failed)")));}
+  EXPECT_THAT(log_lines, Contains(HasSubstr("(failed)")));
+}
 
 TEST_F(LoggingResultSetReaderTest, Finish) {
   Status const expected_status = Status(StatusCode::kOutOfRange, "weird");

--- a/google/cloud/spanner/internal/partial_result_set_reader.h
+++ b/google/cloud/spanner/internal/partial_result_set_reader.h
@@ -36,8 +36,13 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * caller should discard any pending state not covered by the token, as that
  * data will be replayed.
  */
-struct PartialResultSet {
-  google::spanner::v1::PartialResultSet result;
+struct UnownedPartialResultSet {
+  static UnownedPartialResultSet FromPartialResultSet(
+      google::spanner::v1::PartialResultSet& result) {
+    return UnownedPartialResultSet{result, false};
+  }
+
+  google::spanner::v1::PartialResultSet& result;
   bool resumption;
 };
 
@@ -54,8 +59,8 @@ class PartialResultSetReader {
  public:
   virtual ~PartialResultSetReader() = default;
   virtual void TryCancel() = 0;
-  virtual absl::optional<PartialResultSet> Read(
-      absl::optional<std::string> const& resume_token) = 0;
+  virtual bool Read(absl::optional<std::string> const& resume_token,
+                    UnownedPartialResultSet& result) = 0;
   virtual Status Finish() = 0;
 };
 

--- a/google/cloud/spanner/internal/partial_result_set_resume.h
+++ b/google/cloud/spanner/internal/partial_result_set_resume.h
@@ -52,8 +52,8 @@ class PartialResultSetResume : public PartialResultSetReader {
   ~PartialResultSetResume() override = default;
 
   void TryCancel() override;
-  absl::optional<PartialResultSet> Read(
-      absl::optional<std::string> const& resume_token) override;
+  bool Read(absl::optional<std::string> const& resume_token,
+            UnownedPartialResultSet& result) override;
   Status Finish() override;
 
  private:

--- a/google/cloud/spanner/internal/partial_result_set_resume_test.cc
+++ b/google/cloud/spanner/internal/partial_result_set_resume_test.cc
@@ -43,14 +43,6 @@ using ::testing::AtLeast;
 using ::testing::HasSubstr;
 using ::testing::Return;
 
-absl::optional<PartialResultSet> ReadReturn(
-    google::spanner::v1::PartialResultSet response) {
-  bool const resumption = false;  // only a PartialResultSetResume returns true
-  return PartialResultSet{std::move(response), resumption};
-}
-
-absl::optional<PartialResultSet> ReadReturn() { return {}; }
-
 struct MockFactory {
   MOCK_METHOD(std::unique_ptr<PartialResultSetReader>, MakeReader,
               (std::string const& token));
@@ -81,6 +73,19 @@ MATCHER_P(IsValidAndEquals, expected,
   return arg && *arg == expected;
 }
 
+// Helper function for MockPartialResultSetReader::Read to return true and
+// populate result
+auto ReadAction(google::spanner::v1::PartialResultSet& response_proto,
+                bool resumption_val) {
+  return [&response_proto, resumption_val](
+             const absl::optional<std::string>& resume_token,
+             UnownedPartialResultSet& result) {
+    result.result = response_proto;
+    result.resumption = resumption_val;
+    return true;
+  };
+};
+
 TEST(PartialResultSetResume, Success) {
   google::spanner::v1::PartialResultSet response;
   auto constexpr kText = R"pb(
@@ -103,9 +108,9 @@ TEST(PartialResultSetResume, Success) {
       .WillOnce([&response](std::string const& token) {
         EXPECT_TRUE(token.empty());
         auto mock = std::make_unique<MockPartialResultSetReader>();
-        EXPECT_CALL(*mock, Read(_))
-            .WillOnce([&response] { return ReadReturn(response); })
-            .WillOnce(Return(ReadReturn()));
+        EXPECT_CALL(*mock, Read(_, _))
+            .WillOnce(ReadAction(response, false))
+            .WillOnce(Return(false));
         EXPECT_CALL(*mock, Finish()).WillOnce(Return(Status()));
         return mock;
       });
@@ -114,11 +119,11 @@ TEST(PartialResultSetResume, Success) {
     return mock_factory.MakeReader(token);
   };
   auto reader = MakeTestResume(factory, Idempotency::kIdempotent);
-  auto v = reader->Read("");
-  ASSERT_TRUE(v.has_value());
-  EXPECT_THAT(v->result, IsProtoEqual(response));
-  v = reader->Read("resume-after-2");
-  ASSERT_FALSE(v.has_value());
+  google::spanner::v1::PartialResultSet raw_result;
+  auto result = UnownedPartialResultSet::FromPartialResultSet(raw_result);
+  ASSERT_TRUE(reader->Read("", result));
+  EXPECT_THAT(result.result, IsProtoEqual(response));
+  ASSERT_FALSE(reader->Read("resume-after-2", result));
   auto status = reader->Finish();
   EXPECT_STATUS_OK(status);
 }
@@ -153,9 +158,9 @@ TEST(PartialResultSetResume, SuccessWithRestart) {
       .WillOnce([&r12](std::string const& token) {
         EXPECT_TRUE(token.empty());
         auto mock = std::make_unique<MockPartialResultSetReader>();
-        EXPECT_CALL(*mock, Read(_))
-            .WillOnce([&r12] { return ReadReturn(r12); })
-            .WillOnce(Return(ReadReturn()));
+        EXPECT_CALL(*mock, Read(_, _))
+            .WillOnce(ReadAction(r12, false))
+            .WillOnce(Return(false));
         EXPECT_CALL(*mock, Finish())
             .WillOnce(Return(Status(StatusCode::kUnavailable, "Try again 1")));
         return mock;
@@ -163,9 +168,9 @@ TEST(PartialResultSetResume, SuccessWithRestart) {
       .WillOnce([&r34](std::string const& token) {
         EXPECT_EQ("resume-after-2", token);
         auto mock = std::make_unique<MockPartialResultSetReader>();
-        EXPECT_CALL(*mock, Read(_))
-            .WillOnce([&r34] { return ReadReturn(r34); })
-            .WillOnce(Return(ReadReturn()));
+        EXPECT_CALL(*mock, Read(_, _))
+            .WillOnce(ReadAction(r34, false))
+            .WillOnce(Return(false));
         EXPECT_CALL(*mock, Finish())
             .WillOnce(Return(Status(StatusCode::kUnavailable, "Try again 2")));
         return mock;
@@ -173,7 +178,7 @@ TEST(PartialResultSetResume, SuccessWithRestart) {
       .WillOnce([](std::string const& token) {
         EXPECT_EQ("resume-after-4", token);
         auto mock = std::make_unique<MockPartialResultSetReader>();
-        EXPECT_CALL(*mock, Read(_)).WillOnce(Return(ReadReturn()));
+        EXPECT_CALL(*mock, Read(_, _)).WillOnce(Return(false));
         EXPECT_CALL(*mock, Finish()).WillOnce(Return(Status()));
         return mock;
       });
@@ -182,14 +187,13 @@ TEST(PartialResultSetResume, SuccessWithRestart) {
     return mock_factory.MakeReader(token);
   };
   auto reader = MakeTestResume(factory, Idempotency::kIdempotent);
-  auto v = reader->Read("");
-  ASSERT_TRUE(v.has_value());
-  EXPECT_THAT(v->result, IsProtoEqual(r12));
-  v = reader->Read("resume-after-2");
-  ASSERT_TRUE(v.has_value());
-  EXPECT_THAT(v->result, IsProtoEqual(r34));
-  v = reader->Read("resume-after-4");
-  ASSERT_FALSE(v.has_value());
+  google::spanner::v1::PartialResultSet raw_result;
+  auto result = UnownedPartialResultSet::FromPartialResultSet(raw_result);
+  ASSERT_TRUE(reader->Read("", result));
+  EXPECT_THAT(raw_result, IsProtoEqual(r12));
+  ASSERT_TRUE(reader->Read("resume-after-2", result));
+  EXPECT_THAT(raw_result, IsProtoEqual(r34));
+  ASSERT_FALSE(reader->Read("resume-after-4", result));
   auto status = reader->Finish();
   EXPECT_STATUS_OK(status);
 }
@@ -216,9 +220,9 @@ TEST(PartialResultSetResume, PermanentError) {
       .WillOnce([&r12](std::string const& token) {
         EXPECT_TRUE(token.empty());
         auto mock = std::make_unique<MockPartialResultSetReader>();
-        EXPECT_CALL(*mock, Read(_))
-            .WillOnce([&r12] { return ReadReturn(r12); })
-            .WillOnce(Return(ReadReturn()));
+        EXPECT_CALL(*mock, Read(_, _))
+            .WillOnce(ReadAction(r12, false))
+            .WillOnce(Return(false));
         EXPECT_CALL(*mock, Finish())
             .WillOnce(Return(Status(StatusCode::kUnavailable, "Try again")));
         return mock;
@@ -226,7 +230,7 @@ TEST(PartialResultSetResume, PermanentError) {
       .WillOnce([](std::string const& token) {
         EXPECT_EQ("resume-after-2", token);
         auto mock = std::make_unique<MockPartialResultSetReader>();
-        EXPECT_CALL(*mock, Read(_)).WillOnce(Return(ReadReturn()));
+        EXPECT_CALL(*mock, Read(_, _)).WillOnce(Return(false));
         EXPECT_CALL(*mock, Finish())
             .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
         return mock;
@@ -236,11 +240,11 @@ TEST(PartialResultSetResume, PermanentError) {
     return mock_factory.MakeReader(token);
   };
   auto reader = MakeTestResume(factory, Idempotency::kIdempotent);
-  auto v = reader->Read("");
-  ASSERT_TRUE(v.has_value());
-  EXPECT_THAT(v->result, IsProtoEqual(r12));
-  v = reader->Read("resume-after-2");
-  ASSERT_FALSE(v.has_value());
+  google::spanner::v1::PartialResultSet raw_result;
+  auto result = UnownedPartialResultSet::FromPartialResultSet(raw_result);
+  ASSERT_TRUE(reader->Read("", result));
+  EXPECT_THAT(result.result, IsProtoEqual(r12));
+  ASSERT_FALSE(reader->Read("resume-after-2", result));
   auto status = reader->Finish();
   EXPECT_THAT(status,
               StatusIs(StatusCode::kPermissionDenied, HasSubstr("uh-oh")));
@@ -268,9 +272,9 @@ TEST(PartialResultSetResume, TransientNonIdempotent) {
       .WillOnce([&r12](std::string const& token) {
         EXPECT_TRUE(token.empty());
         auto mock = std::make_unique<MockPartialResultSetReader>();
-        EXPECT_CALL(*mock, Read(_))
-            .WillOnce([&r12] { return ReadReturn(r12); })
-            .WillOnce(Return(ReadReturn()));
+        EXPECT_CALL(*mock, Read(_, _))
+            .WillOnce(ReadAction(r12, false))
+            .WillOnce(Return(false));
         EXPECT_CALL(*mock, Finish())
             .WillOnce(Return(Status(StatusCode::kUnavailable, "Try again")));
         return mock;
@@ -280,11 +284,11 @@ TEST(PartialResultSetResume, TransientNonIdempotent) {
     return mock_factory.MakeReader(token);
   };
   auto reader = MakeTestResume(factory, Idempotency::kNonIdempotent);
-  auto v = reader->Read("");
-  ASSERT_TRUE(v.has_value());
-  EXPECT_THAT(v->result, IsProtoEqual(r12));
-  v = reader->Read("resume-after-2");
-  ASSERT_FALSE(v.has_value());
+  google::spanner::v1::PartialResultSet raw_result;
+  auto result = UnownedPartialResultSet::FromPartialResultSet(raw_result);
+  ASSERT_TRUE(reader->Read("", result));
+  EXPECT_THAT(result.result, IsProtoEqual(r12));
+  ASSERT_FALSE(reader->Read("resume-after-2", result));
   auto status = reader->Finish();
   EXPECT_THAT(status,
               StatusIs(StatusCode::kUnavailable, HasSubstr("Try again")));
@@ -297,7 +301,7 @@ TEST(PartialResultSetResume, TooManyTransients) {
       .WillRepeatedly([](std::string const& token) {
         EXPECT_TRUE(token.empty());
         auto mock = std::make_unique<MockPartialResultSetReader>();
-        EXPECT_CALL(*mock, Read(_)).WillOnce(Return(ReadReturn()));
+        EXPECT_CALL(*mock, Read(_, _)).WillOnce(Return(false));
         EXPECT_CALL(*mock, Finish())
             .WillOnce(Return(Status(StatusCode::kUnavailable, "Try again")));
         return mock;
@@ -307,8 +311,9 @@ TEST(PartialResultSetResume, TooManyTransients) {
     return mock_factory.MakeReader(token);
   };
   auto reader = MakeTestResume(factory, Idempotency::kIdempotent);
-  auto v = reader->Read("");
-  ASSERT_FALSE(v.has_value());
+  google::spanner::v1::PartialResultSet raw_result;
+  auto result = UnownedPartialResultSet::FromPartialResultSet(raw_result);
+  ASSERT_FALSE(reader->Read("", result));
   auto status = reader->Finish();
   EXPECT_THAT(status,
               StatusIs(StatusCode::kUnavailable, HasSubstr("Try again")));
@@ -348,10 +353,10 @@ TEST(PartialResultSetResume, ResumptionStart) {
       .WillOnce([&response](std::string const& token) {
         EXPECT_TRUE(token.empty());
         auto mock = std::make_unique<MockPartialResultSetReader>();
-        EXPECT_CALL(*mock, Read(_))
-            .WillOnce([&response] { return ReadReturn(response[0]); })
-            .WillOnce([&response] { return ReadReturn(response[1]); })
-            .WillOnce(Return(ReadReturn()));
+        EXPECT_CALL(*mock, Read(_, _))
+            .WillOnce(ReadAction(response[0], false))
+            .WillOnce(ReadAction(response[1], false))
+            .WillOnce(Return(false));
         EXPECT_CALL(*mock, TryCancel()).Times(0);
         EXPECT_CALL(*mock, Finish())
             .WillOnce(Return(Status(StatusCode::kUnavailable, "Try again")));
@@ -360,11 +365,11 @@ TEST(PartialResultSetResume, ResumptionStart) {
       .WillOnce([&response](std::string const& token) {
         EXPECT_TRUE(token.empty());
         auto mock = std::make_unique<MockPartialResultSetReader>();
-        EXPECT_CALL(*mock, Read(_))
-            .WillOnce([&response] { return ReadReturn(response[0]); })
-            .WillOnce([&response] { return ReadReturn(response[1]); })
-            .WillOnce([&response] { return ReadReturn(response[2]); })
-            .WillOnce(Return(ReadReturn()));
+        EXPECT_CALL(*mock, Read(_, _))
+            .WillOnce(ReadAction(response[0], false))
+            .WillOnce(ReadAction(response[1], false))
+            .WillOnce(ReadAction(response[2], false))
+            .WillOnce(Return(false));
         EXPECT_CALL(*mock, TryCancel()).Times(0);
         EXPECT_CALL(*mock, Finish()).WillOnce(Return(Status()));
         return mock;
@@ -424,10 +429,10 @@ TEST(PartialResultSetResume, ResumptionMidway) {
       .WillOnce([&response](std::string const& token) {
         EXPECT_TRUE(token.empty());
         auto mock = std::make_unique<MockPartialResultSetReader>();
-        EXPECT_CALL(*mock, Read(_))
-            .WillOnce([&response] { return ReadReturn(response[0]); })
-            .WillOnce([&response] { return ReadReturn(response[1]); })
-            .WillOnce(Return(ReadReturn()));
+        EXPECT_CALL(*mock, Read(_, _))
+            .WillOnce(ReadAction(response[0], false))
+            .WillOnce(ReadAction(response[1], false))
+            .WillOnce(Return(false));
         EXPECT_CALL(*mock, TryCancel()).Times(0);
         EXPECT_CALL(*mock, Finish())
             .WillOnce(Return(Status(StatusCode::kUnavailable, "Try again")));
@@ -436,9 +441,9 @@ TEST(PartialResultSetResume, ResumptionMidway) {
       .WillOnce([&response](std::string const& token) {
         EXPECT_EQ("resume-after-4", token);
         auto mock = std::make_unique<MockPartialResultSetReader>();
-        EXPECT_CALL(*mock, Read(_))
-            .WillOnce([&response] { return ReadReturn(response[2]); })
-            .WillOnce(Return(ReadReturn()));
+        EXPECT_CALL(*mock, Read(_, _))
+            .WillOnce(ReadAction(response[2], false))
+            .WillOnce(Return(false));
         EXPECT_CALL(*mock, TryCancel()).Times(0);
         EXPECT_CALL(*mock, Finish()).WillOnce(Return(Status()));
         return mock;
@@ -498,10 +503,10 @@ TEST(PartialResultSetResume, ResumptionAfterResync) {
       .WillOnce([&response](std::string const& token) {
         EXPECT_TRUE(token.empty());
         auto mock = std::make_unique<MockPartialResultSetReader>();
-        EXPECT_CALL(*mock, Read(_))
-            .WillOnce([&response] { return ReadReturn(response[0]); })
-            .WillOnce([&response] { return ReadReturn(response[1]); })
-            .WillOnce(Return(ReadReturn()));
+        EXPECT_CALL(*mock, Read(_, _))
+            .WillOnce(ReadAction(response[0], false))
+            .WillOnce(ReadAction(response[1], false))
+            .WillOnce(Return(false));
         EXPECT_CALL(*mock, TryCancel()).Times(0);
         EXPECT_CALL(*mock, Finish())
             .WillOnce(Return(Status(StatusCode::kUnavailable, "Try again")));
@@ -510,9 +515,9 @@ TEST(PartialResultSetResume, ResumptionAfterResync) {
       .WillOnce([&response](std::string const& token) {
         EXPECT_EQ("resume-after-4", token);
         auto mock = std::make_unique<MockPartialResultSetReader>();
-        EXPECT_CALL(*mock, Read(_))
-            .WillOnce([&response] { return ReadReturn(response[2]); })
-            .WillOnce(Return(ReadReturn()));
+        EXPECT_CALL(*mock, Read(_, _))
+            .WillOnce(ReadAction(response[2], false))
+            .WillOnce(Return(false));
         EXPECT_CALL(*mock, TryCancel()).Times(0);
         EXPECT_CALL(*mock, Finish()).WillOnce(Return(Status()));
         return mock;
@@ -568,9 +573,9 @@ TEST(PartialResultSetResume, ResumptionBeforeResync) {
       .WillOnce([&response](std::string const& token) {
         EXPECT_TRUE(token.empty());
         auto mock = std::make_unique<MockPartialResultSetReader>();
-        EXPECT_CALL(*mock, Read(_))
-            .WillOnce([&response] { return ReadReturn(response[0]); })
-            .WillOnce(Return(ReadReturn()));
+        EXPECT_CALL(*mock, Read(_, _))
+            .WillOnce(ReadAction(response[0], false))
+            .WillOnce(Return(false));
         EXPECT_CALL(*mock, TryCancel()).Times(0);
         EXPECT_CALL(*mock, Finish())
             .WillOnce(Return(Status(StatusCode::kUnavailable, "Try again")));

--- a/google/cloud/spanner/internal/partial_result_set_resume_test.cc
+++ b/google/cloud/spanner/internal/partial_result_set_resume_test.cc
@@ -78,7 +78,7 @@ MATCHER_P(IsValidAndEquals, expected,
 auto ReadAction(google::spanner::v1::PartialResultSet& response_proto,
                 bool resumption_val) {
   return [&response_proto, resumption_val](
-             const absl::optional<std::string>& resume_token,
+             absl::optional<std::string> const& resume_token,
              UnownedPartialResultSet& result) {
     result.result = response_proto;
     result.resumption = resumption_val;

--- a/google/cloud/spanner/internal/partial_result_set_source.cc
+++ b/google/cloud/spanner/internal/partial_result_set_source.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/internal/make_status.h"
 #include "google/cloud/log.h"
 #include "absl/container/fixed_array.h"
+#include "absl/types/optional.h"
 
 namespace google {
 namespace cloud {
@@ -81,7 +82,11 @@ PartialResultSetSource::Create(std::unique_ptr<PartialResultSetReader> reader) {
 
 PartialResultSetSource::PartialResultSetSource(
     std::unique_ptr<PartialResultSetReader> reader)
-    : options_(internal::CurrentOptions()), reader_(std::move(reader)) {
+    : options_(internal::CurrentOptions()),
+      reader_(std::move(reader)),
+      values_(
+          absl::make_optional<google::protobuf::RepeatedPtrField<google::protobuf::Value>>(
+              &arena_)) {
   if (options_.has<spanner::StreamingResumabilityBufferSizeOption>()) {
     values_space_limit_ =
         options_.get<spanner::StreamingResumabilityBufferSizeOption>();
@@ -110,34 +115,61 @@ PartialResultSetSource::~PartialResultSetSource() {
 }
 
 StatusOr<spanner::Row> PartialResultSetSource::NextRow() {
-  while (rows_.empty()) {
+  if (usable_rows_ == 0 && rows_returned_ > 0) {
+    // There may be complete or partial rows in values_ that haven't been 
+    // returned to the clients yet. Let's copy it over before we reset
+    // the arena.
+    int partial_size = values_->size() - rows_returned_ * columns_->size();
+    absl::FixedArray<google::protobuf::Value*> tmp(partial_size);
+    if (!tmp.empty()) {
+      values_->ExtractSubrange(values_->size() - partial_size, partial_size,
+                              tmp.data());
+    }
+    values_.reset();
+    arena_.Reset();
+    values_.emplace(&arena_);
+    for (auto* elem : tmp) {
+      values_->Add(std::move(*elem));
+      delete elem;
+    }
+    rows_returned_ = 0;
+  }
+  while (usable_rows_ == 0) {
     if (state_ == kFinished) return spanner::Row();
     internal::OptionsSpan span(options_);
     auto status = ReadFromStream();
     if (!status.ok()) return status;
   }
-  auto row = std::move(rows_.front());
-  rows_.pop_front();
-  return row;
+  auto value_it = values_->cbegin() + rows_returned_ * columns_->size();
+  ++rows_returned_;
+  --usable_rows_;
+  std::vector<spanner::Value> values;
+  values.reserve(metadata_->row_type().fields_size());
+  for (auto const& field : metadata_->row_type().fields()) {
+    values.push_back(FromProto(field.type(), std::move(*value_it)));
+    ++value_it;
+  }
+  return RowFriend::MakeRow(std::move(values), columns_);
 }
 
 Status PartialResultSetSource::ReadFromStream() {
-  google::spanner::v1::PartialResultSet raw_result_set;
+  if (state_ == kFinished || usable_rows_ != 0 || rows_returned_ != 0) {
+     return internal::InternalError("PartialResultSetSource state error",
+                                    GCP_ERROR_INFO());
+   }
+  auto* raw_result_set =
+      google::protobuf::Arena::Create<google::spanner::v1::PartialResultSet>(&arena_);
   auto result_set =
-      UnownedPartialResultSet::FromPartialResultSet(raw_result_set);
-  if (state_ == kFinished || !rows_.empty()) {
-    return internal::InternalError("PartialResultSetSource state error",
-                                   GCP_ERROR_INFO());
-  }
-  if (state_ == kReading) {
-    if (!reader_->Read(resume_token_, result_set)) state_ = kEndOfStream;
-  }
-  if (state_ == kEndOfStream) {
-    // If we have no buffered data, we're done.
-    if (values_.empty()) {
-      state_ = kFinished;
-      return reader_->Finish();
-    }
+      UnownedPartialResultSet::FromPartialResultSet(*raw_result_set);
+   if (state_ == kReading) {
+     if (!reader_->Read(resume_token_, result_set)) state_ = kEndOfStream;
+   }
+   if (state_ == kEndOfStream) {
+     // If we have no buffered data, we're done.
+    if (values_->empty()) {
+       state_ = kFinished;
+       return reader_->Finish();
+     }
     // Otherwise, proceed with a `PartialResultSet` using a fake resume
     // token to flush the buffer. The service does not appear to yield
     // a resume token in its final response, despite it completing a row.
@@ -185,7 +217,7 @@ Status PartialResultSetSource::ReadFromStream() {
           GCP_ERROR_INFO());
     }
     values_back_incomplete_ = false;
-    values_.Clear();
+    values_->Clear();
   }
 
   // If the final value in the previous `PartialResultSet` was incomplete,
@@ -196,18 +228,18 @@ Status PartialResultSetSource::ReadFromStream() {
     int append_start = 0;
     if (values_back_incomplete_) {
       auto& first = *new_values.Mutable(append_start++);
-      auto status = MergeChunk(*values_.rbegin(), std::move(first));
+      auto status = MergeChunk(*values_->rbegin(), std::move(first));
       if (!status.ok()) return status;
     }
-    ExtractSubrangeAndAppend(new_values, append_start, values_);
+    ExtractSubrangeAndAppend(new_values, append_start, *values_);
     values_back_incomplete_ = result_set.result.chunked_value();
   }
 
   // Deliver whatever rows we can muster.
-  auto const n_values = values_.size() - (values_back_incomplete_ ? 1 : 0);
+  auto const n_values = values_->size() - (values_back_incomplete_ ? 1 : 0);
   auto const n_columns = columns_ ? static_cast<int>(columns_->size()) : 0;
   auto n_rows = n_columns ? n_values / n_columns : 0;
-  if (n_columns == 0 && !values_.empty()) {
+  if (n_columns == 0 && !values_->empty()) {
     return internal::InternalError(
         "PartialResultSetSource metadata is missing row type",
         GCP_ERROR_INFO());
@@ -216,7 +248,7 @@ Status PartialResultSetSource::ReadFromStream() {
   // If we didn't receive a resume token, and have not exceeded our buffer
   // limit, then we choose to `Read()` again so as to maintain resumability.
   if (result_set.result.resume_token().empty()) {
-    if (values_.SpaceUsedExcludingSelfLong() < values_space_limit_) {
+    if (values_->SpaceUsedExcludingSelfLong() < values_space_limit_) {
       return {};  // OK
     }
   }
@@ -226,7 +258,7 @@ Status PartialResultSetSource::ReadFromStream() {
   // Otherwise, if we deliver anything at all, we must disable resumability.
   if (!result_set.result.resume_token().empty()) {
     resume_token_ = result_set.result.resume_token();
-    if (n_rows * n_columns != values_.size()) {
+    if (n_rows * n_columns != values_->size()) {
       if (state_ != kEndOfStream) {
         return internal::InternalError(
             "PartialResultSetSource reader produced a resume token"
@@ -244,24 +276,7 @@ Status PartialResultSetSource::ReadFromStream() {
     resume_token_ = absl::nullopt;
   }
 
-  // Combine the available values into new elements of `rows_`.
-  int values_pos = 0;
-  std::vector<spanner::Value> values;
-  values.reserve(n_columns);
-  for (; n_rows != 0; --n_rows) {
-    for (auto const& field : metadata_->row_type().fields()) {
-      auto& value = *values_.Mutable(values_pos++);
-      values.push_back(FromProto(field.type(), std::move(value)));
-    }
-    rows_.push_back(RowFriend::MakeRow(std::move(values), columns_));
-    values.clear();
-  }
-
-  // If we didn't combine all the values, leave the remainder for next time.
-  auto* rem_values = result_set.result.mutable_values();
-  ExtractSubrangeAndAppend(values_, values_pos, *rem_values);
-  values_.Swap(rem_values);
-
+  usable_rows_ = n_rows;
   return {};  // OK
 }
 

--- a/google/cloud/spanner/internal/partial_result_set_source.h
+++ b/google/cloud/spanner/internal/partial_result_set_source.h
@@ -118,6 +118,19 @@ class PartialResultSetSource : public PartialResultSourceInterface {
   // `NextRow()`.
   absl::optional<google::protobuf::RepeatedPtrField<google::protobuf::Value>> values_;
 
+  // `space_used` is the sum of the SpaceUsedLong() by the values at indexes [0,
+  // index) in `values_`.
+  struct PrecomputedSpaceUsed {
+    void Clear() {
+      space_used = 0;
+      index = 0;
+    }
+
+    std::size_t space_used = 0;
+    int index = 0;
+  };
+  PrecomputedSpaceUsed values_space_;
+
   // When engaged, the token we can use to resume the stream immediately after
   // any data in (or previously in) `rows_`. When disengaged, we have already
   // delivered data that would be replayed, so resumption is disabled until we

--- a/google/cloud/spanner/internal/partial_result_set_source.h
+++ b/google/cloud/spanner/internal/partial_result_set_source.h
@@ -116,7 +116,8 @@ class PartialResultSetSource : public PartialResultSourceInterface {
 
   // Values that can be assembled into `Row`s ready to be returned by
   // `NextRow()`.
-  absl::optional<google::protobuf::RepeatedPtrField<google::protobuf::Value>> values_;
+  absl::optional<google::protobuf::RepeatedPtrField<google::protobuf::Value>>
+      values_;
 
   // `space_used` is the sum of the SpaceUsedLong() by the values at indexes [0,
   // index) in `values_`.

--- a/google/cloud/spanner/testing/mock_partial_result_set_reader.h
+++ b/google/cloud/spanner/testing/mock_partial_result_set_reader.h
@@ -28,8 +28,10 @@ class MockPartialResultSetReader
     : public spanner_internal::PartialResultSetReader {
  public:
   MOCK_METHOD(void, TryCancel, (), (override));
-  MOCK_METHOD(absl::optional<spanner_internal::PartialResultSet>, Read,
-              (absl::optional<std::string> const& resume_token), (override));
+  MOCK_METHOD(bool, Read,
+              (absl::optional<std::string> const& resume_token,
+               spanner_internal::UnownedPartialResultSet& result),
+              (override));
   MOCK_METHOD(Status, Finish, (), (override));
 };
 


### PR DESCRIPTION
Tested by running `multiple_rows_cpu_benchmark --project=${GOOGLE_CLOUD_PROJECT}     --instance=${GOOGLE_CLOUD_CPP_SPANNER_TEST_INSTANCE_ID}     --table-size=1000000     --maximum-channels=8 --maximum-threads=16   --iteration-duration=5 --samples=60 --experiment=select-string --use-only-clients=true --query-size=100000` (larger --query-size than in the README). The data is noisy but seems like a ~20% win on CpuTime. I don't expect this to help much with queries that return few results. For the use case I care about (fetching a whole table), we were limited by CPU when using all the threads on a machine.

<img width="720" height="386" alt="improvement" src="https://github.com/user-attachments/assets/debc7beb-84c4-453b-bdf1-360a067e2930" />

We still have a copy when generating Row in PartialResultSetSource::NextRow() but we'd need a new API to avoid that.
