### PR TITLE
impl(rest): map http code 504 to kUnavailable

### DIFF
--- a/google/cloud/internal/rest_response.cc
+++ b/google/cloud/internal/rest_response.cc
@@ -120,6 +120,9 @@ StatusCode MapHttpCodeToStatus5xx(std::int32_t code) {
   if (code == HttpStatusCode::kServiceUnavailable) {
     return StatusCode::kUnavailable;
   }
+  if (code == HttpStatusCode::kGatewayTimeout) {
+    return StatusCode::kUnavailable;
+  }
   // 5XX - server errors are mapped to kInternal.
   return StatusCode::kInternal;
 }
@@ -153,8 +156,12 @@ Status AsStatus(HttpStatusCode http_status_code, std::string payload) {
   if (payload.empty()) {
     // If there's no payload, create one to make sure the original http status
     // code received is available.
-    return Status(status_code, "Received HTTP status code: " +
-                                   std::to_string(http_status_code));
+    ErrorInfo error_info{
+        {}, {}, {{"http_status_code", std::to_string(http_status_code)}}};
+    return Status(
+        status_code,
+        "Received HTTP status code: " + std::to_string(http_status_code),
+        std::move(error_info));
   }
   auto p =
       ParseJsonError(static_cast<int>(http_status_code), std::move(payload));

--- a/google/cloud/internal/rest_response.h
+++ b/google/cloud/internal/rest_response.h
@@ -67,6 +67,7 @@ enum HttpStatusCode : std::int32_t {
   kInternalServerError = 500,
   kBadGateway = 502,
   kServiceUnavailable = 503,
+  kGatewayTimeout = 504,
 };
 
 // This class contains the results of making a request to a RESTful service.

--- a/google/cloud/internal/rest_response_test.cc
+++ b/google/cloud/internal/rest_response_test.cc
@@ -83,7 +83,8 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_pair(HttpStatusCode::kBadGateway, StatusCode::kUnavailable),
         std::make_pair(HttpStatusCode::kServiceUnavailable,
                        StatusCode::kUnavailable),
-        std::make_pair(static_cast<HttpStatusCode>(504), StatusCode::kInternal),
+        std::make_pair(HttpStatusCode::kGatewayTimeout,
+                       StatusCode::kUnavailable),
         std::make_pair(static_cast<HttpStatusCode>(601), StatusCode::kUnknown)),
     [](testing::TestParamInfo<MapHttpCodeToStatusTest::ParamType> const& info) {
       return std::to_string(std::get<0>(info.param));
@@ -135,6 +136,8 @@ TEST(AsStatus, RestResponseIsNotOkNoPayload) {
   EXPECT_THAT(status, StatusIs(StatusCode::kNotFound));
   EXPECT_THAT(status.message(), Eq("Received HTTP status code: 404"));
   EXPECT_TRUE(status.error_info().reason().empty());
+  EXPECT_THAT(status.error_info().metadata(),
+              Contains(::testing::Pair("http_status_code", "404")));
 }
 
 TEST(AsStatus, RestResponseIsNotOkPayload) {


### PR DESCRIPTION
Upcoming RAB feature considers 504 retryable. Additionally, improve returned error status when no payload is available.