### PR TITLE
feat(storage): Add google_cloud_cpp_storage_grpc_otel target for gRPC metrics

### DIFF
--- a/google/cloud/storage/BUILD.bazel
+++ b/google/cloud/storage/BUILD.bazel
@@ -93,6 +93,43 @@ cc_library(
     }),
 )
 
+cc_library(
+    name = "google_cloud_cpp_storage_grpc_otel",
+    srcs = google_cloud_cpp_storage_grpc_srcs,
+    hdrs = google_cloud_cpp_storage_grpc_hdrs,
+    defines = [
+        "GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC",
+        "GOOGLE_CLOUD_CPP_STORAGE_WITH_OTEL_METRICS",
+    ],
+    local_defines = select({
+        "@platforms//os:windows": GOOGLE_CLOUD_STORAGE_WIN_DEFINES,
+        "//conditions:default": [],
+    }) + select({
+        ":ctype_cord_workaround_enabled": ["GOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND"],
+        "//conditions:default": [],
+    }),
+    visibility = [
+        ":__subpackages__",
+        "//:__pkg__",
+    ],
+    deps = [
+        ":google_cloud_cpp_storage",
+        "//:grpc_utils",
+        "//:opentelemetry",
+        "@com_github_curl_curl//:curl",
+        "@com_github_google_crc32c//:crc32c",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_github_grpc_grpc//:grpcpp_otel_plugin",
+        "@com_github_nlohmann_json//:json",
+        "@com_google_absl//absl/algorithm:container",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/time",
+        "@com_google_googleapis//google/storage/v2:storage_cc_grpc",
+        "@com_google_googleapis//google/storage/v2:storage_cc_proto",
+        "@io_opentelemetry_cpp//sdk/src/metrics",
+    ],
+)
+
 filegroup(
     name = "grpc_mocks_hdrs",
     srcs = [h for h in google_cloud_cpp_storage_grpc_mocks_hdrs if not h.startswith("internal/")],


### PR DESCRIPTION
This change introduces google_cloud_cpp_storage_grpc_otel, a new build target that unconditionally enables gRPC metrics support via OpenTelemetry dependencies and by defining GOOGLE_CLOUD_CPP_STORAGE_WITH_OTEL_METRICS.

This is mainly for the [internal google3 users](https://b.corp.google.com/issues/379935816#comment44) who need to build with gRPC metrics enabled to depend on this target explicitly, separating it from the default google_cloud_cpp_storage_grpc target.
