### PR TITLE
feat(storage): Remove unnecessary code which was causing race condition

### DIFF
--- a/google/cloud/storage/internal/async/writer_connection_resumed.cc
+++ b/google/cloud/storage/internal/async/writer_connection_resumed.cc
@@ -429,9 +429,6 @@ class AsyncWriterConnectionResumedState
 
   void SetFlushed(std::unique_lock<std::mutex> lk, Status const& result) {
     if (!result.ok()) return SetError(std::move(lk), std::move(result));
-    // This flush step completed. We are no longer actively writing this chunk.
-    // WriteLoop will determine if another flush/write is needed.
-    writing_ = false;
     flush_ = false;  // Reset flush flag; WriteLoop may set it again.
     // Do NOT reset finalize_ or finalizing_ here.
     auto handlers = ClearHandlers(lk);


### PR DESCRIPTION
Setting writing_ = false in SetFlushed() is premature because the Flush-Query operation is not complete until OnQuery() finishes. This prematurely signals that no write is in progress, opening a window where StartWriting() can be called again before OnQuery() restarts or terminates the WriteLoop(), leading to concurrent write/flush operations.

To fix this, I am removing writing_ = false; from SetFlushed(). The writing_ flag will now only be updated by WriteLoop() based on whether there is more data to send, or when an error occurs. This ensures writing_ correctly reflects whether an operation is in flight.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15551)
<!-- Reviewable:end -->
