### PR TITLE
fix(storage): Fix Resume() to use append_object_spec instead of write_object_spec for resumed appendable uploads

### DIFF
--- a/google/cloud/storage/internal/async/writer_connection_resumed.cc
+++ b/google/cloud/storage/internal/async/writer_connection_resumed.cc
@@ -324,10 +324,16 @@ class AsyncWriterConnectionResumedState
   void Resume(Status const& s) {
     auto proto_status = ExtractGrpcStatus(s);
     auto request = google::storage::v2::BidiWriteObjectRequest{};
-    auto spec = initial_request_.append_object_spec();
     auto& append_object_spec = *request.mutable_append_object_spec();
-    append_object_spec.set_bucket(spec.bucket());
-    append_object_spec.set_object(spec.object());
+    if (initial_request_.has_write_object_spec()) {
+      auto const& spec = initial_request_.write_object_spec();
+      append_object_spec.set_bucket(spec.resource().bucket());
+      append_object_spec.set_object(spec.resource().name());
+    } else {
+      auto const& spec = initial_request_.append_object_spec();
+      append_object_spec.set_bucket(spec.bucket());
+      append_object_spec.set_object(spec.object());
+    }
     append_object_spec.set_generation(first_response_.resource().generation());
     ApplyWriteRedirectErrors(append_object_spec, std::move(proto_status));
 

--- a/google/cloud/storage/internal/async/writer_connection_resumed_test.cc
+++ b/google/cloud/storage/internal/async/writer_connection_resumed_test.cc
@@ -258,13 +258,13 @@ TEST(WriteConnectionResumed, FlushNonEmpty) {
   EXPECT_THAT(write.get(), StatusIs(StatusCode::kOk));
 }
 
-TEST(WriteConnectionResumed, ResumeUsesGenerationFromFirstResponse) {
+TEST(WriteConnectionResumed, ResumeUsesWriteObjectSpecFromInitialRequest) {
   AsyncSequencer<bool> sequencer;
   auto mock = std::make_unique<MockAsyncWriterConnection>();
   auto initial_request = google::storage::v2::BidiWriteObjectRequest{};
-  initial_request.mutable_append_object_spec()->set_bucket(
+  initial_request.mutable_write_object_spec()->mutable_resource()->set_bucket(
       "projects/_/buckets/test-bucket");
-  initial_request.mutable_append_object_spec()->set_object(
+  initial_request.mutable_write_object_spec()->mutable_resource()->set_name(
       "test-object");
 
   google::storage::v2::BidiWriteObjectResponse first_response;
@@ -316,6 +316,72 @@ TEST(WriteConnectionResumed, ResumeUsesGenerationFromFirstResponse) {
   // factory.
   EXPECT_THAT(write.get(), StatusIs(StatusCode::kAborted));
 
+  EXPECT_FALSE(captured_request.has_write_object_spec());
+  EXPECT_TRUE(captured_request.has_append_object_spec());
+  EXPECT_EQ(captured_request.append_object_spec().generation(), 12345);
+  EXPECT_EQ(captured_request.append_object_spec().object(), "test-object");
+  EXPECT_EQ(captured_request.append_object_spec().bucket(),
+            "projects/_/buckets/test-bucket");
+}
+
+TEST(WriteConnectionResumed, ResumeUsesAppendObjectSpecFromInitialRequest) {
+  AsyncSequencer<bool> sequencer;
+  auto mock = std::make_unique<MockAsyncWriterConnection>();
+  auto initial_request = google::storage::v2::BidiWriteObjectRequest{};
+  initial_request.mutable_append_object_spec()->set_bucket(
+      "projects/_/buckets/test-bucket");
+  initial_request.mutable_append_object_spec()->set_object("test-object");
+
+  google::storage::v2::BidiWriteObjectResponse first_response;
+  first_response.mutable_resource()->set_generation(12345);
+
+  EXPECT_CALL(*mock, PersistedState)
+      .WillRepeatedly(Return(MakePersistedState(0)));
+
+  // Expect Flush to be called because flush_ is true by default.
+  // Make it fail to trigger Resume().
+  EXPECT_CALL(*mock, Flush(_)).WillOnce([&](auto) {
+    return sequencer.PushBack("Flush").then([](auto f) {
+      if (f.get()) return google::cloud::Status{};  // Should not be true
+      return TransientError();
+    });
+  });
+
+  MockFactory mock_factory;
+  google::storage::v2::BidiWriteObjectRequest captured_request;
+  EXPECT_CALL(mock_factory, Call(_))
+      .WillOnce([&](google::storage::v2::BidiWriteObjectRequest request) {
+        captured_request = std::move(request);
+        return sequencer.PushBack("Factory").then([](auto) {
+          return StatusOr<WriteObject::WriteResult>(
+              internal::AbortedError("stop test", GCP_ERROR_INFO()));
+        });
+      });
+
+  auto connection = MakeWriterConnectionResumed(
+      mock_factory.AsStdFunction(), std::move(mock), initial_request, nullptr,
+      first_response, Options{});
+
+  // This will call FlushStep -> mock->Flush()
+  auto write = connection->Write(TestPayload(1));
+  ASSERT_FALSE(write.is_ready());
+
+  // Trigger the Flush error in the mock
+  auto next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "Flush");
+  next.first.set_value(false);  // This makes the lambda return TransientError
+
+  // The error in OnFlush triggers Resume(), which calls the mock_factory.
+  // Allow the factory callback to proceed.
+  next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "Factory");
+  next.first.set_value(true);
+
+  // The write future should now be ready, containing the error from the
+  // factory.
+  EXPECT_THAT(write.get(), StatusIs(StatusCode::kAborted));
+
+  EXPECT_FALSE(captured_request.has_write_object_spec());
   EXPECT_TRUE(captured_request.has_append_object_spec());
   EXPECT_EQ(captured_request.append_object_spec().generation(), 12345);
   EXPECT_EQ(captured_request.append_object_spec().object(), "test-object");


### PR DESCRIPTION
This PR corrects the logic in AsyncWriterConnectionResumedState::Resume() where it incorrectly assumed initial_request_ would always contain an [write_object_spec](https://github.com/googleapis/google-cloud-cpp/blob/97b036b6d548615641f6c8260fb31fa302c74226/google/cloud/storage/internal/async/writer_connection_resumed.cc#L327). This assumption fails when resuming an upload that was initiated with ResumeAppendableObjectUpload, which uses append_object_spec, which leads to passing the bucket and object names empty.

The fix introduces a check to determine whether initial_request_ contains a write_object_spec or an append_object_spec, and then correctly extracts the bucket and object names from the available spec. This approach aligns with the pattern already used in [WriteResultFactory](https://github.com/googleapis/google-cloud-cpp/blob/feb385d8a60b4bf44cb21078369a119d3b42b29d/google/cloud/storage/internal/async/connection_impl.cc#L347) for handling these two types of specifications.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15558)
<!-- Reviewable:end -->
