### PR TITLE
feat(storage): Expose Flush() in AsyncWriter

### DIFF
--- a/google/cloud/storage/async/writer.h
+++ b/google/cloud/storage/async/writer.h
@@ -121,7 +121,24 @@ class AsyncWriter {
                                                          WritePayload payload);
 
   /**
+   * Flush any buffered data to the service.
+   *
+   * For buffered uploads, this forces any data in the buffer to be sent to the
+   * service. The returned future is satisfied when the service acknowledges
+   * the flush. Note that the service may not have persisted the data, it may
+   * only be in ephemeral storage. To query the amount of persisted data use
+   * `PersistedState()` after the flush completes.
+   *
+   * @note This is not a terminal operation. The `AsyncWriter` can be used for
+   *     further `Write()` or `Finalize()` operations.
+   */
+  future<Status> Flush();
+
+  /**
    * Close the upload by flushing the remaining data in buffer.
+   *
+   * @warning This is a terminal operation. The `AsyncWriter` object is not
+   *     usable after this call.
    */
   future<Status> Close();
 


### PR DESCRIPTION
This change introduces a Flush() method to the AsyncWriter class, providing users with more control over the asynchronous upload process. If multiple Flush() calls are made, they are queued and processed sequentially. Each call returns a future<Status> that will be satisfied only when that specific flush operation (and all preceding ones) have been acknowledged by the service.

For unbuffered (StartUnbufferedUpload) and appendable (StartAppendableObjectUpload) uploads, this is implemented using a promise queue to serialize flush operations, ensuring thread safety for concurrent use. For buffered uploads (StartBufferedUpload), the Flush() method currently forwards to Write(). A more complete implementation that forces the buffer to be sent and handles concurrent calls correctly is planned for a follow-up PR.
