### PR TITLE
ci: enable GHA windows-cmake testing

### DIFF
--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -9,7 +9,7 @@ on:
   # branches we can disable builds (to speed up the testing) or add new ones,
   # without impacting the rest of the team.
   push:
-    branches: [ 'ci-gha**', 'prepare-for-v3.0.0' ]
+    branches: [ 'ci-gha**', 'main' ]
   # Start the build in the context of the target branch. This is considered
   # "safe", as the workflow files are already committed. These types of builds
   # have access to the secrets in the build, which we need to use the remote

--- a/.github/workflows/windows-cmake.yml
+++ b/.github/workflows/windows-cmake.yml
@@ -41,7 +41,7 @@ jobs:
         msvc: [ msvc-2022 ]
         build_type: [ Release ]
         arch: [ x64 ]
-        shard: [ Core1, Core2, Core3, Core4, Core5, Compute, AIPlatform, Shard1, Shard2, Shard3, Shard4, Shard5 ]
+        shard: [ Core1, Core2, Core3, Core4, Core5, Shard1 ]
         exclude:
         # Also skip shards (Compute and Other) that contain only generated code.
         - exclude-from-full-trick: ${{ ! inputs.full-matrix }}


### PR DESCRIPTION
Enable GHA windows+cmake testing with a reduced build matrix until kokoro build is working.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/15983)
<!-- Reviewable:end -->
