### PR TITLE
fix(storage): append object spec should only be set in the first request

### DIFF
--- a/google/cloud/storage/internal/async/writer_connection_impl.cc
+++ b/google/cloud/storage/internal/async/writer_connection_impl.cc
@@ -172,16 +172,16 @@ AsyncWriterConnectionImpl::MakeRequest() {
   auto request = request_;
   if (first_request_) {
     first_request_ = false;
+    if (latest_write_handle_.has_value()) {
+      *request.mutable_append_object_spec()->mutable_write_handle() =
+          *latest_write_handle_;
+    }
   } else {
     request.clear_upload_id();
     request.clear_write_object_spec();
     request.clear_append_object_spec();
   }
   request.set_write_offset(offset_);
-  if (latest_write_handle_.has_value()) {
-    *request.mutable_append_object_spec()->mutable_write_handle() =
-        *latest_write_handle_;
-  }
   return request;
 }
 


### PR DESCRIPTION
In some edge cases we are getting the error: "INVALID_ARGUMENT: The 'append_object_spec' must only be specified on the first request."

I was not able repro this, but most likely this is causing the issue, raising this PR to mitigate the issue.