### PR TITLE
feat(bigtable): add explicit instance MakeDataConnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ the APIs in these libraries are stable, and are ready for production use.
 
 - [Agent Registry API](/google/cloud/agentregistry/README.md)
 
+### [Bigtable](/google/cloud/bigtable/README.md)
+
+- Explicit instance declaration is now encouraged during client initialization via a new overload of `MakeDataConnection` that takes a `std::vector<InstanceResource>`. Specifying the target instances at client startup enables optimizing connection pooling (pre-warming/priming channels) and telemetry.
+
+  ```cpp
+  #include "google/cloud/bigtable/data_connection.h"
+
+  namespace cbt = ::google::cloud::bigtable;
+
+  auto connection = cbt::MakeDataConnection(
+      {cbt::InstanceResource(google::cloud::Project("my-project"), "my-instance")},
+      google::cloud::Options{});
+  ```
+
 ## v3.6.0 - 2026-06
 
 ### New Libraries

--- a/google/cloud/bigtable/benchmarks/benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/benchmark.cc
@@ -130,10 +130,13 @@ void Benchmark::DeleteTable() {
 Table Benchmark::MakeTable(Options connection_opts) const {
   auto connection_options = MergeOptions(std::move(connection_opts), opts_);
   auto table_opts = Options{}.set<AppProfileIdOption>(options_.app_profile_id);
-  return Table(MakeDataConnection(std::move(connection_options)),
-               TableResource(options_.project_id, options_.instance_id,
-                             options_.table_id),
-               std::move(table_opts));
+  return Table(
+      MakeDataConnection({InstanceResource(Project(options_.project_id),
+                                           options_.instance_id)},
+                         std::move(connection_options)),
+      TableResource(options_.project_id, options_.instance_id,
+                    options_.table_id),
+      std::move(table_opts));
 }
 
 google::cloud::StatusOr<BenchmarkResult> Benchmark::PopulateTable() {

--- a/google/cloud/bigtable/benchmarks/embedded_server_test.cc
+++ b/google/cloud/bigtable/benchmarks/embedded_server_test.cc
@@ -76,7 +76,9 @@ TEST(EmbeddedServer, TableApply) {
           .set<GrpcCredentialOption>(grpc::InsecureChannelCredentials())
           .set<EndpointOption>(server->address());
 
-  Table table(MakeDataConnection(options),
+  Table table(MakeDataConnection(
+                  {InstanceResource(Project("fake-project"), "fake-instance")},
+                  std::move(options)),
               TableResource("fake-project", "fake-instance", "fake-table"));
 
   SingleRowMutation mutation("row1",
@@ -101,7 +103,9 @@ TEST(EmbeddedServer, TableBulkApply) {
           .set<GrpcCredentialOption>(grpc::InsecureChannelCredentials())
           .set<EndpointOption>(server->address());
 
-  Table table(MakeDataConnection(options),
+  Table table(MakeDataConnection(
+                  {InstanceResource(Project("fake-project"), "fake-instance")},
+                  std::move(options)),
               TableResource("fake-project", "fake-instance", "fake-table"));
 
   BulkMutation bulk;
@@ -128,7 +132,9 @@ TEST(EmbeddedServer, ReadRows1) {
           .set<GrpcCredentialOption>(grpc::InsecureChannelCredentials())
           .set<EndpointOption>(server->address());
 
-  Table table(MakeDataConnection(options),
+  Table table(MakeDataConnection(
+                  {InstanceResource(Project("fake-project"), "fake-instance")},
+                  std::move(options)),
               TableResource("fake-project", "fake-instance", "fake-table"));
 
   EXPECT_EQ(0, server->read_rows_count());
@@ -150,7 +156,9 @@ TEST(EmbeddedServer, ReadRows100) {
           .set<GrpcCredentialOption>(grpc::InsecureChannelCredentials())
           .set<EndpointOption>(server->address());
 
-  Table table(MakeDataConnection(options),
+  Table table(MakeDataConnection(
+                  {InstanceResource(Project("fake-project"), "fake-instance")},
+                  std::move(options)),
               TableResource("fake-project", "fake-instance", "fake-table"));
 
   EXPECT_EQ(0, server->read_rows_count());

--- a/google/cloud/bigtable/benchmarks/mutation_batcher_throughput_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/mutation_batcher_throughput_benchmark.cc
@@ -201,6 +201,8 @@ int main(int argc, char* argv[]) {
 
   auto table = cbt::Table(
       cbt::MakeDataConnection(
+          {cbt::InstanceResource(google::cloud::Project(options->project_id),
+                                 options->instance_id)},
           Options{}.set<google::cloud::GrpcBackgroundThreadPoolSizeOption>(
               options->max_batches)),
       cbt::TableResource(options->project_id, options->instance_id, *table_id));

--- a/google/cloud/bigtable/data_connection.cc
+++ b/google/cloud/bigtable/data_connection.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigtable/data_connection.h"
 #include "google/cloud/bigtable/internal/bigtable_stub_factory.h"
 #include "google/cloud/bigtable/internal/data_connection_impl.h"
@@ -172,6 +173,13 @@ bigtable::RowStream DataConnection::ExecuteQuery(bigtable::ExecuteQueryParams) {
   return RowStream(
       std::make_unique<bigtable_internal::StatusOnlyResultSetSource>(
           Status(StatusCode::kUnimplemented, "not implemented")));
+}
+
+std::shared_ptr<DataConnection> MakeDataConnection(
+    std::vector<InstanceResource> instances, Options options) {
+  options.set<experimental::InstanceChannelAffinityOption>(
+      std::move(instances));
+  return MakeDataConnection(std::move(options));
 }
 
 std::shared_ptr<DataConnection> MakeDataConnection(Options options) {

--- a/google/cloud/bigtable/data_connection.h
+++ b/google/cloud/bigtable/data_connection.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_DATA_CONNECTION_H
 
 #include "google/cloud/bigtable/filters.h"
+#include "google/cloud/bigtable/instance_resource.h"
 #include "google/cloud/bigtable/internal/bigtable_stub.h"
 #include "google/cloud/bigtable/mutation_branch.h"
 #include "google/cloud/bigtable/mutations.h"
@@ -33,6 +34,7 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <memory>
+#include <vector>
 
 namespace google {
 namespace cloud {
@@ -168,6 +170,10 @@ class DataConnection {
  * Returns a `DataConnection` object that can be used for interacting with
  * the Cloud Bigtable Data API.
  *
+ * Calling this function with a list of target @p instances automatically
+ * enables dynamic channel pooling for those instances, allowing the connection
+ * pools to scale dynamically based on outstanding RPC load.
+ *
  * The returned connection object should not be used directly; instead it
  * should be given to a `Table` instance, and methods should be invoked on
  * `Table`.
@@ -186,9 +192,27 @@ class DataConnection {
  *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
  *     options will be logged.
  *
+ * @param instances The target instances to connect to. Specifying target
+ *     instances enables dynamic channel pooling and other connection-level
+ *     optimizations.
  * @param options (optional) Configure the `DataConnection` created by this
  *     function.
  */
+std::shared_ptr<DataConnection> MakeDataConnection(
+    std::vector<InstanceResource> instances, Options options = {});
+
+/**
+ * Returns a `DataConnection` object that can be used for interacting with
+ * the Cloud Bigtable Data API.
+ *
+ * @deprecated Use the MakeDataConnection overload that accepts a vector of
+ *     instances.
+ *
+ * @param options (optional) Configure the `DataConnection` created by this
+ *     function.
+ */
+GOOGLE_CLOUD_CPP_DEPRECATED(
+    "Use the MakeDataConnection overload that accepts a vector of instances.")
 std::shared_ptr<DataConnection> MakeDataConnection(Options options = {});
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/data_connection_test.cc
+++ b/google/cloud/bigtable/data_connection_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigtable/data_connection.h"
 #include "google/cloud/bigtable/internal/bigtable_stub_factory.h"
 #include "google/cloud/bigtable/options.h"
@@ -98,6 +99,22 @@ TEST(MakeDataConnection, TracingDisabled) {
   (void)conn->Apply("table-name", SingleRowMutation("row"));
 
   EXPECT_THAT(span_catcher->GetSpans(), IsEmpty());
+}
+
+TEST(MakeDataConnection, WithInstances) {
+  InstanceResource instance_a{Project("my-project"), "instance-a"};
+  InstanceResource instance_b{Project("my-project"), "instance-b"};
+  auto conn = MakeDataConnection(
+      {instance_a, instance_b},
+      TestOptions().set<AppProfileIdOption>("user-supplied"));
+  auto options = conn->options();
+  EXPECT_TRUE(options.has<DataBackoffPolicyOption>())
+      << "Options are not defaulted in MakeDataConnection()";
+  EXPECT_EQ(options.get<AppProfileIdOption>(), "user-supplied")
+      << "User supplied Options are overridden in MakeDataConnection()";
+  ASSERT_TRUE(options.has<experimental::InstanceChannelAffinityOption>());
+  EXPECT_THAT(options.get<experimental::InstanceChannelAffinityOption>().size(),
+              Eq(2));
 }
 
 }  // namespace

--- a/google/cloud/bigtable/examples/bigtable_examples_common.cc
+++ b/google/cloud/bigtable/examples/bigtable_examples_common.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/bigtable/examples/bigtable_examples_common.h"
 #include "google/cloud/internal/getenv.h"
 #include "absl/strings/str_join.h"
@@ -53,7 +54,9 @@ Commands::value_type MakeCommandEntry(std::string const& name,
       throw Usage{std::move(os).str()};
     }
     google::cloud::bigtable::Table table(
-        google::cloud::bigtable::MakeDataConnection(),
+        google::cloud::bigtable::MakeDataConnection(
+            {google::cloud::bigtable::InstanceResource(
+                google::cloud::Project(argv[0]), argv[1])}),
         google::cloud::bigtable::TableResource(argv[0], argv[1], argv[2]));
     argv.erase(argv.begin(), argv.begin() + 3);
     function(table, argv);
@@ -118,7 +121,9 @@ Commands::value_type MakeCommandEntry(std::string const& name,
       throw Usage{std::move(os).str()};
     }
     google::cloud::bigtable::Table table(
-        google::cloud::bigtable::MakeDataConnection(),
+        google::cloud::bigtable::MakeDataConnection(
+            {google::cloud::bigtable::InstanceResource(
+                google::cloud::Project(argv[0]), argv[1])}),
         google::cloud::bigtable::TableResource(argv[0], argv[1], argv[2]));
     google::cloud::CompletionQueue cq;
     std::thread t([&cq] { cq.Run(); });

--- a/google/cloud/bigtable/examples/bigtable_hello_app_profile.cc
+++ b/google/cloud/bigtable/examples/bigtable_hello_app_profile.cc
@@ -43,7 +43,8 @@ void HelloWorldAppProfile(std::vector<std::string> const& argv) {
   std::string const& profile_id = argv[3];
 
   // Create an object to access the Cloud Bigtable Data API.
-  auto connection = cbt::MakeDataConnection();
+  auto connection = cbt::MakeDataConnection(
+      {cbt::InstanceResource(google::cloud::Project(project_id), instance_id)});
 
   // Use the default profile to write some data.
   cbt::Table write(connection,

--- a/google/cloud/bigtable/examples/bigtable_hello_world.cc
+++ b/google/cloud/bigtable/examples/bigtable_hello_world.cc
@@ -52,7 +52,8 @@ void BigtableHelloWorld(std::vector<std::string> const& argv) {
 
   //! [connect data]
   // Create an object to access the Cloud Bigtable Data API.
-  cbt::Table table(cbt::MakeDataConnection(),
+  cbt::Table table(cbt::MakeDataConnection({cbt::InstanceResource(
+                       google::cloud::Project(project_id), instance_id)}),
                    cbt::TableResource(project_id, instance_id, table_id));
   //! [connect data]
   //! [connect admin] [END bigtable_hw_connect]

--- a/google/cloud/bigtable/examples/client_samples.cc
+++ b/google/cloud/bigtable/examples/client_samples.cc
@@ -40,7 +40,12 @@ void TableSetEndpoint(std::vector<std::string> const& argv) {
     auto options = google::cloud::Options{}.set<google::cloud::EndpointOption>(
         "private.googleapis.com");
     auto resource = bigtable::TableResource(project_id, instance_id, table_id);
-    return bigtable::Table(bigtable::MakeDataConnection(options), resource);
+    return bigtable::Table(
+        bigtable::MakeDataConnection(
+            {bigtable::InstanceResource(google::cloud::Project(project_id),
+                                        instance_id)},
+            std::move(options)),
+        resource);
   }
   //! [table-set-endpoint]
   (argv.at(0), argv.at(1), argv.at(2));
@@ -66,7 +71,10 @@ void SetRetryPolicy(std::vector<std::string> const& argv) {
                                /*maximum_delay=*/std::chrono::seconds(45),
                                /*scaling=*/2.0)
                                .clone());
-    auto connection = cbt::MakeDataConnection(options);
+    auto connection = cbt::MakeDataConnection(
+        {cbt::InstanceResource(google::cloud::Project(project_id),
+                               instance_id)},
+        std::move(options));
 
     auto const table_name =
         cbt::TableResource(project_id, instance_id, table_id);
@@ -111,7 +119,12 @@ void TableWithServiceAccount(std::vector<std::string> const& argv) {
         google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
             google::cloud::MakeServiceAccountCredentials(contents));
     auto resource = bigtable::TableResource(project_id, instance_id, table_id);
-    return bigtable::Table(bigtable::MakeDataConnection(options), resource);
+    return bigtable::Table(
+        bigtable::MakeDataConnection(
+            {bigtable::InstanceResource(google::cloud::Project(project_id),
+                                        instance_id)},
+            std::move(options)),
+        resource);
   }
   //! [table-with-service-account]
   (argv.at(0), argv.at(1), argv.at(2), argv.at(3));
@@ -137,7 +150,12 @@ void TableSetUniverseDomain(std::vector<std::string> const& argv) {
 
     if (!ud_options.ok()) throw std::move(ud_options).status();
     auto resource = bigtable::TableResource(project_id, instance_id, table_id);
-    return bigtable::Table(bigtable::MakeDataConnection(*ud_options), resource);
+    return bigtable::Table(
+        bigtable::MakeDataConnection(
+            {bigtable::InstanceResource(google::cloud::Project(project_id),
+                                        instance_id)},
+            *std::move(ud_options)),
+        resource);
   }
   //! [table-set-universe-domain]
   (argv.at(0), argv.at(1), argv.at(2));

--- a/google/cloud/bigtable/examples/data_async_snippets.cc
+++ b/google/cloud/bigtable/examples/data_async_snippets.cc
@@ -350,7 +350,8 @@ void RunAll(std::vector<std::string> const& argv) {
   if (!schema) throw std::move(schema).status();
 
   using ::google::cloud::Options;
-  cbt::Table table(cbt::MakeDataConnection(),
+  cbt::Table table(cbt::MakeDataConnection({cbt::InstanceResource(
+                       google::cloud::Project(project_id), instance_id)}),
                    cbt::TableResource(project_id, instance_id, table_id),
                    Options{}.set<cbt::IdempotentMutationPolicyOption>(
                        cbt::AlwaysRetryMutationPolicy().clone()));

--- a/google/cloud/bigtable/examples/data_filter_snippets.cc
+++ b/google/cloud/bigtable/examples/data_filter_snippets.cc
@@ -579,7 +579,8 @@ void RunAll(std::vector<std::string> const& argv) {
                                   table_id, std::move(t));
   if (!schema) throw std::move(schema).status();
 
-  cbt::Table table(cbt::MakeDataConnection(),
+  cbt::Table table(cbt::MakeDataConnection({cbt::InstanceResource(
+                       google::cloud::Project(project_id), instance_id)}),
                    cbt::TableResource(project_id, instance_id, table_id));
 
   std::cout << "\nPreparing data for multiple examples" << std::endl;

--- a/google/cloud/bigtable/examples/data_snippets.cc
+++ b/google/cloud/bigtable/examples/data_snippets.cc
@@ -60,7 +60,8 @@ void ApplyRelaxedIdempotency(google::cloud::bigtable::Table const& table,
   namespace cbt = ::google::cloud::bigtable;
   [](std::string const& project_id, std::string const& instance_id,
      std::string const& table_id, std::string const& row_key) {
-    cbt::Table table(cbt::MakeDataConnection(),
+    cbt::Table table(cbt::MakeDataConnection({cbt::InstanceResource(
+                         google::cloud::Project(project_id), instance_id)}),
                      cbt::TableResource(project_id, instance_id, table_id),
                      Options{}.set<cbt::IdempotentMutationPolicyOption>(
                          cbt::AlwaysRetryMutationPolicy().clone()));
@@ -83,7 +84,8 @@ void ApplyCustomRetry(google::cloud::bigtable::Table const& table,
   namespace cbt = ::google::cloud::bigtable;
   [](std::string const& project_id, std::string const& instance_id,
      std::string const& table_id, std::string const& row_key) {
-    cbt::Table table(cbt::MakeDataConnection(),
+    cbt::Table table(cbt::MakeDataConnection({cbt::InstanceResource(
+                         google::cloud::Project(project_id), instance_id)}),
                      cbt::TableResource(project_id, instance_id, table_id),
                      Options{}.set<cbt::DataRetryPolicyOption>(
                          cbt::DataLimitedErrorCountRetryPolicy(7).clone()));
@@ -348,7 +350,10 @@ void MutateDeleteColumns(std::vector<std::string> const& argv) {
   }
   //! [connect data]
   google::cloud::bigtable::Table table(
-      google::cloud::bigtable::MakeDataConnection(),
+      google::cloud::bigtable::MakeDataConnection({
+          google::cloud::bigtable::InstanceResource(
+              google::cloud::Project(project_id), instance_id),
+      }),
       google::cloud::bigtable::TableResource(project_id, instance_id,
                                              table_id));
   //! [connect data]
@@ -408,7 +413,10 @@ void MutateDeleteRowsCommand(std::vector<std::string> const& argv) {
   auto const table_id = *it++;
   std::vector<std::string> rows(it, argv.cend());
   google::cloud::bigtable::Table table(
-      google::cloud::bigtable::MakeDataConnection(),
+      google::cloud::bigtable::MakeDataConnection({
+          google::cloud::bigtable::InstanceResource(
+              google::cloud::Project(project_id), instance_id),
+      }),
       google::cloud::bigtable::TableResource(project_id, instance_id,
                                              table_id));
   MutateDeleteRows(table, std::move(rows));
@@ -477,7 +485,10 @@ void MutateInsertUpdateRowsCommand(std::vector<std::string> const& argv) {
   auto const table_id = *it++;
   std::vector<std::string> rows(it, argv.cend());
   google::cloud::bigtable::Table table(
-      google::cloud::bigtable::MakeDataConnection(),
+      google::cloud::bigtable::MakeDataConnection({
+          google::cloud::bigtable::InstanceResource(
+              google::cloud::Project(project_id), instance_id),
+      }),
       google::cloud::bigtable::TableResource(project_id, instance_id,
                                              table_id));
   MutateInsertUpdateRows(table, std::move(rows));
@@ -708,8 +719,11 @@ void ConfigureConnectionPoolSize(std::vector<std::string> const& argv) {
      std::string const& table_id) {
     auto constexpr kPoolSize = 10;
     auto options = gc::Options{}.set<gc::GrpcNumChannelsOption>(kPoolSize);
-    cbt::Table table(cbt::MakeDataConnection(options),
-                     cbt::TableResource(project_id, instance_id, table_id));
+    cbt::Table table(
+        cbt::MakeDataConnection(
+            {cbt::InstanceResource(gc::Project(project_id), instance_id)},
+            std::move(options)),
+        cbt::TableResource(project_id, instance_id, table_id));
     std::cout << "Connected with channel pool size of " << kPoolSize << "\n";
   }
   // [END bigtable_configure_connection_pool]
@@ -732,7 +746,8 @@ void RunMutateExamples(
   if (!schema) throw std::move(schema).status();
 
   using ::google::cloud::Options;
-  cbt::Table table(cbt::MakeDataConnection(),
+  cbt::Table table(cbt::MakeDataConnection({cbt::InstanceResource(
+                       google::cloud::Project(project_id), instance_id)}),
                    cbt::TableResource(project_id, instance_id, table_id),
                    Options{}.set<cbt::IdempotentMutationPolicyOption>(
                        cbt::AlwaysRetryMutationPolicy().clone()));
@@ -763,7 +778,8 @@ void RunWriteExamples(
   if (!schema) throw std::move(schema).status();
 
   using ::google::cloud::Options;
-  cbt::Table table(cbt::MakeDataConnection(),
+  cbt::Table table(cbt::MakeDataConnection({cbt::InstanceResource(
+                       google::cloud::Project(project_id), instance_id)}),
                    cbt::TableResource(project_id, instance_id, table_id),
                    Options{}.set<cbt::IdempotentMutationPolicyOption>(
                        cbt::AlwaysRetryMutationPolicy().clone()));
@@ -829,7 +845,8 @@ void RunDataExamples(
   if (!schema) throw std::move(schema).status();
 
   using ::google::cloud::Options;
-  cbt::Table table(cbt::MakeDataConnection(),
+  cbt::Table table(cbt::MakeDataConnection({cbt::InstanceResource(
+                       google::cloud::Project(project_id), instance_id)}),
                    cbt::TableResource(project_id, instance_id, table_id),
                    Options{}.set<cbt::IdempotentMutationPolicyOption>(
                        cbt::AlwaysRetryMutationPolicy().clone()));
@@ -914,7 +931,8 @@ void RunDataExamples(
   ReadModifyWrite(table, {"read-modify-write"});
 
   if (!google::cloud::bigtable::examples::UsingEmulator()) {
-    auto client = cbt::Client(cbt::MakeDataConnection());
+    auto client = cbt::Client(cbt::MakeDataConnection({cbt::InstanceResource(
+        google::cloud::Project(project_id), instance_id)}));
     std::cout << "Running PrepareAndExecuteQuery() example" << std::endl;
     PrepareAndExecuteQuery(client, {project_id, instance_id, table_id});
   }

--- a/google/cloud/bigtable/examples/read_snippets.cc
+++ b/google/cloud/bigtable/examples/read_snippets.cc
@@ -145,7 +145,10 @@ void ReadKeysSet(std::vector<std::string> argv) {
   }
 
   google::cloud::bigtable::Table table(
-      google::cloud::bigtable::MakeDataConnection(),
+      google::cloud::bigtable::MakeDataConnection({
+          google::cloud::bigtable::InstanceResource(
+              google::cloud::Project(argv[0]), argv[1]),
+      }),
       google::cloud::bigtable::TableResource(argv[0], argv[1], argv[2]));
   argv.erase(argv.begin(), argv.begin() + 3);
 
@@ -391,7 +394,8 @@ void RunAll(std::vector<std::string> const& argv) {
                                   table_id, std::move(t));
   if (!schema) throw std::move(schema).status();
 
-  cbt::Table table(cbt::MakeDataConnection(),
+  cbt::Table table(cbt::MakeDataConnection({cbt::InstanceResource(
+                       google::cloud::Project(project_id), instance_id)}),
                    cbt::TableResource(project_id, instance_id, table_id));
 
   std::cout << "Preparing data for read examples" << std::endl;

--- a/google/cloud/bigtable/internal/stub_manager.cc
+++ b/google/cloud/bigtable/internal/stub_manager.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/internal/stub_manager.h"
+#include "google/cloud/log.h"
 #include <utility>
 
 namespace google {
@@ -39,6 +40,8 @@ std::shared_ptr<BigtableStub> StubManager::GetStub(
       iter != affinity_stubs_.end()) {
     return iter->second;
   }
+  GCP_LOG(INFO) << "Dynamic connection resolution adding new channel pool "
+                << "for instance: " << instance_name;
   auto inserted = affinity_stubs_.emplace(
       std::string{instance_name},
       stub_creation_fn_(instance_name, Priming::kNoPriming));

--- a/google/cloud/bigtable/internal/stub_manager_test.cc
+++ b/google/cloud/bigtable/internal/stub_manager_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/bigtable/instance_resource.h"
 #include "google/cloud/bigtable/table_resource.h"
 #include "google/cloud/bigtable/testing/mock_bigtable_stub.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 
@@ -27,7 +28,9 @@ namespace {
 
 using ::google::cloud::bigtable::testing::MockBigtableStub;
 using ::google::cloud::testing_util::IsOk;
+using ::testing::Contains;
 using ::testing::Eq;
+using ::testing::HasSubstr;
 using ::testing::MockFunction;
 using ::testing::StartsWith;
 
@@ -87,6 +90,7 @@ TEST(StubManagerTest, AffinityToExistingInstance) {
 }
 
 TEST(StubManagerTest, AffinityToMissingInstance) {
+  testing_util::ScopedLog log;
   bigtable::InstanceResource instance_a(Project("my-project"), "a");
   bigtable::TableResource table_a(instance_a, "my-table");
   auto mock_stub_a = std::make_shared<MockBigtableStub>();
@@ -119,6 +123,9 @@ TEST(StubManagerTest, AffinityToMissingInstance) {
   request.set_table_name(expected_table_name);
   auto result = stub->MutateRow(context, {}, request);
   EXPECT_THAT(result, IsOk());
+  EXPECT_THAT(log.ExtractLines(),
+              Contains(HasSubstr(
+                  "Dynamic connection resolution adding new channel pool")));
 }
 
 }  // namespace

--- a/google/cloud/bigtable/test_proxy/cbt_test_proxy.cc
+++ b/google/cloud/bigtable/test_proxy/cbt_test_proxy.cc
@@ -123,7 +123,8 @@ grpc::Status CbtTestProxy::CreateClient(
         grpc::StatusCode::ALREADY_EXISTS,
         absl::StrCat("Client ", request->client_id(), " already exists."));
   }
-  connections_.insert({request->client_id(), MakeDataConnection(options)});
+  connections_.insert(
+      {request->client_id(), MakeDataConnection(std::move(options))});
   return grpc::Status();
 }
 

--- a/google/cloud/bigtable/testing/table_integration_test.cc
+++ b/google/cloud/bigtable/testing/table_integration_test.cc
@@ -128,7 +128,9 @@ void TableIntegrationTest::SetUp() {
           .value_or("") == "dynamic") {
     options.set<experimental::InstanceChannelAffinityOption>({});
   }
-  data_connection_ = MakeDataConnection(options);
+  data_connection_ = MakeDataConnection(
+      {InstanceResource(Project(project_id()), instance_id())},
+      std::move(options));
 
   // In production, we cannot use `DropAllRows()` to cleanup the table because
   // the integration tests sometimes consume all the 'DropRowRangeGroup' quota.

--- a/google/cloud/bigtable/tests/data_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_integration_test.cc
@@ -129,6 +129,8 @@ TEST_F(DataIntegrationTest, TableBulkApplyThrottling) {
   // Make a custom table with throttling enabled.
   auto table =
       Table(MakeDataConnection(
+                {InstanceResource(Project(TableTestEnvironment::project_id()),
+                                  TableTestEnvironment::instance_id())},
                 Options{}.set<experimental::BulkApplyThrottlingOption>(true)),
             TableResource(TableTestEnvironment::project_id(),
                           TableTestEnvironment::instance_id(),
@@ -578,7 +580,8 @@ TEST_F(DataIntegrationTest, TableApplyWithLogging) {
   // Make a `Table` with an implementation that depends on the test's value
   // parameter.
   auto make_table = [&](Options const& options) {
-    auto conn = MakeDataConnection(options);
+    auto conn = MakeDataConnection(
+        {InstanceResource(Project(project_id()), instance_id())}, options);
     return Table(std::move(conn),
                  TableResource(project_id(), instance_id(), table_id));
   };
@@ -617,7 +620,10 @@ TEST_F(DataIntegrationTest, ClientQueryColumnFamily) {
           .set<
               bigtable::experimental::ExecuteQueryPlanRefreshRetryPolicyOption>(
               std::move(query_refresh_option));
-  auto connection = google::cloud::bigtable::MakeDataConnection(opts);
+  auto connection = google::cloud::bigtable::MakeDataConnection(
+      {google::cloud::bigtable::InstanceResource(
+          google::cloud::Project(project_id()), instance_id())},
+      opts);
   auto table =
       Table(connection, TableResource(project_id(), instance_id(), table_id));
   std::string const row_key = "row-key-for-client-query-test";
@@ -632,7 +638,7 @@ TEST_F(DataIntegrationTest, ClientQueryColumnFamily) {
       {row_key, family, column2, 0, value2},
   };
   BulkApply(table, created);
-  auto client = Client(connection, opts);
+  auto client = Client(connection, std::move(opts));
   std::vector<std::string> full_table_path =
       absl::StrSplit(table.table_name(), '/');
   auto table_name = full_table_path.back();
@@ -683,7 +689,10 @@ TEST_F(DataIntegrationTest, ClientQueryColumnFamilyWithHistory) {
           .set<
               bigtable::experimental::ExecuteQueryPlanRefreshRetryPolicyOption>(
               std::move(query_refresh_option));
-  auto connection = google::cloud::bigtable::MakeDataConnection(opts);
+  auto connection = google::cloud::bigtable::MakeDataConnection(
+      {google::cloud::bigtable::InstanceResource(
+          google::cloud::Project(project_id()), instance_id())},
+      opts);
   auto table =
       Table(connection, TableResource(project_id(), instance_id(), table_id));
   std::string const row_key = "row-key-for-history-test";
@@ -724,7 +733,7 @@ TEST_F(DataIntegrationTest, ClientQueryColumnFamilyWithHistory) {
   ASSERT_TRUE(apply_status.ok()) << apply_status.message();
 
   // Execute query using WITH_HISTORY
-  auto client = Client(connection, opts);
+  auto client = Client(connection, std::move(opts));
   std::vector<std::string> full_table_path =
       absl::StrSplit(table.table_name(), '/');
   auto table_name = full_table_path.back();
@@ -827,7 +836,10 @@ TEST_F(DataIntegrationTest, SingleColumnQuery) {
           .set<
               bigtable::experimental::ExecuteQueryPlanRefreshRetryPolicyOption>(
               std::move(query_refresh_option));
-  auto connection = google::cloud::bigtable::MakeDataConnection(opts);
+  auto connection = google::cloud::bigtable::MakeDataConnection(
+      {google::cloud::bigtable::InstanceResource(
+          google::cloud::Project(project_id()), instance_id())},
+      opts);
   auto table =
       Table(connection, TableResource(project_id(), instance_id(), table_id));
   std::string const row_key = "row-key-for-client-query-test";
@@ -842,7 +854,7 @@ TEST_F(DataIntegrationTest, SingleColumnQuery) {
       {row_key, family, column2, 0, value2},
   };
   BulkApply(table, created);
-  auto client = Client(connection, opts);
+  auto client = Client(connection, std::move(opts));
   std::vector<std::string> full_table_path =
       absl::StrSplit(table.table_name(), '/');
   auto table_name = full_table_path.back();
@@ -890,7 +902,10 @@ TEST_F(DataIntegrationTest, SingleColumnQueryWithHistory) {
           .set<
               bigtable::experimental::ExecuteQueryPlanRefreshRetryPolicyOption>(
               std::move(query_refresh_option));
-  auto connection = google::cloud::bigtable::MakeDataConnection(opts);
+  auto connection = google::cloud::bigtable::MakeDataConnection(
+      {google::cloud::bigtable::InstanceResource(
+          google::cloud::Project(project_id()), instance_id())},
+      opts);
   auto table =
       Table(connection, TableResource(project_id(), instance_id(), table_id));
   std::string const row_key = "row-key-for-history-test";
@@ -920,7 +935,7 @@ TEST_F(DataIntegrationTest, SingleColumnQueryWithHistory) {
   ASSERT_TRUE(apply_status.ok()) << apply_status.message();
 
   // Execute query using WITH_HISTORY
-  auto client = Client(connection, opts);
+  auto client = Client(connection, std::move(opts));
   std::vector<std::string> full_table_path =
       absl::StrSplit(table.table_name(), '/');
   auto table_name = full_table_path.back();
@@ -994,7 +1009,10 @@ TEST_F(DataIntegrationTest, MultiColumnQuery) {
           .set<
               bigtable::experimental::ExecuteQueryPlanRefreshRetryPolicyOption>(
               std::move(query_refresh_option));
-  auto connection = google::cloud::bigtable::MakeDataConnection(opts);
+  auto connection = google::cloud::bigtable::MakeDataConnection(
+      {google::cloud::bigtable::InstanceResource(
+          google::cloud::Project(project_id()), instance_id())},
+      opts);
   auto table =
       Table(connection, TableResource(project_id(), instance_id(), table_id));
   std::string const row_key1 = "multi-column-query-row-1";
@@ -1014,7 +1032,7 @@ TEST_F(DataIntegrationTest, MultiColumnQuery) {
   };
 
   BulkApply(table, created);
-  auto client = Client(connection, opts);
+  auto client = Client(connection, std::move(opts));
   std::vector<std::string> full_table_path =
       absl::StrSplit(table.table_name(), '/');
   auto table_name = full_table_path.back();
@@ -1061,7 +1079,10 @@ TEST_F(DataIntegrationTest, QueryWithNulls) {
           .set<
               bigtable::experimental::ExecuteQueryPlanRefreshRetryPolicyOption>(
               std::move(query_refresh_option));
-  auto connection = google::cloud::bigtable::MakeDataConnection(opts);
+  auto connection = google::cloud::bigtable::MakeDataConnection(
+      {google::cloud::bigtable::InstanceResource(
+          google::cloud::Project(project_id()), instance_id())},
+      opts);
   auto table =
       Table(connection, TableResource(project_id(), instance_id(), table_id));
   std::string const row_key1 = "query-with-nulls-row-1";
@@ -1081,7 +1102,7 @@ TEST_F(DataIntegrationTest, QueryWithNulls) {
   };
   BulkApply(table, created);
 
-  auto client = Client(connection, opts);
+  auto client = Client(connection, std::move(opts));
   std::vector<std::string> full_table_path =
       absl::StrSplit(table.table_name(), '/');
   auto table_name = full_table_path.back();

--- a/google/cloud/bigtable/tests/table_admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/table_admin_integration_test.cc
@@ -182,7 +182,8 @@ TEST_F(TableAdminIntegrationTest, CreateListGetDeleteTable) {
   create_request.set_parent(instance_name);
   create_request.set_table_id(table_id);
   ASSERT_STATUS_OK(table_admin_->CreateTable(create_request));
-  bigtable::Table table(MakeDataConnection(),
+  bigtable::Table table(MakeDataConnection({InstanceResource(
+                            Project(project_id()), instance_id())}),
                         TableResource(project_id(), instance_id(), table_id));
 
   // List tables
@@ -306,8 +307,9 @@ TEST_F(TableAdminIntegrationTest, WaitForConsistencyCheck) {
 
   // We need to mutate the data in the table and then wait for those mutations
   // to propagate to both clusters. First create a `bigtable::Table` object.
-  auto table = Table(MakeDataConnection(),
-                     TableResource(project_id(), id, random_table_id));
+  auto table =
+      Table(MakeDataConnection({InstanceResource(Project(project_id()), id)}),
+            TableResource(project_id(), id, random_table_id));
   // Insert some cells into the table.
   std::string const row_key1 = "check-consistency-row1";
   std::string const row_key2 = "check-consistency-row2";
@@ -379,7 +381,8 @@ TEST_F(TableAdminIntegrationTest, CreateListGetDeleteTableWithLogging) {
   request.set_parent(instance_name);
   request.set_table_id(table_id);
   ASSERT_STATUS_OK(table_admin->CreateTable(request));
-  bigtable::Table table(MakeDataConnection(),
+  bigtable::Table table(MakeDataConnection({InstanceResource(
+                            Project(project_id()), instance_id())}),
                         TableResource(project_id(), instance_id(), table_id));
 
   // List tables

--- a/google/cloud/bigtable/tests/table_sample_rows_integration_test.cc
+++ b/google/cloud/bigtable/tests/table_sample_rows_integration_test.cc
@@ -65,6 +65,8 @@ class SampleRowsIntegrationTest
     // disabled because it simply generates too much data.
     auto table =
         Table(MakeDataConnection(
+                  {InstanceResource(Project(TableTestEnvironment::project_id()),
+                                    TableTestEnvironment::instance_id())},
                   Options{}
                       .set<LoggingComponentsOption>({"rpc"})
                       .set<GrpcTracingOptionsOption>(TracingOptions())),
@@ -112,7 +114,9 @@ class SampleRowsIntegrationTest
 };
 
 TEST_F(SampleRowsIntegrationTest, SyncWithDataConnection) {
-  auto table = Table(MakeDataConnection(),
+  auto table = Table(MakeDataConnection({InstanceResource(
+                         Project(TableTestEnvironment::project_id()),
+                         TableTestEnvironment::instance_id())}),
                      TableResource(TableTestEnvironment::project_id(),
                                    TableTestEnvironment::instance_id(),
                                    TableTestEnvironment::table_id()));
@@ -120,7 +124,9 @@ TEST_F(SampleRowsIntegrationTest, SyncWithDataConnection) {
 };
 
 TEST_F(SampleRowsIntegrationTest, AsyncWithDataConnection) {
-  auto table = Table(MakeDataConnection(),
+  auto table = Table(MakeDataConnection({InstanceResource(
+                         Project(TableTestEnvironment::project_id()),
+                         TableTestEnvironment::instance_id())}),
                      TableResource(TableTestEnvironment::project_id(),
                                    TableTestEnvironment::instance_id(),
                                    TableTestEnvironment::table_id()));


### PR DESCRIPTION
This pull request introduces a new overload of MakeDataConnection that accepts a vector of InstanceResource objects to encourage explicit instance declaration during client initialization, enabling dynamic channel pooling and channel priming. Instances not initially named can be used, but will incur additionally latency on first use as a dynamic channel pool is created for that instance and priming is skipped in favor of immediately sending the RPC.