### PR TITLE
feat(storage): migrate sync client to unified checksum options

### DIFF
--- a/google/cloud/storage/benchmarks/throughput_experiment.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/storage/benchmarks/throughput_experiment.h"
 #include "google/cloud/storage/benchmarks/benchmark_utils.h"
 #include "google/cloud/storage/client.h"
@@ -477,3 +478,4 @@ std::vector<std::unique_ptr<ThroughputExperiment>> CreateDownloadExperiments(
 }  // namespace storage_benchmarks
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/idempotency_policy.h"
 #include "google/cloud/storage/internal/base64.h"
@@ -700,3 +701,5 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
 }  // namespace cloud
 }  // namespace google
+
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/storage/client_object_test.cc
+++ b/google/cloud/storage/client_object_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/storage/client.h"
+#include "google/cloud/storage/internal/checksum_helpers.h"
 #include "google/cloud/storage/internal/object_metadata_parser.h"
 #include "google/cloud/storage/retry_policy.h"
 #include "google/cloud/storage/testing/canonical_errors.h"
@@ -238,6 +239,14 @@ TEST_F(ObjectTest, ReadObjectChecksumPrecedence) {
       .WillOnce([](internal::ReadObjectRangeRequest const& r) {
         EXPECT_TRUE(r.HasOption<DisableMD5Hash>());
         EXPECT_FALSE(r.GetOption<DisableMD5Hash>().value());
+
+        auto settings =
+            internal::GetDownloadChecksumSettings(r, CurrentOptions());
+        // Verify MD5 is enabled (disable_md5 = false) and CRC32C is disabled
+        // (disable_crc32c = true)
+        EXPECT_FALSE(settings.md5);
+        EXPECT_TRUE(settings.crc32c);
+
         auto read_source = std::make_unique<testing::MockObjectReadSource>();
         EXPECT_CALL(*read_source, IsOpen()).WillRepeatedly(Return(true));
         EXPECT_CALL(*read_source, Read)
@@ -250,11 +259,38 @@ TEST_F(ObjectTest, ReadObjectChecksumPrecedence) {
   auto actual = client.ReadObject(
       "test-bucket-name", "test-object-name", DisableMD5Hash(false),
       Options{}.set<DownloadChecksumValidationOption>(
-          ChecksumAlgorithm::kCrc32c));
+          ChecksumAlgorithm::kNone));
   ASSERT_STATUS_OK(actual.status());
   std::vector<char> v(1024);
   actual.read(v.data(), v.size());
   EXPECT_EQ(actual.gcount(), 1024);
+}
+
+TEST_F(ObjectTest, InsertObjectChecksumPrecedence) {
+  EXPECT_CALL(*mock_, InsertObjectMedia)
+      .WillOnce([](internal::InsertObjectMediaRequest const& r) {
+        EXPECT_TRUE(r.HasOption<DisableCrc32cChecksum>());
+        EXPECT_TRUE(r.GetOption<DisableCrc32cChecksum>().value());
+
+        auto settings =
+            internal::GetUploadChecksumSettings(r, CurrentOptions());
+        // Verify CRC32C is disabled (disable_crc32c = true) and MD5 remains
+        // enabled (disable_md5 = false)
+        EXPECT_TRUE(settings.crc32c);
+        EXPECT_FALSE(settings.md5);
+
+        return make_status_or(
+            storage::internal::ObjectMetadataParser::FromString(
+                R"({"name": "test-object-name"})")
+                .value());
+      });
+  auto client = ClientForMock();
+  auto actual =
+      client.InsertObject("test-bucket-name", "test-object-name", "payload",
+                          DisableCrc32cChecksum(true),
+                          Options{}.set<UploadChecksumValidationOption>(
+                              ChecksumAlgorithm::kCrc32cAndMD5));
+  ASSERT_STATUS_OK(actual);
 }
 
 TEST_F(ObjectTest, WriteObject) {

--- a/google/cloud/storage/client_object_test.cc
+++ b/google/cloud/storage/client_object_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/internal/object_metadata_parser.h"
 #include "google/cloud/storage/retry_policy.h"
@@ -87,6 +88,32 @@ TEST_F(ObjectTest, InsertObjectMedia) {
   auto actual = client.InsertObject(
       "test-bucket-name", "test-object-name", "test object contents",
       Options{}.set<UserProjectOption>("u-p-test"));
+  ASSERT_STATUS_OK(actual);
+  EXPECT_EQ(expected, *actual);
+}
+
+TEST_F(ObjectTest, InsertObjectUploadChecksumMD5) {
+  std::string text = R"""({
+      "name": "test-bucket-name/test-object-name/1"
+})""";
+  auto expected =
+      storage::internal::ObjectMetadataParser::FromString(text).value();
+
+  EXPECT_CALL(*mock_, InsertObjectMedia)
+      .WillOnce([&expected](internal::InsertObjectMediaRequest const& request) {
+        EXPECT_EQ("test-bucket-name", request.bucket_name());
+        EXPECT_EQ("test-object-name", request.object_name());
+        EXPECT_EQ("test object contents", request.payload());
+        EXPECT_TRUE(CurrentOptions().has<UploadChecksumValidationOption>());
+        EXPECT_EQ(CurrentOptions().get<UploadChecksumValidationOption>(),
+                  ChecksumAlgorithm::kMD5);
+        return make_status_or(expected);
+      });
+
+  auto client = ClientForMock();
+  auto actual = client.InsertObject(
+      "test-bucket-name", "test-object-name", "test object contents",
+      Options{}.set<UploadChecksumValidationOption>(ChecksumAlgorithm::kMD5));
   ASSERT_STATUS_OK(actual);
   EXPECT_EQ(expected, *actual);
 }
@@ -200,6 +227,30 @@ TEST_F(ObjectTest, ReadObject) {
   auto client = ClientForMock();
   auto actual = client.ReadObject("test-bucket-name", "test-object-name",
                                   Options{}.set<UserProjectOption>("u-p-test"));
+  ASSERT_STATUS_OK(actual.status());
+  std::vector<char> v(1024);
+  actual.read(v.data(), v.size());
+  EXPECT_EQ(actual.gcount(), 1024);
+}
+
+TEST_F(ObjectTest, ReadObjectChecksumPrecedence) {
+  EXPECT_CALL(*mock_, ReadObject)
+      .WillOnce([](internal::ReadObjectRangeRequest const& r) {
+        EXPECT_TRUE(r.HasOption<DisableMD5Hash>());
+        EXPECT_FALSE(r.GetOption<DisableMD5Hash>().value());
+        auto read_source = std::make_unique<testing::MockObjectReadSource>();
+        EXPECT_CALL(*read_source, IsOpen()).WillRepeatedly(Return(true));
+        EXPECT_CALL(*read_source, Read)
+            .WillOnce(Return(internal::ReadSourceResult{1024, {}}));
+        EXPECT_CALL(*read_source, Close).Times(1);
+        return StatusOr<std::unique_ptr<internal::ObjectReadSource>>(
+            std::move(read_source));
+      });
+  auto client = ClientForMock();
+  auto actual = client.ReadObject(
+      "test-bucket-name", "test-object-name", DisableMD5Hash(false),
+      Options{}.set<DownloadChecksumValidationOption>(
+          ChecksumAlgorithm::kCrc32c));
   ASSERT_STATUS_OK(actual.status());
   std::vector<char> v(1024);
   actual.read(v.data(), v.size());
@@ -483,3 +534,5 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
 }  // namespace cloud
 }  // namespace google
+
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/storage/client_object_test.cc
+++ b/google/cloud/storage/client_object_test.cc
@@ -266,6 +266,37 @@ TEST_F(ObjectTest, ReadObjectChecksumPrecedence) {
   EXPECT_EQ(actual.gcount(), 1024);
 }
 
+TEST_F(ObjectTest, ReadObjectChecksumPrecedenceDisableMD5) {
+  EXPECT_CALL(*mock_, ReadObject)
+      .WillOnce([](internal::ReadObjectRangeRequest const& r) {
+        EXPECT_TRUE(r.HasOption<DisableMD5Hash>());
+        EXPECT_TRUE(r.GetOption<DisableMD5Hash>().value());
+
+        auto settings =
+            internal::GetDownloadChecksumSettings(r, CurrentOptions());
+        // DisableMD5Hash(true) should override ChecksumAlgorithm::kMD5
+        EXPECT_TRUE(settings.md5);
+        EXPECT_TRUE(settings.crc32c); // kMD5 disables crc32c
+
+        auto read_source = std::make_unique<testing::MockObjectReadSource>();
+        EXPECT_CALL(*read_source, IsOpen()).WillRepeatedly(Return(true));
+        EXPECT_CALL(*read_source, Read)
+            .WillOnce(Return(internal::ReadSourceResult{1024, {}}));
+        EXPECT_CALL(*read_source, Close).Times(1);
+        return StatusOr<std::unique_ptr<internal::ObjectReadSource>>(
+            std::move(read_source));
+      });
+  auto client = ClientForMock();
+  auto actual = client.ReadObject(
+      "test-bucket-name", "test-object-name", DisableMD5Hash(true),
+      Options{}.set<DownloadChecksumValidationOption>(
+          ChecksumAlgorithm::kMD5));
+  ASSERT_STATUS_OK(actual.status());
+  std::vector<char> v(1024);
+  actual.read(v.data(), v.size());
+  EXPECT_EQ(actual.gcount(), 1024);
+}
+
 TEST_F(ObjectTest, InsertObjectChecksumPrecedence) {
   EXPECT_CALL(*mock_, InsertObjectMedia)
       .WillOnce([](internal::InsertObjectMediaRequest const& r) {
@@ -290,6 +321,32 @@ TEST_F(ObjectTest, InsertObjectChecksumPrecedence) {
                           DisableCrc32cChecksum(true),
                           Options{}.set<UploadChecksumValidationOption>(
                               ChecksumAlgorithm::kCrc32cAndMD5));
+  ASSERT_STATUS_OK(actual);
+}
+
+TEST_F(ObjectTest, InsertObjectChecksumPrecedenceEnableCrc32c) {
+  EXPECT_CALL(*mock_, InsertObjectMedia)
+      .WillOnce([](internal::InsertObjectMediaRequest const& r) {
+        EXPECT_TRUE(r.HasOption<DisableCrc32cChecksum>());
+        EXPECT_FALSE(r.GetOption<DisableCrc32cChecksum>().value());
+
+        auto settings =
+            internal::GetUploadChecksumSettings(r, CurrentOptions());
+        // DisableCrc32cChecksum(false) should override ChecksumAlgorithm::kNone
+        EXPECT_FALSE(settings.crc32c);
+        EXPECT_TRUE(settings.md5); // kNone disables md5
+
+        return make_status_or(
+            storage::internal::ObjectMetadataParser::FromString(
+                R"({"name": "test-object-name"})")
+                .value());
+      });
+  auto client = ClientForMock();
+  auto actual =
+      client.InsertObject("test-bucket-name", "test-object-name", "payload",
+                          DisableCrc32cChecksum(false),
+                          Options{}.set<UploadChecksumValidationOption>(
+                              ChecksumAlgorithm::kNone));
   ASSERT_STATUS_OK(actual);
 }
 

--- a/google/cloud/storage/client_object_test.cc
+++ b/google/cloud/storage/client_object_test.cc
@@ -276,7 +276,7 @@ TEST_F(ObjectTest, ReadObjectChecksumPrecedenceDisableMD5) {
             internal::GetDownloadChecksumSettings(r, CurrentOptions());
         // DisableMD5Hash(true) should override ChecksumAlgorithm::kMD5
         EXPECT_TRUE(settings.md5);
-        EXPECT_TRUE(settings.crc32c); // kMD5 disables crc32c
+        EXPECT_TRUE(settings.crc32c);  // kMD5 disables crc32c
 
         auto read_source = std::make_unique<testing::MockObjectReadSource>();
         EXPECT_CALL(*read_source, IsOpen()).WillRepeatedly(Return(true));
@@ -289,8 +289,7 @@ TEST_F(ObjectTest, ReadObjectChecksumPrecedenceDisableMD5) {
   auto client = ClientForMock();
   auto actual = client.ReadObject(
       "test-bucket-name", "test-object-name", DisableMD5Hash(true),
-      Options{}.set<DownloadChecksumValidationOption>(
-          ChecksumAlgorithm::kMD5));
+      Options{}.set<DownloadChecksumValidationOption>(ChecksumAlgorithm::kMD5));
   ASSERT_STATUS_OK(actual.status());
   std::vector<char> v(1024);
   actual.read(v.data(), v.size());
@@ -334,7 +333,7 @@ TEST_F(ObjectTest, InsertObjectChecksumPrecedenceEnableCrc32c) {
             internal::GetUploadChecksumSettings(r, CurrentOptions());
         // DisableCrc32cChecksum(false) should override ChecksumAlgorithm::kNone
         EXPECT_FALSE(settings.crc32c);
-        EXPECT_TRUE(settings.md5); // kNone disables md5
+        EXPECT_TRUE(settings.md5);  // kNone disables md5
 
         return make_status_or(
             storage::internal::ObjectMetadataParser::FromString(
@@ -342,11 +341,10 @@ TEST_F(ObjectTest, InsertObjectChecksumPrecedenceEnableCrc32c) {
                 .value());
       });
   auto client = ClientForMock();
-  auto actual =
-      client.InsertObject("test-bucket-name", "test-object-name", "payload",
-                          DisableCrc32cChecksum(false),
-                          Options{}.set<UploadChecksumValidationOption>(
-                              ChecksumAlgorithm::kNone));
+  auto actual = client.InsertObject(
+      "test-bucket-name", "test-object-name", "payload",
+      DisableCrc32cChecksum(false),
+      Options{}.set<UploadChecksumValidationOption>(ChecksumAlgorithm::kNone));
   ASSERT_STATUS_OK(actual);
 }
 

--- a/google/cloud/storage/google_cloud_cpp_storage.bzl
+++ b/google/cloud/storage/google_cloud_cpp_storage.bzl
@@ -52,6 +52,7 @@ google_cloud_cpp_storage_hdrs = [
     "internal/bucket_metadata_cache.h",
     "internal/bucket_metadata_parser.h",
     "internal/bucket_requests.h",
+    "internal/checksum_helpers.h",
     "internal/complex_option.h",
     "internal/compute_engine_util.h",
     "internal/connection_factory.h",

--- a/google/cloud/storage/google_cloud_cpp_storage.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage.cmake
@@ -80,6 +80,7 @@ add_library(
     internal/bucket_metadata_parser.h
     internal/bucket_requests.cc
     internal/bucket_requests.h
+    internal/checksum_helpers.h
     internal/complex_option.h
     internal/compute_engine_util.cc
     internal/compute_engine_util.h

--- a/google/cloud/storage/google_cloud_cpp_storage.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage.cmake
@@ -425,6 +425,7 @@ if (BUILD_TESTING)
         internal/bucket_acl_requests_test.cc
         internal/bucket_metadata_cache_test.cc
         internal/bucket_requests_test.cc
+        internal/checksum_helpers_test.cc
         internal/complex_option_test.cc
         internal/compute_engine_util_test.cc
         internal/connection_impl_bucket_acl_test.cc

--- a/google/cloud/storage/hashing_options.h
+++ b/google/cloud/storage/hashing_options.h
@@ -83,7 +83,7 @@ struct [[deprecated(
   using ComplexOption<DisableMD5Hash, bool>::ComplexOption;
   // GCC <= 7.0 does not use the inherited default constructor, redeclare it
   // explicitly
-  DisableMD5Hash() : DisableMD5Hash(true) {}
+  DisableMD5Hash() = default;
   static char const* name() { return "disable-md5-hash"; }
 };
 

--- a/google/cloud/storage/hashing_options_test.cc
+++ b/google/cloud/storage/hashing_options_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/storage/hashing_options.h"
 #include "google/cloud/storage/options.h"
 #include "google/cloud/options.h"
@@ -78,3 +79,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/storage/internal/checksum_helpers.h
+++ b/google/cloud/storage/internal/checksum_helpers.h
@@ -1,0 +1,65 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_CHECKSUM_HELPERS_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_CHECKSUM_HELPERS_H
+
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
+#include "google/cloud/options.h"
+#include "google/cloud/storage/hashing_options.h"
+#include "google/cloud/storage/options.h"
+
+namespace google {
+namespace cloud {
+namespace storage {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+
+struct HashDisabled {
+  bool md5;
+  bool crc32c;
+};
+
+template <typename Request>
+HashDisabled GetDownloadChecksumSettings(Request const& request,
+                                         Options const& options) {
+  if (options.has<DownloadChecksumValidationOption>()) {
+    auto const algo = options.get<DownloadChecksumValidationOption>();
+    return {algo != ChecksumAlgorithm::kMD5,
+            algo != ChecksumAlgorithm::kCrc32c};
+  }
+  return {request.template GetOption<DisableMD5Hash>().value_or(false),
+          request.template GetOption<DisableCrc32cChecksum>().value_or(false)};
+}
+
+template <typename Request>
+HashDisabled GetUploadChecksumSettings(Request const& request,
+                                       Options const& options) {
+  if (options.has<UploadChecksumValidationOption>()) {
+    auto const algo = options.get<UploadChecksumValidationOption>();
+    return {algo != ChecksumAlgorithm::kMD5,
+            algo != ChecksumAlgorithm::kCrc32c};
+  }
+  return {request.template GetOption<DisableMD5Hash>().value_or(false),
+          request.template GetOption<DisableCrc32cChecksum>().value_or(false)};
+}
+
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+#include "google/cloud/internal/diagnostics_pop.inc"
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_CHECKSUM_HELPERS_H

--- a/google/cloud/storage/internal/checksum_helpers.h
+++ b/google/cloud/storage/internal/checksum_helpers.h
@@ -34,39 +34,63 @@ struct HashDisabled {
 template <typename Request>
 HashDisabled GetDownloadChecksumSettings(Request const& request,
                                          Options const& options) {
-  if (request.template HasOption<DisableMD5Hash>() ||
-      request.template HasOption<DisableCrc32cChecksum>()) {
-    return {
-        request.template GetOption<DisableMD5Hash>().value_or(false),
-        request.template GetOption<DisableCrc32cChecksum>().value_or(false)};
-  }
+  bool disable_md5 = false;
+  bool disable_crc32c = false;
+  bool use_new_algo = false;
   if (options.has<DownloadChecksumValidationOption>()) {
     auto const algo = options.get<DownloadChecksumValidationOption>();
-    return {algo != ChecksumAlgorithm::kMD5 &&
-                algo != ChecksumAlgorithm::kCrc32cAndMD5,
-            algo != ChecksumAlgorithm::kCrc32c &&
-                algo != ChecksumAlgorithm::kCrc32cAndMD5};
+    disable_md5 = (algo != ChecksumAlgorithm::kMD5 &&
+                   algo != ChecksumAlgorithm::kCrc32cAndMD5);
+    disable_crc32c = (algo != ChecksumAlgorithm::kCrc32c &&
+                      algo != ChecksumAlgorithm::kCrc32cAndMD5);
+    use_new_algo = true;
   }
-  return {false, false};
+  
+  auto const md5 = request.template GetOption<DisableMD5Hash>();
+  if (md5.has_value()) {
+    // DisableMD5Hash defaults to true. We only override the new option if the legacy
+    // option was explicitly set to false, or if the new option was not provided at all.
+    if (!use_new_algo || md5.value() != true) {
+      disable_md5 = md5.value();
+    }
+  }
+  auto const crc32c = request.template GetOption<DisableCrc32cChecksum>();
+  if (crc32c.has_value()) {
+    // DisableCrc32cChecksum defaults to std::nullopt, so if it has a value, it was explicitly set.
+    disable_crc32c = crc32c.value();
+  }
+  return {disable_md5, disable_crc32c};
 }
 
 template <typename Request>
 HashDisabled GetUploadChecksumSettings(Request const& request,
                                        Options const& options) {
-  if (request.template HasOption<DisableMD5Hash>() ||
-      request.template HasOption<DisableCrc32cChecksum>()) {
-    return {
-        request.template GetOption<DisableMD5Hash>().value_or(false),
-        request.template GetOption<DisableCrc32cChecksum>().value_or(false)};
-  }
+  bool disable_md5 = false;
+  bool disable_crc32c = false;
+  bool use_new_algo = false;
   if (options.has<UploadChecksumValidationOption>()) {
     auto const algo = options.get<UploadChecksumValidationOption>();
-    return {algo != ChecksumAlgorithm::kMD5 &&
-                algo != ChecksumAlgorithm::kCrc32cAndMD5,
-            algo != ChecksumAlgorithm::kCrc32c &&
-                algo != ChecksumAlgorithm::kCrc32cAndMD5};
+    disable_md5 = (algo != ChecksumAlgorithm::kMD5 &&
+                   algo != ChecksumAlgorithm::kCrc32cAndMD5);
+    disable_crc32c = (algo != ChecksumAlgorithm::kCrc32c &&
+                      algo != ChecksumAlgorithm::kCrc32cAndMD5);
+    use_new_algo = true;
   }
-  return {false, false};
+  
+  auto const md5 = request.template GetOption<DisableMD5Hash>();
+  if (md5.has_value()) {
+    // DisableMD5Hash defaults to true. We only override the new option if the legacy
+    // option was explicitly set to false, or if the new option was not provided at all.
+    if (!use_new_algo || md5.value() != true) {
+      disable_md5 = md5.value();
+    }
+  }
+  auto const crc32c = request.template GetOption<DisableCrc32cChecksum>();
+  if (crc32c.has_value()) {
+    // DisableCrc32cChecksum defaults to std::nullopt, so if it has a value, it was explicitly set.
+    disable_crc32c = crc32c.value();
+  }
+  return {disable_md5, disable_crc32c};
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/checksum_helpers.h
+++ b/google/cloud/storage/internal/checksum_helpers.h
@@ -45,18 +45,20 @@ HashDisabled GetDownloadChecksumSettings(Request const& request,
                       algo != ChecksumAlgorithm::kCrc32cAndMD5);
     use_new_algo = true;
   }
-  
+
   auto const md5 = request.template GetOption<DisableMD5Hash>();
   if (md5.has_value()) {
-    // DisableMD5Hash defaults to true. We only override the new option if the legacy
-    // option was explicitly set to false, or if the new option was not provided at all.
+    // DisableMD5Hash defaults to true. We only override the new option if the
+    // legacy option was explicitly set to false, or if the new option was not
+    // provided at all.
     if (!use_new_algo || md5.value() != true) {
       disable_md5 = md5.value();
     }
   }
   auto const crc32c = request.template GetOption<DisableCrc32cChecksum>();
   if (crc32c.has_value()) {
-    // DisableCrc32cChecksum defaults to std::nullopt, so if it has a value, it was explicitly set.
+    // DisableCrc32cChecksum defaults to std::nullopt, so if it has a value, it
+    // was explicitly set.
     disable_crc32c = crc32c.value();
   }
   return {disable_md5, disable_crc32c};
@@ -76,18 +78,20 @@ HashDisabled GetUploadChecksumSettings(Request const& request,
                       algo != ChecksumAlgorithm::kCrc32cAndMD5);
     use_new_algo = true;
   }
-  
+
   auto const md5 = request.template GetOption<DisableMD5Hash>();
   if (md5.has_value()) {
-    // DisableMD5Hash defaults to true. We only override the new option if the legacy
-    // option was explicitly set to false, or if the new option was not provided at all.
+    // DisableMD5Hash defaults to true. We only override the new option if the
+    // legacy option was explicitly set to false, or if the new option was not
+    // provided at all.
     if (!use_new_algo || md5.value() != true) {
       disable_md5 = md5.value();
     }
   }
   auto const crc32c = request.template GetOption<DisableCrc32cChecksum>();
   if (crc32c.has_value()) {
-    // DisableCrc32cChecksum defaults to std::nullopt, so if it has a value, it was explicitly set.
+    // DisableCrc32cChecksum defaults to std::nullopt, so if it has a value, it
+    // was explicitly set.
     disable_crc32c = crc32c.value();
   }
   return {disable_md5, disable_crc32c};

--- a/google/cloud/storage/internal/checksum_helpers.h
+++ b/google/cloud/storage/internal/checksum_helpers.h
@@ -16,9 +16,9 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_CHECKSUM_HELPERS_H
 
 #include "google/cloud/internal/disable_deprecation_warnings.inc"
-#include "google/cloud/options.h"
 #include "google/cloud/storage/hashing_options.h"
 #include "google/cloud/storage/options.h"
+#include "google/cloud/options.h"
 
 namespace google {
 namespace cloud {
@@ -34,25 +34,39 @@ struct HashDisabled {
 template <typename Request>
 HashDisabled GetDownloadChecksumSettings(Request const& request,
                                          Options const& options) {
+  if (request.template HasOption<DisableMD5Hash>() ||
+      request.template HasOption<DisableCrc32cChecksum>()) {
+    return {
+        request.template GetOption<DisableMD5Hash>().value_or(false),
+        request.template GetOption<DisableCrc32cChecksum>().value_or(false)};
+  }
   if (options.has<DownloadChecksumValidationOption>()) {
     auto const algo = options.get<DownloadChecksumValidationOption>();
-    return {algo != ChecksumAlgorithm::kMD5,
-            algo != ChecksumAlgorithm::kCrc32c};
+    return {algo != ChecksumAlgorithm::kMD5 &&
+                algo != ChecksumAlgorithm::kCrc32cAndMD5,
+            algo != ChecksumAlgorithm::kCrc32c &&
+                algo != ChecksumAlgorithm::kCrc32cAndMD5};
   }
-  return {request.template GetOption<DisableMD5Hash>().value_or(false),
-          request.template GetOption<DisableCrc32cChecksum>().value_or(false)};
+  return {false, false};
 }
 
 template <typename Request>
 HashDisabled GetUploadChecksumSettings(Request const& request,
                                        Options const& options) {
+  if (request.template HasOption<DisableMD5Hash>() ||
+      request.template HasOption<DisableCrc32cChecksum>()) {
+    return {
+        request.template GetOption<DisableMD5Hash>().value_or(false),
+        request.template GetOption<DisableCrc32cChecksum>().value_or(false)};
+  }
   if (options.has<UploadChecksumValidationOption>()) {
     auto const algo = options.get<UploadChecksumValidationOption>();
-    return {algo != ChecksumAlgorithm::kMD5,
-            algo != ChecksumAlgorithm::kCrc32c};
+    return {algo != ChecksumAlgorithm::kMD5 &&
+                algo != ChecksumAlgorithm::kCrc32cAndMD5,
+            algo != ChecksumAlgorithm::kCrc32c &&
+                algo != ChecksumAlgorithm::kCrc32cAndMD5};
   }
-  return {request.template GetOption<DisableMD5Hash>().value_or(false),
-          request.template GetOption<DisableCrc32cChecksum>().value_or(false)};
+  return {false, false};
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/checksum_helpers.h
+++ b/google/cloud/storage/internal/checksum_helpers.h
@@ -34,31 +34,22 @@ struct HashDisabled {
 template <typename Request>
 HashDisabled GetDownloadChecksumSettings(Request const& request,
                                          Options const& options) {
-  bool disable_md5 = false;
+  bool disable_md5 = true;
   bool disable_crc32c = false;
-  bool use_new_algo = false;
   if (options.has<DownloadChecksumValidationOption>()) {
     auto const algo = options.get<DownloadChecksumValidationOption>();
     disable_md5 = (algo != ChecksumAlgorithm::kMD5 &&
                    algo != ChecksumAlgorithm::kCrc32cAndMD5);
     disable_crc32c = (algo != ChecksumAlgorithm::kCrc32c &&
                       algo != ChecksumAlgorithm::kCrc32cAndMD5);
-    use_new_algo = true;
   }
 
   auto const md5 = request.template GetOption<DisableMD5Hash>();
   if (md5.has_value()) {
-    // DisableMD5Hash defaults to true. We only override the new option if the
-    // legacy option was explicitly set to false, or if the new option was not
-    // provided at all.
-    if (!use_new_algo || md5.value() != true) {
-      disable_md5 = md5.value();
-    }
+    disable_md5 = md5.value();
   }
   auto const crc32c = request.template GetOption<DisableCrc32cChecksum>();
   if (crc32c.has_value()) {
-    // DisableCrc32cChecksum defaults to std::nullopt, so if it has a value, it
-    // was explicitly set.
     disable_crc32c = crc32c.value();
   }
   return {disable_md5, disable_crc32c};
@@ -67,31 +58,22 @@ HashDisabled GetDownloadChecksumSettings(Request const& request,
 template <typename Request>
 HashDisabled GetUploadChecksumSettings(Request const& request,
                                        Options const& options) {
-  bool disable_md5 = false;
+  bool disable_md5 = true;
   bool disable_crc32c = false;
-  bool use_new_algo = false;
   if (options.has<UploadChecksumValidationOption>()) {
     auto const algo = options.get<UploadChecksumValidationOption>();
     disable_md5 = (algo != ChecksumAlgorithm::kMD5 &&
                    algo != ChecksumAlgorithm::kCrc32cAndMD5);
     disable_crc32c = (algo != ChecksumAlgorithm::kCrc32c &&
                       algo != ChecksumAlgorithm::kCrc32cAndMD5);
-    use_new_algo = true;
   }
 
   auto const md5 = request.template GetOption<DisableMD5Hash>();
   if (md5.has_value()) {
-    // DisableMD5Hash defaults to true. We only override the new option if the
-    // legacy option was explicitly set to false, or if the new option was not
-    // provided at all.
-    if (!use_new_algo || md5.value() != true) {
-      disable_md5 = md5.value();
-    }
+    disable_md5 = md5.value();
   }
   auto const crc32c = request.template GetOption<DisableCrc32cChecksum>();
   if (crc32c.has_value()) {
-    // DisableCrc32cChecksum defaults to std::nullopt, so if it has a value, it
-    // was explicitly set.
     disable_crc32c = crc32c.value();
   }
   return {disable_md5, disable_crc32c};

--- a/google/cloud/storage/internal/checksum_helpers_test.cc
+++ b/google/cloud/storage/internal/checksum_helpers_test.cc
@@ -1,0 +1,183 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/checksum_helpers.h"
+#include "google/cloud/storage/internal/object_requests.h"
+#include <gtest/gtest.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+namespace {
+
+TEST(ChecksumHelpersTest, DownloadChecksumSettingsDefaults) {
+  ReadObjectRangeRequest request("bucket", "object");
+  auto settings = GetDownloadChecksumSettings(request, Options{});
+  EXPECT_FALSE(settings.md5);
+  EXPECT_FALSE(settings.crc32c);
+}
+
+TEST(ChecksumHelpersTest, DownloadChecksumSettingsOnlyNewOptions) {
+  ReadObjectRangeRequest request("bucket", "object");
+  auto settings = GetDownloadChecksumSettings(
+      request, Options{}.set<DownloadChecksumValidationOption>(
+                   ChecksumAlgorithm::kMD5));
+  EXPECT_FALSE(settings.md5);
+  EXPECT_TRUE(settings.crc32c);
+
+  settings = GetDownloadChecksumSettings(
+      request, Options{}.set<DownloadChecksumValidationOption>(
+                   ChecksumAlgorithm::kCrc32c));
+  EXPECT_TRUE(settings.md5);
+  EXPECT_FALSE(settings.crc32c);
+
+  settings = GetDownloadChecksumSettings(
+      request, Options{}.set<DownloadChecksumValidationOption>(
+                   ChecksumAlgorithm::kNone));
+  EXPECT_TRUE(settings.md5);
+  EXPECT_TRUE(settings.crc32c);
+
+  settings = GetDownloadChecksumSettings(
+      request, Options{}.set<DownloadChecksumValidationOption>(
+                   ChecksumAlgorithm::kCrc32cAndMD5));
+  EXPECT_FALSE(settings.md5);
+  EXPECT_FALSE(settings.crc32c);
+}
+
+TEST(ChecksumHelpersTest, DownloadChecksumSettingsOnlyOldOptions) {
+  ReadObjectRangeRequest request("bucket", "object");
+  request.set_option(DisableMD5Hash(true));
+  request.set_option(DisableCrc32cChecksum(true));
+  auto settings = GetDownloadChecksumSettings(request, Options{});
+  EXPECT_TRUE(settings.md5);
+  EXPECT_TRUE(settings.crc32c);
+
+  request.set_option(DisableMD5Hash(false));
+  request.set_option(DisableCrc32cChecksum(false));
+  settings = GetDownloadChecksumSettings(request, Options{});
+  EXPECT_FALSE(settings.md5);
+  EXPECT_FALSE(settings.crc32c);
+}
+
+TEST(ChecksumHelpersTest, DownloadChecksumSettingsOverride) {
+  ReadObjectRangeRequest request("bucket", "object");
+  request.set_option(DisableMD5Hash(true));
+  request.set_option(DisableCrc32cChecksum(false));
+  auto settings = GetDownloadChecksumSettings(
+      request, Options{}.set<DownloadChecksumValidationOption>(
+                   ChecksumAlgorithm::kMD5));
+  EXPECT_FALSE(settings.md5);
+  EXPECT_FALSE(settings.crc32c);
+
+  request.set_option(DisableMD5Hash(false));
+  request.set_option(DisableCrc32cChecksum(true));
+  settings = GetDownloadChecksumSettings(
+      request, Options{}.set<DownloadChecksumValidationOption>(
+                   ChecksumAlgorithm::kMD5));
+  EXPECT_FALSE(settings.md5);
+  EXPECT_TRUE(settings.crc32c);
+
+  request.set_option(DisableMD5Hash(true));
+  request.set_option(DisableCrc32cChecksum(false));
+  settings = GetDownloadChecksumSettings(
+      request, Options{}.set<DownloadChecksumValidationOption>(
+                   ChecksumAlgorithm::kNone));
+  EXPECT_TRUE(settings.md5);
+  EXPECT_FALSE(settings.crc32c);
+}
+
+TEST(ChecksumHelpersTest, UploadChecksumSettingsDefaults) {
+  InsertObjectMediaRequest request("bucket", "object", "contents");
+  auto settings = GetUploadChecksumSettings(request, Options{});
+  EXPECT_FALSE(settings.md5);
+  EXPECT_FALSE(settings.crc32c);
+}
+
+TEST(ChecksumHelpersTest, UploadChecksumSettingsOnlyNewOptions) {
+  InsertObjectMediaRequest request("bucket", "object", "contents");
+  auto settings = GetUploadChecksumSettings(
+      request, Options{}.set<UploadChecksumValidationOption>(
+                   ChecksumAlgorithm::kMD5));
+  EXPECT_FALSE(settings.md5);
+  EXPECT_TRUE(settings.crc32c);
+
+  settings = GetUploadChecksumSettings(
+      request, Options{}.set<UploadChecksumValidationOption>(
+                   ChecksumAlgorithm::kCrc32c));
+  EXPECT_TRUE(settings.md5);
+  EXPECT_FALSE(settings.crc32c);
+
+  settings = GetUploadChecksumSettings(
+      request, Options{}.set<UploadChecksumValidationOption>(
+                   ChecksumAlgorithm::kNone));
+  EXPECT_TRUE(settings.md5);
+  EXPECT_TRUE(settings.crc32c);
+
+  settings = GetUploadChecksumSettings(
+      request, Options{}.set<UploadChecksumValidationOption>(
+                   ChecksumAlgorithm::kCrc32cAndMD5));
+  EXPECT_FALSE(settings.md5);
+  EXPECT_FALSE(settings.crc32c);
+}
+
+TEST(ChecksumHelpersTest, UploadChecksumSettingsOnlyOldOptions) {
+  InsertObjectMediaRequest request("bucket", "object", "contents");
+  request.set_option(DisableMD5Hash(true));
+  request.set_option(DisableCrc32cChecksum(true));
+  auto settings = GetUploadChecksumSettings(request, Options{});
+  EXPECT_TRUE(settings.md5);
+  EXPECT_TRUE(settings.crc32c);
+
+  request.set_option(DisableMD5Hash(false));
+  request.set_option(DisableCrc32cChecksum(false));
+  settings = GetUploadChecksumSettings(request, Options{});
+  EXPECT_FALSE(settings.md5);
+  EXPECT_FALSE(settings.crc32c);
+}
+
+TEST(ChecksumHelpersTest, UploadChecksumSettingsOverride) {
+  InsertObjectMediaRequest request("bucket", "object", "contents");
+  request.set_option(DisableMD5Hash(true));
+  request.set_option(DisableCrc32cChecksum(false));
+  auto settings = GetUploadChecksumSettings(
+      request, Options{}.set<UploadChecksumValidationOption>(
+                   ChecksumAlgorithm::kMD5));
+  EXPECT_FALSE(settings.md5);
+  EXPECT_FALSE(settings.crc32c);
+
+  request.set_option(DisableMD5Hash(false));
+  request.set_option(DisableCrc32cChecksum(true));
+  settings = GetUploadChecksumSettings(
+      request, Options{}.set<UploadChecksumValidationOption>(
+                   ChecksumAlgorithm::kMD5));
+  EXPECT_FALSE(settings.md5);
+  EXPECT_TRUE(settings.crc32c);
+
+  request.set_option(DisableMD5Hash(true));
+  request.set_option(DisableCrc32cChecksum(false));
+  settings = GetUploadChecksumSettings(
+      request, Options{}.set<UploadChecksumValidationOption>(
+                   ChecksumAlgorithm::kNone));
+  EXPECT_TRUE(settings.md5);
+  EXPECT_FALSE(settings.crc32c);
+}
+
+}  // namespace
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/internal/checksum_helpers_test.cc
+++ b/google/cloud/storage/internal/checksum_helpers_test.cc
@@ -26,15 +26,15 @@ namespace {
 TEST(ChecksumHelpersTest, DownloadChecksumSettingsDefaults) {
   ReadObjectRangeRequest request("bucket", "object");
   auto settings = GetDownloadChecksumSettings(request, Options{});
-  EXPECT_FALSE(settings.md5);
+  EXPECT_TRUE(settings.md5);
   EXPECT_FALSE(settings.crc32c);
 }
 
 TEST(ChecksumHelpersTest, DownloadChecksumSettingsOnlyNewOptions) {
   ReadObjectRangeRequest request("bucket", "object");
   auto settings = GetDownloadChecksumSettings(
-      request, Options{}.set<DownloadChecksumValidationOption>(
-                   ChecksumAlgorithm::kMD5));
+      request,
+      Options{}.set<DownloadChecksumValidationOption>(ChecksumAlgorithm::kMD5));
   EXPECT_FALSE(settings.md5);
   EXPECT_TRUE(settings.crc32c);
 
@@ -77,16 +77,16 @@ TEST(ChecksumHelpersTest, DownloadChecksumSettingsOverride) {
   request.set_option(DisableMD5Hash(true));
   request.set_option(DisableCrc32cChecksum(false));
   auto settings = GetDownloadChecksumSettings(
-      request, Options{}.set<DownloadChecksumValidationOption>(
-                   ChecksumAlgorithm::kMD5));
-  EXPECT_FALSE(settings.md5);
+      request,
+      Options{}.set<DownloadChecksumValidationOption>(ChecksumAlgorithm::kMD5));
+  EXPECT_TRUE(settings.md5);
   EXPECT_FALSE(settings.crc32c);
 
   request.set_option(DisableMD5Hash(false));
   request.set_option(DisableCrc32cChecksum(true));
   settings = GetDownloadChecksumSettings(
-      request, Options{}.set<DownloadChecksumValidationOption>(
-                   ChecksumAlgorithm::kMD5));
+      request,
+      Options{}.set<DownloadChecksumValidationOption>(ChecksumAlgorithm::kMD5));
   EXPECT_FALSE(settings.md5);
   EXPECT_TRUE(settings.crc32c);
 
@@ -102,15 +102,15 @@ TEST(ChecksumHelpersTest, DownloadChecksumSettingsOverride) {
 TEST(ChecksumHelpersTest, UploadChecksumSettingsDefaults) {
   InsertObjectMediaRequest request("bucket", "object", "contents");
   auto settings = GetUploadChecksumSettings(request, Options{});
-  EXPECT_FALSE(settings.md5);
+  EXPECT_TRUE(settings.md5);
   EXPECT_FALSE(settings.crc32c);
 }
 
 TEST(ChecksumHelpersTest, UploadChecksumSettingsOnlyNewOptions) {
   InsertObjectMediaRequest request("bucket", "object", "contents");
   auto settings = GetUploadChecksumSettings(
-      request, Options{}.set<UploadChecksumValidationOption>(
-                   ChecksumAlgorithm::kMD5));
+      request,
+      Options{}.set<UploadChecksumValidationOption>(ChecksumAlgorithm::kMD5));
   EXPECT_FALSE(settings.md5);
   EXPECT_TRUE(settings.crc32c);
 
@@ -121,8 +121,8 @@ TEST(ChecksumHelpersTest, UploadChecksumSettingsOnlyNewOptions) {
   EXPECT_FALSE(settings.crc32c);
 
   settings = GetUploadChecksumSettings(
-      request, Options{}.set<UploadChecksumValidationOption>(
-                   ChecksumAlgorithm::kNone));
+      request,
+      Options{}.set<UploadChecksumValidationOption>(ChecksumAlgorithm::kNone));
   EXPECT_TRUE(settings.md5);
   EXPECT_TRUE(settings.crc32c);
 
@@ -153,24 +153,24 @@ TEST(ChecksumHelpersTest, UploadChecksumSettingsOverride) {
   request.set_option(DisableMD5Hash(true));
   request.set_option(DisableCrc32cChecksum(false));
   auto settings = GetUploadChecksumSettings(
-      request, Options{}.set<UploadChecksumValidationOption>(
-                   ChecksumAlgorithm::kMD5));
-  EXPECT_FALSE(settings.md5);
+      request,
+      Options{}.set<UploadChecksumValidationOption>(ChecksumAlgorithm::kMD5));
+  EXPECT_TRUE(settings.md5);
   EXPECT_FALSE(settings.crc32c);
 
   request.set_option(DisableMD5Hash(false));
   request.set_option(DisableCrc32cChecksum(true));
   settings = GetUploadChecksumSettings(
-      request, Options{}.set<UploadChecksumValidationOption>(
-                   ChecksumAlgorithm::kMD5));
+      request,
+      Options{}.set<UploadChecksumValidationOption>(ChecksumAlgorithm::kMD5));
   EXPECT_FALSE(settings.md5);
   EXPECT_TRUE(settings.crc32c);
 
   request.set_option(DisableMD5Hash(true));
   request.set_option(DisableCrc32cChecksum(false));
   settings = GetUploadChecksumSettings(
-      request, Options{}.set<UploadChecksumValidationOption>(
-                   ChecksumAlgorithm::kNone));
+      request,
+      Options{}.set<UploadChecksumValidationOption>(ChecksumAlgorithm::kNone));
   EXPECT_TRUE(settings.md5);
   EXPECT_FALSE(settings.crc32c);
 }

--- a/google/cloud/storage/internal/connection_impl.cc
+++ b/google/cloud/storage/internal/connection_impl.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/storage/internal/connection_impl.h"
 #include "google/cloud/storage/internal/retry_object_read_source.h"
 #include "google/cloud/storage/parallel_upload.h"
@@ -1392,3 +1393,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/storage/internal/grpc/object_request_parser.cc
+++ b/google/cloud/storage/internal/grpc/object_request_parser.cc
@@ -936,16 +936,6 @@ Status Finalize(google::storage::v2::BidiWriteObjectRequest& write_request,
                            Merge(std::move(hashes), hash_function.Finish()));
 }
 
-// If this is the last `Write()` call of the last `InsertObjectMedia()` set the
-// flags to finalize the request
-Status MaybeFinalize(google::storage::v2::WriteObjectRequest& write_request,
-                     grpc::WriteOptions& options,
-                     storage::internal::InsertObjectMediaRequest const& request,
-                     bool chunk_has_more) {
-  if (chunk_has_more) return {};
-  return Finalize(write_request, options, request.hash_function());
-}
-
 // If this is the last `Write()` call of the last `UploadChunk()` set the flags
 // to finalize the request
 Status MaybeFinalize(google::storage::v2::WriteObjectRequest& write_request,

--- a/google/cloud/storage/internal/grpc/object_request_parser.h
+++ b/google/cloud/storage/internal/grpc/object_request_parser.h
@@ -98,11 +98,6 @@ Status Finalize(google::storage::v2::BidiWriteObjectRequest& write_request,
 
 Status MaybeFinalize(google::storage::v2::WriteObjectRequest& write_request,
                      grpc::WriteOptions& options,
-                     storage::internal::InsertObjectMediaRequest const& request,
-                     bool chunk_has_more);
-
-Status MaybeFinalize(google::storage::v2::WriteObjectRequest& write_request,
-                     grpc::WriteOptions& options,
                      storage::internal::UploadChunkRequest const& request,
                      bool chunk_has_more);
 

--- a/google/cloud/storage/internal/grpc/object_request_parser_test.cc
+++ b/google/cloud/storage/internal/grpc/object_request_parser_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/storage/internal/grpc/object_request_parser.h"
 #include "google/cloud/storage/internal/grpc/stub.h"
 #include "google/cloud/storage/internal/hash_function_impl.h"
@@ -736,121 +737,6 @@ TEST(GrpcObjectRequestParser, InsertObjectMediaRequestSimple) {
       "The quick brown fox jumps over the lazy dog");
   auto actual = ToProto(request).value();
   EXPECT_THAT(actual, IsProtoEqual(expected));
-}
-
-TEST(GrpcObjectRequestParser, MaybeFinalizeInsertObjectMediaRequest) {
-  using storage::internal::InsertObjectMediaRequest;
-  // See top-of-file comments for details on the magic numbers
-  struct Test {
-    std::function<void(InsertObjectMediaRequest&)> apply_options;
-    std::string expected_checksums;
-  } cases[] = {
-      // These tests provide the "wrong" hashes. This is what would happen if
-      // one was (for example) reading a GCS file, obtained the expected hashes
-      // from GCS, and then uploaded to another GCS destination *but* the data
-      // was somehow corrupted locally (say a bad disk). In that case, we don't
-      // want to recompute the hashes in the upload.
-      {
-          [](storage::internal::InsertObjectMediaRequest& r) {
-            r.set_option(storage::MD5HashValue(storage::ComputeMD5Hash(kText)));
-            r.set_option(storage::DisableCrc32cChecksum(true));
-          },
-          R"pb(
-            md5_hash: "\x9e\x10\x7d\x9d\x37\x2b\xb6\x82\x6b\xd8\x1d\x35\x42\xa4\x19\xd6")pb",
-      },
-      {
-          [](InsertObjectMediaRequest& r) {
-            r.set_option(storage::MD5HashValue(storage::ComputeMD5Hash(kText)));
-            r.set_option(storage::DisableCrc32cChecksum(false));
-          },
-          R"pb(
-            md5_hash: "\x9e\x10\x7d\x9d\x37\x2b\xb6\x82\x6b\xd8\x1d\x35\x42\xa4\x19\xd6"
-            crc32c: 0x4ad67f80)pb",
-      },
-      {
-          [](InsertObjectMediaRequest& r) {
-            r.set_option(storage::MD5HashValue(storage::ComputeMD5Hash(kText)));
-            r.set_option(storage::Crc32cChecksumValue(
-                storage::ComputeCrc32cChecksum(kText)));
-          },
-          R"pb(
-            md5_hash: "\x9e\x10\x7d\x9d\x37\x2b\xb6\x82\x6b\xd8\x1d\x35\x42\xa4\x19\xd6"
-            crc32c: 0x22620404)pb",
-      },
-
-      {
-          [](InsertObjectMediaRequest& r) {
-            r.set_option(storage::DisableMD5Hash(false));
-            r.set_option(storage::DisableCrc32cChecksum(true));
-          },
-          R"pb(
-            md5_hash: "\x4a\xd1\x2f\xa3\x65\x7f\xaa\x80\xc2\xb9\xa9\x2d\x65\x2c\x37\x21")pb",
-      },
-      {
-          [](InsertObjectMediaRequest& r) {
-            r.set_option(storage::DisableMD5Hash(false));
-            r.set_option(storage::DisableCrc32cChecksum(false));
-          },
-          R"pb(
-            md5_hash: "\x4a\xd1\x2f\xa3\x65\x7f\xaa\x80\xc2\xb9\xa9\x2d\x65\x2c\x37\x21"
-            crc32c: 0x4ad67f80)pb",
-      },
-      {
-          [](InsertObjectMediaRequest& r) {
-            r.set_option(storage::DisableMD5Hash(false));
-            r.set_option(storage::Crc32cChecksumValue(
-                storage::ComputeCrc32cChecksum(kText)));
-          },
-          R"pb(
-            md5_hash: "\x4a\xd1\x2f\xa3\x65\x7f\xaa\x80\xc2\xb9\xa9\x2d\x65\x2c\x37\x21"
-            crc32c: 0x22620404)pb",
-      },
-
-      {
-          [](InsertObjectMediaRequest& r) {
-            r.set_option(storage::DisableMD5Hash(true));
-            r.set_option(storage::DisableCrc32cChecksum(true));
-          },
-          R"pb(
-          )pb",
-      },
-      {
-          [](InsertObjectMediaRequest& r) {
-            r.set_option(storage::DisableMD5Hash(true));
-            r.set_option(storage::DisableCrc32cChecksum(false));
-          },
-          R"pb(
-            crc32c: 0x4ad67f80)pb",
-      },
-      {
-          [](InsertObjectMediaRequest& r) {
-            r.set_option(storage::DisableMD5Hash(true));
-            r.set_option(storage::Crc32cChecksumValue(
-                storage::ComputeCrc32cChecksum(kText)));
-          },
-          R"pb(
-            crc32c: 0x22620404)pb",
-      },
-  };
-  for (auto const& test : cases) {
-    SCOPED_TRACE("Expected outcome " + test.expected_checksums);
-    storage_proto::ObjectChecksums expected;
-    ASSERT_TRUE(
-        TextFormat::ParseFromString(test.expected_checksums, &expected));
-
-    storage::internal::InsertObjectMediaRequest request(
-        "test-bucket-name", "test-object-name", kAlt);
-    test.apply_options(request);
-    request.set_multiple_options();
-    request.hash_function().Update(0, kAlt);
-    storage_proto::WriteObjectRequest write_request;
-    grpc::WriteOptions write_options;
-    auto status = MaybeFinalize(write_request, write_options, request, false);
-    ASSERT_STATUS_OK(status);
-    EXPECT_TRUE(write_request.finish_write());
-    EXPECT_TRUE(write_options.is_last_message());
-    EXPECT_THAT(write_request.object_checksums(), IsProtoEqual(expected));
-  }
 }
 
 TEST(GrpcObjectRequestParser, InsertObjectMediaRequestAllOptions) {
@@ -1582,3 +1468,5 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google
+
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/storage/internal/grpc/stub.cc
+++ b/google/cloud/storage/internal/grpc/stub.cc
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/storage/internal/grpc/stub.h"
+#include "google/cloud/storage/internal/checksum_helpers.h"
 #include "google/cloud/storage/internal/crc32c.h"
 #include "google/cloud/storage/internal/grpc/bucket_access_control_parser.h"
 #include "google/cloud/storage/internal/grpc/bucket_metadata_parser.h"
@@ -346,6 +348,14 @@ StatusOr<storage::ObjectMetadata> GrpcStub::InsertObjectMedia(
   ApplyRoutingHeaders(*ctx, request);
   auto stream = stub_->WriteObject(std::move(ctx), options);
 
+  auto const settings =
+      storage::internal::GetUploadChecksumSettings(request, options);
+  auto disable_md5 = storage::DisableMD5Hash(settings.md5);
+  auto disable_crc32c = storage::DisableCrc32cChecksum(settings.crc32c);
+  auto hash_function = storage::internal::CreateHashFunction(
+      request.GetOption<storage::Crc32cChecksumValue>(), disable_crc32c,
+      request.GetOption<storage::MD5HashValue>(), disable_md5);
+
   auto splitter = SplitObjectWriteData<ContentType>(request.payload());
   std::int64_t offset = 0;
 
@@ -356,11 +366,13 @@ StatusOr<storage::ObjectMetadata> GrpcStub::InsertObjectMedia(
     auto& data = *proto_request.mutable_checksummed_data();
     SetMutableContent(data, splitter.Next());
     data.set_crc32c(Crc32c(GetContent(data)));
-    request.hash_function().Update(offset, GetContent(data), data.crc32c());
+    hash_function->Update(offset, GetContent(data), data.crc32c());
     offset += GetContent(data).size();
 
     auto wopts = grpc::WriteOptions{};
-    MaybeFinalize(proto_request, wopts, request, !splitter.Done());
+    if (splitter.Done()) {
+      storage_internal::Finalize(proto_request, wopts, *hash_function);
+    }
 
     auto watchdog = create_watchdog().then([&stream](auto f) {
       if (!f.get()) return false;
@@ -1216,3 +1228,5 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google
+
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/storage/internal/hash_function.cc
+++ b/google/cloud/storage/internal/hash_function.cc
@@ -14,6 +14,8 @@
 
 #include "google/cloud/storage/internal/hash_function.h"
 #include "google/cloud/storage/internal/hash_function_impl.h"
+#include "google/cloud/options.h"
+#include "google/cloud/storage/options.h"
 #include "google/cloud/storage/internal/object_requests.h"
 #include <memory>
 #include <utility>
@@ -61,9 +63,17 @@ std::unique_ptr<HashFunction> CreateHashFunction(
     ReadObjectRangeRequest const& request) {
   if (request.RequiresRangeHeader()) return CreateNullHashFunction();
 
-  auto const disable_crc32c =
-      request.GetOption<DisableCrc32cChecksum>().value_or(false);
-  auto const disable_md5 = request.GetOption<DisableMD5Hash>().value_or(false);
+  bool disable_md5 = false;
+  bool disable_crc32c = false;
+  auto const& options = google::cloud::internal::CurrentOptions();
+  if (options.has<DownloadChecksumValidationOption>()) {
+    auto const algo = options.get<DownloadChecksumValidationOption>();
+    disable_md5 = (algo != ChecksumAlgorithm::kMD5);
+    disable_crc32c = (algo != ChecksumAlgorithm::kCrc32c);
+  } else {
+    disable_md5 = request.GetOption<DisableMD5Hash>().value_or(false);
+    disable_crc32c = request.GetOption<DisableCrc32cChecksum>().value_or(false);
+  }
   if (disable_md5 && disable_crc32c) {
     return std::make_unique<NullHashFunction>();
   }
@@ -80,10 +90,21 @@ std::unique_ptr<HashFunction> CreateHashFunction(
     // for previous values is lost.
     return CreateNullHashFunction();
   }
+  
+  DisableCrc32cChecksum disable_crc32c;
+  DisableMD5Hash disable_md5;
+  auto const& options = google::cloud::internal::CurrentOptions();
+  if (options.has<UploadChecksumValidationOption>()) {
+    auto const algo = options.get<UploadChecksumValidationOption>();
+    disable_md5 = DisableMD5Hash(algo != ChecksumAlgorithm::kMD5);
+    disable_crc32c = DisableCrc32cChecksum(algo != ChecksumAlgorithm::kCrc32c);
+  } else {
+    disable_md5 = request.GetOption<DisableMD5Hash>();
+    disable_crc32c = request.GetOption<DisableCrc32cChecksum>();
+  }
   return CreateHashFunction(request.GetOption<Crc32cChecksumValue>(),
-                            request.GetOption<DisableCrc32cChecksum>(),
-                            request.GetOption<MD5HashValue>(),
-                            request.GetOption<DisableMD5Hash>());
+                            disable_crc32c, request.GetOption<MD5HashValue>(),
+                            disable_md5);
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/hash_function.cc
+++ b/google/cloud/storage/internal/hash_function.cc
@@ -14,8 +14,8 @@
 
 #include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/storage/internal/hash_function.h"
-#include "google/cloud/storage/internal/hash_function_impl.h"
 #include "google/cloud/storage/internal/checksum_helpers.h"
+#include "google/cloud/storage/internal/hash_function_impl.h"
 #include "google/cloud/storage/internal/object_requests.h"
 #include "google/cloud/storage/options.h"
 #include "google/cloud/options.h"

--- a/google/cloud/storage/internal/hash_function.cc
+++ b/google/cloud/storage/internal/hash_function.cc
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/storage/internal/hash_function.h"
 #include "google/cloud/storage/internal/hash_function_impl.h"
-#include "google/cloud/options.h"
-#include "google/cloud/storage/options.h"
+#include "google/cloud/storage/internal/checksum_helpers.h"
 #include "google/cloud/storage/internal/object_requests.h"
+#include "google/cloud/storage/options.h"
+#include "google/cloud/options.h"
 #include <memory>
 #include <utility>
 
@@ -63,17 +65,10 @@ std::unique_ptr<HashFunction> CreateHashFunction(
     ReadObjectRangeRequest const& request) {
   if (request.RequiresRangeHeader()) return CreateNullHashFunction();
 
-  bool disable_md5 = false;
-  bool disable_crc32c = false;
-  auto const& options = google::cloud::internal::CurrentOptions();
-  if (options.has<DownloadChecksumValidationOption>()) {
-    auto const algo = options.get<DownloadChecksumValidationOption>();
-    disable_md5 = (algo != ChecksumAlgorithm::kMD5);
-    disable_crc32c = (algo != ChecksumAlgorithm::kCrc32c);
-  } else {
-    disable_md5 = request.GetOption<DisableMD5Hash>().value_or(false);
-    disable_crc32c = request.GetOption<DisableCrc32cChecksum>().value_or(false);
-  }
+  auto const settings = GetDownloadChecksumSettings(
+      request, google::cloud::internal::CurrentOptions());
+  auto const disable_md5 = settings.md5;
+  auto const disable_crc32c = settings.crc32c;
   if (disable_md5 && disable_crc32c) {
     return std::make_unique<NullHashFunction>();
   }
@@ -90,18 +85,11 @@ std::unique_ptr<HashFunction> CreateHashFunction(
     // for previous values is lost.
     return CreateNullHashFunction();
   }
-  
-  DisableCrc32cChecksum disable_crc32c;
-  DisableMD5Hash disable_md5;
-  auto const& options = google::cloud::internal::CurrentOptions();
-  if (options.has<UploadChecksumValidationOption>()) {
-    auto const algo = options.get<UploadChecksumValidationOption>();
-    disable_md5 = DisableMD5Hash(algo != ChecksumAlgorithm::kMD5);
-    disable_crc32c = DisableCrc32cChecksum(algo != ChecksumAlgorithm::kCrc32c);
-  } else {
-    disable_md5 = request.GetOption<DisableMD5Hash>();
-    disable_crc32c = request.GetOption<DisableCrc32cChecksum>();
-  }
+
+  auto const settings = GetUploadChecksumSettings(
+      request, google::cloud::internal::CurrentOptions());
+  auto disable_md5 = DisableMD5Hash(settings.md5);
+  auto disable_crc32c = DisableCrc32cChecksum(settings.crc32c);
   return CreateHashFunction(request.GetOption<Crc32cChecksumValue>(),
                             disable_crc32c, request.GetOption<MD5HashValue>(),
                             disable_md5);
@@ -112,3 +100,5 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
 }  // namespace cloud
 }  // namespace google
+
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/storage/internal/hash_function.h
+++ b/google/cloud/storage/internal/hash_function.h
@@ -19,6 +19,7 @@
 #include "google/cloud/storage/hashing_options.h"
 #include "google/cloud/storage/internal/hash_values.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/options.h"
 #include "google/cloud/status.h"
 #include "absl/strings/cord.h"
 #include "absl/strings/string_view.h"
@@ -29,6 +30,11 @@ namespace google {
 namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+struct DownloadChecksumValidationOption;
+struct UploadChecksumValidationOption;
+enum class ChecksumAlgorithm;
+
 namespace internal {
 
 class ReadObjectRangeRequest;

--- a/google/cloud/storage/internal/hash_function.h
+++ b/google/cloud/storage/internal/hash_function.h
@@ -30,9 +30,6 @@ namespace google {
 namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-
-
-
 namespace internal {
 
 class ReadObjectRangeRequest;

--- a/google/cloud/storage/internal/hash_function.h
+++ b/google/cloud/storage/internal/hash_function.h
@@ -31,9 +31,7 @@ namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-struct DownloadChecksumValidationOption;
-struct UploadChecksumValidationOption;
-enum class ChecksumAlgorithm;
+
 
 namespace internal {
 

--- a/google/cloud/storage/internal/hash_function.h
+++ b/google/cloud/storage/internal/hash_function.h
@@ -19,7 +19,6 @@
 #include "google/cloud/storage/hashing_options.h"
 #include "google/cloud/storage/internal/hash_values.h"
 #include "google/cloud/storage/version.h"
-#include "google/cloud/options.h"
 #include "google/cloud/status.h"
 #include "absl/strings/cord.h"
 #include "absl/strings/string_view.h"

--- a/google/cloud/storage/internal/hash_function_impl_test.cc
+++ b/google/cloud/storage/internal/hash_function_impl_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/storage/internal/hash_function_impl.h"
 #include "google/cloud/storage/internal/crc32c.h"
 #include "google/cloud/storage/internal/object_requests.h"
@@ -455,3 +456,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/storage/internal/hash_validator.cc
+++ b/google/cloud/storage/internal/hash_validator.cc
@@ -14,6 +14,8 @@
 
 #include "google/cloud/storage/internal/hash_validator.h"
 #include "google/cloud/storage/internal/hash_validator_impl.h"
+#include "google/cloud/options.h"
+#include "google/cloud/storage/options.h"
 #include "google/cloud/storage/internal/object_requests.h"
 #include "google/cloud/storage/object_metadata.h"
 #include <memory>
@@ -52,19 +54,35 @@ std::unique_ptr<HashValidator> CreateHashValidator(
     ReadObjectRangeRequest const& request) {
   if (request.RequiresRangeHeader()) return CreateNullHashValidator();
 
-  // `DisableMD5Hash`'s default value is `true`.
-  auto disable_md5 = request.GetOption<DisableMD5Hash>().value_or(false);
-  auto disable_crc32c =
-      request.GetOption<DisableCrc32cChecksum>().value_or(false);
+  bool disable_md5 = false;
+  bool disable_crc32c = false;
+  auto const& options = google::cloud::internal::CurrentOptions();
+  if (options.has<DownloadChecksumValidationOption>()) {
+    auto const algo =
+        options.get<DownloadChecksumValidationOption>();
+    disable_md5 = (algo != ChecksumAlgorithm::kMD5);
+    disable_crc32c = (algo != ChecksumAlgorithm::kCrc32c);
+  } else {
+    disable_md5 = request.GetOption<DisableMD5Hash>().value_or(false);
+    disable_crc32c = request.GetOption<DisableCrc32cChecksum>().value_or(false);
+  }
   return CreateHashValidator(disable_md5, disable_crc32c);
 }
 
 std::unique_ptr<HashValidator> CreateHashValidator(
     ResumableUploadRequest const& request) {
-  // `DisableMD5Hash`'s default value is `true`.
-  auto disable_md5 = request.GetOption<DisableMD5Hash>().value_or(false);
-  auto disable_crc32c =
-      request.GetOption<DisableCrc32cChecksum>().value_or(false);
+  bool disable_md5 = false;
+  bool disable_crc32c = false;
+  auto const& options = google::cloud::internal::CurrentOptions();
+  if (options.has<UploadChecksumValidationOption>()) {
+    auto const algo =
+        options.get<UploadChecksumValidationOption>();
+    disable_md5 = (algo != ChecksumAlgorithm::kMD5);
+    disable_crc32c = (algo != ChecksumAlgorithm::kCrc32c);
+  } else {
+    disable_md5 = request.GetOption<DisableMD5Hash>().value_or(false);
+    disable_crc32c = request.GetOption<DisableCrc32cChecksum>().value_or(false);
+  }
   return CreateHashValidator(disable_md5, disable_crc32c);
 }
 

--- a/google/cloud/storage/internal/hash_validator.cc
+++ b/google/cloud/storage/internal/hash_validator.cc
@@ -12,12 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/storage/internal/hash_validator.h"
+#include "google/cloud/storage/internal/checksum_helpers.h"
+#include "google/cloud/storage/internal/hash_function.h"
 #include "google/cloud/storage/internal/hash_validator_impl.h"
-#include "google/cloud/options.h"
-#include "google/cloud/storage/options.h"
 #include "google/cloud/storage/internal/object_requests.h"
 #include "google/cloud/storage/object_metadata.h"
+#include "google/cloud/storage/options.h"
+#include "google/cloud/options.h"
 #include <memory>
 #include <string>
 
@@ -54,35 +57,19 @@ std::unique_ptr<HashValidator> CreateHashValidator(
     ReadObjectRangeRequest const& request) {
   if (request.RequiresRangeHeader()) return CreateNullHashValidator();
 
-  bool disable_md5 = false;
-  bool disable_crc32c = false;
-  auto const& options = google::cloud::internal::CurrentOptions();
-  if (options.has<DownloadChecksumValidationOption>()) {
-    auto const algo =
-        options.get<DownloadChecksumValidationOption>();
-    disable_md5 = (algo != ChecksumAlgorithm::kMD5);
-    disable_crc32c = (algo != ChecksumAlgorithm::kCrc32c);
-  } else {
-    disable_md5 = request.GetOption<DisableMD5Hash>().value_or(false);
-    disable_crc32c = request.GetOption<DisableCrc32cChecksum>().value_or(false);
-  }
+  auto const settings = GetDownloadChecksumSettings(
+      request, google::cloud::internal::CurrentOptions());
+  auto const disable_md5 = settings.md5;
+  auto const disable_crc32c = settings.crc32c;
   return CreateHashValidator(disable_md5, disable_crc32c);
 }
 
 std::unique_ptr<HashValidator> CreateHashValidator(
     ResumableUploadRequest const& request) {
-  bool disable_md5 = false;
-  bool disable_crc32c = false;
-  auto const& options = google::cloud::internal::CurrentOptions();
-  if (options.has<UploadChecksumValidationOption>()) {
-    auto const algo =
-        options.get<UploadChecksumValidationOption>();
-    disable_md5 = (algo != ChecksumAlgorithm::kMD5);
-    disable_crc32c = (algo != ChecksumAlgorithm::kCrc32c);
-  } else {
-    disable_md5 = request.GetOption<DisableMD5Hash>().value_or(false);
-    disable_crc32c = request.GetOption<DisableCrc32cChecksum>().value_or(false);
-  }
+  auto const settings = GetUploadChecksumSettings(
+      request, google::cloud::internal::CurrentOptions());
+  auto const disable_md5 = settings.md5;
+  auto const disable_crc32c = settings.crc32c;
   return CreateHashValidator(disable_md5, disable_crc32c);
 }
 
@@ -99,3 +86,5 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
 }  // namespace cloud
 }  // namespace google
+
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/storage/internal/hash_validator_test.cc
+++ b/google/cloud/storage/internal/hash_validator_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/storage/internal/hash_validator.h"
 #include "google/cloud/storage/internal/hash_function_impl.h"
 #include "google/cloud/storage/internal/hash_validator_impl.h"
@@ -245,3 +246,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/storage/internal/object_requests.cc
+++ b/google/cloud/storage/internal/object_requests.cc
@@ -14,8 +14,8 @@
 
 #include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/storage/internal/object_requests.h"
-#include "google/cloud/storage/internal/checksum_helpers.h"
 #include "google/cloud/storage/internal/binary_data_as_debug_string.h"
+#include "google/cloud/storage/internal/checksum_helpers.h"
 #include "google/cloud/storage/internal/hash_function.h"
 #include "google/cloud/storage/internal/metadata_parser.h"
 #include "google/cloud/storage/internal/object_acl_requests.h"
@@ -211,26 +211,14 @@ std::ostream& operator<<(std::ostream& os, GetObjectMetadataRequest const& r) {
   return os << "}";
 }
 
-InsertObjectMediaRequest::InsertObjectMediaRequest() { reset_hash_function(); }
+InsertObjectMediaRequest::InsertObjectMediaRequest() = default;
 
 InsertObjectMediaRequest::InsertObjectMediaRequest(std::string bucket_name,
                                                    std::string object_name,
                                                    absl::string_view payload)
     : InsertObjectRequestImpl<InsertObjectMediaRequest>(std::move(bucket_name),
                                                         std::move(object_name)),
-      payload_(payload) {
-  reset_hash_function();
-}
-
-void InsertObjectMediaRequest::reset_hash_function() {
-  auto const settings = GetUploadChecksumSettings(
-      *this, google::cloud::internal::CurrentOptions());
-  auto disable_md5 = DisableMD5Hash(settings.md5);
-  auto disable_crc32c = DisableCrc32cChecksum(settings.crc32c);
-  hash_function_ =
-      CreateHashFunction(GetOption<Crc32cChecksumValue>(), disable_crc32c,
-                         GetOption<MD5HashValue>(), disable_md5);
-}
+      payload_(payload) {}
 
 void InsertObjectMediaRequest::set_payload(absl::string_view payload) {
   payload_ = payload;
@@ -249,11 +237,6 @@ void InsertObjectMediaRequest::set_contents(std::string v) {
   payload_ = contents_;
   dirty_ = false;
 }
-
-HashValues FinishHashes(InsertObjectMediaRequest const& request) {
-  return request.hash_function().Finish();
-}
-
 std::ostream& operator<<(std::ostream& os, InsertObjectMediaRequest const& r) {
   os << "InsertObjectMediaRequest={bucket_name=" << r.bucket_name()
      << ", object_name=" << r.object_name();

--- a/google/cloud/storage/internal/object_requests.cc
+++ b/google/cloud/storage/internal/object_requests.cc
@@ -14,6 +14,8 @@
 
 #include "google/cloud/storage/internal/object_requests.h"
 #include "google/cloud/storage/internal/binary_data_as_debug_string.h"
+#include "google/cloud/storage/options.h"
+#include "google/cloud/options.h"
 #include "google/cloud/storage/internal/metadata_parser.h"
 #include "google/cloud/storage/internal/object_acl_requests.h"
 #include "google/cloud/storage/internal/object_metadata_parser.h"
@@ -218,9 +220,20 @@ InsertObjectMediaRequest::InsertObjectMediaRequest(std::string bucket_name,
 }
 
 void InsertObjectMediaRequest::reset_hash_function() {
+  DisableCrc32cChecksum disable_crc32c;
+  DisableMD5Hash disable_md5;
+  auto const& options = google::cloud::internal::CurrentOptions();
+  if (options.has<UploadChecksumValidationOption>()) {
+    auto const algo = options.get<UploadChecksumValidationOption>();
+    disable_md5 = DisableMD5Hash(algo != ChecksumAlgorithm::kMD5);
+    disable_crc32c = DisableCrc32cChecksum(algo != ChecksumAlgorithm::kCrc32c);
+  } else {
+    disable_md5 = GetOption<DisableMD5Hash>();
+    disable_crc32c = GetOption<DisableCrc32cChecksum>();
+  }
   hash_function_ = CreateHashFunction(
-      GetOption<Crc32cChecksumValue>(), GetOption<DisableCrc32cChecksum>(),
-      GetOption<MD5HashValue>(), GetOption<DisableMD5Hash>());
+      GetOption<Crc32cChecksumValue>(), disable_crc32c,
+      GetOption<MD5HashValue>(), disable_md5);
 }
 
 void InsertObjectMediaRequest::set_payload(absl::string_view payload) {

--- a/google/cloud/storage/internal/object_requests.cc
+++ b/google/cloud/storage/internal/object_requests.cc
@@ -12,14 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/storage/internal/object_requests.h"
+#include "google/cloud/storage/internal/checksum_helpers.h"
 #include "google/cloud/storage/internal/binary_data_as_debug_string.h"
-#include "google/cloud/storage/options.h"
-#include "google/cloud/options.h"
+#include "google/cloud/storage/internal/hash_function.h"
 #include "google/cloud/storage/internal/metadata_parser.h"
 #include "google/cloud/storage/internal/object_acl_requests.h"
 #include "google/cloud/storage/internal/object_metadata_parser.h"
 #include "google/cloud/storage/object_metadata.h"
+#include "google/cloud/storage/options.h"
+#include "google/cloud/options.h"
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_split.h"
 #include <algorithm>
@@ -220,20 +223,13 @@ InsertObjectMediaRequest::InsertObjectMediaRequest(std::string bucket_name,
 }
 
 void InsertObjectMediaRequest::reset_hash_function() {
-  DisableCrc32cChecksum disable_crc32c;
-  DisableMD5Hash disable_md5;
-  auto const& options = google::cloud::internal::CurrentOptions();
-  if (options.has<UploadChecksumValidationOption>()) {
-    auto const algo = options.get<UploadChecksumValidationOption>();
-    disable_md5 = DisableMD5Hash(algo != ChecksumAlgorithm::kMD5);
-    disable_crc32c = DisableCrc32cChecksum(algo != ChecksumAlgorithm::kCrc32c);
-  } else {
-    disable_md5 = GetOption<DisableMD5Hash>();
-    disable_crc32c = GetOption<DisableCrc32cChecksum>();
-  }
-  hash_function_ = CreateHashFunction(
-      GetOption<Crc32cChecksumValue>(), disable_crc32c,
-      GetOption<MD5HashValue>(), disable_md5);
+  auto const settings = GetUploadChecksumSettings(
+      *this, google::cloud::internal::CurrentOptions());
+  auto disable_md5 = DisableMD5Hash(settings.md5);
+  auto disable_crc32c = DisableCrc32cChecksum(settings.crc32c);
+  hash_function_ =
+      CreateHashFunction(GetOption<Crc32cChecksumValue>(), disable_crc32c,
+                         GetOption<MD5HashValue>(), disable_md5);
 }
 
 void InsertObjectMediaRequest::set_payload(absl::string_view payload) {
@@ -692,3 +688,5 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
 }  // namespace cloud
 }  // namespace google
+
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -129,15 +129,6 @@ class InsertObjectMediaRequest
   absl::string_view payload() const { return payload_; }
   void set_payload(absl::string_view payload);
 
-  template <typename... O>
-  InsertObjectMediaRequest& set_multiple_options(O&&... o) {
-    InsertObjectRequestImpl<InsertObjectMediaRequest>::set_multiple_options(
-        std::forward<O>(o)...);
-    reset_hash_function();
-    return *this;
-  }
-  HashFunction& hash_function() const { return *hash_function_; }
-
   ///@{
   /**
    * @name Backwards compatibility.
@@ -154,15 +145,10 @@ class InsertObjectMediaRequest
   ///@}
 
  private:
-  void reset_hash_function();
-
   absl::string_view payload_;
-  std::shared_ptr<HashFunction> hash_function_;
   mutable std::string contents_;
   mutable bool dirty_ = true;
 };
-
-HashValues FinishHashes(InsertObjectMediaRequest const& request);
 
 std::ostream& operator<<(std::ostream& os, InsertObjectMediaRequest const& r);
 

--- a/google/cloud/storage/internal/object_requests_test.cc
+++ b/google/cloud/storage/internal/object_requests_test.cc
@@ -1117,7 +1117,7 @@ TEST(DefaultCtorsWork, Trivial) {
   EXPECT_FALSE(ReadFromOffset().has_value());
   EXPECT_FALSE(ReadLast().has_value());
   EXPECT_FALSE(MD5HashValue().has_value());
-  EXPECT_TRUE(DisableMD5Hash().has_value());
+  EXPECT_FALSE(DisableMD5Hash().has_value());
   EXPECT_FALSE(Crc32cChecksumValue().has_value());
   EXPECT_FALSE(DisableCrc32cChecksum().has_value());
   EXPECT_FALSE(WithObjectMetadata().has_value());

--- a/google/cloud/storage/internal/object_write_streambuf_test.cc
+++ b/google/cloud/storage/internal/object_write_streambuf_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/storage/internal/object_write_streambuf.h"
 #include "google/cloud/storage/internal/connection_impl.h"
 #include "google/cloud/storage/object_metadata.h"
@@ -707,3 +708,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/storage/internal/rest/stub.cc
+++ b/google/cloud/storage/internal/rest/stub.cc
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/storage/internal/rest/stub.h"
 #include "google/cloud/storage/internal/bucket_access_control_parser.h"
 #include "google/cloud/storage/internal/bucket_metadata_parser.h"
 #include "google/cloud/storage/internal/bucket_requests.h"
+#include "google/cloud/storage/internal/checksum_helpers.h"
 #include "google/cloud/storage/internal/generate_message_boundary.h"
 #include "google/cloud/storage/internal/hmac_key_metadata_parser.h"
 #include "google/cloud/storage/internal/notification_metadata_parser.h"
@@ -378,8 +380,16 @@ StatusOr<ObjectMetadata> RestStub::InsertObjectMediaMultipart(
         request.GetOption<WithObjectMetadata>().value());
   }
 
-  request.hash_function().Update(/*offset=*/0, request.payload());
-  auto hashes = storage::internal::FinishHashes(request);
+  auto const settings =
+      storage::internal::GetUploadChecksumSettings(request, options);
+  auto disable_md5 = storage::DisableMD5Hash(settings.md5);
+  auto disable_crc32c = storage::DisableCrc32cChecksum(settings.crc32c);
+  auto hash_function = storage::internal::CreateHashFunction(
+      request.GetOption<storage::Crc32cChecksumValue>(), disable_crc32c,
+      request.GetOption<storage::MD5HashValue>(), disable_md5);
+
+  hash_function->Update(/*offset=*/0, request.payload());
+  auto hashes = hash_function->Finish();
   if (!hashes.crc32c.empty()) metadata["crc32c"] = hashes.crc32c;
   if (!hashes.md5.empty()) metadata["md5Hash"] = hashes.md5;
 
@@ -450,9 +460,9 @@ StatusOr<ObjectMetadata> RestStub::InsertObjectMedia(
   // If the application has set an explicit hash value we need to use multipart
   // uploads. `DisableMD5Hash` and `DisableCrc32cChecksum` should not be
   // dependent on each other.
-  if (!request.GetOption<DisableMD5Hash>().value_or(false) ||
-      !request.GetOption<DisableCrc32cChecksum>().value_or(false) ||
-      request.HasOption<MD5HashValue>() ||
+  auto const settings =
+      storage::internal::GetUploadChecksumSettings(request, options);
+  if (!settings.md5 || !settings.crc32c || request.HasOption<MD5HashValue>() ||
       request.HasOption<Crc32cChecksumValue>()) {
     return InsertObjectMediaMultipart(context, options, request);
   }
@@ -1265,3 +1275,5 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
 }  // namespace cloud
 }  // namespace google
+
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/storage/internal/rest/stub.cc
+++ b/google/cloud/storage/internal/rest/stub.cc
@@ -457,9 +457,9 @@ StatusOr<ObjectMetadata> RestStub::InsertObjectMedia(
     return InsertObjectMediaMultipart(context, options, request);
   }
 
-  // If the application has set an explicit hash value we need to use multipart
-  // uploads. `DisableMD5Hash` and `DisableCrc32cChecksum` should not be
-  // dependent on each other.
+  // If the application has set an explicit hash value, or if it requires
+  // computing the MD5 hash or CRC32C checksum, we need to use multipart
+  // uploads.
   auto const settings =
       storage::internal::GetUploadChecksumSettings(request, options);
   if (!settings.md5 || !settings.crc32c || request.HasOption<MD5HashValue>() ||

--- a/google/cloud/storage/options.h
+++ b/google/cloud/storage/options.h
@@ -89,9 +89,10 @@ struct CAPathOption {
  * @ingroup storage-options
  */
 enum class ChecksumAlgorithm {
-  kNone,    ///< Disable checksum validation
-  kCrc32c,  ///< Use CRC32C for checksum validation
-  kMD5,     ///< Use MD5 for checksum validation
+  kNone,          ///< Disable checksum validation
+  kCrc32c,        ///< Use CRC32C for checksum validation
+  kMD5,           ///< Use MD5 for checksum validation
+  kCrc32cAndMD5,  ///< Use CRC32C and MD5 for checksum validation
 };
 
 /**

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -45,6 +45,7 @@ storage_client_unit_tests = [
     "internal/bucket_acl_requests_test.cc",
     "internal/bucket_metadata_cache_test.cc",
     "internal/bucket_requests_test.cc",
+    "internal/checksum_helpers_test.cc",
     "internal/complex_option_test.cc",
     "internal/compute_engine_util_test.cc",
     "internal/connection_impl_bucket_acl_test.cc",

--- a/google/cloud/storage/testing/upload_hash_cases.cc
+++ b/google/cloud/storage/testing/upload_hash_cases.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/storage/testing/upload_hash_cases.h"
 #include <vector>
 
@@ -66,3 +67,5 @@ std::vector<UploadHashCase> UploadHashCases() {
 }  // namespace storage
 }  // namespace cloud
 }  // namespace google
+
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/storage/testing/upload_hash_cases.h
+++ b/google/cloud/storage/testing/upload_hash_cases.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_TESTING_UPLOAD_HASH_CASES_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_TESTING_UPLOAD_HASH_CASES_H
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/storage/options.h"
 #include <string>
 #include <vector>
@@ -41,3 +42,4 @@ std::vector<UploadHashCase> UploadHashCases();
 }  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_TESTING_UPLOAD_HASH_CASES_H
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/storage/tests/object_checksum_integration_test.cc
+++ b/google/cloud/storage/tests/object_checksum_integration_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
 #include "google/cloud/internal/getenv.h"
@@ -421,3 +422,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/storage/tests/object_file_integration_test.cc
+++ b/google/cloud/storage/tests/object_file_integration_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
 #include "google/cloud/internal/filesystem.h"
@@ -579,3 +580,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/storage/tests/object_hash_integration_test.cc
+++ b/google/cloud/storage/tests/object_hash_integration_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/testing/canonical_errors.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
@@ -372,3 +373,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/storage/tests/object_insert_integration_test.cc
+++ b/google/cloud/storage/tests/object_insert_integration_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/internal/object_metadata_parser.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
@@ -495,3 +496,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
 }  // namespace cloud
 }  // namespace google
+#include "google/cloud/internal/diagnostics_pop.inc"


### PR DESCRIPTION
Migrates the Sync client to use the newly introduced unified checksum options. Also includes the necessary fallback logic to support users who are still using the deprecated options.

Note: This PR is stacked on top of #16261 and includes its commits. It should be merged after #16261.