### PR TITLE
feat(bigtable): add support for RowStream

### DIFF
--- a/google/cloud/bigtable/query_row.cc
+++ b/google/cloud/bigtable/query_row.cc
@@ -66,17 +66,17 @@ bool operator==(QueryRow const& a, QueryRow const& b) {
 }
 
 //
-// QueryRowStreamIterator
+// RowStreamIterator
 //
 
-QueryRowStreamIterator::QueryRowStreamIterator() = default;
+RowStreamIterator::RowStreamIterator() = default;
 
-QueryRowStreamIterator::QueryRowStreamIterator(Source source)
+RowStreamIterator::RowStreamIterator(Source source)
     : source_(std::move(source)) {
   ++*this;
 }
 
-QueryRowStreamIterator& QueryRowStreamIterator::operator++() {
+RowStreamIterator& RowStreamIterator::operator++() {
   if (!row_ok_) {
     source_ = nullptr;  // Last row was an error; become "end"
     return *this;
@@ -90,14 +90,13 @@ QueryRowStreamIterator& QueryRowStreamIterator::operator++() {
   return *this;
 }
 
-QueryRowStreamIterator QueryRowStreamIterator::operator++(int) {
+RowStreamIterator RowStreamIterator::operator++(int) {
   auto old = *this;
   ++*this;
   return old;
 }
 
-bool operator==(QueryRowStreamIterator const& a,
-                QueryRowStreamIterator const& b) {
+bool operator==(RowStreamIterator const& a, RowStreamIterator const& b) {
   // Input iterators may only be compared to (copies of) themselves and end.
   // See https://en.cppreference.com/w/cpp/named_req/InputIterator. Therefore,
   // by definition, all input iterators are equal unless one is end and the
@@ -105,8 +104,7 @@ bool operator==(QueryRowStreamIterator const& a,
   return !a.source_ == !b.source_;
 }
 
-bool operator!=(QueryRowStreamIterator const& a,
-                QueryRowStreamIterator const& b) {
+bool operator!=(RowStreamIterator const& a, RowStreamIterator const& b) {
   return !(a == b);
 }
 

--- a/google/cloud/bigtable/query_row.h
+++ b/google/cloud/bigtable/query_row.h
@@ -205,11 +205,11 @@ class QueryRow {
 };
 
 /**
- * A `QueryRowStreamIterator` is an _Input Iterator_ (see below) that returns a
+ * A `RowStreamIterator` is an _Input Iterator_ (see below) that returns a
  * sequence of `StatusOr<QueryRow>` objects.
  *
  * As an [Input Iterator][input-iterator], the sequence may only be consumed
- * once. Default constructing a `QueryRowStreamIterator` creates an instance
+ * once. Default constructing a `RowStreamIterator` creates an instance
  * that represents "end".
  *
  * @note The term "stream" in this name refers to the general nature
@@ -218,7 +218,7 @@ class QueryRow {
  *
  * [input-iterator]: https://en.cppreference.com/w/cpp/named_req/InputIterator
  */
-class QueryRowStreamIterator {
+class RowStreamIterator {
  public:
   /**
    * A function that returns a sequence of `StatusOr<QueryRow>` objects.
@@ -239,13 +239,13 @@ class QueryRowStreamIterator {
   ///@}
 
   /// Default constructs an "end" iterator.
-  QueryRowStreamIterator();
+  RowStreamIterator();
 
   /**
-   * Constructs a `QueryRowStreamIterator` that will consume rows from the given
+   * Constructs a `RowStreamIterator` that will consume rows from the given
    * @p source, which must not be `nullptr`.
    */
-  explicit QueryRowStreamIterator(Source source);
+  explicit RowStreamIterator(Source source);
 
   reference operator*() { return row_; }
   pointer operator->() { return &row_; }
@@ -253,13 +253,11 @@ class QueryRowStreamIterator {
   const_reference operator*() const { return row_; }
   const_pointer operator->() const { return &row_; }
 
-  QueryRowStreamIterator& operator++();
-  QueryRowStreamIterator operator++(int);
+  RowStreamIterator& operator++();
+  RowStreamIterator operator++(int);
 
-  friend bool operator==(QueryRowStreamIterator const&,
-                         QueryRowStreamIterator const&);
-  friend bool operator!=(QueryRowStreamIterator const&,
-                         QueryRowStreamIterator const&);
+  friend bool operator==(RowStreamIterator const&, RowStreamIterator const&);
+  friend bool operator!=(RowStreamIterator const&, RowStreamIterator const&);
 
  private:
   bool row_ok_{true};
@@ -269,7 +267,7 @@ class QueryRowStreamIterator {
 
 /**
  * A `TupleStreamIterator<Tuple>` is an "Input Iterator" that wraps a
- * `QueryRowStreamIterator`,
+ * `RowStreamIterator`,
  * parsing its elements into a sequence of
  * `StatusOr<Tuple>` objects.
  *
@@ -278,7 +276,7 @@ class QueryRowStreamIterator {
  *
  * Default constructing this object creates an instance that represents "end".
  *
- * Each `QueryRow` returned by the wrapped `QueryRowStreamIterator` must be
+ * Each `QueryRow` returned by the wrapped `RowStreamIterator` must be
  * convertible to the specified `Tuple` template parameter.
  *
  * @note The term "stream" in this name refers to the general nature
@@ -304,8 +302,8 @@ class TupleStreamIterator {
   /// Default constructs an "end" iterator.
   TupleStreamIterator() = default;
 
-  /// Creates an iterator that wraps the given `QueryRowStreamIterator` range.
-  TupleStreamIterator(QueryRowStreamIterator begin, QueryRowStreamIterator end)
+  /// Creates an iterator that wraps the given `RowStreamIterator` range.
+  TupleStreamIterator(RowStreamIterator begin, RowStreamIterator end)
       : it_(std::move(begin)), end_(std::move(end)) {
     ParseTuple();
   }
@@ -351,13 +349,13 @@ class TupleStreamIterator {
 
   bool tup_ok_{false};
   value_type tup_;
-  QueryRowStreamIterator it_;
-  QueryRowStreamIterator end_;
+  RowStreamIterator it_;
+  RowStreamIterator end_;
 };
 
 /**
  * A `TupleStream<Tuple>` defines a range that parses `Tuple` objects from the
- * given range of `QueryRowStreamIterator`s.
+ * given range of `RowStreamIterator`s.
  *
  * Users create instances using the `StreamOf<T>(range)` non-member factory
  * function (defined below). The following is a typical usage of this class in
@@ -407,13 +405,13 @@ class TupleStream {
 /**
  * A factory that creates a `TupleStream<Tuple>` by wrapping the given @p
  * range. The `QueryRowRange` must be a range defined by
- * `QueryRowStreamIterator` objects.
+ * `RowStreamIterator` objects.
  *
  *
  * @note Ownership of the @p range is not transferred, so it must outlive the
  *     returned `TupleStream`.
  *
- * @tparam QueryRowRange must be a range defined by `QueryRowStreamIterator`s.
+ * @tparam QueryRowRange must be a range defined by `RowStreamIterator`s.
  */
 template <typename Tuple, typename QueryRowRange>
 TupleStream<Tuple> StreamOf(QueryRowRange&& range) {

--- a/google/cloud/bigtable/query_row_test.cc
+++ b/google/cloud/bigtable/query_row_test.cc
@@ -33,7 +33,7 @@ using ::testing::Not;
 
 // Given a `vector<StatusOr<QueryRow>>` creates a 'QueryRow::Source' object.
 // This is helpful for unit testing and letting the test inject a non-OK Status.
-QueryRowStreamIterator::Source MakeQueryRowStreamIteratorSource(
+RowStreamIterator::Source MakeRowStreamIteratorSource(
     std::vector<StatusOr<QueryRow>> const& rows) {
   std::size_t index = 0;
   return [=]() mutable -> StatusOr<QueryRow> {
@@ -43,21 +43,21 @@ QueryRowStreamIterator::Source MakeQueryRowStreamIteratorSource(
 }
 
 // Given a `vector<QueryRow>` creates a 'QueryRow::Source' object.
-QueryRowStreamIterator::Source MakeQueryRowStreamIteratorSource(
+RowStreamIterator::Source MakeRowStreamIteratorSource(
     std::vector<QueryRow> const& rows = {}) {
-  return MakeQueryRowStreamIteratorSource(
+  return MakeRowStreamIterator(
       std::vector<StatusOr<QueryRow>>(rows.begin(), rows.end()));
 }
 
 class QueryRowRange {
  public:
-  explicit QueryRowRange(QueryRowStreamIterator::Source s) : s_(std::move(s)) {}
-  QueryRowStreamIterator begin() { return QueryRowStreamIterator(s_); }
+  explicit QueryRowRange(RowStreamIterator::Source s) : s_(std::move(s)) {}
+  RowStreamIterator begin() { return RowStreamIterator(s_); }
   // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
-  QueryRowStreamIterator end() { return QueryRowStreamIterator(); }
+  RowStreamIterator end() { return RowStreamIterator(); }
 
  private:
-  QueryRowStreamIterator::Source s_;
+  RowStreamIterator::Source s_;
 };
 
 TEST(QueryRow, DefaultConstruct) {
@@ -196,8 +196,8 @@ TEST(MakeQueryRow, ImplicitColumnNames) {
   EXPECT_EQ(Value(52), *row.get("1"));
 }
 
-TEST(QueryRowStreamIterator, Basics) {
-  QueryRowStreamIterator end;
+TEST(RowStreamIterator, Basics) {
+  RowStreamIterator end;
   EXPECT_EQ(end, end);
 
   std::vector<QueryRow> rows;
@@ -205,7 +205,7 @@ TEST(QueryRowStreamIterator, Basics) {
   rows.emplace_back(bigtable_mocks::MakeQueryRow(2, "bar", true));
   rows.emplace_back(bigtable_mocks::MakeQueryRow(3, "baz", true));
 
-  auto it = QueryRowStreamIterator(MakeQueryRowStreamIteratorSource(rows));
+  auto it = RowStreamIterator(RowStreamIteratorSource(rows));
   EXPECT_EQ(it, it);
   EXPECT_NE(it, end);
   ASSERT_STATUS_OK(*it);
@@ -235,17 +235,17 @@ TEST(QueryRowStreamIterator, Basics) {
   EXPECT_EQ(it, end);
 }
 
-TEST(QueryRowStreamIterator, Empty) {
-  QueryRowStreamIterator end;
-  auto it = QueryRowStreamIterator(MakeQueryRowStreamIteratorSource());
+TEST(RowStreamIterator, Empty) {
+  RowStreamIterator end;
+  auto it = RowStreamIterator(MakeRowStreamIteratorSource());
   EXPECT_EQ(it, end);
 }
 
-TEST(QueryRowStreamIterator, OneRow) {
-  QueryRowStreamIterator end;
+TEST(RowStreamIterator, OneRow) {
+  RowStreamIterator end;
   std::vector<QueryRow> rows;
   rows.emplace_back(bigtable_mocks::MakeQueryRow(1, "foo", true));
-  auto it = QueryRowStreamIterator(MakeQueryRowStreamIteratorSource(rows));
+  auto it = RowStreamIterator(MakeRowStreamIteratorSource(rows));
   EXPECT_NE(it, end);
   ASSERT_STATUS_OK(*it);
   EXPECT_EQ(rows[0], **it);
@@ -255,14 +255,14 @@ TEST(QueryRowStreamIterator, OneRow) {
   EXPECT_EQ(it, end);
 }
 
-TEST(QueryRowStreamIterator, IterationError) {
-  QueryRowStreamIterator end;
+TEST(RowStreamIterator, IterationError) {
+  RowStreamIterator end;
   std::vector<StatusOr<QueryRow>> rows;
   rows.emplace_back(bigtable_mocks::MakeQueryRow(1, "foo", true));
   rows.emplace_back(Status(StatusCode::kUnknown, "some error"));
   rows.emplace_back(bigtable_mocks::MakeQueryRow(2, "bar", true));
 
-  auto it = QueryRowStreamIterator(MakeQueryRowStreamIteratorSource(rows));
+  auto it = RowStreamIterator(MakeRowStreamIteratorSource(rows));
   ASSERT_NE(it, end);
   EXPECT_STATUS_OK(*it);
   EXPECT_EQ(rows[0], *it);
@@ -278,15 +278,15 @@ TEST(QueryRowStreamIterator, IterationError) {
   EXPECT_EQ(it, end);
 }
 
-TEST(QueryRowStreamIterator, ForLoop) {
+TEST(RowStreamIterator, ForLoop) {
   std::vector<QueryRow> rows;
   rows.emplace_back(bigtable_mocks::MakeQueryRow({{"num", Value(2)}}));
   rows.emplace_back(bigtable_mocks::MakeQueryRow({{"num", Value(3)}}));
   rows.emplace_back(bigtable_mocks::MakeQueryRow({{"num", Value(5)}}));
 
-  auto source = MakeQueryRowStreamIteratorSource(rows);
+  auto source = MakeRowStreamIteratorSource(rows);
   std::int64_t product = 1;
-  for (QueryRowStreamIterator it(source), end; it != end; ++it) {
+  for (RowStreamIterator it(source), end; it != end; ++it) {
     ASSERT_STATUS_OK(*it);
     auto num = (*it)->get<std::int64_t>("num");
     ASSERT_STATUS_OK(num);
@@ -295,13 +295,13 @@ TEST(QueryRowStreamIterator, ForLoop) {
   EXPECT_EQ(product, 30);
 }
 
-TEST(QueryRowStreamIterator, RangeForLoopFloat32) {
+TEST(RowStreamIterator, RangeForLoopFloat32) {
   std::vector<QueryRow> rows;
   rows.emplace_back(bigtable_mocks::MakeQueryRow({{"num", Value(2.1F)}}));
   rows.emplace_back(bigtable_mocks::MakeQueryRow({{"num", Value(3.2F)}}));
   rows.emplace_back(bigtable_mocks::MakeQueryRow({{"num", Value(5.4F)}}));
 
-  QueryRowRange range(MakeQueryRowStreamIteratorSource(rows));
+  QueryRowRange range(RowStreamIteratorSource(rows));
   float sum = 0;
   for (auto const& row : range) {
     ASSERT_STATUS_OK(row);
@@ -312,13 +312,13 @@ TEST(QueryRowStreamIterator, RangeForLoopFloat32) {
   EXPECT_FLOAT_EQ(sum, 10.7F);
 }
 
-TEST(QueryRowStreamIterator, RangeForLoop) {
+TEST(RowStreamIterator, RangeForLoop) {
   std::vector<QueryRow> rows;
   rows.emplace_back(bigtable_mocks::MakeQueryRow({{"num", Value(2)}}));
   rows.emplace_back(bigtable_mocks::MakeQueryRow({{"num", Value(3)}}));
   rows.emplace_back(bigtable_mocks::MakeQueryRow({{"num", Value(5)}}));
 
-  QueryRowRange range(MakeQueryRowStreamIteratorSource(rows));
+  QueryRowRange range(MakeRowStreamIteratorSource(rows));
   std::int64_t product = 1;
   for (auto const& row : range) {
     ASSERT_STATUS_OK(row);
@@ -329,12 +329,12 @@ TEST(QueryRowStreamIterator, RangeForLoop) {
   EXPECT_EQ(product, 30);
 }
 
-TEST(QueryRowStreamIterator, MovedFromValueOk) {
+TEST(RowStreamIterator, MovedFromValueOk) {
   std::vector<QueryRow> rows;
   rows.emplace_back(bigtable_mocks::MakeQueryRow({{"num", Value(1)}}));
   rows.emplace_back(bigtable_mocks::MakeQueryRow({{"num", Value(2)}}));
 
-  QueryRowRange range(MakeQueryRowStreamIteratorSource(rows));
+  QueryRowRange range(MakeRowStreamIteratorSource(rows));
   auto it = range.begin();
   auto end = range.end();
 
@@ -369,9 +369,8 @@ TEST(TupleStreamIterator, Basics) {
   auto end = TupleIterator();
   EXPECT_EQ(end, end);
 
-  auto it = TupleIterator(
-      QueryRowStreamIterator(MakeQueryRowStreamIteratorSource(rows)),
-      QueryRowStreamIterator());
+  auto it = TupleIterator(RowStreamIterator(MakeRowStreamIteratorSource(rows)),
+                          RowStreamIterator());
 
   EXPECT_EQ(it, it);
   ASSERT_NE(it, end);
@@ -409,9 +408,8 @@ TEST(TupleStreamIterator, Empty) {
   auto end = TupleIterator();
   EXPECT_EQ(end, end);
 
-  auto it =
-      TupleIterator(QueryRowStreamIterator(MakeQueryRowStreamIteratorSource()),
-                    QueryRowStreamIterator());
+  auto it = TupleIterator(RowStreamIterator(MakeRowStreamIteratorSource()),
+                          RowStreamIterator());
   EXPECT_EQ(it, end);
 }
 
@@ -427,9 +425,8 @@ TEST(TupleStreamIterator, Error) {
   auto end = TupleIterator();
   EXPECT_EQ(end, end);
 
-  auto it = TupleIterator(
-      QueryRowStreamIterator(MakeQueryRowStreamIteratorSource(rows)),
-      QueryRowStreamIterator());
+  auto it = TupleIterator(RowStreamIterator(MakeRowStreamIteratorSource(rows)),
+                          RowStreamIterator());
 
   EXPECT_EQ(it, it);
   ASSERT_NE(it, end);
@@ -451,7 +448,7 @@ TEST(TupleStreamIterator, MovedFromValueOk) {
   rows.emplace_back(bigtable_mocks::MakeQueryRow({{"num", Value(1)}}));
   rows.emplace_back(bigtable_mocks::MakeQueryRow({{"num", Value(2)}}));
 
-  QueryRowRange range(MakeQueryRowStreamIteratorSource(rows));
+  QueryRowRange range(MakeRowStreamIteratorSource(rows));
   using RowType = std::tuple<std::int64_t>;
   using TupleIterator = TupleStreamIterator<RowType>;
   auto it = TupleIterator(range.begin(), range.end());
@@ -479,7 +476,7 @@ TEST(TupleStream, Basics) {
   rows.emplace_back(bigtable_mocks::MakeQueryRow(3, "baz", true));
 
   using RowType = std::tuple<std::int64_t, std::string, bool>;
-  QueryRowRange range(MakeQueryRowStreamIteratorSource(rows));
+  QueryRowRange range(MakeRowStreamIteratorSource(rows));
   auto parser = StreamOf<RowType>(range);
   auto it = parser.begin();
   auto end = parser.end();
@@ -514,7 +511,7 @@ TEST(TupleStream, RangeForLoop) {
   rows.emplace_back(bigtable_mocks::MakeQueryRow({{"num", Value(5)}}));
   using RowType = std::tuple<std::int64_t>;
 
-  QueryRowRange range(MakeQueryRowStreamIteratorSource(rows));
+  QueryRowRange range(MakeRowStreamIteratorSource(rows));
   std::int64_t product = 1;
   for (auto const& row : StreamOf<RowType>(range)) {
     ASSERT_STATUS_OK(row);
@@ -529,7 +526,7 @@ TEST(TupleStream, IterationError) {
   rows.emplace_back(Status(StatusCode::kUnknown, "some error"));
   rows.emplace_back(bigtable_mocks::MakeQueryRow(2, "bar", true));
 
-  QueryRowRange range(MakeQueryRowStreamIteratorSource(rows));
+  QueryRowRange range(MakeRowStreamIteratorSource(rows));
 
   using RowType = std::tuple<std::int64_t, std::string, bool>;
   auto stream = StreamOf<RowType>(range);
@@ -553,7 +550,7 @@ TEST(TupleStream, IterationError) {
 
 TEST(GetSingularRow, BasicEmpty) {
   std::vector<QueryRow> rows;
-  QueryRowRange range(MakeQueryRowStreamIteratorSource(rows));
+  QueryRowRange range(MakeRowStreamIteratorSource(rows));
   auto row = GetSingularRow(range);
   EXPECT_THAT(row,
               StatusIs(StatusCode::kInvalidArgument, HasSubstr("no rows")));
@@ -561,7 +558,7 @@ TEST(GetSingularRow, BasicEmpty) {
 
 TEST(GetSingularRow, TupleStreamEmpty) {
   std::vector<QueryRow> rows;
-  QueryRowRange range(MakeQueryRowStreamIteratorSource(rows));
+  QueryRowRange range(MakeRowStreamIteratorSource(rows));
   auto row = GetSingularRow(StreamOf<std::tuple<std::int64_t>>(range));
   EXPECT_THAT(row,
               StatusIs(StatusCode::kInvalidArgument, HasSubstr("no rows")));
@@ -571,7 +568,7 @@ TEST(GetSingularRow, BasicSingleRow) {
   std::vector<QueryRow> rows;
   rows.emplace_back(bigtable_mocks::MakeQueryRow({{"num", Value(1)}}));
 
-  QueryRowRange range(MakeQueryRowStreamIteratorSource(rows));
+  QueryRowRange range(MakeRowStreamIteratorSource(rows));
   auto row = GetSingularRow(range);
   ASSERT_STATUS_OK(row);
   EXPECT_EQ(1, *row->get<std::int64_t>(0));
@@ -581,7 +578,7 @@ TEST(GetSingularRow, TupleStreamSingleRow) {
   std::vector<QueryRow> rows;
   rows.emplace_back(bigtable_mocks::MakeQueryRow({{"num", Value(1)}}));
 
-  auto row_range = QueryRowRange(MakeQueryRowStreamIteratorSource(rows));
+  auto row_range = QueryRowRange(MakeRowStreamIteratorSource(rows));
   auto tup_range = StreamOf<std::tuple<std::int64_t>>(row_range);
 
   auto row = GetSingularRow(tup_range);
@@ -594,7 +591,7 @@ TEST(GetSingularRow, BasicTooManyRows) {
   rows.emplace_back(bigtable_mocks::MakeQueryRow({{"num", Value(1)}}));
   rows.emplace_back(bigtable_mocks::MakeQueryRow({{"num", Value(2)}}));
 
-  QueryRowRange range(MakeQueryRowStreamIteratorSource(rows));
+  QueryRowRange range(MakeRowStreamIteratorSource(rows));
   auto row = GetSingularRow(range);
   EXPECT_THAT(
       row, StatusIs(StatusCode::kInvalidArgument, HasSubstr("too many rows")));
@@ -605,7 +602,7 @@ TEST(GetSingularRow, TupleStreamTooManyRows) {
   rows.emplace_back(bigtable_mocks::MakeQueryRow({{"num", Value(1)}}));
   rows.emplace_back(bigtable_mocks::MakeQueryRow({{"num", Value(2)}}));
 
-  QueryRowRange range(MakeQueryRowStreamIteratorSource(rows));
+  QueryRowRange range(MakeRowStreamIteratorSource(rows));
   auto row = GetSingularRow(StreamOf<std::tuple<std::int64_t>>(range));
   EXPECT_THAT(
       row, StatusIs(StatusCode::kInvalidArgument, HasSubstr("too many rows")));

--- a/google/cloud/bigtable/query_row_test.cc
+++ b/google/cloud/bigtable/query_row_test.cc
@@ -45,7 +45,7 @@ RowStreamIterator::Source MakeRowStreamIteratorSource(
 // Given a `vector<QueryRow>` creates a 'QueryRow::Source' object.
 RowStreamIterator::Source MakeRowStreamIteratorSource(
     std::vector<QueryRow> const& rows = {}) {
-  return MakeRowStreamIterator(
+  return MakeRowStreamIteratorSource(
       std::vector<StatusOr<QueryRow>>(rows.begin(), rows.end()));
 }
 
@@ -205,7 +205,7 @@ TEST(RowStreamIterator, Basics) {
   rows.emplace_back(bigtable_mocks::MakeQueryRow(2, "bar", true));
   rows.emplace_back(bigtable_mocks::MakeQueryRow(3, "baz", true));
 
-  auto it = RowStreamIterator(RowStreamIteratorSource(rows));
+  auto it = RowStreamIterator(MakeRowStreamIteratorSource(rows));
   EXPECT_EQ(it, it);
   EXPECT_NE(it, end);
   ASSERT_STATUS_OK(*it);
@@ -301,7 +301,7 @@ TEST(RowStreamIterator, RangeForLoopFloat32) {
   rows.emplace_back(bigtable_mocks::MakeQueryRow({{"num", Value(3.2F)}}));
   rows.emplace_back(bigtable_mocks::MakeQueryRow({{"num", Value(5.4F)}}));
 
-  QueryRowRange range(RowStreamIteratorSource(rows));
+  QueryRowRange range(MakeRowStreamIteratorSource(rows));
   float sum = 0;
   for (auto const& row : range) {
     ASSERT_STATUS_OK(row);

--- a/google/cloud/bigtable/results.h
+++ b/google/cloud/bigtable/results.h
@@ -69,8 +69,7 @@ class RowStream {
 
   /// Returns a `RowStreamIterator` defining the beginning of this range.
   RowStreamIterator begin() {
-    return RowStreamIterator(
-        [this]() mutable { return source_->NextRow(); });
+    return RowStreamIterator([this]() mutable { return source_->NextRow(); });
   }
 
   /// Returns a `RowStreamIterator` defining the end of this range.

--- a/google/cloud/bigtable/results.h
+++ b/google/cloud/bigtable/results.h
@@ -28,11 +28,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 /**
  * Defines the interface for `RowStream` implementations.
  *
- * The `RowStream` class represents a stream of `Rows` returned from
- * `bigtable::Table::ReadRows()`. There are
- * different implementations depending the the RPC. Applications can also
- * mock this class when testing their code and mocking the `bigtable::Table`
- * behavior.
+ * The `RowStream` class represents a stream of `QueryRows` returned from
+ * `bigtable::Client::ExecuteQuery()`.
  */
 class ResultSourceInterface {
  public:
@@ -56,14 +53,9 @@ class ResultSourceInterface {
 };
 
 /**
- * Represents the stream of `Rows` returned from `bigtable::Table::ReadRows()`.
+ * Represents the stream of `QueryRows` returned from
+ * `bigtable::Client::ExecuteQuery`.
  *
- * This is a range defined by the [Input Iterators][input-iterator] returned
- * from its `begin()` and `end()` members. Callers may directly iterate the
- * `RowStream` instance, which will return a sequence of `StatusOr<QueryRow>`
- * objects.
- *
- * [input-iterator]: https://en.cppreference.com/w/cpp/named_req/InputIterator
  */
 class RowStream {
  public:
@@ -75,14 +67,14 @@ class RowStream {
   RowStream(RowStream&&) = default;
   RowStream& operator=(RowStream&&) = default;
 
-  /// Returns a `QueryRowStreamIterator` defining the beginning of this range.
-  QueryRowStreamIterator begin() {
-    return QueryRowStreamIterator(
+  /// Returns a `RowStreamIterator` defining the beginning of this range.
+  RowStreamIterator begin() {
+    return RowStreamIterator(
         [this]() mutable { return source_->NextRow(); });
   }
 
-  /// Returns a `QueryRowStreamIterator` defining the end of this range.
-  QueryRowStreamIterator end() { return {}; }
+  /// Returns a `RowStreamIterator` defining the end of this range.
+  RowStreamIterator end() { return {}; }
 
  private:
   std::unique_ptr<ResultSourceInterface> source_;


### PR DESCRIPTION
Porting RowStream from `google/cloud/spanner` to `google/cloud/bigtable`.