### PR TITLE
impl(bigtable): add operation context support and retry exhaustion detection to streaming types

### DIFF
--- a/google/cloud/bigtable/internal/data_connection_impl.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl.cc
@@ -148,7 +148,12 @@ class DefaultPartialResultSetReader
     }
   }
 
-  Status Finish() override { return final_status_; }
+  grpc::ClientContext const& context() const override { return *context_; }
+
+  Status Finish() override {
+    //    operation_context_->OnDone(final_status_);
+    return final_status_;
+  }
 
  private:
   std::shared_ptr<grpc::ClientContext> context_;
@@ -840,30 +845,32 @@ bigtable::RowStream DataConnectionImpl::ExecuteQuery(
           google::bigtable::v2::ResultSetMetadata metadata,
           std::unique_ptr<bigtable::DataRetryPolicy> retry_policy_prototype,
           std::unique_ptr<BackoffPolicy> backoff_policy_prototype,
-          std::shared_ptr<OperationContext> const&) mutable
+          std::shared_ptr<OperationContext> const& operation_context) mutable
       -> StatusOr<std::unique_ptr<bigtable::ResultSourceInterface>> {
-    auto factory = [stub, request, tracing_enabled,
-                    tracing_options](std::string const& resume_token) mutable {
-      if (!resume_token.empty()) request.set_resume_token(resume_token);
-      auto context = std::make_shared<grpc::ClientContext>();
-      auto const& options = internal::CurrentOptions();
-      internal::ConfigureContext(*context, options);
-      auto stream = stub->ExecuteQuery(context, options, request);
-      std::unique_ptr<PartialResultSetReader> reader =
-          std::make_unique<DefaultPartialResultSetReader>(std::move(context),
-                                                          std::move(stream));
-      if (tracing_enabled) {
-        reader = std::make_unique<LoggingResultSetReader>(std::move(reader),
-                                                          tracing_options);
-      }
-      return reader;
-    };
+    auto factory =
+        [stub, request, tracing_enabled, tracing_options,
+         operation_context](std::string const& resume_token) mutable {
+          if (!resume_token.empty()) request.set_resume_token(resume_token);
+          auto context = std::make_shared<grpc::ClientContext>();
+          auto const& options = internal::CurrentOptions();
+          internal::ConfigureContext(*context, options);
+          auto stream = stub->ExecuteQuery(context, options, request);
+          std::unique_ptr<PartialResultSetReader> reader =
+              std::make_unique<DefaultPartialResultSetReader>(
+                  std::move(context), std::move(stream));
+          if (tracing_enabled) {
+            reader = std::make_unique<LoggingResultSetReader>(std::move(reader),
+                                                              tracing_options);
+          }
+          return reader;
+        };
 
     auto rpc = std::make_unique<PartialResultSetResume>(
         std::move(factory), Idempotency::kIdempotent,
         retry_policy_prototype->clone(), backoff_policy_prototype->clone());
 
-    return PartialResultSetSource::Create(std::move(metadata), std::move(rpc));
+    return PartialResultSetSource::Create(std::move(metadata),
+                                          operation_context, std::move(rpc));
   };
 
   auto operation_context = std::make_shared<OperationContext>();

--- a/google/cloud/bigtable/internal/logging_result_set_reader.cc
+++ b/google/cloud/bigtable/internal/logging_result_set_reader.cc
@@ -43,6 +43,9 @@ bool LoggingResultSetReader::Read(
   }
   return success;
 }
+grpc::ClientContext const& LoggingResultSetReader::context() const {
+  return impl_->context();
+}
 
 Status LoggingResultSetReader::Finish() { return impl_->Finish(); }
 

--- a/google/cloud/bigtable/internal/logging_result_set_reader.h
+++ b/google/cloud/bigtable/internal/logging_result_set_reader.h
@@ -41,6 +41,7 @@ class LoggingResultSetReader : public PartialResultSetReader {
   void TryCancel() override;
   bool Read(absl::optional<std::string> const& resume_token,
             UnownedPartialResultSet& result) override;
+  grpc::ClientContext const& context() const override;
   Status Finish() override;
 
  private:

--- a/google/cloud/bigtable/internal/partial_result_set_reader.h
+++ b/google/cloud/bigtable/internal/partial_result_set_reader.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/status.h"
 #include <google/bigtable/v2/data.pb.h>
+#include <grpcpp/client_context.h>
 
 namespace google {
 namespace cloud {
@@ -55,6 +56,7 @@ class PartialResultSetReader {
   virtual void TryCancel() = 0;
   virtual bool Read(absl::optional<std::string> const& resume_token,
                     UnownedPartialResultSet& result) = 0;
+  virtual grpc::ClientContext const& context() const = 0;
   virtual Status Finish() = 0;
 };
 

--- a/google/cloud/bigtable/internal/partial_result_set_resume.h
+++ b/google/cloud/bigtable/internal/partial_result_set_resume.h
@@ -45,8 +45,8 @@ class PartialResultSetResume : public PartialResultSetReader {
       std::unique_ptr<BackoffPolicy> backoff_policy)
       : factory_(std::move(factory)),
         idempotency_(idempotency),
-        retry_policy_prototype_(std::move(retry_policy)),
-        backoff_policy_prototype_(std::move(backoff_policy)),
+        retry_policy_(std::move(retry_policy)),
+        backoff_policy_(std::move(backoff_policy)),
         reader_(factory_(std::string{})) {}
 
   ~PartialResultSetResume() override = default;
@@ -54,13 +54,14 @@ class PartialResultSetResume : public PartialResultSetReader {
   void TryCancel() override;
   bool Read(absl::optional<std::string> const& resume_token,
             UnownedPartialResultSet& result) override;
+  grpc::ClientContext const& context() const override;
   Status Finish() override;
 
  private:
   PartialResultSetReaderFactory factory_;
   google::cloud::Idempotency idempotency_;
-  std::unique_ptr<bigtable::DataRetryPolicy> retry_policy_prototype_;
-  std::unique_ptr<BackoffPolicy> backoff_policy_prototype_;
+  std::unique_ptr<bigtable::DataRetryPolicy> retry_policy_;
+  std::unique_ptr<BackoffPolicy> backoff_policy_;
   std::unique_ptr<PartialResultSetReader> reader_;
   absl::optional<Status> last_status_;
 };

--- a/google/cloud/bigtable/internal/partial_result_set_source.h
+++ b/google/cloud/bigtable/internal/partial_result_set_source.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_PARTIAL_RESULT_SET_SOURCE_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_PARTIAL_RESULT_SET_SOURCE_H
 
+#include "google/cloud/bigtable/internal/operation_context.h"
 #include "google/cloud/bigtable/internal/partial_result_set_reader.h"
 #include "google/cloud/bigtable/results.h"
 #include "google/cloud/bigtable/value.h"
@@ -43,6 +44,7 @@ class PartialResultSetSource : public bigtable::ResultSourceInterface {
   /// Factory method to create a PartialResultSetSource.
   static StatusOr<std::unique_ptr<bigtable::ResultSourceInterface>> Create(
       absl::optional<google::bigtable::v2::ResultSetMetadata> metadata,
+      std::shared_ptr<OperationContext> operation_context,
       std::unique_ptr<PartialResultSetReader> reader);
 
   ~PartialResultSetSource() override;
@@ -56,6 +58,7 @@ class PartialResultSetSource : public bigtable::ResultSourceInterface {
  private:
   explicit PartialResultSetSource(
       absl::optional<google::bigtable::v2::ResultSetMetadata> metadata,
+      std::shared_ptr<OperationContext> operation_context,
       std::unique_ptr<PartialResultSetReader> reader);
 
   Status ReadFromStream();
@@ -68,7 +71,7 @@ class PartialResultSetSource : public bigtable::ResultSourceInterface {
 
   Options options_;
   std::unique_ptr<PartialResultSetReader> reader_;
-
+  std::shared_ptr<OperationContext> operation_context_;
   // The ResultSetMetadata is received in the first response. It is received
   // from ExecuteQueryResponse
   absl::optional<google::bigtable::v2::ResultSetMetadata> metadata_;
@@ -84,6 +87,7 @@ class PartialResultSetSource : public bigtable::ResultSourceInterface {
   // see a new token.
   absl::optional<std::string> resume_token_ = "";
 
+  Status last_status_;
   // The state of our PartialResultSetReader.
   enum class State {
     // `Read()` has yet to return nullopt.

--- a/google/cloud/bigtable/testing/mock_partial_result_set_reader.h
+++ b/google/cloud/bigtable/testing/mock_partial_result_set_reader.h
@@ -32,6 +32,7 @@ class MockPartialResultSetReader
               (absl::optional<std::string> const& resume_token,
                bigtable_internal::UnownedPartialResultSet& result),
               (override));
+  MOCK_METHOD(grpc::ClientContext const&, context, (), (const, override));
   MOCK_METHOD(Status, Finish, (), (override));
 };
 


### PR DESCRIPTION
This PR updates the streaming types used by ExecuteQuery to support some of the methods on OperationContext and return better error Status information when a retry_policy is exhausted.