### PR TITLE
chore(spanner): migrate to std::optional

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -27,9 +27,9 @@
 #include "google/cloud/internal/retry_loop.h"
 #include "google/cloud/log.h"
 #include "google/cloud/status.h"
-#include "absl/types/optional.h"
 #include <grpcpp/grpcpp.h>
 #include <chrono>
+#include <optional>
 #include <thread>
 
 namespace google {
@@ -59,7 +59,7 @@ RowStream Client::Read(std::string table, KeySet keys,
   return conn_->Read({spanner_internal::MakeSingleUseTransaction(
                           Transaction::ReadOnlyOptions()),
                       std::move(table), std::move(keys), std::move(columns),
-                      ToReadOptions(internal::CurrentOptions()), absl::nullopt,
+                      ToReadOptions(internal::CurrentOptions()), std::nullopt,
                       false, std::move(directed_read_option),
                       std::move(order_by), std::move(lock_hint)});
 }
@@ -75,7 +75,7 @@ RowStream Client::Read(Transaction::SingleUseOptions transaction_options,
   return conn_->Read({spanner_internal::MakeSingleUseTransaction(
                           std::move(transaction_options)),
                       std::move(table), std::move(keys), std::move(columns),
-                      ToReadOptions(internal::CurrentOptions()), absl::nullopt,
+                      ToReadOptions(internal::CurrentOptions()), std::nullopt,
                       false, std::move(directed_read_option),
                       std::move(order_by), std::move(lock_hint)});
 }
@@ -89,7 +89,7 @@ RowStream Client::Read(Transaction transaction, std::string table, KeySet keys,
   internal::OptionsSpan span(std::move(opts));
   return conn_->Read({std::move(transaction), std::move(table), std::move(keys),
                       std::move(columns),
-                      ToReadOptions(internal::CurrentOptions()), absl::nullopt,
+                      ToReadOptions(internal::CurrentOptions()), std::nullopt,
                       false, std::move(directed_read_option),
                       std::move(order_by), std::move(lock_hint)});
 }
@@ -112,7 +112,7 @@ StatusOr<std::vector<ReadPartition>> Client::PartitionRead(
   return conn_->PartitionRead(
       {{std::move(transaction), std::move(table), std::move(keys),
         std::move(columns), ToReadOptions(internal::CurrentOptions()),
-        absl::nullopt, false, DirectedReadOption::Type{},
+        std::nullopt, false, DirectedReadOption::Type{},
         OrderBy::kOrderByUnspecified, LockHint::kLockHintUnspecified},
        ToPartitionOptions(internal::CurrentOptions())});
 }
@@ -125,7 +125,7 @@ RowStream Client::ExecuteQuery(SqlStatement statement, Options opts) {
       {spanner_internal::MakeSingleUseTransaction(
            Transaction::ReadOnlyOptions()),
        std::move(statement), QueryOptions(internal::CurrentOptions()),
-       absl::nullopt, false, std::move(directed_read_option)});
+       std::nullopt, false, std::move(directed_read_option)});
 }
 
 RowStream Client::ExecuteQuery(
@@ -138,7 +138,7 @@ RowStream Client::ExecuteQuery(
       {spanner_internal::MakeSingleUseTransaction(
            std::move(transaction_options)),
        std::move(statement), QueryOptions(internal::CurrentOptions()),
-       absl::nullopt, false, std::move(directed_read_option)});
+       std::nullopt, false, std::move(directed_read_option)});
 }
 
 RowStream Client::ExecuteQuery(Transaction transaction, SqlStatement statement,
@@ -148,7 +148,7 @@ RowStream Client::ExecuteQuery(Transaction transaction, SqlStatement statement,
   internal::OptionsSpan span(std::move(opts));
   return conn_->ExecuteQuery({std::move(transaction), std::move(statement),
                               QueryOptions(internal::CurrentOptions()),
-                              absl::nullopt, false,
+                              std::nullopt, false,
                               std::move(directed_read_option)});
 }
 
@@ -169,7 +169,7 @@ ProfileQueryResult Client::ProfileQuery(SqlStatement statement, Options opts) {
       {spanner_internal::MakeSingleUseTransaction(
            Transaction::ReadOnlyOptions()),
        std::move(statement), QueryOptions(internal::CurrentOptions()),
-       absl::nullopt, false, std::move(directed_read_option)});
+       std::nullopt, false, std::move(directed_read_option)});
 }
 
 ProfileQueryResult Client::ProfileQuery(
@@ -182,7 +182,7 @@ ProfileQueryResult Client::ProfileQuery(
       {spanner_internal::MakeSingleUseTransaction(
            std::move(transaction_options)),
        std::move(statement), QueryOptions(internal::CurrentOptions()),
-       absl::nullopt, false, std::move(directed_read_option)});
+       std::nullopt, false, std::move(directed_read_option)});
 }
 
 ProfileQueryResult Client::ProfileQuery(Transaction transaction,
@@ -192,7 +192,7 @@ ProfileQueryResult Client::ProfileQuery(Transaction transaction,
   internal::OptionsSpan span(std::move(opts));
   return conn_->ProfileQuery({std::move(transaction), std::move(statement),
                               QueryOptions(internal::CurrentOptions()),
-                              absl::nullopt, false,
+                              std::nullopt, false,
                               std::move(directed_read_option)});
 }
 
@@ -209,7 +209,7 @@ StatusOr<DmlResult> Client::ExecuteDml(Transaction transaction,
   internal::OptionsSpan span(internal::MergeOptions(std::move(opts), opts_));
   return conn_->ExecuteDml({std::move(transaction), std::move(statement),
                             QueryOptions(internal::CurrentOptions()),
-                            absl::nullopt, false, DirectedReadOption::Type{}});
+                            std::nullopt, false, DirectedReadOption::Type{}});
 }
 
 StatusOr<ProfileDmlResult> Client::ProfileDml(Transaction transaction,
@@ -218,7 +218,7 @@ StatusOr<ProfileDmlResult> Client::ProfileDml(Transaction transaction,
   internal::OptionsSpan span(internal::MergeOptions(std::move(opts), opts_));
   return conn_->ProfileDml({std::move(transaction), std::move(statement),
                             QueryOptions(internal::CurrentOptions()),
-                            absl::nullopt, false, DirectedReadOption::Type{}});
+                            std::nullopt, false, DirectedReadOption::Type{}});
 }
 
 StatusOr<ExecutionPlan> Client::AnalyzeSql(Transaction transaction,
@@ -227,7 +227,7 @@ StatusOr<ExecutionPlan> Client::AnalyzeSql(Transaction transaction,
   internal::OptionsSpan span(internal::MergeOptions(std::move(opts), opts_));
   return conn_->AnalyzeSql({std::move(transaction), std::move(statement),
                             QueryOptions(internal::CurrentOptions()),
-                            absl::nullopt, false, DirectedReadOption::Type{}});
+                            std::nullopt, false, DirectedReadOption::Type{}});
 }
 
 StatusOr<BatchDmlResult> Client::ExecuteBatchDml(

--- a/google/cloud/spanner/client_test.cc
+++ b/google/cloud/spanner/client_test.cc
@@ -26,12 +26,12 @@
 #include "google/cloud/testing_util/is_proto_equal.h"
 #include "google/cloud/testing_util/scoped_environment.h"
 #include "google/cloud/testing_util/status_matchers.h"
-#include "absl/types/optional.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
 #include <array>
 #include <chrono>
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -481,7 +481,7 @@ TEST(ClientTest, CommitMutatorSuccess) {
                       Return(ByMove(RowStream(std::move(source))))));
   EXPECT_CALL(*conn, Commit)
       .WillOnce(DoAll(SaveArg<0>(&actual_commit_params),
-                      Return(CommitResult{*timestamp, absl::nullopt})));
+                      Return(CommitResult{*timestamp, std::nullopt})));
 
   Client client(conn);
   auto mutation = MakeDeleteMutation("table", KeySet::All());
@@ -668,7 +668,7 @@ TEST(ClientTest, CommitMutatorRerunTransientFailures) {
         return Status(StatusCode::kAborted, "Aborted transaction");
       })
       .WillOnce([&timestamp](Connection::CommitParams const&) {
-        return CommitResult{*timestamp, absl::nullopt};
+        return CommitResult{*timestamp, std::nullopt};
       });
 
   auto mutator = [](Transaction const&) -> StatusOr<Mutations> {
@@ -740,7 +740,7 @@ TEST(ClientTest, CommitMutations) {
   EXPECT_CALL(*conn, Commit)
       .WillOnce([&mutation, &timestamp](Connection::CommitParams const& cp) {
         EXPECT_EQ(cp.mutations, Mutations{mutation});
-        return CommitResult{*timestamp, absl::nullopt};
+        return CommitResult{*timestamp, std::nullopt};
       });
 
   Client client(conn);
@@ -886,7 +886,7 @@ TEST(ClientTest, CommitMutatorWithTags) {
       .WillOnce([&](Connection::CommitParams const& params) {
         EXPECT_EQ(params.options.transaction_tag(), transaction_tag);
         EXPECT_THAT(params.transaction, HasTag(transaction_tag));
-        return CommitResult{*timestamp, absl::nullopt};
+        return CommitResult{*timestamp, std::nullopt};
       });
 
   Client client(conn);
@@ -928,7 +928,7 @@ TEST(ClientTest, CommitMutatorSessionAffinity) {
             EXPECT_THAT(cp.transaction, HasSession(session_name));
             EXPECT_THAT(cp.transaction, HasBegin());
             SetTransactionId(cp.transaction, "last-transaction-id");
-            return CommitResult{*timestamp, absl::nullopt};
+            return CommitResult{*timestamp, std::nullopt};
           });
   // But only after some aborts, the first of which sets the session.
   EXPECT_CALL(*conn, Commit)
@@ -967,7 +967,7 @@ TEST(ClientTest, CommitMutatorSessionNotFound) {
   EXPECT_CALL(*conn, Commit)
       .WillOnce([&timestamp](Connection::CommitParams const& cp) {
         EXPECT_THAT(cp.transaction, HasSession("session-3"));
-        return CommitResult{*timestamp, absl::nullopt};
+        return CommitResult{*timestamp, std::nullopt};
       });
 
   int n = 0;
@@ -998,7 +998,7 @@ TEST(ClientTest, CommitSessionNotFound) {
       })
       .WillOnce([&timestamp](Connection::CommitParams const& cp) {
         EXPECT_THAT(cp.transaction, HasSession("session-2"));
-        return CommitResult{*timestamp, absl::nullopt};
+        return CommitResult{*timestamp, std::nullopt};
       });
 
   int n = 0;
@@ -1046,7 +1046,7 @@ TEST(ClientTest, MaxCommitDelay) {
       .WillOnce([&timestamp](Connection::CommitParams const& cp) {
         EXPECT_EQ(cp.options.max_commit_delay(),
                   std::chrono::milliseconds(100));
-        return CommitResult{*timestamp, absl::nullopt};
+        return CommitResult{*timestamp, std::nullopt};
       });
 
   Client client(conn);
@@ -1074,7 +1074,7 @@ TEST(ClientTest, CommitAtLeastOnce) {
         EXPECT_FALSE(cp.options.request_priority().has_value());
         EXPECT_FALSE(cp.options.max_commit_delay().has_value());
         EXPECT_EQ(cp.options.transaction_tag(), transaction_tag);
-        return CommitResult{*timestamp, absl::nullopt};
+        return CommitResult{*timestamp, std::nullopt};
       });
 
   Client client(conn);

--- a/google/cloud/spanner/commit_options.h
+++ b/google/cloud/spanner/commit_options.h
@@ -18,8 +18,8 @@
 #include "google/cloud/spanner/request_priority.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/options.h"
-#include "absl/types/optional.h"
 #include <chrono>
+#include <optional>
 #include <string>
 
 namespace google {
@@ -70,13 +70,13 @@ class CommitOptions {
 
   /// Set the priority of the `spanner::Client::Commit()` call.
   CommitOptions& set_request_priority(
-      absl::optional<RequestPriority> request_priority) {
+      std::optional<RequestPriority> request_priority) {
     request_priority_ = std::move(request_priority);
     return *this;
   }
 
   /// The priority of the `spanner::Client::Commit()` call.
-  absl::optional<RequestPriority> request_priority() const {
+  std::optional<RequestPriority> request_priority() const {
     return request_priority_;
   }
 
@@ -85,25 +85,25 @@ class CommitOptions {
    * Ignored for the overload that already takes a `spanner::Transaction`.
    */
   CommitOptions& set_transaction_tag(
-      absl::optional<std::string> transaction_tag) {
+      std::optional<std::string> transaction_tag) {
     transaction_tag_ = std::move(transaction_tag);
     return *this;
   }
 
   /// The transaction tag for the `spanner::Client::Commit()` call.
-  absl::optional<std::string> const& transaction_tag() const {
+  std::optional<std::string> const& transaction_tag() const {
     return transaction_tag_;
   }
 
   // Set the max commit delay of the `spanner::Client::Commit()` call.
   CommitOptions& set_max_commit_delay(
-      absl::optional<std::chrono::milliseconds> max_commit_delay) {
+      std::optional<std::chrono::milliseconds> max_commit_delay) {
     max_commit_delay_ = std::move(max_commit_delay);
     return *this;
   }
 
   // The max commit delay for the `spanner::Client::Commit()` call.
-  absl::optional<std::chrono::milliseconds> const& max_commit_delay() const {
+  std::optional<std::chrono::milliseconds> const& max_commit_delay() const {
     return max_commit_delay_;
   }
 
@@ -111,9 +111,9 @@ class CommitOptions {
   // Note that CommitRequest.request_options.request_tag is ignored,
   // so we do not even provide a mechanism to specify one.
   bool return_stats_ = false;
-  absl::optional<RequestPriority> request_priority_;
-  absl::optional<std::string> transaction_tag_;
-  absl::optional<std::chrono::milliseconds> max_commit_delay_;
+  std::optional<RequestPriority> request_priority_;
+  std::optional<std::string> transaction_tag_;
+  std::optional<std::chrono::milliseconds> max_commit_delay_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/spanner/commit_result.h
+++ b/google/cloud/spanner/commit_result.h
@@ -19,9 +19,9 @@
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/stream_range.h"
-#include "absl/types/optional.h"
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <vector>
 
 namespace google {
@@ -44,7 +44,7 @@ struct CommitResult {
   Timestamp commit_timestamp;
 
   /// Additional statistics about the committed transaction.
-  absl::optional<CommitStats> commit_stats;
+  std::optional<CommitStats> commit_stats;
 };
 
 /**

--- a/google/cloud/spanner/connection.cc
+++ b/google/cloud/spanner/connection.cc
@@ -29,10 +29,10 @@ class StatusOnlyResultSetSource : public ResultSourceInterface {
       : status_(std::move(status)) {}
 
   StatusOr<Row> NextRow() override { return status_; }
-  absl::optional<google::spanner::v1::ResultSetMetadata> Metadata() override {
+  std::optional<google::spanner::v1::ResultSetMetadata> Metadata() override {
     return {};
   }
-  absl::optional<google::spanner::v1::ResultSetStats> Stats() const override {
+  std::optional<google::spanner::v1::ResultSetStats> Stats() const override {
     return {};
   }
 

--- a/google/cloud/spanner/connection.h
+++ b/google/cloud/spanner/connection.h
@@ -34,7 +34,7 @@
 #include "google/cloud/optional.h"
 #include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
-#include "absl/types/optional.h"
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -80,7 +80,7 @@ class Connection {
     KeySet keys;
     std::vector<std::string> columns;
     ReadOptions read_options;
-    absl::optional<std::string> partition_token;
+    std::optional<std::string> partition_token;
     bool partition_data_boost = false;  // when partition_token
     DirectedReadOption::Type directed_read_option;
     OrderBy order_by;
@@ -99,7 +99,7 @@ class Connection {
     Transaction transaction;
     SqlStatement statement;
     QueryOptions query_options;
-    absl::optional<std::string> partition_token;
+    std::optional<std::string> partition_token;
     bool partition_data_boost = false;  // when partition_token
     DirectedReadOption::Type directed_read_option;
   };

--- a/google/cloud/spanner/directed_read_replicas.h
+++ b/google/cloud/spanner/directed_read_replicas.h
@@ -16,8 +16,8 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_DIRECTED_READ_REPLICAS_H
 
 #include "google/cloud/spanner/version.h"
-#include "absl/types/optional.h"
 #include <initializer_list>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -53,19 +53,19 @@ class ReplicaSelection {
   // Replicas in the location, of any available type, will be used to
   // process the request.
   explicit ReplicaSelection(std::string location)
-      : location_(std::move(location)), type_(absl::nullopt) {}
+      : location_(std::move(location)), type_(std::nullopt) {}
 
   // Replicas of the given type, in the nearest available location, will
   // be used to process the request.
   explicit ReplicaSelection(ReplicaType type)
-      : location_(absl::nullopt), type_(type) {}
+      : location_(std::nullopt), type_(type) {}
 
-  absl::optional<std::string> const& location() const { return location_; }
-  absl::optional<ReplicaType> const& type() const { return type_; }
+  std::optional<std::string> const& location() const { return location_; }
+  std::optional<ReplicaType> const& type() const { return type_; }
 
  private:
-  absl::optional<std::string> location_;
-  absl::optional<ReplicaType> type_;
+  std::optional<std::string> location_;
+  std::optional<ReplicaType> type_;
 };
 
 inline bool operator==(ReplicaSelection const& a, ReplicaSelection const& b) {

--- a/google/cloud/spanner/doc/spanner-mocking.dox
+++ b/google/cloud/spanner/doc/spanner-mocking.dox
@@ -50,7 +50,7 @@ returned one value at a time, even if a row contains multiple values.
 
 @snippet mock_execute_query.cc simulate-streaming-results
 
-Note that the last value in the stream is indicated by an absl::optional
+Note that the last value in the stream is indicated by an std::optional
 without a value:
 
 @snippet mock_execute_query.cc simulate-streaming-end

--- a/google/cloud/spanner/integration_tests/data_types_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/data_types_integration_test.cc
@@ -767,7 +767,7 @@ TEST_F(PgDataTypeIntegrationTest, InsertAndQueryWithJson) {
       client_->ExecuteQuery(SqlStatement("SELECT Id, JsonValue FROM DataTypes"
                                          "  WHERE Id = $1",
                                          {{"p1", Value("Id-1")}}));
-  using RowType = std::tuple<std::string, absl::optional<JsonB>>;
+  using RowType = std::tuple<std::string, std::optional<JsonB>>;
   auto row = GetSingularRow(StreamOf<RowType>(rows));
   ASSERT_STATUS_OK(row);
 

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -137,7 +137,7 @@ class DefaultPartialResultSetReader : public PartialResultSetReader {
 
   void TryCancel() override { context_->TryCancel(); }
 
-  bool Read(absl::optional<std::string> const&,
+  bool Read(std::optional<std::string> const&,
             UnownedPartialResultSet& response) override {
     auto opt_status = reader_->Read(&response.result);
     response.resumption = false;
@@ -171,7 +171,7 @@ google::spanner::v1::TransactionOptions PartitionedDmlTransactionOptions() {
 }
 
 google::spanner::v1::RequestOptions_Priority ProtoRequestPriority(
-    absl::optional<spanner::RequestPriority> const& request_priority) {
+    std::optional<spanner::RequestPriority> const& request_priority) {
   if (request_priority) {
     switch (*request_priority) {
       case spanner::RequestPriority::kLow:
@@ -186,7 +186,7 @@ google::spanner::v1::RequestOptions_Priority ProtoRequestPriority(
 }
 
 google::spanner::v1::ReadRequest_OrderBy ProtoOrderBy(
-    absl::optional<spanner::OrderBy> const& order_by) {
+    std::optional<spanner::OrderBy> const& order_by) {
   if (order_by) {
     switch (*order_by) {
       case spanner::OrderBy::kOrderByUnspecified:
@@ -201,7 +201,7 @@ google::spanner::v1::ReadRequest_OrderBy ProtoOrderBy(
 }
 
 google::spanner::v1::ReadRequest_LockHint ProtoLockHint(
-    absl::optional<spanner::LockHint> const& order_by) {
+    std::optional<spanner::LockHint> const& order_by) {
   if (order_by) {
     switch (*order_by) {
       case spanner::LockHint::kLockHintUnspecified:
@@ -247,10 +247,10 @@ class StatusOnlyResultSetSource : public spanner::ResultSourceInterface {
   ~StatusOnlyResultSetSource() override = default;
 
   StatusOr<spanner::Row> NextRow() override { return status_; }
-  absl::optional<google::spanner::v1::ResultSetMetadata> Metadata() override {
+  std::optional<google::spanner::v1::ResultSetMetadata> Metadata() override {
     return {};
   }
-  absl::optional<google::spanner::v1::ResultSetStats> Stats() const override {
+  std::optional<google::spanner::v1::ResultSetStats> Stats() const override {
     return {};
   }
 
@@ -279,26 +279,26 @@ class DmlResultSetSource : public PartialResultSourceInterface {
 
   StatusOr<spanner::Row> NextRow() override { return {}; }
 
-  absl::optional<google::spanner::v1::ResultSetMetadata> Metadata() override {
+  std::optional<google::spanner::v1::ResultSetMetadata> Metadata() override {
     if (result_set_.has_metadata()) {
       return result_set_.metadata();
     }
     return {};
   }
 
-  absl::optional<google::spanner::v1::ResultSetStats> Stats() const override {
+  std::optional<google::spanner::v1::ResultSetStats> Stats() const override {
     if (result_set_.has_stats()) {
       return result_set_.stats();
     }
     return {};
   }
 
-  absl::optional<google::spanner::v1::MultiplexedSessionPrecommitToken>
+  std::optional<google::spanner::v1::MultiplexedSessionPrecommitToken>
   PrecommitToken() const override {
     if (result_set_.has_precommit_token()) {
       return result_set_.precommit_token();
     }
-    return absl::nullopt;
+    return std::nullopt;
   }
 
  private:
@@ -357,9 +357,9 @@ spanner::BatchedCommitResult FromProto(
 }
 
 template <typename T>
-absl::optional<T> GetRandomElement(
+std::optional<T> GetRandomElement(
     google::protobuf::RepeatedPtrField<T> const& m) {
-  if (m.empty()) return absl::nullopt;
+  if (m.empty()) return std::nullopt;
   std::uniform_int_distribution<decltype(m.size())> d(0, m.size() - 1);
   auto rng = internal::MakeDefaultPRNG();
   auto index = d(rng);
@@ -556,7 +556,7 @@ std::shared_ptr<SpannerStub> ConnectionImpl::GetStubBasedOnSessionMode(
 StatusOr<google::spanner::v1::Transaction> ConnectionImpl::BeginTransaction(
     SessionHolder& session, google::spanner::v1::TransactionOptions options,
     std::string request_tag, TransactionContext& ctx,
-    absl::optional<google::spanner::v1::Mutation> mutation, char const* func) {
+    std::optional<google::spanner::v1::Mutation> mutation, char const* func) {
   google::spanner::v1::BeginTransactionRequest begin;
   begin.set_session(session->session_name());
   *begin.mutable_options() = std::move(options);
@@ -597,7 +597,7 @@ StatusOr<google::spanner::v1::Transaction> ConnectionImpl::BeginTransaction(
     SessionHolder& session, google::spanner::v1::TransactionOptions options,
     std::string request_tag, TransactionContext& ctx, char const* func) {
   return BeginTransaction(session, std::move(options), std::move(request_tag),
-                          ctx, absl::nullopt, func);
+                          ctx, std::nullopt, func);
 }
 
 spanner::RowStream ConnectionImpl::ReadImpl(
@@ -1191,7 +1191,7 @@ ConnectionImpl::ExecutePartitionedDmlImpl(
                              ctx.route_to_leader, ctx.tag),
       std::move(params.statement),
       std::move(params.query_options),
-      /*partition_token=*/absl::nullopt,
+      /*partition_token=*/std::nullopt,
       /*partition_data_boost=*/false,
       spanner::DirectedReadOption::Type{}};
   auto dml_result = CommonQueryImpl<StreamingPartitionedDmlResult>(
@@ -1245,7 +1245,7 @@ StatusOr<spanner::CommitResult> ConnectionImpl::CommitImpl(
       break;
     }
     case google::spanner::v1::TransactionSelector::kBegin: {
-      absl::optional<google::spanner::v1::Mutation> mutation = absl::nullopt;
+      std::optional<google::spanner::v1::Mutation> mutation = std::nullopt;
       if (session->is_multiplexed()) {
         // Commit requests containing Mutations on multiplexed sessions require
         // a random mutation key in order for the service to generate a
@@ -1278,7 +1278,7 @@ StatusOr<spanner::CommitResult> ConnectionImpl::CommitImpl(
   char const* calling_func = __func__;
   auto retry_loop_fn =
       [&, func = std::move(calling_func)](
-          absl::optional<
+          std::optional<
               google::spanner::v1::MultiplexedSessionPrecommitToken> const&
               token) {
         if (token.has_value()) {

--- a/google/cloud/spanner/internal/connection_impl.h
+++ b/google/cloud/spanner/internal/connection_impl.h
@@ -78,7 +78,7 @@ class ConnectionImpl : public spanner::Connection {
   StatusOr<google::spanner::v1::Transaction> BeginTransaction(
       SessionHolder& session, google::spanner::v1::TransactionOptions options,
       std::string request_tag, TransactionContext& ctx,
-      absl::optional<google::spanner::v1::Mutation> mutation, char const* func);
+      std::optional<google::spanner::v1::Mutation> mutation, char const* func);
 
   StatusOr<google::spanner::v1::Transaction> BeginTransaction(
       SessionHolder& session, google::spanner::v1::TransactionOptions options,

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -29,7 +29,6 @@
 #include "google/cloud/testing_util/is_proto_equal.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "absl/time/time.h"
-#include "absl/types/optional.h"
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/time_util.h>
 #include <gmock/gmock.h>
@@ -39,6 +38,7 @@
 #include <chrono>
 #include <future>
 #include <memory>
+#include <optional>
 #include <string>
 #include <thread>
 #include <vector>
@@ -289,9 +289,9 @@ google::spanner::v1::Transaction MakeTestTransaction(
 // `commit_stats`.
 google::spanner::v1::CommitResponse MakeCommitResponse(
     spanner::Timestamp commit_timestamp,
-    absl::optional<spanner::CommitStats> commit_stats = absl::nullopt,
-    absl::optional<google::spanner::v1::MultiplexedSessionPrecommitToken>
-        precommit_token = absl::nullopt) {
+    std::optional<spanner::CommitStats> commit_stats = std::nullopt,
+    std::optional<google::spanner::v1::MultiplexedSessionPrecommitToken>
+        precommit_token = std::nullopt) {
   google::spanner::v1::CommitResponse response;
   *response.mutable_commit_timestamp() =
       commit_timestamp.get<protobuf::Timestamp>().value();
@@ -349,7 +349,7 @@ template <typename ResponseType>
 class MockStreamingReadRpc : public internal::StreamingReadRpc<ResponseType> {
  public:
   MOCK_METHOD(void, Cancel, (), (override));
-  MOCK_METHOD(absl::optional<Status>, Read, (ResponseType*), (override));
+  MOCK_METHOD(std::optional<Status>, Read, (ResponseType*), (override));
   MOCK_METHOD(RpcMetadata, GetRequestMetadata, (), (const, override));
 };
 
@@ -363,8 +363,8 @@ std::unique_ptr<MockStreamingReadRpc<ResponseType>> MakeReader(
   for (auto& response : responses) {
     EXPECT_CALL(*reader, Read)
         .InSequence(s)
-        .WillOnce(DoAll(SetArgPointee<0>(std::move(response)),
-                        Return(absl::nullopt)));
+        .WillOnce(
+            DoAll(SetArgPointee<0>(std::move(response)), Return(std::nullopt)));
   }
   EXPECT_CALL(*reader, Read).InSequence(s).WillOnce(Return(std::move(status)));
   return reader;
@@ -560,7 +560,7 @@ TEST(ConnectionImplTest, ReadDirectedRead) {
        spanner::KeySet::All(),
        {"UserId", "UserName"},
        spanner::ReadOptions{},
-       /*partition_token=*/absl::nullopt,
+       /*partition_token=*/std::nullopt,
        /*partition_data_boost=*/false,
        spanner::IncludeReplicas(
            {spanner::ReplicaSelection("us-east4"),
@@ -890,12 +890,12 @@ TEST(ConnectionImplTest, ExecuteQueryReadSuccess) {
        spanner::SqlStatement("SELECT * FROM Table")});
 
   using RowType =
-      std::tuple<std::int64_t, std::string, absl::optional<spanner::Numeric>>;
+      std::tuple<std::int64_t, std::string, std::optional<spanner::Numeric>>;
   auto stream = spanner::StreamOf<RowType>(rows);
   auto actual = std::vector<StatusOr<RowType>>{stream.begin(), stream.end()};
   EXPECT_THAT(
       actual,
-      ElementsAre(IsOkAndHolds(RowType(12, "Steve", absl::nullopt)),
+      ElementsAre(IsOkAndHolds(RowType(12, "Steve", std::nullopt)),
                   IsOkAndHolds(RowType(
                       42, "Ann", spanner::MakeNumeric(12345678, -2).value()))));
 }
@@ -931,7 +931,7 @@ TEST(ConnectionImplTest, ExecuteQueryDirectedRead) {
   auto rows = conn->ExecuteQuery(
       {txn, spanner::SqlStatement("SELECT * FROM Table"),
        spanner::QueryOptions{},
-       /*partition_token=*/absl::nullopt,
+       /*partition_token=*/std::nullopt,
        /*partition_data_boost=*/false,
        spanner::ExcludeReplicas(
            {spanner::ReplicaSelection(spanner::ReplicaType::kReadWrite),
@@ -975,14 +975,14 @@ TEST(ConnectionImplTest, ExecuteQueryPgNumericResult) {
        spanner::SqlStatement("SELECT * FROM Table")});
 
   using RowType =
-      std::tuple<spanner::PgNumeric, absl::optional<spanner::PgNumeric>>;
+      std::tuple<spanner::PgNumeric, std::optional<spanner::PgNumeric>>;
   auto stream = spanner::StreamOf<RowType>(rows);
   auto actual = std::vector<StatusOr<RowType>>{stream.begin(), stream.end()};
   EXPECT_THAT(
       actual,
       ElementsAre(
           IsOkAndHolds(RowType(spanner::MakePgNumeric(42).value(),  //
-                               absl::nullopt)),
+                               std::nullopt)),
           IsOkAndHolds(RowType(spanner::MakePgNumeric("NaN").value(),
                                spanner::MakePgNumeric(42, -2).value()))));
 }
@@ -1020,13 +1020,13 @@ TEST(ConnectionImplTest, ExecuteQueryJsonBResult) {
       {MakeSingleUseTransaction(spanner::Transaction::ReadOnlyOptions()),
        spanner::SqlStatement("SELECT * FROM Table")});
 
-  using RowType = std::tuple<spanner::JsonB, absl::optional<spanner::JsonB>>;
+  using RowType = std::tuple<spanner::JsonB, std::optional<spanner::JsonB>>;
   auto stream = spanner::StreamOf<RowType>(rows);
   auto actual = std::vector<StatusOr<RowType>>{stream.begin(), stream.end()};
   EXPECT_THAT(
       actual,
       ElementsAre(
-          IsOkAndHolds(RowType(spanner::JsonB("42"), absl::nullopt)),
+          IsOkAndHolds(RowType(spanner::JsonB("42"), std::nullopt)),
           IsOkAndHolds(RowType(spanner::JsonB("[null, null]"),
                                spanner::JsonB(R"({"a": 1, "b": 2})")))));
 }
@@ -1147,13 +1147,13 @@ TEST(ConnectionImplTest, ExecuteQueryPgOidResult) {
       {MakeSingleUseTransaction(spanner::Transaction::ReadOnlyOptions()),
        spanner::SqlStatement("SELECT * FROM Table")});
 
-  using RowType = std::tuple<spanner::PgOid, absl::optional<spanner::PgOid>>;
+  using RowType = std::tuple<spanner::PgOid, std::optional<spanner::PgOid>>;
   auto stream = spanner::StreamOf<RowType>(rows);
   auto actual = std::vector<StatusOr<RowType>>{stream.begin(), stream.end()};
   EXPECT_THAT(
       actual,
       ElementsAre(
-          IsOkAndHolds(RowType(spanner::PgOid(42), absl::nullopt)),
+          IsOkAndHolds(RowType(spanner::PgOid(42), std::nullopt)),
           IsOkAndHolds(RowType(spanner::PgOid(0), spanner::PgOid(999)))));
 }
 
@@ -1308,7 +1308,7 @@ TEST(ConnectionImplTest, QueryOptions) {
     read_options.request_priority = tc.options.request_priority();
     read_options.request_tag = tc.options.request_tag();
     auto read_params = spanner::Connection::ReadParams{
-        txn, "table", spanner::KeySet::All(), {}, read_options, absl::nullopt};
+        txn, "table", spanner::KeySet::All(), {}, read_options, std::nullopt};
     auto commit_params = spanner::Connection::CommitParams{
         txn, spanner::Mutations{},
         spanner::CommitOptions{}
@@ -1327,7 +1327,7 @@ TEST(ConnectionImplTest, QueryOptions) {
     PartialResultSet response;
     ASSERT_TRUE(TextFormat::ParseFromString(kResponseText, &response));
     EXPECT_CALL(*stream, Read)
-        .WillOnce(DoAll(SetArgPointee<0>(response), Return(absl::nullopt)));
+        .WillOnce(DoAll(SetArgPointee<0>(response), Return(std::nullopt)));
     {
       InSequence seq;
 
@@ -3430,7 +3430,7 @@ TEST(ConnectionImplTest, PartitionReadSuccess) {
                             spanner::KeySet::All(),
                             {"UserId", "UserName"},
                             read_options},
-                           {absl::nullopt, absl::nullopt, data_boost}});
+                           {std::nullopt, std::nullopt, data_boost}});
   ASSERT_STATUS_OK(result);
   EXPECT_THAT(txn,
               HasSessionAndTransaction("multiplexed", "CAFEDEAD", false, ""));
@@ -3571,7 +3571,7 @@ TEST(ConnectionImplTest, PartitionQuerySuccess) {
   StatusOr<std::vector<spanner::QueryPartition>> result = conn->PartitionQuery(
       {MakeReadOnlyTransaction(spanner::Transaction::ReadOnlyOptions()),
        sql_statement,
-       {absl::nullopt, absl::nullopt, data_boost}});
+       {std::nullopt, std::nullopt, data_boost}});
   ASSERT_STATUS_OK(result);
 
   std::vector<spanner::QueryPartition> expected_query_partitions = {
@@ -3981,7 +3981,7 @@ TEST(ConnectionImplTest, ReadRequestOrderByParameterNoOrder) {
                                       spanner::KeySet::All(),
                                       {"col"},
                                       read_options,
-                                      absl::nullopt,
+                                      std::nullopt,
                                       false,
                                       spanner::DirectedReadOption::Type{},
                                       spanner::OrderBy::kOrderByNoOrder};
@@ -4052,7 +4052,7 @@ TEST(ConnectionImplTest, ReadRequestLockHintShared) {
                                       spanner::KeySet::All(),
                                       {"col"},
                                       read_options,
-                                      absl::nullopt,
+                                      std::nullopt,
                                       false,
                                       spanner::DirectedReadOption::Type{},
                                       spanner::OrderBy::kOrderByUnspecified,

--- a/google/cloud/spanner/internal/defaults_test.cc
+++ b/google/cloud/spanner/internal/defaults_test.cc
@@ -47,19 +47,19 @@ auto gcloud_user_agent_matcher = [] {
 
 TEST(Options, Defaults) {
   testing_util::ScopedEnvironment endpoint_env(
-      "GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT", absl::nullopt);
+      "GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT", std::nullopt);
   testing_util::ScopedEnvironment authority_env(
-      "GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_AUTHORITY", absl::nullopt);
+      "GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_AUTHORITY", std::nullopt);
   testing_util::ScopedEnvironment tracing_components_env(
-      "GOOGLE_CLOUD_CPP_ENABLE_TRACING", absl::nullopt);
+      "GOOGLE_CLOUD_CPP_ENABLE_TRACING", std::nullopt);
   testing_util::ScopedEnvironment tracing_options_env(
-      "GOOGLE_CLOUD_CPP_TRACING_OPTIONS", absl::nullopt);
+      "GOOGLE_CLOUD_CPP_TRACING_OPTIONS", std::nullopt);
   testing_util::ScopedEnvironment emulator_env("SPANNER_EMULATOR_HOST",
-                                               absl::nullopt);
+                                               std::nullopt);
   testing_util::ScopedEnvironment user_project_env(
-      "GOOGLE_CLOUD_CPP_USER_PROJECT", absl::nullopt);
+      "GOOGLE_CLOUD_CPP_USER_PROJECT", std::nullopt);
   testing_util::ScopedEnvironment route_to_leader_env(
-      "GOOGLE_CLOUD_CPP_SPANNER_ROUTE_TO_LEADER", absl::nullopt);
+      "GOOGLE_CLOUD_CPP_SPANNER_ROUTE_TO_LEADER", std::nullopt);
   auto opts = spanner_internal::DefaultOptions();
 
   EXPECT_EQ(opts.get<EndpointOption>(), "spanner.googleapis.com");
@@ -90,17 +90,17 @@ TEST(Options, Defaults) {
 
 TEST(Options, AdminDefaults) {
   testing_util::ScopedEnvironment endpoint_env(
-      "GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT", absl::nullopt);
+      "GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT", std::nullopt);
   testing_util::ScopedEnvironment authority_env(
-      "GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_AUTHORITY", absl::nullopt);
+      "GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_AUTHORITY", std::nullopt);
   testing_util::ScopedEnvironment tracing_components_env(
-      "GOOGLE_CLOUD_CPP_ENABLE_TRACING", absl::nullopt);
+      "GOOGLE_CLOUD_CPP_ENABLE_TRACING", std::nullopt);
   testing_util::ScopedEnvironment tracing_options_env(
-      "GOOGLE_CLOUD_CPP_TRACING_OPTIONS", absl::nullopt);
+      "GOOGLE_CLOUD_CPP_TRACING_OPTIONS", std::nullopt);
   testing_util::ScopedEnvironment emulator_env("SPANNER_EMULATOR_HOST",
-                                               absl::nullopt);
+                                               std::nullopt);
   testing_util::ScopedEnvironment user_project_env(
-      "GOOGLE_CLOUD_CPP_USER_PROJECT", absl::nullopt);
+      "GOOGLE_CLOUD_CPP_USER_PROJECT", std::nullopt);
   auto opts = spanner_internal::DefaultAdminOptions();
 
   EXPECT_EQ(opts.get<EndpointOption>(), "spanner.googleapis.com");
@@ -133,9 +133,9 @@ TEST(Options, EndpointFromEnv) {
   testing_util::ScopedEnvironment endpoint_env(
       "GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT", "foo.bar.baz");
   testing_util::ScopedEnvironment authority_env(
-      "GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_AUTHORITY", absl::nullopt);
+      "GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_AUTHORITY", std::nullopt);
   testing_util::ScopedEnvironment emulator_env("SPANNER_EMULATOR_HOST",
-                                               absl::nullopt);
+                                               std::nullopt);
   auto opts = spanner_internal::DefaultOptions();
   EXPECT_EQ(opts.get<EndpointOption>(), "foo.bar.baz");
   EXPECT_EQ(opts.get<AuthorityOption>(), "spanner.googleapis.com");
@@ -145,7 +145,7 @@ TEST(Options, SpannerEmulatorHost) {
   testing_util::ScopedEnvironment endpoint_env(
       "GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT", "no.thank.you");
   testing_util::ScopedEnvironment authority_env(
-      "GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_AUTHORITY", absl::nullopt);
+      "GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_AUTHORITY", std::nullopt);
   testing_util::ScopedEnvironment emulator_env("SPANNER_EMULATOR_HOST",
                                                "foo.bar.baz");
   auto opts = spanner_internal::DefaultOptions();
@@ -197,7 +197,7 @@ TEST(Options, TracingOptionsFromEnv) {
 
 TEST(Options, UserProject) {
   auto env = testing_util::ScopedEnvironment("GOOGLE_CLOUD_CPP_USER_PROJECT",
-                                             absl::nullopt);
+                                             std::nullopt);
   auto opts = spanner_internal::DefaultOptions(
       Options{}.set<UserProjectOption>("opt-user-project"));
   EXPECT_THAT(opts.get<UserProjectOption>(), "opt-user-project");
@@ -224,7 +224,7 @@ TEST(Options, OverrideEndpoint) {
   testing_util::ScopedEnvironment authority_env(
       "GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_AUTHORITY", "baz.bar.foo");
   testing_util::ScopedEnvironment emulator_env("SPANNER_EMULATOR_HOST",
-                                               absl::nullopt);
+                                               std::nullopt);
   auto opts = Options{}.set<EndpointOption>("no.thank.you");
   opts = spanner_internal::DefaultOptions(std::move(opts));
   EXPECT_EQ(opts.get<EndpointOption>(), "foo.bar.baz");

--- a/google/cloud/spanner/internal/logging_result_set_reader.cc
+++ b/google/cloud/spanner/internal/logging_result_set_reader.cc
@@ -26,7 +26,7 @@ using ::google::cloud::internal::DebugString;
 void LoggingResultSetReader::TryCancel() { impl_->TryCancel(); }
 
 bool LoggingResultSetReader::Read(
-    absl::optional<std::string> const& resume_token,
+    std::optional<std::string> const& resume_token,
     UnownedPartialResultSet& result) {
   if (resume_token) {
     GCP_LOG(DEBUG) << __func__ << "() << resume_token=\""

--- a/google/cloud/spanner/internal/logging_result_set_reader.h
+++ b/google/cloud/spanner/internal/logging_result_set_reader.h
@@ -18,8 +18,8 @@
 #include "google/cloud/spanner/internal/partial_result_set_reader.h"
 #include "google/cloud/spanner/tracing_options.h"
 #include "google/cloud/spanner/version.h"
-#include "absl/types/optional.h"
 #include <memory>
+#include <optional>
 
 namespace google {
 namespace cloud {
@@ -39,7 +39,7 @@ class LoggingResultSetReader : public PartialResultSetReader {
   ~LoggingResultSetReader() override = default;
 
   void TryCancel() override;
-  bool Read(absl::optional<std::string> const& resume_token,
+  bool Read(std::optional<std::string> const& resume_token,
             UnownedPartialResultSet& result) override;
   Status Finish() override;
 

--- a/google/cloud/spanner/internal/logging_result_set_reader_test.cc
+++ b/google/cloud/spanner/internal/logging_result_set_reader_test.cc
@@ -50,7 +50,7 @@ TEST_F(LoggingResultSetReaderTest, TryCancel) {
 TEST_F(LoggingResultSetReaderTest, Read) {
   auto mock = std::make_unique<spanner_testing::MockPartialResultSetReader>();
   EXPECT_CALL(*mock, Read(_, _))
-      .WillOnce([](absl::optional<std::string> const&,
+      .WillOnce([](std::optional<std::string> const&,
                    UnownedPartialResultSet& result) {
         result.resumption = false;
         result.result.set_resume_token("test-token");

--- a/google/cloud/spanner/internal/partial_result_set_reader.h
+++ b/google/cloud/spanner/internal/partial_result_set_reader.h
@@ -18,10 +18,10 @@
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
-#include "absl/types/optional.h"
 #include "google/spanner/v1/spanner.pb.h"
 #include <grpcpp/grpcpp.h>
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace google {
@@ -59,7 +59,7 @@ class PartialResultSetReader {
  public:
   virtual ~PartialResultSetReader() = default;
   virtual void TryCancel() = 0;
-  virtual bool Read(absl::optional<std::string> const& resume_token,
+  virtual bool Read(std::optional<std::string> const& resume_token,
                     UnownedPartialResultSet& result) = 0;
   virtual Status Finish() = 0;
 };

--- a/google/cloud/spanner/internal/partial_result_set_resume.cc
+++ b/google/cloud/spanner/internal/partial_result_set_resume.cc
@@ -23,7 +23,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 void PartialResultSetResume::TryCancel() { child_->TryCancel(); }
 
 bool PartialResultSetResume::Read(
-    absl::optional<std::string> const& resume_token,
+    std::optional<std::string> const& resume_token,
     UnownedPartialResultSet& result) {
   bool resumption = false;
   do {

--- a/google/cloud/spanner/internal/partial_result_set_resume.h
+++ b/google/cloud/spanner/internal/partial_result_set_resume.h
@@ -20,9 +20,9 @@
 #include "google/cloud/spanner/retry_policy.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/backoff_policy.h"
-#include "absl/types/optional.h"
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace google {
@@ -52,7 +52,7 @@ class PartialResultSetResume : public PartialResultSetReader {
   ~PartialResultSetResume() override = default;
 
   void TryCancel() override;
-  bool Read(absl::optional<std::string> const& resume_token,
+  bool Read(std::optional<std::string> const& resume_token,
             UnownedPartialResultSet& result) override;
   Status Finish() override;
 
@@ -62,7 +62,7 @@ class PartialResultSetResume : public PartialResultSetReader {
   std::unique_ptr<spanner::RetryPolicy> retry_policy_prototype_;
   std::unique_ptr<spanner::BackoffPolicy> backoff_policy_prototype_;
   std::unique_ptr<PartialResultSetReader> child_;
-  absl::optional<Status> last_status_;
+  std::optional<Status> last_status_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/spanner/internal/partial_result_set_resume_test.cc
+++ b/google/cloud/spanner/internal/partial_result_set_resume_test.cc
@@ -77,7 +77,7 @@ MATCHER_P(IsValidAndEquals, expected,
 // populate result
 auto ReadAction(google::spanner::v1::PartialResultSet& response_proto,
                 bool resumption_val) {
-  return [&response_proto, resumption_val](absl::optional<std::string> const&,
+  return [&response_proto, resumption_val](std::optional<std::string> const&,
                                            UnownedPartialResultSet& result) {
     result.result = response_proto;
     result.resumption = resumption_val;

--- a/google/cloud/spanner/internal/partial_result_set_source.cc
+++ b/google/cloud/spanner/internal/partial_result_set_source.cc
@@ -18,7 +18,7 @@
 #include "google/cloud/internal/make_status.h"
 #include "google/cloud/log.h"
 #include "absl/container/fixed_array.h"
-#include "absl/types/optional.h"
+#include <optional>
 
 namespace google {
 namespace cloud {
@@ -84,7 +84,7 @@ PartialResultSetSource::PartialResultSetSource(
     std::unique_ptr<PartialResultSetReader> reader)
     : options_(internal::CurrentOptions()),
       reader_(std::move(reader)),
-      values_(absl::make_optional(
+      values_(std::make_optional(
           google::protobuf::Arena::Create<
               google::protobuf::RepeatedPtrField<google::protobuf::Value>>(
               &arena_))) {
@@ -288,7 +288,7 @@ Status PartialResultSetSource::ReadFromStream() {
       }
     }
   } else if (n_rows != 0) {
-    resume_token_ = absl::nullopt;
+    resume_token_ = std::nullopt;
   }
 
   usable_rows_ = n_rows;

--- a/google/cloud/spanner/internal/partial_result_set_source.h
+++ b/google/cloud/spanner/internal/partial_result_set_source.h
@@ -22,7 +22,6 @@
 #include "google/cloud/options.h"
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
-#include "absl/types/optional.h"
 #include "google/protobuf/struct.pb.h"
 #include "google/spanner/v1/spanner.pb.h"
 #include <google/protobuf/arena.h>
@@ -30,6 +29,7 @@
 #include <cstddef>
 #include <deque>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -46,9 +46,9 @@ class PartialResultSourceInterface : public spanner::ResultSourceInterface {
    * number from this transaction attempt is added to the Commit request for
    * this transaction by the library.
    */
-  virtual absl::optional<google::spanner::v1::MultiplexedSessionPrecommitToken>
+  virtual std::optional<google::spanner::v1::MultiplexedSessionPrecommitToken>
   PrecommitToken() const {
-    return absl::nullopt;
+    return std::nullopt;
   }
 };
 
@@ -67,15 +67,15 @@ class PartialResultSetSource : public PartialResultSourceInterface {
 
   StatusOr<spanner::Row> NextRow() override;
 
-  absl::optional<google::spanner::v1::ResultSetMetadata> Metadata() override {
+  std::optional<google::spanner::v1::ResultSetMetadata> Metadata() override {
     return metadata_;
   }
 
-  absl::optional<google::spanner::v1::ResultSetStats> Stats() const override {
+  std::optional<google::spanner::v1::ResultSetStats> Stats() const override {
     return stats_;
   }
 
-  absl::optional<google::spanner::v1::MultiplexedSessionPrecommitToken>
+  std::optional<google::spanner::v1::MultiplexedSessionPrecommitToken>
   PrecommitToken() const override {
     return precommit_token_;
   }
@@ -94,17 +94,17 @@ class PartialResultSetSource : public PartialResultSourceInterface {
 
   // The `PartialResultSet.metadata` we received in the first response, and
   // the column names it contained (which will be shared between rows).
-  absl::optional<google::spanner::v1::ResultSetMetadata> metadata_;
+  std::optional<google::spanner::v1::ResultSetMetadata> metadata_;
   std::shared_ptr<std::vector<std::string>> columns_;
 
   // The `PartialResultSet.stats` received in the last response, corresponding
   // to the `QueryMode` implied by the particular streaming read/query type.
-  absl::optional<google::spanner::v1::ResultSetStats> stats_;
+  std::optional<google::spanner::v1::ResultSetStats> stats_;
 
   // Each PartialResultSet proto message can contain a token when using a
   // multiplexed session.
-  absl::optional<google::spanner::v1::MultiplexedSessionPrecommitToken>
-      precommit_token_ = absl::nullopt;
+  std::optional<google::spanner::v1::MultiplexedSessionPrecommitToken>
+      precommit_token_ = std::nullopt;
 
   // Number of rows returned to the client.
   int rows_returned_ = 0;
@@ -116,7 +116,7 @@ class PartialResultSetSource : public PartialResultSourceInterface {
 
   // Values that can be assembled into `Row`s ready to be returned by
   // `NextRow()`. This is a pointer to an arena-allocated RepeatedPtrField.
-  absl::optional<google::protobuf::RepeatedPtrField<google::protobuf::Value>*>
+  std::optional<google::protobuf::RepeatedPtrField<google::protobuf::Value>*>
       values_;
 
   // `space_used` is the sum of the SpaceUsedLong() by the values at indexes [0,
@@ -136,7 +136,7 @@ class PartialResultSetSource : public PartialResultSourceInterface {
   // any data in (or previously in) `rows_`. When disengaged, we have already
   // delivered data that would be replayed, so resumption is disabled until we
   // see a new token.
-  absl::optional<std::string> resume_token_ = "";
+  std::optional<std::string> resume_token_ = "";
 
   // Should the space used by `values_` get larger than this limit, we will
   // move complete rows into `rows_` and disable resumption until we see a

--- a/google/cloud/spanner/internal/partial_result_set_source_test.cc
+++ b/google/cloud/spanner/internal/partial_result_set_source_test.cc
@@ -92,7 +92,7 @@ TEST(PartialResultSetSourceTest, InitialReadFailure) {
   auto grpc_reader = std::make_unique<MockPartialResultSetReader>();
   EXPECT_CALL(*grpc_reader, Read(_, _))
       .WillOnce(
-          [](absl::optional<std::string> const&,
+          [](std::optional<std::string> const&,
              spanner_internal::UnownedPartialResultSet&) { return false; });
   EXPECT_CALL(*grpc_reader, Finish())
       .WillOnce(ResultMock(Status(StatusCode::kInvalidArgument, "invalid")));
@@ -124,7 +124,7 @@ TEST(PartialResultSetSourceTest, ReadSuccessThenFailure) {
 
   auto grpc_reader = std::make_unique<MockPartialResultSetReader>();
   EXPECT_CALL(*grpc_reader, Read(_, _))
-      .WillOnce([&response](absl::optional<std::string> const&,
+      .WillOnce([&response](std::optional<std::string> const&,
                             spanner_internal::UnownedPartialResultSet& result) {
         result.result = response;
         return true;
@@ -150,7 +150,7 @@ TEST(PartialResultSetSourceTest, MissingMetadata) {
 
   auto grpc_reader = std::make_unique<MockPartialResultSetReader>();
   EXPECT_CALL(*grpc_reader, Read(_, _))
-      .WillOnce([&response](absl::optional<std::string> const&,
+      .WillOnce([&response](std::optional<std::string> const&,
                             spanner_internal::UnownedPartialResultSet& result) {
         result.result = response;
         return true;
@@ -178,7 +178,7 @@ TEST(PartialResultSetSourceTest, MissingRowTypeNoData) {
 
   auto grpc_reader = std::make_unique<MockPartialResultSetReader>();
   EXPECT_CALL(*grpc_reader, Read(_, _))
-      .WillOnce([&response](absl::optional<std::string> const&,
+      .WillOnce([&response](std::optional<std::string> const&,
                             spanner_internal::UnownedPartialResultSet& result) {
         result.result = response;
         return true;
@@ -207,7 +207,7 @@ TEST(PartialResultSetSourceTest, MissingRowTypeWithData) {
 
   auto grpc_reader = std::make_unique<MockPartialResultSetReader>();
   EXPECT_CALL(*grpc_reader, Read(_, _))
-      .WillOnce([&response](absl::optional<std::string> const&,
+      .WillOnce([&response](std::optional<std::string> const&,
                             spanner_internal::UnownedPartialResultSet& result) {
         result.result = response;
         return true;
@@ -267,7 +267,7 @@ TEST(PartialResultSetSourceTest, SingleResponse) {
 
   auto grpc_reader = std::make_unique<MockPartialResultSetReader>();
   EXPECT_CALL(*grpc_reader, Read(_, _))
-      .WillOnce([&response](absl::optional<std::string> const&,
+      .WillOnce([&response](std::optional<std::string> const&,
                             spanner_internal::UnownedPartialResultSet& result) {
         result.result = response;
         return true;
@@ -397,31 +397,31 @@ TEST(PartialResultSetSourceTest, MultipleResponses) {
     auto grpc_reader = std::make_unique<MockPartialResultSetReader>();
     EXPECT_CALL(*grpc_reader, Read(_, _))
         .WillOnce(
-            [&response](absl::optional<std::string> const&,
+            [&response](std::optional<std::string> const&,
                         spanner_internal::UnownedPartialResultSet& result) {
               result.result = response[0];
               return true;
             })
         .WillOnce(
-            [&response](absl::optional<std::string> const&,
+            [&response](std::optional<std::string> const&,
                         spanner_internal::UnownedPartialResultSet& result) {
               result.result = response[1];
               return true;
             })
         .WillOnce(
-            [&response](absl::optional<std::string> const&,
+            [&response](std::optional<std::string> const&,
                         spanner_internal::UnownedPartialResultSet& result) {
               result.result = response[2];
               return true;
             })
         .WillOnce(
-            [&response](absl::optional<std::string> const&,
+            [&response](std::optional<std::string> const&,
                         spanner_internal::UnownedPartialResultSet& result) {
               result.result = response[3];
               return true;
             })
         .WillOnce(
-            [&response](absl::optional<std::string> const&,
+            [&response](std::optional<std::string> const&,
                         spanner_internal::UnownedPartialResultSet& result) {
               result.result = response[4];
               return true;
@@ -488,17 +488,17 @@ TEST(PartialResultSetSourceTest, ResponseWithNoValues) {
 
   auto grpc_reader = std::make_unique<MockPartialResultSetReader>();
   EXPECT_CALL(*grpc_reader, Read(_, _))
-      .WillOnce([&response](absl::optional<std::string> const&,
+      .WillOnce([&response](std::optional<std::string> const&,
                             spanner_internal::UnownedPartialResultSet& result) {
         result.result = response[0];
         return true;
       })
-      .WillOnce([&response](absl::optional<std::string> const&,
+      .WillOnce([&response](std::optional<std::string> const&,
                             spanner_internal::UnownedPartialResultSet& result) {
         result.result = response[1];
         return true;
       })
-      .WillOnce([&response](absl::optional<std::string> const&,
+      .WillOnce([&response](std::optional<std::string> const&,
                             spanner_internal::UnownedPartialResultSet& result) {
         result.result = response[2];
         return true;
@@ -564,27 +564,27 @@ TEST(PartialResultSetSourceTest, ChunkedStringValueWellFormed) {
 
   auto grpc_reader = std::make_unique<MockPartialResultSetReader>();
   EXPECT_CALL(*grpc_reader, Read(_, _))
-      .WillOnce([&response](absl::optional<std::string> const&,
+      .WillOnce([&response](std::optional<std::string> const&,
                             spanner_internal::UnownedPartialResultSet& result) {
         result.result = response[0];
         return true;
       })
-      .WillOnce([&response](absl::optional<std::string> const&,
+      .WillOnce([&response](std::optional<std::string> const&,
                             spanner_internal::UnownedPartialResultSet& result) {
         result.result = response[1];
         return true;
       })
-      .WillOnce([&response](absl::optional<std::string> const&,
+      .WillOnce([&response](std::optional<std::string> const&,
                             spanner_internal::UnownedPartialResultSet& result) {
         result.result = response[2];
         return true;
       })
-      .WillOnce([&response](absl::optional<std::string> const&,
+      .WillOnce([&response](std::optional<std::string> const&,
                             spanner_internal::UnownedPartialResultSet& result) {
         result.result = response[3];
         return true;
       })
-      .WillOnce([&response](absl::optional<std::string> const&,
+      .WillOnce([&response](std::optional<std::string> const&,
                             spanner_internal::UnownedPartialResultSet& result) {
         result.result = response[4];
         return true;
@@ -638,12 +638,12 @@ TEST(PartialResultSetSourceTest, ChunkedValueSetNoValue) {
 
   auto grpc_reader = std::make_unique<MockPartialResultSetReader>();
   EXPECT_CALL(*grpc_reader, Read(_, _))
-      .WillOnce([&response](absl::optional<std::string> const&,
+      .WillOnce([&response](std::optional<std::string> const&,
                             spanner_internal::UnownedPartialResultSet& result) {
         result.result = response[0];
         return true;
       })
-      .WillOnce([&response](absl::optional<std::string> const&,
+      .WillOnce([&response](std::optional<std::string> const&,
                             spanner_internal::UnownedPartialResultSet& result) {
         result.result = response[1];
         return true;
@@ -689,12 +689,12 @@ TEST(PartialResultSetSourceTest, ChunkedValueSetNoFollowingValue) {
 
   auto grpc_reader = std::make_unique<MockPartialResultSetReader>();
   EXPECT_CALL(*grpc_reader, Read(_, _))
-      .WillOnce([&response](absl::optional<std::string> const&,
+      .WillOnce([&response](std::optional<std::string> const&,
                             spanner_internal::UnownedPartialResultSet& result) {
         result.result = response[0];
         return true;
       })
-      .WillOnce([&response](absl::optional<std::string> const&,
+      .WillOnce([&response](std::optional<std::string> const&,
                             spanner_internal::UnownedPartialResultSet& result) {
         result.result = response[1];
         return true;
@@ -742,12 +742,12 @@ TEST(PartialResultSetSourceTest, ChunkedValueSetAtEndOfStream) {
 
   auto grpc_reader = std::make_unique<MockPartialResultSetReader>();
   EXPECT_CALL(*grpc_reader, Read(_, _))
-      .WillOnce([&response](absl::optional<std::string> const&,
+      .WillOnce([&response](std::optional<std::string> const&,
                             spanner_internal::UnownedPartialResultSet& result) {
         result.result = response[0];
         return true;
       })
-      .WillOnce([&response](absl::optional<std::string> const&,
+      .WillOnce([&response](std::optional<std::string> const&,
                             spanner_internal::UnownedPartialResultSet& result) {
         result.result = response[1];
         return true;
@@ -799,17 +799,17 @@ TEST(PartialResultSetSourceTest, ChunkedValueMergeFailure) {
 
   auto grpc_reader = std::make_unique<MockPartialResultSetReader>();
   EXPECT_CALL(*grpc_reader, Read(_, _))
-      .WillOnce([&response](absl::optional<std::string> const&,
+      .WillOnce([&response](std::optional<std::string> const&,
                             spanner_internal::UnownedPartialResultSet& result) {
         result.result = response[0];
         return true;
       })
-      .WillOnce([&response](absl::optional<std::string> const&,
+      .WillOnce([&response](std::optional<std::string> const&,
                             spanner_internal::UnownedPartialResultSet& result) {
         result.result = response[1];
         return true;
       })
-      .WillOnce([&response](absl::optional<std::string> const&,
+      .WillOnce([&response](std::optional<std::string> const&,
                             spanner_internal::UnownedPartialResultSet& result) {
         result.result = response[2];
         return true;
@@ -883,27 +883,27 @@ TEST(PartialResultSetSourceTest, ErrorOnIncompleteRow) {
 
   auto grpc_reader = std::make_unique<MockPartialResultSetReader>();
   EXPECT_CALL(*grpc_reader, Read(_, _))
-      .WillOnce([&response](absl::optional<std::string> const&,
+      .WillOnce([&response](std::optional<std::string> const&,
                             spanner_internal::UnownedPartialResultSet& result) {
         result.result = response[0];
         return true;
       })
-      .WillOnce([&response](absl::optional<std::string> const&,
+      .WillOnce([&response](std::optional<std::string> const&,
                             spanner_internal::UnownedPartialResultSet& result) {
         result.result = response[1];
         return true;
       })
-      .WillOnce([&response](absl::optional<std::string> const&,
+      .WillOnce([&response](std::optional<std::string> const&,
                             spanner_internal::UnownedPartialResultSet& result) {
         result.result = response[2];
         return true;
       })
-      .WillOnce([&response](absl::optional<std::string> const&,
+      .WillOnce([&response](std::optional<std::string> const&,
                             spanner_internal::UnownedPartialResultSet& result) {
         result.result = response[3];
         return true;
       })
-      .WillOnce([&response](absl::optional<std::string> const&,
+      .WillOnce([&response](std::optional<std::string> const&,
                             spanner_internal::UnownedPartialResultSet& result) {
         result.result = response[4];
         return true;

--- a/google/cloud/spanner/internal/transaction_impl.cc
+++ b/google/cloud/spanner/internal/transaction_impl.cc
@@ -25,7 +25,7 @@ TransactionImpl::TransactionImpl(
     google::spanner::v1::TransactionSelector selector, bool route_to_leader,
     std::string tag)
     : TransactionImpl(/*session=*/{}, std::move(selector), route_to_leader,
-                      std::move(tag), absl::nullopt) {}
+                      std::move(tag), std::nullopt) {}
 
 TransactionImpl::TransactionImpl(
     TransactionImpl const& impl,
@@ -35,13 +35,13 @@ TransactionImpl::TransactionImpl(
                       std::move(tag),
                       (impl.session_ && impl.session_->is_multiplexed() &&
                        impl.selector_->has_id())
-                          ? absl::optional<std::string>(impl.selector_->id())
-                          : absl::nullopt) {}
+                          ? std::optional<std::string>(impl.selector_->id())
+                          : std::nullopt) {}
 
 TransactionImpl::TransactionImpl(
     SessionHolder session, google::spanner::v1::TransactionSelector selector,
     bool route_to_leader, std::string tag,
-    absl::optional<std::string> multiplexed_session_previous_transaction_id)
+    std::optional<std::string> multiplexed_session_previous_transaction_id)
     : session_(std::move(session)),
       selector_(std::move(selector)),
       route_to_leader_(route_to_leader),
@@ -62,7 +62,7 @@ TransactionImpl::TransactionImpl(
 
 void TransactionImpl::UpdatePrecommitToken(
     std::unique_lock<std::mutex> const&,
-    absl::optional<google::spanner::v1::MultiplexedSessionPrecommitToken>
+    std::optional<google::spanner::v1::MultiplexedSessionPrecommitToken>
         token) {
   if (token.has_value() && (!precommit_token_.has_value() ||
                             token->seq_num() > precommit_token_->seq_num())) {

--- a/google/cloud/spanner/internal/transaction_impl.h
+++ b/google/cloud/spanner/internal/transaction_impl.h
@@ -36,8 +36,8 @@ struct TransactionContext {
   bool route_to_leader;
   std::string const& tag;
   std::int64_t seqno;
-  absl::optional<std::shared_ptr<SpannerStub>> stub;
-  absl::optional<google::spanner::v1::MultiplexedSessionPrecommitToken>
+  std::optional<std::shared_ptr<SpannerStub>> stub;
+  std::optional<google::spanner::v1::MultiplexedSessionPrecommitToken>
       precommit_token;
 };
 
@@ -61,7 +61,7 @@ class TransactionImpl {
   TransactionImpl(
       SessionHolder session, google::spanner::v1::TransactionSelector selector,
       bool route_to_leader, std::string tag,
-      absl::optional<std::string> multiplexed_session_previous_transaction_id);
+      std::optional<std::string> multiplexed_session_previous_transaction_id);
 
   ~TransactionImpl();
 
@@ -91,8 +91,8 @@ class TransactionImpl {
                       StatusOr<google::spanner::v1::TransactionSelector>&,
                       TransactionContext&>::value,
                   "TransactionImpl::Visit() functor has incompatible type.");
-    TransactionContext ctx{route_to_leader_, tag_, 0, absl::nullopt,
-                           absl::nullopt};
+    TransactionContext ctx{route_to_leader_, tag_, 0, std::nullopt,
+                           std::nullopt};
     {
       std::unique_lock<std::mutex> lock(mu_);
       ctx.seqno = ++seqno_;  // what about overflow?
@@ -143,7 +143,7 @@ class TransactionImpl {
  private:
   void UpdatePrecommitToken(
       std::unique_lock<std::mutex> const&,
-      absl::optional<google::spanner::v1::MultiplexedSessionPrecommitToken>
+      std::optional<google::spanner::v1::MultiplexedSessionPrecommitToken>
           token);
 
   enum class State {
@@ -160,9 +160,9 @@ class TransactionImpl {
   bool route_to_leader_;
   std::string tag_;
   std::int64_t seqno_;
-  absl::optional<std::shared_ptr<SpannerStub>> stub_ = absl::nullopt;
-  absl::optional<google::spanner::v1::MultiplexedSessionPrecommitToken>
-      precommit_token_ = absl::nullopt;
+  std::optional<std::shared_ptr<SpannerStub>> stub_ = std::nullopt;
+  std::optional<google::spanner::v1::MultiplexedSessionPrecommitToken>
+      precommit_token_ = std::nullopt;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/spanner/internal/transaction_impl_test.cc
+++ b/google/cloud/spanner/internal/transaction_impl_test.cc
@@ -63,7 +63,7 @@ class Client {
   // `txn_id` we want to use during the upcoming `Read()` calls.
   void Reset(spanner::Timestamp read_timestamp, std::string session_id,
              std::string txn_id,
-             absl::optional<std::shared_ptr<SpannerStub>> stub) {
+             std::optional<std::shared_ptr<SpannerStub>> stub) {
     read_timestamp_ = read_timestamp;
     session_id_ = std::move(session_id);
     txn_id_ = std::move(txn_id);
@@ -125,7 +125,7 @@ class Client {
   spanner::Timestamp read_timestamp_;
   std::string session_id_;
   std::string txn_id_;
-  absl::optional<std::shared_ptr<SpannerStub>> expected_stub_;
+  std::optional<std::shared_ptr<SpannerStub>> expected_stub_;
   std::array<std::shared_ptr<SpannerStub>, 3>::iterator next_stub_;
   std::array<std::shared_ptr<SpannerStub>, 3> stubs_;
   std::mutex mu_;
@@ -248,7 +248,7 @@ ResultSet Client::Read(SessionHolder& session,
 // number of valid visitations to that transaction (should be `n_threads`).
 int MultiThreadedRead(int n_threads, Client* client, std::time_t read_time,
                       std::string const& session_id, std::string const& txn_id,
-                      absl::optional<std::shared_ptr<SpannerStub>> stub) {
+                      std::optional<std::shared_ptr<SpannerStub>> stub) {
   auto read_timestamp =
       spanner::MakeTimestamp(std::chrono::system_clock::from_time_t(read_time))
           .value();
@@ -297,21 +297,21 @@ TEST(InternalTransaction, ReadSucceeds) {
 TEST(InternalTransaction, ReadFailsAndTxnRemainsBegin) {
   Client client(Client::Mode::kReadFailsAndTxnRemainsBegin);
   EXPECT_EQ(1, MultiThreadedRead(1, &client, 1562359982, "sess0", "txn0",
-                                 absl::nullopt));
+                                 std::nullopt));
   EXPECT_EQ(64, MultiThreadedRead(64, &client, 1562360571, "sess1", "txn1",
-                                  absl::nullopt));
+                                  std::nullopt));
   EXPECT_EQ(128, MultiThreadedRead(128, &client, 1562361252, "sess2", "txn2",
-                                   absl::nullopt));
+                                   std::nullopt));
 }
 
 TEST(InternalTransaction, ReadFailsAndTxnInvalidated) {
   Client client(Client::Mode::kReadFailsAndTxnInvalidated);
   EXPECT_EQ(1, MultiThreadedRead(1, &client, 1562359982, "sess0", "txn0",
-                                 absl::nullopt));
+                                 std::nullopt));
   EXPECT_EQ(64, MultiThreadedRead(64, &client, 1562360571, "sess1", "txn1",
-                                  absl::nullopt));
+                                  std::nullopt));
   EXPECT_EQ(128, MultiThreadedRead(128, &client, 1562361252, "sess2", "txn2",
-                                   absl::nullopt));
+                                   std::nullopt));
 }
 
 }  // namespace

--- a/google/cloud/spanner/mocks/mock_spanner_connection.h
+++ b/google/cloud/spanner/mocks/mock_spanner_connection.h
@@ -76,9 +76,9 @@ class MockConnection : public spanner::Connection {
 class MockResultSetSource : public spanner::ResultSourceInterface {
  public:
   MOCK_METHOD(StatusOr<spanner::Row>, NextRow, (), (override));
-  MOCK_METHOD(absl::optional<google::spanner::v1::ResultSetMetadata>, Metadata,
+  MOCK_METHOD(std::optional<google::spanner::v1::ResultSetMetadata>, Metadata,
               (), (override));
-  MOCK_METHOD(absl::optional<google::spanner::v1::ResultSetStats>, Stats, (),
+  MOCK_METHOD(std::optional<google::spanner::v1::ResultSetStats>, Stats, (),
               (const, override));
 };
 

--- a/google/cloud/spanner/mutations_test.cc
+++ b/google/cloud/spanner/mutations_test.cc
@@ -20,11 +20,11 @@
 #include "google/cloud/spanner/numeric.h"
 #include "google/cloud/spanner/timestamp.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
-#include "absl/types/optional.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
 #include <cstdint>
 #include <limits>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <tuple>
@@ -116,8 +116,8 @@ TEST(MutationsTest, InsertFloat32) {
 TEST(MutationsTest, InsertComplex) {
   auto builder = InsertMutationBuilder("table-name", {"col1", "col2", "col3"})
                      .AddRow({Value(42), Value("foo"), Value(false)})
-                     .EmplaceRow(absl::optional<std::int64_t>(), "bar",
-                                 absl::optional<bool>{});
+                     .EmplaceRow(std::optional<std::int64_t>(), "bar",
+                                 std::optional<bool>{});
   Mutation insert = builder.Build();
   Mutation moved = std::move(builder).Build();
   EXPECT_EQ(insert, moved);
@@ -177,7 +177,7 @@ TEST(MutationsTest, UpdateComplex) {
   auto builder = UpdateMutationBuilder("table-name", {"col_a", "col_b"})
                      .AddRow({Value(std::vector<std::string>{}), Value(7.0)})
                      .EmplaceRow(std::vector<std::string>{"a", "b"},
-                                 absl::optional<double>{});
+                                 std::optional<double>{});
   Mutation update = builder.Build();
   Mutation moved = std::move(builder).Build();
   EXPECT_EQ(update, moved);

--- a/google/cloud/spanner/partition_options.h
+++ b/google/cloud/spanner/partition_options.h
@@ -18,9 +18,9 @@
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/optional.h"
 #include "google/cloud/options.h"
-#include "absl/types/optional.h"
 #include "google/spanner/v1/spanner.pb.h"
 #include <cstdint>
+#include <optional>
 
 namespace google {
 namespace cloud {
@@ -52,7 +52,7 @@ struct PartitionOptions {
    * actual size of each partition may be smaller or larger than this size
    * request.
    */
-  absl::optional<std::int64_t> partition_size_bytes;
+  std::optional<std::int64_t> partition_size_bytes;
 
   /**
    * The desired maximum number of partitions to return.
@@ -62,7 +62,7 @@ struct PartitionOptions {
    * currently 200,000. This is only a hint.  The actual number of partitions
    * returned may be smaller or larger than this maximum count request.
    */
-  absl::optional<std::int64_t> max_partitions;
+  std::optional<std::int64_t> max_partitions;
 
   /**
    * Use "data boost" in the returned partitions.

--- a/google/cloud/spanner/partition_options_test.cc
+++ b/google/cloud/spanner/partition_options_test.cc
@@ -49,13 +49,13 @@ TEST(PartitionOptionsTest, Proto) {
 
 TEST(PartitionOptionsTest, OptionsRoundTrip) {
   for (auto const& po : {
-           PartitionOptions{absl::nullopt, absl::nullopt, false},
-           PartitionOptions{42, absl::nullopt, false},
-           PartitionOptions{absl::nullopt, 42, false},
+           PartitionOptions{std::nullopt, std::nullopt, false},
+           PartitionOptions{42, std::nullopt, false},
+           PartitionOptions{std::nullopt, 42, false},
            PartitionOptions{32, 64, false},
-           PartitionOptions{absl::nullopt, absl::nullopt, true},
-           PartitionOptions{42, absl::nullopt, true},
-           PartitionOptions{absl::nullopt, 42, true},
+           PartitionOptions{std::nullopt, std::nullopt, true},
+           PartitionOptions{42, std::nullopt, true},
+           PartitionOptions{std::nullopt, 42, true},
            PartitionOptions{32, 64, true},
        }) {
     EXPECT_EQ(po, ToPartitionOptions(ToOptions(po)));

--- a/google/cloud/spanner/query_options.h
+++ b/google/cloud/spanner/query_options.h
@@ -19,7 +19,7 @@
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/optional.h"
 #include "google/cloud/options.h"
-#include "absl/types/optional.h"
+#include <optional>
 #include <string>
 
 namespace google {
@@ -66,7 +66,7 @@ class QueryOptions {
   explicit operator Options() const;
 
   /// Returns the optimizer version
-  absl::optional<std::string> const& optimizer_version() const {
+  std::optional<std::string> const& optimizer_version() const {
     return optimizer_version_;
   }
 
@@ -75,13 +75,13 @@ class QueryOptions {
    * the empty string will use the database default. Use the string "latest" to
    * use the latest available optimizer version.
    */
-  QueryOptions& set_optimizer_version(absl::optional<std::string> version) {
+  QueryOptions& set_optimizer_version(std::optional<std::string> version) {
     optimizer_version_ = std::move(version);
     return *this;
   }
 
   /// Returns the optimizer statistics package
-  absl::optional<std::string> const& optimizer_statistics_package() const {
+  std::optional<std::string> const& optimizer_statistics_package() const {
     return optimizer_statistics_package_;
   }
 
@@ -90,29 +90,27 @@ class QueryOptions {
    * the empty string will use the database default.
    */
   QueryOptions& set_optimizer_statistics_package(
-      absl::optional<std::string> stats_package) {
+      std::optional<std::string> stats_package) {
     optimizer_statistics_package_ = std::move(stats_package);
     return *this;
   }
 
   /// Returns the request priority.
-  absl::optional<RequestPriority> const& request_priority() const {
+  std::optional<RequestPriority> const& request_priority() const {
     return request_priority_;
   }
 
   /// Sets the request priority.
-  QueryOptions& set_request_priority(absl::optional<RequestPriority> priority) {
+  QueryOptions& set_request_priority(std::optional<RequestPriority> priority) {
     request_priority_ = std::move(priority);
     return *this;
   }
 
   /// Returns the request tag.
-  absl::optional<std::string> const& request_tag() const {
-    return request_tag_;
-  }
+  std::optional<std::string> const& request_tag() const { return request_tag_; }
 
   /// Sets the request tag.
-  QueryOptions& set_request_tag(absl::optional<std::string> tag) {
+  QueryOptions& set_request_tag(std::optional<std::string> tag) {
     request_tag_ = std::move(tag);
     return *this;
   }
@@ -129,10 +127,10 @@ class QueryOptions {
   }
 
  private:
-  absl::optional<std::string> optimizer_version_;
-  absl::optional<std::string> optimizer_statistics_package_;
-  absl::optional<RequestPriority> request_priority_;
-  absl::optional<std::string> request_tag_;
+  std::optional<std::string> optimizer_version_;
+  std::optional<std::string> optimizer_statistics_package_;
+  std::optional<RequestPriority> request_priority_;
+  std::optional<std::string> request_tag_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/spanner/query_options_test.cc
+++ b/google/cloud/spanner/query_options_test.cc
@@ -37,13 +37,13 @@ TEST(QueryOptionsTest, Values) {
   copy.set_request_priority(RequestPriority::kHigh);
   EXPECT_NE(copy, default_constructed);
 
-  copy.set_request_priority(absl::optional<RequestPriority>{});
+  copy.set_request_priority(std::optional<RequestPriority>{});
   EXPECT_EQ(copy, default_constructed);
 
   copy.set_request_tag("foo");
   EXPECT_NE(copy, default_constructed);
 
-  copy.set_request_tag(absl::optional<std::string>{});
+  copy.set_request_tag(std::optional<std::string>{});
   EXPECT_EQ(copy, default_constructed);
 }
 
@@ -62,7 +62,7 @@ TEST(QueryOptionsTest, OptimizerVersion) {
   EXPECT_NE(copy, default_constructed);
   EXPECT_EQ("foo", copy.optimizer_version().value());
 
-  copy.set_optimizer_version(absl::nullopt);
+  copy.set_optimizer_version(std::nullopt);
   EXPECT_EQ(copy, default_constructed);
 }
 
@@ -81,7 +81,7 @@ TEST(QueryOptionsTest, OptimizerStatisticsPackage) {
   EXPECT_NE(copy, default_constructed);
   EXPECT_EQ("foo", copy.optimizer_statistics_package().value());
 
-  copy.set_optimizer_statistics_package(absl::nullopt);
+  copy.set_optimizer_statistics_package(std::nullopt);
   EXPECT_EQ(copy, default_constructed);
 }
 

--- a/google/cloud/spanner/read_options.h
+++ b/google/cloud/spanner/read_options.h
@@ -19,8 +19,8 @@
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/optional.h"
 #include "google/cloud/options.h"
-#include "absl/types/optional.h"
 #include <cstdint>
+#include <optional>
 #include <string>
 
 namespace google {
@@ -59,12 +59,12 @@ struct ReadOptions {
   /**
    * Priority for the read request.
    */
-  absl::optional<RequestPriority> request_priority;
+  std::optional<RequestPriority> request_priority;
 
   /**
    * Tag for the read request.
    */
-  absl::optional<std::string> request_tag;
+  std::optional<std::string> request_tag;
 };
 
 inline bool operator==(ReadOptions const& lhs, ReadOptions const& rhs) {

--- a/google/cloud/spanner/read_options_test.cc
+++ b/google/cloud/spanner/read_options_test.cc
@@ -57,12 +57,12 @@ TEST(ReadOptionsTest, OptionsRoundTrip) {
     for (std::int64_t limit : {0, 42}) {
       ro.limit = limit;
       for (auto const& request_priority :
-           {absl::optional<RequestPriority>(absl::nullopt),
-            absl::optional<RequestPriority>(RequestPriority::kLow)}) {
+           {std::optional<RequestPriority>(std::nullopt),
+            std::optional<RequestPriority>(RequestPriority::kLow)}) {
         ro.request_priority = request_priority;
         for (auto const& request_tag :
-             {absl::optional<std::string>(absl::nullopt),
-              absl::optional<std::string>("tag")}) {
+             {std::optional<std::string>(std::nullopt),
+              std::optional<std::string>("tag")}) {
           ro.request_tag = request_tag;
           EXPECT_EQ(ro, ToReadOptions(ToOptions(ro)));
         }

--- a/google/cloud/spanner/results.cc
+++ b/google/cloud/spanner/results.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/results.h"
-#include "absl/types/optional.h"
 #include "google/spanner/v1/result_set.pb.h"
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -25,10 +25,10 @@ namespace spanner {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-absl::optional<Timestamp> GetReadTimestamp(
+std::optional<Timestamp> GetReadTimestamp(
     std::unique_ptr<ResultSourceInterface> const& source) {
   auto metadata = source->Metadata();
-  absl::optional<Timestamp> timestamp;
+  std::optional<Timestamp> timestamp;
   if (metadata.has_value() && metadata->has_transaction() &&
       metadata->transaction().has_read_timestamp()) {
     auto ts = MakeTimestamp(metadata->transaction().read_timestamp());
@@ -43,7 +43,7 @@ std::int64_t GetRowsModified(
   return stats ? stats->row_count_exact() : 0;
 }
 
-absl::optional<std::unordered_map<std::string, std::string>> GetExecutionStats(
+std::optional<std::unordered_map<std::string, std::string>> GetExecutionStats(
     std::unique_ptr<ResultSourceInterface> const& source) {
   auto stats = source->Stats();
   if (stats && stats->has_query_stats()) {
@@ -57,7 +57,7 @@ absl::optional<std::unordered_map<std::string, std::string>> GetExecutionStats(
   return {};
 }
 
-absl::optional<spanner::ExecutionPlan> GetExecutionPlan(
+std::optional<spanner::ExecutionPlan> GetExecutionPlan(
     std::unique_ptr<spanner_internal::ResultSourceInterface> const& source) {
   auto stats = source->Stats();
   if (stats && stats->has_query_plan()) {
@@ -71,7 +71,7 @@ std::int64_t RowStream::RowsModified() const {
   return GetRowsModified(source_);
 }
 
-absl::optional<Timestamp> RowStream::ReadTimestamp() const {
+std::optional<Timestamp> RowStream::ReadTimestamp() const {
   return GetReadTimestamp(source_);
 }
 
@@ -79,16 +79,16 @@ std::int64_t DmlResult::RowsModified() const {
   return GetRowsModified(source_);
 }
 
-absl::optional<Timestamp> ProfileQueryResult::ReadTimestamp() const {
+std::optional<Timestamp> ProfileQueryResult::ReadTimestamp() const {
   return GetReadTimestamp(source_);
 }
 
-absl::optional<std::unordered_map<std::string, std::string>>
+std::optional<std::unordered_map<std::string, std::string>>
 ProfileQueryResult::ExecutionStats() const {
   return GetExecutionStats(source_);
 }
 
-absl::optional<spanner::ExecutionPlan> ProfileQueryResult::ExecutionPlan()
+std::optional<spanner::ExecutionPlan> ProfileQueryResult::ExecutionPlan()
     const {
   return GetExecutionPlan(source_);
 }
@@ -97,12 +97,12 @@ std::int64_t ProfileDmlResult::RowsModified() const {
   return GetRowsModified(source_);
 }
 
-absl::optional<std::unordered_map<std::string, std::string>>
+std::optional<std::unordered_map<std::string, std::string>>
 ProfileDmlResult::ExecutionStats() const {
   return GetExecutionStats(source_);
 }
 
-absl::optional<spanner::ExecutionPlan> ProfileDmlResult::ExecutionPlan() const {
+std::optional<spanner::ExecutionPlan> ProfileDmlResult::ExecutionPlan() const {
   return GetExecutionPlan(source_);
 }
 

--- a/google/cloud/spanner/results.h
+++ b/google/cloud/spanner/results.h
@@ -19,9 +19,9 @@
 #include "google/cloud/spanner/timestamp.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/optional.h"
-#include "absl/types/optional.h"
 #include "google/spanner/v1/spanner.pb.h"
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -60,7 +60,7 @@ class ResultSourceInterface {
    * @see https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#resultsetmetadata
    *     for more information.
    */
-  virtual absl::optional<google::spanner::v1::ResultSetMetadata> Metadata() = 0;
+  virtual std::optional<google::spanner::v1::ResultSetMetadata> Metadata() = 0;
 
   /**
    * Returns statistics about the result set, such as the number of rows, and
@@ -69,7 +69,7 @@ class ResultSourceInterface {
    * @see https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#resultsetstats
    *     for more information.
    */
-  virtual absl::optional<google::spanner::v1::ResultSetStats> Stats() const = 0;
+  virtual std::optional<google::spanner::v1::ResultSetStats> Stats() const = 0;
 };
 
 /**
@@ -125,7 +125,7 @@ class RowStream {
    *
    * @note Only available if a read-only transaction was used.
    */
-  absl::optional<Timestamp> ReadTimestamp() const;
+  std::optional<Timestamp> ReadTimestamp() const;
 
  private:
   std::unique_ptr<ResultSourceInterface> source_;
@@ -207,7 +207,7 @@ class ProfileQueryResult {
    *
    * @note Only available if a read-only transaction was used.
    */
-  absl::optional<Timestamp> ReadTimestamp() const;
+  std::optional<Timestamp> ReadTimestamp() const;
 
   /**
    * Returns a collection of key value pair statistics for the SQL statement
@@ -216,13 +216,13 @@ class ProfileQueryResult {
    * @note Only available when the statement is executed and all results have
    *     been read.
    */
-  absl::optional<std::unordered_map<std::string, std::string>> ExecutionStats()
+  std::optional<std::unordered_map<std::string, std::string>> ExecutionStats()
       const;
 
   /**
    * Returns the plan of execution for the SQL statement.
    */
-  absl::optional<spanner::ExecutionPlan> ExecutionPlan() const;
+  std::optional<spanner::ExecutionPlan> ExecutionPlan() const;
 
  private:
   std::unique_ptr<ResultSourceInterface> source_;
@@ -265,13 +265,13 @@ class ProfileDmlResult {
    *
    * @note Only available when the SQL statement is executed.
    */
-  absl::optional<std::unordered_map<std::string, std::string>> ExecutionStats()
+  std::optional<std::unordered_map<std::string, std::string>> ExecutionStats()
       const;
 
   /**
    * Returns the plan of execution for the SQL statement.
    */
-  absl::optional<spanner::ExecutionPlan> ExecutionPlan() const;
+  std::optional<spanner::ExecutionPlan> ExecutionPlan() const;
 
  private:
   std::unique_ptr<ResultSourceInterface> source_;

--- a/google/cloud/spanner/samples/postgresql_samples.cc
+++ b/google/cloud/spanner/samples/postgresql_samples.cc
@@ -137,7 +137,7 @@ void DmlGettingStartedUpdate(google::cloud::spanner::Client client) {
     auto key = google::cloud::spanner::KeySet().AddKey(
         google::cloud::spanner::MakeKey(album_id, singer_id));
     auto rows = client.Read(std::move(txn), "Albums", key, {"MarketingBudget"});
-    using RowType = std::tuple<absl::optional<std::int64_t>>;
+    using RowType = std::tuple<std::optional<std::int64_t>>;
     auto row = google::cloud::spanner::GetSingularRow(
         google::cloud::spanner::StreamOf<RowType>(rows));
     if (!row) return std::move(row).status();
@@ -232,7 +232,7 @@ void UpdateUsingDmlReturning(google::cloud::spanner::Client client) {
               WHERE SingerId = 1 AND AlbumId = 1
               RETURNING MarketingBudget
         )""");
-        using RowType = std::tuple<absl::optional<std::int64_t>>;
+        using RowType = std::tuple<std::optional<std::int64_t>>;
         auto rows = client.ExecuteQuery(std::move(txn), std::move(sql));
         for (auto& row : google::cloud::spanner::StreamOf<RowType>(rows)) {
           if (!row) return std::move(row).status();
@@ -479,7 +479,7 @@ void OrderNulls(google::cloud::spanner::Client client) {
   if (!commit) throw std::move(commit).status();
   std::cout << "Insertion of NULL LastName was successful.\n";
 
-  using RowType = std::tuple<absl::optional<std::string>>;
+  using RowType = std::tuple<std::optional<std::string>>;
   for (std::string option : {"", " DESC", " NULLS FIRST", " NULLS LAST"}) {
     auto sql = google::cloud::spanner::SqlStatement(
         R"""(SELECT "LastName" FROM Singers ORDER BY "LastName")""" + option);
@@ -635,9 +635,9 @@ void InformationSchema(
           WHERE table_schema = 'public'
   )""");
   using RowType =
-      std::tuple<absl::optional<std::string>, std::string, std::string,
-                 absl::optional<std::string>, absl::optional<std::string>,
-                 absl::optional<std::string>>;
+      std::tuple<std::optional<std::string>, std::string, std::string,
+                 std::optional<std::string>, std::optional<std::string>,
+                 std::optional<std::string>>;
   auto rows = client.ExecuteQuery(std::move(sql));
   for (auto& row : google::cloud::spanner::StreamOf<RowType>(rows)) {
     if (!row) throw std::move(row).status();
@@ -741,8 +741,8 @@ void NumericDataType(google::cloud::spanner::Client client) {
   auto sql = google::cloud::spanner::SqlStatement(R"""(
       SELECT Name, Revenue FROM Venues
   )""");
-  using RowType = std::tuple<std::string,
-                             absl::optional<google::cloud::spanner::PgNumeric>>;
+  using RowType =
+      std::tuple<std::string, std::optional<google::cloud::spanner::PgNumeric>>;
   auto rows = client.ExecuteQuery(std::move(sql));
   for (auto& row : google::cloud::spanner::StreamOf<RowType>(rows)) {
     if (!row) throw std::move(row).status();
@@ -840,7 +840,7 @@ void JsonbQueryWithParameter(google::cloud::spanner::Client client) {
       "  WHERE CAST(VenueDetails ->> 'rating' AS INTEGER) > $1",
       {{"p1", google::cloud::spanner::Value(2)}});
   using RowType =
-      std::tuple<std::int64_t, absl::optional<google::cloud::spanner::JsonB>>;
+      std::tuple<std::int64_t, std::optional<google::cloud::spanner::JsonB>>;
   auto rows = client.ExecuteQuery(std::move(sql));
   for (auto& row : google::cloud::spanner::StreamOf<RowType>(rows)) {
     if (!row) throw std::move(row).status();

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -42,11 +42,11 @@
 #include "absl/strings/string_view.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
-#include "absl/types/optional.h"
 #include "protos/google/cloud/spanner/testing/singer.pb.h"
 #include <chrono>
 #include <iomanip>
 #include <iterator>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -487,7 +487,7 @@ void AddDatabaseReader(google::cloud::spanner_admin::InstanceAdminClient client,
   auto result = client.SetIamPolicy(
       in.FullName(),
       [&new_reader](google::iam::v1::Policy current)
-          -> absl::optional<google::iam::v1::Policy> {
+          -> std::optional<google::iam::v1::Policy> {
         // Find (or create) the binding for "roles/spanner.databaseReader".
         auto& binding = [&current]() -> google::iam::v1::Binding& {
           auto role_pos = std::find_if(
@@ -544,7 +544,7 @@ void RemoveDatabaseReader(
   auto result = client.SetIamPolicy(
       in.FullName(),
       [&reader](google::iam::v1::Policy current)
-          -> absl::optional<google::iam::v1::Policy> {
+          -> std::optional<google::iam::v1::Policy> {
         // Find the binding for "roles/spanner.databaseReader".
         auto role_pos =
             std::find_if(current.mutable_bindings()->begin(),
@@ -2507,8 +2507,8 @@ void QueryWithArrayParameter(google::cloud::spanner::Client client) {
       " UNNEST(v.AvailableDates) as AvailableDate "
       " WHERE AvailableDate in UNNEST(@available_dates)",
       {{"available_dates", spanner::Value(example_array)}});
-  using RowType = std::tuple<std::int64_t, absl::optional<std::string>,
-                             absl::optional<absl::CivilDay>>;
+  using RowType = std::tuple<std::int64_t, std::optional<std::string>,
+                             std::optional<absl::CivilDay>>;
   auto rows = client.ExecuteQuery(std::move(select));
   for (auto& row : spanner::StreamOf<RowType>(rows)) {
     if (!row) throw std::move(row).status();
@@ -2528,8 +2528,8 @@ void QueryWithBoolParameter(google::cloud::spanner::Client client) {
       "SELECT VenueId, VenueName, OutdoorVenue FROM Venues"
       " WHERE OutdoorVenue = @outdoor_venue",
       {{"outdoor_venue", spanner::Value(example_bool)}});
-  using RowType = std::tuple<std::int64_t, absl::optional<std::string>,
-                             absl::optional<bool>>;
+  using RowType =
+      std::tuple<std::int64_t, std::optional<std::string>, std::optional<bool>>;
   auto rows = client.ExecuteQuery(std::move(select));
   for (auto& row : spanner::StreamOf<RowType>(rows)) {
     if (!row) throw std::move(row).status();
@@ -2549,7 +2549,7 @@ void QueryWithBytesParameter(google::cloud::spanner::Client client) {
       "SELECT VenueId, VenueName FROM Venues"
       " WHERE VenueInfo = @venue_info",
       {{"venue_info", spanner::Value(example_bytes)}});
-  using RowType = std::tuple<std::int64_t, absl::optional<std::string>>;
+  using RowType = std::tuple<std::int64_t, std::optional<std::string>>;
   auto rows = client.ExecuteQuery(std::move(select));
   for (auto& row : spanner::StreamOf<RowType>(rows)) {
     if (!row) throw std::move(row).status();
@@ -2568,8 +2568,8 @@ void QueryWithDateParameter(google::cloud::spanner::Client client) {
       "SELECT VenueId, VenueName, LastContactDate FROM Venues"
       " WHERE LastContactDate < @last_contact_date",
       {{"last_contact_date", spanner::Value(example_date)}});
-  using RowType = std::tuple<std::int64_t, absl::optional<std::string>,
-                             absl::optional<absl::CivilDay>>;
+  using RowType = std::tuple<std::int64_t, std::optional<std::string>,
+                             std::optional<absl::CivilDay>>;
   auto rows = client.ExecuteQuery(std::move(select));
   for (auto& row : spanner::StreamOf<RowType>(rows)) {
     if (!row) throw std::move(row).status();
@@ -2589,8 +2589,8 @@ void QueryWithFloatParameter(google::cloud::spanner::Client client) {
       "SELECT VenueId, VenueName, PopularityScore FROM Venues"
       " WHERE PopularityScore > @popularity_score",
       {{"popularity_score", spanner::Value(example_float)}});
-  using RowType = std::tuple<std::int64_t, absl::optional<std::string>,
-                             absl::optional<double>>;
+  using RowType = std::tuple<std::int64_t, std::optional<std::string>,
+                             std::optional<double>>;
   auto rows = client.ExecuteQuery(std::move(select));
   for (auto& row : spanner::StreamOf<RowType>(rows)) {
     if (!row) throw std::move(row).status();
@@ -2610,8 +2610,8 @@ void QueryWithIntParameter(google::cloud::spanner::Client client) {
       "SELECT VenueId, VenueName, Capacity FROM Venues"
       " WHERE Capacity >= @capacity",
       {{"capacity", spanner::Value(example_int)}});
-  using RowType = std::tuple<std::int64_t, absl::optional<std::string>,
-                             absl::optional<std::int64_t>>;
+  using RowType = std::tuple<std::int64_t, std::optional<std::string>,
+                             std::optional<std::int64_t>>;
   auto rows = client.ExecuteQuery(std::move(select));
   for (auto& row : spanner::StreamOf<RowType>(rows)) {
     if (!row) throw std::move(row).status();
@@ -2631,7 +2631,7 @@ void QueryWithStringParameter(google::cloud::spanner::Client client) {
       "SELECT VenueId, VenueName FROM Venues"
       " WHERE VenueName = @venue_name",
       {{"venue_name", spanner::Value(example_string)}});
-  using RowType = std::tuple<std::int64_t, absl::optional<std::string>>;
+  using RowType = std::tuple<std::int64_t, std::optional<std::string>>;
   auto rows = client.ExecuteQuery(std::move(select));
   for (auto& row : spanner::StreamOf<RowType>(rows)) {
     if (!row) throw std::move(row).status();
@@ -2651,8 +2651,8 @@ void QueryWithTimestampParameter(
       "SELECT VenueId, VenueName, LastUpdateTime FROM Venues"
       " WHERE LastUpdateTime <= @last_update_time",
       {{"last_update_time", spanner::Value(example_timestamp)}});
-  using RowType = std::tuple<std::int64_t, absl::optional<std::string>,
-                             absl::optional<spanner::Timestamp>>;
+  using RowType = std::tuple<std::int64_t, std::optional<std::string>,
+                             std::optional<spanner::Timestamp>>;
   auto rows = client.ExecuteQuery(std::move(select));
   for (auto& row : spanner::StreamOf<RowType>(rows)) {
     if (!row) throw std::move(row).status();
@@ -2896,8 +2896,8 @@ void QueryDataWithTimestamp(google::cloud::spanner::Client client) {
       "  FROM Albums"
       " ORDER BY LastUpdateTime DESC");
   using RowType =
-      std::tuple<std::int64_t, std::int64_t, absl::optional<std::int64_t>,
-                 absl::optional<spanner::Timestamp>>;
+      std::tuple<std::int64_t, std::int64_t, std::optional<std::int64_t>,
+                 std::optional<spanner::Timestamp>>;
 
   auto rows = client.ExecuteQuery(std::move(select));
   for (auto& row : spanner::StreamOf<RowType>(rows)) {
@@ -2985,7 +2985,7 @@ void QueryWithJsonParameter(google::cloud::spanner::Client client) {
       " WHERE JSON_VALUE(VenueDetails, '$.rating') ="
       "       JSON_VALUE(@details, '$.rating')",
       {{"details", spanner::Value(std::move(rating9_details))}});
-  using RowType = std::tuple<std::int64_t, absl::optional<spanner::Json>>;
+  using RowType = std::tuple<std::int64_t, std::optional<spanner::Json>>;
 
   auto rows = client.ExecuteQuery(std::move(select));
   for (auto& row : spanner::StreamOf<RowType>(rows)) {
@@ -3048,7 +3048,7 @@ void QueryWithNumericParameter(google::cloud::spanner::Client client) {
       "  FROM Venues"
       " WHERE Revenue < @revenue",
       {{"revenue", spanner::Value(std::move(revenue))}});
-  using RowType = std::tuple<std::int64_t, absl::optional<spanner::Numeric>>;
+  using RowType = std::tuple<std::int64_t, std::optional<spanner::Numeric>>;
 
   auto rows = client.ExecuteQuery(std::move(select));
   for (auto& row : spanner::StreamOf<RowType>(rows)) {
@@ -3285,7 +3285,7 @@ void QueryNewColumn(google::cloud::spanner::Client client) {
   spanner::SqlStatement select(
       "SELECT SingerId, AlbumId, MarketingBudget FROM Albums");
   using RowType =
-      std::tuple<std::int64_t, std::int64_t, absl::optional<std::int64_t>>;
+      std::tuple<std::int64_t, std::int64_t, std::optional<std::int64_t>>;
 
   auto rows = client.ExecuteQuery(std::move(select));
   for (auto& row : spanner::StreamOf<RowType>(rows)) {
@@ -3337,7 +3337,7 @@ void QueryUsingIndex(google::cloud::spanner::Client client) {
       {{"start_title", spanner::Value("Aardvark")},
        {"end_title", spanner::Value("Goo")}});
   using RowType =
-      std::tuple<std::int64_t, std::string, absl::optional<std::int64_t>>;
+      std::tuple<std::int64_t, std::string, std::optional<std::int64_t>>;
   auto rows = client.ExecuteQuery(std::move(select));
   for (auto& row : spanner::StreamOf<RowType>(rows)) {
     if (!row) throw std::move(row).status();
@@ -3409,7 +3409,7 @@ void ReadDataWithStoringIndex(google::cloud::spanner::Client client) {
                   google::cloud::Options{}.set<spanner::ReadIndexNameOption>(
                       "AlbumsByAlbumTitle2"));
   using RowType =
-      std::tuple<std::int64_t, std::string, absl::optional<std::int64_t>>;
+      std::tuple<std::int64_t, std::string, std::optional<std::int64_t>>;
   for (auto& row : spanner::StreamOf<RowType>(rows)) {
     if (!row) throw std::move(row).status();
     std::cout << "AlbumId: " << std::get<0>(*row) << "\t";
@@ -3949,7 +3949,7 @@ void DmlGettingStartedUpdate(google::cloud::spanner::Client client) {
                         std::int64_t singer_id) -> StatusOr<std::int64_t> {
     auto key = spanner::KeySet().AddKey(spanner::MakeKey(album_id, singer_id));
     auto rows = client.Read(std::move(txn), "Albums", key, {"MarketingBudget"});
-    using RowType = std::tuple<absl::optional<std::int64_t>>;
+    using RowType = std::tuple<std::optional<std::int64_t>>;
     auto row = spanner::GetSingularRow(spanner::StreamOf<RowType>(rows));
     if (!row) return std::move(row).status();
     auto const budget = std::get<0>(*row);
@@ -4190,7 +4190,7 @@ void UpdateUsingDmlReturning(google::cloud::spanner::Client client) {
               WHERE SingerId = 1 AND AlbumId = 1
               THEN RETURN MarketingBudget
         )""");
-        using RowType = std::tuple<absl::optional<std::int64_t>>;
+        using RowType = std::tuple<std::optional<std::int64_t>>;
         auto rows = client.ExecuteQuery(std::move(txn), std::move(sql));
         // Note: This mutator might be re-run, or its effects discarded, so
         // changing non-transactional state (e.g., by producing output) is,
@@ -4417,8 +4417,8 @@ void UpdateDataWithProtoMessageColumn(google::cloud::spanner::Client client) {
               "Singers", {"SingerId", "SingerInfo", "SingerInfoArray"})
               .EmplaceRow(2, singer_info,
                           std::vector<SingerInfoMessage>{singer_info})
-              .EmplaceRow(3, absl::optional<SingerInfoMessage>(),
-                          absl::optional<std::vector<SingerInfoMessage>>())
+              .EmplaceRow(3, std::optional<SingerInfoMessage>(),
+                          std::optional<std::vector<SingerInfoMessage>>())
               .Build()}});
   for (auto& commit_result : commit_results) {
     if (!commit_result) throw std::move(commit_result).status();
@@ -4473,8 +4473,8 @@ void QueryWithProtoMessageParameter(google::cloud::spanner::Client client) {
       {{"nationality", google::cloud::spanner::Value("British")}});
   using SingerInfoMessage = google::cloud::spanner::ProtoMessage<
       google::cloud::spanner::testing::SingerInfo>;
-  using RowType = std::tuple<std::int64_t, absl::optional<SingerInfoMessage>,
-                             absl::optional<std::vector<SingerInfoMessage>>>;
+  using RowType = std::tuple<std::int64_t, std::optional<SingerInfoMessage>,
+                             std::optional<std::vector<SingerInfoMessage>>>;
   auto rows = client.ExecuteQuery(std::move(select));
   for (auto& row : google::cloud::spanner::StreamOf<RowType>(rows)) {
     if (!row) throw std::move(row).status();
@@ -4516,8 +4516,8 @@ void UpdateDataWithProtoEnumColumn(google::cloud::spanner::Client client) {
           google::cloud::spanner::InsertOrUpdateMutationBuilder(
               "Singers", {"SingerId", "SingerGenre", "SingerGenreArray"})
               .EmplaceRow(2, singer_genre, std::vector<GenreEnum>{singer_genre})
-              .EmplaceRow(3, absl::optional<GenreEnum>(),
-                          absl::optional<std::vector<GenreEnum>>())
+              .EmplaceRow(3, std::optional<GenreEnum>(),
+                          std::optional<std::vector<GenreEnum>>())
               .Build()}});
   for (auto& commit_result : commit_results) {
     if (!commit_result) throw std::move(commit_result).status();
@@ -4568,8 +4568,8 @@ void QueryWithProtoEnumParameter(google::cloud::spanner::Client client) {
       "SELECT SingerId, SingerGenre, SingerGenreArray FROM Singers"
       " WHERE SingerGenre = @singer_genre",
       {{"singer_genre", google::cloud::spanner::Value(singer_genre)}});
-  using RowType = std::tuple<std::int64_t, absl::optional<GenreEnum>,
-                             absl::optional<std::vector<GenreEnum>>>;
+  using RowType = std::tuple<std::int64_t, std::optional<GenreEnum>,
+                             std::optional<std::vector<GenreEnum>>>;
   auto rows = client.ExecuteQuery(std::move(select));
   for (auto& row : google::cloud::spanner::StreamOf<RowType>(rows)) {
     if (!row) throw std::move(row).status();

--- a/google/cloud/spanner/testing/mock_partial_result_set_reader.h
+++ b/google/cloud/spanner/testing/mock_partial_result_set_reader.h
@@ -29,7 +29,7 @@ class MockPartialResultSetReader
  public:
   MOCK_METHOD(void, TryCancel, (), (override));
   MOCK_METHOD(bool, Read,
-              (absl::optional<std::string> const& resume_token,
+              (std::optional<std::string> const& resume_token,
                spanner_internal::UnownedPartialResultSet& result),
               (override));
   MOCK_METHOD(Status, Finish, (), (override));

--- a/google/cloud/spanner/transaction.cc
+++ b/google/cloud/spanner/transaction.cc
@@ -36,7 +36,7 @@ google::protobuf::Duration ToProto(std::chrono::nanoseconds ns) {
 
 google::spanner::v1::TransactionOptions_ReadWrite_ReadLockMode
 ProtoReadLockMode(
-    absl::optional<Transaction::ReadLockMode> const& read_lock_mode) {
+    std::optional<Transaction::ReadLockMode> const& read_lock_mode) {
   if (!read_lock_mode) {
     return google::spanner::v1::TransactionOptions_ReadWrite_ReadLockMode::
         TransactionOptions_ReadWrite_ReadLockMode_READ_LOCK_MODE_UNSPECIFIED;
@@ -55,7 +55,7 @@ ProtoReadLockMode(
 }
 
 google::spanner::v1::TransactionOptions_IsolationLevel ProtoIsolationLevel(
-    absl::optional<Transaction::IsolationLevel> const& isolation_level) {
+    std::optional<Transaction::IsolationLevel> const& isolation_level) {
   if (!isolation_level) {
     return google::spanner::v1::TransactionOptions::ISOLATION_LEVEL_UNSPECIFIED;
   }
@@ -79,7 +79,7 @@ google::spanner::v1::TransactionOptions MakeOpts(
 
 google::spanner::v1::TransactionOptions MakeOpts(
     google::spanner::v1::TransactionOptions_ReadWrite rw_opts,
-    absl::optional<Transaction::IsolationLevel> isolation_level) {
+    std::optional<Transaction::IsolationLevel> isolation_level) {
   google::spanner::v1::TransactionOptions opts;
   *opts.mutable_read_write() = std::move(rw_opts);
   auto const& current = internal::CurrentOptions();
@@ -130,7 +130,7 @@ Transaction::ReadWriteOptions::ReadWriteOptions(ReadLockMode read_lock_mode) {
 }
 
 Transaction::ReadWriteOptions& Transaction::ReadWriteOptions::WithTag(
-    absl::optional<std::string> tag) {
+    std::optional<std::string> tag) {
   tag_ = std::move(tag);
   return *this;
 }
@@ -211,7 +211,7 @@ Transaction::Transaction(std::string session_id, std::string transaction_id,
   impl_ = std::make_shared<spanner_internal::TransactionImpl>(
       spanner_internal::MakeDissociatedSessionHolder(std::move(session_id)),
       std::move(selector), route_to_leader, std::move(transaction_tag),
-      absl::nullopt);
+      std::nullopt);
 }
 
 Transaction::~Transaction() = default;

--- a/google/cloud/spanner/transaction.h
+++ b/google/cloud/spanner/transaction.h
@@ -18,10 +18,10 @@
 #include "google/cloud/spanner/internal/transaction_impl.h"
 #include "google/cloud/spanner/timestamp.h"
 #include "google/cloud/spanner/version.h"
-#include "absl/types/optional.h"
 #include "google/spanner/v1/transaction.pb.h"
 #include <chrono>
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace google {
@@ -132,7 +132,7 @@ class Transaction {
     explicit ReadWriteOptions(ReadLockMode read_lock_mode);
 
     // A tag used for collecting statistics about the transaction.
-    ReadWriteOptions& WithTag(absl::optional<std::string> tag);
+    ReadWriteOptions& WithTag(std::optional<std::string> tag);
 
     // Sets the isolation level for the transaction. This controls how the
     // transaction interacts with other concurrent transactions, primarily
@@ -143,8 +143,8 @@ class Transaction {
    private:
     friend Transaction;
     google::spanner::v1::TransactionOptions_ReadWrite rw_opts_;
-    absl::optional<std::string> tag_;
-    absl::optional<IsolationLevel> isolation_level_;
+    std::optional<std::string> tag_;
+    std::optional<IsolationLevel> isolation_level_;
   };
 
   /**

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -33,10 +33,10 @@
 #include "google/cloud/optional.h"
 #include "google/cloud/status_or.h"
 #include "absl/time/civil_time.h"
-#include "absl/types/optional.h"
 #include "google/protobuf/struct.pb.h"
 #include "google/spanner/v1/type.pb.h"
 #include <google/protobuf/util/message_differencer.h>
+#include <optional>
 #include <ostream>
 #include <string>
 #include <tuple>
@@ -101,7 +101,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * Callers may create instances by passing any of the supported values
  * (shown in the table above) to the constructor. "Null" values are created
  * using the `MakeNullValue<T>()` factory function or by passing an empty
- * `absl::optional<T>` to the Value constructor..
+ * `std::optional<T>` to the Value constructor..
  *
  * @par Example
  * Using a non-null value.
@@ -120,8 +120,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * spanner::Value v = spanner::MakeNullValue<std::int64_t>();
  * StatusOr<std::int64_t> i = v.get<std::int64_t>();
  * assert(!i.ok());  // Can't get the value because v is null
- * StatusOr < absl::optional<std::int64_t> j =
- *     v.get<absl::optional<std::int64_t>>();
+ * StatusOr < std::optional<std::int64_t> j =
+ *     v.get<std::optional<std::int64_t>>();
  * assert(j.ok());  // OK because an empty option can represent the null
  * assert(!j->has_value());  // v held no value.
  * @endcode
@@ -131,11 +131,11 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * All of the supported types (above) are "nullable". A null is created in one
  * of two ways:
  *
- * 1. Passing an `absl::optional<T>()` with no value to `Value`'s constructor.
+ * 1. Passing an `std::optional<T>()` with no value to `Value`'s constructor.
  * 2. Using the `MakeNullValue<T>()` helper function (defined below).
  *
  * Nulls can be retrieved from a `Value::get<T>` by specifying the type `T`
- * as an `absl::optional<U>`. The returned optional will either be empty
+ * as an `std::optional<U>`. The returned optional will either be empty
  * (indicating null) or it will contain the actual value. See the documentation
  * for `Value::get<T>` below for more details.
  *
@@ -263,7 +263,7 @@ class Value {
    * a null instance with the specified type `T`.
    */
   template <typename T>
-  explicit Value(absl::optional<T> opt)
+  explicit Value(std::optional<T> opt)
       : Value(PrivateConstructor{}, std::move(opt)) {}
 
   /**
@@ -303,7 +303,7 @@ class Value {
    *
    * Returns a non-OK status IFF:
    *
-   * * The contained value is "null", and `T` is not an `absl::optional`.
+   * * The contained value is "null", and `T` is not an `std::optional`.
    * * There is an error converting the contained value to `T`.
    *
    * @par Example
@@ -321,8 +321,8 @@ class Value {
    * if (!i) {
    *   std::cerr << "Could not get integer: " << i.status();
    * }
-   * StatusOr<absl::optional<std::int64_t>> j =
-   *     v.get<absl::optional<std::int64_t>>();
+   * StatusOr<std::optional<std::int64_t>> j =
+   *     v.get<std::optional<std::int64_t>>();
    * assert(j.ok());  // Since we know the types match in this example
    * assert(!v->has_value());  // Since we know v was null in this example
    * @endcode
@@ -374,11 +374,11 @@ class Value {
   friend void PrintTo(Value const& v, std::ostream* os) { *os << v; }
 
  private:
-  // Metafunction that returns true if `T` is an `absl::optional<U>`
+  // Metafunction that returns true if `T` is an `std::optional<U>`
   template <typename T>
   struct IsOptional : std::false_type {};
   template <typename T>
-  struct IsOptional<absl::optional<T>> : std::true_type {};
+  struct IsOptional<std::optional<T>> : std::true_type {};
 
   // Metafunction that returns true if `T` is a std::vector<U>
   template <typename T>
@@ -417,7 +417,7 @@ class Value {
            type.proto_type_fqn() == ProtoMessage<M>::TypeName();
   }
   template <typename T>
-  static bool TypeProtoIs(absl::optional<T>,
+  static bool TypeProtoIs(std::optional<T>,
                           google::spanner::v1::Type const& type) {
     return TypeProtoIs(T{}, type);
   }
@@ -490,7 +490,7 @@ class Value {
   static google::spanner::v1::Type MakeTypeProto(int);
   static google::spanner::v1::Type MakeTypeProto(char const*);
   template <typename T>
-  static google::spanner::v1::Type MakeTypeProto(absl::optional<T> const&) {
+  static google::spanner::v1::Type MakeTypeProto(std::optional<T> const&) {
     return MakeTypeProto(T{});
   }
   template <typename T>
@@ -568,7 +568,7 @@ class Value {
   static google::protobuf::Value MakeValueProto(int i);
   static google::protobuf::Value MakeValueProto(char const* s);
   template <typename T>
-  static google::protobuf::Value MakeValueProto(absl::optional<T> opt) {
+  static google::protobuf::Value MakeValueProto(std::optional<T> opt) {
     if (opt.has_value()) return MakeValueProto(*std::move(opt));
     google::protobuf::Value v;
     v.set_null_value(google::protobuf::NullValue::NULL_VALUE);
@@ -676,14 +676,14 @@ class Value {
     return ProtoMessage<M>(std::string(bytes->begin(), bytes->end()));
   }
   template <typename T, typename V>
-  static StatusOr<absl::optional<T>> GetValue(
-      absl::optional<T> const&, V&& pv, google::spanner::v1::Type const& pt) {
+  static StatusOr<std::optional<T>> GetValue(
+      std::optional<T> const&, V&& pv, google::spanner::v1::Type const& pt) {
     if (pv.kind_case() == google::protobuf::Value::kNullValue) {
-      return absl::optional<T>{};
+      return std::optional<T>{};
     }
     auto value = GetValue(T{}, std::forward<V>(pv), pt);
     if (!value) return std::move(value).status();
-    return absl::optional<T>{*std::move(value)};
+    return std::optional<T>{*std::move(value)};
   }
   template <typename T, typename V>
   static StatusOr<std::vector<T>> GetValue(
@@ -786,13 +786,13 @@ class Value {
 /**
  * Factory to construct a "null" Value of the specified type `T`.
  *
- * This is equivalent to passing an `absl::optional<T>` without a value to
+ * This is equivalent to passing an `std::optional<T>` without a value to
  * the constructor, though this factory may be easier to invoke and result
  * in clearer code at the call site.
  */
 template <typename T>
 Value MakeNullValue() {
-  return Value(absl::optional<T>{});
+  return Value(std::optional<T>{});
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -17,7 +17,6 @@
 #include "google/cloud/testing_util/is_proto_equal.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "absl/time/time.h"
-#include "absl/types/optional.h"
 #include "protos/google/cloud/spanner/testing/singer.pb.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
@@ -26,6 +25,7 @@
 #include <iomanip>
 #include <ios>
 #include <limits>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -99,8 +99,8 @@ void TestBasicSemantics(T init) {
   Value const null = MakeNullValue<T>();
 
   EXPECT_THAT(null.get<T>(), Not(IsOk()));
-  ASSERT_STATUS_OK(null.get<absl::optional<T>>());
-  EXPECT_EQ(absl::optional<T>{}, *null.get<absl::optional<T>>());
+  ASSERT_STATUS_OK(null.get<std::optional<T>>());
+  EXPECT_EQ(std::optional<T>{}, *null.get<std::optional<T>>());
 
   Value copy_null = null;
   EXPECT_EQ(copy_null, null);
@@ -117,11 +117,11 @@ void TestBasicSemantics(T init) {
   EXPECT_EQ(null_protos.second.null_value(),
             google::protobuf::NullValue::NULL_VALUE);
 
-  Value const not_null{absl::optional<T>(init)};
+  Value const not_null{std::optional<T>(init)};
   ASSERT_STATUS_OK(not_null.get<T>());
   EXPECT_EQ(init, *not_null.get<T>());
-  ASSERT_STATUS_OK(not_null.get<absl::optional<T>>());
-  EXPECT_EQ(init, **not_null.get<absl::optional<T>>());
+  ASSERT_STATUS_OK(not_null.get<std::optional<T>>());
+  EXPECT_EQ(init, **not_null.get<std::optional<T>>());
 }
 
 TEST(Value, BasicSemantics) {
@@ -129,7 +129,7 @@ TEST(Value, BasicSemantics) {
     SCOPED_TRACE("Testing: bool " + std::to_string(x));
     TestBasicSemantics(x);
     TestBasicSemantics(std::vector<bool>(5, x));
-    std::vector<absl::optional<bool>> v(5, x);
+    std::vector<std::optional<bool>> v(5, x);
     v.resize(10);
     TestBasicSemantics(v);
   }
@@ -140,7 +140,7 @@ TEST(Value, BasicSemantics) {
     SCOPED_TRACE("Testing: std::int64_t " + std::to_string(x));
     TestBasicSemantics(x);
     TestBasicSemantics(std::vector<std::int64_t>(5, x));
-    std::vector<absl::optional<std::int64_t>> v(5, x);
+    std::vector<std::optional<std::int64_t>> v(5, x);
     v.resize(10);
     TestBasicSemantics(v);
   }
@@ -153,7 +153,7 @@ TEST(Value, BasicSemantics) {
     SCOPED_TRACE("Testing: double " + std::to_string(x));
     TestBasicSemantics(x);
     TestBasicSemantics(std::vector<double>(5, x));
-    std::vector<absl::optional<double>> v(5, x);
+    std::vector<std::optional<double>> v(5, x);
     v.resize(10);
     TestBasicSemantics(v);
   }
@@ -166,7 +166,7 @@ TEST(Value, BasicSemantics) {
     SCOPED_TRACE("Testing: float " + std::to_string(x));
     TestBasicSemantics(x);
     TestBasicSemantics(std::vector<float>(5, x));
-    std::vector<absl::optional<float>> v(5, x);
+    std::vector<std::optional<float>> v(5, x);
     v.resize(10);
     TestBasicSemantics(v);
   }
@@ -176,7 +176,7 @@ TEST(Value, BasicSemantics) {
     SCOPED_TRACE("Testing: std::string " + std::string(x));
     TestBasicSemantics(x);
     TestBasicSemantics(std::vector<std::string>(5, x));
-    std::vector<absl::optional<std::string>> v(5, x);
+    std::vector<std::optional<std::string>> v(5, x);
     v.resize(10);
     TestBasicSemantics(v);
   }
@@ -186,7 +186,7 @@ TEST(Value, BasicSemantics) {
     SCOPED_TRACE("Testing: Bytes " + x.get<std::string>());
     TestBasicSemantics(x);
     TestBasicSemantics(std::vector<Bytes>(5, x));
-    std::vector<absl::optional<Bytes>> v(5, x);
+    std::vector<std::optional<Bytes>> v(5, x);
     v.resize(10);
     TestBasicSemantics(v);
   }
@@ -196,7 +196,7 @@ TEST(Value, BasicSemantics) {
     SCOPED_TRACE("Testing: JSON " + std::string(x));
     TestBasicSemantics(x);
     TestBasicSemantics(std::vector<Json>(5, x));
-    std::vector<absl::optional<Json>> v(5, x);
+    std::vector<std::optional<Json>> v(5, x);
     v.resize(10);
     TestBasicSemantics(v);
   }
@@ -206,7 +206,7 @@ TEST(Value, BasicSemantics) {
     SCOPED_TRACE("Testing: JSONB " + std::string(x));
     TestBasicSemantics(x);
     TestBasicSemantics(std::vector<JsonB>(5, x));
-    std::vector<absl::optional<JsonB>> v(5, x);
+    std::vector<std::optional<JsonB>> v(5, x);
     v.resize(10);
     TestBasicSemantics(v);
   }
@@ -223,7 +223,7 @@ TEST(Value, BasicSemantics) {
     SCOPED_TRACE("Testing: google::cloud::spanner::Numeric " + x.ToString());
     TestBasicSemantics(x);
     TestBasicSemantics(std::vector<Numeric>(5, x));
-    std::vector<absl::optional<Numeric>> v(5, x);
+    std::vector<std::optional<Numeric>> v(5, x);
     v.resize(10);
     TestBasicSemantics(v);
   }
@@ -234,7 +234,7 @@ TEST(Value, BasicSemantics) {
     TestBasicSemantics(ts);
     std::vector<Timestamp> v(5, ts);
     TestBasicSemantics(v);
-    std::vector<absl::optional<Timestamp>> ov(5, ts);
+    std::vector<std::optional<Timestamp>> ov(5, ts);
     ov.resize(10);
     TestBasicSemantics(ov);
   }
@@ -251,7 +251,7 @@ TEST(Value, BasicSemantics) {
     SCOPED_TRACE("Testing: absl::CivilDay " + absl::FormatCivilTime(x));
     TestBasicSemantics(x);
     TestBasicSemantics(std::vector<absl::CivilDay>(5, x));
-    std::vector<absl::optional<absl::CivilDay>> v(5, x);
+    std::vector<std::optional<absl::CivilDay>> v(5, x);
     v.resize(10);
     TestBasicSemantics(v);
   }
@@ -260,7 +260,7 @@ TEST(Value, BasicSemantics) {
   auto const x = CommitTimestamp{};
   TestBasicSemantics(x);
   TestBasicSemantics(std::vector<CommitTimestamp>(5, x));
-  std::vector<absl::optional<CommitTimestamp>> v(5, x);
+  std::vector<std::optional<CommitTimestamp>> v(5, x);
   v.resize(10);
   TestBasicSemantics(v);
 
@@ -268,7 +268,7 @@ TEST(Value, BasicSemantics) {
     SCOPED_TRACE("Testing: google::cloud::spanner::Interval " + std::string{x});
     TestBasicSemantics(x);
     TestBasicSemantics(std::vector<Interval>(5, x));
-    std::vector<absl::optional<Interval>> v(5, x);
+    std::vector<std::optional<Interval>> v(5, x);
     v.resize(10);
     TestBasicSemantics(v);
   }
@@ -277,7 +277,7 @@ TEST(Value, BasicSemantics) {
     SCOPED_TRACE("Testing: google::cloud::spanner::Uuid " + std::string{x});
     TestBasicSemantics(x);
     TestBasicSemantics(std::vector<Uuid>(5, x));
-    std::vector<absl::optional<Uuid>> v(5, x);
+    std::vector<std::optional<Uuid>> v(5, x);
     v.resize(10);
     TestBasicSemantics(v);
   }
@@ -288,7 +288,7 @@ TEST(Value, BasicSemantics) {
                  testing::Genre_Name(x));
     TestBasicSemantics(ProtoEnum<testing::Genre>(x));
     TestBasicSemantics(std::vector<ProtoEnum<testing::Genre>>(5, x));
-    std::vector<absl::optional<ProtoEnum<testing::Genre>>> v(5, x);
+    std::vector<std::optional<ProtoEnum<testing::Genre>>> v(5, x);
     v.resize(10);
     TestBasicSemantics(v);
   }
@@ -300,7 +300,7 @@ TEST(Value, BasicSemantics) {
                  x.ShortDebugString() + " }");
     TestBasicSemantics(ProtoMessage<testing::SingerInfo>(x));
     TestBasicSemantics(std::vector<ProtoMessage<testing::SingerInfo>>(5, x));
-    std::vector<absl::optional<ProtoMessage<testing::SingerInfo>>> v(5, x);
+    std::vector<std::optional<ProtoMessage<testing::SingerInfo>>> v(5, x);
     v.resize(10);
     TestBasicSemantics(v);
   }
@@ -374,7 +374,7 @@ TEST(Value, RvalueGetString) {
 // on some platform, we could probably delete this, unless we can think of a
 // better way to test move semantics.
 TEST(Value, RvalueGetOptionalString) {
-  using Type = absl::optional<std::string>;
+  using Type = std::optional<std::string>;
   Type const data = std::string(128, 'x');
   Value v(data);
 
@@ -667,9 +667,9 @@ TEST(Value, SpannerStruct) {
   EXPECT_STATUS_OK(v1.get<T2>());
   EXPECT_STATUS_OK(v2.get<T1>());
 
-  Value v_null(absl::optional<T1>{});
-  EXPECT_FALSE(v_null.get<absl::optional<T1>>()->has_value());
-  EXPECT_FALSE(v_null.get<absl::optional<T2>>()->has_value());
+  Value v_null(std::optional<T1>{});
+  EXPECT_FALSE(v_null.get<std::optional<T1>>()->has_value());
+  EXPECT_FALSE(v_null.get<std::optional<T2>>()->has_value());
 
   EXPECT_NE(v1, v_null);
   EXPECT_NE(v2, v_null);
@@ -698,7 +698,7 @@ TEST(Value, SpannerStruct) {
 
   EXPECT_THAT(v5.get<T5>(), IsOkAndHolds(empty));
 
-  auto deeply_nested = tuple<tuple<std::vector<absl::optional<bool>>>>{};
+  auto deeply_nested = tuple<tuple<std::vector<std::optional<bool>>>>{};
   using T6 = decltype(deeply_nested);
   Value v6(deeply_nested);
   EXPECT_STATUS_OK(v6.get<T6>());
@@ -711,7 +711,7 @@ TEST(Value, SpannerStruct) {
 
 TEST(Value, SpannerStructWithNull) {
   auto v1 = Value(std::make_tuple(123, true));
-  auto v2 = Value(std::make_tuple(123, absl::optional<bool>{}));
+  auto v2 = Value(std::make_tuple(123, std::optional<bool>{}));
 
   auto protos1 = spanner_internal::ToProto(v1);
   auto protos2 = spanner_internal::ToProto(v2);
@@ -1395,15 +1395,15 @@ TEST(Value, GetBadProtoMessageFQN) {
 }
 
 TEST(Value, GetBadOptional) {
-  Value v(absl::optional<double>{});
+  Value v(std::optional<double>{});
   ClearProtoKind(v);
-  EXPECT_THAT(v.get<absl::optional<double>>(), Not(IsOk()));
+  EXPECT_THAT(v.get<std::optional<double>>(), Not(IsOk()));
 
   SetProtoKind(v, true);
-  EXPECT_THAT(v.get<absl::optional<double>>(), Not(IsOk()));
+  EXPECT_THAT(v.get<std::optional<double>>(), Not(IsOk()));
 
   SetProtoKind(v, "blah");
-  EXPECT_THAT(v.get<absl::optional<double>>(), Not(IsOk()));
+  EXPECT_THAT(v.get<std::optional<double>>(), Not(IsOk()));
 }
 
 TEST(Value, GetBadArray) {
@@ -1585,7 +1585,7 @@ TEST(Value, OutputStream) {
        normal},
 
       // Tests arrays with null elements
-      {Value(std::vector<absl::optional<double>>{1, {}, 2}), "[1, NULL, 2]",
+      {Value(std::vector<std::optional<double>>{1, {}, 2}), "[1, NULL, 2]",
        normal},
 
       // Tests null arrays
@@ -1631,12 +1631,12 @@ TEST(Value, OutputStream) {
        "((([a, b, c])))", hex},
 
       // Tests struct with null members
-      {Value(std::make_tuple(absl::optional<bool>{})), "(NULL)", normal},
-      {Value(std::make_tuple(absl::optional<bool>{}, 123)), "(NULL, 123)",
+      {Value(std::make_tuple(std::optional<bool>{})), "(NULL)", normal},
+      {Value(std::make_tuple(std::optional<bool>{}, 123)), "(NULL, 123)",
        normal},
-      {Value(std::make_tuple(absl::optional<bool>{}, 123)), "(NULL, 7b)", hex},
-      {Value(std::make_tuple(absl::optional<bool>{},
-                             absl::optional<std::int64_t>{})),
+      {Value(std::make_tuple(std::optional<bool>{}, 123)), "(NULL, 7b)", hex},
+      {Value(std::make_tuple(std::optional<bool>{},
+                             std::optional<std::int64_t>{})),
        "(NULL, NULL)", normal},
 
       // Tests null structs


### PR DESCRIPTION
Replacing explicit usages of absl::optional with std::optional in the Spanner Client library as part of broader modernization efforts