### PR TITLE
fix(pubsub): run lease refresh-timer continuation via RunAsync

### DIFF
--- a/google/cloud/pubsub/internal/subscription_lease_management.cc
+++ b/google/cloud/pubsub/internal/subscription_lease_management.cc
@@ -144,9 +144,25 @@ void SubscriptionLeaseManagement::StartRefreshTimer(
   shutdown_manager_->StartOperation(__func__, "OnRefreshTimer", [&] {
     using TimerFuture = future<StatusOr<std::chrono::system_clock::time_point>>;
     if (refresh_timer_.valid()) refresh_timer_.cancel();
-    refresh_timer_ =
-        cq_.MakeDeadlineTimer(deadline).then([weak](TimerFuture tp) {
-          if (auto self = weak.lock()) self->OnRefreshTimer(!tp.get());
+    // The caller holds mu_ (the unnamed unique_lock parameter) for the full
+    // duration of this function.  If the timer future is already satisfied
+    // when .then() attaches its continuation -- a deadline in the past
+    // (RefreshMessageLeases can compute extensions as small as 1s, and
+    // kAckDeadlineSlack then puts the deadline before now), or a CQ thread
+    // winning the satisfaction race -- the continuation runs INLINE on this
+    // thread, re-enters OnRefreshTimer -> RefreshMessageLeases, and
+    // self-deadlocks re-acquiring the non-recursive mu_.  Every other path
+    // (AckMessage, OnRead, Shutdown) then blocks behind mu_ and the
+    // subscription freezes until the process restarts.  Dispatch the
+    // continuation through the CompletionQueue so OnRefreshTimer always runs
+    // on a CQ thread with no locks held.
+    auto cq = cq_;
+    refresh_timer_ = cq_.MakeDeadlineTimer(deadline).then(
+        [weak, cq](TimerFuture tp) mutable {
+          auto const cancelled = !tp.get();
+          cq.RunAsync([weak, cancelled] {
+            if (auto self = weak.lock()) self->OnRefreshTimer(cancelled);
+          });
         });
   });
 }

--- a/google/cloud/pubsub/internal/subscription_lease_management_test.cc
+++ b/google/cloud/pubsub/internal/subscription_lease_management_test.cc
@@ -280,6 +280,73 @@ TEST(SubscriptionLeaseManagementTest, ExpiredMessage) {
   EXPECT_THAT(done.get(), IsOk());
 }
 
+/// @test Regression test for the self-deadlock in StartRefreshTimer: the lease
+/// refresh-timer continuation must be dispatched via `CompletionQueue::RunAsync`
+/// rather than run inline in the timer callback. Running it inline re-entered
+/// the already-held `mu_` and self-deadlocked the subscription. Here we verify
+/// that firing the timer only *schedules* the refresh (a RunAsync task); the
+/// lease extension runs on a subsequent completion, never synchronously inside
+/// the timer callback.
+TEST(SubscriptionLeaseManagementTest,
+     RefreshTimerContinuationDispatchedViaRunAsync) {
+  auto mock = std::make_shared<pubsub_testing::MockSubscriptionBatchSource>();
+  std::shared_ptr<BatchCallback> batch_callback;
+  EXPECT_CALL(*mock, Start).WillOnce([&](std::shared_ptr<BatchCallback> cb) {
+    batch_callback = std::move(cb);
+  });
+
+  auto mock_batch_callback =
+      std::make_shared<pubsub_testing::MockBatchCallback>();
+  EXPECT_CALL(*mock_batch_callback, callback).Times(1);
+
+  int extend_calls = 0;
+  EXPECT_CALL(*mock, ExtendLeases)
+      .WillRepeatedly([&](std::vector<std::string> const&,
+                          std::chrono::seconds) {
+        ++extend_calls;
+        return make_ready_future(Status{});
+      });
+  EXPECT_CALL(*mock, BulkNack).WillRepeatedly([](std::vector<std::string>
+                                                     const&) {
+    return make_ready_future(Status{});
+  });
+  EXPECT_CALL(*mock, Shutdown).Times(1);
+
+  auto fake_cq = std::make_shared<FakeCompletionQueueImpl>();
+  CompletionQueue cq(fake_cq);
+
+  auto shutdown_manager = std::make_shared<SessionShutdownManager>();
+  auto uut = SubscriptionLeaseManagement::Create(
+      cq, shutdown_manager, mock, std::chrono::seconds(345),
+      std::chrono::seconds(600));
+
+  auto done = shutdown_manager->Start({});
+  uut->Start(mock_batch_callback);
+  batch_callback->callback(
+      BatchCallback::StreamingPullResponse{GenerateMessages("0-", 1)});
+  ASSERT_EQ(1U, fake_cq->size());  // the refresh timer is pending
+
+  // Fire the timer. With the fix, the timer callback only *schedules*
+  // OnRefreshTimer via RunAsync; it must NOT extend leases inline (doing so
+  // re-enters the held mutex and deadlocks).
+  fake_cq->SimulateCompletion(true);
+  EXPECT_EQ(0, extend_calls)
+      << "lease refresh ran inline in the timer callback (deadlock path)";
+  EXPECT_EQ(1U, fake_cq->size());  // a RunAsync task is now pending
+
+  // Draining the RunAsync task runs OnRefreshTimer -> ExtendLeases.
+  fake_cq->SimulateCompletion(true);
+  EXPECT_EQ(1, extend_calls);
+
+  // Drain any remaining scheduled work so shutdown can complete.
+  shutdown_manager->MarkAsShutdown(__func__, Status{});
+  uut->Shutdown();
+  for (int i = 0; i != 16 && fake_cq->size() != 0; ++i) {
+    fake_cq->SimulateCompletion(false);
+  }
+  EXPECT_THAT(done.get(), IsOk());
+}
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace pubsub_internal

--- a/google/cloud/pubsub/internal/subscription_lease_management_test.cc
+++ b/google/cloud/pubsub/internal/subscription_lease_management_test.cc
@@ -109,18 +109,21 @@ TEST(SubscriptionLeaseManagementTest, NormalLifecycle) {
   // will verify that only the remaining messages have their lease extended.
   uut->AckMessage("ack-0-1");
   fake_cq->SimulateCompletion(true);
+  fake_cq->SimulateCompletion(true);  // drain the deferred OnRefreshTimer
   ASSERT_EQ(1U, fake_cq->size());
 
   // Ack one more message and trigger the new timer.
   uut->NackMessage("ack-0-2");
   fake_cq->SimulateCompletion(true);
+  fake_cq->SimulateCompletion(true);  // drain the deferred OnRefreshTimer
   ASSERT_EQ(1U, fake_cq->size());
 
   shutdown_manager->MarkAsShutdown(__func__, Status{});
   uut->Shutdown();
 
-  fake_cq->SimulateCompletion(false);
-  ASSERT_EQ(0U, fake_cq->size());
+  for (int i = 0; i != 16 && fake_cq->size() != 0; ++i) {
+    fake_cq->SimulateCompletion(true);
+  }
   EXPECT_THAT(done.get(), IsOk());
 }
 
@@ -154,8 +157,9 @@ TEST(SubscriptionLeaseManagementTest, ShutdownOnError) {
           Status(StatusCode::kPermissionDenied, "uh-oh"))});
   ASSERT_EQ(1U, fake_cq->size());
 
-  fake_cq->SimulateCompletion(false);
-  ASSERT_EQ(0U, fake_cq->size());
+  for (int i = 0; i != 16 && fake_cq->size() != 0; ++i) {
+    fake_cq->SimulateCompletion(true);
+  }
   EXPECT_THAT(done.get(), StatusIs(StatusCode::kPermissionDenied));
 }
 
@@ -219,12 +223,14 @@ TEST(SubscriptionLeaseManagementTest, UsesDeadlineExtension) {
 
   // Ignore message and then fire the timer. This will extend the deadline.
   fake_cq->SimulateCompletion(true);
+  fake_cq->SimulateCompletion(true);  // drain the deferred OnRefreshTimer
   ASSERT_EQ(1U, fake_cq->size());
 
   shutdown_manager->MarkAsShutdown(__func__, Status{});
   uut->Shutdown();
-  fake_cq->SimulateCompletion(false);
-  ASSERT_EQ(0U, fake_cq->size());
+  for (int i = 0; i != 16 && fake_cq->size() != 0; ++i) {
+    fake_cq->SimulateCompletion(true);
+  }
   EXPECT_THAT(done.get(), IsOk());
 }
 
@@ -270,13 +276,15 @@ TEST(SubscriptionLeaseManagementTest, ExpiredMessage) {
   // will verify that only the remaining messages have their lease extended.
   uut->AckMessage("ack-0-1");
   fake_cq->SimulateCompletion(true);
+  fake_cq->SimulateCompletion(true);  // drain the deferred OnRefreshTimer
   ASSERT_EQ(1U, fake_cq->size());
 
   shutdown_manager->MarkAsShutdown(__func__, Status{});
   uut->Shutdown();
 
-  fake_cq->SimulateCompletion(false);
-  ASSERT_EQ(0U, fake_cq->size());
+  for (int i = 0; i != 16 && fake_cq->size() != 0; ++i) {
+    fake_cq->SimulateCompletion(true);
+  }
   EXPECT_THAT(done.get(), IsOk());
 }
 
@@ -337,11 +345,13 @@ TEST(SubscriptionLeaseManagementTest,
   fake_cq->SimulateCompletion(true);
   EXPECT_EQ(1, extend_calls);
 
-  // Drain any remaining scheduled work so shutdown can complete.
+  // The fix defers OnRefreshTimer to RunAsync, which the fake CQ only executes
+  // on SimulateCompletion(true) (false drops the task). Drain with true so the
+  // deferred refresh operation finishes and the session shutdown completes.
   shutdown_manager->MarkAsShutdown(__func__, Status{});
   uut->Shutdown();
   for (int i = 0; i != 16 && fake_cq->size() != 0; ++i) {
-    fake_cq->SimulateCompletion(false);
+    fake_cq->SimulateCompletion(true);
   }
   EXPECT_THAT(done.get(), IsOk());
 }

--- a/google/cloud/pubsub/internal/subscription_lease_management_test.cc
+++ b/google/cloud/pubsub/internal/subscription_lease_management_test.cc
@@ -281,12 +281,11 @@ TEST(SubscriptionLeaseManagementTest, ExpiredMessage) {
 }
 
 /// @test Regression test for the self-deadlock in StartRefreshTimer: the lease
-/// refresh-timer continuation must be dispatched via `CompletionQueue::RunAsync`
-/// rather than run inline in the timer callback. Running it inline re-entered
-/// the already-held `mu_` and self-deadlocked the subscription. Here we verify
-/// that firing the timer only *schedules* the refresh (a RunAsync task); the
-/// lease extension runs on a subsequent completion, never synchronously inside
-/// the timer callback.
+/// refresh-timer continuation must be dispatched via `RunAsync` rather than run
+/// inline in the timer callback. Running it inline re-entered the already-held
+/// `mu_` and self-deadlocked the subscription. Here we verify that firing the
+/// timer only *schedules* the refresh (a RunAsync task); the lease extension
+/// runs on a subsequent completion, never synchronously in the timer callback.
 TEST(SubscriptionLeaseManagementTest,
      RefreshTimerContinuationDispatchedViaRunAsync) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriptionBatchSource>();

--- a/google/cloud/pubsub/internal/subscription_lease_management_test.cc
+++ b/google/cloud/pubsub/internal/subscription_lease_management_test.cc
@@ -109,19 +109,21 @@ TEST(SubscriptionLeaseManagementTest, NormalLifecycle) {
   // will verify that only the remaining messages have their lease extended.
   uut->AckMessage("ack-0-1");
   fake_cq->SimulateCompletion(true);
-  fake_cq->SimulateCompletion(true);  // drain the deferred OnRefreshTimer
+  // RunAsync, drain the deferred OnRefreshTimer
+  fake_cq->SimulateCompletion(true);
   ASSERT_EQ(1U, fake_cq->size());
 
   // Ack one more message and trigger the new timer.
   uut->NackMessage("ack-0-2");
   fake_cq->SimulateCompletion(true);
-  fake_cq->SimulateCompletion(true);  // drain the deferred OnRefreshTimer
+  // RunAsync, drain the deferred OnRefreshTimer
+  fake_cq->SimulateCompletion(true);
   ASSERT_EQ(1U, fake_cq->size());
 
   shutdown_manager->MarkAsShutdown(__func__, Status{});
   uut->Shutdown();
 
-  for (int i = 0; i != 16 && fake_cq->size() != 0; ++i) {
+  for (int i = 0; i != 16 && !fake_cq->empty(); ++i) {
     fake_cq->SimulateCompletion(true);
   }
   EXPECT_THAT(done.get(), IsOk());
@@ -157,7 +159,7 @@ TEST(SubscriptionLeaseManagementTest, ShutdownOnError) {
           Status(StatusCode::kPermissionDenied, "uh-oh"))});
   ASSERT_EQ(1U, fake_cq->size());
 
-  for (int i = 0; i != 16 && fake_cq->size() != 0; ++i) {
+  for (int i = 0; i != 16 && !fake_cq->empty(); ++i) {
     fake_cq->SimulateCompletion(true);
   }
   EXPECT_THAT(done.get(), StatusIs(StatusCode::kPermissionDenied));
@@ -223,12 +225,13 @@ TEST(SubscriptionLeaseManagementTest, UsesDeadlineExtension) {
 
   // Ignore message and then fire the timer. This will extend the deadline.
   fake_cq->SimulateCompletion(true);
-  fake_cq->SimulateCompletion(true);  // drain the deferred OnRefreshTimer
+  // RunAsync, drain the deferred OnRefreshTimer
+  fake_cq->SimulateCompletion(true);
   ASSERT_EQ(1U, fake_cq->size());
 
   shutdown_manager->MarkAsShutdown(__func__, Status{});
   uut->Shutdown();
-  for (int i = 0; i != 16 && fake_cq->size() != 0; ++i) {
+  for (int i = 0; i != 16 && !fake_cq->empty(); ++i) {
     fake_cq->SimulateCompletion(true);
   }
   EXPECT_THAT(done.get(), IsOk());
@@ -276,13 +279,14 @@ TEST(SubscriptionLeaseManagementTest, ExpiredMessage) {
   // will verify that only the remaining messages have their lease extended.
   uut->AckMessage("ack-0-1");
   fake_cq->SimulateCompletion(true);
-  fake_cq->SimulateCompletion(true);  // drain the deferred OnRefreshTimer
+  // RunAsync, drain the deferred OnRefreshTimer
+  fake_cq->SimulateCompletion(true);
   ASSERT_EQ(1U, fake_cq->size());
 
   shutdown_manager->MarkAsShutdown(__func__, Status{});
   uut->Shutdown();
 
-  for (int i = 0; i != 16 && fake_cq->size() != 0; ++i) {
+  for (int i = 0; i != 16 && !fake_cq->empty(); ++i) {
     fake_cq->SimulateCompletion(true);
   }
   EXPECT_THAT(done.get(), IsOk());
@@ -308,15 +312,15 @@ TEST(SubscriptionLeaseManagementTest,
 
   int extend_calls = 0;
   EXPECT_CALL(*mock, ExtendLeases)
-      .WillRepeatedly([&](std::vector<std::string> const&,
-                          std::chrono::seconds) {
-        ++extend_calls;
+      .WillRepeatedly(
+          [&](std::vector<std::string> const&, std::chrono::seconds) {
+            ++extend_calls;
+            return make_ready_future(Status{});
+          });
+  EXPECT_CALL(*mock, BulkNack)
+      .WillRepeatedly([](std::vector<std::string> const&) {
         return make_ready_future(Status{});
       });
-  EXPECT_CALL(*mock, BulkNack).WillRepeatedly([](std::vector<std::string>
-                                                     const&) {
-    return make_ready_future(Status{});
-  });
   EXPECT_CALL(*mock, Shutdown).Times(1);
 
   auto fake_cq = std::make_shared<FakeCompletionQueueImpl>();
@@ -350,7 +354,7 @@ TEST(SubscriptionLeaseManagementTest,
   // deferred refresh operation finishes and the session shutdown completes.
   shutdown_manager->MarkAsShutdown(__func__, Status{});
   uut->Shutdown();
-  for (int i = 0; i != 16 && fake_cq->size() != 0; ++i) {
+  for (int i = 0; i != 16 && !fake_cq->empty(); ++i) {
     fake_cq->SimulateCompletion(true);
   }
   EXPECT_THAT(done.get(), IsOk());

--- a/google/cloud/pubsub/internal/subscription_lease_management_test.cc
+++ b/google/cloud/pubsub/internal/subscription_lease_management_test.cc
@@ -327,9 +327,9 @@ TEST(SubscriptionLeaseManagementTest,
   CompletionQueue cq(fake_cq);
 
   auto shutdown_manager = std::make_shared<SessionShutdownManager>();
-  auto uut = SubscriptionLeaseManagement::Create(
-      cq, shutdown_manager, mock, std::chrono::seconds(345),
-      std::chrono::seconds(600));
+  auto uut = SubscriptionLeaseManagement::Create(cq, shutdown_manager, mock,
+                                                 std::chrono::seconds(345),
+                                                 std::chrono::seconds(600));
 
   auto done = shutdown_manager->Start({});
   uut->Start(mock_batch_callback);


### PR DESCRIPTION
Fixes #16248.

## Problem

`SubscriptionLeaseManagement::StartRefreshTimer()` attaches its refresh-timer continuation with `.then()` while `mu_` is held (the unnamed `unique_lock` parameter is live for the whole function). When the timer future is **already satisfied** at attach time — a deadline in the past (`RefreshMessageLeases` can compute extensions as small as 1s and `kAckDeadlineSlack` then places the deadline before `now`), or a completion-queue thread winning the satisfaction race — the continuation runs **inline** on the calling thread, re-enters `OnRefreshTimer` → `RefreshMessageLeases`, and **self-deadlocks** re-acquiring the non-recursive `mu_`. Every other path (`AckMessage`, `OnRead`, `Shutdown`) then blocks behind `mu_` and the subscription freezes until the process restarts. It is per-subscription, has no self-recovery, and low-traffic subscriptions are the most exposed.

## Fix

Dispatch the continuation through the `CompletionQueue` via `RunAsync`, so `OnRefreshTimer` always runs on a CQ thread with **no locks held** and never inline under `mu_`. This mirrors the Bigtable `MutationBatcher` fix for the same re-entrancy class (#4083 → #4327).

## Testing

We have been running exactly this change as a local patch to the v2.28.0 recipe and it resolves the deadlock in our deployment. I'm happy to add a regression test to `subscription_lease_management_test.cc` (a fake `CompletionQueue` that fires the timer inline to exercise the re-entrant path) — let me know the form you'd prefer.

---
Note: our corporate CLA signature is in progress (expected Monday); opening now so the CLA-assistant link is generated. Left as **draft** until the CLA is in place and you've had a first look.
