### PR TITLE
fix(build): use static runtime for windows builds

### DIFF
--- a/ci/kokoro/windows/builds/cmake.ps1
+++ b/ci/kokoro/windows/builds/cmake.ps1
@@ -57,7 +57,8 @@ $cmake_args=@(
     "-DCMAKE_C_COMPILER=cl.exe",
     "-DCMAKE_CXX_COMPILER=cl.exe",
     "-DGOOGLE_CLOUD_CPP_ENABLE_WERROR=ON",
-    "-DGOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND=ON"
+    "-DGOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND=ON",
+    "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded$<$<CONFIG:Debug>:Debug>"
 )
 
 # Configure CMake and create the build directory.


### PR DESCRIPTION
This change forces the use of the static C++ runtime library (/MT) on Windows builds to resolve linker errors caused by a mismatch with the vcpkg-provided dependencies.