### PR TITLE
chore(storage): Keep the region_tag and START in one line

### DIFF
--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -51,8 +51,8 @@ void ListBuckets(google::cloud::storage::Client client,
 
 void ListBucketsPartialSuccess(google::cloud::storage::Client client,
                                std::vector<std::string> const& /*argv*/) {
-  //! [list buckets partial success] [START
-  //! storage_list_buckets_partial_success]
+  //! [list buckets partial success]
+  //! [START storage_list_buckets_partial_success]
   namespace gcs = ::google::cloud::storage;
   using ::google::cloud::StatusOr;
   [](gcs::Client client) {


### PR DESCRIPTION
This was causing problem in adding the code sample in public documentation