### PR TITLE
 fix: remove_upb_c_rules.patch file path issue

### DIFF
--- a/bazel/workspace0.bzl
+++ b/bazel/workspace0.bzl
@@ -150,7 +150,7 @@ def gl_cpp_workspace0(name = None):
             #"googleapis.patch",
 
             # Mirrors the patch from the current bazel module
-            "//bazel:remove_upb_c_rules.patch",
+            Label("//bazel:remove_upb_c_rules.patch"),
         ],
         patch_tool = "patch",
 


### PR DESCRIPTION
This PR fixes an issue with how the `remove_upb_c_rules.patch` file path is resolved when the `googleapis `dependency is used internally by the `google-cloud-cpp` client library.

Previously, `googleapis `attempted to locate the patch file in the source directory of the parent workspace that includes `google-cloud-cpp`. This behavior is incorrect because the patch file actually belongs to the `google-cloud-cpp` repository itself.

With this fix, the patch file is now searched relative to the `google-cloud-cpp` directory, ensuring it works correctly regardless of the name or location of the parent project/workspace using the library.

Current Error:
<img width="1306" height="105" alt="image" src="https://github.com/user-attachments/assets/a91fa48c-cc76-49f5-8b27-b7d2fd5eea12" />
