### PR TITLE
fix(storage): Disable failing unified_credentials_integration_test

### DIFF
--- a/ci/kokoro/macos/builds/bazel.sh
+++ b/ci/kokoro/macos/builds/bazel.sh
@@ -81,10 +81,12 @@ if [[ -r "${TEST_KEY_FILE_JSON}" ]]; then
 fi
 
 io::log_h2 "build and run unit tests"
-readonly BAZEL_TEST_EXCLUDES=(
+readonly BAZEL_EXCLUDES=(
   # See #15544
   "-//generator/integration_tests:benchmarks_client_benchmark"
   "-//google/cloud:options_benchmark"
+  # See #15546
+  "-//google/cloud/storage/tests:unified_credentials_integration_test-grpc-metadata"
 )
 readonly BAZEL_TEST_COMMAND=(
   "test"
@@ -92,13 +94,13 @@ readonly BAZEL_TEST_COMMAND=(
   "--test_tag_filters=-integration-test"
   "--"
   "..."
-  "${BAZEL_TEST_EXCLUDES[@]}"
+  "${BAZEL_EXCLUDES[@]}"
 )
 echo "bazelisk" "${BAZEL_TEST_COMMAND[@]}"
 bazelisk "${BAZEL_TEST_COMMAND[@]}"
 
 io::log_h2 "build all targets"
-bazelisk build "${bazel_args[@]}" ...
+bazelisk build "${bazel_args[@]}" -- ... "${BAZEL_EXCLUDES[@]}"
 
 io::log_h2 "running minimal quickstart programs"
 bazelisk run "${bazel_args[@]}" \


### PR DESCRIPTION
This commit disables the unified_credentials_integration_test on macOS due to build and test failures.
    
- The test target //google/cloud/storage/tests:unified_credentials_integration_test-grpc-metadata is excluded from the CI run in ci/kokoro/macos/builds/bazel.sh.
    
The work to fix and re-enable these tests is tracked in issue #15546.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15547)
<!-- Reviewable:end -->
