### PR TITLE
chore(actions): address zizmor findings

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base",
+    "config:best-practices",
     "docker:disable",
     "schedule:weekdays"
   ],

--- a/.github/workflows/macos-cmake.yml
+++ b/.github/workflows/macos-cmake.yml
@@ -292,16 +292,20 @@ jobs:
         mv sccache /Users/runner/.cargo/bin/sccache
     - name: Download and Install vcpkg
       working-directory: "${{runner.temp}}"
+      env:
+        VCPKG_VERSION: ${{ steps.dynamic.outputs.vcpkg-version }}
       run: |
         mkdir -p vcpkg
-        curl -fsSL "https://github.com/microsoft/vcpkg/archive/${{ steps.dynamic.outputs.vcpkg-version }}.tar.gz" |
+        curl -fsSL "https://github.com/microsoft/vcpkg/archive/${VCPKG_VERSION}.tar.gz" |
             tar -C vcpkg --strip-components=1 -zxf -
         vcpkg/bootstrap-vcpkg.sh -disableMetrics
     - name: Build google-cloud-cpp
+      env:
+        FEATURES: ${{ steps.dynamic.outputs.features }}
       run: |
         export VCPKG_ROOT="${{ runner.temp }}/vcpkg"
         export EXECUTE_INTEGRATION_TESTS=${{ inputs.execute-integration-tests }}
-        /opt/homebrew/bin/bash ci/gha/builds/macos-cmake.sh ${{ steps.dynamic.outputs.features }}
+        /opt/homebrew/bin/bash ci/gha/builds/macos-cmake.sh ${FEATURES}
     - name: Post Tests Disk Space
       run: df -m
     env:


### PR DESCRIPTION
This PR is an auto-generated attempt to address zizmor findings. It may not catch everything, and should be reviewed by repository owners.

These changes were generated by running `zizmor --fix=all --gh-token=$(gh auth token) ./.github/workflows`, and then applying some fixes for any remaining issues reported by zizmor. See go/github-zizmor-help for instructions to install and run. 

Additionally, it updates renovate configuration (if present) to extend [best-practices](https://docs.renovatebot.com/presets-config/#configbest-practices), which includes pinning action digests and image digests, among other things.

If this PR is unhelpful, feel free to close the PR and address separately. If it is helpful, feel free to approve and merge, or edit/modify as needed to get it to the right state. Repository owners must ultimately ensure compliance by 2026-07-13. The purpose of this PR is to provide some assistance with achieving that as a first pass. This will become a blocking check for new changes to github workflows on 2026-07-13 within the `googleapis` org.

There may be some ignored findings (with the comment `# zizmor: ignore[...]`), which you may fix if feasible.
