### PR TITLE
feat(storage): log additional bytes received from GCS in read path

### DIFF
--- a/google/cloud/storage/internal/object_read_streambuf.cc
+++ b/google/cloud/storage/internal/object_read_streambuf.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/storage/hash_mismatch_error.h"
 #include "google/cloud/storage/internal/hash_function.h"
 #include "google/cloud/internal/make_status.h"
+#include "google/cloud/log.h"
 #include <algorithm>
 #include <cstring>
 #include <memory>
@@ -37,6 +38,18 @@ std::streamoff InitialOffset(ReadObjectRangeRequest const& request) {
   return request.StartingByte();
 }
 
+absl::optional<std::int64_t> ExpectedBytes(
+    ReadObjectRangeRequest const& request) {
+  if (request.HasOption<ReadRange>()) {
+    auto const& range = request.GetOption<ReadRange>().value();
+    return range.end - range.begin;
+  }
+  if (request.HasOption<ReadLast>()) {
+    return request.GetOption<ReadLast>().value();
+  }
+  return absl::nullopt;
+}
+
 }  // namespace
 
 ObjectReadStreambuf::ObjectReadStreambuf(
@@ -45,14 +58,20 @@ ObjectReadStreambuf::ObjectReadStreambuf(
     : source_(std::move(source)),
       source_pos_(InitialOffset(request)),
       hash_function_(CreateHashFunction(request)),
-      hash_validator_(CreateHashValidator(request)) {}
+      hash_validator_(CreateHashValidator(request)),
+      bucket_name_(request.bucket_name()),
+      object_name_(request.object_name()),
+      expected_bytes_(ExpectedBytes(request)) {}
 
-ObjectReadStreambuf::ObjectReadStreambuf(ReadObjectRangeRequest const&,
+ObjectReadStreambuf::ObjectReadStreambuf(ReadObjectRangeRequest const& request,
                                          Status status)
     : source_(new ObjectReadErrorSource(status)),
       source_pos_(-1),
       hash_validator_(CreateNullHashValidator()),
-      status_(std::move(status)) {}
+      status_(std::move(status)),
+      bucket_name_(request.bucket_name()),
+      object_name_(request.object_name()),
+      expected_bytes_(ExpectedBytes(request)) {}
 
 ObjectReadStreambuf::pos_type ObjectReadStreambuf::seekpos(
     pos_type /*pos*/, std::ios_base::openmode /*which*/) {
@@ -77,6 +96,16 @@ ObjectReadStreambuf::pos_type ObjectReadStreambuf::seekoff(
 bool ObjectReadStreambuf::IsOpen() const { return source_->IsOpen(); }
 
 void ObjectReadStreambuf::Close() {
+  if (expected_bytes_.has_value() && total_bytes_received_ > *expected_bytes_) {
+    if (!transformation().has_value()) {
+      GCP_LOG(WARNING) << "storage: received "
+                       << (total_bytes_received_ - *expected_bytes_)
+                       << " more bytes than requested from GCS for bucket "
+                       << bucket_name_ << ", object " << object_name_;
+    }
+    expected_bytes_ = absl::nullopt;
+  }
+
   auto response = source_->Close();
   if (!response.ok()) {
     ReportError(std::move(response).status());
@@ -223,6 +252,8 @@ std::streamsize ObjectReadStreambuf::xsgetn(char* s, std::streamsize count) {
   if (!storage_class_) storage_class_ = std::move(read->storage_class);
   if (!size_) size_ = std::move(read->size);
   if (!transformation_) transformation_ = std::move(read->transformation);
+
+  total_bytes_received_ += read->bytes_received;
 
   if (source_pos_ >= 0) {
     source_pos_ += static_cast<std::streamoff>(read->bytes_received);

--- a/google/cloud/storage/internal/object_read_streambuf.h
+++ b/google/cloud/storage/internal/object_read_streambuf.h
@@ -106,6 +106,10 @@ class ObjectReadStreambuf : public std::basic_streambuf<char> {
   absl::optional<std::string> storage_class_;
   absl::optional<std::uint64_t> size_;
   absl::optional<std::string> transformation_;
+  std::string bucket_name_;
+  std::string object_name_;
+  absl::optional<std::int64_t> expected_bytes_;
+  std::int64_t total_bytes_received_ = 0;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/object_read_streambuf_test.cc
+++ b/google/cloud/storage/internal/object_read_streambuf_test.cc
@@ -14,8 +14,8 @@
 
 #include "google/cloud/storage/internal/object_read_streambuf.h"
 #include "google/cloud/storage/testing/mock_client.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include <gmock/gmock.h>
-#include <memory>
 #include <utility>
 #include <vector>
 
@@ -171,6 +171,84 @@ TEST(ObjectReadStreambufTest, WrongSeek) {
   stream.clear();
   stream.seekg(0, std::ios_base::end);
   EXPECT_TRUE(stream.fail());
+}
+
+TEST(ObjectReadStreambufTest, LogsWarningOnExcessBytes) {
+  testing_util::ScopedLog log;
+  auto read_source = std::make_unique<testing::MockObjectReadSource>();
+  EXPECT_CALL(*read_source, IsOpen()).WillRepeatedly(Return(true));
+  EXPECT_CALL(*read_source, Read).WillOnce(Return(ReadSourceResult{15, {}}));
+  EXPECT_CALL(*read_source, Close())
+      .WillOnce(Return(HttpResponse{200, "OK", {}}));
+
+  ObjectReadStreambuf buf(
+      ReadObjectRangeRequest("test-bucket", "test-object")
+          .set_option(ReadRange(0, 10)),
+      std::move(read_source));
+
+  std::istream stream(&buf);
+  std::vector<char> v(1024);
+  stream.read(v.data(), 15);
+  buf.Close();
+
+  auto const log_lines = log.ExtractLines();
+  EXPECT_THAT(
+      log_lines,
+      testing::Contains(testing::HasSubstr(
+          "storage: received 5 more bytes than requested from GCS for bucket "
+          "test-bucket, object test-object")));
+}
+
+TEST(ObjectReadStreambufTest, NoWarningWhenExactBytesReceived) {
+  testing_util::ScopedLog log;
+  auto read_source = std::make_unique<testing::MockObjectReadSource>();
+  EXPECT_CALL(*read_source, IsOpen()).WillRepeatedly(Return(true));
+  EXPECT_CALL(*read_source, Read).WillOnce(Return(ReadSourceResult{10, {}}));
+  EXPECT_CALL(*read_source, Close())
+      .WillOnce(Return(HttpResponse{200, "OK", {}}));
+
+  ObjectReadStreambuf buf(
+      ReadObjectRangeRequest("test-bucket", "test-object")
+          .set_option(ReadRange(0, 10)),
+      std::move(read_source));
+
+  std::istream stream(&buf);
+  std::vector<char> v(1024);
+  stream.read(v.data(), 10);
+  buf.Close();
+
+  auto const log_lines = log.ExtractLines();
+  EXPECT_THAT(
+      log_lines,
+      testing::Not(testing::Contains(testing::HasSubstr(
+          "more bytes than requested from GCS for bucket"))));
+}
+
+TEST(ObjectReadStreambufTest, NoWarningWhenDecompressed) {
+  testing_util::ScopedLog log;
+  auto read_source = std::make_unique<testing::MockObjectReadSource>();
+  EXPECT_CALL(*read_source, IsOpen()).WillRepeatedly(Return(true));
+  auto response = ReadSourceResult{15, {}};
+  response.transformation = "gunzipped";
+  EXPECT_CALL(*read_source, Read).WillOnce(Return(response));
+  EXPECT_CALL(*read_source, Close())
+      .WillOnce(Return(HttpResponse{200, "OK", {}}));
+
+  ObjectReadStreambuf buf(
+      ReadObjectRangeRequest("test-bucket", "test-object")
+          .set_option(ReadRange(0, 10)),
+      std::move(read_source));
+
+  std::istream stream(&buf);
+  std::vector<char> v(1024);
+  stream.read(v.data(), 15);
+  buf.Close();
+
+  auto const log_lines = log.ExtractLines();
+  EXPECT_THAT(
+      log_lines,
+      testing::Not(testing::Contains(testing::HasSubstr(
+          "more bytes than requested from GCS for bucket"))));
 }
 
 }  // namespace


### PR DESCRIPTION
When the GCS client requests a specific range of bytes but the transport provides more bytes than expected, we now emit a warning log. This matches the behavior of other GCS client libraries and aids in debugging. Decompressed objects are ignored because their wire size varies from the requested size.

Fixes: #475824752

[Generated-by: AI]