### PR TITLE
impl(universe_domain): remove experimental from bazel target

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -249,7 +249,7 @@ cc_library(
 )
 
 cc_library(
-    name = "experimental-universe_domain",
+    name = "universe_domain",
     deps = [
         "//google/cloud:google_cloud_cpp_universe_domain",
     ],

--- a/google/cloud/storage/tests/BUILD.bazel
+++ b/google/cloud/storage/tests/BUILD.bazel
@@ -71,8 +71,8 @@ VARIATIONS = {
     ],
     deps = [
         "//:common",
-        "//:experimental-universe_domain",
         "//:storage",
+        "//:universe_domain",
         "//google/cloud/storage:storage_client_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc_private",
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",

--- a/google/cloud/universe_domain/demo/BUILD.bazel
+++ b/google/cloud/universe_domain/demo/BUILD.bazel
@@ -31,6 +31,6 @@ service_demos = [
     ],
     deps = [
         "@google_cloud_cpp//:" + demo,
-        "@google_cloud_cpp//:experimental-universe_domain",
+        "@google_cloud_cpp//:universe_domain",
     ],
 ) for demo in service_demos]

--- a/google/cloud/universe_domain/integration_tests/BUILD.bazel
+++ b/google/cloud/universe_domain/integration_tests/BUILD.bazel
@@ -28,7 +28,7 @@ cc_test(
     ],
     deps = [
         "//:common",
-        "//:experimental-universe_domain",
+        "//:universe_domain",
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
         "@com_google_googletest//:gtest_main",
         "@google_cloud_cpp//:compute",


### PR DESCRIPTION
This was overlooked in the previous PR that removed the ExperimentalTag params.