### PR TITLE
impl(bigtable): add query plan refresh policy and option

### DIFF
--- a/google/cloud/bigtable/bound_query.cc
+++ b/google/cloud/bigtable/bound_query.cc
@@ -19,8 +19,7 @@ namespace cloud {
 namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-StatusOr<google::bigtable::v2::PrepareQueryResponse> BoundQuery::response()
-    const {
+StatusOr<google::bigtable::v2::PrepareQueryResponse> BoundQuery::response() {
   return query_plan_->response();
 }
 

--- a/google/cloud/bigtable/bound_query.h
+++ b/google/cloud/bigtable/bound_query.h
@@ -48,7 +48,7 @@ class BoundQuery {
   BoundQuery& operator=(BoundQuery&&) = default;
 
   // Accessors
-  StatusOr<google::bigtable::v2::PrepareQueryResponse> response() const;
+  StatusOr<google::bigtable::v2::PrepareQueryResponse> response();
   std::unordered_map<std::string, Value> const& parameters() const;
   InstanceResource const& instance() const;
 

--- a/google/cloud/bigtable/internal/defaults.cc
+++ b/google/cloud/bigtable/internal/defaults.cc
@@ -251,6 +251,12 @@ Options DefaultDataOptions(Options opts) {
             kBigtableLimits.maximum_retry_period)
             .clone());
   }
+  if (!opts.has<bigtable::experimental::QueryPlanRefreshRetryPolicyOption>()) {
+    opts.set<bigtable::experimental::QueryPlanRefreshRetryPolicyOption>(
+        bigtable::experimental::QueryPlanRefreshLimitedTimeRetryPolicy(
+            kBigtableLimits.maximum_retry_period)
+            .clone());
+  }
   if (!opts.has<bigtable::DataBackoffPolicyOption>()) {
     opts.set<bigtable::DataBackoffPolicyOption>(
         ExponentialBackoffPolicy(kBigtableLimits.initial_delay / 2,

--- a/google/cloud/bigtable/options.h
+++ b/google/cloud/bigtable/options.h
@@ -187,6 +187,15 @@ struct BulkApplyThrottlingOption {
   using Type = bool;
 };
 
+/**
+ * Option to configure the retry policy used in `bigtable::Client::ExecuteQuery`
+ * to automatically refresh expired or invalid query plans encountered during
+ * execution.
+ */
+struct QueryPlanRefreshRetryPolicyOption {
+  using Type = std::shared_ptr<DataRetryPolicy>;
+};
+
 }  // namespace experimental
 
 /// The complete list of options accepted by `bigtable::*Client`

--- a/google/cloud/bigtable/retry_policy.h
+++ b/google/cloud/bigtable/retry_policy.h
@@ -153,6 +153,139 @@ class DataLimitedTimeRetryPolicy : public DataRetryPolicy {
       impl_;
 };
 
+namespace experimental {
+
+/**
+ * A retry policy used in `bigtable::DataConnection::ExecuteQuery` based on
+ * counting errors.
+ *
+ * This policy stops retrying if:
+ * - An RPC returns a non-transient error.
+ * - More than a prescribed number of transient failures is detected.
+ *
+ * In this class the following status codes are treated as transient errors:
+ * - [`kAborted`](@ref google::cloud::StatusCode)
+ * - [`kUnavailable`](@ref google::cloud::StatusCode)
+ * - [`kInternal`](@ref google::cloud::StatusCode) if the error message
+ *   indicates this was caused by a connection reset.
+ * - [`kFailedPrecondition`](@ref google::cloud::StatusCode) if the error
+ *   message indicates this was caused by a an expired prepared query.
+ */
+class QueryPlanRefreshLimitedErrorCountRetryPolicy : public DataRetryPolicy {
+ public:
+  /**
+   * Create an instance that tolerates up to @p maximum_failures transient
+   * errors.
+   *
+   * @note Disable the retry loop by providing an instance of this policy with
+   *     @p maximum_failures == 0.
+   */
+  explicit QueryPlanRefreshLimitedErrorCountRetryPolicy(int maximum_failures)
+      : impl_(maximum_failures) {}
+
+  QueryPlanRefreshLimitedErrorCountRetryPolicy(
+      QueryPlanRefreshLimitedErrorCountRetryPolicy&& rhs) noexcept
+      : QueryPlanRefreshLimitedErrorCountRetryPolicy(rhs.maximum_failures()) {}
+  QueryPlanRefreshLimitedErrorCountRetryPolicy(
+      QueryPlanRefreshLimitedErrorCountRetryPolicy const& rhs) noexcept
+      : QueryPlanRefreshLimitedErrorCountRetryPolicy(rhs.maximum_failures()) {}
+
+  int maximum_failures() const { return impl_.maximum_failures(); }
+
+  bool OnFailure(Status const& s) override { return impl_.OnFailure(s); }
+  bool IsExhausted() const override { return impl_.IsExhausted(); }
+  bool IsPermanentFailure(Status const& s) const override {
+    return impl_.IsPermanentFailure(s);
+  }
+  std::unique_ptr<DataRetryPolicy> clone() const override {
+    return std::make_unique<QueryPlanRefreshLimitedErrorCountRetryPolicy>(
+        impl_.maximum_failures());
+  }
+
+  // This is provided only for backwards compatibility.
+  using BaseType = RetryPolicy;
+
+ private:
+  google::cloud::internal::LimitedErrorCountRetryPolicy<
+      bigtable_internal::SafeGrpcRetryAllowingQueryPlanRefresh>
+      impl_;
+};
+
+/**
+ * A retry policy used in `bigtable::DataConnection::ExecuteQuery` based on
+ * elapsed time.
+ *
+ * This policy stops retrying if:
+ * - An RPC returns a non-transient error.
+ * - The elapsed time in the retry loop exceeds a prescribed duration.
+ *
+ * In this class the following status codes are treated as transient errors:
+ * - [`kAborted`](@ref google::cloud::StatusCode)
+ * - [`kUnavailable`](@ref google::cloud::StatusCode)
+ * - [`kInternal`](@ref google::cloud::StatusCode) if the error message
+ *   indicates this was caused by a connection reset.
+ * - [`kFailedPrecondition`](@ref google::cloud::StatusCode) if the error
+ *   message indicates this was caused by a an expired prepared query.
+ */
+class QueryPlanRefreshLimitedTimeRetryPolicy : public DataRetryPolicy {
+ public:
+  /**
+   * Constructor given a `std::chrono::duration<>` object.
+   *
+   * @tparam DurationRep a placeholder to match the `Rep` tparam for
+   *     @p maximum_duration's type. The semantics of this template parameter
+   *     are documented in `std::chrono::duration<>`. In brief, the underlying
+   *     arithmetic type used to store the number of ticks. For our purposes it
+   *     is simply a formal parameter.
+   * @tparam DurationPeriod a placeholder to match the `Period` tparam for
+   *     @p maximum_duration's type. The semantics of this template parameter
+   *     are documented in `std::chrono::duration<>`. In brief, the length of
+   *     the tick in seconds, expressed as a `std::ratio<>`. For our purposes it
+   *     is simply a formal parameter.
+   * @param maximum_duration the maximum time allowed before the policy expires,
+   *     while the application can express this time in any units they desire,
+   *     the class truncates to milliseconds.
+   *
+   * @see https://en.cppreference.com/w/cpp/chrono/duration for more details
+   *     about `std::chrono::duration`.
+   */
+  template <typename DurationRep, typename DurationPeriod>
+  explicit QueryPlanRefreshLimitedTimeRetryPolicy(
+      std::chrono::duration<DurationRep, DurationPeriod> maximum_duration)
+      : impl_(maximum_duration) {}
+
+  QueryPlanRefreshLimitedTimeRetryPolicy(
+      QueryPlanRefreshLimitedTimeRetryPolicy&& rhs) noexcept
+      : QueryPlanRefreshLimitedTimeRetryPolicy(rhs.maximum_duration()) {}
+  QueryPlanRefreshLimitedTimeRetryPolicy(
+      QueryPlanRefreshLimitedTimeRetryPolicy const& rhs) noexcept
+      : QueryPlanRefreshLimitedTimeRetryPolicy(rhs.maximum_duration()) {}
+
+  std::chrono::milliseconds maximum_duration() const {
+    return impl_.maximum_duration();
+  }
+
+  bool OnFailure(Status const& s) override { return impl_.OnFailure(s); }
+  bool IsExhausted() const override { return impl_.IsExhausted(); }
+  bool IsPermanentFailure(Status const& s) const override {
+    return impl_.IsPermanentFailure(s);
+  }
+  std::unique_ptr<DataRetryPolicy> clone() const override {
+    return std::make_unique<QueryPlanRefreshLimitedTimeRetryPolicy>(
+        impl_.maximum_duration());
+  }
+
+  // This is provided only for backwards compatibility.
+  using BaseType = RetryPolicy;
+
+ private:
+  google::cloud::internal::LimitedTimeRetryPolicy<
+      bigtable_internal::SafeGrpcRetryAllowingQueryPlanRefresh>
+      impl_;
+};
+
+}  // namespace experimental
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable
 }  // namespace cloud


### PR DESCRIPTION
Adds a new retry policy type (and Option) that treats expired query plans as transient for use with ExecuteQuery and its auto refreshing retry loop.