### PR TITLE
impl(bigtable): update retry logic and add operation contexts to Query methods

### DIFF
--- a/google/cloud/bigtable/internal/data_connection_impl.h
+++ b/google/cloud/bigtable/internal/data_connection_impl.h
@@ -118,9 +118,6 @@ class DataConnectionImpl : public bigtable::DataConnection {
                            bigtable::Filter filter,
                            internal::ImmutableOptions const& current,
                            std::shared_ptr<OperationContext> operation_context);
-  std::unique_ptr<PartialResultSetReader> CreateResumableReader(
-      google::bigtable::v2::ExecuteQueryRequest request,
-      std::string const& resume_token);
 
   std::unique_ptr<BackgroundThreads> background_;
   std::shared_ptr<BigtableStub> stub_;

--- a/google/cloud/bigtable/internal/data_connection_impl_test.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl_test.cc
@@ -442,6 +442,28 @@ class FakeOperationContextFactory : public OperationContextFactory {
   std::shared_ptr<OperationContext::Clock> clock_;
 };
 
+class MockOperationContextFactory : public OperationContextFactory {
+ public:
+  MOCK_METHOD(std::shared_ptr<OperationContext>, ReadRow,
+              (std::string const&, std::string const&), (override));
+  MOCK_METHOD(std::shared_ptr<OperationContext>, ReadRows,
+              (std::string const&, std::string const&), (override));
+  MOCK_METHOD(std::shared_ptr<OperationContext>, MutateRow,
+              (std::string const&, std::string const&), (override));
+  MOCK_METHOD(std::shared_ptr<OperationContext>, MutateRows,
+              (std::string const&, std::string const&), (override));
+  MOCK_METHOD(std::shared_ptr<OperationContext>, CheckAndMutateRow,
+              (std::string const&, std::string const&), (override));
+  MOCK_METHOD(std::shared_ptr<OperationContext>, SampleRowKeys,
+              (std::string const&, std::string const&), (override));
+  MOCK_METHOD(std::shared_ptr<OperationContext>, ReadModifyWriteRow,
+              (std::string const&, std::string const&), (override));
+  MOCK_METHOD(std::shared_ptr<OperationContext>, PrepareQuery,
+              (std::string const&, std::string const&), (override));
+  MOCK_METHOD(std::shared_ptr<OperationContext>, ExecuteQuery,
+              (std::string const&, std::string const&), (override));
+};
+
 #endif  // GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
 
 class DataConnectionTest : public ::testing::Test {
@@ -2961,6 +2983,21 @@ TEST_F(DataConnectionTest, AsyncPrepareQueryPermanentError) {
 }
 
 TEST_F(DataConnectionTest, ExecuteQuerySuccessWithTransientErrors) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(3);
+  EXPECT_CALL(*mock_metric, PostCall).Times(3);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(3);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(3);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   auto mock = std::make_shared<MockBigtableStub>();
   auto fake_cq_impl = std::make_shared<FakeCompletionQueueImpl>();
   auto mock_bg = std::make_unique<MockBackgroundThreads>();
@@ -3032,7 +3069,7 @@ TEST_F(DataConnectionTest, ExecuteQuerySuccessWithTransientErrors) {
         return stream;
       });
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(CallOptions());
   Project p("test-project");
   bigtable::SqlStatement statement("SELECT * FROM the-table");
@@ -3065,6 +3102,21 @@ TEST_F(DataConnectionTest, ExecuteQuerySuccessWithTransientErrors) {
 }
 
 TEST_F(DataConnectionTest, ExecuteQueryFailure) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(1);
+  EXPECT_CALL(*mock_metric, PostCall).Times(1);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   auto mock = std::make_shared<MockBigtableStub>();
   auto fake_cq_impl = std::make_shared<FakeCompletionQueueImpl>();
   auto mock_bg = std::make_unique<MockBackgroundThreads>();
@@ -3088,7 +3140,7 @@ TEST_F(DataConnectionTest, ExecuteQueryFailure) {
         return stream;
       });
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(CallOptions());
   Project p("test-project");
   bigtable::SqlStatement statement("SELECT key, val FROM t");
@@ -3104,6 +3156,21 @@ TEST_F(DataConnectionTest, ExecuteQueryFailure) {
 }
 
 TEST_F(DataConnectionTest, ExecuteQueryOperationRetryExhausted) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(3);
+  EXPECT_CALL(*mock_metric, PostCall).Times(3);
+  EXPECT_CALL(*mock_metric, OnDone).Times(1);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   auto mock = std::make_shared<MockBigtableStub>();
   auto fake_cq_impl = std::make_shared<FakeCompletionQueueImpl>();
   auto mock_bg = std::make_unique<MockBackgroundThreads>();
@@ -3121,14 +3188,14 @@ TEST_F(DataConnectionTest, ExecuteQueryOperationRetryExhausted) {
                         std::move(refresh_fn));
 
   EXPECT_CALL(*mock, ExecuteQuery)
-      .Times(9)
+      .Times(3)
       .WillRepeatedly([&](auto, auto const&, auto const&) {
         auto stream = std::make_unique<MockExecuteQueryStream>();
         EXPECT_CALL(*stream, Read).WillOnce(Return(TransientError()));
         return stream;
       });
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(CallOptions());
   Project p("test-project");
   bigtable::SqlStatement statement("SELECT key, val FROM t");
@@ -3144,6 +3211,21 @@ TEST_F(DataConnectionTest, ExecuteQueryOperationRetryExhausted) {
 }
 
 TEST_F(DataConnectionTest, ExecuteQuerySuccessWithQueryPlanRefresh) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto mock_metric = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric, PreCall).Times(2);
+  EXPECT_CALL(*mock_metric, PostCall).Times(2);
+  EXPECT_CALL(*mock_metric, OnDone).Times(2);
+  EXPECT_CALL(*mock_metric, ElementRequest).Times(3);
+  EXPECT_CALL(*mock_metric, ElementDelivery).Times(3);
+  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<FakeOperationContextFactory>(
+      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+
   auto mock = std::make_shared<MockBigtableStub>();
   auto fake_cq_impl = std::make_shared<FakeCompletionQueueImpl>();
   auto mock_bg = std::make_unique<MockBackgroundThreads>();
@@ -3241,7 +3323,7 @@ TEST_F(DataConnectionTest, ExecuteQuerySuccessWithQueryPlanRefresh) {
         return stream;
       });
 
-  auto conn = TestConnection(std::move(mock));
+  auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(CallOptions());
   Project p("test-project");
   bigtable::SqlStatement statement("SELECT * FROM the-table");
@@ -3271,6 +3353,345 @@ TEST_F(DataConnectionTest, ExecuteQuerySuccessWithQueryPlanRefresh) {
   EXPECT_THAT(row2.values().at(0).get<std::string>(), IsOkAndHolds("r2"));
   EXPECT_THAT(row2.values().at(1).get<std::string>(), IsOkAndHolds("v2"));
   fake_cq_impl->SimulateCompletion(false);
+}
+
+TEST_F(DataConnectionTest, PrepareAndExecuteQuerySuccessWithQueryPlanRefresh) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<MockOperationContextFactory>();
+
+  auto mock_metric_prepared_query_initial = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric_prepared_query_initial, PreCall).Times(1);
+  EXPECT_CALL(*mock_metric_prepared_query_initial, PostCall).Times(1);
+  EXPECT_CALL(*mock_metric_prepared_query_initial, OnDone).Times(1);
+  auto mock_metric_prepared_query_refresh = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric_prepared_query_refresh, PreCall).Times(1);
+  EXPECT_CALL(*mock_metric_prepared_query_refresh, PostCall).Times(1);
+  EXPECT_CALL(*mock_metric_prepared_query_refresh, OnDone).Times(1);
+
+  EXPECT_CALL(*factory, PrepareQuery)
+      .WillOnce([&](auto const&, auto const&) {
+        std::vector<std::shared_ptr<Metric const>> metrics;
+        metrics.push_back(std::make_shared<CloningMetric>(
+            std::move(mock_metric_prepared_query_initial)));
+        return std::make_shared<OperationContext>(
+            ResourceLabels{}, DataLabels{}, std::move(metrics), clock);
+      })
+      .WillOnce([&](auto const&, auto const&) {
+        std::vector<std::shared_ptr<Metric const>> metrics;
+        metrics.push_back(std::make_shared<CloningMetric>(
+            std::move(mock_metric_prepared_query_refresh)));
+        return std::make_shared<OperationContext>(
+            ResourceLabels{}, DataLabels{}, std::move(metrics), clock);
+      });
+
+  auto mock_metric_execute_query = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric_execute_query, PreCall).Times(2);
+  EXPECT_CALL(*mock_metric_execute_query, PostCall).Times(2);
+  EXPECT_CALL(*mock_metric_execute_query, OnDone).Times(2);
+  EXPECT_CALL(*mock_metric_execute_query, ElementRequest).Times(3);
+  EXPECT_CALL(*mock_metric_execute_query, ElementDelivery).Times(3);
+
+  EXPECT_CALL(*factory, ExecuteQuery).WillOnce([&](auto const&, auto const&) {
+    std::vector<std::shared_ptr<Metric const>> metrics;
+    metrics.push_back(
+        std::make_shared<CloningMetric>(std::move(mock_metric_execute_query)));
+    return std::make_shared<OperationContext>(ResourceLabels{}, DataLabels{},
+                                              std::move(metrics), clock);
+  });
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+  using google::bigtable::v2::ExecuteQueryRequest;
+  using google::bigtable::v2::ExecuteQueryResponse;
+  using google::bigtable::v2::PrepareQueryRequest;
+  using google::bigtable::v2::PrepareQueryResponse;
+
+  auto constexpr kInitialResultMetadataText = R"pb(
+    proto_schema {
+      columns {
+        name: "row_key"
+        type { string_type {} }
+      }
+      columns {
+        name: "value"
+        type { string_type {} }
+      }
+      columns {
+        name: "other_value"
+        type { string_type {} }
+      }
+    }
+  )pb";
+  PrepareQueryResponse initial_pq_response;
+  initial_pq_response.set_prepared_query("test-pq-id-initial");
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      kInitialResultMetadataText, initial_pq_response.mutable_metadata()));
+  *initial_pq_response.mutable_valid_until() = internal::ToProtoTimestamp(
+      std::chrono::system_clock::now() + std::chrono::seconds(3600));
+
+  auto constexpr kRefreshResultMetadataText = R"pb(
+    proto_schema {
+      columns {
+        name: "row_key"
+        type { string_type {} }
+      }
+      columns {
+        name: "value"
+        type { string_type {} }
+      }
+    }
+  )pb";
+  PrepareQueryResponse refresh_pq_response;
+  refresh_pq_response.set_prepared_query("test-pq-id-refresh");
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      kRefreshResultMetadataText, refresh_pq_response.mutable_metadata()));
+  *refresh_pq_response.mutable_valid_until() = internal::ToProtoTimestamp(
+      std::chrono::system_clock::now() + std::chrono::seconds(3));
+
+  auto mock = std::make_shared<MockBigtableStub>();
+  EXPECT_CALL(*mock, PrepareQuery)
+      .WillOnce(
+          [&](grpc::ClientContext&, Options const&,
+              PrepareQueryRequest const&) { return initial_pq_response; });
+  EXPECT_CALL(*mock, AsyncPrepareQuery)
+      .WillOnce([&](CompletionQueue const&, auto, auto,
+                    v2::PrepareQueryRequest const&) {
+        return make_ready_future(make_status_or(refresh_pq_response));
+      });
+  EXPECT_CALL(*mock, ExecuteQuery)
+      .WillOnce([&](auto, auto const&, ExecuteQueryRequest const& request) {
+        EXPECT_EQ(request.prepared_query(), "test-pq-id-initial");
+        auto error_stream = std::make_unique<MockExecuteQueryStream>();
+        EXPECT_CALL(*error_stream, Read).WillOnce(Return(QueryPlanError()));
+        return error_stream;
+      })
+      .WillOnce([&](auto, auto const&, ExecuteQueryRequest const& request) {
+        EXPECT_EQ(request.app_profile_id(), kAppProfile);
+        EXPECT_EQ(request.instance_name(),
+                  "projects/test-project/instances/test-instance");
+        EXPECT_EQ(request.prepared_query(), "test-pq-id-refresh");
+
+        auto stream = std::make_unique<MockExecuteQueryStream>();
+        EXPECT_CALL(*stream, Read)
+            .WillOnce([&](ExecuteQueryResponse* r) {
+              *r->mutable_metadata() = refresh_pq_response.metadata();
+              return absl::nullopt;
+            })
+            .WillOnce([&](ExecuteQueryResponse* r) {
+              MakeResponse(*r->mutable_results(), {"r1", "v1"}, absl::nullopt,
+                           false);
+              return absl::nullopt;
+            })
+            .WillOnce([&](ExecuteQueryResponse* r) {
+              MakeResponse(*r->mutable_results(), {"r2", "v2"},
+                           "sentinel-token", false);
+              return absl::nullopt;
+            })
+            // End of stream
+            .WillOnce(Return(google::cloud::Status()));
+
+        return stream;
+      });
+
+  auto conn = TestConnection(std::move(mock), std::move(factory));
+  internal::OptionsSpan span(CallOptions());
+  Project p("test-project");
+  bigtable::SqlStatement statement("SELECT * FROM the-table");
+  bigtable::InstanceResource instance(p, "test-instance");
+
+  auto prepared_query = conn->PrepareQuery({instance, statement});
+  ASSERT_STATUS_OK(prepared_query);
+  auto bound_query = prepared_query->BindParameters({});
+  bigtable::ExecuteQueryParams params{std::move(bound_query)};
+
+  auto row_stream = conn->ExecuteQuery(std::move(params));
+
+  std::vector<StatusOr<bigtable::QueryRow>> rows;
+  for (auto const& row : row_stream) {
+    ASSERT_STATUS_OK(row);
+    rows.push_back(row);
+  }
+  ASSERT_EQ(rows.size(), 2);
+  ASSERT_STATUS_OK(rows[0]);
+  auto const& row1 = *rows[0];
+  EXPECT_EQ(row1.columns().at(0), "row_key");
+  EXPECT_EQ(row1.columns().at(1), "value");
+  EXPECT_THAT(row1.values().at(0).get<std::string>(), IsOkAndHolds("r1"));
+  EXPECT_THAT(row1.values().at(1).get<std::string>(), IsOkAndHolds("v1"));
+  auto const& row2 = *rows[1];
+  EXPECT_THAT(row2.values().at(0).get<std::string>(), IsOkAndHolds("r2"));
+  EXPECT_THAT(row2.values().at(1).get<std::string>(), IsOkAndHolds("v2"));
+}
+
+TEST_F(DataConnectionTest,
+       AsyncPrepareAndExecuteQuerySuccessWithQueryPlanRefresh) {
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+  auto clock = std::make_shared<testing_util::FakeSteadyClock>();
+  auto factory = std::make_unique<MockOperationContextFactory>();
+
+  auto mock_metric_prepared_query_initial = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric_prepared_query_initial, PreCall).Times(1);
+  EXPECT_CALL(*mock_metric_prepared_query_initial, PostCall).Times(1);
+  EXPECT_CALL(*mock_metric_prepared_query_initial, OnDone).Times(1);
+  auto mock_metric_prepared_query_refresh = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric_prepared_query_refresh, PreCall).Times(1);
+  EXPECT_CALL(*mock_metric_prepared_query_refresh, PostCall).Times(1);
+  EXPECT_CALL(*mock_metric_prepared_query_refresh, OnDone).Times(1);
+
+  EXPECT_CALL(*factory, PrepareQuery)
+      .WillOnce([&](auto const&, auto const&) {
+        std::vector<std::shared_ptr<Metric const>> metrics;
+        metrics.push_back(std::make_shared<CloningMetric>(
+            std::move(mock_metric_prepared_query_initial)));
+        return std::make_shared<OperationContext>(
+            ResourceLabels{}, DataLabels{}, std::move(metrics), clock);
+      })
+      .WillOnce([&](auto const&, auto const&) {
+        std::vector<std::shared_ptr<Metric const>> metrics;
+        metrics.push_back(std::make_shared<CloningMetric>(
+            std::move(mock_metric_prepared_query_refresh)));
+        return std::make_shared<OperationContext>(
+            ResourceLabels{}, DataLabels{}, std::move(metrics), clock);
+      });
+
+  auto mock_metric_execute_query = std::make_unique<MockMetric>();
+  EXPECT_CALL(*mock_metric_execute_query, PreCall).Times(2);
+  EXPECT_CALL(*mock_metric_execute_query, PostCall).Times(2);
+  EXPECT_CALL(*mock_metric_execute_query, OnDone).Times(2);
+  EXPECT_CALL(*mock_metric_execute_query, ElementRequest).Times(3);
+  EXPECT_CALL(*mock_metric_execute_query, ElementDelivery).Times(3);
+
+  EXPECT_CALL(*factory, ExecuteQuery).WillOnce([&](auto const&, auto const&) {
+    std::vector<std::shared_ptr<Metric const>> metrics;
+    metrics.push_back(
+        std::make_shared<CloningMetric>(std::move(mock_metric_execute_query)));
+    return std::make_shared<OperationContext>(ResourceLabels{}, DataLabels{},
+                                              std::move(metrics), clock);
+  });
+#else
+  auto factory = std::make_unique<SimpleOperationContextFactory>();
+#endif
+  using google::bigtable::v2::ExecuteQueryRequest;
+  using google::bigtable::v2::ExecuteQueryResponse;
+  using google::bigtable::v2::PrepareQueryRequest;
+  using google::bigtable::v2::PrepareQueryResponse;
+
+  auto constexpr kInitialResultMetadataText = R"pb(
+    proto_schema {
+      columns {
+        name: "row_key"
+        type { string_type {} }
+      }
+      columns {
+        name: "value"
+        type { string_type {} }
+      }
+      columns {
+        name: "other_value"
+        type { string_type {} }
+      }
+    }
+  )pb";
+  PrepareQueryResponse initial_pq_response;
+  initial_pq_response.set_prepared_query("test-pq-id-initial");
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      kInitialResultMetadataText, initial_pq_response.mutable_metadata()));
+  *initial_pq_response.mutable_valid_until() = internal::ToProtoTimestamp(
+      std::chrono::system_clock::now() + std::chrono::seconds(3600));
+
+  auto constexpr kRefreshResultMetadataText = R"pb(
+    proto_schema {
+      columns {
+        name: "row_key"
+        type { string_type {} }
+      }
+      columns {
+        name: "value"
+        type { string_type {} }
+      }
+    }
+  )pb";
+  PrepareQueryResponse refresh_pq_response;
+  refresh_pq_response.set_prepared_query("test-pq-id-refresh");
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      kRefreshResultMetadataText, refresh_pq_response.mutable_metadata()));
+  *refresh_pq_response.mutable_valid_until() = internal::ToProtoTimestamp(
+      std::chrono::system_clock::now() + std::chrono::seconds(3));
+
+  auto mock = std::make_shared<MockBigtableStub>();
+  EXPECT_CALL(*mock, AsyncPrepareQuery)
+      .WillOnce(
+          [&](CompletionQueue const&, auto, auto, PrepareQueryRequest const&) {
+            return make_ready_future(make_status_or(initial_pq_response));
+          })
+      .WillOnce(
+          [&](CompletionQueue const&, auto, auto, PrepareQueryRequest const&) {
+            return make_ready_future(make_status_or(refresh_pq_response));
+          });
+  EXPECT_CALL(*mock, ExecuteQuery)
+      .WillOnce([&](auto, auto const&, ExecuteQueryRequest const& request) {
+        EXPECT_EQ(request.prepared_query(), "test-pq-id-initial");
+        auto error_stream = std::make_unique<MockExecuteQueryStream>();
+        EXPECT_CALL(*error_stream, Read).WillOnce(Return(QueryPlanError()));
+        return error_stream;
+      })
+      .WillOnce([&](auto, auto const&, ExecuteQueryRequest const& request) {
+        EXPECT_EQ(request.app_profile_id(), kAppProfile);
+        EXPECT_EQ(request.instance_name(),
+                  "projects/test-project/instances/test-instance");
+        EXPECT_EQ(request.prepared_query(), "test-pq-id-refresh");
+
+        auto stream = std::make_unique<MockExecuteQueryStream>();
+        EXPECT_CALL(*stream, Read)
+            .WillOnce([&](ExecuteQueryResponse* r) {
+              *r->mutable_metadata() = refresh_pq_response.metadata();
+              return absl::nullopt;
+            })
+            .WillOnce([&](ExecuteQueryResponse* r) {
+              MakeResponse(*r->mutable_results(), {"r1", "v1"}, absl::nullopt,
+                           false);
+              return absl::nullopt;
+            })
+            .WillOnce([&](ExecuteQueryResponse* r) {
+              MakeResponse(*r->mutable_results(), {"r2", "v2"},
+                           "sentinel-token", false);
+              return absl::nullopt;
+            })
+            // End of stream
+            .WillOnce(Return(google::cloud::Status()));
+
+        return stream;
+      });
+
+  auto conn = TestConnection(std::move(mock), std::move(factory));
+  internal::OptionsSpan span(CallOptions());
+  Project p("test-project");
+  bigtable::SqlStatement statement("SELECT * FROM the-table");
+  bigtable::InstanceResource instance(p, "test-instance");
+
+  auto prepared_query = conn->AsyncPrepareQuery({instance, statement}).get();
+  ASSERT_STATUS_OK(prepared_query);
+  auto bound_query = prepared_query->BindParameters({});
+  bigtable::ExecuteQueryParams params{std::move(bound_query)};
+
+  auto row_stream = conn->ExecuteQuery(std::move(params));
+
+  std::vector<StatusOr<bigtable::QueryRow>> rows;
+  for (auto const& row : row_stream) {
+    ASSERT_STATUS_OK(row);
+    rows.push_back(row);
+  }
+  ASSERT_EQ(rows.size(), 2);
+  ASSERT_STATUS_OK(rows[0]);
+  auto const& row1 = *rows[0];
+  EXPECT_EQ(row1.columns().at(0), "row_key");
+  EXPECT_EQ(row1.columns().at(1), "value");
+  EXPECT_THAT(row1.values().at(0).get<std::string>(), IsOkAndHolds("r1"));
+  EXPECT_THAT(row1.values().at(1).get<std::string>(), IsOkAndHolds("v1"));
+  auto const& row2 = *rows[1];
+  EXPECT_THAT(row2.values().at(0).get<std::string>(), IsOkAndHolds("r2"));
+  EXPECT_THAT(row2.values().at(1).get<std::string>(), IsOkAndHolds("v2"));
 }
 
 }  // namespace

--- a/google/cloud/bigtable/internal/operation_context_factory.cc
+++ b/google/cloud/bigtable/internal/operation_context_factory.cc
@@ -497,6 +497,8 @@ std::shared_ptr<OperationContext> MetricsOperationContextFactory::ExecuteQuery(
     v.emplace_back(std::make_shared<AttemptLatency>(kRpc, provider_));
     v.emplace_back(std::make_shared<RetryCount>(kRpc, provider_));
     v.emplace_back(std::make_shared<FirstResponseLatency>(kRpc, provider_));
+    v.emplace_back(
+        std::make_shared<ApplicationBlockingLatency>(kRpc, provider_));
     v.emplace_back(std::make_shared<ServerLatency>(kRpc, provider_));
     v.emplace_back(std::make_shared<ConnectivityErrorCount>(kRpc, provider_));
     swap(execute_query_metrics_.metrics, v);

--- a/google/cloud/bigtable/internal/query_plan.cc
+++ b/google/cloud/bigtable/internal/query_plan.cc
@@ -22,7 +22,7 @@ namespace cloud {
 namespace bigtable_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
-auto constexpr kRefreshDeadlineOffsetMs = 1000;
+auto constexpr kRefreshDeadlineOffsetMs = std::chrono::milliseconds(1000);
 }  // namespace
 
 std::shared_ptr<QueryPlan> QueryPlan::Create(
@@ -46,7 +46,7 @@ void QueryPlan::ScheduleRefresh(std::unique_lock<std::mutex> const&) {
   // We want to start the refresh process before the query plan expires.
   auto refresh_deadline =
       internal::ToChronoTimePoint(response_->valid_until()) -
-      std::chrono::milliseconds(kRefreshDeadlineOffsetMs);
+      kRefreshDeadlineOffsetMs;
   std::weak_ptr<QueryPlan> plan = shared_from_this();
   refresh_timer_ =
       cq_.MakeDeadlineTimer(refresh_deadline)


### PR DESCRIPTION
- ExecuteQuery and the refresh functions created in (Async)PrepareQuery are now properly instrumented to collect metrics.
- Update ExecuteQuery retry loop to honor when the ExecuteQuery RPC retry policy is exhausted.
- Added unit test that combines PrepareQuery and ExecuteQuery calls to test the refresh_fn created by PrepareQuery. 
- Added unit test that combines AsyncPrepareQuery and ExecuteQuery calls to test the refresh_fn created by AsyncPrepareQuery.