### PR TITLE
feat(storage): Increase AsyncWriter default MinLwmValue to avoid frequent flushes

### DIFF
--- a/google/cloud/storage/internal/async/default_options.cc
+++ b/google/cloud/storage/internal/async/default_options.cc
@@ -27,7 +27,7 @@ namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-std::size_t MinLwmValue() { return 256 * 1024; }
+std::size_t MinLwmValue() { return 16 * 1024 * 1024; }
 
 std::size_t MaxLwmValue() {
   if (std::numeric_limits<std::size_t>::digits < 64) {


### PR DESCRIPTION
The AsyncWriter was using small values of [LWM (256 KiB)](https://github.com/googleapis/google-cloud-cpp/blob/77ebc1e5e90ce5f743df2d81b6f46ba52d21604d/google/cloud/storage/internal/async/default_options.cc#L41) and [HWM (512 KiB)](https://github.com/googleapis/google-cloud-cpp/blob/77ebc1e5e90ce5f743df2d81b6f46ba52d21604d/google/cloud/storage/internal/async/default_options.cc#L48). This caused the writer to flush data far too frequently, creating a bottleneck,
- LWM i.e. Low Water Mark: When the write buffer size is equal to or greater than this value, the SDK code sets flush_=true and prepares for flush.
- HWM i.e. High Water Mark: When the write buffer size is equal to or greater than this value, writes are paused until the buffer size reaches below the LWM.

This PR increases the default MinLwmValue from 256 KiB to 16 MiB which significantly reduce the number of flush operations, allowing the AsyncWriter to batch more data and achieve much higher throughput. The new default is chosen based on Nokoro test results which demonstrated optimal performance at 16 MiB,
- 4 MiB LWM: ~275 MiB/s throughput
- 8 MiB LWM: ~470 MiB/s throughput
- 16 MiB LWM: ~603 MiB/s throughput
- 32 MiB LWM: ~305 MiB/s throughput