### PR TITLE
impl(oauth2): only enable RAB when testing with bazel CI

### DIFF
--- a/ci/cloudbuild/builds/lib/bazel.sh
+++ b/ci/cloudbuild/builds/lib/bazel.sh
@@ -61,6 +61,8 @@ function bazel::common_args() {
     "--keep_going"
     "--experimental_convenience_symlinks=ignore"
     "--cache_test_results=$(should_cache_test_results)"
+    # TODO(#16079): Remove macro definition when GA.
+    "--copt=-DGOOGLE_CLOUD_CPP_TESTING_ENABLE_RAB"
   )
   if [[ -n "${BAZEL_REMOTE_CACHE:-}" ]]; then
     args+=("--remote_cache=${BAZEL_REMOTE_CACHE}")

--- a/google/cloud/BUILD.bazel
+++ b/google/cloud/BUILD.bazel
@@ -237,8 +237,6 @@ cc_library(
     name = "google_cloud_cpp_rest_internal",
     srcs = google_cloud_cpp_rest_internal_srcs,
     hdrs = google_cloud_cpp_rest_internal_hdrs,
-    # TODO(#16079): Remove macro definition when GA.
-    cxxopts = ["-DGOOGLE_CLOUD_CPP_TESTING_ENABLE_RAB"],
     linkopts = select({
         "@platforms//os:windows": [
             "-DEFAULTLIB:bcrypt.lib",
@@ -275,8 +273,6 @@ cc_library(
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
-    # TODO(#16079): Remove macro definition when GA.
-    cxxopts = ["-DGOOGLE_CLOUD_CPP_TESTING_ENABLE_RAB"],
     deps = [
         ":google_cloud_cpp_rest_internal",
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",


### PR DESCRIPTION
This PR allows continued testing RAB code paths in bazel builds, testing non-RAB code paths in cmake builds, and turns the feature off by default when building the SDK.