### PR TITLE
chore: exclude speech from CI

### DIFF
--- a/ci/kokoro/macos/builds/bazel.sh
+++ b/ci/kokoro/macos/builds/bazel.sh
@@ -87,6 +87,11 @@ readonly BAZEL_EXCLUDES=(
   "-//google/cloud:options_benchmark"
   # See #15546
   "-//google/cloud/storage/tests:unified_credentials_integration_test-grpc-metadata"
+  # See #15662
+  "-//google/cloud/speech:v1_samples_adaptation_client_samples"
+  "-//google/cloud/speech:v1_samples_speech_client_samples"
+  "-//google/cloud/speech:v2_samples_speech_client_samples"
+  "-//google/cloud/speech/quickstart:quickstart"
 )
 readonly BAZEL_TEST_COMMAND=(
   "test"


### PR DESCRIPTION
This PR temporarily disables the failing google/cloud/speech CIs. The failures of CIs are tracked in https://github.com/googleapis/google-cloud-cpp/issues/15662.

kokoro/macos/bazel CI passes with this PR.