### PR TITLE
benchmark(bigtable): update sync and async scan benchmarks

### DIFF
--- a/google/cloud/bigtable/benchmarks/CMakeLists.txt
+++ b/google/cloud/bigtable/benchmarks/CMakeLists.txt
@@ -85,6 +85,7 @@ set(bigtable_benchmark_programs
     endurance_benchmark.cc
     mutation_batcher_throughput_benchmark.cc
     read_sync_vs_async_benchmark.cc
+    scan_async_throughput_benchmark.cc
     scan_throughput_benchmark.cc)
 export_list_to_bazel("bigtable_benchmark_programs.bzl"
                      "bigtable_benchmark_programs" YEAR "2018")

--- a/google/cloud/bigtable/benchmarks/benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/benchmark.cc
@@ -127,7 +127,7 @@ void Benchmark::DeleteTable() {
 
 Table Benchmark::MakeTable(Options connection_opts) const {
   auto connection_options =
-      google::cloud::internal::MergeOptions(connection_opts, opts_);
+      google::cloud::internal::MergeOptions(std::move(connection_opts), opts_);
   auto table_opts = Options{}.set<AppProfileIdOption>(options_.app_profile_id);
   return Table(MakeDataConnection(std::move(connection_options)),
                TableResource(options_.project_id, options_.instance_id,

--- a/google/cloud/bigtable/benchmarks/benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/benchmark.cc
@@ -62,6 +62,7 @@ google::cloud::StatusOr<BenchmarkOptions> ParseArgs(
             "--thread-count=1",
             "--test-duration=1s",
             "--table-size=11000",
+            "--enable-metrics=true",
         },
         description);
   }
@@ -124,9 +125,11 @@ void Benchmark::DeleteTable() {
   }
 }
 
-Table Benchmark::MakeTable() const {
+Table Benchmark::MakeTable(Options connection_opts) const {
+  auto connection_options =
+      google::cloud::internal::MergeOptions(connection_opts, opts_);
   auto table_opts = Options{}.set<AppProfileIdOption>(options_.app_profile_id);
-  return Table(MakeDataConnection(opts_),
+  return Table(MakeDataConnection(std::move(connection_options)),
                TableResource(options_.project_id, options_.instance_id,
                              options_.table_id),
                std::move(table_opts));

--- a/google/cloud/bigtable/benchmarks/benchmark.h
+++ b/google/cloud/bigtable/benchmarks/benchmark.h
@@ -63,7 +63,7 @@ class Benchmark {
   google::cloud::StatusOr<BenchmarkResult> PopulateTable();
 
   /// Return a `bigtable::Table` configured for this benchmark.
-  Table MakeTable() const;
+  Table MakeTable(Options connection_opts = Options{}) const;
 
   /// Create a random key.
   std::string MakeRandomKey(google::cloud::internal::DefaultPRNG& gen) const;

--- a/google/cloud/bigtable/benchmarks/benchmark_options.cc
+++ b/google/cloud/bigtable/benchmarks/benchmark_options.cc
@@ -95,7 +95,11 @@ google::cloud::StatusOr<BenchmarkOptions> ParseBenchmarkOptions(
        [&options](std::string const& val) {
          options.include_read_rows = ParseBoolean(val).value_or(true);
        }},
-
+      {"--enable-metrics",
+       "whether to enable Client Side Metrics for benchmarking",
+       [&options](std::string const& val) {
+         options.enable_metrics = ParseBoolean(val).value_or(true);
+       }},
   };
 
   auto usage = BuildUsage(desc, argv[0]);

--- a/google/cloud/bigtable/benchmarks/benchmark_options.h
+++ b/google/cloud/bigtable/benchmarks/benchmark_options.h
@@ -41,6 +41,7 @@ struct BenchmarkOptions {
   int parallel_requests = 10;
   bool exit_after_parse = false;
   bool include_read_rows = false;
+  bool enable_metrics = true;
 };
 
 google::cloud::StatusOr<BenchmarkOptions> ParseBenchmarkOptions(

--- a/google/cloud/bigtable/benchmarks/bigtable_benchmark_programs.bzl
+++ b/google/cloud/bigtable/benchmarks/bigtable_benchmark_programs.bzl
@@ -21,5 +21,6 @@ bigtable_benchmark_programs = [
     "endurance_benchmark.cc",
     "mutation_batcher_throughput_benchmark.cc",
     "read_sync_vs_async_benchmark.cc",
+    "scan_async_throughput_benchmark.cc",
     "scan_throughput_benchmark.cc",
 ]

--- a/google/cloud/bigtable/benchmarks/scan_async_throughput_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/scan_async_throughput_benchmark.cc
@@ -98,6 +98,11 @@ int main(int argc, char* argv[]) {
   auto generator = google::cloud::internal::MakeDefaultPRNG();
 
 #ifdef PROFILE
+  // Profiling docs: https://gperftools.github.io/gperftools/cpuprofile.html
+  // Typical execution:
+  //   $ PROFILER_PATH="/tmp/<filename>" bazel run -c opt --copt=-DPROFILE \
+  //       --copt=-g --linkopt='-lprofiler' \
+  //       google/cloud/bigtable/benchmarks:scan_async_throughput_benchmark
   auto profile_data_path = google::cloud::internal::GetEnv("PROFILER_PATH");
   if (profile_data_path) ProfilerStart(profile_data_path->c_str());
   auto profiler_start = std::chrono::steady_clock::now();

--- a/google/cloud/bigtable/benchmarks/scan_async_throughput_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/scan_async_throughput_benchmark.cc
@@ -98,11 +98,13 @@ int main(int argc, char* argv[]) {
   auto generator = google::cloud::internal::MakeDefaultPRNG();
 
 #ifdef PROFILE
-  // Profiling docs: https://gperftools.github.io/gperftools/cpuprofile.html
-  // Typical execution:
-  //   $ PROFILER_PATH="/tmp/<filename>" bazel run -c opt --copt=-DPROFILE \
-  //       --copt=-g --linkopt='-lprofiler' \
-  //       google/cloud/bigtable/benchmarks:scan_async_throughput_benchmark
+  /*
+   * Profiling docs: https://gperftools.github.io/gperftools/cpuprofile.html
+   * Typical execution:
+   *   $ PROFILER_PATH="/tmp/<filename>" bazel run -c opt --copt=-DPROFILE \
+   *       --copt=-g --linkopt='-lprofiler' \
+   *       google/cloud/bigtable/benchmarks:scan_async_throughput_benchmark
+   */
   auto profile_data_path = google::cloud::internal::GetEnv("PROFILER_PATH");
   if (profile_data_path) ProfilerStart(profile_data_path->c_str());
   auto profiler_start = std::chrono::steady_clock::now();
@@ -159,8 +161,9 @@ BenchmarkResult RunBenchmark(bigtable::benchmarks::Benchmark const& benchmark,
   while (std::chrono::steady_clock::now() < test_start + test_duration) {
     auto row_set = bigtable::RowSet{
         bigtable::RowRange::StartingAt(benchmark.MakeKey(prng(generator)))};
-    long count = 0;  // NOLINT(google-runtime-int)
-    std::promise<long> all_done;
+    long count = 0;               // NOLINT(google-runtime-int)
+    std::promise<long> all_done;  // NOLINT(google-runtime-int)
+    // NOLINTNEXTLINE(google-runtime-int)
     std::future<long> all_done_future = all_done.get_future();
 
     auto op = [&all_done, &all_done_future, &count, &table, scan_size,

--- a/google/cloud/bigtable/benchmarks/scan_throughput_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/scan_throughput_benchmark.cc
@@ -97,11 +97,13 @@ int main(int argc, char* argv[]) {
   auto generator = google::cloud::internal::MakeDefaultPRNG();
 
 #ifdef PROFILE
-  // Profiling docs: https://gperftools.github.io/gperftools/cpuprofile.html
-  // Typical execution:
-  //   $ PROFILER_PATH="/tmp/<filename>" bazel run -c opt --copt=-DPROFILE \
-  //       --copt=-g --linkopt='-lprofiler' \
-  //       google/cloud/bigtable/benchmarks:scan_async_throughput_benchmark
+  /*
+   * Profiling docs: https://gperftools.github.io/gperftools/cpuprofile.html
+   * Typical execution:
+   *   $ PROFILER_PATH="/tmp/<filename>" bazel run -c opt --copt=-DPROFILE \
+   *       --copt=-g --linkopt='-lprofiler' \
+   *       google/cloud/bigtable/benchmarks:scan_async_throughput_benchmark
+   */
   auto profile_data_path = google::cloud::internal::GetEnv("PROFILER_PATH");
   if (profile_data_path) ProfilerStart(profile_data_path->c_str());
   auto profiler_start = std::chrono::steady_clock::now();

--- a/google/cloud/bigtable/benchmarks/scan_throughput_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/scan_throughput_benchmark.cc
@@ -97,6 +97,11 @@ int main(int argc, char* argv[]) {
   auto generator = google::cloud::internal::MakeDefaultPRNG();
 
 #ifdef PROFILE
+  // Profiling docs: https://gperftools.github.io/gperftools/cpuprofile.html
+  // Typical execution:
+  //   $ PROFILER_PATH="/tmp/<filename>" bazel run -c opt --copt=-DPROFILE \
+  //       --copt=-g --linkopt='-lprofiler' \
+  //       google/cloud/bigtable/benchmarks:scan_async_throughput_benchmark
   auto profile_data_path = google::cloud::internal::GetEnv("PROFILER_PATH");
   if (profile_data_path) ProfilerStart(profile_data_path->c_str());
   auto profiler_start = std::chrono::steady_clock::now();


### PR DESCRIPTION
Adds scan_async_throughput_benchmark as an async version of scan_throughput_benchmark. Both now support profiling around ReadRows sections which require gperftools to be installed and can be enabled via:

```
PROFILER_PATH="/tmp/<filename>" bazel run -c opt --copt=-DPROFILE --copt=-g --linkopt='-lprofiler' //google/cloud/bigtable/benchmarks:scan_async_throughput_benchmark
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15557)
<!-- Reviewable:end -->
