### PR TITLE
build(vcpkg): pin opentelemetry to 1.20.0

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -44,5 +44,12 @@
       "$description": "Only used for the docfx feature.",
       "name": "yaml-cpp"
     }
+  ],
+  "builtin-baseline": "5ed70064390f11112c34b91a6382bba0fdc1706d",
+  "overrides": [
+    {
+      "name": "opentelemetry-cpp",
+      "version": "1.20.0"
+    }
   ]
 }


### PR DESCRIPTION
Version [v1.22.0](https://github.com/open-telemetry/opentelemetry-cpp/releases/tag/v1.22.0) of opentelemtry removes semantic_conversions.h, and my CMake job fails:

```
Installing 17/19 opentelemetry-cpp:x64-linux@1.22.0#1...
...
/usr/local/google/home/diegomarquezp/google/google-cloud-cpp/google/cloud/internal/rest_opentelemetry.cc:26:10: fatal error: opentelemetry/trace/semantic_conventions.h: No such file or directory
   26 | #include <opentelemetry/trace/semantic_conventions.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This PR temporarily pins opentelemtry to the current version supported by `main`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15459)
<!-- Reviewable:end -->
