### PR TITLE
impl(oauth2): omit RAB header when locations unbounded

### DIFF
--- a/google/cloud/internal/oauth2_minimal_iam_credentials_rest.cc
+++ b/google/cloud/internal/oauth2_minimal_iam_credentials_rest.cc
@@ -45,6 +45,10 @@ std::string IamCredentialsEndpoint(
 
 using ::google::cloud::internal::InvalidArgumentError;
 
+bool AllowedLocationsResponse::IsUnbounded() const {
+  return !encoded_locations.empty() && encoded_locations == "0x0";
+}
+
 MinimalIamCredentialsRestStub::MinimalIamCredentialsRestStub(
     std::shared_ptr<oauth2_internal::Credentials> credentials, Options options,
     HttpClientFactory client_factory)

--- a/google/cloud/internal/oauth2_minimal_iam_credentials_rest.h
+++ b/google/cloud/internal/oauth2_minimal_iam_credentials_rest.h
@@ -40,6 +40,7 @@ struct GenerateAccessTokenRequest {
 };
 
 struct AllowedLocationsResponse {
+  bool IsUnbounded() const;
   std::vector<std::string> locations;
   std::string encoded_locations;
 };

--- a/google/cloud/internal/oauth2_regional_access_boundary_token_manager.h
+++ b/google/cloud/internal/oauth2_regional_access_boundary_token_manager.h
@@ -112,8 +112,11 @@ class RegionalAccessBoundaryTokenManager
     if (IsTokenValid(lock, tp)) {
       // Check to see if we're near expiry and if so, start refresh process.
       if (tp > (expire_time_ - TtlGracePeriod())) RefreshToken(lock, request);
-      return rest_internal::HttpHeader{"x-allowed-locations",
-                                       allowed_locations_.encoded_locations};
+      if (!allowed_locations_.IsUnbounded()) {
+        return rest_internal::HttpHeader{"x-allowed-locations",
+                                         allowed_locations_.encoded_locations};
+      }
+      return rest_internal::HttpHeader{};
     }
     RefreshToken(lock, request);
     // Don't wait for a valid token, just return an empty header.

--- a/google/cloud/internal/oauth2_regional_access_boundary_token_manager_test.cc
+++ b/google/cloud/internal/oauth2_regional_access_boundary_token_manager_test.cc
@@ -192,6 +192,30 @@ TEST_F(RegionalAccessBoundaryTokenManagerTest,
 }
 
 TEST_F(RegionalAccessBoundaryTokenManagerTest,
+       GetAllowedLocationsHeaderValidTokenUnbounded) {
+  fake_clock_->SetTime(std::chrono::system_clock::now());
+  MockFunction<std::unique_ptr<BackoffPolicy>()> backoff_fn;
+  EXPECT_CALL(backoff_fn, Call).Times(0);
+
+  EXPECT_CALL(*mock_credentials_, AllowedLocationsRequest)
+      .WillRepeatedly(Return(WorkforceIdentityAllowedLocationsRequest{}));
+
+  AllowedLocationsResponse allowed_locations;
+  allowed_locations.locations = {""};
+  allowed_locations.encoded_locations = "0x0";
+
+  auto manager = RegionalAccessBoundaryTokenManager::Create(
+      mock_credentials_, mock_iam_stub_, {}, backoff_fn.AsStdFunction(),
+      fake_clock_, allowed_locations);
+
+  fake_clock_->AdvanceTime(std::chrono::seconds(1));
+
+  auto header =
+      manager->AllowedLocations(fake_clock_->Now(), "service.googleapis.com");
+  EXPECT_THAT(header, IsOkAndHolds(IsEmpty()));
+}
+
+TEST_F(RegionalAccessBoundaryTokenManagerTest,
        GetAllowedLocationsHeaderNoInitialValidTokenWithRetry) {
   EXPECT_CALL(*mock_credentials_, AllowedLocationsRequest)
       .WillRepeatedly(Return(WorkloadIdentityAllowedLocationsRequest{}));


### PR DESCRIPTION
If the returned `encoded_locations` has a value of `0x0`, then omit the `x-allowed-locations` header altogether.