### PR TITLE
chore: instruct renovate-bot to ignore googleapis dep

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -90,7 +90,7 @@
   ],
   "ignoreDeps": [
     "boringssl",
-    "com_google_googleapis"
+    "com_google_googleapis",
     "googleapis"
   ]
 }


### PR DESCRIPTION
We update this dependency manually as specific commit SHAs.