### PR TITLE
impl(oauth2): also exclude mtls regional endpoints from RAB

### DIFF
--- a/google/cloud/internal/oauth2_regional_access_boundary_token_manager.cc
+++ b/google/cloud/internal/oauth2_regional_access_boundary_token_manager.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/internal/rest_response.h"
 #include "google/cloud/log.h"
 #include "absl/strings/str_cat.h"
+#include <array>
 
 namespace google {
 namespace cloud {
@@ -159,9 +160,19 @@ RegionalAccessBoundaryTokenManager::RegionalAccessBoundaryTokenManager(
 
 bool RegionalAccessBoundaryTokenManager::DoesEndpointRequireToken(
     std::string_view endpoint) {
+  static constexpr std::array<char const*, 4> kRegionalEndpointSuffixes = {
+      ".rep.googleapis.com",
+      ".rep.sandbox.googleapis.com",
+      ".rep.mtls.googleapis.com",
+      ".rep.mtls.sandbox.googleapis.com",
+  };
+
   return absl::EndsWithIgnoreCase(endpoint, ".googleapis.com") &&
-         !absl::EndsWithIgnoreCase(endpoint, ".rep.googleapis.com") &&
-         !absl::EndsWithIgnoreCase(endpoint, (".rep.sandbox.googleapis.com"));
+         std::all_of(kRegionalEndpointSuffixes.begin(),
+                     kRegionalEndpointSuffixes.end(),
+                     [&](std::string_view suffix) {
+                       return !absl::EndsWithIgnoreCase(endpoint, suffix);
+                     });
 }
 
 bool RegionalAccessBoundaryTokenManager::IsTokenValid(

--- a/google/cloud/internal/oauth2_regional_access_boundary_token_manager.cc
+++ b/google/cloud/internal/oauth2_regional_access_boundary_token_manager.cc
@@ -160,7 +160,7 @@ RegionalAccessBoundaryTokenManager::RegionalAccessBoundaryTokenManager(
 
 bool RegionalAccessBoundaryTokenManager::DoesEndpointRequireToken(
     std::string_view endpoint) {
-  static constexpr std::array<char const*, 4> kRegionalEndpointSuffixes = {
+  static constexpr std::array<std::string_view, 4> kRegionalEndpointSuffixes = {
       ".rep.googleapis.com",
       ".rep.sandbox.googleapis.com",
       ".rep.mtls.googleapis.com",

--- a/google/cloud/internal/oauth2_regional_access_boundary_token_manager_test.cc
+++ b/google/cloud/internal/oauth2_regional_access_boundary_token_manager_test.cc
@@ -120,12 +120,18 @@ TEST_F(RegionalAccessBoundaryTokenManagerTest,
   auto header = manager->GetAllowedLocationsHeader(
       request, std::chrono::system_clock::now(), "service.rep.googleapis.com");
   EXPECT_THAT(header, IsOkAndHolds(IsEmpty()));
-
+  auto header_mtls = manager->GetAllowedLocationsHeader(
+      request, std::chrono::system_clock::now(),
+      "service.rep.mtls.googleapis.com");
+  EXPECT_THAT(header_mtls, IsOkAndHolds(IsEmpty()));
   auto header_sandbox = manager->GetAllowedLocationsHeader(
       request, std::chrono::system_clock::now(),
       "service.rep.sandbox.googleapis.com");
   EXPECT_THAT(header_sandbox, IsOkAndHolds(IsEmpty()));
-
+  auto header_mtls_sandbox = manager->GetAllowedLocationsHeader(
+      request, std::chrono::system_clock::now(),
+      "service.rep.mtls.sandbox.googleapis.com");
+  EXPECT_THAT(header_mtls_sandbox, IsOkAndHolds(IsEmpty()));
   auto header_non_gdu = manager->GetAllowedLocationsHeader(
       request, std::chrono::system_clock::now(), "service.bar.com");
   EXPECT_THAT(header_non_gdu, IsOkAndHolds(IsEmpty()));


### PR DESCRIPTION
Expand the collection of potential regional endpoint suffixes that do not need location tokens to include mtls regional endpoints.