### PR TITLE
chore: add universe domain dep to storage examples

### DIFF
--- a/google/cloud/storage/examples/BUILD.bazel
+++ b/google/cloud/storage/examples/BUILD.bazel
@@ -29,6 +29,7 @@ cc_library(
     deps = [
         "//:common",
         "//:storage",
+        "//:universe_domain",
         "//google/cloud/storage:storage_client_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
     ],


### PR DESCRIPTION
To resolve: 
```[third_party/cloud_cpp/google/cloud/storage/examples/storage_client_initialization_samples.cc:21](https://cs.corp.google.com/piper///depot/google3/third_party/cloud_cpp/google/cloud/storage/examples/storage_client_initialization_samples.cc?l=21&ws=codereview/1198452892&snapshot=1):10: fatal error: 'third_party/cloud_cpp/google/cloud/universe_domain.h' file not found
   21 | #include "third_party/cloud_cpp/google/cloud/universe_domain.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.```