### PR TITLE
impl(bigtable): add DeadlineOption

### DIFF
--- a/generator/internal/client_generator.cc
+++ b/generator/internal/client_generator.cc
@@ -20,11 +20,11 @@
 #include "generator/internal/pagination.h"
 #include "generator/internal/predicate_utils.h"
 #include "generator/internal/printer.h"
+#include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_replace.h"
 #include "google/api/client.pb.h"
 #include <google/protobuf/descriptor.h>
-#include <absl/strings/match.h>
 
 namespace google {
 namespace cloud {

--- a/generator/internal/client_generator.cc
+++ b/generator/internal/client_generator.cc
@@ -24,6 +24,7 @@
 #include "absl/strings/str_replace.h"
 #include "google/api/client.pb.h"
 #include <google/protobuf/descriptor.h>
+#include <absl/strings/match.h>
 
 namespace google {
 namespace cloud {
@@ -456,7 +457,10 @@ Status ClientGenerator::GenerateCc() {
   if (MethodSignatureUsesDeprecatedField()) {
     CcLocalIncludes({"google/cloud/internal/disable_deprecation_warnings.inc"});
   }
-  CcLocalIncludes({vars("client_header_path")});
+  CcLocalIncludes({vars("client_header_path"),
+                   absl::StartsWithIgnoreCase(vars("service_name"), "Bigtable")
+                       ? "google/cloud/bigtable/options.h"
+                       : ""});
   CcSystemIncludes({"memory"});
   if (get_iam_policy_extension_ && set_iam_policy_extension_) {
     CcLocalIncludes({vars("options_header_path")});
@@ -473,7 +477,7 @@ $client_class_name$::$client_class_name$()""");
   CcPrint(R"""(
     std::shared_ptr<$connection_class_name$> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(std::move(opts),
+      options_($merge_options_fn$(std::move(opts),
       connection_->options())) {}
 $client_class_name$::~$client_class_name$() = default;
 )""");
@@ -488,7 +492,7 @@ std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
     $response_type$>>
 $client_class_name$::Async$method_name$(Options opts) {
   internal::OptionsSpan span(
-      internal::MergeOptions(std::move(opts), options_));
+      $merge_options_fn$(std::move(opts), options_));
   return connection_->Async$method_name$();
 }
 )""");
@@ -513,7 +517,7 @@ $client_class_name$::Async$method_name$(Options opts) {
                    {"\n$return_type$\n"},
                    // clang-format off
                   {method_string},
-                  {"  internal::OptionsSpan span(internal::MergeOptions("
+                  {"  internal::OptionsSpan span($merge_options_fn$("
                    "std::move(opts), options_));\n"},
                   {"  $request_type$ request;\n"},
                    {method_request_string},
@@ -529,7 +533,7 @@ $client_class_name$::Async$method_name$(Options opts) {
                     "\nfuture<Status>\n",
                     "\nfuture<StatusOr<$longrunning_deduced_response_type$>>\n"},
                   {method_string},
-                  {"  internal::OptionsSpan span(internal::MergeOptions("
+                  {"  internal::OptionsSpan span($merge_options_fn$("
                    "std::move(opts), options_));\n"},
                   {"  $request_type$ request;\n"},
                    {method_request_string},
@@ -541,7 +545,7 @@ $client_class_name$::Async$method_name$(Options opts) {
                     "\nStatus\n",
                     "\nStatusOr<$longrunning_operation_type$>\n"},
                   {start_method_string},
-                  {"  internal::OptionsSpan span(internal::MergeOptions("
+                  {"  internal::OptionsSpan span($merge_options_fn$("
                    "std::move(opts), options_));\n"},
                   {"  $request_type$ request;\n"},
                    {method_request_string},
@@ -554,7 +558,7 @@ $client_class_name$::Async$method_name$(Options opts) {
                    // clang-format off
                    {"\nStreamRange<$range_output_type$>\n"},
                   {method_string},
-                  {"  internal::OptionsSpan span(internal::MergeOptions("
+                  {"  internal::OptionsSpan span($merge_options_fn$("
                    "std::move(opts), options_));\n"},
                   {"  $request_type$ request;\n"},
                    {method_request_string},
@@ -567,7 +571,7 @@ $client_class_name$::Async$method_name$(Options opts) {
                    // clang-format off
                    {"\nStreamRange<$response_type$>\n"},
                   {method_string},
-                  {"  internal::OptionsSpan span(internal::MergeOptions("
+                  {"  internal::OptionsSpan span($merge_options_fn$("
                    "std::move(opts), options_));\n"},
                   {"  $request_type$ request;\n"},
                    {method_request_string},
@@ -591,7 +595,7 @@ $client_class_name$::Async$method_name$(Options opts) {
              " Options opts) {\n"
              "  internal::CheckExpectedOptions<$service_name$"
              "BackoffPolicyOption>(opts, __func__);\n"
-             "  internal::OptionsSpan span(internal::MergeOptions("
+             "  internal::OptionsSpan span($merge_options_fn$("
              "std::move(opts), options_));\n"},
             {"  "},
             {ProtoNameToCppName(
@@ -644,7 +648,7 @@ $client_class_name$::Async$method_name$(Options opts) {
                  // clang-format off
    {"$client_class_name$::$method_name$($request_type$ const& request"
     ", Options opts) {\n"
-    "  internal::OptionsSpan span(internal::MergeOptions("
+    "  internal::OptionsSpan span($merge_options_fn$("
     "std::move(opts), options_));\n"
     "  return connection_->$method_name$(request);\n"
     "}\n"}  // clang-format on
@@ -659,7 +663,7 @@ $client_class_name$::Async$method_name$(Options opts) {
     "\nfuture<StatusOr<$longrunning_deduced_response_type$>>\n"},
    {"$client_class_name$::$method_name$($request_type$ const& request"
     ", Options opts) {\n"
-    "  internal::OptionsSpan span(internal::MergeOptions("
+    "  internal::OptionsSpan span($merge_options_fn$("
     "std::move(opts), options_));\n"
     "  return connection_->$method_name$(request);\n"
     "}\n"},
@@ -671,7 +675,7 @@ $client_class_name$::Async$method_name$(Options opts) {
    {"$client_class_name$::$method_name$(NoAwaitTag"
     ", $request_type$ const& request"
     ", Options opts) {\n"
-    "  internal::OptionsSpan span(internal::MergeOptions("
+    "  internal::OptionsSpan span($merge_options_fn$("
     "std::move(opts), options_));\n"
     "  return connection_->$method_name$(NoAwaitTag{}, request);\n"
     "}\n"},
@@ -682,7 +686,7 @@ $client_class_name$::Async$method_name$(Options opts) {
     "\nfuture<StatusOr<$longrunning_deduced_response_type$>>\n"},
    {"$client_class_name$::$method_name$("
     "$longrunning_operation_type$ const& operation, Options opts) {\n"
-    "  internal::OptionsSpan span(internal::MergeOptions("
+    "  internal::OptionsSpan span($merge_options_fn$("
     "std::move(opts), options_));\n"
     "  return connection_->$method_name$(operation);\n"},
    {"}\n"}  // clang-format on
@@ -694,7 +698,7 @@ $client_class_name$::Async$method_name$(Options opts) {
    {"\nStreamRange<$range_output_type$>\n"
     "$client_class_name$::$method_name$($request_type$ request"
     ", Options opts) {\n"
-    "  internal::OptionsSpan span(internal::MergeOptions("
+    "  internal::OptionsSpan span($merge_options_fn$("
     "std::move(opts), options_));\n"
     "  return connection_->$method_name$(std::move(request));\n"
     "}\n"}  // clang-format on
@@ -706,7 +710,7 @@ $client_class_name$::Async$method_name$(Options opts) {
    {"\nStreamRange<$response_type$>\n"
     "$client_class_name$::$method_name$($request_type$ const& request"
     ", Options opts) {\n"
-    "  internal::OptionsSpan span(internal::MergeOptions("
+    "  internal::OptionsSpan span($merge_options_fn$("
     "std::move(opts), options_));\n"
     "  return connection_->$method_name$(request);\n"
     "}\n"}  // clang-format on
@@ -733,7 +737,7 @@ $client_class_name$::Async$method_name$(Options opts) {
                   {"\nfuture<$return_type$>\n"},
                   // clang-format off
                   {method_string},
-                  {"  internal::OptionsSpan span(internal::MergeOptions("
+                  {"  internal::OptionsSpan span($merge_options_fn$("
                    "std::move(opts), options_));\n"},
                   {"  $request_type$ request;\n"},
                    {method_request_string},
@@ -752,7 +756,7 @@ $client_class_name$::Async$method_name$(Options opts) {
                 // clang-format off
    {"$client_class_name$::Async$method_name$($request_type$ const& request"
     ", Options opts) {\n"
-    "  internal::OptionsSpan span(internal::MergeOptions("
+    "  internal::OptionsSpan span($merge_options_fn$("
     "std::move(opts), options_));\n"
     "  return connection_->Async$method_name$(request);\n"
     "}\n"}  // clang-format on
@@ -768,7 +772,7 @@ $client_class_name$::Async$method_name$(Options opts) {
         method.return_type(), R"""( $client_class_name$::)""", method.name(),
         absl::StrReplaceAll(method.parameters(), {{" = {}", ""}}),
         absl::StrFormat(R"""( {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span($merge_options_fn$(std::move(opts), options_));
   return connection_->%s(request);
 }
 )""",

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -725,6 +725,10 @@ VarsDictionary CreateServiceVars(
   vars["logging_rest_header_path"] = absl::StrCat(
       vars["product_path"], "internal/", ServiceNameToFilePath(service_name),
       "_rest_logging_decorator.h");
+  vars["merge_options_fn"] =
+      absl::StartsWithIgnoreCase(service_name, "Bigtable")
+          ? "bigtable_internal::MergeOptions"
+          : "internal::MergeOptions";
   vars["metadata_class_name"] = absl::StrCat(service_name, "Metadata");
   vars["metadata_cc_path"] = absl::StrCat(vars["product_path"], "internal/",
                                           ServiceNameToFilePath(service_name),

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -229,6 +229,7 @@ add_library(
     mutation_branch.h
     mutations.cc
     mutations.h
+    options.cc
     options.h
     polling_policy.cc
     polling_policy.h
@@ -476,6 +477,7 @@ if (BUILD_TESTING)
         mocks/mock_row_reader_test.cc
         mutation_batcher_test.cc
         mutations_test.cc
+        options_test.cc
         polling_policy_test.cc
         prepared_query_test.cc
         query_row_test.cc

--- a/google/cloud/bigtable/admin/bigtable_instance_admin_client.cc
+++ b/google/cloud/bigtable/admin/bigtable_instance_admin_client.cc
@@ -18,6 +18,7 @@
 
 #include "google/cloud/bigtable/admin/bigtable_instance_admin_client.h"
 #include "google/cloud/bigtable/admin/bigtable_instance_admin_options.h"
+#include "google/cloud/bigtable/options.h"
 #include <memory>
 #include <thread>
 #include <utility>
@@ -30,8 +31,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 BigtableInstanceAdminClient::BigtableInstanceAdminClient(
     std::shared_ptr<BigtableInstanceAdminConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(
-          internal::MergeOptions(std::move(opts), connection_->options())) {}
+      options_(bigtable_internal::MergeOptions(std::move(opts),
+                                               connection_->options())) {}
 BigtableInstanceAdminClient::~BigtableInstanceAdminClient() = default;
 
 future<StatusOr<google::bigtable::admin::v2::Instance>>
@@ -40,7 +41,8 @@ BigtableInstanceAdminClient::CreateInstance(
     google::bigtable::admin::v2::Instance const& instance,
     std::map<std::string, google::bigtable::admin::v2::Cluster> const& clusters,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::CreateInstanceRequest request;
   request.set_parent(parent);
   request.set_instance_id(instance_id);
@@ -55,7 +57,8 @@ BigtableInstanceAdminClient::CreateInstance(
     google::bigtable::admin::v2::Instance const& instance,
     std::map<std::string, google::bigtable::admin::v2::Cluster> const& clusters,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::CreateInstanceRequest request;
   request.set_parent(parent);
   request.set_instance_id(instance_id);
@@ -68,7 +71,8 @@ future<StatusOr<google::bigtable::admin::v2::Instance>>
 BigtableInstanceAdminClient::CreateInstance(
     google::bigtable::admin::v2::CreateInstanceRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateInstance(request);
 }
 
@@ -77,21 +81,24 @@ BigtableInstanceAdminClient::CreateInstance(
     NoAwaitTag,
     google::bigtable::admin::v2::CreateInstanceRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateInstance(NoAwaitTag{}, request);
 }
 
 future<StatusOr<google::bigtable::admin::v2::Instance>>
 BigtableInstanceAdminClient::CreateInstance(
     google::longrunning::Operation const& operation, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateInstance(operation);
 }
 
 StatusOr<google::bigtable::admin::v2::Instance>
 BigtableInstanceAdminClient::GetInstance(std::string const& name,
                                          Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::GetInstanceRequest request;
   request.set_name(name);
   return connection_->GetInstance(request);
@@ -101,14 +108,16 @@ StatusOr<google::bigtable::admin::v2::Instance>
 BigtableInstanceAdminClient::GetInstance(
     google::bigtable::admin::v2::GetInstanceRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->GetInstance(request);
 }
 
 StatusOr<google::bigtable::admin::v2::ListInstancesResponse>
 BigtableInstanceAdminClient::ListInstances(std::string const& parent,
                                            Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::ListInstancesRequest request;
   request.set_parent(parent);
   return connection_->ListInstances(request);
@@ -118,14 +127,16 @@ StatusOr<google::bigtable::admin::v2::ListInstancesResponse>
 BigtableInstanceAdminClient::ListInstances(
     google::bigtable::admin::v2::ListInstancesRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->ListInstances(request);
 }
 
 StatusOr<google::bigtable::admin::v2::Instance>
 BigtableInstanceAdminClient::UpdateInstance(
     google::bigtable::admin::v2::Instance const& request, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateInstance(request);
 }
 
@@ -133,7 +144,8 @@ future<StatusOr<google::bigtable::admin::v2::Instance>>
 BigtableInstanceAdminClient::PartialUpdateInstance(
     google::bigtable::admin::v2::Instance const& instance,
     google::protobuf::FieldMask const& update_mask, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::PartialUpdateInstanceRequest request;
   *request.mutable_instance() = instance;
   *request.mutable_update_mask() = update_mask;
@@ -144,7 +156,8 @@ StatusOr<google::longrunning::Operation>
 BigtableInstanceAdminClient::PartialUpdateInstance(
     NoAwaitTag, google::bigtable::admin::v2::Instance const& instance,
     google::protobuf::FieldMask const& update_mask, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::PartialUpdateInstanceRequest request;
   *request.mutable_instance() = instance;
   *request.mutable_update_mask() = update_mask;
@@ -155,7 +168,8 @@ future<StatusOr<google::bigtable::admin::v2::Instance>>
 BigtableInstanceAdminClient::PartialUpdateInstance(
     google::bigtable::admin::v2::PartialUpdateInstanceRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->PartialUpdateInstance(request);
 }
 
@@ -164,20 +178,23 @@ BigtableInstanceAdminClient::PartialUpdateInstance(
     NoAwaitTag,
     google::bigtable::admin::v2::PartialUpdateInstanceRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->PartialUpdateInstance(NoAwaitTag{}, request);
 }
 
 future<StatusOr<google::bigtable::admin::v2::Instance>>
 BigtableInstanceAdminClient::PartialUpdateInstance(
     google::longrunning::Operation const& operation, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->PartialUpdateInstance(operation);
 }
 
 Status BigtableInstanceAdminClient::DeleteInstance(std::string const& name,
                                                    Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::DeleteInstanceRequest request;
   request.set_name(name);
   return connection_->DeleteInstance(request);
@@ -186,7 +203,8 @@ Status BigtableInstanceAdminClient::DeleteInstance(std::string const& name,
 Status BigtableInstanceAdminClient::DeleteInstance(
     google::bigtable::admin::v2::DeleteInstanceRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteInstance(request);
 }
 
@@ -194,7 +212,8 @@ future<StatusOr<google::bigtable::admin::v2::Cluster>>
 BigtableInstanceAdminClient::CreateCluster(
     std::string const& parent, std::string const& cluster_id,
     google::bigtable::admin::v2::Cluster const& cluster, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::CreateClusterRequest request;
   request.set_parent(parent);
   request.set_cluster_id(cluster_id);
@@ -206,7 +225,8 @@ StatusOr<google::longrunning::Operation>
 BigtableInstanceAdminClient::CreateCluster(
     NoAwaitTag, std::string const& parent, std::string const& cluster_id,
     google::bigtable::admin::v2::Cluster const& cluster, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::CreateClusterRequest request;
   request.set_parent(parent);
   request.set_cluster_id(cluster_id);
@@ -218,7 +238,8 @@ future<StatusOr<google::bigtable::admin::v2::Cluster>>
 BigtableInstanceAdminClient::CreateCluster(
     google::bigtable::admin::v2::CreateClusterRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateCluster(request);
 }
 
@@ -227,20 +248,23 @@ BigtableInstanceAdminClient::CreateCluster(
     NoAwaitTag,
     google::bigtable::admin::v2::CreateClusterRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateCluster(NoAwaitTag{}, request);
 }
 
 future<StatusOr<google::bigtable::admin::v2::Cluster>>
 BigtableInstanceAdminClient::CreateCluster(
     google::longrunning::Operation const& operation, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateCluster(operation);
 }
 
 StatusOr<google::bigtable::admin::v2::Cluster>
 BigtableInstanceAdminClient::GetCluster(std::string const& name, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::GetClusterRequest request;
   request.set_name(name);
   return connection_->GetCluster(request);
@@ -250,14 +274,16 @@ StatusOr<google::bigtable::admin::v2::Cluster>
 BigtableInstanceAdminClient::GetCluster(
     google::bigtable::admin::v2::GetClusterRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->GetCluster(request);
 }
 
 StatusOr<google::bigtable::admin::v2::ListClustersResponse>
 BigtableInstanceAdminClient::ListClusters(std::string const& parent,
                                           Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::ListClustersRequest request;
   request.set_parent(parent);
   return connection_->ListClusters(request);
@@ -267,14 +293,16 @@ StatusOr<google::bigtable::admin::v2::ListClustersResponse>
 BigtableInstanceAdminClient::ListClusters(
     google::bigtable::admin::v2::ListClustersRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->ListClusters(request);
 }
 
 future<StatusOr<google::bigtable::admin::v2::Cluster>>
 BigtableInstanceAdminClient::UpdateCluster(
     google::bigtable::admin::v2::Cluster const& request, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateCluster(request);
 }
 
@@ -282,14 +310,16 @@ StatusOr<google::longrunning::Operation>
 BigtableInstanceAdminClient::UpdateCluster(
     NoAwaitTag, google::bigtable::admin::v2::Cluster const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateCluster(NoAwaitTag{}, request);
 }
 
 future<StatusOr<google::bigtable::admin::v2::Cluster>>
 BigtableInstanceAdminClient::UpdateCluster(
     google::longrunning::Operation const& operation, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateCluster(operation);
 }
 
@@ -297,7 +327,8 @@ future<StatusOr<google::bigtable::admin::v2::Cluster>>
 BigtableInstanceAdminClient::PartialUpdateCluster(
     google::bigtable::admin::v2::Cluster const& cluster,
     google::protobuf::FieldMask const& update_mask, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::PartialUpdateClusterRequest request;
   *request.mutable_cluster() = cluster;
   *request.mutable_update_mask() = update_mask;
@@ -308,7 +339,8 @@ StatusOr<google::longrunning::Operation>
 BigtableInstanceAdminClient::PartialUpdateCluster(
     NoAwaitTag, google::bigtable::admin::v2::Cluster const& cluster,
     google::protobuf::FieldMask const& update_mask, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::PartialUpdateClusterRequest request;
   *request.mutable_cluster() = cluster;
   *request.mutable_update_mask() = update_mask;
@@ -319,7 +351,8 @@ future<StatusOr<google::bigtable::admin::v2::Cluster>>
 BigtableInstanceAdminClient::PartialUpdateCluster(
     google::bigtable::admin::v2::PartialUpdateClusterRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->PartialUpdateCluster(request);
 }
 
@@ -328,20 +361,23 @@ BigtableInstanceAdminClient::PartialUpdateCluster(
     NoAwaitTag,
     google::bigtable::admin::v2::PartialUpdateClusterRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->PartialUpdateCluster(NoAwaitTag{}, request);
 }
 
 future<StatusOr<google::bigtable::admin::v2::Cluster>>
 BigtableInstanceAdminClient::PartialUpdateCluster(
     google::longrunning::Operation const& operation, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->PartialUpdateCluster(operation);
 }
 
 Status BigtableInstanceAdminClient::DeleteCluster(std::string const& name,
                                                   Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::DeleteClusterRequest request;
   request.set_name(name);
   return connection_->DeleteCluster(request);
@@ -350,7 +386,8 @@ Status BigtableInstanceAdminClient::DeleteCluster(std::string const& name,
 Status BigtableInstanceAdminClient::DeleteCluster(
     google::bigtable::admin::v2::DeleteClusterRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteCluster(request);
 }
 
@@ -358,7 +395,8 @@ StatusOr<google::bigtable::admin::v2::AppProfile>
 BigtableInstanceAdminClient::CreateAppProfile(
     std::string const& parent, std::string const& app_profile_id,
     google::bigtable::admin::v2::AppProfile const& app_profile, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::CreateAppProfileRequest request;
   request.set_parent(parent);
   request.set_app_profile_id(app_profile_id);
@@ -370,14 +408,16 @@ StatusOr<google::bigtable::admin::v2::AppProfile>
 BigtableInstanceAdminClient::CreateAppProfile(
     google::bigtable::admin::v2::CreateAppProfileRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateAppProfile(request);
 }
 
 StatusOr<google::bigtable::admin::v2::AppProfile>
 BigtableInstanceAdminClient::GetAppProfile(std::string const& name,
                                            Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::GetAppProfileRequest request;
   request.set_name(name);
   return connection_->GetAppProfile(request);
@@ -387,14 +427,16 @@ StatusOr<google::bigtable::admin::v2::AppProfile>
 BigtableInstanceAdminClient::GetAppProfile(
     google::bigtable::admin::v2::GetAppProfileRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->GetAppProfile(request);
 }
 
 StreamRange<google::bigtable::admin::v2::AppProfile>
 BigtableInstanceAdminClient::ListAppProfiles(std::string const& parent,
                                              Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::ListAppProfilesRequest request;
   request.set_parent(parent);
   return connection_->ListAppProfiles(request);
@@ -403,7 +445,8 @@ BigtableInstanceAdminClient::ListAppProfiles(std::string const& parent,
 StreamRange<google::bigtable::admin::v2::AppProfile>
 BigtableInstanceAdminClient::ListAppProfiles(
     google::bigtable::admin::v2::ListAppProfilesRequest request, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->ListAppProfiles(std::move(request));
 }
 
@@ -411,7 +454,8 @@ future<StatusOr<google::bigtable::admin::v2::AppProfile>>
 BigtableInstanceAdminClient::UpdateAppProfile(
     google::bigtable::admin::v2::AppProfile const& app_profile,
     google::protobuf::FieldMask const& update_mask, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::UpdateAppProfileRequest request;
   *request.mutable_app_profile() = app_profile;
   *request.mutable_update_mask() = update_mask;
@@ -422,7 +466,8 @@ StatusOr<google::longrunning::Operation>
 BigtableInstanceAdminClient::UpdateAppProfile(
     NoAwaitTag, google::bigtable::admin::v2::AppProfile const& app_profile,
     google::protobuf::FieldMask const& update_mask, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::UpdateAppProfileRequest request;
   *request.mutable_app_profile() = app_profile;
   *request.mutable_update_mask() = update_mask;
@@ -433,7 +478,8 @@ future<StatusOr<google::bigtable::admin::v2::AppProfile>>
 BigtableInstanceAdminClient::UpdateAppProfile(
     google::bigtable::admin::v2::UpdateAppProfileRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateAppProfile(request);
 }
 
@@ -442,21 +488,24 @@ BigtableInstanceAdminClient::UpdateAppProfile(
     NoAwaitTag,
     google::bigtable::admin::v2::UpdateAppProfileRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateAppProfile(NoAwaitTag{}, request);
 }
 
 future<StatusOr<google::bigtable::admin::v2::AppProfile>>
 BigtableInstanceAdminClient::UpdateAppProfile(
     google::longrunning::Operation const& operation, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateAppProfile(operation);
 }
 
 Status BigtableInstanceAdminClient::DeleteAppProfile(std::string const& name,
                                                      bool ignore_warnings,
                                                      Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::DeleteAppProfileRequest request;
   request.set_name(name);
   request.set_ignore_warnings(ignore_warnings);
@@ -466,13 +515,15 @@ Status BigtableInstanceAdminClient::DeleteAppProfile(std::string const& name,
 Status BigtableInstanceAdminClient::DeleteAppProfile(
     google::bigtable::admin::v2::DeleteAppProfileRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteAppProfile(request);
 }
 
 StatusOr<google::iam::v1::Policy> BigtableInstanceAdminClient::GetIamPolicy(
     std::string const& resource, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(resource);
   return connection_->GetIamPolicy(request);
@@ -480,14 +531,16 @@ StatusOr<google::iam::v1::Policy> BigtableInstanceAdminClient::GetIamPolicy(
 
 StatusOr<google::iam::v1::Policy> BigtableInstanceAdminClient::GetIamPolicy(
     google::iam::v1::GetIamPolicyRequest const& request, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> BigtableInstanceAdminClient::SetIamPolicy(
     std::string const& resource, google::iam::v1::Policy const& policy,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::SetIamPolicyRequest request;
   request.set_resource(resource);
   *request.mutable_policy() = policy;
@@ -498,7 +551,8 @@ StatusOr<google::iam::v1::Policy> BigtableInstanceAdminClient::SetIamPolicy(
     std::string const& resource, IamUpdater const& updater, Options opts) {
   internal::CheckExpectedOptions<BigtableInstanceAdminBackoffPolicyOption>(
       opts, __func__);
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::GetIamPolicyRequest get_request;
   get_request.set_resource(resource);
   google::iam::v1::SetIamPolicyRequest set_request;
@@ -531,7 +585,8 @@ StatusOr<google::iam::v1::Policy> BigtableInstanceAdminClient::SetIamPolicy(
 
 StatusOr<google::iam::v1::Policy> BigtableInstanceAdminClient::SetIamPolicy(
     google::iam::v1::SetIamPolicyRequest const& request, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->SetIamPolicy(request);
 }
 
@@ -539,7 +594,8 @@ StatusOr<google::iam::v1::TestIamPermissionsResponse>
 BigtableInstanceAdminClient::TestIamPermissions(
     std::string const& resource, std::vector<std::string> const& permissions,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::TestIamPermissionsRequest request;
   request.set_resource(resource);
   *request.mutable_permissions() = {permissions.begin(), permissions.end()};
@@ -549,14 +605,16 @@ BigtableInstanceAdminClient::TestIamPermissions(
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 BigtableInstanceAdminClient::TestIamPermissions(
     google::iam::v1::TestIamPermissionsRequest const& request, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->TestIamPermissions(request);
 }
 
 StreamRange<google::bigtable::admin::v2::HotTablet>
 BigtableInstanceAdminClient::ListHotTablets(std::string const& parent,
                                             Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::ListHotTabletsRequest request;
   request.set_parent(parent);
   return connection_->ListHotTablets(request);
@@ -565,7 +623,8 @@ BigtableInstanceAdminClient::ListHotTablets(std::string const& parent,
 StreamRange<google::bigtable::admin::v2::HotTablet>
 BigtableInstanceAdminClient::ListHotTablets(
     google::bigtable::admin::v2::ListHotTabletsRequest request, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->ListHotTablets(std::move(request));
 }
 
@@ -574,7 +633,8 @@ BigtableInstanceAdminClient::CreateLogicalView(
     std::string const& parent,
     google::bigtable::admin::v2::LogicalView const& logical_view,
     std::string const& logical_view_id, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::CreateLogicalViewRequest request;
   request.set_parent(parent);
   *request.mutable_logical_view() = logical_view;
@@ -587,7 +647,8 @@ BigtableInstanceAdminClient::CreateLogicalView(
     NoAwaitTag, std::string const& parent,
     google::bigtable::admin::v2::LogicalView const& logical_view,
     std::string const& logical_view_id, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::CreateLogicalViewRequest request;
   request.set_parent(parent);
   *request.mutable_logical_view() = logical_view;
@@ -599,7 +660,8 @@ future<StatusOr<google::bigtable::admin::v2::LogicalView>>
 BigtableInstanceAdminClient::CreateLogicalView(
     google::bigtable::admin::v2::CreateLogicalViewRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateLogicalView(request);
 }
 
@@ -608,21 +670,24 @@ BigtableInstanceAdminClient::CreateLogicalView(
     NoAwaitTag,
     google::bigtable::admin::v2::CreateLogicalViewRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateLogicalView(NoAwaitTag{}, request);
 }
 
 future<StatusOr<google::bigtable::admin::v2::LogicalView>>
 BigtableInstanceAdminClient::CreateLogicalView(
     google::longrunning::Operation const& operation, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateLogicalView(operation);
 }
 
 StatusOr<google::bigtable::admin::v2::LogicalView>
 BigtableInstanceAdminClient::GetLogicalView(std::string const& name,
                                             Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::GetLogicalViewRequest request;
   request.set_name(name);
   return connection_->GetLogicalView(request);
@@ -632,14 +697,16 @@ StatusOr<google::bigtable::admin::v2::LogicalView>
 BigtableInstanceAdminClient::GetLogicalView(
     google::bigtable::admin::v2::GetLogicalViewRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->GetLogicalView(request);
 }
 
 StreamRange<google::bigtable::admin::v2::LogicalView>
 BigtableInstanceAdminClient::ListLogicalViews(std::string const& parent,
                                               Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::ListLogicalViewsRequest request;
   request.set_parent(parent);
   return connection_->ListLogicalViews(request);
@@ -649,7 +716,8 @@ StreamRange<google::bigtable::admin::v2::LogicalView>
 BigtableInstanceAdminClient::ListLogicalViews(
     google::bigtable::admin::v2::ListLogicalViewsRequest request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->ListLogicalViews(std::move(request));
 }
 
@@ -657,7 +725,8 @@ future<StatusOr<google::bigtable::admin::v2::LogicalView>>
 BigtableInstanceAdminClient::UpdateLogicalView(
     google::bigtable::admin::v2::LogicalView const& logical_view,
     google::protobuf::FieldMask const& update_mask, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::UpdateLogicalViewRequest request;
   *request.mutable_logical_view() = logical_view;
   *request.mutable_update_mask() = update_mask;
@@ -668,7 +737,8 @@ StatusOr<google::longrunning::Operation>
 BigtableInstanceAdminClient::UpdateLogicalView(
     NoAwaitTag, google::bigtable::admin::v2::LogicalView const& logical_view,
     google::protobuf::FieldMask const& update_mask, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::UpdateLogicalViewRequest request;
   *request.mutable_logical_view() = logical_view;
   *request.mutable_update_mask() = update_mask;
@@ -679,7 +749,8 @@ future<StatusOr<google::bigtable::admin::v2::LogicalView>>
 BigtableInstanceAdminClient::UpdateLogicalView(
     google::bigtable::admin::v2::UpdateLogicalViewRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateLogicalView(request);
 }
 
@@ -688,20 +759,23 @@ BigtableInstanceAdminClient::UpdateLogicalView(
     NoAwaitTag,
     google::bigtable::admin::v2::UpdateLogicalViewRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateLogicalView(NoAwaitTag{}, request);
 }
 
 future<StatusOr<google::bigtable::admin::v2::LogicalView>>
 BigtableInstanceAdminClient::UpdateLogicalView(
     google::longrunning::Operation const& operation, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateLogicalView(operation);
 }
 
 Status BigtableInstanceAdminClient::DeleteLogicalView(std::string const& name,
                                                       Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::DeleteLogicalViewRequest request;
   request.set_name(name);
   return connection_->DeleteLogicalView(request);
@@ -710,7 +784,8 @@ Status BigtableInstanceAdminClient::DeleteLogicalView(std::string const& name,
 Status BigtableInstanceAdminClient::DeleteLogicalView(
     google::bigtable::admin::v2::DeleteLogicalViewRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteLogicalView(request);
 }
 
@@ -719,7 +794,8 @@ BigtableInstanceAdminClient::CreateMaterializedView(
     std::string const& parent,
     google::bigtable::admin::v2::MaterializedView const& materialized_view,
     std::string const& materialized_view_id, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::CreateMaterializedViewRequest request;
   request.set_parent(parent);
   *request.mutable_materialized_view() = materialized_view;
@@ -732,7 +808,8 @@ BigtableInstanceAdminClient::CreateMaterializedView(
     NoAwaitTag, std::string const& parent,
     google::bigtable::admin::v2::MaterializedView const& materialized_view,
     std::string const& materialized_view_id, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::CreateMaterializedViewRequest request;
   request.set_parent(parent);
   *request.mutable_materialized_view() = materialized_view;
@@ -744,7 +821,8 @@ future<StatusOr<google::bigtable::admin::v2::MaterializedView>>
 BigtableInstanceAdminClient::CreateMaterializedView(
     google::bigtable::admin::v2::CreateMaterializedViewRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateMaterializedView(request);
 }
 
@@ -753,21 +831,24 @@ BigtableInstanceAdminClient::CreateMaterializedView(
     NoAwaitTag,
     google::bigtable::admin::v2::CreateMaterializedViewRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateMaterializedView(NoAwaitTag{}, request);
 }
 
 future<StatusOr<google::bigtable::admin::v2::MaterializedView>>
 BigtableInstanceAdminClient::CreateMaterializedView(
     google::longrunning::Operation const& operation, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateMaterializedView(operation);
 }
 
 StatusOr<google::bigtable::admin::v2::MaterializedView>
 BigtableInstanceAdminClient::GetMaterializedView(std::string const& name,
                                                  Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::GetMaterializedViewRequest request;
   request.set_name(name);
   return connection_->GetMaterializedView(request);
@@ -777,14 +858,16 @@ StatusOr<google::bigtable::admin::v2::MaterializedView>
 BigtableInstanceAdminClient::GetMaterializedView(
     google::bigtable::admin::v2::GetMaterializedViewRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->GetMaterializedView(request);
 }
 
 StreamRange<google::bigtable::admin::v2::MaterializedView>
 BigtableInstanceAdminClient::ListMaterializedViews(std::string const& parent,
                                                    Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::ListMaterializedViewsRequest request;
   request.set_parent(parent);
   return connection_->ListMaterializedViews(request);
@@ -794,7 +877,8 @@ StreamRange<google::bigtable::admin::v2::MaterializedView>
 BigtableInstanceAdminClient::ListMaterializedViews(
     google::bigtable::admin::v2::ListMaterializedViewsRequest request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->ListMaterializedViews(std::move(request));
 }
 
@@ -802,7 +886,8 @@ future<StatusOr<google::bigtable::admin::v2::MaterializedView>>
 BigtableInstanceAdminClient::UpdateMaterializedView(
     google::bigtable::admin::v2::MaterializedView const& materialized_view,
     google::protobuf::FieldMask const& update_mask, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::UpdateMaterializedViewRequest request;
   *request.mutable_materialized_view() = materialized_view;
   *request.mutable_update_mask() = update_mask;
@@ -814,7 +899,8 @@ BigtableInstanceAdminClient::UpdateMaterializedView(
     NoAwaitTag,
     google::bigtable::admin::v2::MaterializedView const& materialized_view,
     google::protobuf::FieldMask const& update_mask, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::UpdateMaterializedViewRequest request;
   *request.mutable_materialized_view() = materialized_view;
   *request.mutable_update_mask() = update_mask;
@@ -825,7 +911,8 @@ future<StatusOr<google::bigtable::admin::v2::MaterializedView>>
 BigtableInstanceAdminClient::UpdateMaterializedView(
     google::bigtable::admin::v2::UpdateMaterializedViewRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateMaterializedView(request);
 }
 
@@ -834,20 +921,23 @@ BigtableInstanceAdminClient::UpdateMaterializedView(
     NoAwaitTag,
     google::bigtable::admin::v2::UpdateMaterializedViewRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateMaterializedView(NoAwaitTag{}, request);
 }
 
 future<StatusOr<google::bigtable::admin::v2::MaterializedView>>
 BigtableInstanceAdminClient::UpdateMaterializedView(
     google::longrunning::Operation const& operation, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateMaterializedView(operation);
 }
 
 Status BigtableInstanceAdminClient::DeleteMaterializedView(
     std::string const& name, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::DeleteMaterializedViewRequest request;
   request.set_name(name);
   return connection_->DeleteMaterializedView(request);
@@ -856,7 +946,8 @@ Status BigtableInstanceAdminClient::DeleteMaterializedView(
 Status BigtableInstanceAdminClient::DeleteMaterializedView(
     google::bigtable::admin::v2::DeleteMaterializedViewRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteMaterializedView(request);
 }
 

--- a/google/cloud/bigtable/admin/bigtable_table_admin_client.cc
+++ b/google/cloud/bigtable/admin/bigtable_table_admin_client.cc
@@ -18,6 +18,7 @@
 
 #include "google/cloud/bigtable/admin/bigtable_table_admin_client.h"
 #include "google/cloud/bigtable/admin/bigtable_table_admin_options.h"
+#include "google/cloud/bigtable/options.h"
 #include <memory>
 #include <thread>
 #include <utility>
@@ -30,15 +31,16 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 BigtableTableAdminClient::BigtableTableAdminClient(
     std::shared_ptr<BigtableTableAdminConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(
-          internal::MergeOptions(std::move(opts), connection_->options())) {}
+      options_(bigtable_internal::MergeOptions(std::move(opts),
+                                               connection_->options())) {}
 BigtableTableAdminClient::~BigtableTableAdminClient() = default;
 
 StatusOr<google::bigtable::admin::v2::Table>
 BigtableTableAdminClient::CreateTable(
     std::string const& parent, std::string const& table_id,
     google::bigtable::admin::v2::Table const& table, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::CreateTableRequest request;
   request.set_parent(parent);
   request.set_table_id(table_id);
@@ -50,13 +52,15 @@ StatusOr<google::bigtable::admin::v2::Table>
 BigtableTableAdminClient::CreateTable(
     google::bigtable::admin::v2::CreateTableRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateTable(request);
 }
 
 StreamRange<google::bigtable::admin::v2::Table>
 BigtableTableAdminClient::ListTables(std::string const& parent, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::ListTablesRequest request;
   request.set_parent(parent);
   return connection_->ListTables(request);
@@ -65,13 +69,15 @@ BigtableTableAdminClient::ListTables(std::string const& parent, Options opts) {
 StreamRange<google::bigtable::admin::v2::Table>
 BigtableTableAdminClient::ListTables(
     google::bigtable::admin::v2::ListTablesRequest request, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->ListTables(std::move(request));
 }
 
 StatusOr<google::bigtable::admin::v2::Table> BigtableTableAdminClient::GetTable(
     std::string const& name, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::GetTableRequest request;
   request.set_name(name);
   return connection_->GetTable(request);
@@ -79,7 +85,8 @@ StatusOr<google::bigtable::admin::v2::Table> BigtableTableAdminClient::GetTable(
 
 StatusOr<google::bigtable::admin::v2::Table> BigtableTableAdminClient::GetTable(
     google::bigtable::admin::v2::GetTableRequest const& request, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->GetTable(request);
 }
 
@@ -87,7 +94,8 @@ future<StatusOr<google::bigtable::admin::v2::Table>>
 BigtableTableAdminClient::UpdateTable(
     google::bigtable::admin::v2::Table const& table,
     google::protobuf::FieldMask const& update_mask, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::UpdateTableRequest request;
   *request.mutable_table() = table;
   *request.mutable_update_mask() = update_mask;
@@ -97,7 +105,8 @@ BigtableTableAdminClient::UpdateTable(
 StatusOr<google::longrunning::Operation> BigtableTableAdminClient::UpdateTable(
     NoAwaitTag, google::bigtable::admin::v2::Table const& table,
     google::protobuf::FieldMask const& update_mask, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::UpdateTableRequest request;
   *request.mutable_table() = table;
   *request.mutable_update_mask() = update_mask;
@@ -108,27 +117,31 @@ future<StatusOr<google::bigtable::admin::v2::Table>>
 BigtableTableAdminClient::UpdateTable(
     google::bigtable::admin::v2::UpdateTableRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateTable(request);
 }
 
 StatusOr<google::longrunning::Operation> BigtableTableAdminClient::UpdateTable(
     NoAwaitTag, google::bigtable::admin::v2::UpdateTableRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateTable(NoAwaitTag{}, request);
 }
 
 future<StatusOr<google::bigtable::admin::v2::Table>>
 BigtableTableAdminClient::UpdateTable(
     google::longrunning::Operation const& operation, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateTable(operation);
 }
 
 Status BigtableTableAdminClient::DeleteTable(std::string const& name,
                                              Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::DeleteTableRequest request;
   request.set_name(name);
   return connection_->DeleteTable(request);
@@ -137,13 +150,15 @@ Status BigtableTableAdminClient::DeleteTable(std::string const& name,
 Status BigtableTableAdminClient::DeleteTable(
     google::bigtable::admin::v2::DeleteTableRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteTable(request);
 }
 
 future<StatusOr<google::bigtable::admin::v2::Table>>
 BigtableTableAdminClient::UndeleteTable(std::string const& name, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::UndeleteTableRequest request;
   request.set_name(name);
   return connection_->UndeleteTable(request);
@@ -152,7 +167,8 @@ BigtableTableAdminClient::UndeleteTable(std::string const& name, Options opts) {
 StatusOr<google::longrunning::Operation>
 BigtableTableAdminClient::UndeleteTable(NoAwaitTag, std::string const& name,
                                         Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::UndeleteTableRequest request;
   request.set_name(name);
   return connection_->UndeleteTable(NoAwaitTag{}, request);
@@ -162,7 +178,8 @@ future<StatusOr<google::bigtable::admin::v2::Table>>
 BigtableTableAdminClient::UndeleteTable(
     google::bigtable::admin::v2::UndeleteTableRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->UndeleteTable(request);
 }
 
@@ -171,14 +188,16 @@ BigtableTableAdminClient::UndeleteTable(
     NoAwaitTag,
     google::bigtable::admin::v2::UndeleteTableRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->UndeleteTable(NoAwaitTag{}, request);
 }
 
 future<StatusOr<google::bigtable::admin::v2::Table>>
 BigtableTableAdminClient::UndeleteTable(
     google::longrunning::Operation const& operation, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->UndeleteTable(operation);
 }
 
@@ -187,7 +206,8 @@ BigtableTableAdminClient::CreateAuthorizedView(
     std::string const& parent,
     google::bigtable::admin::v2::AuthorizedView const& authorized_view,
     std::string const& authorized_view_id, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::CreateAuthorizedViewRequest request;
   request.set_parent(parent);
   *request.mutable_authorized_view() = authorized_view;
@@ -200,7 +220,8 @@ BigtableTableAdminClient::CreateAuthorizedView(
     NoAwaitTag, std::string const& parent,
     google::bigtable::admin::v2::AuthorizedView const& authorized_view,
     std::string const& authorized_view_id, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::CreateAuthorizedViewRequest request;
   request.set_parent(parent);
   *request.mutable_authorized_view() = authorized_view;
@@ -212,7 +233,8 @@ future<StatusOr<google::bigtable::admin::v2::AuthorizedView>>
 BigtableTableAdminClient::CreateAuthorizedView(
     google::bigtable::admin::v2::CreateAuthorizedViewRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateAuthorizedView(request);
 }
 
@@ -221,21 +243,24 @@ BigtableTableAdminClient::CreateAuthorizedView(
     NoAwaitTag,
     google::bigtable::admin::v2::CreateAuthorizedViewRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateAuthorizedView(NoAwaitTag{}, request);
 }
 
 future<StatusOr<google::bigtable::admin::v2::AuthorizedView>>
 BigtableTableAdminClient::CreateAuthorizedView(
     google::longrunning::Operation const& operation, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateAuthorizedView(operation);
 }
 
 StreamRange<google::bigtable::admin::v2::AuthorizedView>
 BigtableTableAdminClient::ListAuthorizedViews(std::string const& parent,
                                               Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::ListAuthorizedViewsRequest request;
   request.set_parent(parent);
   return connection_->ListAuthorizedViews(request);
@@ -245,14 +270,16 @@ StreamRange<google::bigtable::admin::v2::AuthorizedView>
 BigtableTableAdminClient::ListAuthorizedViews(
     google::bigtable::admin::v2::ListAuthorizedViewsRequest request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->ListAuthorizedViews(std::move(request));
 }
 
 StatusOr<google::bigtable::admin::v2::AuthorizedView>
 BigtableTableAdminClient::GetAuthorizedView(std::string const& name,
                                             Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::GetAuthorizedViewRequest request;
   request.set_name(name);
   return connection_->GetAuthorizedView(request);
@@ -262,7 +289,8 @@ StatusOr<google::bigtable::admin::v2::AuthorizedView>
 BigtableTableAdminClient::GetAuthorizedView(
     google::bigtable::admin::v2::GetAuthorizedViewRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->GetAuthorizedView(request);
 }
 
@@ -270,7 +298,8 @@ future<StatusOr<google::bigtable::admin::v2::AuthorizedView>>
 BigtableTableAdminClient::UpdateAuthorizedView(
     google::bigtable::admin::v2::AuthorizedView const& authorized_view,
     google::protobuf::FieldMask const& update_mask, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::UpdateAuthorizedViewRequest request;
   *request.mutable_authorized_view() = authorized_view;
   *request.mutable_update_mask() = update_mask;
@@ -282,7 +311,8 @@ BigtableTableAdminClient::UpdateAuthorizedView(
     NoAwaitTag,
     google::bigtable::admin::v2::AuthorizedView const& authorized_view,
     google::protobuf::FieldMask const& update_mask, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::UpdateAuthorizedViewRequest request;
   *request.mutable_authorized_view() = authorized_view;
   *request.mutable_update_mask() = update_mask;
@@ -293,7 +323,8 @@ future<StatusOr<google::bigtable::admin::v2::AuthorizedView>>
 BigtableTableAdminClient::UpdateAuthorizedView(
     google::bigtable::admin::v2::UpdateAuthorizedViewRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateAuthorizedView(request);
 }
 
@@ -302,20 +333,23 @@ BigtableTableAdminClient::UpdateAuthorizedView(
     NoAwaitTag,
     google::bigtable::admin::v2::UpdateAuthorizedViewRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateAuthorizedView(NoAwaitTag{}, request);
 }
 
 future<StatusOr<google::bigtable::admin::v2::AuthorizedView>>
 BigtableTableAdminClient::UpdateAuthorizedView(
     google::longrunning::Operation const& operation, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateAuthorizedView(operation);
 }
 
 Status BigtableTableAdminClient::DeleteAuthorizedView(std::string const& name,
                                                       Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::DeleteAuthorizedViewRequest request;
   request.set_name(name);
   return connection_->DeleteAuthorizedView(request);
@@ -324,7 +358,8 @@ Status BigtableTableAdminClient::DeleteAuthorizedView(std::string const& name,
 Status BigtableTableAdminClient::DeleteAuthorizedView(
     google::bigtable::admin::v2::DeleteAuthorizedViewRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteAuthorizedView(request);
 }
 
@@ -334,7 +369,8 @@ BigtableTableAdminClient::ModifyColumnFamilies(
     std::vector<google::bigtable::admin::v2::ModifyColumnFamiliesRequest::
                     Modification> const& modifications,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::ModifyColumnFamiliesRequest request;
   request.set_name(name);
   *request.mutable_modifications() = {modifications.begin(),
@@ -346,21 +382,24 @@ StatusOr<google::bigtable::admin::v2::Table>
 BigtableTableAdminClient::ModifyColumnFamilies(
     google::bigtable::admin::v2::ModifyColumnFamiliesRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->ModifyColumnFamilies(request);
 }
 
 Status BigtableTableAdminClient::DropRowRange(
     google::bigtable::admin::v2::DropRowRangeRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->DropRowRange(request);
 }
 
 StatusOr<google::bigtable::admin::v2::GenerateConsistencyTokenResponse>
 BigtableTableAdminClient::GenerateConsistencyToken(std::string const& name,
                                                    Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::GenerateConsistencyTokenRequest request;
   request.set_name(name);
   return connection_->GenerateConsistencyToken(request);
@@ -370,7 +409,8 @@ StatusOr<google::bigtable::admin::v2::GenerateConsistencyTokenResponse>
 BigtableTableAdminClient::GenerateConsistencyToken(
     google::bigtable::admin::v2::GenerateConsistencyTokenRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->GenerateConsistencyToken(request);
 }
 
@@ -378,7 +418,8 @@ StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>
 BigtableTableAdminClient::CheckConsistency(std::string const& name,
                                            std::string const& consistency_token,
                                            Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::CheckConsistencyRequest request;
   request.set_name(name);
   request.set_consistency_token(consistency_token);
@@ -389,7 +430,8 @@ StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>
 BigtableTableAdminClient::CheckConsistency(
     google::bigtable::admin::v2::CheckConsistencyRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->CheckConsistency(request);
 }
 
@@ -397,7 +439,8 @@ future<StatusOr<google::bigtable::admin::v2::Backup>>
 BigtableTableAdminClient::CreateBackup(
     std::string const& parent, std::string const& backup_id,
     google::bigtable::admin::v2::Backup const& backup, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::CreateBackupRequest request;
   request.set_parent(parent);
   request.set_backup_id(backup_id);
@@ -408,7 +451,8 @@ BigtableTableAdminClient::CreateBackup(
 StatusOr<google::longrunning::Operation> BigtableTableAdminClient::CreateBackup(
     NoAwaitTag, std::string const& parent, std::string const& backup_id,
     google::bigtable::admin::v2::Backup const& backup, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::CreateBackupRequest request;
   request.set_parent(parent);
   request.set_backup_id(backup_id);
@@ -420,27 +464,31 @@ future<StatusOr<google::bigtable::admin::v2::Backup>>
 BigtableTableAdminClient::CreateBackup(
     google::bigtable::admin::v2::CreateBackupRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateBackup(request);
 }
 
 StatusOr<google::longrunning::Operation> BigtableTableAdminClient::CreateBackup(
     NoAwaitTag, google::bigtable::admin::v2::CreateBackupRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateBackup(NoAwaitTag{}, request);
 }
 
 future<StatusOr<google::bigtable::admin::v2::Backup>>
 BigtableTableAdminClient::CreateBackup(
     google::longrunning::Operation const& operation, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateBackup(operation);
 }
 
 StatusOr<google::bigtable::admin::v2::Backup>
 BigtableTableAdminClient::GetBackup(std::string const& name, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::GetBackupRequest request;
   request.set_name(name);
   return connection_->GetBackup(request);
@@ -450,7 +498,8 @@ StatusOr<google::bigtable::admin::v2::Backup>
 BigtableTableAdminClient::GetBackup(
     google::bigtable::admin::v2::GetBackupRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->GetBackup(request);
 }
 
@@ -458,7 +507,8 @@ StatusOr<google::bigtable::admin::v2::Backup>
 BigtableTableAdminClient::UpdateBackup(
     google::bigtable::admin::v2::Backup const& backup,
     google::protobuf::FieldMask const& update_mask, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::UpdateBackupRequest request;
   *request.mutable_backup() = backup;
   *request.mutable_update_mask() = update_mask;
@@ -469,13 +519,15 @@ StatusOr<google::bigtable::admin::v2::Backup>
 BigtableTableAdminClient::UpdateBackup(
     google::bigtable::admin::v2::UpdateBackupRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateBackup(request);
 }
 
 Status BigtableTableAdminClient::DeleteBackup(std::string const& name,
                                               Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::DeleteBackupRequest request;
   request.set_name(name);
   return connection_->DeleteBackup(request);
@@ -484,13 +536,15 @@ Status BigtableTableAdminClient::DeleteBackup(std::string const& name,
 Status BigtableTableAdminClient::DeleteBackup(
     google::bigtable::admin::v2::DeleteBackupRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteBackup(request);
 }
 
 StreamRange<google::bigtable::admin::v2::Backup>
 BigtableTableAdminClient::ListBackups(std::string const& parent, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::ListBackupsRequest request;
   request.set_parent(parent);
   return connection_->ListBackups(request);
@@ -499,7 +553,8 @@ BigtableTableAdminClient::ListBackups(std::string const& parent, Options opts) {
 StreamRange<google::bigtable::admin::v2::Backup>
 BigtableTableAdminClient::ListBackups(
     google::bigtable::admin::v2::ListBackupsRequest request, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->ListBackups(std::move(request));
 }
 
@@ -507,21 +562,24 @@ future<StatusOr<google::bigtable::admin::v2::Table>>
 BigtableTableAdminClient::RestoreTable(
     google::bigtable::admin::v2::RestoreTableRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->RestoreTable(request);
 }
 
 StatusOr<google::longrunning::Operation> BigtableTableAdminClient::RestoreTable(
     NoAwaitTag, google::bigtable::admin::v2::RestoreTableRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->RestoreTable(NoAwaitTag{}, request);
 }
 
 future<StatusOr<google::bigtable::admin::v2::Table>>
 BigtableTableAdminClient::RestoreTable(
     google::longrunning::Operation const& operation, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->RestoreTable(operation);
 }
 
@@ -530,7 +588,8 @@ BigtableTableAdminClient::CopyBackup(
     std::string const& parent, std::string const& backup_id,
     std::string const& source_backup,
     google::protobuf::Timestamp const& expire_time, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::CopyBackupRequest request;
   request.set_parent(parent);
   request.set_backup_id(backup_id);
@@ -543,7 +602,8 @@ StatusOr<google::longrunning::Operation> BigtableTableAdminClient::CopyBackup(
     NoAwaitTag, std::string const& parent, std::string const& backup_id,
     std::string const& source_backup,
     google::protobuf::Timestamp const& expire_time, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::CopyBackupRequest request;
   request.set_parent(parent);
   request.set_backup_id(backup_id);
@@ -556,27 +616,31 @@ future<StatusOr<google::bigtable::admin::v2::Backup>>
 BigtableTableAdminClient::CopyBackup(
     google::bigtable::admin::v2::CopyBackupRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->CopyBackup(request);
 }
 
 StatusOr<google::longrunning::Operation> BigtableTableAdminClient::CopyBackup(
     NoAwaitTag, google::bigtable::admin::v2::CopyBackupRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->CopyBackup(NoAwaitTag{}, request);
 }
 
 future<StatusOr<google::bigtable::admin::v2::Backup>>
 BigtableTableAdminClient::CopyBackup(
     google::longrunning::Operation const& operation, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->CopyBackup(operation);
 }
 
 StatusOr<google::iam::v1::Policy> BigtableTableAdminClient::GetIamPolicy(
     std::string const& resource, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(resource);
   return connection_->GetIamPolicy(request);
@@ -584,14 +648,16 @@ StatusOr<google::iam::v1::Policy> BigtableTableAdminClient::GetIamPolicy(
 
 StatusOr<google::iam::v1::Policy> BigtableTableAdminClient::GetIamPolicy(
     google::iam::v1::GetIamPolicyRequest const& request, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> BigtableTableAdminClient::SetIamPolicy(
     std::string const& resource, google::iam::v1::Policy const& policy,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::SetIamPolicyRequest request;
   request.set_resource(resource);
   *request.mutable_policy() = policy;
@@ -602,7 +668,8 @@ StatusOr<google::iam::v1::Policy> BigtableTableAdminClient::SetIamPolicy(
     std::string const& resource, IamUpdater const& updater, Options opts) {
   internal::CheckExpectedOptions<BigtableTableAdminBackoffPolicyOption>(
       opts, __func__);
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::GetIamPolicyRequest get_request;
   get_request.set_resource(resource);
   google::iam::v1::SetIamPolicyRequest set_request;
@@ -635,7 +702,8 @@ StatusOr<google::iam::v1::Policy> BigtableTableAdminClient::SetIamPolicy(
 
 StatusOr<google::iam::v1::Policy> BigtableTableAdminClient::SetIamPolicy(
     google::iam::v1::SetIamPolicyRequest const& request, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->SetIamPolicy(request);
 }
 
@@ -643,7 +711,8 @@ StatusOr<google::iam::v1::TestIamPermissionsResponse>
 BigtableTableAdminClient::TestIamPermissions(
     std::string const& resource, std::vector<std::string> const& permissions,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::TestIamPermissionsRequest request;
   request.set_resource(resource);
   *request.mutable_permissions() = {permissions.begin(), permissions.end()};
@@ -653,7 +722,8 @@ BigtableTableAdminClient::TestIamPermissions(
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 BigtableTableAdminClient::TestIamPermissions(
     google::iam::v1::TestIamPermissionsRequest const& request, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->TestIamPermissions(request);
 }
 
@@ -662,7 +732,8 @@ BigtableTableAdminClient::CreateSchemaBundle(
     std::string const& parent, std::string const& schema_bundle_id,
     google::bigtable::admin::v2::SchemaBundle const& schema_bundle,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::CreateSchemaBundleRequest request;
   request.set_parent(parent);
   request.set_schema_bundle_id(schema_bundle_id);
@@ -675,7 +746,8 @@ BigtableTableAdminClient::CreateSchemaBundle(
     NoAwaitTag, std::string const& parent, std::string const& schema_bundle_id,
     google::bigtable::admin::v2::SchemaBundle const& schema_bundle,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::CreateSchemaBundleRequest request;
   request.set_parent(parent);
   request.set_schema_bundle_id(schema_bundle_id);
@@ -687,7 +759,8 @@ future<StatusOr<google::bigtable::admin::v2::SchemaBundle>>
 BigtableTableAdminClient::CreateSchemaBundle(
     google::bigtable::admin::v2::CreateSchemaBundleRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateSchemaBundle(request);
 }
 
@@ -696,14 +769,16 @@ BigtableTableAdminClient::CreateSchemaBundle(
     NoAwaitTag,
     google::bigtable::admin::v2::CreateSchemaBundleRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateSchemaBundle(NoAwaitTag{}, request);
 }
 
 future<StatusOr<google::bigtable::admin::v2::SchemaBundle>>
 BigtableTableAdminClient::CreateSchemaBundle(
     google::longrunning::Operation const& operation, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateSchemaBundle(operation);
 }
 
@@ -711,7 +786,8 @@ future<StatusOr<google::bigtable::admin::v2::SchemaBundle>>
 BigtableTableAdminClient::UpdateSchemaBundle(
     google::bigtable::admin::v2::SchemaBundle const& schema_bundle,
     google::protobuf::FieldMask const& update_mask, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::UpdateSchemaBundleRequest request;
   *request.mutable_schema_bundle() = schema_bundle;
   *request.mutable_update_mask() = update_mask;
@@ -722,7 +798,8 @@ StatusOr<google::longrunning::Operation>
 BigtableTableAdminClient::UpdateSchemaBundle(
     NoAwaitTag, google::bigtable::admin::v2::SchemaBundle const& schema_bundle,
     google::protobuf::FieldMask const& update_mask, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::UpdateSchemaBundleRequest request;
   *request.mutable_schema_bundle() = schema_bundle;
   *request.mutable_update_mask() = update_mask;
@@ -733,7 +810,8 @@ future<StatusOr<google::bigtable::admin::v2::SchemaBundle>>
 BigtableTableAdminClient::UpdateSchemaBundle(
     google::bigtable::admin::v2::UpdateSchemaBundleRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateSchemaBundle(request);
 }
 
@@ -742,21 +820,24 @@ BigtableTableAdminClient::UpdateSchemaBundle(
     NoAwaitTag,
     google::bigtable::admin::v2::UpdateSchemaBundleRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateSchemaBundle(NoAwaitTag{}, request);
 }
 
 future<StatusOr<google::bigtable::admin::v2::SchemaBundle>>
 BigtableTableAdminClient::UpdateSchemaBundle(
     google::longrunning::Operation const& operation, Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateSchemaBundle(operation);
 }
 
 StatusOr<google::bigtable::admin::v2::SchemaBundle>
 BigtableTableAdminClient::GetSchemaBundle(std::string const& name,
                                           Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::GetSchemaBundleRequest request;
   request.set_name(name);
   return connection_->GetSchemaBundle(request);
@@ -766,14 +847,16 @@ StatusOr<google::bigtable::admin::v2::SchemaBundle>
 BigtableTableAdminClient::GetSchemaBundle(
     google::bigtable::admin::v2::GetSchemaBundleRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->GetSchemaBundle(request);
 }
 
 StreamRange<google::bigtable::admin::v2::SchemaBundle>
 BigtableTableAdminClient::ListSchemaBundles(std::string const& parent,
                                             Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::ListSchemaBundlesRequest request;
   request.set_parent(parent);
   return connection_->ListSchemaBundles(request);
@@ -783,13 +866,15 @@ StreamRange<google::bigtable::admin::v2::SchemaBundle>
 BigtableTableAdminClient::ListSchemaBundles(
     google::bigtable::admin::v2::ListSchemaBundlesRequest request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->ListSchemaBundles(std::move(request));
 }
 
 Status BigtableTableAdminClient::DeleteSchemaBundle(std::string const& name,
                                                     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::DeleteSchemaBundleRequest request;
   request.set_name(name);
   return connection_->DeleteSchemaBundle(request);
@@ -798,7 +883,8 @@ Status BigtableTableAdminClient::DeleteSchemaBundle(std::string const& name,
 Status BigtableTableAdminClient::DeleteSchemaBundle(
     google::bigtable::admin::v2::DeleteSchemaBundleRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteSchemaBundle(request);
 }
 
@@ -806,7 +892,8 @@ future<StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>>
 BigtableTableAdminClient::AsyncCheckConsistency(
     std::string const& name, std::string const& consistency_token,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::CheckConsistencyRequest request;
   request.set_name(name);
   request.set_consistency_token(consistency_token);
@@ -817,7 +904,8 @@ future<StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>>
 BigtableTableAdminClient::AsyncCheckConsistency(
     google::bigtable::admin::v2::CheckConsistencyRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->AsyncCheckConsistency(request);
 }
 
@@ -825,7 +913,8 @@ future<StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>>
 BigtableTableAdminClient::WaitForConsistency(
     google::bigtable::admin::v2::CheckConsistencyRequest const& request,
     Options opts) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  internal::OptionsSpan span(
+      bigtable_internal::MergeOptions(std::move(opts), options_));
   return connection_->WaitForConsistency(request);
 }
 

--- a/google/cloud/bigtable/benchmarks/benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/benchmark.cc
@@ -32,6 +32,7 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 namespace benchmarks {
+using ::google::cloud::bigtable_internal::MergeOptions;
 using ::google::cloud::internal::GetEnv;
 
 google::cloud::StatusOr<BenchmarkOptions> ParseArgs(
@@ -127,8 +128,7 @@ void Benchmark::DeleteTable() {
 }
 
 Table Benchmark::MakeTable(Options connection_opts) const {
-  auto connection_options =
-      google::cloud::internal::MergeOptions(std::move(connection_opts), opts_);
+  auto connection_options = MergeOptions(std::move(connection_opts), opts_);
   auto table_opts = Options{}.set<AppProfileIdOption>(options_.app_profile_id);
   return Table(MakeDataConnection(std::move(connection_options)),
                TableResource(options_.project_id, options_.instance_id,

--- a/google/cloud/bigtable/bigtable_client_unit_tests.bzl
+++ b/google/cloud/bigtable/bigtable_client_unit_tests.bzl
@@ -72,6 +72,7 @@ bigtable_client_unit_tests = [
     "mocks/mock_row_reader_test.cc",
     "mutation_batcher_test.cc",
     "mutations_test.cc",
+    "options_test.cc",
     "polling_policy_test.cc",
     "prepared_query_test.cc",
     "query_row_test.cc",

--- a/google/cloud/bigtable/client.cc
+++ b/google/cloud/bigtable/client.cc
@@ -21,7 +21,7 @@ namespace cloud {
 namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::MergeOptions;
+using ::google::cloud::bigtable_internal::MergeOptions;
 using ::google::cloud::internal::OptionsSpan;
 
 StatusOr<PreparedQuery> Client::PrepareQuery(InstanceResource const& instance,

--- a/google/cloud/bigtable/client.h
+++ b/google/cloud/bigtable/client.h
@@ -18,6 +18,7 @@
 #include "google/cloud/bigtable/bound_query.h"
 #include "google/cloud/bigtable/data_connection.h"
 #include "google/cloud/bigtable/instance_resource.h"
+#include "google/cloud/bigtable/options.h"
 #include "google/cloud/bigtable/prepared_query.h"
 #include "google/cloud/bigtable/sql_statement.h"
 #include "google/cloud/bigtable/version.h"
@@ -62,8 +63,8 @@ class Client {
    */
   explicit Client(std::shared_ptr<DataConnection> conn, Options opts = {})
       : conn_(std::move(conn)),
-        opts_(google::cloud::internal::MergeOptions(std::move(opts),
-                                                    conn_->options())) {}
+        opts_(bigtable_internal::MergeOptions(std::move(opts),
+                                              conn_->options())) {}
 
   /**
    * Prepares a query for future execution.

--- a/google/cloud/bigtable/google_cloud_cpp_bigtable.bzl
+++ b/google/cloud/bigtable/google_cloud_cpp_bigtable.bzl
@@ -222,6 +222,7 @@ google_cloud_cpp_bigtable_srcs = [
     "internal/traced_row_reader.cc",
     "mutation_batcher.cc",
     "mutations.cc",
+    "options.cc",
     "polling_policy.cc",
     "prepared_query.cc",
     "query_row.cc",

--- a/google/cloud/bigtable/internal/data_connection_impl.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl.cc
@@ -224,8 +224,7 @@ DataConnectionImpl::DataConnectionImpl(
     : background_(std::move(background)),
       stub_manager_(std::move(stub_manager)),
       limiter_(std::move(limiter)),
-      options_(internal::MergeOptions(std::move(options),
-                                      DataConnection::options())) {
+      options_(MergeOptions(std::move(options), DataConnection::options())) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
   if (options_.get<bigtable::EnableMetricsOption>()) {
     // The client_uid is eventually used in conjunction with other data labels
@@ -264,8 +263,7 @@ DataConnectionImpl::DataConnectionImpl(
       stub_manager_(std::move(stub_manager)),
       operation_context_factory_(std::move(operation_context_factory)),
       limiter_(std::move(limiter)),
-      options_(internal::MergeOptions(std::move(options),
-                                      DataConnection::options())) {}
+      options_(MergeOptions(std::move(options), DataConnection::options())) {}
 
 DataConnectionImpl::DataConnectionImpl(
     std::unique_ptr<BackgroundThreads> background,

--- a/google/cloud/bigtable/internal/defaults.cc
+++ b/google/cloud/bigtable/internal/defaults.cc
@@ -36,8 +36,9 @@ namespace cloud {
 namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
-
 namespace {
+
+using ::google::cloud::bigtable_internal::MergeOptions;
 
 auto constexpr kBackoffScaling = 2.0;
 
@@ -219,8 +220,7 @@ Options DefaultOptions(Options opts) {
                           ::google::cloud::internal::DefaultTracingOptions())
                       .set<GrpcNumChannelsOption>(DefaultConnectionPoolSize());
 
-  opts = google::cloud::internal::MergeOptions(std::move(opts),
-                                               std::move(defaults));
+  opts = MergeOptions(std::move(opts), std::move(defaults));
 
   if (!emulator) opts = DefaultConnectionRefreshOptions(std::move(opts));
   opts = DefaultChannelArgumentOptions(std::move(opts));

--- a/google/cloud/bigtable/options.cc
+++ b/google/cloud/bigtable/options.cc
@@ -1,0 +1,63 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigtable/options.h"
+#include "google/cloud/grpc_options.h"
+#include "google/cloud/options.h"
+#include <chrono>
+#include <utility>
+
+namespace google {
+namespace cloud {
+namespace bigtable_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+Options MergeOptions(Options preferred, Options alternatives) {
+  return MergeOptions(std::move(preferred), std::move(alternatives),
+                      [] { return std::chrono::system_clock::now(); });
+}
+
+Options MergeOptions(
+    Options preferred, Options alternatives,
+    std::function<std::chrono::system_clock::time_point()> now_fn) {
+  auto merged_options =
+      internal::MergeOptions(std::move(preferred), std::move(alternatives));
+
+  if (merged_options.has<bigtable::DeadlineOption>()) {
+    auto deadline = merged_options.get<bigtable::DeadlineOption>();
+    auto existing_fn =
+        internal::ExtractOption<internal::GrpcSetupOption>(merged_options);
+    if (existing_fn.has_value()) {
+      auto apply_deadline = [existing_fn = *std::move(existing_fn),
+                             now_fn = std::move(now_fn),
+                             deadline](grpc::ClientContext& context) {
+        existing_fn(context);
+        context.set_deadline(now_fn() + deadline);
+      };
+      merged_options.set<internal::GrpcSetupOption>(apply_deadline);
+    } else {
+      auto apply_deadline = [now_fn = std::move(now_fn),
+                             deadline](grpc::ClientContext& context) {
+        context.set_deadline(now_fn() + deadline);
+      };
+      merged_options.set<internal::GrpcSetupOption>(apply_deadline);
+    }
+  }
+  return merged_options;
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable_internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/options.h
+++ b/google/cloud/bigtable/options.h
@@ -44,8 +44,11 @@
 #include "google/cloud/bigtable/retry_policy.h"
 #include "google/cloud/bigtable/version.h"
 #include "google/cloud/backoff_policy.h"
+#include "google/cloud/grpc_options.h"
 #include "google/cloud/options.h"
 #include <chrono>
+#include <functional>
+#include <memory>
 #include <string>
 
 namespace google {
@@ -251,6 +254,23 @@ struct DataBackoffPolicyOption {
 };
 
 /**
+ * Option to set the per RPC attempt deadline.
+ *
+ * @note If used in conjunction with a LimitedTimeRetryPolicy the last RPC
+ *     attempt could cause the maximum duration of the RetryPolicy to be
+ *     extended up to the RPC attempt deadline duration.
+ *
+ * @note If both DeadlineOption and GrpcSetupOption are set, DeadlineOption will
+ *     be applied after GrpcSetupOption, overwriting any changes GrpcSetupOption
+ *     made to grpc::ClientContext::deadline.
+ *
+ * @ingroup google-cloud-bigtable-options
+ */
+struct DeadlineOption {
+  using Type = std::chrono::milliseconds;
+};
+
+/**
  * Option to configure the idempotency policy used by `Table`.
  *
  * @ingroup google-cloud-bigtable-options
@@ -299,6 +319,21 @@ using DataPolicyOptionList =
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable
+
+namespace bigtable_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+/// Bigtable specific MergeOptions that has special handling for merging
+/// `GrpcSetupOption` and `DeadlineOption`.
+Options MergeOptions(Options preferred, Options alternatives);
+
+/// For testing only.
+Options MergeOptions(
+    Options preferred, Options alternatives,
+    std::function<std::chrono::system_clock::time_point()> now_fn);
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/options_test.cc
+++ b/google/cloud/bigtable/options_test.cc
@@ -1,0 +1,177 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigtable/options.h"
+#include "google/cloud/grpc_options.h"
+#include "google/cloud/options.h"
+#include "google/cloud/testing_util/fake_clock.h"
+#include <gmock/gmock.h>
+#include <chrono>
+#include <memory>
+
+namespace google {
+namespace cloud {
+namespace bigtable_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+using ::google::cloud::bigtable::DeadlineOption;
+using ::google::cloud::internal::GrpcSetupOption;
+using ::google::cloud::testing_util::FakeSystemClock;
+using ::testing::Eq;
+
+TEST(MergeOptions, ConnectionDeadlineOption) {
+  FakeSystemClock clock;
+  clock.SetTime(std::chrono::system_clock::now());
+  auto now_fn = [&] { return clock.Now(); };
+
+  auto connection_opts = Options{}.set<DeadlineOption>(std::chrono::seconds(1));
+  Options client_opts;
+
+  // Merge in a deadline. This should populate the GrpcSetupOption with a call
+  // to ClientContext::set_deadline
+  auto merged_client_opts =
+      MergeOptions(std::move(client_opts), std::move(connection_opts), now_fn);
+
+  ASSERT_TRUE(merged_client_opts.has<GrpcSetupOption>());
+  grpc::ClientContext context;
+  merged_client_opts.get<GrpcSetupOption>()(context);
+  EXPECT_THAT(context.deadline() - clock.Now(), Eq(std::chrono::seconds(1)));
+}
+
+TEST(MergeOptions, ClientOverridesDeadlineOption) {
+  FakeSystemClock clock;
+  clock.SetTime(std::chrono::system_clock::now());
+  auto now_fn = [&] { return clock.Now(); };
+
+  auto connection_opts = Options{}.set<DeadlineOption>(std::chrono::seconds(1));
+  auto client_opts = Options{}.set<DeadlineOption>(std::chrono::seconds(2));
+
+  // Merge in a deadline. This should populate the GrpcSetupOption with a call
+  // to ClientContext::set_deadline
+  auto merged_client_opts =
+      MergeOptions(std::move(client_opts), std::move(connection_opts), now_fn);
+
+  ASSERT_TRUE(merged_client_opts.has<GrpcSetupOption>());
+  grpc::ClientContext context;
+  merged_client_opts.get<GrpcSetupOption>()(context);
+  EXPECT_THAT(context.deadline() - clock.Now(), Eq(std::chrono::seconds(2)));
+}
+
+TEST(MergeOptions, CallOverridesAllOtherDeadlineOption) {
+  FakeSystemClock clock;
+  clock.SetTime(std::chrono::system_clock::now());
+  auto now_fn = [&] { return clock.Now(); };
+
+  auto connection_opts = Options{}.set<DeadlineOption>(std::chrono::seconds(1));
+  auto client_opts = Options{}.set<DeadlineOption>(std::chrono::seconds(2));
+
+  // Merge in a deadline. This should populate the GrpcSetupOption with a call
+  // to ClientContext::set_deadline
+  auto merged_client_opts =
+      MergeOptions(std::move(client_opts), std::move(connection_opts), now_fn);
+
+  auto call_opts = Options{}.set<DeadlineOption>(std::chrono::seconds(5));
+
+  auto merged_call_opts =
+      MergeOptions(std::move(call_opts), std::move(merged_client_opts), now_fn);
+
+  ASSERT_TRUE(merged_call_opts.has<GrpcSetupOption>());
+  grpc::ClientContext context;
+  merged_call_opts.get<GrpcSetupOption>()(context);
+  EXPECT_THAT(context.deadline() - clock.Now(), Eq(std::chrono::seconds(5)));
+}
+
+TEST(MergeOptions, OnlyDeadlineOptionSupersedesGrpcSetupOptionDeadline) {
+  FakeSystemClock clock;
+  clock.SetTime(std::chrono::system_clock::now());
+  auto now_fn = [&] { return clock.Now(); };
+
+  auto setup_fn = [&](grpc::ClientContext& context) {
+    EXPECT_THAT(context.compression_algorithm(), Eq(GRPC_COMPRESS_NONE));
+    // compression_algorithm is set to verify the non-deadline aspects of the
+    // GrpcSetupOption are preserved.
+    context.set_compression_algorithm(GRPC_COMPRESS_GZIP);
+    context.set_deadline(now_fn() + std::chrono::seconds(10));
+  };
+
+  auto connection_opts = Options{}.set<GrpcSetupOption>(setup_fn);
+  Options client_opts;
+
+  auto merged_client_opts =
+      MergeOptions(std::move(client_opts), std::move(connection_opts), now_fn);
+  {
+    ASSERT_TRUE(merged_client_opts.has<GrpcSetupOption>());
+    grpc::ClientContext context;
+    merged_client_opts.get<GrpcSetupOption>()(context);
+    EXPECT_THAT(context.compression_algorithm(), Eq(GRPC_COMPRESS_GZIP));
+    EXPECT_THAT(context.deadline() - clock.Now(), Eq(std::chrono::seconds(10)));
+  }
+
+  connection_opts =
+      Options{}.set<GrpcSetupOption>(setup_fn).set<DeadlineOption>(
+          std::chrono::seconds(1));
+  client_opts = Options{};
+
+  // Merge in a deadline. This should populate the GrpcSetupOption with a call
+  // to ClientContext::set_deadline after calling the GrpcSetupOption function.
+  merged_client_opts =
+      MergeOptions(std::move(client_opts), std::move(connection_opts), now_fn);
+
+  ASSERT_TRUE(merged_client_opts.has<GrpcSetupOption>());
+  grpc::ClientContext context;
+  merged_client_opts.get<GrpcSetupOption>()(context);
+  EXPECT_THAT(context.compression_algorithm(), Eq(GRPC_COMPRESS_GZIP));
+  EXPECT_THAT(context.deadline() - clock.Now(), Eq(std::chrono::seconds(1)));
+}
+
+TEST(MergeOptions, ClientDeadlineOptionCallGrpcSetupOption) {
+  FakeSystemClock clock;
+  clock.SetTime(std::chrono::system_clock::now());
+  auto now_fn = [&] { return clock.Now(); };
+
+  auto setup_fn = [&](grpc::ClientContext& context) {
+    EXPECT_THAT(context.compression_algorithm(), Eq(GRPC_COMPRESS_NONE));
+    // compression_algorithm is set to verify the non-deadline aspects of the
+    // GrpcSetupOption are preserved.
+    context.set_compression_algorithm(GRPC_COMPRESS_GZIP);
+    context.set_deadline(now_fn() + std::chrono::seconds(10));
+  };
+
+  auto call_setup_fn = [&](grpc::ClientContext& context) {
+    EXPECT_THAT(context.compression_algorithm(), Eq(GRPC_COMPRESS_NONE));
+    context.set_compression_algorithm(GRPC_COMPRESS_DEFLATE);
+  };
+
+  auto connection_opts = Options{}.set<GrpcSetupOption>(setup_fn);
+  auto client_opts = Options{}.set<DeadlineOption>(std::chrono::seconds(5));
+  auto call_opts = Options{}.set<GrpcSetupOption>(call_setup_fn);
+
+  auto merged_client_opts =
+      MergeOptions(std::move(client_opts), std::move(connection_opts), now_fn);
+  auto merged_call_opts =
+      MergeOptions(std::move(call_opts), std::move(merged_client_opts), now_fn);
+
+  ASSERT_TRUE(merged_call_opts.has<GrpcSetupOption>());
+  grpc::ClientContext context;
+  merged_call_opts.get<GrpcSetupOption>()(context);
+  EXPECT_THAT(context.compression_algorithm(), Eq(GRPC_COMPRESS_DEFLATE));
+  EXPECT_THAT(context.deadline() - clock.Now(), Eq(std::chrono::seconds(5)));
+}
+
+}  // namespace
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable_internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/table.cc
+++ b/google/cloud/bigtable/table.cc
@@ -22,7 +22,7 @@ namespace cloud {
 namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::MergeOptions;
+using ::google::cloud::bigtable_internal::MergeOptions;
 using ::google::cloud::internal::OptionsSpan;
 
 namespace {

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -194,8 +194,8 @@ class Table {
       : table_(std::move(tr)),
         table_name_(table_.FullName()),
         connection_(std::move(conn)),
-        options_(google::cloud::internal::MergeOptions(
-            std::move(options), connection_->options())) {}
+        options_(bigtable_internal::MergeOptions(std::move(options),
+                                                 connection_->options())) {}
 
   std::string const& table_name() const { return table_name_; }
   std::string const& app_profile_id() const {
@@ -755,7 +755,7 @@ class Table {
     };
 
     google::cloud::internal::OptionsSpan span(
-        google::cloud::internal::MergeOptions(std::move(opts), options_));
+        bigtable_internal::MergeOptions(std::move(opts), options_));
     connection_->AsyncReadRows(table_name_, std::move(on_row_fn),
                                std::move(on_finish_fn), std::move(row_set),
                                rows_limit, std::move(filter));


### PR DESCRIPTION
This PR adds the `bigtable::DeadlineOption` for specifying the deadline for a single attempt at an RPC. This new option is being introduced first in Bigtable but will eventually be expanded to apply to other services (#4926).