### PR TITLE
ci(gha): revert back to windows-2022 for now

### DIFF
--- a/.github/workflows/windows-bazel.yml
+++ b/.github/workflows/windows-bazel.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   bazel:
     name: bazel + ${{ matrix.msvc }} + ${{ matrix.compilation_mode }} + ${{ matrix.shard }}
-    runs-on: windows-2025
+    runs-on: windows-2022
     permissions:
       contents: 'read'
     strategy:

--- a/.github/workflows/windows-cmake.yml
+++ b/.github/workflows/windows-cmake.yml
@@ -30,7 +30,7 @@ permissions:
 jobs:
   cmake:
     name: cmake + ${{ matrix.msvc }} + ${{ matrix.arch }} + ${{ matrix.build_type }} + ${{ matrix.shard }}
-    runs-on: windows-2025
+    runs-on: windows-2022
     permissions:
       contents: 'read'
     strategy:


### PR DESCRIPTION
This may or may not have broken some builds.