### PR TITLE
fix(bazel): Add missing dependency to benchmark targets

### DIFF
--- a/google/cloud/BUILD.bazel
+++ b/google/cloud/BUILD.bazel
@@ -140,6 +140,7 @@ cc_library(
     tags = ["benchmark"],
     deps = [
         ":google_cloud_cpp_common",
+        "@com_google_benchmark//:benchmark",
         "@com_google_benchmark//:benchmark_main",
     ],
 ) for benchmark in google_cloud_cpp_common_benchmarks]
@@ -228,6 +229,7 @@ cc_library(
     deps = [
         ":google_cloud_cpp_common",
         ":google_cloud_cpp_grpc_utils",
+        "@com_google_benchmark//:benchmark",
         "@com_google_benchmark//:benchmark_main",
         "@com_google_googleapis//google/bigtable/admin/v2:admin_cc_grpc",
         "@com_google_googleapis//google/bigtable/v2:bigtable_cc_grpc",
@@ -333,6 +335,7 @@ cc_library(
     tags = ["benchmark"],
     deps = [
         ":google_cloud_cpp_rest_internal",
+        "@com_google_benchmark//:benchmark",
         "@com_google_benchmark//:benchmark_main",
     ],
 ) for benchmark in google_cloud_cpp_rest_internal_benchmarks]

--- a/google/cloud/spanner/BUILD.bazel
+++ b/google/cloud/spanner/BUILD.bazel
@@ -150,6 +150,7 @@ cc_library(
         ":google_cloud_cpp_spanner",
         ":google_cloud_cpp_spanner_mocks",
         "//:common",
+        "@com_google_benchmark//:benchmark",
         "@com_google_benchmark//:benchmark_main",
     ],
 ) for benchmark in spanner_client_benchmarks]

--- a/google/cloud/storage/BUILD.bazel
+++ b/google/cloud/storage/BUILD.bazel
@@ -259,6 +259,7 @@ cc_library(
     deps = [
         ":google_cloud_cpp_storage",
         "//:common",
+        "@com_google_benchmark//:benchmark",
         "@com_google_benchmark//:benchmark_main",
     ],
 ) for benchmark in storage_client_benchmarks]


### PR DESCRIPTION
This commit resolves build failures in several benchmark targets by explicitly adding a dependency on `@com_google_benchmark//:benchmark`.

The kokoro macos bazel build was failing to compile because they were missing a direct dependency on the core Google Benchmark library, even though they depended on `:benchmark_main`. This change ensures the benchmark APIs are available to the targets, fixing the build errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15543)
<!-- Reviewable:end -->
