### PR TITLE
fix: kokoro for macos and windows CIs

### DIFF
--- a/ci/kokoro/macos/common.cfg
+++ b/ci/kokoro/macos/common.cfg
@@ -15,15 +15,5 @@
 build_file: "google-cloud-cpp/ci/kokoro/macos/build.sh"
 timeout_mins: 240
 
-before_action {
-  fetch_keystore {
-    keystore_resource {
-      keystore_config_id: 73713
-      keyname: "cloud-cpp-kokoro-run-sa-key"
-      backend: "blade:keystore-fastconfigpush"
-    }
-  }
-}
-
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/kokoro-run-key.json"

--- a/ci/kokoro/windows/common.cfg
+++ b/ci/kokoro/windows/common.cfg
@@ -16,16 +16,6 @@
 build_file: "google-cloud-cpp/ci/kokoro/windows/build.bat"
 timeout_mins: 240
 
-before_action {
-  fetch_keystore {
-    keystore_resource {
-      keystore_config_id: 73713
-      keyname: "cloud-cpp-kokoro-run-sa-key"
-      backend: "blade:keystore-fastconfigpush"
-    }
-  }
-}
-
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/kokoro-run-key.json"
 


### PR DESCRIPTION
* homebrew clean up in ci/kokoro/macos/build.sh is to fix install of bash and ninja.
* homebrew updates for cmake in ci/kokoro/macos/builds/cmake-vcpkg.sh is to fix install of cmake.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15454)
<!-- Reviewable:end -->
