### PR TITLE
feat(storage): Add full object checksum validation for appendable uploads finalize

### DIFF
--- a/google/cloud/storage/examples/storage_async_samples.cc
+++ b/google/cloud/storage/examples/storage_async_samples.cc
@@ -750,8 +750,8 @@ void CreateAndWriteAppendableObjectWithChecksum(
 
     // Set the expected CRC32C checksum in the current options scope
     // just before calling Finalize().
-    // Note: 548262564U is the pre-computed CRC32C checksum for the string "Some data\n".
-    // If the data changes, this checksum must be updated to match.
+    // Note: 548262564U is the pre-computed CRC32C checksum for the string "Some
+    // data\n". If the data changes, this checksum must be updated to match.
     google::cloud::internal::OptionsSpan span(
         google::cloud::Options{}.set<gcs::UseCrc32cValueOption>(548262564U));
     co_return (co_await writer.Finalize(std::move(token))).value();

--- a/google/cloud/storage/examples/storage_async_samples.cc
+++ b/google/cloud/storage/examples/storage_async_samples.cc
@@ -728,6 +728,40 @@ void CreateAndWriteAppendableObject(google::cloud::storage::AsyncClient& client,
   std::cout << "File successfully uploaded " << object.DebugString() << "\n";
 }
 
+void CreateAndWriteAppendableObjectWithChecksum(
+    google::cloud::storage::AsyncClient& client,
+    std::vector<std::string> const& argv) {
+  //! [create-and-write-appendable-object-with-checksum]
+  // [START storage_create_and_write_appendable_object_with_checksum]
+  namespace gcs = google::cloud::storage;
+  auto coro = [](gcs::AsyncClient& client, std::string bucket_name,
+                 std::string object_name)
+      -> google::cloud::future<google::storage::v2::Object> {
+    auto [writer, token] =
+        (co_await client.StartAppendableObjectUpload(
+             gcs::BucketName(std::move(bucket_name)), std::move(object_name)))
+            .value();
+    std::cout << "Appendable upload started for object " << object_name << "\n";
+
+    token = (co_await writer.Write(std::move(token),
+                                   gcs::WritePayload("Some data\n")))
+                .value();
+    std::cout << "Wrote some data.\n";
+
+    // Set the expected CRC32C checksum in the current options scope
+    // just before calling Finalize().
+    google::cloud::internal::OptionsSpan span(
+        google::cloud::Options{}.set<gcs::UseCrc32cValueOption>(1848151177U));
+    co_return (co_await writer.Finalize(std::move(token))).value();
+  };
+  // [END storage_create_and_write_appendable_object_with_checksum]
+  //! [create-and-write-appendable-object-with-checksum]
+  // The example is easier to test and run if we call the coroutine and block
+  // until it completes..
+  auto const object = coro(client, argv.at(0), argv.at(1)).get();
+  std::cout << "File successfully uploaded " << object.DebugString() << "\n";
+}
+
 void PauseAndResumeAppendableUpload(google::cloud::storage::AsyncClient& client,
                                     std::vector<std::string> const& argv) {
   //! [pause-and-resume-appendable-upload]
@@ -1033,6 +1067,12 @@ void CreateAndWriteAppendableObject(google::cloud::storage::AsyncClient&,
                                     std::vector<std::string> const&) {
   std::cerr << "AsyncClient::CreateAndWriteAppendableObject() example requires "
                "coroutines\n";
+}
+
+void CreateAndWriteAppendableObjectWithChecksum(
+    google::cloud::storage::AsyncClient&, std::vector<std::string> const&) {
+  std::cerr << "AsyncClient::CreateAndWriteAppendableObjectWithChecksum() "
+               "example requires coroutines\n";
 }
 
 void PauseAndResumeAppendableUpload(google::cloud::storage::AsyncClient&,
@@ -1505,6 +1545,8 @@ int main(int argc, char* argv[]) try {
 
       make_entry("create-and-write-appendable-object", {},
                  CreateAndWriteAppendableObject),
+      make_entry("create-and-write-appendable-object-with-checksum", {},
+                 CreateAndWriteAppendableObjectWithChecksum),
       make_entry("pause-and-resume-appendable-upload", {},
                  PauseAndResumeAppendableUpload),
       make_entry("finalize-appendable-object-upload", {},

--- a/google/cloud/storage/examples/storage_async_samples.cc
+++ b/google/cloud/storage/examples/storage_async_samples.cc
@@ -751,7 +751,7 @@ void CreateAndWriteAppendableObjectWithChecksum(
     // Set the expected CRC32C checksum in the current options scope
     // just before calling Finalize().
     google::cloud::internal::OptionsSpan span(
-        google::cloud::Options{}.set<gcs::UseCrc32cValueOption>(1848151177U));
+        google::cloud::Options{}.set<gcs::UseCrc32cValueOption>(548262564U));
     co_return (co_await writer.Finalize(std::move(token))).value();
   };
   // [END storage_create_and_write_appendable_object_with_checksum]

--- a/google/cloud/storage/examples/storage_async_samples.cc
+++ b/google/cloud/storage/examples/storage_async_samples.cc
@@ -750,6 +750,8 @@ void CreateAndWriteAppendableObjectWithChecksum(
 
     // Set the expected CRC32C checksum in the current options scope
     // just before calling Finalize().
+    // Note: 548262564U is the pre-computed CRC32C checksum for the string "Some data\n".
+    // If the data changes, this checksum must be updated to match.
     google::cloud::internal::OptionsSpan span(
         google::cloud::Options{}.set<gcs::UseCrc32cValueOption>(548262564U));
     co_return (co_await writer.Finalize(std::move(token))).value();

--- a/google/cloud/storage/internal/async/writer_connection_impl.cc
+++ b/google/cloud/storage/internal/async/writer_connection_impl.cc
@@ -20,6 +20,7 @@
 #include "google/cloud/storage/internal/grpc/object_metadata_parser.h"
 #include "google/cloud/storage/internal/grpc/object_request_parser.h"
 #include "google/cloud/storage/async/options.h"
+#include "google/cloud/storage/hashing_options.h"
 #include "google/cloud/internal/make_status.h"
 
 namespace google {
@@ -153,10 +154,27 @@ AsyncWriterConnectionImpl::Finalize(storage::WritePayload payload) {
     write.mutable_object_checksums()->set_crc32c(
         current_options.get<google::cloud::storage::UseCrc32cValueOption>());
     action = PartialUpload::kFinalize;
-  } else if (is_append && !options_->has<google::cloud::storage::UseCrc32cValueOption>()) {
+  } else if (current_options.has<google::cloud::storage::UseMD5ValueOption>()) {
+    auto as_proto = storage_internal::MD5ToProto(
+        current_options.get<google::cloud::storage::UseMD5ValueOption>());
+    if (as_proto) {
+      write.mutable_object_checksums()->set_md5_hash(*as_proto);
+      action = PartialUpload::kFinalize;
+    }
+  } else if (is_append) {
+    if (options_->has<google::cloud::storage::UseCrc32cValueOption>()) {
+      write.mutable_object_checksums()->set_crc32c(
+          options_->get<google::cloud::storage::UseCrc32cValueOption>());
+    } else if (options_->has<google::cloud::storage::UseMD5ValueOption>()) {
+      auto as_proto = storage_internal::MD5ToProto(
+          options_->get<google::cloud::storage::UseMD5ValueOption>());
+      if (as_proto) {
+        write.mutable_object_checksums()->set_md5_hash(*as_proto);
+      }
+    }
     // For appendable uploads, the internal hash function only sees the chunks uploaded
     // in this stream, not the full object. We use `kFinalize` to avoid sending this
-    // partial CRC, which would otherwise fail validation.
+    // partial hash, which would otherwise fail validation.
     action = PartialUpload::kFinalize;
   }
 

--- a/google/cloud/storage/internal/async/writer_connection_impl.cc
+++ b/google/cloud/storage/internal/async/writer_connection_impl.cc
@@ -13,14 +13,14 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/async/writer_connection_impl.h"
+#include "google/cloud/storage/async/options.h"
+#include "google/cloud/storage/hashing_options.h"
 #include "google/cloud/storage/internal/async/handle_redirect_error.h"
 #include "google/cloud/storage/internal/async/partial_upload.h"
 #include "google/cloud/storage/internal/async/write_payload_impl.h"
 #include "google/cloud/storage/internal/grpc/ctype_cord_workaround.h"
 #include "google/cloud/storage/internal/grpc/object_metadata_parser.h"
 #include "google/cloud/storage/internal/grpc/object_request_parser.h"
-#include "google/cloud/storage/async/options.h"
-#include "google/cloud/storage/hashing_options.h"
 #include "google/cloud/internal/make_status.h"
 
 namespace google {
@@ -143,31 +143,38 @@ AsyncWriterConnectionImpl::Finalize(storage::WritePayload payload) {
   auto size = p.size();
   auto is_append = request_.has_append_object_spec() ||
                    request_.write_object_spec().appendable();
-  auto current_options = google::cloud::internal::CurrentOptions();
+  auto const& current_options = google::cloud::internal::CurrentOptions();
   auto merged = google::cloud::internal::MergeOptions(
       current_options, options_ ? *options_ : google::cloud::Options{});
 
-  // Default to letting the internal hash function compute and send the checksum.
+  // Default to letting the internal hash function compute and send the
+  // checksum.
   auto action = PartialUpload::kFinalizeWithChecksum;
 
-  if (is_append || current_options.has<google::cloud::storage::UseCrc32cValueOption>() ||
-      current_options.has<google::cloud::storage::UseMD5ValueOption>()) {
+  if (is_append) {
+    // For appendable uploads, the internal hash function only sees the chunks
+    // uploaded in this stream, not the full object. We use `kFinalize` to avoid
+    // sending this partial hash, which would otherwise fail validation.
     if (merged.has<google::cloud::storage::UseCrc32cValueOption>()) {
       write.mutable_object_checksums()->set_crc32c(
           merged.get<google::cloud::storage::UseCrc32cValueOption>());
     }
-    if (merged.has<google::cloud::storage::UseMD5ValueOption>()) {
-      auto as_proto = storage_internal::MD5ToProto(
-          merged.get<google::cloud::storage::UseMD5ValueOption>());
-      if (as_proto) {
-        write.mutable_object_checksums()->set_md5_hash(*as_proto);
-      }
+    action = PartialUpload::kFinalize;
+  } else if (current_options
+                 .has<google::cloud::storage::UseCrc32cValueOption>() ||
+             current_options.has<google::cloud::storage::UseMD5ValueOption>()) {
+    // If the user specified a manual expected checksum dynamically at
+    // Finalize() via current_options, we manually inject it and use `kFinalize`
+    // so the internal hash function doesn't overwrite it with its own computed
+    // hash.
+    if (current_options.has<google::cloud::storage::UseCrc32cValueOption>()) {
+      write.mutable_object_checksums()->set_crc32c(
+          current_options.get<google::cloud::storage::UseCrc32cValueOption>());
     }
-    // For appendable uploads, the internal hash function only sees the chunks uploaded
-    // in this stream, not the full object. We use `kFinalize` to avoid sending this
-    // partial hash, which would otherwise fail validation.
-    // If the user specified a manual expected checksum in `current_options`, we must
-    // also use `kFinalize` so the internal hash function doesn't overwrite it.
+    if (current_options.has<google::cloud::storage::UseMD5ValueOption>()) {
+      write.mutable_object_checksums()->set_md5_hash(
+          current_options.get<google::cloud::storage::UseMD5ValueOption>());
+    }
     action = PartialUpload::kFinalize;
   }
 

--- a/google/cloud/storage/internal/async/writer_connection_impl.cc
+++ b/google/cloud/storage/internal/async/writer_connection_impl.cc
@@ -18,6 +18,8 @@
 #include "google/cloud/storage/internal/async/write_payload_impl.h"
 #include "google/cloud/storage/internal/grpc/ctype_cord_workaround.h"
 #include "google/cloud/storage/internal/grpc/object_metadata_parser.h"
+#include "google/cloud/storage/internal/grpc/object_request_parser.h"
+#include "google/cloud/storage/async/options.h"
 #include "google/cloud/internal/make_status.h"
 
 namespace google {
@@ -138,10 +140,26 @@ AsyncWriterConnectionImpl::Finalize(storage::WritePayload payload) {
 
   auto p = WritePayloadImpl::GetImpl(payload);
   auto size = p.size();
-  auto action = request_.has_append_object_spec() ||
-                        request_.write_object_spec().appendable()
-                    ? PartialUpload::kFinalize
-                    : PartialUpload::kFinalizeWithChecksum;
+  auto is_append = request_.has_append_object_spec() ||
+                   request_.write_object_spec().appendable();
+  auto current_options = google::cloud::internal::CurrentOptions();
+  
+  // Default to letting the internal hash function compute and send the checksum.
+  auto action = PartialUpload::kFinalizeWithChecksum;
+
+  if (current_options.has<google::cloud::storage::UseCrc32cValueOption>()) {
+    // The user provided a final CRC via OptionsSpan. We manually inject it into the
+    // request. We use `kFinalize` so the internal hash function doesn't overwrite it.
+    write.mutable_object_checksums()->set_crc32c(
+        current_options.get<google::cloud::storage::UseCrc32cValueOption>());
+    action = PartialUpload::kFinalize;
+  } else if (is_append && !options_->has<google::cloud::storage::UseCrc32cValueOption>()) {
+    // For appendable uploads, the internal hash function only sees the chunks uploaded
+    // in this stream, not the full object. We use `kFinalize` to avoid sending this
+    // partial CRC, which would otherwise fail validation.
+    action = PartialUpload::kFinalize;
+  }
+
   auto coro = PartialUpload::Call(impl_, hash_function_, std::move(write),
                                   std::move(p), std::move(action));
   return coro->Start().then([coro, size, this](auto f) mutable {

--- a/google/cloud/storage/internal/async/writer_connection_impl.cc
+++ b/google/cloud/storage/internal/async/writer_connection_impl.cc
@@ -144,30 +144,21 @@ AsyncWriterConnectionImpl::Finalize(storage::WritePayload payload) {
   auto is_append = request_.has_append_object_spec() ||
                    request_.write_object_spec().appendable();
   auto current_options = google::cloud::internal::CurrentOptions();
-  
+  auto merged = google::cloud::internal::MergeOptions(
+      current_options, options_ ? *options_ : google::cloud::Options{});
+
   // Default to letting the internal hash function compute and send the checksum.
   auto action = PartialUpload::kFinalizeWithChecksum;
 
-  if (current_options.has<google::cloud::storage::UseCrc32cValueOption>()) {
-    // The user provided a final CRC via OptionsSpan. We manually inject it into the
-    // request. We use `kFinalize` so the internal hash function doesn't overwrite it.
-    write.mutable_object_checksums()->set_crc32c(
-        current_options.get<google::cloud::storage::UseCrc32cValueOption>());
-    action = PartialUpload::kFinalize;
-  } else if (current_options.has<google::cloud::storage::UseMD5ValueOption>()) {
-    auto as_proto = storage_internal::MD5ToProto(
-        current_options.get<google::cloud::storage::UseMD5ValueOption>());
-    if (as_proto) {
-      write.mutable_object_checksums()->set_md5_hash(*as_proto);
-      action = PartialUpload::kFinalize;
-    }
-  } else if (is_append) {
-    if (options_->has<google::cloud::storage::UseCrc32cValueOption>()) {
+  if (is_append || current_options.has<google::cloud::storage::UseCrc32cValueOption>() ||
+      current_options.has<google::cloud::storage::UseMD5ValueOption>()) {
+    if (merged.has<google::cloud::storage::UseCrc32cValueOption>()) {
       write.mutable_object_checksums()->set_crc32c(
-          options_->get<google::cloud::storage::UseCrc32cValueOption>());
-    } else if (options_->has<google::cloud::storage::UseMD5ValueOption>()) {
+          merged.get<google::cloud::storage::UseCrc32cValueOption>());
+    }
+    if (merged.has<google::cloud::storage::UseMD5ValueOption>()) {
       auto as_proto = storage_internal::MD5ToProto(
-          options_->get<google::cloud::storage::UseMD5ValueOption>());
+          merged.get<google::cloud::storage::UseMD5ValueOption>());
       if (as_proto) {
         write.mutable_object_checksums()->set_md5_hash(*as_proto);
       }
@@ -175,6 +166,8 @@ AsyncWriterConnectionImpl::Finalize(storage::WritePayload payload) {
     // For appendable uploads, the internal hash function only sees the chunks uploaded
     // in this stream, not the full object. We use `kFinalize` to avoid sending this
     // partial hash, which would otherwise fail validation.
+    // If the user specified a manual expected checksum in `current_options`, we must
+    // also use `kFinalize` so the internal hash function doesn't overwrite it.
     action = PartialUpload::kFinalize;
   }
 

--- a/google/cloud/storage/internal/async/writer_connection_impl_test.cc
+++ b/google/cloud/storage/internal/async/writer_connection_impl_test.cc
@@ -14,9 +14,11 @@
 
 #include "google/cloud/storage/internal/async/writer_connection_impl.h"
 #include "google/cloud/mocks/mock_async_streaming_read_write_rpc.h"
+#include "google/cloud/storage/async/options.h"
 #include "google/cloud/storage/internal/async/write_object.h"
 #include "google/cloud/storage/internal/crc32c.h"
 #include "google/cloud/storage/internal/grpc/ctype_cord_workaround.h"
+#include "google/cloud/storage/internal/grpc/object_metadata_parser.h"
 #include "google/cloud/storage/internal/hash_function_impl.h"
 #include "google/cloud/storage/options.h"
 #include "google/cloud/storage/testing/canonical_errors.h"
@@ -728,6 +730,123 @@ TEST(AsyncWriterConnectionTest, FinalizeAppendableNoChecksum) {
   auto tested = std::make_unique<AsyncWriterConnectionImpl>(
       TestOptions(), std::move(request), std::move(mock), hash, 1024);
   auto response = tested->Finalize(WritePayload{});
+  auto next = sequencer.PopFrontWithName();
+  ASSERT_THAT(next.second, "Write");
+  next.first.set_value(true);
+  next = sequencer.PopFrontWithName();
+  ASSERT_THAT(next.second, "Read");
+  next.first.set_value(true);
+  auto object = response.get();
+  EXPECT_THAT(object, IsOkAndHolds(IsProtoEqual(MakeTestObject())))
+      << "=" << object->DebugString();
+
+  tested = {};
+  next = sequencer.PopFrontWithName();
+  ASSERT_THAT(next.second, "Finish");
+  next.first.set_value(true);
+}
+
+TEST(AsyncWriterConnectionTest, FinalizeAppendableWithExpectedChecksum) {
+  AsyncSequencer<bool> sequencer;
+  auto mock = std::make_unique<MockStream>();
+  EXPECT_CALL(*mock, Cancel).Times(1);
+  EXPECT_CALL(*mock, Write)
+      .WillOnce([&](Request const& request, grpc::WriteOptions wopt) {
+        EXPECT_TRUE(request.finish_write());
+        EXPECT_TRUE(wopt.is_last_message());
+        EXPECT_EQ(request.common_object_request_params().encryption_algorithm(),
+                  "test-only-algo");
+        EXPECT_TRUE(request.has_object_checksums());
+        EXPECT_EQ(request.object_checksums().crc32c(),
+                  123456);  // wait, it might be an int in proto
+        return sequencer.PushBack("Write");
+      });
+  EXPECT_CALL(*mock, Read).WillOnce([&]() {
+    return sequencer.PushBack("Read").then([](auto f) {
+      if (!f.get()) return absl::optional<Response>();
+      return absl::make_optional(MakeTestResponse());
+    });
+  });
+  EXPECT_CALL(*mock, Finish).WillOnce([&] {
+    return sequencer.PushBack("Finish").then([](auto f) {
+      if (f.get()) return Status{};
+      return PermanentError();
+    });
+  });
+  auto hash = std::make_shared<MockHashFunction>();
+  EXPECT_CALL(*hash, Update(_, An<absl::Cord const&>(), _)).Times(1);
+  EXPECT_CALL(*hash, Finish)
+      .WillOnce(Return(storage::internal::HashValues{
+          storage_internal::Crc32cFromProto(123456), {}}));
+
+  auto request = MakeRequest();
+  request.mutable_write_object_spec()->set_appendable(true);
+
+  auto options = internal::MakeImmutableOptions(
+      Options{}.set<storage::UseCrc32cValueOption>(123456));
+
+  auto tested = std::make_unique<AsyncWriterConnectionImpl>(
+      options, std::move(request), std::move(mock), hash, 1024);
+  auto response = tested->Finalize(WritePayload{});
+
+  auto next = sequencer.PopFrontWithName();
+  ASSERT_THAT(next.second, "Write");
+  next.first.set_value(true);
+  next = sequencer.PopFrontWithName();
+  ASSERT_THAT(next.second, "Read");
+  next.first.set_value(true);
+  auto object = response.get();
+  EXPECT_THAT(object, IsOkAndHolds(IsProtoEqual(MakeTestObject())))
+      << "=" << object->DebugString();
+
+  tested = {};
+  next = sequencer.PopFrontWithName();
+  ASSERT_THAT(next.second, "Finish");
+  next.first.set_value(true);
+}
+
+TEST(AsyncWriterConnectionTest,
+     FinalizeAppendableWithExpectedChecksumFromCurrentOptions) {
+  AsyncSequencer<bool> sequencer;
+  auto mock = std::make_unique<MockStream>();
+  EXPECT_CALL(*mock, Cancel).Times(1);
+  EXPECT_CALL(*mock, Write)
+      .WillOnce([&](Request const& request, grpc::WriteOptions wopt) {
+        EXPECT_TRUE(request.finish_write());
+        EXPECT_TRUE(wopt.is_last_message());
+        EXPECT_EQ(request.common_object_request_params().encryption_algorithm(),
+                  "test-only-algo");
+        EXPECT_TRUE(request.has_object_checksums());
+        EXPECT_EQ(request.object_checksums().crc32c(), 654321);
+        return sequencer.PushBack("Write");
+      });
+  EXPECT_CALL(*mock, Read).WillOnce([&]() {
+    return sequencer.PushBack("Read").then([](auto f) {
+      if (!f.get()) return absl::optional<Response>();
+      return absl::make_optional(MakeTestResponse());
+    });
+  });
+  EXPECT_CALL(*mock, Finish).WillOnce([&] {
+    return sequencer.PushBack("Finish").then([](auto f) {
+      if (f.get()) return Status{};
+      return PermanentError();
+    });
+  });
+  auto hash = std::make_shared<MockHashFunction>();
+  EXPECT_CALL(*hash, Update(_, An<absl::Cord const&>(), _)).Times(1);
+  // It shouldn't call Finish() because we use kFinalize!
+  EXPECT_CALL(*hash, Finish).Times(0);
+
+  auto request = MakeRequest();
+  request.mutable_write_object_spec()->set_appendable(true);
+
+  auto tested = std::make_unique<AsyncWriterConnectionImpl>(
+      TestOptions(), std::move(request), std::move(mock), hash, 1024);
+
+  internal::OptionsSpan span(
+      Options{}.set<storage::UseCrc32cValueOption>(654321));
+  auto response = tested->Finalize(WritePayload{});
+
   auto next = sequencer.PopFrontWithName();
   ASSERT_THAT(next.second, "Write");
   next.first.set_value(true);

--- a/google/cloud/storage/internal/async/writer_connection_impl_test.cc
+++ b/google/cloud/storage/internal/async/writer_connection_impl_test.cc
@@ -757,8 +757,7 @@ TEST(AsyncWriterConnectionTest, FinalizeAppendableWithExpectedChecksum) {
         EXPECT_EQ(request.common_object_request_params().encryption_algorithm(),
                   "test-only-algo");
         EXPECT_TRUE(request.has_object_checksums());
-        EXPECT_EQ(request.object_checksums().crc32c(),
-                  123456);
+        EXPECT_EQ(request.object_checksums().crc32c(), 123456);
         return sequencer.PushBack("Write");
       });
   EXPECT_CALL(*mock, Read).WillOnce([&]() {
@@ -843,6 +842,124 @@ TEST(AsyncWriterConnectionTest,
 
   internal::OptionsSpan span(
       Options{}.set<storage::UseCrc32cValueOption>(654321));
+  auto response = tested->Finalize(WritePayload{});
+
+  auto next = sequencer.PopFrontWithName();
+  ASSERT_THAT(next.second, "Write");
+  next.first.set_value(true);
+  next = sequencer.PopFrontWithName();
+  ASSERT_THAT(next.second, "Read");
+  next.first.set_value(true);
+  auto object = response.get();
+  EXPECT_THAT(object, IsOkAndHolds(IsProtoEqual(MakeTestObject())))
+      << "=" << object->DebugString();
+
+  tested = {};
+  next = sequencer.PopFrontWithName();
+  ASSERT_THAT(next.second, "Finish");
+  next.first.set_value(true);
+}
+
+TEST(AsyncWriterConnectionTest,
+     FinalizeNonAppendableWithExpectedChecksumFromCurrentOptions) {
+  AsyncSequencer<bool> sequencer;
+  auto mock = std::make_unique<MockStream>();
+  EXPECT_CALL(*mock, Cancel).Times(1);
+  EXPECT_CALL(*mock, Write)
+      .WillOnce([&](Request const& request, grpc::WriteOptions wopt) {
+        EXPECT_TRUE(request.finish_write());
+        EXPECT_TRUE(wopt.is_last_message());
+        EXPECT_EQ(request.common_object_request_params().encryption_algorithm(),
+                  "test-only-algo");
+        EXPECT_TRUE(request.has_object_checksums());
+        EXPECT_EQ(request.object_checksums().crc32c(), 654321);
+        return sequencer.PushBack("Write");
+      });
+  EXPECT_CALL(*mock, Read).WillOnce([&]() {
+    return sequencer.PushBack("Read").then([](auto f) {
+      if (!f.get()) return absl::optional<Response>();
+      return absl::make_optional(MakeTestResponse());
+    });
+  });
+  EXPECT_CALL(*mock, Finish).WillOnce([&] {
+    return sequencer.PushBack("Finish").then([](auto f) {
+      if (f.get()) return Status{};
+      return PermanentError();
+    });
+  });
+  auto hash = std::make_shared<MockHashFunction>();
+  EXPECT_CALL(*hash, Update(_, An<absl::Cord const&>(), _)).Times(1);
+  // It shouldn't call Finish() because we use kFinalize!
+  EXPECT_CALL(*hash, Finish).Times(0);
+
+  auto request = MakeRequest();
+  // Ensure it's explicitly not appendable.
+  request.mutable_write_object_spec()->set_appendable(false);
+
+  auto tested = std::make_unique<AsyncWriterConnectionImpl>(
+      TestOptions(), std::move(request), std::move(mock), hash, 1024);
+
+  internal::OptionsSpan span(
+      Options{}.set<storage::UseCrc32cValueOption>(654321));
+  auto response = tested->Finalize(WritePayload{});
+
+  auto next = sequencer.PopFrontWithName();
+  ASSERT_THAT(next.second, "Write");
+  next.first.set_value(true);
+  next = sequencer.PopFrontWithName();
+  ASSERT_THAT(next.second, "Read");
+  next.first.set_value(true);
+  auto object = response.get();
+  EXPECT_THAT(object, IsOkAndHolds(IsProtoEqual(MakeTestObject())))
+      << "=" << object->DebugString();
+
+  tested = {};
+  next = sequencer.PopFrontWithName();
+  ASSERT_THAT(next.second, "Finish");
+  next.first.set_value(true);
+}
+
+TEST(AsyncWriterConnectionTest,
+     FinalizeNonAppendableWithExpectedMD5FromCurrentOptions) {
+  AsyncSequencer<bool> sequencer;
+  auto mock = std::make_unique<MockStream>();
+  EXPECT_CALL(*mock, Cancel).Times(1);
+  EXPECT_CALL(*mock, Write)
+      .WillOnce([&](Request const& request, grpc::WriteOptions wopt) {
+        EXPECT_TRUE(request.finish_write());
+        EXPECT_TRUE(wopt.is_last_message());
+        EXPECT_EQ(request.common_object_request_params().encryption_algorithm(),
+                  "test-only-algo");
+        EXPECT_TRUE(request.has_object_checksums());
+        EXPECT_EQ(request.object_checksums().md5_hash(), "test-md5");
+        return sequencer.PushBack("Write");
+      });
+  EXPECT_CALL(*mock, Read).WillOnce([&]() {
+    return sequencer.PushBack("Read").then([](auto f) {
+      if (!f.get()) return absl::optional<Response>();
+      return absl::make_optional(MakeTestResponse());
+    });
+  });
+  EXPECT_CALL(*mock, Finish).WillOnce([&] {
+    return sequencer.PushBack("Finish").then([](auto f) {
+      if (f.get()) return Status{};
+      return PermanentError();
+    });
+  });
+  auto hash = std::make_shared<MockHashFunction>();
+  EXPECT_CALL(*hash, Update(_, An<absl::Cord const&>(), _)).Times(1);
+  // It shouldn't call Finish() because we use kFinalize!
+  EXPECT_CALL(*hash, Finish).Times(0);
+
+  auto request = MakeRequest();
+  // Ensure it's explicitly not appendable.
+  request.mutable_write_object_spec()->set_appendable(false);
+
+  auto tested = std::make_unique<AsyncWriterConnectionImpl>(
+      TestOptions(), std::move(request), std::move(mock), hash, 1024);
+
+  internal::OptionsSpan span(
+      Options{}.set<storage::UseMD5ValueOption>("test-md5"));
   auto response = tested->Finalize(WritePayload{});
 
   auto next = sequencer.PopFrontWithName();

--- a/google/cloud/storage/internal/async/writer_connection_impl_test.cc
+++ b/google/cloud/storage/internal/async/writer_connection_impl_test.cc
@@ -758,7 +758,7 @@ TEST(AsyncWriterConnectionTest, FinalizeAppendableWithExpectedChecksum) {
                   "test-only-algo");
         EXPECT_TRUE(request.has_object_checksums());
         EXPECT_EQ(request.object_checksums().crc32c(),
-                  123456);  // wait, it might be an int in proto
+                  123456);
         return sequencer.PushBack("Write");
       });
   EXPECT_CALL(*mock, Read).WillOnce([&]() {

--- a/google/cloud/storage/internal/async/writer_connection_impl_test.cc
+++ b/google/cloud/storage/internal/async/writer_connection_impl_test.cc
@@ -775,9 +775,7 @@ TEST(AsyncWriterConnectionTest, FinalizeAppendableWithExpectedChecksum) {
   });
   auto hash = std::make_shared<MockHashFunction>();
   EXPECT_CALL(*hash, Update(_, An<absl::Cord const&>(), _)).Times(1);
-  EXPECT_CALL(*hash, Finish)
-      .WillOnce(Return(storage::internal::HashValues{
-          storage_internal::Crc32cFromProto(123456), {}}));
+  EXPECT_CALL(*hash, Finish).Times(0);
 
   auto request = MakeRequest();
   request.mutable_write_object_spec()->set_appendable(true);


### PR DESCRIPTION
#GeminiAlert

1. is_append == true
For appendable uploads, the internal HashFunction is broken. It only sees the chunks uploaded in the current stream, not the full object, so its locally computed hashes are wrong. Because it's broken, we MUST bypass it (by setting action = kFinalize) and manually inject the checksum ourselves. Since we are doing it manually, we want to respect the user's expected checksum regardless of whether they set it at the start of the upload (options_) OR dynamically at the end (current_options). Therefore, we pull the value from merged to cover both bases.

2. is_append == false (Normal Uploads)
For normal uploads, the internal HashFunction works perfectly! It computes the hashes over the whole object, validates them locally, and injects them into the gRPC request. HOWEVER, the HashFunction is initialized at the start of the upload. It only knows about options_. It has absolutely zero knowledge of current_options (options passed dynamically at the exact moment of Finalize()).

If the user provided the checksum at the start (options_), we WANT the HashFunction to handle it. If we checked merged here, we would mistakenly bypass the HashFunction. BUT, if the user provided the checksum dynamically at the end (current_options), the HashFunction doesn't know about it. It will compute its own hash and aggressively overwrite whatever the user wanted! Therefore, for normal uploads, we only check current_options. If the user provided a last-second checksum, we bypass the HashFunction and manually inject it. Otherwise, we leave the HashFunction alone to do its job.

Summary:

We use merged for appends because we must manually inject the checksum no matter when it was provided.
We use current_options for normal uploads because we only want to manually inject it if the user provided a last-second checksum that the HashFunction doesn't know about.