### PR TITLE
ci: use sccache v0.10.0 with C++20

### DIFF
--- a/ci/cloudbuild/dockerfiles/fedora-latest-cxx20.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-latest-cxx20.Dockerfile
@@ -179,7 +179,7 @@ RUN curl -fsSL https://github.com/grpc/grpc/archive/v1.81.0.tar.gz | \
     cd /var/tmp && rm -fr build
 
 WORKDIR /var/tmp/sccache
-RUN curl -fsSL https://github.com/mozilla/sccache/releases/download/v0.15.0/sccache-v0.15.0-x86_64-unknown-linux-musl.tar.gz | \
+RUN curl -fsSL https://github.com/mozilla/sccache/releases/download/v0.10.0/sccache-v0.10.0-x86_64-unknown-linux-musl.tar.gz | \
     tar -zxf - --strip-components=1 && \
     mkdir -p /usr/local/bin && \
     mv sccache /usr/local/bin/sccache && \


### PR DESCRIPTION
After upgrading to sccache v0.15.0, the cxx-20 build time tripled. I don't have a good explanation for why this occurred, but the increased time began on the next commit after upgrading to v0.15.0 from v0.10.0. We will continue to monitor the build time after this PR is merged to determine if reverting the sccache version helped.