### PR TITLE
feat(storage): log warning when GCS serves more bytes than requested

### DIFF
--- a/google/cloud/storage/async/object_descriptor.cc
+++ b/google/cloud/storage/async/object_descriptor.cc
@@ -33,21 +33,21 @@ std::pair<AsyncReader, AsyncToken> ObjectDescriptor::Read(std::int64_t offset,
     impl_->MakeSubsequentStream();
   }
 
-  auto reader = impl_->Read({offset, limit});
+  auto reader = impl_->Read({offset, limit, /*read_to_end=*/false});
   auto token = storage_internal::MakeAsyncToken(reader.get());
   return {AsyncReader(std::move(reader)), std::move(token)};
 }
 
 std::pair<AsyncReader, AsyncToken> ObjectDescriptor::ReadFromOffset(
     std::int64_t offset) {
-  auto reader = impl_->Read({offset, 0});
+  auto reader = impl_->Read({offset, 0, /*read_to_end=*/true});
   auto token = storage_internal::MakeAsyncToken(reader.get());
   return {AsyncReader(std::move(reader)), std::move(token)};
 }
 
 std::pair<AsyncReader, AsyncToken> ObjectDescriptor::ReadLast(
     std::int64_t limit) {
-  auto reader = impl_->Read({-limit, 0});
+  auto reader = impl_->Read({-limit, 0, /*read_to_end=*/true});
   auto token = storage_internal::MakeAsyncToken(reader.get());
   return {AsyncReader(std::move(reader)), std::move(token)};
 }

--- a/google/cloud/storage/async/object_descriptor_connection.h
+++ b/google/cloud/storage/async/object_descriptor_connection.h
@@ -53,6 +53,7 @@ class ObjectDescriptorConnection {
   struct ReadParams {
     std::int64_t start;
     std::int64_t length;
+    bool read_to_end = false;
   };
 
   /**

--- a/google/cloud/storage/internal/async/object_descriptor_impl.cc
+++ b/google/cloud/storage/internal/async/object_descriptor_impl.cc
@@ -166,7 +166,8 @@ std::unique_ptr<storage::AsyncReaderConnection> ObjectDescriptorImpl::Read(
   auto hash_validator = CreateHashValidator(is_full_read);
 
   auto range = std::make_shared<ReadRange>(
-      p.start, p.length, read_object_spec_.bucket(), read_object_spec_.object(),
+      p.start, p.length > 0 ? absl::make_optional(p.length) : absl::nullopt,
+      read_object_spec_.bucket(), read_object_spec_.object(),
       hash_function, std::move(hash_validator),
       [impl = WeakFromThis()]() -> absl::optional<google::storage::v2::Object> {
         if (auto shared = impl.lock()) {

--- a/google/cloud/storage/internal/async/object_descriptor_impl.cc
+++ b/google/cloud/storage/internal/async/object_descriptor_impl.cc
@@ -165,8 +165,14 @@ std::unique_ptr<storage::AsyncReaderConnection> ObjectDescriptorImpl::Read(
   auto hash_function = CreateHashFunction(is_full_read);
   auto hash_validator = CreateHashValidator(is_full_read);
 
+  absl::optional<std::int64_t> limit;
+  if (p.start < 0) {
+    limit = -p.start;
+  } else if (!p.read_to_end) {
+    limit = p.length;
+  }
   auto range = std::make_shared<ReadRange>(
-      p.start, p.read_to_end ? absl::nullopt : absl::make_optional(p.length),
+      p.start, limit,
       read_object_spec_.bucket(), read_object_spec_.object(),
       hash_function, std::move(hash_validator));
 

--- a/google/cloud/storage/internal/async/object_descriptor_impl.cc
+++ b/google/cloud/storage/internal/async/object_descriptor_impl.cc
@@ -167,7 +167,13 @@ std::unique_ptr<storage::AsyncReaderConnection> ObjectDescriptorImpl::Read(
 
   auto range = std::make_shared<ReadRange>(
       p.start, p.length, read_object_spec_.bucket(), read_object_spec_.object(),
-      hash_function, std::move(hash_validator));
+      hash_function, std::move(hash_validator),
+      [impl = WeakFromThis()]() -> absl::optional<google::storage::v2::Object> {
+        if (auto shared = impl.lock()) {
+          return shared->metadata();
+        }
+        return absl::nullopt;
+      });
 
   std::unique_lock<std::mutex> lk(mu_);
   if (stream_manager_->Empty()) {

--- a/google/cloud/storage/internal/async/object_descriptor_impl.cc
+++ b/google/cloud/storage/internal/async/object_descriptor_impl.cc
@@ -165,8 +165,9 @@ std::unique_ptr<storage::AsyncReaderConnection> ObjectDescriptorImpl::Read(
   auto hash_function = CreateHashFunction(is_full_read);
   auto hash_validator = CreateHashValidator(is_full_read);
 
-  auto range = std::make_shared<ReadRange>(p.start, p.length, hash_function,
-                                           std::move(hash_validator));
+  auto range = std::make_shared<ReadRange>(
+      p.start, p.length, read_object_spec_.bucket(), read_object_spec_.object(),
+      hash_function, std::move(hash_validator));
 
   std::unique_lock<std::mutex> lk(mu_);
   if (stream_manager_->Empty()) {

--- a/google/cloud/storage/internal/async/object_descriptor_impl.cc
+++ b/google/cloud/storage/internal/async/object_descriptor_impl.cc
@@ -168,13 +168,7 @@ std::unique_ptr<storage::AsyncReaderConnection> ObjectDescriptorImpl::Read(
   auto range = std::make_shared<ReadRange>(
       p.start, p.read_to_end ? absl::nullopt : absl::make_optional(p.length),
       read_object_spec_.bucket(), read_object_spec_.object(),
-      hash_function, std::move(hash_validator),
-      [impl = WeakFromThis()]() -> absl::optional<google::storage::v2::Object> {
-        if (auto shared = impl.lock()) {
-          return shared->metadata();
-        }
-        return absl::nullopt;
-      });
+      hash_function, std::move(hash_validator));
 
   std::unique_lock<std::mutex> lk(mu_);
   if (stream_manager_->Empty()) {
@@ -337,6 +331,8 @@ void ObjectDescriptorImpl::OnRead(
         std::move(*response->mutable_read_handle());
   }
   auto copy = it->active_ranges;
+  bool is_transcoded =
+      metadata_.has_value() && (metadata_->content_encoding() == "gzip");
   // Release the lock while notifying the ranges. The notifications may trigger
   // application code, and that code may callback on this class.
   lk.unlock();
@@ -346,7 +342,7 @@ void ObjectDescriptorImpl::OnRead(
     if (l == copy.end()) continue;
     // TODO(#15104) - Consider returning if the range is done, and then
     // skipping CleanupDoneRanges().
-    l->second->OnRead(std::move(range_data));
+    l->second->OnRead(std::move(range_data), is_transcoded);
   }
   lk.lock();
   stream_manager_->CleanupDoneRanges(it);

--- a/google/cloud/storage/internal/async/object_descriptor_impl.cc
+++ b/google/cloud/storage/internal/async/object_descriptor_impl.cc
@@ -166,7 +166,7 @@ std::unique_ptr<storage::AsyncReaderConnection> ObjectDescriptorImpl::Read(
   auto hash_validator = CreateHashValidator(is_full_read);
 
   auto range = std::make_shared<ReadRange>(
-      p.start, p.length > 0 ? absl::make_optional(p.length) : absl::nullopt,
+      p.start, p.read_to_end ? absl::nullopt : absl::make_optional(p.length),
       read_object_spec_.bucket(), read_object_spec_.object(),
       hash_function, std::move(hash_validator),
       [impl = WeakFromThis()]() -> absl::optional<google::storage::v2::Object> {

--- a/google/cloud/storage/internal/async/read_range.cc
+++ b/google/cloud/storage/internal/async/read_range.cc
@@ -61,6 +61,7 @@ void ReadRange::OnFinish(Status status) {
   std::unique_lock<std::mutex> lk(mu_);
   if (status_) return;
   status_ = std::move(status);
+  CheckOverrun();
   if (!wait_) return;
   auto p = std::move(*wait_);
   wait_.reset();
@@ -77,15 +78,18 @@ void ReadRange::OnRead(google::storage::v2::ObjectRangeData data) {
       hash_function_->Update(offset_, content, check_summed_data->crc32c());
   if (!status.ok()) {
     status_ = std::move(status);
+    CheckOverrun();
     return Notify(std::move(lk), ReadPayloadImpl::Make(std::move(content)));
   }
 
   offset_ += content.size();
+  received_bytes_ += content.size();
   if (length_ != 0) length_ -= std::min<std::int64_t>(content.size(), length_);
   auto p = ReadPayloadImpl::Make(std::move(content));
 
   if (data.range_end()) {
     status_ = Status{};
+    CheckOverrun();
     auto result = std::move(*hash_validator_).Finish(hash_function_->Finish());
     if (result.is_mismatch) {
       status_ = google::cloud::internal::DataLossError(
@@ -112,6 +116,19 @@ void ReadRange::Notify(std::unique_lock<std::mutex> lk,
   payload_.reset();
   lk.unlock();
   wait.set_value(std::move(p));
+}
+
+void ReadRange::CheckOverrun() {
+  if (!logged_warning_) {
+    logged_warning_ = true;
+    if (requested_length_ > 0 && received_bytes_ > requested_length_) {
+      GCP_LOG(WARNING) << "storage: received "
+                       << (received_bytes_ - requested_length_)
+                       << " more bytes than requested from GCS for bucket \""
+                       << bucket_name_ << "\", object \"" << object_name_
+                       << "\"";
+    }
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/async/read_range.cc
+++ b/google/cloud/storage/internal/async/read_range.cc
@@ -69,8 +69,9 @@ void ReadRange::OnFinish(Status status) {
   p.set_value(*status_);
 }
 
-void ReadRange::OnRead(google::storage::v2::ObjectRangeData data) {
+void ReadRange::OnRead(google::storage::v2::ObjectRangeData data, bool is_transcoded) {
   std::unique_lock<std::mutex> lk(mu_);
+  is_transcoded_ = is_transcoded;
   if (status_) return;
   auto* check_summed_data = data.mutable_checksummed_data();
   auto content = StealMutableContent(*data.mutable_checksummed_data());
@@ -124,13 +125,7 @@ void ReadRange::CheckOverrun() {
     logged_warning_ = true;
     if (requested_length_.has_value() && *requested_length_ >= 0 &&
         received_bytes_ > *requested_length_) {
-      bool is_transcoded = false;
-      if (metadata_accessor_) {
-        if (auto metadata = metadata_accessor_()) {
-          is_transcoded = metadata->content_encoding() == "gzip";
-        }
-      }
-      if (!is_transcoded) {
+      if (!is_transcoded_) {
         GCP_LOG(WARNING) << "storage: received "
                          << (received_bytes_ - *requested_length_)
                          << " more bytes than requested from GCS for bucket \""

--- a/google/cloud/storage/internal/async/read_range.cc
+++ b/google/cloud/storage/internal/async/read_range.cc
@@ -71,7 +71,7 @@ void ReadRange::OnFinish(Status status) {
 
 void ReadRange::OnRead(google::storage::v2::ObjectRangeData data, bool is_transcoded) {
   std::unique_lock<std::mutex> lk(mu_);
-  is_transcoded_ = is_transcoded;
+  is_transcoded_ = is_transcoded_ || is_transcoded;
   if (status_) return;
   auto* check_summed_data = data.mutable_checksummed_data();
   auto content = StealMutableContent(*data.mutable_checksummed_data());

--- a/google/cloud/storage/internal/async/read_range.cc
+++ b/google/cloud/storage/internal/async/read_range.cc
@@ -122,9 +122,9 @@ void ReadRange::Notify(std::unique_lock<std::mutex> lk,
 // Must be called while holding mu_.
 void ReadRange::CheckOverrun() {
   if (!logged_warning_) {
-    logged_warning_ = true;
     if (requested_length_.has_value() && *requested_length_ >= 0 &&
         received_bytes_ > *requested_length_) {
+      logged_warning_ = true;
       if (!is_transcoded_) {
         GCP_LOG(WARNING) << "storage: received "
                          << (received_bytes_ - *requested_length_)

--- a/google/cloud/storage/internal/async/read_range.cc
+++ b/google/cloud/storage/internal/async/read_range.cc
@@ -32,10 +32,14 @@ bool ReadRange::IsDone() const {
 
 absl::optional<google::storage::v2::ReadRange> ReadRange::RangeForResume(
     std::int64_t read_id) const {
-  auto range = google::storage::v2::ReadRange{};
-  range.set_read_id(read_id);
   std::lock_guard<std::mutex> lk(mu_);
   if (status_.has_value()) return absl::nullopt;
+  if (requested_length_.has_value() && *requested_length_ >= 0 &&
+      received_bytes_ >= *requested_length_) {
+    return absl::nullopt;
+  }
+  auto range = google::storage::v2::ReadRange{};
+  range.set_read_id(read_id);
   range.set_read_offset(offset_);
   range.set_read_length(length_);
   return range;
@@ -86,11 +90,11 @@ void ReadRange::OnRead(google::storage::v2::ObjectRangeData data, bool is_transc
   offset_ += content.size();
   received_bytes_ += content.size();
   if (length_ != 0) length_ -= std::min<std::int64_t>(content.size(), length_);
+  CheckOverrun();
   auto p = ReadPayloadImpl::Make(std::move(content));
 
   if (data.range_end()) {
     status_ = Status{};
-    CheckOverrun();
     auto result = std::move(*hash_validator_).Finish(hash_function_->Finish());
     if (result.is_mismatch && !is_transcoded_) {
       status_ = google::cloud::internal::DataLossError(

--- a/google/cloud/storage/internal/async/read_range.cc
+++ b/google/cloud/storage/internal/async/read_range.cc
@@ -118,6 +118,7 @@ void ReadRange::Notify(std::unique_lock<std::mutex> lk,
   wait.set_value(std::move(p));
 }
 
+// Must be called while holding mu_.
 void ReadRange::CheckOverrun() {
   if (!logged_warning_) {
     logged_warning_ = true;

--- a/google/cloud/storage/internal/async/read_range.cc
+++ b/google/cloud/storage/internal/async/read_range.cc
@@ -122,7 +122,8 @@ void ReadRange::Notify(std::unique_lock<std::mutex> lk,
 void ReadRange::CheckOverrun() {
   if (!logged_warning_) {
     logged_warning_ = true;
-    if (requested_length_ > 0 && received_bytes_ > requested_length_) {
+    if (requested_length_.has_value() && *requested_length_ >= 0 &&
+        received_bytes_ > *requested_length_) {
       bool is_transcoded = false;
       if (metadata_accessor_) {
         if (auto metadata = metadata_accessor_()) {
@@ -131,7 +132,7 @@ void ReadRange::CheckOverrun() {
       }
       if (!is_transcoded) {
         GCP_LOG(WARNING) << "storage: received "
-                         << (received_bytes_ - requested_length_)
+                         << (received_bytes_ - *requested_length_)
                          << " more bytes than requested from GCS for bucket \""
                          << bucket_name_ << "\", object \"" << object_name_
                          << "\"";

--- a/google/cloud/storage/internal/async/read_range.cc
+++ b/google/cloud/storage/internal/async/read_range.cc
@@ -123,11 +123,19 @@ void ReadRange::CheckOverrun() {
   if (!logged_warning_) {
     logged_warning_ = true;
     if (requested_length_ > 0 && received_bytes_ > requested_length_) {
-      GCP_LOG(WARNING) << "storage: received "
-                       << (received_bytes_ - requested_length_)
-                       << " more bytes than requested from GCS for bucket \""
-                       << bucket_name_ << "\", object \"" << object_name_
-                       << "\"";
+      bool is_transcoded = false;
+      if (metadata_accessor_) {
+        if (auto metadata = metadata_accessor_()) {
+          is_transcoded = metadata->content_encoding() == "gzip";
+        }
+      }
+      if (!is_transcoded) {
+        GCP_LOG(WARNING) << "storage: received "
+                         << (received_bytes_ - requested_length_)
+                         << " more bytes than requested from GCS for bucket \""
+                         << bucket_name_ << "\", object \"" << object_name_
+                         << "\"";
+      }
     }
   }
 }

--- a/google/cloud/storage/internal/async/read_range.cc
+++ b/google/cloud/storage/internal/async/read_range.cc
@@ -92,7 +92,7 @@ void ReadRange::OnRead(google::storage::v2::ObjectRangeData data, bool is_transc
     status_ = Status{};
     CheckOverrun();
     auto result = std::move(*hash_validator_).Finish(hash_function_->Finish());
-    if (result.is_mismatch) {
+    if (result.is_mismatch && !is_transcoded_) {
       status_ = google::cloud::internal::DataLossError(
           absl::StrCat("mismatched checksums detected at the end of the "
                        "download, received={",

--- a/google/cloud/storage/internal/async/read_range.h
+++ b/google/cloud/storage/internal/async/read_range.h
@@ -49,7 +49,7 @@ class ReadRange {
    using MetadataAccessor =
        std::function<absl::optional<google::storage::v2::Object>()>;
 
-  ReadRange(std::int64_t offset, std::int64_t length,
+  ReadRange(std::int64_t offset, absl::optional<std::int64_t> requested_length,
             std::string bucket_name, std::string object_name,
             std::shared_ptr<storage::internal::HashFunction> hash_function =
                 storage::internal::CreateNullHashFunction(),
@@ -57,8 +57,8 @@ class ReadRange {
                 storage::internal::CreateNullHashValidator(),
             MetadataAccessor metadata_accessor = [] { return absl::nullopt; })
       : offset_(offset),
-        length_(length),
-        requested_length_(length),
+        length_(requested_length.value_or(0)),
+        requested_length_(requested_length),
         bucket_name_(std::move(bucket_name)),
         object_name_(std::move(object_name)),
         metadata_accessor_(std::move(metadata_accessor)),
@@ -83,7 +83,7 @@ class ReadRange {
   mutable std::mutex mu_;
   std::int64_t offset_;
   std::int64_t length_;
-  std::int64_t requested_length_;
+  absl::optional<std::int64_t> requested_length_;
   std::int64_t received_bytes_ = 0;
   std::string bucket_name_;
   std::string object_name_;

--- a/google/cloud/storage/internal/async/read_range.h
+++ b/google/cloud/storage/internal/async/read_range.h
@@ -26,6 +26,7 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -46,14 +47,25 @@ class ReadRange {
   using ReadResponse = storage::AsyncReaderConnection::ReadResponse;
 
   ReadRange(std::int64_t offset, std::int64_t length,
+            std::string bucket_name = "", std::string object_name = "",
             std::shared_ptr<storage::internal::HashFunction> hash_function =
                 storage::internal::CreateNullHashFunction(),
             std::unique_ptr<storage::internal::HashValidator> hash_validator =
                 storage::internal::CreateNullHashValidator())
       : offset_(offset),
         length_(length),
+        requested_length_(length),
+        bucket_name_(std::move(bucket_name)),
+        object_name_(std::move(object_name)),
         hash_function_(std::move(hash_function)),
         hash_validator_(std::move(hash_validator)) {}
+
+  ReadRange(std::int64_t offset, std::int64_t length,
+            std::shared_ptr<storage::internal::HashFunction> hash_function,
+            std::unique_ptr<storage::internal::HashValidator> hash_validator =
+                storage::internal::CreateNullHashValidator())
+      : ReadRange(offset, length, "", "", std::move(hash_function),
+                  std::move(hash_validator)) {}
 
   bool IsDone() const;
 
@@ -67,10 +79,16 @@ class ReadRange {
 
  private:
   void Notify(std::unique_lock<std::mutex> lk, storage::ReadPayload p);
+  void CheckOverrun();
 
   mutable std::mutex mu_;
   std::int64_t offset_;
   std::int64_t length_;
+  std::int64_t requested_length_;
+  std::int64_t received_bytes_ = 0;
+  std::string bucket_name_;
+  std::string object_name_;
+  bool logged_warning_ = false;
   absl::optional<storage::ReadPayload> payload_;
   absl::optional<Status> status_;
   absl::optional<promise<ReadResponse>> wait_;

--- a/google/cloud/storage/internal/async/read_range.h
+++ b/google/cloud/storage/internal/async/read_range.h
@@ -46,22 +46,18 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ReadRange {
  public:
    using ReadResponse = storage::AsyncReaderConnection::ReadResponse;
-   using MetadataAccessor =
-       std::function<absl::optional<google::storage::v2::Object>()>;
 
   ReadRange(std::int64_t offset, absl::optional<std::int64_t> requested_length,
             std::string bucket_name, std::string object_name,
             std::shared_ptr<storage::internal::HashFunction> hash_function =
                 storage::internal::CreateNullHashFunction(),
             std::unique_ptr<storage::internal::HashValidator> hash_validator =
-                storage::internal::CreateNullHashValidator(),
-            MetadataAccessor metadata_accessor = [] { return absl::nullopt; })
+                storage::internal::CreateNullHashValidator())
       : offset_(offset),
         length_(requested_length.value_or(0)),
         requested_length_(requested_length),
         bucket_name_(std::move(bucket_name)),
         object_name_(std::move(object_name)),
-        metadata_accessor_(std::move(metadata_accessor)),
         hash_function_(std::move(hash_function)),
         hash_validator_(std::move(hash_validator)) {}
 
@@ -73,7 +69,7 @@ class ReadRange {
   future<ReadResponse> Read();
   void OnFinish(Status status);
 
-  void OnRead(google::storage::v2::ObjectRangeData data);
+  void OnRead(google::storage::v2::ObjectRangeData data, bool is_transcoded);
 
  private:
   void Notify(std::unique_lock<std::mutex> lk, storage::ReadPayload p);
@@ -87,7 +83,7 @@ class ReadRange {
   std::int64_t received_bytes_ = 0;
   std::string bucket_name_;
   std::string object_name_;
-  MetadataAccessor metadata_accessor_;
+  bool is_transcoded_ = false;
   bool logged_warning_ = false;
   absl::optional<storage::ReadPayload> payload_;
   absl::optional<Status> status_;

--- a/google/cloud/storage/internal/async/read_range.h
+++ b/google/cloud/storage/internal/async/read_range.h
@@ -24,6 +24,7 @@
 #include "absl/types/optional.h"
 #include "google/storage/v2/storage.pb.h"
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -44,19 +45,23 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  */
 class ReadRange {
  public:
-  using ReadResponse = storage::AsyncReaderConnection::ReadResponse;
+   using ReadResponse = storage::AsyncReaderConnection::ReadResponse;
+   using MetadataAccessor =
+       std::function<absl::optional<google::storage::v2::Object>()>;
 
   ReadRange(std::int64_t offset, std::int64_t length,
             std::string bucket_name = "", std::string object_name = "",
             std::shared_ptr<storage::internal::HashFunction> hash_function =
                 storage::internal::CreateNullHashFunction(),
             std::unique_ptr<storage::internal::HashValidator> hash_validator =
-                storage::internal::CreateNullHashValidator())
+                storage::internal::CreateNullHashValidator(),
+            MetadataAccessor metadata_accessor = [] { return absl::nullopt; })
       : offset_(offset),
         length_(length),
         requested_length_(length),
         bucket_name_(std::move(bucket_name)),
         object_name_(std::move(object_name)),
+        metadata_accessor_(std::move(metadata_accessor)),
         hash_function_(std::move(hash_function)),
         hash_validator_(std::move(hash_validator)) {}
 
@@ -65,7 +70,7 @@ class ReadRange {
             std::unique_ptr<storage::internal::HashValidator> hash_validator =
                 storage::internal::CreateNullHashValidator())
       : ReadRange(offset, length, "", "", std::move(hash_function),
-                  std::move(hash_validator)) {}
+                  std::move(hash_validator), [] { return absl::nullopt; }) {}
 
   bool IsDone() const;
 
@@ -89,6 +94,7 @@ class ReadRange {
   std::int64_t received_bytes_ = 0;
   std::string bucket_name_;
   std::string object_name_;
+  MetadataAccessor metadata_accessor_;
   bool logged_warning_ = false;
   absl::optional<storage::ReadPayload> payload_;
   absl::optional<Status> status_;

--- a/google/cloud/storage/internal/async/read_range.h
+++ b/google/cloud/storage/internal/async/read_range.h
@@ -50,7 +50,7 @@ class ReadRange {
        std::function<absl::optional<google::storage::v2::Object>()>;
 
   ReadRange(std::int64_t offset, std::int64_t length,
-            std::string bucket_name = "", std::string object_name = "",
+            std::string bucket_name, std::string object_name,
             std::shared_ptr<storage::internal::HashFunction> hash_function =
                 storage::internal::CreateNullHashFunction(),
             std::unique_ptr<storage::internal::HashValidator> hash_validator =
@@ -64,13 +64,6 @@ class ReadRange {
         metadata_accessor_(std::move(metadata_accessor)),
         hash_function_(std::move(hash_function)),
         hash_validator_(std::move(hash_validator)) {}
-
-  ReadRange(std::int64_t offset, std::int64_t length,
-            std::shared_ptr<storage::internal::HashFunction> hash_function,
-            std::unique_ptr<storage::internal::HashValidator> hash_validator =
-                storage::internal::CreateNullHashValidator())
-      : ReadRange(offset, length, "", "", std::move(hash_function),
-                  std::move(hash_validator), [] { return absl::nullopt; }) {}
 
   bool IsDone() const;
 

--- a/google/cloud/storage/internal/async/read_range.h
+++ b/google/cloud/storage/internal/async/read_range.h
@@ -79,6 +79,7 @@ class ReadRange {
 
  private:
   void Notify(std::unique_lock<std::mutex> lk, storage::ReadPayload p);
+  // Must be called while holding mu_.
   void CheckOverrun();
 
   mutable std::mutex mu_;

--- a/google/cloud/storage/internal/async/read_range_test.cc
+++ b/google/cloud/storage/internal/async/read_range_test.cc
@@ -604,6 +604,42 @@ TEST(ReadRange, TranscodingIgnoresChecksumMismatch) {
   actual.OnFinish(Status{});
 }
 
+TEST(ReadRange, NoResumeIfRequestSatisfied) {
+  ReadRange actual(0, 10, "my-bucket", "my-object");
+
+  // Receive exactly 10 bytes (satisfied!)
+  auto data = google::storage::v2::ObjectRangeData{};
+  auto constexpr kData0 = R"pb(
+    checksummed_data { content: "0123456789" }
+    read_range { read_offset: 0 read_length: 10 read_id: 7 }
+    range_end: false
+  )pb";
+  EXPECT_TRUE(TextFormat::ParseFromString(kData0, &data));
+  actual.OnRead(std::move(data), /*is_transcoded=*/false);
+
+  // RangeForResume should return nullopt because it's already satisfied!
+  auto resume_range = actual.RangeForResume(7);
+  EXPECT_FALSE(resume_range.has_value());
+}
+
+TEST(ReadRange, NoResumeIfRequestExceeded) {
+  ReadRange actual(0, 10, "my-bucket", "my-object");
+
+  // Receive 12 bytes (overrun!)
+  auto data = google::storage::v2::ObjectRangeData{};
+  auto constexpr kData0 = R"pb(
+    checksummed_data { content: "0123456789ab" }
+    read_range { read_offset: 0 read_length: 12 read_id: 7 }
+    range_end: false
+  )pb";
+  EXPECT_TRUE(TextFormat::ParseFromString(kData0, &data));
+  actual.OnRead(std::move(data), /*is_transcoded=*/false);
+
+  // RangeForResume should return nullopt because it's already exceeded!
+  auto resume_range = actual.RangeForResume(7);
+  EXPECT_FALSE(resume_range.has_value());
+}
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage_internal

--- a/google/cloud/storage/internal/async/read_range_test.cc
+++ b/google/cloud/storage/internal/async/read_range_test.cc
@@ -79,7 +79,7 @@ TEST(ReadRange, BasicLifecycle) {
     range_end: false
   )pb";
   EXPECT_TRUE(TextFormat::ParseFromString(kData0, &data));
-  actual.OnRead(std::move(data));
+  actual.OnRead(std::move(data), /*is_transcoded=*/false);
 
   EXPECT_TRUE(pending.is_ready());
   EXPECT_THAT(pending.get(),
@@ -99,7 +99,7 @@ TEST(ReadRange, BasicLifecycle) {
     range_end: false
   )pb";
   EXPECT_TRUE(TextFormat::ParseFromString(kData1, &data));
-  actual.OnRead(std::move(data));
+  actual.OnRead(std::move(data), /*is_transcoded=*/false);
 
   pending = actual.Read();
   EXPECT_TRUE(pending.is_ready());
@@ -115,7 +115,7 @@ TEST(ReadRange, BasicLifecycle) {
     range_end: true
   )pb";
   EXPECT_TRUE(TextFormat::ParseFromString(kData2, &data));
-  actual.OnRead(std::move(data));
+  actual.OnRead(std::move(data), /*is_transcoded=*/false);
 
   EXPECT_TRUE(actual.IsDone());
   EXPECT_FALSE(actual.RangeForResume(7).has_value());
@@ -153,7 +153,7 @@ TEST(ReadRange, Queue) {
     range_end: false
   )pb";
   EXPECT_TRUE(TextFormat::ParseFromString(kData0, &data));
-  actual.OnRead(std::move(data));
+  actual.OnRead(std::move(data), /*is_transcoded=*/false);
 
   auto constexpr kData1 = R"pb(
     checksummed_data { content: "1234567890" }
@@ -161,7 +161,7 @@ TEST(ReadRange, Queue) {
     range_end: false
   )pb";
   EXPECT_TRUE(TextFormat::ParseFromString(kData1, &data));
-  actual.OnRead(std::move(data));
+  actual.OnRead(std::move(data), /*is_transcoded=*/false);
 
   auto matcher = ResultOf(
       "contents",
@@ -193,7 +193,7 @@ TEST(ReadRange, HashFunctionCalled) {
   )pb";
 
   EXPECT_TRUE(TextFormat::ParseFromString(kData0, &data));
-  actual.OnRead(std::move(data));
+  actual.OnRead(std::move(data), /*is_transcoded=*/false);
 }
 
 TEST(ReadRange, FullObjectChecksumValidationMismatch) {
@@ -218,7 +218,7 @@ TEST(ReadRange, FullObjectChecksumValidationMismatch) {
   EXPECT_TRUE(TextFormat::ParseFromString(kData0, &data));
 
   auto pending = actual.Read();
-  actual.OnRead(std::move(data));
+  actual.OnRead(std::move(data), /*is_transcoded=*/false);
 
   EXPECT_TRUE(actual.IsDone());
 
@@ -257,7 +257,7 @@ TEST(ReadRange, FullObjectChecksumValidationMismatchMD5) {
   EXPECT_TRUE(TextFormat::ParseFromString(kData0, &data));
 
   auto pending = actual.Read();
-  actual.OnRead(std::move(data));
+  actual.OnRead(std::move(data), /*is_transcoded=*/false);
 
   EXPECT_TRUE(actual.IsDone());
 
@@ -300,7 +300,7 @@ TEST(ReadRange, FullObjectChecksumValidationMismatchComposite) {
   EXPECT_TRUE(TextFormat::ParseFromString(kData0, &data));
 
   auto pending = actual.Read();
-  actual.OnRead(std::move(data));
+  actual.OnRead(std::move(data), /*is_transcoded=*/false);
 
   EXPECT_TRUE(actual.IsDone());
 
@@ -346,7 +346,7 @@ TEST(ReadRange, FullObjectChecksumValidationSuccessComposite) {
   EXPECT_TRUE(TextFormat::ParseFromString(kData0, &data));
 
   auto pending = actual.Read();
-  actual.OnRead(std::move(data));
+  actual.OnRead(std::move(data), /*is_transcoded=*/false);
 
   EXPECT_TRUE(actual.IsDone());
 
@@ -371,7 +371,7 @@ TEST(ReadRange, OverrunLogging) {
     range_end: false
   )pb";
   EXPECT_TRUE(TextFormat::ParseFromString(kData0, &data));
-  actual.OnRead(std::move(data));
+  actual.OnRead(std::move(data), /*is_transcoded=*/false);
   EXPECT_TRUE(log.ExtractLines().empty());
 
   auto constexpr kData1 = R"pb(
@@ -380,7 +380,7 @@ TEST(ReadRange, OverrunLogging) {
     range_end: true
   )pb";
   EXPECT_TRUE(TextFormat::ParseFromString(kData1, &data));
-  actual.OnRead(std::move(data));
+  actual.OnRead(std::move(data), /*is_transcoded=*/false);
 
   auto lines = log.ExtractLines();
   EXPECT_EQ(lines.size(), 1);
@@ -406,7 +406,7 @@ TEST(ReadRange, ReadLastLessIndexNoLogging) {
     range_end: true
   )pb";
   EXPECT_TRUE(TextFormat::ParseFromString(kData0, &data));
-  actual.OnRead(std::move(data));
+  actual.OnRead(std::move(data), /*is_transcoded=*/false);
   EXPECT_TRUE(log.ExtractLines().empty());
 
   actual.OnFinish(Status{});
@@ -425,7 +425,7 @@ TEST(ReadRange, ReadLastOvershootLogging) {
     range_end: false
   )pb";
   EXPECT_TRUE(TextFormat::ParseFromString(kData0, &data));
-  actual.OnRead(std::move(data));
+  actual.OnRead(std::move(data), /*is_transcoded=*/false);
   EXPECT_TRUE(log.ExtractLines().empty());
 
   auto constexpr kData1 = R"pb(
@@ -434,7 +434,7 @@ TEST(ReadRange, ReadLastOvershootLogging) {
     range_end: true
   )pb";
   EXPECT_TRUE(TextFormat::ParseFromString(kData1, &data));
-  actual.OnRead(std::move(data));
+  actual.OnRead(std::move(data), /*is_transcoded=*/false);
 
   auto lines = log.ExtractLines();
   EXPECT_EQ(lines.size(), 1);
@@ -451,16 +451,7 @@ TEST(ReadRange, ReadLastOvershootLogging) {
 TEST(ReadRange, TranscodingSuppressesWarning) {
   ScopedLog log;
   
-  auto metadata_accessor = []() -> absl::optional<google::storage::v2::Object> {
-    google::storage::v2::Object metadata;
-    metadata.set_content_encoding("gzip");
-    return metadata;
-  };
-
-  ReadRange actual(0, 10, "my-bucket", "my-object",
-                   storage::internal::CreateNullHashFunction(),
-                   storage::internal::CreateNullHashValidator(),
-                   metadata_accessor);
+  ReadRange actual(0, 10, "my-bucket", "my-object");
 
   auto data = google::storage::v2::ObjectRangeData{};
   auto constexpr kData0 = R"pb(
@@ -469,7 +460,7 @@ TEST(ReadRange, TranscodingSuppressesWarning) {
     range_end: false
   )pb";
   EXPECT_TRUE(TextFormat::ParseFromString(kData0, &data));
-  actual.OnRead(std::move(data));
+  actual.OnRead(std::move(data), /*is_transcoded=*/true);
   EXPECT_TRUE(log.ExtractLines().empty());
 
   auto constexpr kData1 = R"pb(
@@ -478,7 +469,7 @@ TEST(ReadRange, TranscodingSuppressesWarning) {
     range_end: true
   )pb";
   EXPECT_TRUE(TextFormat::ParseFromString(kData1, &data));
-  actual.OnRead(std::move(data));
+  actual.OnRead(std::move(data), /*is_transcoded=*/true);
 
   // Should NOT log because content_encoding is gzip
   EXPECT_TRUE(log.ExtractLines().empty());
@@ -501,7 +492,7 @@ TEST(ReadRange, ZeroLengthOverrunLogging) {
     range_end: true
   )pb";
   EXPECT_TRUE(TextFormat::ParseFromString(kData0, &data));
-  actual.OnRead(std::move(data));
+  actual.OnRead(std::move(data), /*is_transcoded=*/false);
 
   auto lines = log.ExtractLines();
   EXPECT_EQ(lines.size(), 1);

--- a/google/cloud/storage/internal/async/read_range_test.cc
+++ b/google/cloud/storage/internal/async/read_range_test.cc
@@ -487,6 +487,34 @@ TEST(ReadRange, TranscodingSuppressesWarning) {
   EXPECT_TRUE(log.ExtractLines().empty());
 }
 
+TEST(ReadRange, ZeroLengthOverrunLogging) {
+  ScopedLog log;
+
+  // Pass 0 as the limit (not nullopt, which would mean read to end).
+  ReadRange actual(0, absl::make_optional<std::int64_t>(0),
+                   "my-bucket", "my-object");
+
+  auto data = google::storage::v2::ObjectRangeData{};
+  auto constexpr kData0 = R"pb(
+    checksummed_data { content: "abcde" }
+    read_range { read_offset: 0 read_length: 5 read_id: 7 }
+    range_end: true
+  )pb";
+  EXPECT_TRUE(TextFormat::ParseFromString(kData0, &data));
+  actual.OnRead(std::move(data));
+
+  auto lines = log.ExtractLines();
+  EXPECT_EQ(lines.size(), 1);
+  EXPECT_THAT(
+      lines[0],
+      HasSubstr(
+          "storage: received 5 more bytes than requested from GCS for bucket "
+          "\"my-bucket\", object \"my-object\""));
+
+  actual.OnFinish(Status{});
+  EXPECT_TRUE(log.ExtractLines().empty());
+}
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage_internal

--- a/google/cloud/storage/internal/async/read_range_test.cc
+++ b/google/cloud/storage/internal/async/read_range_test.cc
@@ -543,6 +543,35 @@ TEST(ReadRange, MultiChunkOverrunLogging) {
   EXPECT_TRUE(log.ExtractLines().empty());
 }
 
+TEST(ReadRange, ReadLastOverrunLogging) {
+  ScopedLog log;
+
+  // ReadLast(5) is represented by start = -5, limit = 5.
+  ReadRange actual(-5, absl::make_optional<std::int64_t>(5),
+                   "my-bucket", "my-object");
+
+  // GCS returns 10 bytes (overrun of 5 bytes)
+  auto data = google::storage::v2::ObjectRangeData{};
+  auto constexpr kData0 = R"pb(
+    checksummed_data { content: "0123456789" }
+    read_range { read_offset: -5 read_length: 10 read_id: 7 }
+    range_end: true
+  )pb";
+  EXPECT_TRUE(TextFormat::ParseFromString(kData0, &data));
+  actual.OnRead(std::move(data), /*is_transcoded=*/false);
+
+  auto lines = log.ExtractLines();
+  EXPECT_EQ(lines.size(), 1);
+  EXPECT_THAT(
+      lines[0],
+      HasSubstr(
+          "storage: received 5 more bytes than requested from GCS for bucket "
+          "\"my-bucket\", object \"my-object\""));
+
+  actual.OnFinish(Status{});
+  EXPECT_TRUE(log.ExtractLines().empty());
+}
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage_internal

--- a/google/cloud/storage/internal/async/read_range_test.cc
+++ b/google/cloud/storage/internal/async/read_range_test.cc
@@ -448,6 +448,45 @@ TEST(ReadRange, ReadLastOvershootLogging) {
   EXPECT_TRUE(log.ExtractLines().empty());
 }
 
+TEST(ReadRange, TranscodingSuppressesWarning) {
+  ScopedLog log;
+  
+  auto metadata_accessor = []() -> absl::optional<google::storage::v2::Object> {
+    google::storage::v2::Object metadata;
+    metadata.set_content_encoding("gzip");
+    return metadata;
+  };
+
+  ReadRange actual(0, 10, "my-bucket", "my-object",
+                   storage::internal::CreateNullHashFunction(),
+                   storage::internal::CreateNullHashValidator(),
+                   metadata_accessor);
+
+  auto data = google::storage::v2::ObjectRangeData{};
+  auto constexpr kData0 = R"pb(
+    checksummed_data { content: "0123456789" }
+    read_range { read_offset: 0 read_length: 10 read_id: 7 }
+    range_end: false
+  )pb";
+  EXPECT_TRUE(TextFormat::ParseFromString(kData0, &data));
+  actual.OnRead(std::move(data));
+  EXPECT_TRUE(log.ExtractLines().empty());
+
+  auto constexpr kData1 = R"pb(
+    checksummed_data { content: "abcde" }
+    read_range { read_offset: 10 read_length: 5 read_id: 7 }
+    range_end: true
+  )pb";
+  EXPECT_TRUE(TextFormat::ParseFromString(kData1, &data));
+  actual.OnRead(std::move(data));
+
+  // Should NOT log because content_encoding is gzip
+  EXPECT_TRUE(log.ExtractLines().empty());
+
+  actual.OnFinish(Status{});
+  EXPECT_TRUE(log.ExtractLines().empty());
+}
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage_internal

--- a/google/cloud/storage/internal/async/read_range_test.cc
+++ b/google/cloud/storage/internal/async/read_range_test.cc
@@ -506,6 +506,43 @@ TEST(ReadRange, ZeroLengthOverrunLogging) {
   EXPECT_TRUE(log.ExtractLines().empty());
 }
 
+TEST(ReadRange, MultiChunkOverrunLogging) {
+  ScopedLog log;
+
+  ReadRange actual(0, 10, "my-bucket", "my-object");
+
+  // First chunk: 5 bytes (valid, within 10-byte limit)
+  auto data = google::storage::v2::ObjectRangeData{};
+  auto constexpr kData0 = R"pb(
+    checksummed_data { content: "12345" }
+    read_range { read_offset: 0 read_length: 5 read_id: 7 }
+    range_end: false
+  )pb";
+  EXPECT_TRUE(TextFormat::ParseFromString(kData0, &data));
+  actual.OnRead(std::move(data), /*is_transcoded=*/false);
+  EXPECT_TRUE(log.ExtractLines().empty());
+
+  // Second chunk: 10 bytes (total 15 bytes, exceeds 10-byte limit by 5)
+  auto constexpr kData1 = R"pb(
+    checksummed_data { content: "67890abcde" }
+    read_range { read_offset: 5 read_length: 10 read_id: 7 }
+    range_end: true
+  )pb";
+  EXPECT_TRUE(TextFormat::ParseFromString(kData1, &data));
+  actual.OnRead(std::move(data), /*is_transcoded=*/false);
+
+  auto lines = log.ExtractLines();
+  EXPECT_EQ(lines.size(), 1);
+  EXPECT_THAT(
+      lines[0],
+      HasSubstr(
+          "storage: received 5 more bytes than requested from GCS for bucket "
+          "\"my-bucket\", object \"my-object\""));
+
+  actual.OnFinish(Status{});
+  EXPECT_TRUE(log.ExtractLines().empty());
+}
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage_internal

--- a/google/cloud/storage/internal/async/read_range_test.cc
+++ b/google/cloud/storage/internal/async/read_range_test.cc
@@ -394,6 +394,60 @@ TEST(ReadRange, OverrunLogging) {
   EXPECT_TRUE(log.ExtractLines().empty());
 }
 
+TEST(ReadRange, ReadLastLessIndexNoLogging) {
+  ScopedLog log;
+  // Simulating ReadLast(100) where GCS returns 50 bytes (e.g. object size is 50)
+  ReadRange actual(-100, 100, "my-bucket", "my-object");
+
+  auto data = google::storage::v2::ObjectRangeData{};
+  auto constexpr kData0 = R"pb(
+    checksummed_data { content: "01234567890123456789012345678901234567890123456789" }
+    read_range { read_offset: -100 read_length: 100 read_id: 7 }
+    range_end: true
+  )pb";
+  EXPECT_TRUE(TextFormat::ParseFromString(kData0, &data));
+  actual.OnRead(std::move(data));
+  EXPECT_TRUE(log.ExtractLines().empty());
+
+  actual.OnFinish(Status{});
+  EXPECT_TRUE(log.ExtractLines().empty());
+}
+
+TEST(ReadRange, ReadLastOvershootLogging) {
+  ScopedLog log;
+  // Simulating ReadLast(50) where GCS returns 60 bytes
+  ReadRange actual(-50, 50, "my-bucket", "my-object");
+
+  auto data = google::storage::v2::ObjectRangeData{};
+  auto constexpr kData0 = R"pb(
+    checksummed_data { content: "01234567890123456789012345678901234567890123456789" }
+    read_range { read_offset: -50 read_length: 50 read_id: 7 }
+    range_end: false
+  )pb";
+  EXPECT_TRUE(TextFormat::ParseFromString(kData0, &data));
+  actual.OnRead(std::move(data));
+  EXPECT_TRUE(log.ExtractLines().empty());
+
+  auto constexpr kData1 = R"pb(
+    checksummed_data { content: "0123456789" }
+    read_range { read_offset: 0 read_length: 10 read_id: 7 }
+    range_end: true
+  )pb";
+  EXPECT_TRUE(TextFormat::ParseFromString(kData1, &data));
+  actual.OnRead(std::move(data));
+
+  auto lines = log.ExtractLines();
+  EXPECT_EQ(lines.size(), 1);
+  EXPECT_THAT(
+      lines[0],
+      HasSubstr(
+          "storage: received 10 more bytes than requested from GCS for bucket "
+          "\"my-bucket\", object \"my-object\""));
+
+  actual.OnFinish(Status{});
+  EXPECT_TRUE(log.ExtractLines().empty());
+}
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage_internal

--- a/google/cloud/storage/internal/async/read_range_test.cc
+++ b/google/cloud/storage/internal/async/read_range_test.cc
@@ -21,6 +21,7 @@
 #include "google/cloud/storage/testing/canonical_errors.h"
 #include "google/cloud/storage/testing/mock_hash_function.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "absl/strings/cord.h"
 #include "absl/strings/string_view.h"
@@ -42,12 +43,14 @@ using ::google::cloud::storage::testing::MockHashFunction;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::IsProtoEqual;
+using ::google::cloud::testing_util::ScopedLog;
 using ::google::cloud::testing_util::StatusIs;
 using ::google::protobuf::TextFormat;
 using ::testing::_;
 using ::testing::An;
 using ::testing::AtLeast;
 using ::testing::ElementsAre;
+using ::testing::HasSubstr;
 using ::testing::Optional;
 using ::testing::ResultOf;
 using ::testing::VariantWith;
@@ -355,6 +358,40 @@ TEST(ReadRange, FullObjectChecksumValidationSuccessComposite) {
   auto next_read = actual.Read();
   EXPECT_TRUE(next_read.is_ready());
   EXPECT_THAT(next_read.get(), VariantWith<Status>(IsOk()));
+}
+
+TEST(ReadRange, OverrunLogging) {
+  ScopedLog log;
+  ReadRange actual(0, 10, "my-bucket", "my-object");
+
+  auto data = google::storage::v2::ObjectRangeData{};
+  auto constexpr kData0 = R"pb(
+    checksummed_data { content: "0123456789" }
+    read_range { read_offset: 0 read_length: 10 read_id: 7 }
+    range_end: false
+  )pb";
+  EXPECT_TRUE(TextFormat::ParseFromString(kData0, &data));
+  actual.OnRead(std::move(data));
+  EXPECT_TRUE(log.ExtractLines().empty());
+
+  auto constexpr kData1 = R"pb(
+    checksummed_data { content: "abcde" }
+    read_range { read_offset: 10 read_length: 5 read_id: 7 }
+    range_end: true
+  )pb";
+  EXPECT_TRUE(TextFormat::ParseFromString(kData1, &data));
+  actual.OnRead(std::move(data));
+
+  auto lines = log.ExtractLines();
+  EXPECT_EQ(lines.size(), 1);
+  EXPECT_THAT(
+      lines[0],
+      HasSubstr(
+          "storage: received 5 more bytes than requested from GCS for bucket "
+          "\"my-bucket\", object \"my-object\""));
+
+  actual.OnFinish(Status{});
+  EXPECT_TRUE(log.ExtractLines().empty());
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/async/read_range_test.cc
+++ b/google/cloud/storage/internal/async/read_range_test.cc
@@ -60,7 +60,7 @@ using HashUpdateType =
                        absl::Cord const&, absl::string_view>;
 
 TEST(ReadRange, BasicLifecycle) {
-  ReadRange actual(10000, 40);
+  ReadRange actual(10000, 40, "my-bucket", "my-object");
   EXPECT_FALSE(actual.IsDone());
   auto range = google::storage::v2::ReadRange{};
   auto constexpr kRange0 = R"pb(
@@ -134,7 +134,7 @@ TEST(ReadRange, BasicLifecycle) {
 }
 
 TEST(ReadRange, Error) {
-  ReadRange actual(10000, 40);
+  ReadRange actual(10000, 40, "my-bucket", "my-object");
   auto pending = actual.Read();
   EXPECT_FALSE(pending.is_ready());
   actual.OnFinish(PermanentError());
@@ -144,7 +144,7 @@ TEST(ReadRange, Error) {
 }
 
 TEST(ReadRange, Queue) {
-  ReadRange actual(10000, 40);
+  ReadRange actual(10000, 40, "my-bucket", "my-object");
 
   auto data = google::storage::v2::ObjectRangeData{};
   auto constexpr kData0 = R"pb(
@@ -184,7 +184,7 @@ TEST(ReadRange, HashFunctionCalled) {
   EXPECT_CALL(*hash_function, Update(0, An<HashUpdateType>(), _))
       .Times(AtLeast(1));
 
-  ReadRange actual(0, 10, hash_function);
+  ReadRange actual(0, 10, "my-bucket", "my-object", hash_function);
   auto data = google::storage::v2::ObjectRangeData{};
   auto constexpr kData0 = R"pb(
     checksummed_data { content: "1234567890" }
@@ -206,7 +206,7 @@ TEST(ReadRange, FullObjectChecksumValidationMismatch) {
   expected_hashes.crc32c = "n3tPLw==";  // Some expected hash
   hash_validator->ProcessHashValues(expected_hashes);
 
-  ReadRange actual(0, 10, hash_function, std::move(hash_validator));
+  ReadRange actual(0, 10, "my-bucket", "my-object", hash_function, std::move(hash_validator));
 
   auto data = google::storage::v2::ObjectRangeData{};
   auto constexpr kData0 = R"pb(
@@ -242,7 +242,7 @@ TEST(ReadRange, FullObjectChecksumValidationMismatchMD5) {
   expected_hashes.md5 = "wrong-md5-hash";
   hash_validator->ProcessHashValues(expected_hashes);
 
-  ReadRange actual(0, 43, std::move(hash_function), std::move(hash_validator));
+  ReadRange actual(0, 43, "my-bucket", "my-object", std::move(hash_function), std::move(hash_validator));
 
   auto data = google::storage::v2::ObjectRangeData{};
   auto constexpr kData0 = R"pb(
@@ -285,7 +285,7 @@ TEST(ReadRange, FullObjectChecksumValidationMismatchComposite) {
   expected_hashes.md5 = "wrong-md5";
   hash_validator->ProcessHashValues(expected_hashes);
 
-  ReadRange actual(0, 43, hash_function, std::move(hash_validator));
+  ReadRange actual(0, 43, "my-bucket", "my-object", hash_function, std::move(hash_validator));
 
   auto data = google::storage::v2::ObjectRangeData{};
   auto constexpr kData0 = R"pb(
@@ -331,7 +331,7 @@ TEST(ReadRange, FullObjectChecksumValidationSuccessComposite) {
   expected_hashes.md5 = "nhB9nTcrtoJr2B01QqQZ1g==";
   hash_validator->ProcessHashValues(expected_hashes);
 
-  ReadRange actual(0, 43, hash_function, std::move(hash_validator));
+  ReadRange actual(0, 43, "my-bucket", "my-object", hash_function, std::move(hash_validator));
 
   auto data = google::storage::v2::ObjectRangeData{};
   auto constexpr kData0 = R"pb(

--- a/google/cloud/storage/internal/async/read_range_test.cc
+++ b/google/cloud/storage/internal/async/read_range_test.cc
@@ -572,6 +572,38 @@ TEST(ReadRange, ReadLastOverrunLogging) {
   EXPECT_TRUE(log.ExtractLines().empty());
 }
 
+TEST(ReadRange, TranscodingIgnoresChecksumMismatch) {
+  ScopedLog log;
+
+  auto hash_function =
+      std::make_shared<storage::internal::Crc32cHashFunction>();
+  auto hash_validator =
+      std::make_unique<storage::internal::Crc32cHashValidator>();
+
+  // Seed with a mismatching expected hash (so it would normally fail)
+  storage::internal::HashValues expected_hashes;
+  expected_hashes.crc32c = "n3tPLw==";
+  hash_validator->ProcessHashValues(expected_hashes);
+
+  ReadRange actual(0, 10, "my-bucket", "my-object", hash_function, std::move(hash_validator));
+
+  auto data = google::storage::v2::ObjectRangeData{};
+  auto constexpr kData0 = R"pb(
+    checksummed_data { content: "1234567890" }
+    read_range { read_offset: 0 read_length: 10 read_id: 7 }
+    range_end: true
+  )pb";
+  EXPECT_TRUE(TextFormat::ParseFromString(kData0, &data));
+  actual.OnRead(std::move(data), /*is_transcoded=*/true);
+
+  auto pending = actual.Read();
+  EXPECT_TRUE(actual.IsDone());
+  auto response = pending.get();
+  EXPECT_THAT(response, VariantWith<ReadPayload>(_));
+
+  actual.OnFinish(Status{});
+}
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage_internal

--- a/google/cloud/storage/internal/object_read_streambuf.cc
+++ b/google/cloud/storage/internal/object_read_streambuf.cc
@@ -53,12 +53,12 @@ ObjectReadStreambuf::ObjectReadStreambuf(
     auto const range = request.GetOption<ReadRange>().value();
     auto const offset = request.GetOption<ReadFromOffset>().value();
     auto const begin = (std::max)(range.begin, offset);
-    if (range.end > begin) {
+    if (range.end >= begin) {
       remain_ = range.end - begin;
     }
   } else if (request.HasOption<ReadRange>()) {
     auto const range = request.GetOption<ReadRange>().value();
-    if (range.end > range.begin) {
+    if (range.end >= range.begin) {
       remain_ = range.end - range.begin;
     }
   } else if (request.HasOption<ReadLast>()) {
@@ -105,7 +105,7 @@ void ObjectReadStreambuf::Close() {
     std::lock_guard<std::mutex> lk(mu_);
     if (!logged_warning_) {
       logged_warning_ = true;
-      if (remain_.has_value() && *remain_ < 0) {
+      if (remain_.has_value() && *remain_ < 0 && !transformation().has_value()) {
         GCP_LOG(WARNING)
             << "storage: received " << -(*remain_)
             << " more bytes than requested from GCS for bucket \""

--- a/google/cloud/storage/internal/object_read_streambuf.cc
+++ b/google/cloud/storage/internal/object_read_streambuf.cc
@@ -86,6 +86,7 @@ ObjectReadStreambuf::pos_type ObjectReadStreambuf::seekpos(
 
 ObjectReadStreambuf::pos_type ObjectReadStreambuf::seekoff(
     off_type off, std::ios_base::seekdir dir, std::ios_base::openmode which) {
+  std::lock_guard<std::mutex> lk(mu_);
   // TODO(#4013): Implement proper seeking.
   // Seeking is non-trivial because the hash validator and `source_` have to be
   // recreated in the general case, which doesn't fit the current code

--- a/google/cloud/storage/internal/object_read_streambuf.cc
+++ b/google/cloud/storage/internal/object_read_streambuf.cc
@@ -86,7 +86,6 @@ ObjectReadStreambuf::pos_type ObjectReadStreambuf::seekpos(
 
 ObjectReadStreambuf::pos_type ObjectReadStreambuf::seekoff(
     off_type off, std::ios_base::seekdir dir, std::ios_base::openmode which) {
-  std::lock_guard<std::mutex> lk(mu_);
   // TODO(#4013): Implement proper seeking.
   // Seeking is non-trivial because the hash validator and `source_` have to be
   // recreated in the general case, which doesn't fit the current code
@@ -256,22 +255,28 @@ std::streamsize ObjectReadStreambuf::xsgetn(char* s, std::streamsize count) {
 
   {
     std::lock_guard<std::mutex> lk(mu_);
-    if (remain_.has_value()) {
-      *remain_ -= read->bytes_received;
-    }
     for (auto const& kv : read->response.headers) {
       headers_.emplace(kv.first, kv.second);
     }
     if (!generation_) generation_ = std::move(read->generation);
     if (!metageneration_) metageneration_ = std::move(read->metageneration);
     if (!storage_class_) storage_class_ = std::move(read->storage_class);
-    if (!size_) size_ = std::move(read->size);
+    if (!size_) {
+      size_ = std::move(read->size);
+      if (size_ && !remain_.has_value()) {
+        remain_ = *size_;
+      }
+    }
     if (!transformation_) transformation_ = std::move(read->transformation);
 
     if (source_pos_ >= 0) {
       source_pos_ += static_cast<std::streamoff>(read->bytes_received);
     } else if (size_) {
       source_pos_ += *size_ + static_cast<std::streamoff>(read->bytes_received);
+    }
+
+    if (remain_.has_value()) {
+      *remain_ -= read->bytes_received;
     }
   }
   return run_validator_if_closed(Status());

--- a/google/cloud/storage/internal/object_read_streambuf.cc
+++ b/google/cloud/storage/internal/object_read_streambuf.cc
@@ -264,6 +264,9 @@ std::streamsize ObjectReadStreambuf::xsgetn(char* s, std::streamsize count) {
     if (!size_) {
       size_ = std::move(read->size);
       if (size_ && !remain_.has_value()) {
+        // For full object reads (where no range options are set), we don't
+        // know the expected size upfront. We initialize `remain_` dynamically
+        // the first time we learn the object's size from the GCS response metadata.
         remain_ = *size_;
       }
     }

--- a/google/cloud/storage/internal/object_read_streambuf.cc
+++ b/google/cloud/storage/internal/object_read_streambuf.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/storage/hash_mismatch_error.h"
 #include "google/cloud/storage/internal/hash_function.h"
 #include "google/cloud/internal/make_status.h"
+#include "google/cloud/log.h"
 #include <algorithm>
 #include <cstring>
 #include <memory>
@@ -45,14 +46,37 @@ ObjectReadStreambuf::ObjectReadStreambuf(
     : source_(std::move(source)),
       source_pos_(InitialOffset(request)),
       hash_function_(CreateHashFunction(request)),
-      hash_validator_(CreateHashValidator(request)) {}
+      hash_validator_(CreateHashValidator(request)),
+      bucket_name_(request.bucket_name()),
+      object_name_(request.object_name()) {
+  if (request.HasOption<ReadRange>() && request.HasOption<ReadFromOffset>()) {
+    auto const range = request.GetOption<ReadRange>().value();
+    auto const offset = request.GetOption<ReadFromOffset>().value();
+    auto const begin = (std::max)(range.begin, offset);
+    if (range.end > begin) {
+      remain_ = range.end - begin;
+    }
+  } else if (request.HasOption<ReadRange>()) {
+    auto const range = request.GetOption<ReadRange>().value();
+    if (range.end > range.begin) {
+      remain_ = range.end - range.begin;
+    }
+  } else if (request.HasOption<ReadLast>()) {
+    auto const last = request.GetOption<ReadLast>().value();
+    if (last > 0) {
+      remain_ = last;
+    }
+  }
+}
 
-ObjectReadStreambuf::ObjectReadStreambuf(ReadObjectRangeRequest const&,
+ObjectReadStreambuf::ObjectReadStreambuf(ReadObjectRangeRequest const& request,
                                          Status status)
     : source_(new ObjectReadErrorSource(status)),
       source_pos_(-1),
       hash_validator_(CreateNullHashValidator()),
-      status_(std::move(status)) {}
+      status_(std::move(status)),
+      bucket_name_(request.bucket_name()),
+      object_name_(request.object_name()) {}
 
 ObjectReadStreambuf::pos_type ObjectReadStreambuf::seekpos(
     pos_type /*pos*/, std::ios_base::openmode /*which*/) {
@@ -77,6 +101,18 @@ ObjectReadStreambuf::pos_type ObjectReadStreambuf::seekoff(
 bool ObjectReadStreambuf::IsOpen() const { return source_->IsOpen(); }
 
 void ObjectReadStreambuf::Close() {
+  {
+    std::lock_guard<std::mutex> lk(mu_);
+    if (!logged_warning_) {
+      logged_warning_ = true;
+      if (remain_.has_value() && *remain_ < 0) {
+        GCP_LOG(WARNING)
+            << "storage: received " << -(*remain_)
+            << " more bytes than requested from GCS for bucket \""
+            << bucket_name_ << "\", object \"" << object_name_ << "\"";
+      }
+    }
+  }
   auto response = source_->Close();
   if (!response.ok()) {
     ReportError(std::move(response).status());
@@ -211,6 +247,13 @@ std::streamsize ObjectReadStreambuf::xsgetn(char* s, std::streamsize count) {
   // If there was an error set the internal state, but we still return the
   // number of bytes.
   if (!read) return run_validator_if_closed(std::move(read).status());
+
+  {
+    std::lock_guard<std::mutex> lk(mu_);
+    if (remain_.has_value()) {
+      *remain_ -= read->bytes_received;
+    }
+  }
 
   hash_function_->Update(absl::string_view{s + offset, read->bytes_received});
   hash_validator_->ProcessHashValues(read->hashes);

--- a/google/cloud/storage/internal/object_read_streambuf.cc
+++ b/google/cloud/storage/internal/object_read_streambuf.cc
@@ -99,7 +99,10 @@ ObjectReadStreambuf::pos_type ObjectReadStreambuf::seekoff(
   return -1;
 }
 
-bool ObjectReadStreambuf::IsOpen() const { return source_->IsOpen(); }
+bool ObjectReadStreambuf::IsOpen() const {
+  std::lock_guard<std::mutex> lk(mu_);
+  return source_ != nullptr && source_->IsOpen();
+}
 
 void ObjectReadStreambuf::Close() {
   {
@@ -132,6 +135,7 @@ ObjectReadStreambuf::int_type ObjectReadStreambuf::ReportError(Status status) {
   if (status.ok()) {
     return traits_type::eof();
   }
+  std::lock_guard<std::mutex> lk(mu_);
   status_ = std::move(status);
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   google::cloud::internal::ThrowStatus(status_);
@@ -145,9 +149,9 @@ void ObjectReadStreambuf::ThrowHashMismatchDelegate(char const* function_name) {
   msg += function_name;
   msg += "(): mismatched hashes in download";
   msg += ", computed=";
-  msg += computed_hash();
+  msg += computed_hash_;
   msg += ", received=";
-  msg += received_hash();
+  msg += received_hash_;
   if (status_.ok()) {
     // If there is an existing error, we should report that instead because
     // it is more specific, for example, every permanent network error will
@@ -163,20 +167,16 @@ void ObjectReadStreambuf::ThrowHashMismatchDelegate(char const* function_name) {
   // case we set `status_`, and report the error as an 0-byte read. This is
   // obviously not ideal, but it is the best we can do when the application
   // disables the standard mechanism to signal errors.
-  throw HashMismatchError(msg, received_hash(), computed_hash());
+  throw HashMismatchError(msg, received_hash_, computed_hash_);
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 bool ObjectReadStreambuf::ValidateHashes(char const* function_name) {
-  // This function is called once the stream is "closed" (either an explicit
-  // `Close()` call or a permanent error). After this point the validator is
-  // not usable.
-
-  // If there are any data transformations, such as decompressive transcoding,
-  // then the computed hashes will not match the returned hashes.  GCS always
-  // returns the hashes of the **stored** data, which are different from the
-  // hashes of the **returned** data under transcoding.
-  if (transformation().has_value()) return true;
+  std::lock_guard<std::mutex> lk(mu_);
+  if (!hash_function_) {
+    return !hash_validator_result_.is_mismatch;
+  }
+  if (transformation_.has_value()) return true;
 
   auto function = std::move(hash_function_);
   auto validator = std::move(hash_validator_);
@@ -190,11 +190,12 @@ bool ObjectReadStreambuf::ValidateHashes(char const* function_name) {
 }
 
 bool ObjectReadStreambuf::CheckPreconditions(char const* function_name) {
+  std::lock_guard<std::mutex> lk(mu_);
   if (hash_validator_result_.is_mismatch) {
     ThrowHashMismatchDelegate(function_name);
   }
   if (in_avail() != 0) return true;
-  return status_.ok() && IsOpen();
+  return status_.ok() && (source_ != nullptr && source_->IsOpen());
 }
 
 ObjectReadStreambuf::int_type ObjectReadStreambuf::underflow() {

--- a/google/cloud/storage/internal/object_read_streambuf.cc
+++ b/google/cloud/storage/internal/object_read_streambuf.cc
@@ -63,7 +63,7 @@ ObjectReadStreambuf::ObjectReadStreambuf(
     }
   } else if (request.HasOption<ReadLast>()) {
     auto const last = request.GetOption<ReadLast>().value();
-    if (last > 0) {
+    if (last >= 0) {
       remain_ = last;
     }
   }

--- a/google/cloud/storage/internal/object_read_streambuf.cc
+++ b/google/cloud/storage/internal/object_read_streambuf.cc
@@ -105,7 +105,7 @@ void ObjectReadStreambuf::Close() {
     std::lock_guard<std::mutex> lk(mu_);
     if (!logged_warning_) {
       logged_warning_ = true;
-      if (remain_.has_value() && *remain_ < 0 && !transformation().has_value()) {
+      if (remain_.has_value() && *remain_ < 0 && !transformation_.has_value()) {
         GCP_LOG(WARNING)
             << "storage: received " << -(*remain_)
             << " more bytes than requested from GCS for bucket \""
@@ -248,29 +248,29 @@ std::streamsize ObjectReadStreambuf::xsgetn(char* s, std::streamsize count) {
   // number of bytes.
   if (!read) return run_validator_if_closed(std::move(read).status());
 
+  hash_function_->Update(absl::string_view{s + offset, read->bytes_received});
+  hash_validator_->ProcessHashValues(read->hashes);
+  offset += static_cast<std::streamsize>(read->bytes_received);
+
   {
     std::lock_guard<std::mutex> lk(mu_);
     if (remain_.has_value()) {
       *remain_ -= read->bytes_received;
     }
-  }
+    for (auto const& kv : read->response.headers) {
+      headers_.emplace(kv.first, kv.second);
+    }
+    if (!generation_) generation_ = std::move(read->generation);
+    if (!metageneration_) metageneration_ = std::move(read->metageneration);
+    if (!storage_class_) storage_class_ = std::move(read->storage_class);
+    if (!size_) size_ = std::move(read->size);
+    if (!transformation_) transformation_ = std::move(read->transformation);
 
-  hash_function_->Update(absl::string_view{s + offset, read->bytes_received});
-  hash_validator_->ProcessHashValues(read->hashes);
-  offset += static_cast<std::streamsize>(read->bytes_received);
-  for (auto const& kv : read->response.headers) {
-    headers_.emplace(kv.first, kv.second);
-  }
-  if (!generation_) generation_ = std::move(read->generation);
-  if (!metageneration_) metageneration_ = std::move(read->metageneration);
-  if (!storage_class_) storage_class_ = std::move(read->storage_class);
-  if (!size_) size_ = std::move(read->size);
-  if (!transformation_) transformation_ = std::move(read->transformation);
-
-  if (source_pos_ >= 0) {
-    source_pos_ += static_cast<std::streamoff>(read->bytes_received);
-  } else if (size_) {
-    source_pos_ += *size_ + static_cast<std::streamoff>(read->bytes_received);
+    if (source_pos_ >= 0) {
+      source_pos_ += static_cast<std::streamoff>(read->bytes_received);
+    } else if (size_) {
+      source_pos_ += *size_ + static_cast<std::streamoff>(read->bytes_received);
+    }
   }
   return run_validator_if_closed(Status());
 }

--- a/google/cloud/storage/internal/object_read_streambuf.h
+++ b/google/cloud/storage/internal/object_read_streambuf.h
@@ -67,7 +67,8 @@ class ObjectReadStreambuf : public std::basic_streambuf<char> {
   Status const& status() const { return status_; }
   std::string const& received_hash() const { return received_hash_; }
   std::string const& computed_hash() const { return computed_hash_; }
-  std::multimap<std::string, std::string> const& headers() const {
+  std::multimap<std::string, std::string> headers() const {
+    std::lock_guard<std::mutex> lk(mu_);
     return headers_;
   }
   absl::optional<std::int64_t> Remain() const {
@@ -76,15 +77,24 @@ class ObjectReadStreambuf : public std::basic_streambuf<char> {
   }
 
   // See ObjectReadStream for details about these attributes.
-  absl::optional<std::int64_t> const& generation() const { return generation_; }
-  absl::optional<std::int64_t> const& metageneration() const {
+  absl::optional<std::int64_t> generation() const {
+    std::lock_guard<std::mutex> lk(mu_);
+    return generation_;
+  }
+  absl::optional<std::int64_t> metageneration() const {
+    std::lock_guard<std::mutex> lk(mu_);
     return metageneration_;
   }
-  absl::optional<std::string> const& storage_class() const {
+  absl::optional<std::string> storage_class() const {
+    std::lock_guard<std::mutex> lk(mu_);
     return storage_class_;
   }
-  absl::optional<std::uint64_t> const& size() const { return size_; }
-  absl::optional<std::string> const& transformation() const {
+  absl::optional<std::uint64_t> size() const {
+    std::lock_guard<std::mutex> lk(mu_);
+    return size_;
+  }
+  absl::optional<std::string> transformation() const {
+    std::lock_guard<std::mutex> lk(mu_);
     return transformation_;
   }
 

--- a/google/cloud/storage/internal/object_read_streambuf.h
+++ b/google/cloud/storage/internal/object_read_streambuf.h
@@ -64,9 +64,18 @@ class ObjectReadStreambuf : public std::basic_streambuf<char> {
 
   bool IsOpen() const;
   void Close();
-  Status const& status() const { return status_; }
-  std::string const& received_hash() const { return received_hash_; }
-  std::string const& computed_hash() const { return computed_hash_; }
+  Status status() const {
+    std::lock_guard<std::mutex> lk(mu_);
+    return status_;
+  }
+  std::string received_hash() const {
+    std::lock_guard<std::mutex> lk(mu_);
+    return received_hash_;
+  }
+  std::string computed_hash() const {
+    std::lock_guard<std::mutex> lk(mu_);
+    return computed_hash_;
+  }
   std::multimap<std::string, std::string> headers() const {
     std::lock_guard<std::mutex> lk(mu_);
     return headers_;

--- a/google/cloud/storage/internal/object_read_streambuf.h
+++ b/google/cloud/storage/internal/object_read_streambuf.h
@@ -25,8 +25,10 @@
 #include <iostream>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
+#include "absl/types/optional.h"
 
 namespace google {
 namespace cloud {
@@ -68,6 +70,10 @@ class ObjectReadStreambuf : public std::basic_streambuf<char> {
   std::multimap<std::string, std::string> const& headers() const {
     return headers_;
   }
+  absl::optional<std::int64_t> Remain() const {
+    std::lock_guard<std::mutex> lk(mu_);
+    return remain_;
+  }
 
   // See ObjectReadStream for details about these attributes.
   absl::optional<std::int64_t> const& generation() const { return generation_; }
@@ -106,6 +112,11 @@ class ObjectReadStreambuf : public std::basic_streambuf<char> {
   absl::optional<std::string> storage_class_;
   absl::optional<std::uint64_t> size_;
   absl::optional<std::string> transformation_;
+  mutable std::mutex mu_;
+  std::string bucket_name_;
+  std::string object_name_;
+  absl::optional<std::int64_t> remain_;
+  bool logged_warning_ = false;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/object_read_streambuf_test.cc
+++ b/google/cloud/storage/internal/object_read_streambuf_test.cc
@@ -306,6 +306,66 @@ TEST(ObjectReadStreambufTest, ReadLastOvershootLogging) {
           "\"my-bucket\", object \"my-object\""));
 }
 
+TEST(ObjectReadStreambufTest, EmptyRangeOverrunLogging) {
+  ScopedLog log;
+  auto read_source = std::make_unique<testing::MockObjectReadSource>();
+  EXPECT_CALL(*read_source, IsOpen()).WillRepeatedly(Return(true));
+  EXPECT_CALL(*read_source, Read)
+      .WillOnce(Return(ReadSourceResult{5, {}}))
+      .WillRepeatedly(Return(ReadSourceResult{0, {}}));
+  EXPECT_CALL(*read_source, Close())
+      .WillRepeatedly(Return(HttpResponse{}));
+
+  ObjectReadStreambuf buf(
+      ReadObjectRangeRequest("my-bucket", "my-object")
+          .set_option(ReadRange(10, 10)),
+      std::move(read_source));
+
+  std::istream stream(&buf);
+  std::vector<char> v(10);
+  stream.read(v.data(), 10);
+  
+  EXPECT_EQ(buf.Remain().value(), -5);
+
+  buf.Close();
+  auto lines = log.ExtractLines();
+  EXPECT_EQ(lines.size(), 1);
+  EXPECT_THAT(
+      lines[0],
+      HasSubstr(
+          "storage: received 5 more bytes than requested from GCS for bucket "
+          "\"my-bucket\", object \"my-object\""));
+}
+
+TEST(ObjectReadStreambufTest, TranscodingSuppressesWarning) {
+  ScopedLog log;
+  auto read_source = std::make_unique<testing::MockObjectReadSource>();
+  EXPECT_CALL(*read_source, IsOpen()).WillRepeatedly(Return(true));
+  
+  ReadSourceResult result{15, {}};
+  result.transformation = "gunzipped";
+  
+  EXPECT_CALL(*read_source, Read)
+      .WillOnce(Return(result))
+      .WillRepeatedly(Return(ReadSourceResult{0, {}}));
+  EXPECT_CALL(*read_source, Close())
+      .WillRepeatedly(Return(HttpResponse{}));
+
+  ObjectReadStreambuf buf(
+      ReadObjectRangeRequest("my-bucket", "my-object")
+          .set_option(ReadRange(0, 10)),
+      std::move(read_source));
+
+  std::istream stream(&buf);
+  std::vector<char> v(20);
+  stream.read(v.data(), 20);
+  
+  EXPECT_EQ(buf.Remain().value(), -5);
+
+  buf.Close();
+  EXPECT_TRUE(log.ExtractLines().empty());
+}
+
 }  // namespace
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/object_read_streambuf_test.cc
+++ b/google/cloud/storage/internal/object_read_streambuf_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/internal/object_read_streambuf.h"
 #include "google/cloud/storage/testing/mock_client.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include <gmock/gmock.h>
 #include <memory>
 #include <utility>
@@ -26,6 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 namespace {
 
+using ::google::cloud::testing_util::ScopedLog;
+using ::testing::HasSubstr;
 using ::testing::Return;
 
 TEST(ObjectReadStreambufTest, FailedTellg) {
@@ -171,6 +174,43 @@ TEST(ObjectReadStreambufTest, WrongSeek) {
   stream.clear();
   stream.seekg(0, std::ios_base::end);
   EXPECT_TRUE(stream.fail());
+}
+
+TEST(ObjectReadStreambufTest, OverrunLogging) {
+  ScopedLog log;
+  auto read_source = std::make_unique<testing::MockObjectReadSource>();
+  EXPECT_CALL(*read_source, IsOpen()).WillRepeatedly(Return(true));
+  EXPECT_CALL(*read_source, Read)
+      .WillOnce(Return(ReadSourceResult{10, {}}))
+      .WillOnce(Return(ReadSourceResult{15, {}}));
+  EXPECT_CALL(*read_source, Close())
+      .WillRepeatedly(Return(HttpResponse{}));
+
+  ObjectReadStreambuf buf(
+      ReadObjectRangeRequest("my-bucket", "my-object")
+          .set_option(ReadRange(0, 20)),
+      std::move(read_source));
+
+  std::istream stream(&buf);
+  std::vector<char> v(25);
+  stream.read(v.data(), 10);
+  EXPECT_TRUE(log.ExtractLines().empty());
+  stream.read(v.data() + 10, 15);
+  EXPECT_TRUE(log.ExtractLines().empty());
+
+  EXPECT_EQ(buf.Remain().value(), -5);
+
+  buf.Close();
+  auto lines = log.ExtractLines();
+  EXPECT_EQ(lines.size(), 1);
+  EXPECT_THAT(
+      lines[0],
+      HasSubstr(
+          "storage: received 5 more bytes than requested from GCS for bucket "
+          "\"my-bucket\", object \"my-object\""));
+
+  buf.Close();
+  EXPECT_TRUE(log.ExtractLines().empty());
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/object_read_streambuf_test.cc
+++ b/google/cloud/storage/internal/object_read_streambuf_test.cc
@@ -213,6 +213,99 @@ TEST(ObjectReadStreambufTest, OverrunLogging) {
   EXPECT_TRUE(log.ExtractLines().empty());
 }
 
+TEST(ObjectReadStreambufTest, OverrunLoggingCharByChar) {
+  ScopedLog log;
+  auto read_source = std::make_unique<testing::MockObjectReadSource>();
+  EXPECT_CALL(*read_source, IsOpen()).WillRepeatedly(Return(true));
+  EXPECT_CALL(*read_source, Read)
+      .WillOnce(Return(ReadSourceResult{15, {}}))
+      .WillRepeatedly(Return(ReadSourceResult{0, {}}));
+  EXPECT_CALL(*read_source, Close())
+      .WillRepeatedly(Return(HttpResponse{}));
+
+  ObjectReadStreambuf buf(
+      ReadObjectRangeRequest("my-bucket", "my-object")
+          .set_option(ReadRange(0, 10)),
+      std::move(read_source));
+
+  std::istream stream(&buf);
+  
+  // Read character by character
+  int count = 0;
+  while (stream.get() != EOF) {
+    ++count;
+  }
+  EXPECT_EQ(count, 15);
+  EXPECT_TRUE(log.ExtractLines().empty());
+
+  EXPECT_EQ(buf.Remain().value(), -5);
+
+  buf.Close();
+  auto lines = log.ExtractLines();
+  EXPECT_EQ(lines.size(), 1);
+  EXPECT_THAT(
+      lines[0],
+      HasSubstr(
+          "storage: received 5 more bytes than requested from GCS for bucket "
+          "\"my-bucket\", object \"my-object\""));
+}
+
+TEST(ObjectReadStreambufTest, ReadLastLessIndexNoLogging) {
+  ScopedLog log;
+  auto read_source = std::make_unique<testing::MockObjectReadSource>();
+  EXPECT_CALL(*read_source, IsOpen()).WillRepeatedly(Return(true));
+  EXPECT_CALL(*read_source, Read)
+      .WillOnce(Return(ReadSourceResult{50, {}}))
+      .WillRepeatedly(Return(ReadSourceResult{0, {}}));
+  EXPECT_CALL(*read_source, Close())
+      .WillRepeatedly(Return(HttpResponse{}));
+
+  ObjectReadStreambuf buf(
+      ReadObjectRangeRequest("my-bucket", "my-object")
+          .set_option(ReadLast(100)),
+      std::move(read_source));
+
+  std::istream stream(&buf);
+  std::vector<char> v(100);
+  stream.read(v.data(), 100);
+  
+  EXPECT_EQ(buf.Remain().value(), 50);
+
+  buf.Close();
+  EXPECT_TRUE(log.ExtractLines().empty());
+}
+
+TEST(ObjectReadStreambufTest, ReadLastOvershootLogging) {
+  ScopedLog log;
+  auto read_source = std::make_unique<testing::MockObjectReadSource>();
+  EXPECT_CALL(*read_source, IsOpen()).WillRepeatedly(Return(true));
+  EXPECT_CALL(*read_source, Read)
+      .WillOnce(Return(ReadSourceResult{60, {}}))
+      .WillRepeatedly(Return(ReadSourceResult{0, {}}));
+  EXPECT_CALL(*read_source, Close())
+      .WillRepeatedly(Return(HttpResponse{}));
+
+  ObjectReadStreambuf buf(
+      ReadObjectRangeRequest("my-bucket", "my-object")
+          .set_option(ReadLast(50)),
+      std::move(read_source));
+
+  std::istream stream(&buf);
+  std::vector<char> v(100);
+  stream.read(v.data(), 100);
+  
+  EXPECT_EQ(buf.Remain().value(), -10);
+
+  buf.Close();
+  auto lines = log.ExtractLines();
+  EXPECT_EQ(lines.size(), 1);
+  EXPECT_THAT(
+      lines[0],
+      HasSubstr(
+          "storage: received 10 more bytes than requested from GCS for bucket "
+          "\"my-bucket\", object \"my-object\""));
+}
+
 }  // namespace
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/object_read_streambuf_test.cc
+++ b/google/cloud/storage/internal/object_read_streambuf_test.cc
@@ -366,6 +366,43 @@ TEST(ObjectReadStreambufTest, TranscodingSuppressesWarning) {
   EXPECT_TRUE(log.ExtractLines().empty());
 }
 
+TEST(ObjectReadStreambufTest, FullObjectReadOverrunLogging) {
+  ScopedLog log;
+  auto read_source = std::make_unique<testing::MockObjectReadSource>();
+  EXPECT_CALL(*read_source, IsOpen()).WillRepeatedly(Return(true));
+
+  // GCS returns 15 bytes, and tells us the object size is 10 bytes (in metadata)
+  ReadSourceResult result{15, {}};
+  result.size = 10;
+
+  EXPECT_CALL(*read_source, Read)
+      .WillOnce(Return(result))
+      .WillRepeatedly(Return(ReadSourceResult{0, {}}));
+  EXPECT_CALL(*read_source, Close())
+      .WillRepeatedly(Return(HttpResponse{}));
+
+  // Full object read request (no range options)
+  ObjectReadStreambuf buf(
+      ReadObjectRangeRequest("my-bucket", "my-object"),
+      std::move(read_source));
+
+  std::istream stream(&buf);
+  std::vector<char> v(20);
+  stream.read(v.data(), 20);
+
+  // We should have remain_ = -5
+  EXPECT_EQ(buf.Remain().value(), -5);
+
+  buf.Close();
+  auto lines = log.ExtractLines();
+  EXPECT_EQ(lines.size(), 1);
+  EXPECT_THAT(
+      lines[0],
+      HasSubstr(
+          "storage: received 5 more bytes than requested from GCS for bucket "
+          "\"my-bucket\", object \"my-object\""));
+}
+
 }  // namespace
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/object_read_stream.h
+++ b/google/cloud/storage/object_read_stream.h
@@ -93,7 +93,7 @@ class ObjectReadStream : public std::basic_istream<char> {
    *
    * Note that errors may go undetected until the download completes.
    */
-  Status const& status() const& { return buf_->status(); }
+  Status status() const { return buf_ ? buf_->status() : Status{}; }
 
   /**
    * The received CRC32C checksum and the MD5 hash values as reported by GCS.
@@ -111,7 +111,9 @@ class ObjectReadStream : public std::basic_istream<char> {
    * @see https://cloud.google.com/storage/docs/hashes-etags for more
    *     information on checksums and hashes in GCS.
    */
-  std::string const& received_hash() const { return buf_->received_hash(); }
+  std::string received_hash() const {
+    return buf_ ? buf_->received_hash() : std::string{};
+  }
 
   /**
    * The locally computed checksum and hashes, as a string.
@@ -130,7 +132,9 @@ class ObjectReadStream : public std::basic_istream<char> {
    * @see https://cloud.google.com/storage/docs/hashes-etags for more
    *     information on checksums and hashes in GCS.
    */
-  std::string const& computed_hash() const { return buf_->computed_hash(); }
+  std::string computed_hash() const {
+    return buf_ ? buf_->computed_hash() : std::string{};
+  }
 
   /**
    * The headers (if any) returned by the service. For debugging only.

--- a/google/cloud/storage/object_read_stream.h
+++ b/google/cloud/storage/object_read_stream.h
@@ -77,6 +77,18 @@ class ObjectReadStream : public std::basic_istream<char> {
   void Close();
 
   /**
+   * The number of bytes remaining in the requested range.
+   *
+   * If the requested range has been fully read, or if the request did not
+   * specify a range limit (e.g. read to end), this returns `absl::nullopt`.
+   * If GCS has served more bytes than requested, this will return a negative
+   * value.
+   */
+  absl::optional<std::int64_t> Remain() const {
+    return buf_ ? buf_->Remain() : absl::nullopt;
+  }
+
+  /**
    * Report any download errors.
    *
    * Note that errors may go undetected until the download completes.

--- a/google/cloud/storage/object_read_stream.h
+++ b/google/cloud/storage/object_read_stream.h
@@ -141,7 +141,9 @@ class ObjectReadStream : public std::basic_istream<char> {
    *     the next, as we find more (or different) opportunities for
    *     optimization.
    */
-  HeadersMap const& headers() const { return buf_->headers(); }
+  HeadersMap headers() const {
+    return buf_ ? buf_->headers() : HeadersMap{};
+  }
 
   ///@{
   /**
@@ -162,18 +164,18 @@ class ObjectReadStream : public std::basic_istream<char> {
    * should fetch the object metadata when the attribute is not available.
    */
   /// The object's generation at the time of the download, if known.
-  absl::optional<std::int64_t> const& generation() const {
-    return buf_->generation();
+  absl::optional<std::int64_t> generation() const {
+    return buf_ ? buf_->generation() : absl::nullopt;
   }
 
   /// The object's metageneration at the time of the download, if known.
-  absl::optional<std::int64_t> const& metageneration() const {
-    return buf_->metageneration();
+  absl::optional<std::int64_t> metageneration() const {
+    return buf_ ? buf_->metageneration() : absl::nullopt;
   }
 
   /// The object's storage class at the time of the download, if known.
-  absl::optional<std::string> const& storage_class() const {
-    return buf_->storage_class();
+  absl::optional<std::string> storage_class() const {
+    return buf_ ? buf_->storage_class() : absl::nullopt;
   }
 
   /**
@@ -185,7 +187,9 @@ class ObjectReadStream : public std::basic_istream<char> {
    *
    * [object transcoding]: https://cloud.google.com/storage/docs/transcoding
    */
-  absl::optional<std::uint64_t> const& size() const { return buf_->size(); }
+  absl::optional<std::uint64_t> size() const {
+    return buf_ ? buf_->size() : absl::nullopt;
+  }
   ///@}
 
  private:


### PR DESCRIPTION
Implement a thread-safe, one-shot mechanism to detect when a range request is overshot, and print an actionable warning log at the end of the stream.

This is implemented for all kinds of reads Sync, Async, MRD.
The warning log contains: bucket name, object name, and the amount of extra bytes served.
