### PR TITLE
ci: update bigtable conformance tests version

### DIFF
--- a/ci/cloudbuild/dockerfiles/fedora-latest-bazel.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-latest-bazel.Dockerfile
@@ -56,11 +56,11 @@ RUN curl -o /usr/bin/bazelisk -sSL "https://github.com/bazelbuild/bazelisk/relea
 
 # Download the packages needed to run Bigtable conformance tests.
 WORKDIR /var/tmp/downloads
-RUN wget -O go.tgz https://go.dev/dl/go1.20.5.linux-amd64.tar.gz
+RUN wget -O go.tgz https://go.dev/dl/go1.25.4.linux-amd64.tar.gz
 RUN tar -C /usr/local/ -xzf go.tgz
 ENV GO_LOCATION=/usr/local/go
 ENV PATH=${GO_LOCATION}/bin:${PATH}
 RUN go version
 WORKDIR /var/tmp/downloads/cloud-bigtable-clients-test
-RUN curl -fsSL https://github.com/googleapis/cloud-bigtable-clients-test/archive/v0.0.2.tar.gz | \
+RUN curl -fsSL https://github.com/googleapis/cloud-bigtable-clients-test/archive/v0.0.4.tar.gz | \
     tar -xzf - --strip-components=1

--- a/google/cloud/bigtable/ci/run_conformance_tests_proxy_bazel.sh
+++ b/google/cloud/bigtable/ci/run_conformance_tests_proxy_bazel.sh
@@ -41,7 +41,10 @@ popd >/dev/null
 
 # Run the test
 pushd /var/tmp/downloads/cloud-bigtable-clients-test/tests >/dev/null
-go test -v -skip Generic_CloseClient -proxy_addr=:9999
+# Run all non ExecuteQuery tests with skips for non ExecuteQuery tests.
+go test -v \
+  -skip "Generic_CloseClient|Generic_DeadlineExceeded|NoRetry_OutOfOrderError_Reverse|Retry_LastScannedRow_Reverse|Retry_WithRetryInfo_OverallDedaline|TestExecuteQuery" \
+  -proxy_addr=:9999
 exit_status=$?
 # Remove the entire module cache, including unpacked source code of versioned
 # dependencies.


### PR DESCRIPTION
Skips all the tests we do not yet implement.