### PR TITLE
fix: kokoro/windows/cmake-release-x86 CI

### DIFF
--- a/google/cloud/pubsub/internal/subscription_session_test.cc
+++ b/google/cloud/pubsub/internal/subscription_session_test.cc
@@ -225,7 +225,7 @@ TEST(SubscriptionSessionTest, ScheduleCallbacksWithOtelEnabled) {
 
   auto spans = span_catcher->GetSpans();
   // There should be a process and ack span for each message.
-  EXPECT_THAT(spans, SizeIs(Ge(2 * kAckCount)));
+  EXPECT_THAT(spans, SizeIs(Ge(static_cast<std::size_t>(2 * kAckCount))));
   // Verify there is at least one process span.
   EXPECT_THAT(
       spans, Contains(AllOf(SpanHasInstrumentationScope(), SpanKindIsInternal(),


### PR DESCRIPTION
The `kokoro/windows/cmake-release-x86` CI build is failing with a C2220 error, which treats warnings as errors. The specific error is a signed/unsigned mismatch in `google/cloud/pubsub/internal/subscription_session_test.cc`.

The warning is triggered by a GoogleTest matcher (`SizeIs(Ge(...))`) that compares the size of a vector (`size_t`) with an integer (`int`). This commit fixes the issue by adding a `static_cast<std::size_t>` to the integer in the comparison, ensuring that both sides of the comparison have the same type. This resolves the warning and allows the build to succeed.