### PR TITLE
Change test case terminology and create sample for snapshot isolation

### DIFF
--- a/google/cloud/spanner/doc/spanner-main.dox
+++ b/google/cloud/spanner/doc/spanner-main.dox
@@ -34,6 +34,7 @@ into your project.
 - @ref spanner-auth-example
 - @ref spanner-universe-domain-example
 - @ref spanner-mocking
+- @ref spanner-isolation-level-example
 - The [Setting up your development environment] guide describes how to set up
   a C++ development environment in various platforms, including the Google Cloud
   C++ client libraries.
@@ -62,6 +63,19 @@ Follow these links to find examples for other `*Client` classes:
 
 - [`DatabaseAdminClient`](@ref DatabaseAdminClient-set-endpoint-snippet)
 - [`InstanceAdminClient`](@ref InstanceAdminClient-set-endpoint-snippet)
+
+*/
+
+/**
+@page spanner-isolation-level-example Support Isolation Level
+
+Cloud Spanner supports different isolation levels for read-write transactions.
+You can specify a default isolation level at the client-level, or override it
+at the transaction-level.
+
+The following example shows how to set the isolation level:
+
+@snippet samples.cc spanner_isolation_level
 
 */
 

--- a/google/cloud/spanner/transaction.h
+++ b/google/cloud/spanner/transaction.h
@@ -83,7 +83,7 @@ class Transaction {
      * absence of conflicts between its updates and any concurrent updates
      * that have occurred since that snapshot. Consequently, in contrast to
      * `kSerializable` transactions, only write-write conflicts are detected in
-     * snapshot transactions.
+     * repeatable read transactions.
      */
     kRepeatableRead,
   };

--- a/google/cloud/spanner/transaction_test.cc
+++ b/google/cloud/spanner/transaction_test.cc
@@ -188,7 +188,7 @@ TEST(Transaction, IsolationLevelPrecedence) {
         return 0;
       });
 
-  // Case 2: Fallback to client default
+  // Case 2: Fallback to default options
   auto opts_default = Transaction::ReadWriteOptions();
   Transaction txn_default = MakeReadWriteTransaction(opts_default);
   spanner_internal::Visit(
@@ -202,7 +202,7 @@ TEST(Transaction, IsolationLevelPrecedence) {
 }
 
 TEST(Transaction, IsolationLevelNotSpecified) {
-  // Case: Isolation not specified in transaction level or client level
+  // Case: Isolation not specified in transaction options or default options
   auto opts = Transaction::ReadWriteOptions();
   Transaction txn = MakeReadWriteTransaction(opts);
   spanner_internal::Visit(


### PR DESCRIPTION
This PR addresses the following:

- Changes the terminology for client default options commented for transaction unit test.
- Creates a Sample for Snapshot Isolation