### PR TITLE
fix(bazel): set c++ standard for windows builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -26,6 +26,8 @@ build:macos --cxxopt=-std=c++14
 # targets, such as protoc and the grpc plugin.
 build:linux --host_cxxopt=-std=c++14
 build:macos --host_cxxopt=-std=c++14
+build:windows --cxxopt=/std:c++14
+build:windows --host_cxxopt=/std:c++14
 
 # Do not create the convenience links. They are inconvenient when the build
 # runs inside a docker image or if one builds a quickstart and then builds


### PR DESCRIPTION
The Windows Bazel build is failing with the error: `fatal error C1083: Cannot open include file: stdalign.h: No such file or directory`

This is because the C++ standard is not being set for Windows builds, and the MSVC compiler is defaulting to an older standard that does not support `stdalign.h`.

This change fixes the build by adding `/std:c++14` to the compiler flags for Windows builds in the `.bazelrc` file. This is consistent with the settings for Linux and macOS.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15466)
<!-- Reviewable:end -->
