### PR TITLE
ci: isolate storage emulator tests

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -373,6 +373,7 @@ if [[ "${DOCKER_FLAG}" = "true" ]]; then
     "--env=VERBOSE_FLAG=${VERBOSE_FLAG:-}"
     "--env=USE_BAZEL_VERSION=${USE_BAZEL_VERSION:-}"
     "--env=LIBRARIES=${LIBRARIES:-}"
+    "--env=INTEGRATION_LIBRARIES=${INTEGRATION_LIBRARIES:-}"
     "--env=SHARD=${SHARD:-}"
     # Mounts an empty volume over "build-out" to isolate builds from each
     # other. Doesn't affect GCB builds, but it helps our local docker builds.

--- a/ci/cloudbuild/builds/asan.sh
+++ b/ci/cloudbuild/builds/asan.sh
@@ -27,4 +27,8 @@ args+=(--config=asan)
 io::run bazel test "${args[@]}" --test_tag_filters=-integration-test "${BAZEL_TARGETS[@]}"
 
 mapfile -t integration_args < <(integration::bazel_args)
-integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"
+if [[ "${INTEGRATION_LIBRARIES:-}" == "storage" ]]; then
+  integration::bazel_storage_with_emulators test "${args[@]}" "${integration_args[@]}"
+else
+  integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"
+fi

--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -168,7 +168,7 @@ function integration::bazel_args() {
 #
 # Runs Pub/Sub integration tests (including Pub/Sub Lite if BAZEL_TARGETS is default).
 function integration::bazel_pubsub_with_emulators() {
-  readonly EMULATOR_SCRIPT="run_integration_tests_emulator_bazel.sh"
+  local EMULATOR_SCRIPT="run_integration_tests_emulator_bazel.sh"
   if [[ $# == 0 ]]; then
     io::log_red "error: bazel verb required"
     return 1
@@ -197,7 +197,7 @@ function integration::bazel_pubsub_with_emulators() {
 
 # Runs Storage integration tests.
 function integration::bazel_storage_with_emulators() {
-  readonly EMULATOR_SCRIPT="run_integration_tests_emulator_bazel.sh"
+  local EMULATOR_SCRIPT="run_integration_tests_emulator_bazel.sh"
   if [[ $# == 0 ]]; then
     io::log_red "error: bazel verb required"
     return 1
@@ -212,7 +212,7 @@ function integration::bazel_storage_with_emulators() {
 
 # Runs Spanner integration tests.
 function integration::bazel_spanner_with_emulators() {
-  readonly EMULATOR_SCRIPT="run_integration_tests_emulator_bazel.sh"
+  local EMULATOR_SCRIPT="run_integration_tests_emulator_bazel.sh"
   if [[ $# == 0 ]]; then
     io::log_red "error: bazel verb required"
     return 1
@@ -227,7 +227,7 @@ function integration::bazel_spanner_with_emulators() {
 
 # Runs Bigtable integration tests.
 function integration::bazel_bigtable_with_emulators() {
-  readonly EMULATOR_SCRIPT="run_integration_tests_emulator_bazel.sh"
+  local EMULATOR_SCRIPT="run_integration_tests_emulator_bazel.sh"
   if [[ $# == 0 ]]; then
     io::log_red "error: bazel verb required"
     return 1
@@ -254,7 +254,7 @@ function integration::bazel_bigtable_with_emulators() {
 
 # Runs REST integration tests.
 function integration::bazel_rest_with_emulators() {
-  readonly EMULATOR_SCRIPT="run_integration_tests_emulator_bazel.sh"
+  local EMULATOR_SCRIPT="run_integration_tests_emulator_bazel.sh"
   if [[ $# == 0 ]]; then
     io::log_red "error: bazel verb required"
     return 1

--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -166,71 +166,82 @@ function integration::bazel_args() {
 #   mapfile -t integration_args < <(integration::bazel_args)
 #   integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"
 #
-function integration::bazel_with_emulators() {
+# Runs Pub/Sub integration tests (including Pub/Sub Lite if BAZEL_TARGETS is default).
+function integration::bazel_pubsub_with_emulators() {
   readonly EMULATOR_SCRIPT="run_integration_tests_emulator_bazel.sh"
   if [[ $# == 0 ]]; then
     io::log_red "error: bazel verb required"
     return 1
   fi
-
   local verb="$1"
   local args=("${@:2}")
 
-  production_integration_tests=(
-    # gRPC Utils integration tests
-    "google/cloud:internal_grpc_impersonate_service_account_integration_test"
-    # Generator integration tests
-    "generator/..."
-    # BigQuery integration tests
-    "google/cloud/bigquery/..."
-    # Compute integration tests
-    "google/cloud/compute/..."
-    # IAM and IAM Credentials integration tests
-    "google/cloud/iam/..."
-    # Logging integration tests
-    "google/cloud/logging/..."
-    # Pub/Sub Lite integration tests
-    "google/cloud/pubsublite/..."
-    # Cloud Sql Admin integration tests
-    "google/cloud/sql/integration_tests/..."
-    # Unified Rest Credentials test
-    "google/cloud:internal_unified_rest_credentials_integration_test"
-  )
+  io::log_h2 "Running Pub/Sub integration tests (with emulator)"
+  "google/cloud/pubsub/ci/${EMULATOR_SCRIPT}" \
+    bazel "${verb}" "${args[@]}" --test_tag_filters="integration-test,-ud-only"
+
+  if [[ "${BAZEL_TARGETS[*]}" != "..." ]]; then
+    return 0
+  fi
 
   production_tests_tag_filters="integration-test,-ud-only"
   if echo "${args[@]}" | grep -w -q -- "--config=msan"; then
     production_tests_tag_filters="integration-test,-no-msan,-ud-only"
   fi
 
-  io::log_h2 "Running Pub/Sub integration tests (with emulator)"
-  "google/cloud/pubsub/ci/${EMULATOR_SCRIPT}" \
-    bazel "${verb}" "${args[@]}" --test_tag_filters="integration-test,-ud-only"
+  io::log_h2 "Running Pub/Sub production integration tests"
+  bazel "${verb}" "${args[@]}" \
+    --test_tag_filters="${production_tests_tag_filters}" \
+    "google/cloud/pubsublite/..."
+}
+
+# Runs Storage integration tests.
+function integration::bazel_storage_with_emulators() {
+  readonly EMULATOR_SCRIPT="run_integration_tests_emulator_bazel.sh"
+  if [[ $# == 0 ]]; then
+    io::log_red "error: bazel verb required"
+    return 1
+  fi
+  local verb="$1"
+  local args=("${@:2}")
 
   io::log_h2 "Running Storage integration tests (with emulator)"
   "google/cloud/storage/ci/${EMULATOR_SCRIPT}" \
     bazel "${verb}" "${args[@]}" --test_tag_filters="integration-test,-ud-only"
+}
+
+# Runs Spanner integration tests.
+function integration::bazel_spanner_with_emulators() {
+  readonly EMULATOR_SCRIPT="run_integration_tests_emulator_bazel.sh"
+  if [[ $# == 0 ]]; then
+    io::log_red "error: bazel verb required"
+    return 1
+  fi
+  local verb="$1"
+  local args=("${@:2}")
 
   io::log_h2 "Running Spanner integration tests (with emulator)"
   "google/cloud/spanner/ci/${EMULATOR_SCRIPT}" \
     bazel "${verb}" "${args[@]}" --test_tag_filters="integration-test,-ud-only"
+}
+
+# Runs Bigtable integration tests.
+function integration::bazel_bigtable_with_emulators() {
+  readonly EMULATOR_SCRIPT="run_integration_tests_emulator_bazel.sh"
+  if [[ $# == 0 ]]; then
+    io::log_red "error: bazel verb required"
+    return 1
+  fi
+  local verb="$1"
+  local args=("${@:2}")
 
   io::log_h2 "Running Bigtable integration tests (with emulator)"
   "google/cloud/bigtable/ci/${EMULATOR_SCRIPT}" \
     bazel "${verb}" "${args[@]}" --test_tag_filters="integration-test,-ud-only"
 
-  io::log_h2 "Running REST integration tests (with emulator)"
-  "google/cloud/internal/ci/${EMULATOR_SCRIPT}" \
-    bazel "${verb}" "${args[@]}" --test_tag_filters="integration-test,-ud-only"
-
   if [[ "${BAZEL_TARGETS[*]}" != "..." ]]; then
-    io::log_h2 "Skipping some integration tests because BAZEL_TARGETS is not the default"
     return 0
   fi
-
-  io::log_h2 "Running integration tests that require production access"
-  bazel "${verb}" "${args[@]}" \
-    --test_tag_filters="${production_tests_tag_filters}" \
-    "${production_integration_tests[@]}"
 
   # This test is run separately because the access token changes every time and
   # that would mess up bazel's test cache for all the other tests.
@@ -239,6 +250,49 @@ function integration::bazel_with_emulators() {
   bazel "${verb}" "${args[@]}" \
     "--test_env=GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ACCESS_TOKEN=${access_token}" \
     //google/cloud/bigtable/examples:bigtable_grpc_credentials
+}
+
+# Runs REST integration tests.
+function integration::bazel_rest_with_emulators() {
+  readonly EMULATOR_SCRIPT="run_integration_tests_emulator_bazel.sh"
+  if [[ $# == 0 ]]; then
+    io::log_red "error: bazel verb required"
+    return 1
+  fi
+  local verb="$1"
+  local args=("${@:2}")
+
+  io::log_h2 "Running REST integration tests (with emulator)"
+  "google/cloud/internal/ci/${EMULATOR_SCRIPT}" \
+    bazel "${verb}" "${args[@]}" --test_tag_filters="integration-test,-ud-only"
+
+  if [[ "${BAZEL_TARGETS[*]}" != "..." ]]; then
+    return 0
+  fi
+
+  production_tests_tag_filters="integration-test,-ud-only"
+  if echo "${args[@]}" | grep -w -q -- "--config=msan"; then
+    production_tests_tag_filters="integration-test,-no-msan,-ud-only"
+  fi
+
+  io::log_h2 "Running REST production integration tests"
+  bazel "${verb}" "${args[@]}" \
+    --test_tag_filters="${production_tests_tag_filters}" \
+    "google/cloud:internal_unified_rest_credentials_integration_test"
+}
+
+# Runs combined examples integration tests.
+function integration::bazel_examples_with_emulators() {
+  if [[ $# == 0 ]]; then
+    io::log_red "error: bazel verb required"
+    return 1
+  fi
+  local verb="$1"
+  local args=("${@:2}")
+
+  if [[ "${BAZEL_TARGETS[*]}" != "..." ]]; then
+    return 0
+  fi
 
   # This test is run separately because the URL may change and that would mess
   # up Bazel's test cache for all the other tests.
@@ -260,6 +314,30 @@ function integration::bazel_with_emulators() {
     "--test_env=GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_GRPC_URL=${hello_world_grpc}" \
     "--test_env=GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_SERVICE_ACCOUNT=${GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_SERVICE_ACCOUNT}" \
     //examples/...
+}
+
+# Runs generator integration tests.
+function integration::bazel_generator_with_emulators() {
+  if [[ $# == 0 ]]; then
+    io::log_red "error: bazel verb required"
+    return 1
+  fi
+  local verb="$1"
+  local args=("${@:2}")
+
+  if [[ "${BAZEL_TARGETS[*]}" != "..." ]]; then
+    return 0
+  fi
+
+  production_tests_tag_filters="integration-test,-ud-only"
+  if echo "${args[@]}" | grep -w -q -- "--config=msan"; then
+    production_tests_tag_filters="integration-test,-no-msan,-ud-only"
+  fi
+
+  io::log_h2 "Running generator production integration tests"
+  bazel "${verb}" "${args[@]}" \
+    --test_tag_filters="${production_tests_tag_filters}" \
+    "generator/..."
 
   local bazel_output_base
   if echo "${args[@]}" | grep -w -q -- "--config=msan"; then
@@ -291,6 +369,55 @@ function integration::bazel_with_emulators() {
       ':(exclude)generator/integration_tests/golden/*_stub.h' \
       ':(exclude)generator/integration_tests/golden/streaming.cc'
   fi
+}
+
+# Runs all integration tests with bazel using emulators when possible.
+function integration::bazel_with_emulators() {
+  if [[ $# == 0 ]]; then
+    io::log_red "error: bazel verb required"
+    return 1
+  fi
+
+  local verb="$1"
+  local args=("${@:2}")
+
+  integration::bazel_pubsub_with_emulators "${verb}" "${args[@]}"
+  integration::bazel_spanner_with_emulators "${verb}" "${args[@]}"
+  integration::bazel_bigtable_with_emulators "${verb}" "${args[@]}"
+  integration::bazel_rest_with_emulators "${verb}" "${args[@]}"
+
+  if [[ "${BAZEL_TARGETS[*]}" != "..." ]]; then
+    io::log_h2 "Skipping some integration tests because BAZEL_TARGETS is not the default"
+    return 0
+  fi
+
+  production_integration_tests=(
+    # gRPC Utils integration tests
+    "google/cloud:internal_grpc_impersonate_service_account_integration_test"
+    # BigQuery integration tests
+    "google/cloud/bigquery/..."
+    # Compute integration tests
+    "google/cloud/compute/..."
+    # IAM and IAM Credentials integration tests
+    "google/cloud/iam/..."
+    # Logging integration tests
+    "google/cloud/logging/..."
+    # Cloud Sql Admin integration tests
+    "google/cloud/sql/integration_tests/..."
+  )
+
+  production_tests_tag_filters="integration-test,-ud-only"
+  if echo "${args[@]}" | grep -w -q -- "--config=msan"; then
+    production_tests_tag_filters="integration-test,-no-msan,-ud-only"
+  fi
+
+  io::log_h2 "Running production integration tests for other libraries"
+  bazel "${verb}" "${args[@]}" \
+    --test_tag_filters="${production_tests_tag_filters}" \
+    "${production_integration_tests[@]}"
+
+  integration::bazel_examples_with_emulators "${verb}" "${args[@]}"
+  integration::bazel_generator_with_emulators "${verb}" "${args[@]}"
 }
 
 # Runs integration tests with CTest using emulators. This function requires a

--- a/ci/cloudbuild/builds/msan.sh
+++ b/ci/cloudbuild/builds/msan.sh
@@ -30,4 +30,8 @@ args+=("--config=msan")
 io::run bazel test "${args[@]}" --test_tag_filters=-integration-test,-no-msan "${BAZEL_TARGETS[@]}"
 
 mapfile -t integration_args < <(integration::bazel_args)
-integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"
+if [[ "${INTEGRATION_LIBRARIES:-}" == "storage" ]]; then
+  integration::bazel_storage_with_emulators test "${args[@]}" "${integration_args[@]}"
+else
+  integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"
+fi

--- a/ci/cloudbuild/builds/tsan.sh
+++ b/ci/cloudbuild/builds/tsan.sh
@@ -32,4 +32,8 @@ args+=("--test_env=TSAN_OPTIONS=suppressions=${PROJECT_ROOT}/ci/tsan_suppression
 io::run bazel test "${args[@]}" --test_tag_filters=-integration-test "${BAZEL_TARGETS[@]}"
 
 mapfile -t integration_args < <(integration::bazel_args)
-integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"
+if [[ "${INTEGRATION_LIBRARIES:-}" == "storage" ]]; then
+  integration::bazel_storage_with_emulators test "${args[@]}" "${integration_args[@]}"
+else
+  integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"
+fi

--- a/ci/cloudbuild/builds/ubsan.sh
+++ b/ci/cloudbuild/builds/ubsan.sh
@@ -35,4 +35,8 @@ args+=("--deleted_packages=${deleted_packages:1}")
 io::run bazel test "${args[@]}" --test_tag_filters=-integration-test "${BAZEL_TARGETS[@]}"
 
 mapfile -t integration_args < <(integration::bazel_args)
-integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"
+if [[ "${INTEGRATION_LIBRARIES:-}" == "storage" ]]; then
+  integration::bazel_storage_with_emulators test "${args[@]}" "${integration_args[@]}"
+else
+  integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"
+fi

--- a/ci/cloudbuild/builds/xsan.sh
+++ b/ci/cloudbuild/builds/xsan.sh
@@ -30,4 +30,8 @@ args+=("--config=xsan")
 io::run bazel test "${args[@]}" --test_tag_filters=-integration-test "${BAZEL_TARGETS[@]}"
 
 mapfile -t integration_args < <(integration::bazel_args)
-integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"
+if [[ "${INTEGRATION_LIBRARIES:-}" == "storage" ]]; then
+  integration::bazel_storage_with_emulators test "${args[@]}" "${integration_args[@]}"
+else
+  integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"
+fi

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -50,6 +50,7 @@ substitutions:
   _TAG1: 'team-only'
   _LIBRARIES: 'all_bar_compute'
   _SHARD: '__default__'
+  _INTEGRATION_LIBRARIES: 'all'
 
 timeout: 36000s
 tags: [
@@ -126,6 +127,7 @@ steps:
   env: [
     'BAZEL_REMOTE_CACHE=https://storage.googleapis.com/${_CACHE_BUCKET}/bazel-cache/${_DISTRO}-${_BUILD_NAME}',
     'LIBRARIES=${_LIBRARIES}',
+    'INTEGRATION_LIBRARIES=${_INTEGRATION_LIBRARIES}',
     'SHARD=${_SHARD}',
     'SCCACHE_GCS_BUCKET=${_CACHE_BUCKET}',
     'SCCACHE_GCS_KEY_PREFIX=sccache/${_DISTRO}-${_BUILD_NAME}',

--- a/ci/cloudbuild/triggers/asan-pr.yaml
+++ b/ci/cloudbuild/triggers/asan-pr.yaml
@@ -24,6 +24,7 @@ name: asan-pr
 substitutions:
   _BUILD_NAME: asan
   _DISTRO: fedora-latest-bazel
+  _INTEGRATION_LIBRARIES: all_bar_storage
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/asan-storage-ci.yaml
+++ b/ci/cloudbuild/triggers/asan-storage-ci.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,11 +19,11 @@ github:
   push:
     branch: main
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
-name: asan-ci
+name: asan-storage-ci
 substitutions:
   _BUILD_NAME: asan
   _DISTRO: fedora-latest-bazel
-  _INTEGRATION_LIBRARIES: all_bar_storage
+  _INTEGRATION_LIBRARIES: storage
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/asan-storage-pr.yaml
+++ b/ci/cloudbuild/triggers/asan-storage-pr.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,14 +16,15 @@ filename: ci/cloudbuild/cloudbuild.yaml
 github:
   name: google-cloud-cpp
   owner: googleapis
-  push:
+  pullRequest:
     branch: main
+    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
-name: asan-ci
+name: asan-storage-pr
 substitutions:
   _BUILD_NAME: asan
   _DISTRO: fedora-latest-bazel
-  _INTEGRATION_LIBRARIES: all_bar_storage
-  _TRIGGER_TYPE: ci
+  _INTEGRATION_LIBRARIES: storage
+  _TRIGGER_TYPE: pr
 tags:
-- ci
+- pr

--- a/ci/cloudbuild/triggers/msan-ci.yaml
+++ b/ci/cloudbuild/triggers/msan-ci.yaml
@@ -23,6 +23,7 @@ name: msan-ci
 substitutions:
   _BUILD_NAME: msan
   _DISTRO: fedora-msan
+  _INTEGRATION_LIBRARIES: all_bar_storage
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/msan-pr.yaml
+++ b/ci/cloudbuild/triggers/msan-pr.yaml
@@ -24,6 +24,7 @@ name: msan-pr
 substitutions:
   _BUILD_NAME: msan
   _DISTRO: fedora-msan
+  _INTEGRATION_LIBRARIES: all_bar_storage
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/msan-storage-ci.yaml
+++ b/ci/cloudbuild/triggers/msan-storage-ci.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,11 +19,11 @@ github:
   push:
     branch: main
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
-name: xsan-ci
+name: msan-storage-ci
 substitutions:
-  _BUILD_NAME: xsan
-  _DISTRO: fedora-latest-bazel
-  _INTEGRATION_LIBRARIES: all_bar_storage
+  _BUILD_NAME: msan
+  _DISTRO: fedora-msan
+  _INTEGRATION_LIBRARIES: storage
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/msan-storage-pr.yaml
+++ b/ci/cloudbuild/triggers/msan-storage-pr.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,14 +16,15 @@ filename: ci/cloudbuild/cloudbuild.yaml
 github:
   name: google-cloud-cpp
   owner: googleapis
-  push:
+  pullRequest:
     branch: main
+    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
-name: xsan-ci
+name: msan-storage-pr
 substitutions:
-  _BUILD_NAME: xsan
-  _DISTRO: fedora-latest-bazel
-  _INTEGRATION_LIBRARIES: all_bar_storage
-  _TRIGGER_TYPE: ci
+  _BUILD_NAME: msan
+  _DISTRO: fedora-msan
+  _INTEGRATION_LIBRARIES: storage
+  _TRIGGER_TYPE: pr
 tags:
-- ci
+- pr

--- a/ci/cloudbuild/triggers/tsan-ci.yaml
+++ b/ci/cloudbuild/triggers/tsan-ci.yaml
@@ -23,6 +23,7 @@ name: tsan-ci
 substitutions:
   _BUILD_NAME: tsan
   _DISTRO: fedora-latest-bazel
+  _INTEGRATION_LIBRARIES: all_bar_storage
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/tsan-pr.yaml
+++ b/ci/cloudbuild/triggers/tsan-pr.yaml
@@ -24,6 +24,7 @@ name: tsan-pr
 substitutions:
   _BUILD_NAME: tsan
   _DISTRO: fedora-latest-bazel
+  _INTEGRATION_LIBRARIES: all_bar_storage
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/tsan-storage-ci.yaml
+++ b/ci/cloudbuild/triggers/tsan-storage-ci.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,11 +19,11 @@ github:
   push:
     branch: main
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
-name: xsan-ci
+name: tsan-storage-ci
 substitutions:
-  _BUILD_NAME: xsan
+  _BUILD_NAME: tsan
   _DISTRO: fedora-latest-bazel
-  _INTEGRATION_LIBRARIES: all_bar_storage
+  _INTEGRATION_LIBRARIES: storage
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/tsan-storage-pr.yaml
+++ b/ci/cloudbuild/triggers/tsan-storage-pr.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,14 +16,15 @@ filename: ci/cloudbuild/cloudbuild.yaml
 github:
   name: google-cloud-cpp
   owner: googleapis
-  push:
+  pullRequest:
     branch: main
+    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
-name: xsan-ci
+name: tsan-storage-pr
 substitutions:
-  _BUILD_NAME: xsan
+  _BUILD_NAME: tsan
   _DISTRO: fedora-latest-bazel
-  _INTEGRATION_LIBRARIES: all_bar_storage
-  _TRIGGER_TYPE: ci
+  _INTEGRATION_LIBRARIES: storage
+  _TRIGGER_TYPE: pr
 tags:
-- ci
+- pr

--- a/ci/cloudbuild/triggers/ubsan-ci.yaml
+++ b/ci/cloudbuild/triggers/ubsan-ci.yaml
@@ -23,6 +23,7 @@ name: ubsan-ci
 substitutions:
   _BUILD_NAME: ubsan
   _DISTRO: fedora-latest-bazel
+  _INTEGRATION_LIBRARIES: all_bar_storage
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/ubsan-pr.yaml
+++ b/ci/cloudbuild/triggers/ubsan-pr.yaml
@@ -24,6 +24,7 @@ name: ubsan-pr
 substitutions:
   _BUILD_NAME: ubsan
   _DISTRO: fedora-latest-bazel
+  _INTEGRATION_LIBRARIES: all_bar_storage
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/ubsan-storage-ci.yaml
+++ b/ci/cloudbuild/triggers/ubsan-storage-ci.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,11 +19,11 @@ github:
   push:
     branch: main
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
-name: xsan-ci
+name: ubsan-storage-ci
 substitutions:
-  _BUILD_NAME: xsan
+  _BUILD_NAME: ubsan
   _DISTRO: fedora-latest-bazel
-  _INTEGRATION_LIBRARIES: all_bar_storage
+  _INTEGRATION_LIBRARIES: storage
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/ubsan-storage-pr.yaml
+++ b/ci/cloudbuild/triggers/ubsan-storage-pr.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,14 +16,15 @@ filename: ci/cloudbuild/cloudbuild.yaml
 github:
   name: google-cloud-cpp
   owner: googleapis
-  push:
+  pullRequest:
     branch: main
+    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
-name: xsan-ci
+name: ubsan-storage-pr
 substitutions:
-  _BUILD_NAME: xsan
+  _BUILD_NAME: ubsan
   _DISTRO: fedora-latest-bazel
-  _INTEGRATION_LIBRARIES: all_bar_storage
-  _TRIGGER_TYPE: ci
+  _INTEGRATION_LIBRARIES: storage
+  _TRIGGER_TYPE: pr
 tags:
-- ci
+- pr

--- a/ci/cloudbuild/triggers/xsan-pr.yaml
+++ b/ci/cloudbuild/triggers/xsan-pr.yaml
@@ -24,6 +24,7 @@ name: xsan-pr
 substitutions:
   _BUILD_NAME: xsan
   _DISTRO: fedora-latest-bazel
+  _INTEGRATION_LIBRARIES: all_bar_storage
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/xsan-storage-ci.yaml
+++ b/ci/cloudbuild/triggers/xsan-storage-ci.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,11 +19,11 @@ github:
   push:
     branch: main
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
-name: xsan-ci
+name: xsan-storage-ci
 substitutions:
   _BUILD_NAME: xsan
   _DISTRO: fedora-latest-bazel
-  _INTEGRATION_LIBRARIES: all_bar_storage
+  _INTEGRATION_LIBRARIES: storage
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/xsan-storage-pr.yaml
+++ b/ci/cloudbuild/triggers/xsan-storage-pr.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,14 +16,15 @@ filename: ci/cloudbuild/cloudbuild.yaml
 github:
   name: google-cloud-cpp
   owner: googleapis
-  push:
+  pullRequest:
     branch: main
+    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
-name: xsan-ci
+name: xsan-storage-pr
 substitutions:
   _BUILD_NAME: xsan
   _DISTRO: fedora-latest-bazel
-  _INTEGRATION_LIBRARIES: all_bar_storage
-  _TRIGGER_TYPE: ci
+  _INTEGRATION_LIBRARIES: storage
+  _TRIGGER_TYPE: pr
 tags:
-- ci
+- pr


### PR DESCRIPTION
Crashes in the storage emulator has made the various sanitizer builds flaky. This PR isolates use of the storage emulator to separate builds where they can ideally be rehabilitated.