### PR TITLE
fix: uninstall before install cmake

### DIFF
--- a/.github/workflows/macos-cmake.yml
+++ b/.github/workflows/macos-cmake.yml
@@ -280,13 +280,9 @@ jobs:
         # Tap the local repository
         brew tap user/homebrew-tap "${{runner.temp}}/user/homebrew-tap"
 
-        # Install CMake from the local tap
+        # Uninstall existing CMake and install CMake from the local tap
+        brew uninstall cmake
         brew install --build-from-source user/homebrew-tap/cmake
-
-        # Clean up the tap
-        brew untap user/homebrew-tap
-        cd "${{runner.temp}}"
-        rm -rf user
     - name: Download and Install sccache
       if: ${{ inputs.sccache-mode != 'DISABLED' }}
       working-directory: "${{runner.temp}}"


### PR DESCRIPTION
Updates to uninstall before install cmake. Also updates to remove clean-up, which caused failures in kokoro jobs.

Fixes https://github.com/googleapis/google-cloud-cpp/issues/15448 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15453)
<!-- Reviewable:end -->
