### PR TITLE
fix library  build for msvc

### DIFF
--- a/google/cloud/internal/oauth2_regional_access_boundary_token_manager.h
+++ b/google/cloud/internal/oauth2_regional_access_boundary_token_manager.h
@@ -183,7 +183,8 @@ class RegionalAccessBoundaryTokenManager
                                stub = iam_stub_,
                                retry_policy = retry_policy_->clone(),
                                backoff_policy = backoff_policy_->clone(),
-                               options = options_]() mutable {
+                               options = options_,
+                               kLocation = kLocation]() mutable {
       auto refresh_attempt_fn = [stub](rest_internal::RestContext&,
                                        Options const&, Request const& request) {
         return stub->AllowedLocations(request);

--- a/google/cloud/internal/rest_opentelemetry.cc
+++ b/google/cloud/internal/rest_opentelemetry.cc
@@ -81,7 +81,7 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> MakeSpanHttp(
        {/*sc::kUrlFull=*/"url.full", request.path()}},
       options);
   for (auto const& kv : request.headers()) {
-    auto const name = "http.request.header." + std::string{kv.first};
+    auto const name = std::string("http.request.header.") + kv.first.name();
     if (kv.second.EmptyValues()) {
       span->SetAttribute(name, "");
       continue;

--- a/google/cloud/internal/tracing_rest_client.cc
+++ b/google/cloud/internal/tracing_rest_client.cc
@@ -71,7 +71,7 @@ StatusOr<std::unique_ptr<RestResponse>> EndResponseSpan(
                        *context.local_port());
   }
   for (auto const& kv : context.headers()) {
-    auto const name = "http.request.header." + std::string{kv.first};
+    auto const name = std::string("http.request.header.") + kv.first.name();
     if (kv.second.EmptyValues()) {
       span->SetAttribute(name, "");
       continue;

--- a/google/cloud/internal/win32/sign_using_sha256.cc
+++ b/google/cloud/internal/win32/sign_using_sha256.cc
@@ -136,7 +136,8 @@ StatusOr<std::vector<std::uint8_t>> SignSha256Digest(BCRYPT_KEY_HANDLE key,
 }  // namespace
 
 StatusOr<std::vector<std::uint8_t>> SignUsingSha256(
-    std::string const& str, std::string const& pem_contents) {
+    std::string const& str, std::string const& pem_contents,
+    SignatureFormat format) {
   auto pem_buffer = DecodePem(pem_contents);
   if (!pem_buffer) return std::move(pem_buffer).status();
 


### PR DESCRIPTION
This PR fixes compilation issues when building with the `MSVC compiler` on Windows.

- The MSVC compiler was reporting an undefined reference error for the `SignUsingSha256` function defined in `/internal/win32/sign_using_sha256.cc`. This issue has now been fixed.
- Multiple `error C2440: '<function-style-cast>': cannot convert from 'initializer list' to 'std::string'` errors were occurring in several lambda functions. These have been fixed.
- A string concatenation issue in `rest_opentelemetry.cc` that was causing compilation failures has also been fixed.