### PR TITLE
feat(bigtable): preserve base64 padding on bigtable-features header

### DIFF
--- a/google/cloud/bigtable/internal/bigtable_stub_factory.cc
+++ b/google/cloud/bigtable/internal/bigtable_stub_factory.cc
@@ -60,7 +60,7 @@ std::string CreateFeaturesMetadata(bool is_direct_path) {
     proto.set_traffic_director_enabled(true);
     proto.set_direct_access_requested(true);
   }
-  return internal::UrlsafeBase64Encode(proto.SerializeAsString());
+  return internal::UrlsafeBase64EncodeWithPadding(proto.SerializeAsString());
 }
 
 std::string FeaturesMetadata() {

--- a/google/cloud/internal/base64_transforms.h
+++ b/google/cloud/internal/base64_transforms.h
@@ -104,6 +104,22 @@ StatusOr<std::vector<std::uint8_t>> Base64DecodeToBytes(
 
 /**
  * Returns a Base64-encoded version of @p bytes. Using the URL- and
+ * filesystem-safe alphabet, retaining trailing '=' padding characters.
+ * -  Replace '+' with '-'
+ * -  Replace '/' with '_'
+ */
+template <typename Collection>
+inline std::string UrlsafeBase64EncodeWithPadding(Collection const& bytes) {
+  Base64Encoder encoder;
+  for (auto c : bytes) encoder.PushBack(c);
+  std::string b64str = std::move(encoder).FlushAndPad();
+  std::replace(b64str.begin(), b64str.end(), '+', '-');
+  std::replace(b64str.begin(), b64str.end(), '/', '_');
+  return b64str;
+}
+
+/**
+ * Returns a Base64-encoded version of @p bytes. Using the URL- and
  * filesystem-safe alphabet, making these adjustments:
  * -  Replace '+' with '-'
  * -  Replace '/' with '_'
@@ -111,11 +127,7 @@ StatusOr<std::vector<std::uint8_t>> Base64DecodeToBytes(
  */
 template <typename Collection>
 inline std::string UrlsafeBase64Encode(Collection const& bytes) {
-  Base64Encoder encoder;
-  for (auto c : bytes) encoder.PushBack(c);
-  std::string b64str = std::move(encoder).FlushAndPad();
-  std::replace(b64str.begin(), b64str.end(), '+', '-');
-  std::replace(b64str.begin(), b64str.end(), '/', '_');
+  std::string b64str = UrlsafeBase64EncodeWithPadding(bytes);
   auto end_pos = b64str.find_last_not_of('=');
   if (end_pos != std::string::npos) {
     b64str.resize(end_pos + 1);

--- a/google/cloud/internal/base64_transforms_test.cc
+++ b/google/cloud/internal/base64_transforms_test.cc
@@ -153,6 +153,14 @@ TEST(Base64, UrlsafeBase64Encode) {
   EXPECT_EQ("TG9yZ-W0gaXBz_dW1cMACg", UrlsafeBase64Encode(input));
 }
 
+TEST(Base64, UrlsafeBase64EncodeWithPadding) {
+  std::vector<std::uint8_t> input{
+      0x4c, 0x6f, 0x72, 0x67, 0xe5, 0xb4, 0x81, 0xa5,
+      0xc1, 0xcf, 0xf7, 0x56, 0xd5, 0xc3, 0x00, 0x0a,
+  };
+  EXPECT_EQ("TG9yZ-W0gaXBz_dW1cMACg==", UrlsafeBase64EncodeWithPadding(input));
+}
+
 TEST(Base64, Base64Decode) {
   // Produced input using:
   //     echo 'TG9yZ+W0gaXBz/dW1cMACg==' | openssl base64 -d | od -t x1


### PR DESCRIPTION
Go's conformant `base64.URLEncoding.DecodeString` requires base64 padding (`=`) to decode successfully, failing with status 16 when padding is missing.

To resolve this, introduce `UrlsafeBase64EncodeWithPadding` helper that preserves base64 padding and use it to encode features metadata in the bigtable stub factory.