### PR TITLE
feat(bigtable): pass default app profile ID in quickstart

### DIFF
--- a/google/cloud/bigtable/README.md
+++ b/google/cloud/bigtable/README.md
@@ -21,23 +21,26 @@ this library.
 #include "google/cloud/bigtable/table.h"
 
 int main(int argc, char* argv[]) try {
-  if (argc != 4) {
+  if (argc != 4 && argc != 5) {
     std::string const cmd = argv[0];
     auto last_slash = std::string(cmd).find_last_of('/');
     std::cerr << "Usage: " << cmd.substr(last_slash + 1)
-              << " <project_id> <instance_id> <table_id>\n";
+              << " <project_id> <instance_id> <table_id> [app_profile_id]\n";
     return 1;
   }
 
   std::string const project_id = argv[1];
   std::string const instance_id = argv[2];
   std::string const table_id = argv[3];
+  std::string const app_profile_id = (argc == 5 ? argv[4] : "default");
 
   // Create a namespace alias to make the code easier to read.
   namespace cbt = ::google::cloud::bigtable;
 
-  cbt::Table table(cbt::MakeDataConnection(),
-                   cbt::TableResource(project_id, instance_id, table_id));
+  cbt::Table table(
+      cbt::MakeDataConnection(),
+      cbt::TableResource(project_id, instance_id, table_id),
+      google::cloud::Options{}.set<cbt::AppProfileIdOption>(app_profile_id));
 
   std::string row_key = "r1";
   std::string column_family = "cf1";

--- a/google/cloud/bigtable/quickstart/README.md
+++ b/google/cloud/bigtable/quickstart/README.md
@@ -55,10 +55,11 @@ review the [Authentication methods at Google][authentication-quickstart].
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-1. Run the example, changing the placeholder(s) to appropriate values:
+1. Run the example, changing the placeholder(s) to appropriate values (the app
+   profile ID is optional):
 
    ```bash
-   bazel run :quickstart -- [GCP PROJECT] [CLOUD BIGTABLE INSTANCE] [CLOUD BIGTABLE TABLE]
+   bazel run :quickstart -- [GCP PROJECT] [CLOUD BIGTABLE INSTANCE] [CLOUD BIGTABLE TABLE] [[APP PROFILE ID]]
    ```
 
 ## Using with CMake
@@ -92,10 +93,11 @@ review the [Authentication methods at Google][authentication-quickstart].
    cmake --build .build
    ```
 
-1. Run the example, changing the placeholder(s) to appropriate values:
+1. Run the example, changing the placeholder(s) to appropriate values (the app
+   profile ID is optional):
 
    ```bash
-   .build/quickstart [GCP PROJECT] [CLOUD BIGTABLE INSTANCE] [CLOUD BIGTABLE TABLE]
+   .build/quickstart [GCP PROJECT] [CLOUD BIGTABLE INSTANCE] [CLOUD BIGTABLE TABLE] [[APP PROFILE ID]]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/bigtable/quickstart/quickstart.cc
+++ b/google/cloud/bigtable/quickstart/quickstart.cc
@@ -16,23 +16,26 @@
 #include "google/cloud/bigtable/table.h"
 
 int main(int argc, char* argv[]) try {
-  if (argc != 4) {
+  if (argc != 4 && argc != 5) {
     std::string const cmd = argv[0];
     auto last_slash = std::string(cmd).find_last_of('/');
     std::cerr << "Usage: " << cmd.substr(last_slash + 1)
-              << " <project_id> <instance_id> <table_id>\n";
+              << " <project_id> <instance_id> <table_id> [app_profile_id]\n";
     return 1;
   }
 
   std::string const project_id = argv[1];
   std::string const instance_id = argv[2];
   std::string const table_id = argv[3];
+  std::string const app_profile_id = (argc == 5 ? argv[4] : "default");
 
   // Create a namespace alias to make the code easier to read.
   namespace cbt = ::google::cloud::bigtable;
 
-  cbt::Table table(cbt::MakeDataConnection(),
-                   cbt::TableResource(project_id, instance_id, table_id));
+  cbt::Table table(
+      cbt::MakeDataConnection(),
+      cbt::TableResource(project_id, instance_id, table_id),
+      google::cloud::Options{}.set<cbt::AppProfileIdOption>(app_profile_id));
 
   std::string row_key = "r1";
   std::string column_family = "cf1";


### PR DESCRIPTION
Update the quickstart example to explicitly configure the Table instance with the "default" application profile ID using AppProfileIdOption.