### PR TITLE
impl(bigtable): add string literal constructor to Bytes

### DIFF
--- a/google/cloud/bigtable/bytes.h
+++ b/google/cloud/bigtable/bytes.h
@@ -44,7 +44,7 @@ class Bytes {
   /// An empty sequence.
   Bytes() = default;
 
-  /// Strips the null-terminator character from input bytes.
+  /// Stops copying at the null-terminator character from input bytes.
   explicit Bytes(char const* bytes) : bytes_(bytes) {}
 
   /// @name Construction from a sequence of octets.

--- a/google/cloud/bigtable/bytes_test.cc
+++ b/google/cloud/bigtable/bytes_test.cc
@@ -105,8 +105,8 @@ TEST(Bytes, OutputStream) {
       {Bytes(std::string("a\377B")), R"(B"a\377B")"},
       {Bytes(std::string("!@#$%^&*()-.")), R"(B"!@#$%^&*()-.")"},
       {Bytes(std::string(3, '\0')), R"(B"\000\000\000")"},
-      {Bytes(""), R"(B"\000")"},
-      {Bytes("foo"), R"(B"foo\000")"},
+      {Bytes(""), R"(B"")"},
+      {Bytes("foo"), R"(B"foo")"},
   };
 
   for (auto const& tc : test_cases) {


### PR DESCRIPTION
Lacking this constructor, Bytes("foo") would end up in the request proto as "foo\000" instead of "foo" as the null-terminator was being slurped in with the other constructors.