### PR TITLE
test(auth): verify malformed JSON array payloads do not crash credentials parser

### DIFF
--- a/google/cloud/internal/oauth2_compute_engine_credentials_test.cc
+++ b/google/cloud/internal/oauth2_compute_engine_credentials_test.cc
@@ -224,6 +224,7 @@ TEST(ComputeEngineCredentialsTest, ParseMetadataServerResponse) {
       {R"js({"email": "foo@bar.baz"})js",
        ServiceAccountMetadata{{}, "foo@bar.baz", "googleapis.com"}},
       {R"js({})js", ServiceAccountMetadata{{}, "", "googleapis.com"}},
+      {R"js([])js", ServiceAccountMetadata{{}, "", "googleapis.com"}},
   };
 
   for (auto const& test : cases) {


### PR DESCRIPTION
`nlohmann::json` library safely returns `.end()` on non-object types. Added this test to explicitly verify and enforce this type-safe behavior moving forward.