### PR TITLE
fix(bazel): Add -no-canonical-prefixes to macOS Bazel build to resolve OpenSSL header conflicts.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -21,7 +21,7 @@ build --enable_platform_specific_config=true
 # The project requires C++ >= 14. By default Bazel adds `-std=c++0x` which
 # disables C++14 features, even if the compilers defaults to C++ >= 14
 build:linux --cxxopt=-std=c++14
-build:macos --cxxopt=-std=c++14
+build:macos --cxxopt=-std=c++14 --copt=-no-canonical-prefixes
 # Protobuf and gRPC require (or soon will require) C++14 to compile the "host"
 # targets, such as protoc and the grpc plugin.
 build:linux --host_cxxopt=-std=c++14


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15460)
<!-- Reviewable:end -->
