### PR TITLE
ci: disable datacatalog quickstart as service is deprecated

### DIFF
--- a/google/cloud/datacatalog/CMakeLists.txt
+++ b/google/cloud/datacatalog/CMakeLists.txt
@@ -25,12 +25,4 @@ if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     target_link_libraries(datacatalog_quickstart
                           PRIVATE google-cloud-cpp::datacatalog)
     google_cloud_cpp_add_common_options(datacatalog_quickstart)
-    add_test(
-        NAME datacatalog_quickstart
-        COMMAND
-            cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
-            $<TARGET_FILE:datacatalog_quickstart> GOOGLE_CLOUD_PROJECT
-            GOOGLE_CLOUD_CPP_TEST_REGION)
-    set_tests_properties(datacatalog_quickstart
-                         PROPERTIES LABELS "integration-test;quickstart")
 endif ()


### PR DESCRIPTION
The deprecated datacatalog service is denying RPCs to its endpoint. This PR disables the quickstart to get CI passing. The library for the deprecated service will be removed in a future PR, tracked by  #16165.