### PR TITLE
fix(testing_util): link opentelemetry-cpp SDK as PUBLIC

### DIFF
--- a/google/cloud/testing_util/CMakeLists.txt
+++ b/google/cloud/testing_util/CMakeLists.txt
@@ -57,9 +57,9 @@ add_library(
     timer.h)
 target_link_libraries(
     google_cloud_cpp_testing
-    PUBLIC absl::symbolize absl::failure_signal_handler google-cloud-cpp::common
-           GTest::gmock
-    PRIVATE opentelemetry-cpp::in_memory_span_exporter opentelemetry-cpp::trace)
+    PUBLIC absl::symbolize absl::failure_signal_handler
+           google-cloud-cpp::common GTest::gmock
+           opentelemetry-cpp::in_memory_span_exporter opentelemetry-cpp::trace)
 
 google_cloud_cpp_add_common_options(google_cloud_cpp_testing)
 


### PR DESCRIPTION
## Problem

`google/cloud/testing_util/opentelemetry_matchers.h` is a **public header** of the `google_cloud_cpp_testing` target, and it includes and uses opentelemetry-cpp **SDK** symbols inline (e.g. `opentelemetry::sdk::trace::SpanData::GetAttributes()`).

Any test that links `google_cloud_cpp_testing` and includes that header (e.g. `google/cloud/internal/opentelemetry_test.cc`) therefore references those SDK symbols directly from its own translation unit.

The CMake build, however, links the SDK targets as `PRIVATE`:

```cmake
target_link_libraries(
    google_cloud_cpp_testing
    PUBLIC absl::symbolize absl::failure_signal_handler google-cloud-cpp::common
           GTest::gmock
    PRIVATE opentelemetry-cpp::in_memory_span_exporter opentelemetry-cpp::trace)
```

So they are not propagated to the test executables. When building with shared libraries (`BUILD_SHARED_LIBS=ON`), linking the test fails:

```
undefined reference to symbol
  '...opentelemetry::v1::sdk::trace::SpanData::GetAttributes[abi:cxx11]() const'
libopentelemetry_trace.so: error adding symbols: DSO missing from command line
```

because `libopentelemetry_trace.so` only arrives as an indirect `DT_NEEDED` of `libgoogle_cloud_cpp_testing.so`, which modern binutils refuses to resolve symbols from.

## Fix

Move `opentelemetry-cpp::in_memory_span_exporter` and `opentelemetry-cpp::trace` to the `PUBLIC` link interface, since they are part of the public (header) interface of `google_cloud_cpp_testing`.

## Consistency with Bazel

The Bazel build already exposes these dependencies transitively: `:google_cloud_cpp_testing` depends on `:google_cloud_cpp_testing_private`, which lists `@opentelemetry-cpp//exporters/memory:in_memory_span_exporter` and `@opentelemetry-cpp//sdk/src/trace` in `deps`. This change aligns the CMake build with the existing Bazel behavior.

Discovered while packaging google-cloud-cpp for nixpkgs (shared-library build with tests enabled).