### PR TITLE
impl(bigtable): add response accessor to PreparedQuery

### DIFF
--- a/google/cloud/bigtable/bound_query.h
+++ b/google/cloud/bigtable/bound_query.h
@@ -52,6 +52,10 @@ class BoundQuery {
   std::unordered_map<std::string, Value> const& parameters() const {
     return parameters_;
   }
+
+  // This data may change if a Query Plan Refresh is performed. If the original
+  // response data is needed for your application, consider copying the response
+  // data immediately after a successful Client::PrepareQuery.
   StatusOr<google::bigtable::v2::PrepareQueryResponse> response();
 
   google::bigtable::v2::ExecuteQueryRequest ToRequestProto() const;

--- a/google/cloud/bigtable/prepared_query.cc
+++ b/google/cloud/bigtable/prepared_query.cc
@@ -13,12 +13,17 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/prepared_query.h"
+#include "google/cloud/bigtable/internal/query_plan.h"
 #include "google/cloud/bigtable/sql_statement.h"
 
 namespace google {
 namespace cloud {
 namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+StatusOr<google::bigtable::v2::PrepareQueryResponse> PreparedQuery::response() {
+  return query_plan_->response();
+}
 
 BoundQuery PreparedQuery::BindParameters(
     std::unordered_map<std::string, Value> params) const {

--- a/google/cloud/bigtable/prepared_query.h
+++ b/google/cloud/bigtable/prepared_query.h
@@ -49,6 +49,11 @@ class PreparedQuery {
   InstanceResource const& instance() const { return instance_; }
   SqlStatement const& sql_statement() const { return sql_statement_; }
 
+  // This data may change if a Query Plan Refresh is performed. If the original
+  // response data is needed for your application, consider copying the response
+  // data immediately after a successful Client::PrepareQuery.
+  StatusOr<google::bigtable::v2::PrepareQueryResponse> response();
+
   // Creates an instance of BoundQuery using the query plan ID from the
   // response.
   BoundQuery BindParameters(


### PR DESCRIPTION
Adding `PreparedQuery::response` provides a mechanism to get metadata that may have changed due to a Query Plan refresh.