### PR TITLE
chore: replace gcs-sdk-team with gcs-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 * @googleapis/cloud-sdk-cpp-team
 
 # These libraries are also owned by the GCS clients team.
-/google/cloud/storage/ @googleapis/gcs-sdk-team @googleapis/cloud-sdk-cpp-team
-/google/cloud/storagecontrol/ @googleapis/gcs-sdk-team @googleapis/cloud-sdk-cpp-team
-/google/cloud/storageinsights/ @googleapis/gcs-sdk-team @googleapis/cloud-sdk-cpp-team
-/google/cloud/storagetransfer/ @googleapis/gcs-sdk-team @googleapis/cloud-sdk-cpp-team
+/google/cloud/storage/ @googleapis/gcs-team @googleapis/cloud-sdk-cpp-team
+/google/cloud/storagecontrol/ @googleapis/gcs-team @googleapis/cloud-sdk-cpp-team
+/google/cloud/storageinsights/ @googleapis/gcs-team @googleapis/cloud-sdk-cpp-team
+/google/cloud/storagetransfer/ @googleapis/gcs-team @googleapis/cloud-sdk-cpp-team


### PR DESCRIPTION
This PR replaces @googleapis/gcs-sdk-team with @googleapis/gcs-team in CODEOWNERS. b/478003109

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15982)
<!-- Reviewable:end -->
