### PR TITLE
fix: install bash, ninja, cmake for macos CIs

### DIFF
--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -16,6 +16,15 @@
 
 set -euo pipefail
 
+# Homebrew cleanup
+git -C "/usr/local/Homebrew" remote set-url origin https://github.com/Homebrew/brew || echo "Failed to set Homebrew origin"
+git -C "/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core" remote set-url origin https://github.com/Homebrew/homebrew-core || echo "Failed to set homebrew-core origin"
+brew untap homebrew/cask --force || echo "Failed to untap homebrew/cask"
+brew untap homebrew/core --force || echo "Failed to untap homebrew/core"
+brew untap homebrew/cask-versions --force || echo "Failed to untap homebrew/cask-versions"
+brew cleanup -s || echo "brew cleanup failed"
+brew update-reset
+
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/lib/io.sh
 

--- a/ci/kokoro/macos/builds/cmake-vcpkg.sh
+++ b/ci/kokoro/macos/builds/cmake-vcpkg.sh
@@ -34,18 +34,22 @@ brew install bash ninja
 # Install a specific version of CMake to match our GHA builds
 (
   cd "${HOME}"
+  # Create a temporary local tap
   mkdir -p user/homebrew-tap/Formula
   cd user/homebrew-tap
-
   git init
 
+  # Download the Homebrew formula for CMake==3.27.2
   curl -fsSL -o cmake.rb https://raw.githubusercontent.com/Homebrew/homebrew-core/fd21fcf239bcd0231c9fed5719403ec128151af4/Formula/cmake.rb
   mv cmake.rb ./Formula/
 
   git add .
   git commit -m "Add CMake formula"
 
+  # Tap the local repository
   brew tap user/homebrew-tap "${HOME}/user/homebrew-tap"
+
+  # Uninstall existing CMake and install CMake from the local tap
   brew uninstall cmake
   brew install --build-from-source user/homebrew-tap/cmake
 )

--- a/ci/kokoro/macos/builds/cmake-vcpkg.sh
+++ b/ci/kokoro/macos/builds/cmake-vcpkg.sh
@@ -34,8 +34,20 @@ brew install bash ninja
 # Install a specific version of CMake to match our GHA builds
 (
   cd "${HOME}"
+  mkdir -p user/homebrew-tap/Formula
+  cd user/homebrew-tap
+
+  git init
+
   curl -fsSL -o cmake.rb https://raw.githubusercontent.com/Homebrew/homebrew-core/fd21fcf239bcd0231c9fed5719403ec128151af4/Formula/cmake.rb
-  brew install cmake.rb
+  mv cmake.rb ./Formula/
+
+  git add .
+  git commit -m "Add CMake formula"
+
+  brew tap user/homebrew-tap "${HOME}/user/homebrew-tap"
+  brew uninstall cmake
+  brew install --build-from-source user/homebrew-tap/cmake
 )
 
 io::log_h2 "Using CMake version"


### PR DESCRIPTION
homebrew clean up in ci/kokoro/macos/build.sh is to fix install of bash and ninja.

homebrew updates for cmake in ci/kokoro/macos/builds/cmake-vcpkg.sh is to fix install of cmake.