### PR TITLE
chore(bigquery): migrate to std::optional

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/common_v2_resources.h
+++ b/google/cloud/bigquery/v2/minimal/internal/common_v2_resources.h
@@ -316,7 +316,7 @@ bool operator==(Struct const& lhs, Struct const& rhs);
 
 struct ColumnData {
   std::string value;
-  // TODO(#14387): Use absl::optional instead.
+  // TODO(#14387): Use std::optional instead.
   bool is_null{false};
   std::string DebugString(absl::string_view name,
                           TracingOptions const& options = {},

--- a/google/cloud/bigquery/v2/minimal/internal/dataset_request.h
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset_request.h
@@ -21,7 +21,7 @@
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
 #include "absl/strings/string_view.h"
-#include "absl/types/optional.h"
+#include <optional>
 #include <string>
 
 namespace google {

--- a/google/cloud/bigquery/v2/minimal/internal/job.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job.h
@@ -20,8 +20,8 @@
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
 #include "absl/strings/string_view.h"
-#include "absl/types/optional.h"
 #include <nlohmann/json.hpp>
+#include <optional>
 #include <string>
 
 namespace google {

--- a/google/cloud/bigquery/v2/minimal/internal/job_query_stats.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_query_stats.h
@@ -20,9 +20,9 @@
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
 #include "absl/strings/string_view.h"
-#include "absl/types/optional.h"
 #include <nlohmann/json.hpp>
 #include <chrono>
+#include <optional>
 #include <string>
 
 namespace google {

--- a/google/cloud/bigquery/v2/minimal/internal/job_request.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_request.h
@@ -23,9 +23,9 @@
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
 #include "absl/strings/string_view.h"
-#include "absl/types/optional.h"
 #include <nlohmann/json.hpp>
 #include <chrono>
+#include <optional>
 #include <ostream>
 #include <string>
 
@@ -114,11 +114,11 @@ class ListJobsRequest {
   std::string const& project_id() const { return project_id_; }
   bool const& all_users() const { return all_users_; }
   std::int32_t const& max_results() const { return max_results_; }
-  absl::optional<std::chrono::system_clock::time_point> const&
+  std::optional<std::chrono::system_clock::time_point> const&
   min_creation_time() const {
     return min_creation_time_;
   }
-  absl::optional<std::chrono::system_clock::time_point> const&
+  std::optional<std::chrono::system_clock::time_point> const&
   max_creation_time() const {
     return max_creation_time_;
   }
@@ -211,8 +211,8 @@ class ListJobsRequest {
   std::string project_id_;
   bool all_users_;
   std::int32_t max_results_;
-  absl::optional<std::chrono::system_clock::time_point> min_creation_time_;
-  absl::optional<std::chrono::system_clock::time_point> max_creation_time_;
+  std::optional<std::chrono::system_clock::time_point> min_creation_time_;
+  std::optional<std::chrono::system_clock::time_point> max_creation_time_;
   std::string page_token_;
   Projection projection_;
   StateFilter state_filter_;

--- a/google/cloud/bigquery/v2/minimal/internal/job_stats.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_stats.h
@@ -20,9 +20,9 @@
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
 #include "absl/strings/string_view.h"
-#include "absl/types/optional.h"
 #include <nlohmann/json.hpp>
 #include <chrono>
+#include <optional>
 #include <string>
 
 namespace google {

--- a/google/cloud/bigquery/v2/minimal/internal/project.h
+++ b/google/cloud/bigquery/v2/minimal/internal/project.h
@@ -18,8 +18,8 @@
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
 #include "absl/strings/string_view.h"
-#include "absl/types/optional.h"
 #include <nlohmann/json.hpp>
+#include <optional>
 #include <string>
 
 namespace google {

--- a/google/cloud/bigquery/v2/minimal/internal/project_request.h
+++ b/google/cloud/bigquery/v2/minimal/internal/project_request.h
@@ -21,7 +21,7 @@
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
 #include "absl/strings/string_view.h"
-#include "absl/types/optional.h"
+#include <optional>
 #include <string>
 
 namespace google {

--- a/google/cloud/bigquery/v2/minimal/internal/table.h
+++ b/google/cloud/bigquery/v2/minimal/internal/table.h
@@ -23,9 +23,9 @@
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
 #include "absl/strings/string_view.h"
-#include "absl/types/optional.h"
 #include <nlohmann/json.hpp>
 #include <chrono>
+#include <optional>
 #include <string>
 
 namespace google {

--- a/google/cloud/bigquery/v2/minimal/internal/table_request.h
+++ b/google/cloud/bigquery/v2/minimal/internal/table_request.h
@@ -22,7 +22,7 @@
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
 #include "absl/strings/string_view.h"
-#include "absl/types/optional.h"
+#include <optional>
 #include <string>
 
 namespace google {

--- a/google/cloud/bigquery/v2/minimal/testing/job_query_test_utils.cc
+++ b/google/cloud/bigquery/v2/minimal/testing/job_query_test_utils.cc
@@ -58,7 +58,7 @@ QueryRequest MakeQueryRequest() {
       .set_create_session(true)
       .set_max_results(10)
       .set_maximum_bytes_billed(100000)
-      .set_timeout(std::chrono ::milliseconds(10));
+      .set_timeout(std::chrono::milliseconds(10));
 
   std::vector<ConnectionProperty> props;
   props.push_back(MakeConnectionProperty());


### PR DESCRIPTION
Replacing explicit usages of absl::optional with std::optional in the BigQuery Client library as part of broader modernization efforts