### PR TITLE
ci: enable windows-cmake on free runners

### DIFF
--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -104,8 +104,6 @@ jobs:
       execute-integration-tests: true
     secrets: inherit
   windows-cmake:
-    # Disabled
-    if: false
     name: Windows-CMake
     needs: [pre-flight]
     uses: ./.github/workflows/windows-cmake.yml


### PR DESCRIPTION
Now that the large hosted runners with the same names as the default runners have been removed from the pool of available runners, the windows-cmake workflow will execute on the default runner `windows-2022`.