### PR TITLE
fix: remove BAZEL_NO_APPLE_CPP_TOOLCHAIN from .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -41,10 +41,6 @@ build --experimental_downloader_config=bazel/downloader.cfg
 # frustrating when they fail and don't give any output. So, remove the limit.
 build --experimental_ui_max_stdouterr_bytes=-1
 
-# TODO(#13311) - remove once gRPC works with Bazel v7 or when gRPC stops using
-#     `apple_rules`.
-common:macos --repo_env=BAZEL_NO_APPLE_CPP_TOOLCHAIN=1
-
 # Inject ${GTEST_SHUFFLE} and ${GTEST_RANDOM_SEED} into the test environment
 # if they are set in the enclosing environment. This allows for running tests
 # in a random order to help expose undesirable interdependencies.


### PR DESCRIPTION
This change removes the `common:macos --repo_env=BAZEL_NO_APPLE_CPP_TOOLCHAIN=1` setting from the `.bazelrc` file.

This flag was originally added as a workaround for an incompatibility between gRPC and Bazel 7, as tracked in issue https://github.com/googleapis/google-cloud-cpp/issues/13311. This incompatibility has since been resolved, and the workaround is no longer necessary.

Fixes https://github.com/googleapis/google-cloud-cpp/issues/13311.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15542)
<!-- Reviewable:end -->
