### PR TITLE
fix: add -DGOOGLE_CLOUD_CPP_ENABLE=universe_domain

### DIFF
--- a/ci/kokoro/macos/builds/cmake-vcpkg.sh
+++ b/ci/kokoro/macos/builds/cmake-vcpkg.sh
@@ -81,6 +81,7 @@ cmake_flags=(
   "-DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=ON"
   "-DGOOGLE_CLOUD_CPP_ENABLE_WERROR=ON"
   "-DGOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND=ON"
+  "-DGOOGLE_CLOUD_CPP_ENABLE=universe_domain"
 )
 
 # The downloads can fail, therefore require a retry loop.


### PR DESCRIPTION
[kokoro/macos/cmake-vcpkg](https://source.cloud.google.com/results/invocations/633b093d-aea1-4807-b958-924e976be136) passes with this fix.