### PR TITLE
fix(bigtable): use `google-c2p://` as the Bigtable DirectPath endpoint

### DIFF
--- a/google/cloud/bigtable/internal/defaults.cc
+++ b/google/cloud/bigtable/internal/defaults.cc
@@ -186,7 +186,7 @@ Options DefaultOptions(Options opts) {
   // Set the specific data endpoints if Direct Path is enabled.
   if (IsDirectPath()) {
     opts.set<::google::cloud::bigtable_internal::DataEndpointOption>(
-            "c2p:///bigtable.googleapis.com")
+            "google-c2p:///bigtable.googleapis.com")
         .set<AuthorityOption>("bigtable.googleapis.com");
   }
 

--- a/google/cloud/bigtable/internal/defaults_test.cc
+++ b/google/cloud/bigtable/internal/defaults_test.cc
@@ -504,7 +504,7 @@ TEST(EndpointEnvTest, CloudDirectPathEnabled) {
   ScopedEnvironment cbt_direct_path("CBT_ENABLE_DIRECTPATH", absl::nullopt);
 
   auto opts = DefaultOptions();
-  EXPECT_EQ("c2p:///bigtable.googleapis.com",
+  EXPECT_EQ("google-c2p:///bigtable.googleapis.com",
             opts.get<::google::cloud::bigtable_internal::DataEndpointOption>());
   EXPECT_EQ("bigtable.googleapis.com", opts.get<AuthorityOption>());
   // Admin endpoints are not affected.
@@ -525,7 +525,7 @@ TEST(EndpointEnvTest, BigtableDirectPathEnabled) {
   ScopedEnvironment cbt_direct_path("CBT_ENABLE_DIRECTPATH", "true");
 
   auto opts = DefaultOptions();
-  EXPECT_EQ("c2p:///bigtable.googleapis.com",
+  EXPECT_EQ("google-c2p:///bigtable.googleapis.com",
             opts.get<::google::cloud::bigtable_internal::DataEndpointOption>());
   EXPECT_EQ("bigtable.googleapis.com", opts.get<AuthorityOption>());
   // Admin endpoints are not affected.
@@ -564,7 +564,8 @@ TEST(EndpointEnvTest, CloudDirectPathOverridesUserEndpoints) {
 
   auto opts = DefaultDataOptions(
       Options{}.set<EndpointOption>("ignored").set<AuthorityOption>("ignored"));
-  EXPECT_EQ("c2p:///bigtable.googleapis.com", opts.get<EndpointOption>());
+  EXPECT_EQ("google-c2p:///bigtable.googleapis.com",
+            opts.get<EndpointOption>());
   EXPECT_EQ("bigtable.googleapis.com", opts.get<AuthorityOption>());
 }
 
@@ -574,7 +575,8 @@ TEST(EndpointEnvTest, BigtableDirectPathOverridesUserEndpoints) {
 
   auto opts = DefaultDataOptions(
       Options{}.set<EndpointOption>("ignored").set<AuthorityOption>("ignored"));
-  EXPECT_EQ("c2p:///bigtable.googleapis.com", opts.get<EndpointOption>());
+  EXPECT_EQ("google-c2p:///bigtable.googleapis.com",
+            opts.get<EndpointOption>());
   EXPECT_EQ("bigtable.googleapis.com", opts.get<AuthorityOption>());
 }
 


### PR DESCRIPTION
Fix to use the correct Bigtable DirectPath endpoint, similar to [storage](https://github.com/googleapis/google-cloud-cpp/blob/55df15baab2986fd0a7b5c57f5736ab6bc26374b/google/cloud/storage/internal/grpc/default_options.cc#L109).