### PR TITLE
feat(rest): enable PQC EC curves in libcurl

### DIFF
--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -381,6 +381,20 @@ Status CurlImpl::MakeRequest(HttpMethod method, RestContext& context,
     if (!status.ok()) return OnTransferError(context, std::move(status));
   }
 
+#if CURL_AT_LEAST_VERSION(7, 73, 0)
+  auto ec_curves_status = handle_.SetOption(
+      CURLOPT_SSL_EC_CURVES, "X25519MLKEM768:X25519:P-256:P-384");
+  if (!ec_curves_status.ok()) {
+    GCP_LOG(INFO) << "Could not set CURLOPT_SSL_EC_CURVES: "
+                  << ec_curves_status.message();
+  }
+#else
+  GCP_LOG(INFO)
+      << "Could not set CURLOPT_SSL_EC_CURVES: libcurl 7.73.0 or later is"
+         " required (compiled with "
+      << LIBCURL_VERSION << ")";
+#endif
+
   if (client_ssl_cert_.has_value()) {
 #if CURL_AT_LEAST_VERSION(7, 71, 0)
     status = handle_.SetOption(CURLOPT_SSL_VERIFYPEER, 1L);

--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -382,8 +382,10 @@ Status CurlImpl::MakeRequest(HttpMethod method, RestContext& context,
   }
 
 #if CURL_AT_LEAST_VERSION(7, 73, 0)
-  handle_.SetOptionUnchecked(CURLOPT_SSL_EC_CURVES,
-                             "X25519MLKEM768:X25519:P-256:P-384");
+  if (pqc_curves_enabled_) {
+    handle_.SetOptionUnchecked(CURLOPT_SSL_EC_CURVES,
+                               "X25519MLKEM768:X25519:P-256:P-384");
+  }
 #endif
 
   if (client_ssl_cert_.has_value()) {

--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -382,17 +382,8 @@ Status CurlImpl::MakeRequest(HttpMethod method, RestContext& context,
   }
 
 #if CURL_AT_LEAST_VERSION(7, 73, 0)
-  auto ec_curves_status = handle_.SetOption(
-      CURLOPT_SSL_EC_CURVES, "X25519MLKEM768:X25519:P-256:P-384");
-  if (!ec_curves_status.ok()) {
-    GCP_LOG(INFO) << "Could not set CURLOPT_SSL_EC_CURVES: "
-                  << ec_curves_status.message();
-  }
-#else
-  GCP_LOG(INFO)
-      << "Could not set CURLOPT_SSL_EC_CURVES: libcurl 7.73.0 or later is"
-         " required (compiled with "
-      << LIBCURL_VERSION << ")";
+  handle_.SetOptionUnchecked(CURLOPT_SSL_EC_CURVES,
+                             "X25519MLKEM768:X25519:P-256:P-384");
 #endif
 
   if (client_ssl_cert_.has_value()) {

--- a/google/cloud/internal/curl_impl.h
+++ b/google/cloud/internal/curl_impl.h
@@ -84,6 +84,7 @@ class CurlImpl {
 
   void SetHeader(HttpHeader header);
   void SetHeaders(HttpHeaders const& headers);
+  void EnablePqcCurves(bool enabled) { pqc_curves_enabled_ = enabled; }
 
   std::string MakeEscapedString(std::string const& s);
 
@@ -141,6 +142,7 @@ class CurlImpl {
 
   bool logging_enabled_;
   bool follow_location_;
+  bool pqc_curves_enabled_ = true;
   CurlHandle::SocketOptions socket_options_;
   std::string user_agent_;
   std::string http_version_;

--- a/google/cloud/internal/curl_impl_test.cc
+++ b/google/cloud/internal/curl_impl_test.cc
@@ -394,25 +394,16 @@ TEST_F(CurlImplTest, MergeAndWriteHeadersDoNotMergeContentLength) {
   EXPECT_THAT(headers_written, ElementsAre(std::string(expected)));
 }
 
-TEST_F(CurlImplTest, MakeRequestPqcCurves) {
+TEST_F(CurlImplTest, MakeRequestPqcCurvesNoLog) {
   testing_util::ScopedLog log;
   RestContext context;
   auto impl = CurlImpl(std::move(handle_), factory_, {});
   (void)impl.MakeRequest(CurlImpl::HttpMethod::kGet, context, {});
   auto const log_lines = log.ExtractLines();
-#if CURL_AT_LEAST_VERSION(7, 73, 0)
   for (auto const& line : log_lines) {
-    if (absl::StrContains(line, "Could not set CURLOPT_SSL_EC_CURVES")) {
-      EXPECT_THAT(line,
-                  testing::HasSubstr("Could not set CURLOPT_SSL_EC_CURVES: "));
-    }
+    EXPECT_THAT(line, testing::Not(testing::HasSubstr(
+                          "Could not set CURLOPT_SSL_EC_CURVES")));
   }
-#else
-  EXPECT_THAT(
-      log_lines,
-      testing::Contains(testing::HasSubstr(
-          "Could not set CURLOPT_SSL_EC_CURVES: libcurl 7.73.0 or later")));
-#endif
 }
 
 }  // namespace

--- a/google/cloud/internal/curl_impl_test.cc
+++ b/google/cloud/internal/curl_impl_test.cc
@@ -15,6 +15,8 @@
 #include "google/cloud/internal/curl_impl.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/rest_options.h"
+#include "google/cloud/testing_util/scoped_log.h"
+#include "absl/strings/match.h"
 #include <gmock/gmock.h>
 #include <vector>
 
@@ -390,6 +392,27 @@ TEST_F(CurlImplTest, MergeAndWriteHeadersDoNotMergeContentLength) {
   impl.MergeAndWriteHeaders(write_fn);
   HttpHeader expected("content-length", "42");
   EXPECT_THAT(headers_written, ElementsAre(std::string(expected)));
+}
+
+TEST_F(CurlImplTest, MakeRequestPqcCurves) {
+  testing_util::ScopedLog log;
+  RestContext context;
+  auto impl = CurlImpl(std::move(handle_), factory_, {});
+  (void)impl.MakeRequest(CurlImpl::HttpMethod::kGet, context, {});
+  auto const log_lines = log.ExtractLines();
+#if CURL_AT_LEAST_VERSION(7, 73, 0)
+  for (auto const& line : log_lines) {
+    if (absl::StrContains(line, "Could not set CURLOPT_SSL_EC_CURVES")) {
+      EXPECT_THAT(line,
+                  testing::HasSubstr("Could not set CURLOPT_SSL_EC_CURVES: "));
+    }
+  }
+#else
+  EXPECT_THAT(
+      log_lines,
+      testing::Contains(testing::HasSubstr(
+          "Could not set CURLOPT_SSL_EC_CURVES: libcurl 7.73.0 or later")));
+#endif
 }
 
 }  // namespace

--- a/google/cloud/internal/curl_impl_test.cc
+++ b/google/cloud/internal/curl_impl_test.cc
@@ -406,6 +406,19 @@ TEST_F(CurlImplTest, MakeRequestPqcCurvesNoLog) {
   }
 }
 
+TEST_F(CurlImplTest, EnablePqcCurvesFalse) {
+  testing_util::ScopedLog log;
+  RestContext context;
+  auto impl = CurlImpl(std::move(handle_), factory_, {});
+  impl.EnablePqcCurves(false);
+  (void)impl.MakeRequest(CurlImpl::HttpMethod::kGet, context, {});
+  auto const log_lines = log.ExtractLines();
+  for (auto const& line : log_lines) {
+    EXPECT_THAT(line, testing::Not(testing::HasSubstr(
+                          "Could not set CURLOPT_SSL_EC_CURVES")));
+  }
+}
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace rest_internal

--- a/google/cloud/internal/curl_rest_client.cc
+++ b/google/cloud/internal/curl_rest_client.cc
@@ -15,14 +15,17 @@
 #include "google/cloud/internal/curl_rest_client.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/credentials.h"
+#include "google/cloud/internal/curl_handle.h"
 #include "google/cloud/internal/curl_handle_factory.h"
 #include "google/cloud/internal/curl_impl.h"
 #include "google/cloud/internal/curl_options.h"
 #include "google/cloud/internal/curl_rest_response.h"
+#include "google/cloud/internal/curl_wrappers.h"
 #include "google/cloud/internal/oauth2_google_credentials.h"
 #include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/internal/tracing_rest_client.h"
 #include "google/cloud/internal/unified_rest_credentials.h"
+#include "google/cloud/log.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
@@ -115,6 +118,21 @@ CurlRestClient::CurlRestClient(std::string endpoint_address,
   if (options_.has<UnifiedCredentialsOption>()) {
     credentials_ = MapCredentials(*options_.get<UnifiedCredentialsOption>());
   }
+#if CURL_AT_LEAST_VERSION(7, 73, 0)
+  auto handle = CurlHandle::MakeFromPool(*handle_factory_);
+  auto status = handle.SetOption(CURLOPT_SSL_EC_CURVES,
+                                 "X25519MLKEM768:X25519:P-256:P-384");
+  if (!status.ok()) {
+    GCP_LOG(INFO) << "Could not set CURLOPT_SSL_EC_CURVES: "
+                  << status.message();
+  }
+  CurlHandle::ReturnToPool(*handle_factory_, std::move(handle));
+#else
+  GCP_LOG(INFO)
+      << "Could not set CURLOPT_SSL_EC_CURVES: libcurl 7.73.0 or later is"
+         " required (compiled with "
+      << LIBCURL_VERSION << ")";
+#endif
 }
 
 StatusOr<std::unique_ptr<CurlImpl>> CurlRestClient::CreateCurlImpl(

--- a/google/cloud/internal/curl_rest_client.cc
+++ b/google/cloud/internal/curl_rest_client.cc
@@ -125,6 +125,7 @@ CurlRestClient::CurlRestClient(std::string endpoint_address,
   if (!status.ok()) {
     GCP_LOG(INFO) << "Could not set CURLOPT_SSL_EC_CURVES: "
                   << status.message();
+    pqc_curves_enabled_ = false;
   }
   CurlHandle::ReturnToPool(*handle_factory_, std::move(handle));
 #else
@@ -132,6 +133,7 @@ CurlRestClient::CurlRestClient(std::string endpoint_address,
       << "Could not set CURLOPT_SSL_EC_CURVES: libcurl 7.73.0 or later is"
          " required (compiled with "
       << LIBCURL_VERSION << ")";
+  pqc_curves_enabled_ = false;
 #endif
 }
 
@@ -141,6 +143,7 @@ StatusOr<std::unique_ptr<CurlImpl>> CurlRestClient::CreateCurlImpl(
   auto handle = CurlHandle::MakeFromPool(*handle_factory_);
   auto impl =
       std::make_unique<CurlImpl>(std::move(handle), handle_factory_, options);
+  impl->EnablePqcCurves(pqc_curves_enabled_);
   if (credentials_) {
     auto auth_headers = credentials_->AuthenticationHeaders(
         std::chrono::system_clock::now(), endpoint_address_);

--- a/google/cloud/internal/curl_rest_client.h
+++ b/google/cloud/internal/curl_rest_client.h
@@ -79,6 +79,7 @@ class CurlRestClient : public RestClient {
   std::shared_ptr<CurlHandleFactory> handle_factory_;
   std::shared_ptr<oauth2_internal::Credentials> credentials_;
   Options options_;
+  bool pqc_curves_enabled_ = true;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/curl_rest_client_test.cc
+++ b/google/cloud/internal/curl_rest_client_test.cc
@@ -14,6 +14,10 @@
 
 #include "google/cloud/internal/curl_rest_client.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/internal/curl_handle_factory.h"
+#include "google/cloud/internal/curl_wrappers.h"
+#include "google/cloud/testing_util/scoped_log.h"
+#include "absl/strings/match.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -63,6 +67,27 @@ TEST(CurlRestClientStandaloneFunctions, HostHeader) {
     auto const actual = CurlRestClient::HostHeader(options, test.endpoint);
     EXPECT_EQ(test.expected, std::string(actual));
   }
+}
+
+TEST(CurlRestClientTest, PqcCurvesLogging) {
+  testing_util::ScopedLog log;
+  auto factory = GetDefaultCurlHandleFactory();
+  auto client =
+      CurlRestClient("https://endpoint.googleapis.com", factory, Options{});
+  auto const log_lines = log.ExtractLines();
+#if CURL_AT_LEAST_VERSION(7, 73, 0)
+  for (auto const& line : log_lines) {
+    if (absl::StrContains(line, "Could not set CURLOPT_SSL_EC_CURVES")) {
+      EXPECT_THAT(line,
+                  testing::HasSubstr("Could not set CURLOPT_SSL_EC_CURVES: "));
+    }
+  }
+#else
+  EXPECT_THAT(
+      log_lines,
+      testing::Contains(testing::HasSubstr(
+          "Could not set CURLOPT_SSL_EC_CURVES: libcurl 7.73.0 or later")));
+#endif
 }
 
 }  // namespace


### PR DESCRIPTION
The errors that can result when a call to set `CURLOPT_SSL_EC_CURVES` are not recoverable during program execution: `CURLE_UNKNOWN_OPTION`, `CURLE_SSL_ENGINE_SETFAILED`, `CURLE_NOT_BUILT_IN`, `CURLE_BAD_FUNCTION_ARGUMENT`, `CURLE_OUT_OF_MEMORY`.

Thus, we can check once when the rest client is created and avoid log spam.