### PR TITLE
impl(universe_domain): remove ExperimentalTag

### DIFF
--- a/google/cloud/storage/tests/universe_domain_integration_test.cc
+++ b/google/cloud/storage/tests/universe_domain_integration_test.cc
@@ -62,8 +62,8 @@ auto TestOptions() {
   options.set<UnifiedCredentialsOption>(
       MakeServiceAccountCredentials(contents));
 
-  auto ud_options = AddUniverseDomainOption(
-      ExperimentalTag{}, options.set<ProjectIdOption>(projectId));
+  auto ud_options =
+      AddUniverseDomainOption(options.set<ProjectIdOption>(projectId));
   if (!ud_options.ok()) throw std::move(ud_options).status();
 
   return *ud_options;

--- a/google/cloud/universe_domain.cc
+++ b/google/cloud/universe_domain.cc
@@ -22,21 +22,20 @@ namespace google {
 namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-StatusOr<Options> AddUniverseDomainOption(ExperimentalTag, Options options) {
+StatusOr<Options> AddUniverseDomainOption(Options options) {
   if (!options.has<UnifiedCredentialsOption>()) {
     options.set<UnifiedCredentialsOption>(
         MakeGoogleDefaultCredentials(internal::MakeAuthOptions(options)));
   }
 
-  auto universe_domain = GetUniverseDomain(
-      ExperimentalTag{}, *options.get<UnifiedCredentialsOption>(), options);
+  auto universe_domain =
+      GetUniverseDomain(*options.get<UnifiedCredentialsOption>(), options);
   if (!universe_domain) return std::move(universe_domain).status();
   return options.set<internal::UniverseDomainOption>(
       *std::move(universe_domain));
 }
 
-StatusOr<std::string> GetUniverseDomain(ExperimentalTag,
-                                        Credentials const& credentials,
+StatusOr<std::string> GetUniverseDomain(Credentials const& credentials,
                                         Options const& options) {
   return rest_internal::MapCredentials(credentials)->universe_domain(options);
 }

--- a/google/cloud/universe_domain.h
+++ b/google/cloud/universe_domain.h
@@ -17,7 +17,6 @@
 
 #include "google/cloud/backoff_policy.h"
 #include "google/cloud/credentials.h"
-#include "google/cloud/experimental_tag.h"
 #include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/universe_domain_options.h"
@@ -47,8 +46,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * If the `RetryPolicy` becomes exhausted or other errors are encountered, that
  * `Status` is returned.
  */
-StatusOr<Options> AddUniverseDomainOption(ExperimentalTag tag,
-                                          Options options = {});
+StatusOr<Options> AddUniverseDomainOption(Options options = {});
 
 /**
  * Interrogates the provided credentials for the universe_domain.
@@ -61,8 +59,7 @@ StatusOr<Options> AddUniverseDomainOption(ExperimentalTag tag,
  * If successful the universe_domain value is returned, otherwise a `Status`
  * indicating the error encountered is returned.
  */
-StatusOr<std::string> GetUniverseDomain(ExperimentalTag tag,
-                                        Credentials const& credentials,
+StatusOr<std::string> GetUniverseDomain(Credentials const& credentials,
                                         Options const& options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/universe_domain/demo/bigquery.cc
+++ b/google/cloud/universe_domain/demo/bigquery.cc
@@ -35,8 +35,7 @@ int main(int argc, char* argv[]) try {
   namespace bigquery_storage = ::google::cloud::bigquery_storage_v1;
   constexpr int kMaxReadStreams = 1;
 
-  auto options =
-      google::cloud::AddUniverseDomainOption(google::cloud::ExperimentalTag{});
+  auto options = google::cloud::AddUniverseDomainOption();
   if (!options.ok()) throw std::move(options).status();
 
   // Override retry policy to quickly exit if there's a failure.

--- a/google/cloud/universe_domain/demo/bigtable.cc
+++ b/google/cloud/universe_domain/demo/bigtable.cc
@@ -42,7 +42,7 @@ int main(int argc, char* argv[]) try {
 
   // Interrogate credentials for universe_domain and add the value to returned
   // options.
-  auto ud_options = gc::AddUniverseDomainOption(gc::ExperimentalTag{}, options);
+  auto ud_options = gc::AddUniverseDomainOption(options);
   if (!ud_options.ok()) throw std::move(ud_options).status();
 
   // Override retry policy to quickly exit if there's a failure.

--- a/google/cloud/universe_domain/demo/compute.cc
+++ b/google/cloud/universe_domain/demo/compute.cc
@@ -43,8 +43,7 @@ int main(int argc, char* argv[]) try {
 
   // Create aliases to make the code easier to read.
   namespace disks = ::google::cloud::compute_disks_v1;
-  auto options =
-      google::cloud::AddUniverseDomainOption(google::cloud::ExperimentalTag{});
+  auto options = google::cloud::AddUniverseDomainOption();
   if (!options.ok()) throw std::move(options).status();
 
   // Override retry policy to quickly exit if there's a failure.

--- a/google/cloud/universe_domain/demo/kms.cc
+++ b/google/cloud/universe_domain/demo/kms.cc
@@ -42,7 +42,7 @@ int main(int argc, char* argv[]) try {
 
   // Interrogate credentials for universe_domain and add the value to returned
   // options.
-  auto ud_options = gc::AddUniverseDomainOption(gc::ExperimentalTag{}, options);
+  auto ud_options = gc::AddUniverseDomainOption(options);
   if (!ud_options.ok()) throw std::move(ud_options).status();
 
   // Override retry policy to quickly exit if there's a failure.

--- a/google/cloud/universe_domain/demo/pubsub.cc
+++ b/google/cloud/universe_domain/demo/pubsub.cc
@@ -28,8 +28,7 @@ int main(int argc, char* argv[]) try {
   // Create a namespace alias to make the code easier to read.
   namespace pubsub_admin = ::google::cloud::pubsub_admin;
 
-  auto options =
-      google::cloud::AddUniverseDomainOption(google::cloud::ExperimentalTag{});
+  auto options = google::cloud::AddUniverseDomainOption();
   if (!options.ok()) throw std::move(options).status();
 
   // Override retry policy to quickly exit if there's a failure.

--- a/google/cloud/universe_domain/demo/spanner.cc
+++ b/google/cloud/universe_domain/demo/spanner.cc
@@ -42,7 +42,7 @@ int main(int argc, char* argv[]) try {
 
   // Interrogate credentials for universe_domain and add the value to returned
   // options.
-  auto ud_options = gc::AddUniverseDomainOption(gc::ExperimentalTag{}, options);
+  auto ud_options = gc::AddUniverseDomainOption(options);
   if (!ud_options.ok()) throw std::move(ud_options).status();
 
   // Override retry policy to quickly exit if there's a failure.

--- a/google/cloud/universe_domain/demo/storage.cc
+++ b/google/cloud/universe_domain/demo/storage.cc
@@ -27,8 +27,7 @@ int main(int argc, char* argv[]) try {
   // Create aliases to make the code easier to read.
   namespace gcs = ::google::cloud::storage;
 
-  auto options =
-      google::cloud::AddUniverseDomainOption(google::cloud::ExperimentalTag{});
+  auto options = google::cloud::AddUniverseDomainOption();
   if (!options.ok()) throw std::move(options).status();
 
   // Override retry policy to quickly exit if there's a failure.

--- a/google/cloud/universe_domain/integration_tests/impersonation_tests.cc
+++ b/google/cloud/universe_domain/integration_tests/impersonation_tests.cc
@@ -110,7 +110,7 @@ TEST_F(ServiceAccountImpersonationTest, SAToSAImpersonationRest) {
           google::cloud::MakeServiceAccountCredentials(credential_),
           impersonated_sa_));
 
-  auto ud_options = gc::AddUniverseDomainOption(gc::ExperimentalTag{}, options);
+  auto ud_options = gc::AddUniverseDomainOption(options);
   ASSERT_STATUS_OK(ud_options);
 
   auto client = disks::DisksClient(disks::MakeDisksConnectionRest(*ud_options));
@@ -130,7 +130,7 @@ TEST_F(ServiceAccountImpersonationTest, SAToSAImpersonationGrpc) {
           google::cloud::MakeServiceAccountCredentials(credential_),
           impersonated_sa_));
 
-  auto ud_options = gc::AddUniverseDomainOption(gc::ExperimentalTag{}, options);
+  auto ud_options = gc::AddUniverseDomainOption(options);
   ASSERT_STATUS_OK(ud_options);
 
   auto client = kms::KeyManagementServiceClient(
@@ -150,7 +150,7 @@ TEST_F(ExternalAccountImpersonationTest, EAToSAImpersonationRest) {
           google::cloud::MakeExternalAccountCredentials(credential_),
           impersonated_sa_));
 
-  auto ud_options = gc::AddUniverseDomainOption(gc::ExperimentalTag{}, options);
+  auto ud_options = gc::AddUniverseDomainOption(options);
   ASSERT_STATUS_OK(ud_options);
 
   auto client = disks::DisksClient(disks::MakeDisksConnectionRest(*ud_options));
@@ -170,7 +170,7 @@ TEST_F(ExternalAccountImpersonationTest, EAToSAImpersonationGrpc) {
           google::cloud::MakeExternalAccountCredentials(credential_),
           impersonated_sa_));
 
-  auto ud_options = gc::AddUniverseDomainOption(gc::ExperimentalTag{}, options);
+  auto ud_options = gc::AddUniverseDomainOption(options);
   ASSERT_STATUS_OK(ud_options);
 
   auto client = kms::KeyManagementServiceClient(
@@ -189,7 +189,7 @@ TEST_F(DomainUniverseImpersonationTest, IdTokenSAToSAImpersonationRest) {
   // Use ADC credential
   ScopedEnvironment env("GOOGLE_APPLICATION_CREDENTIALS", id_token_key_file);
 
-  auto ud_options = gc::AddUniverseDomainOption(gc::ExperimentalTag{});
+  auto ud_options = gc::AddUniverseDomainOption();
   ASSERT_STATUS_OK(ud_options);
 
   auto client = disks::DisksClient(disks::MakeDisksConnectionRest(*ud_options));

--- a/google/cloud/universe_domain_test.cc
+++ b/google/cloud/universe_domain_test.cc
@@ -59,7 +59,7 @@ TEST(AddUniverseDomainOption, GoogleDefaultCredentialsAuthorizedUser) {
   std::ofstream(filename) << kAuthorizedUserCredContents;
   auto const env =
       ScopedEnvironment(oauth2_internal::GoogleAdcEnvVar(), filename.c_str());
-  auto result_options = AddUniverseDomainOption(ExperimentalTag{}, Options{});
+  auto result_options = AddUniverseDomainOption(Options{});
   (void)std::remove(filename.c_str());
 
   ASSERT_STATUS_OK(result_options);
@@ -90,7 +90,7 @@ TEST(AddUniverseDomainOption, GoogleDefaultCredentialsServiceAccount) {
   std::ofstream(filename) << kServiceAccountCredContents;
   auto const env =
       ScopedEnvironment(oauth2_internal::GoogleAdcEnvVar(), filename.c_str());
-  auto result_options = AddUniverseDomainOption(ExperimentalTag{}, Options{});
+  auto result_options = AddUniverseDomainOption(Options{});
   (void)std::remove(filename.c_str());
 
   ASSERT_STATUS_OK(result_options);
@@ -103,7 +103,7 @@ TEST(AddUniverseDomainOption, GoogleDefaultCredentialsServiceAccount) {
 TEST(AddUniverseDomainOption, CredentialsSpecified) {
   auto expected_creds = MakeInsecureCredentials();
   auto options = Options{}.set<UnifiedCredentialsOption>(expected_creds);
-  auto result_options = AddUniverseDomainOption(ExperimentalTag{}, options);
+  auto result_options = AddUniverseDomainOption(options);
 
   ASSERT_STATUS_OK(result_options);
   auto const& creds = result_options->get<UnifiedCredentialsOption>();
@@ -116,7 +116,7 @@ TEST(AddUniverseDomainOption, ErrorCredentials) {
   auto options =
       Options{}.set<UnifiedCredentialsOption>(internal::MakeErrorCredentials(
           internal::FailedPreconditionError("error")));
-  auto result_options = AddUniverseDomainOption(ExperimentalTag{}, options);
+  auto result_options = AddUniverseDomainOption(options);
   EXPECT_THAT(result_options, StatusIs(StatusCode::kFailedPrecondition));
 }
 


### PR DESCRIPTION
In preparation for universe domain support being declared GA, remove the ExperimentalTag parameter.