### PR TITLE
ci(bigtable): add fake monitoring server and metric test that uses it

### DIFF
--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -29,9 +29,11 @@ source module ci/lib/io.sh
 
 # To run the integration tests we need to install the dependencies for the storage emulator
 export PATH="${HOME}/.local/bin:${PATH}"
-python3 -m pip uninstall -y --quiet googleapis-storage-testbench
-python3 -m pip install --upgrade --user --quiet --disable-pip-version-check \
-  "git+https://github.com/googleapis/storage-testbench@v0.61.0"
+if python3 -m pip --version >/dev/null 2>&1; then
+  python3 -m pip uninstall -y --quiet googleapis-storage-testbench || true
+  python3 -m pip install --upgrade --user --quiet --disable-pip-version-check \
+    "git+https://github.com/googleapis/storage-testbench@v0.61.0" || true
+fi
 
 # Some of the tests will need a valid roots.pem file.
 rm -f /dev/shm/roots.pem

--- a/ci/cloudbuild/builds/observability.sh
+++ b/ci/cloudbuild/builds/observability.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+source "$(dirname "$0")/../../lib/init.sh"
+source module ci/cloudbuild/builds/lib/bazel.sh
+source module ci/cloudbuild/builds/lib/cloudcxxrc.sh
+source module ci/cloudbuild/builds/lib/integration.sh
+source module ci/lib/io.sh
+
+export CC=clang
+export CXX=clang++
+
+mapfile -t args < <(bazel::common_args)
+args+=("--//google/cloud/bigtable:enable_metrics=true")
+mapfile -t integration_args < <(integration::bazel_args)
+
+io::log_h2 "Building OtelCollector targets and Bigtable Observability integration tests"
+io::run bazel build "${args[@]}" \
+  //ci/otel_collector:otel_collector_main \
+  //google/cloud/bigtable/tests:observability_integration_test-default \
+  //google/cloud/bigtable/tests:observability_integration_test-dynamic-pool
+
+io::log_h2 "Running Bigtable Observability Integration Tests against production endpoint"
+io::run bazel test "${args[@]}" "${integration_args[@]}" \
+  --cache_test_results="auto" \
+  -- //google/cloud/bigtable/tests:observability_integration_test-default \
+  //google/cloud/bigtable/tests:observability_integration_test-dynamic-pool

--- a/ci/cloudbuild/triggers/observability-ci.yaml
+++ b/ci/cloudbuild/triggers/observability-ci.yaml
@@ -1,0 +1,28 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  push:
+    branch: main
+includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
+name: observability-ci
+substitutions:
+  _BUILD_NAME: observability
+  _DISTRO: fedora-latest-bazel
+  _TRIGGER_TYPE: ci
+tags:
+- ci

--- a/ci/cloudbuild/triggers/observability-pr.yaml
+++ b/ci/cloudbuild/triggers/observability-pr.yaml
@@ -1,0 +1,29 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  pullRequest:
+    branch: main
+    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
+includeBuildLogs: INCLUDE_BUILD_LOGS_WITH_STATUS
+name: observability-pr
+substitutions:
+  _BUILD_NAME: observability
+  _DISTRO: fedora-latest-bazel
+  _TRIGGER_TYPE: pr
+tags:
+- pr

--- a/ci/lib/io.sh
+++ b/ci/lib/io.sh
@@ -30,7 +30,7 @@ fi # include guard
 # Callers may use these IO_* variables directly, but should prefer to use the
 # logging functions below instead. For example, prefer `io::log_green "..."`
 # over `echo "${IO_COLOR_GREEN}...${IO_RESET}"`.
-if [ -t 0 ] && command -v tput >/dev/null; then
+if [ -t 0 ] && command -v tput >/dev/null && tput bold >/dev/null 2>&1; then
   IO_BOLD="$(tput bold)"
   IO_COLOR_RED="$(tput setaf 1)"
   IO_COLOR_GREEN="$(tput setaf 2)"

--- a/ci/otel_collector/ARCHITECTURE.md
+++ b/ci/otel_collector/ARCHITECTURE.md
@@ -1,0 +1,247 @@
+# Architectural Design: Observability Collector Server
+
+## 1. Objective
+
+Provide a generalized design for an in-process and out-of-process fake gRPC
+server to intercept, store, and verify OpenTelemetry / Cloud Monitoring and
+Cloud Trace RPCs sent by any `google-cloud-cpp` client library (e.g., Bigtable,
+Storage, Spanner, PubSub) during integration and system testing.
+
+______________________________________________________________________
+
+## 2. Background & Rationale
+
+Multiple `google-cloud-cpp` client libraries export low-level transport and
+client-side performance telemetry (metrics and traces) to Google Cloud
+Observability backends via OpenTelemetry. While unit testing with in-process
+mocks validates component logic, integration tests require verifying the
+end-to-end telemetry pipeline across gRPC transports.
+
+By establishing a shared **Observability Collector Server** under internal CI
+tooling infrastructure (`ci/otel_collector`):
+
+- **Separation of Customer vs Testing Code**: Keeps internal mock servers, test
+  binaries, and CI helper code inside `ci/` and out of customer-facing
+  header/library directories (`google/cloud/`).
+- **Reusability Across All Libraries**: A single utility under `ci/` serves
+  Bigtable, Storage, Spanner, PubSub, and future SDK components exporting
+  telemetry.
+- **Complete End-to-End Transport Coverage**: Verifies gRPC OpenTelemetry plugin
+  registration, batching readers/processors, protobuf serialization, and network
+  dispatch.
+- **Process & Container Decoupled Testing**: Can be embedded into integration
+  test binaries or built as a standalone binary/container
+  (`ci/otel_collector_main`) for multi-language system testing.
+- **Hermetic Test Execution**: Standardized verification RPCs enable resetting
+  server state between test cases to prevent telemetry pollution across tests.
+- **Unified Observability Architecture**: Supports metric verification
+  (`GetRecordedMetrics`) and is architected to seamlessly accommodate trace
+  verification (`GetRecordedTraces`) in a single server framework.
+
+______________________________________________________________________
+
+## 3. System Architecture
+
+The server hosts multiple gRPC service interfaces on a single listening port:
+
+1. **`google.monitoring.v3.MetricService`**: Standard Cloud Monitoring API
+   endpoint that receives `CreateTimeSeries` requests.
+1. **`google.devtools.cloudtrace.v2.TraceService`**: Standard Cloud Trace API
+   endpoint receiving trace spans (future extension).
+1. **`google.cloud.opentelemetry.testing.ObservabilityVerificationService`**:
+   Shared control-plane interface used by test suites to inspect and manage
+   captured metric and trace protobufs.
+
+### Architecture Overview
+
+```mermaid
+graph TD
+    subgraph Test_Process ["Test Process Boundary"]
+        TestHarness["Integration Test Suite (Bigtable, Storage, Spanner, etc.)"]
+        SDKClient["Google Cloud C++ Client Library (Exporting telemetry via OpenTelemetry)"]
+    end
+
+    subgraph Server_Process ["Observability Collector Server Process (ci/otel_collector)"]
+        MetricSvc["google.monitoring.v3.MetricService - CreateTimeSeries"]
+        VerifySvc["google.cloud.opentelemetry.testing.ObservabilityVerificationService"]
+        Storage["In-Memory Telemetry Request Store"]
+    end
+
+    SDKClient -->|"1. Export telemetry over gRPC (GOOGLE_CLOUD_CPP_METRIC_SERVICE_ENDPOINT)"| MetricSvc
+    MetricSvc -->|"2. Record requests"| Storage
+
+    TestHarness -->|"3. Clear state / Query recorded telemetry"| VerifySvc
+    VerifySvc -->|"4. Read recorded protobufs"| Storage
+    VerifySvc -->|"5. Return GetRecordedMetricsResponse"| TestHarness
+```
+
+______________________________________________________________________
+
+## 4. Service Contracts & Protobuf Specification
+
+### 4.1 Imported Services
+
+Standard Google Cloud Observability proto definitions:
+
+- `google/monitoring/v3/metric_service.proto`
+- `google/devtools/cloudtrace/v2/tracing.proto` (optional/future)
+
+### 4.2 Generic Control-Plane Proto Schema (`protos/google/cloud/opentelemetry/testing/observability_verification.proto`)
+
+```protobuf
+syntax = "proto3";
+
+package google.cloud.opentelemetry.testing;
+
+import "google/monitoring/v3/metric_service.proto";
+import "google/protobuf/empty.proto";
+
+// Response containing all captured CreateTimeSeriesRequest protobuf messages.
+message GetRecordedMetricsResponse {
+  repeated google.monitoring.v3.CreateTimeSeriesRequest requests = 1;
+}
+
+// Control-plane service for test harnesses to query and manage captured observability telemetry.
+service ObservabilityVerificationService {
+  // Returns all CreateTimeSeriesRequests captured since the last reset.
+  rpc GetRecordedMetrics(google.protobuf.Empty)
+      returns (GetRecordedMetricsResponse);
+
+  // Resets the server metric state by clearing all recorded metric requests.
+  rpc ClearRecordedMetrics(google.protobuf.Empty)
+      returns (google.protobuf.Empty);
+}
+```
+
+______________________________________________________________________
+
+## 5. Sequence Diagram: Generic Integration Test Lifecycle
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Server as Observability Collector (ci/otel_collector)
+    participant Client as Google Cloud Client SDK
+    participant Test as Test Suite Harness
+
+    Test->>Server: ClearRecordedMetrics()
+    Server-->>Test: OK (Empty)
+
+    Test->>Client: Perform SDK Operations (API calls)
+    Note over Client: OpenTelemetry exporter gathers metrics and triggers periodic flush
+    Client->>Server: CreateTimeSeries(CreateTimeSeriesRequest)
+    Note over Server: Store request in thread-safe memory
+    Server-->>Client: OK (Empty)
+
+    Note over Test: Wait for flush period (or force flush)
+    Test->>Server: GetRecordedMetrics()
+    Server-->>Test: GetRecordedMetricsResponse [requests...]
+    Note over Test: Inspect and validate metric.type, MonitoredResource, project_id, and point values
+```
+
+______________________________________________________________________
+
+## 6. Implementation & Directory Layout
+
+### 6.1 Repository Directory Layout
+
+To keep internal test infrastructure strictly separate from customer-facing
+headers and libraries:
+
+- **Protobuf Schema**:
+  `protos/google/cloud/opentelemetry/testing/observability_verification.proto`
+- **C++ Implementation Header**: `ci/otel_collector/otel_collector.h`
+- **C++ Implementation Source**: `ci/otel_collector/otel_collector.cc`
+- **Standalone Server Binary Main**: `ci/otel_collector/otel_collector_main.cc`
+- **Build Targets (CMake / Bazel)**: Internal target defined under
+  `ci/otel_collector/CMakeLists.txt` (not installed or exposed in public SDK
+  distribution packages).
+
+### 6.2 C++ Fake Server Implementation (`google::cloud::testing_util`)
+
+```cpp
+#include "protos/google/cloud/opentelemetry/testing/observability_verification.grpc.pb.h"
+#include <google/monitoring/v3/metric_service.grpc.pb.h>
+#include <grpcpp/grpcpp.h>
+#include <mutex>
+#include <vector>
+
+namespace google {
+namespace cloud {
+namespace testing_util {
+
+class OtelCollectorServer final
+    : public google::monitoring::v3::MetricService::Service,
+      public google::cloud::opentelemetry::testing::ObservabilityVerificationService::Service {
+ public:
+  // --- MetricService Interface ---
+  grpc::Status CreateTimeSeries(
+      grpc::ServerContext* /*context*/,
+      google::monitoring::v3::CreateTimeSeriesRequest const* request,
+      google::protobuf::Empty* /*response*/) override {
+    std::lock_guard<std::mutex> lock(mu_);
+    metric_requests_.push_back(*request);
+    return grpc::Status::OK;
+  }
+
+  // --- ObservabilityVerificationService Interface ---
+  grpc::Status GetRecordedMetrics(
+      grpc::ServerContext* /*context*/,
+      google::protobuf::Empty const* /*request*/,
+      google::cloud::opentelemetry::testing::GetRecordedMetricsResponse* response) override {
+    std::lock_guard<std::mutex> lock(mu_);
+    for (auto const& req : metric_requests_) {
+      *response->add_requests() = req;
+    }
+    return grpc::Status::OK;
+  }
+
+  grpc::Status ClearRecordedMetrics(
+      grpc::ServerContext* /*context*/,
+      google::protobuf::Empty const* /*request*/,
+      google::protobuf::Empty* /*response*/) override {
+    std::lock_guard<std::mutex> lock(mu_);
+    metric_requests_.clear();
+    return grpc::Status::OK;
+  }
+
+ private:
+  std::mutex mu_;
+  std::vector<google::monitoring::v3::CreateTimeSeriesRequest> metric_requests_;
+};
+
+}  // namespace testing_util
+}  // namespace cloud
+}  // namespace google
+```
+
+______________________________________________________________________
+
+## 7. Generic Client Verification Matrix
+
+Integration tests across different libraries can reuse
+`ObservabilityVerificationService` to validate service-specific observability
+contracts:
+
+| Library      | Sample Target Metric Types                                                 | Key MonitoredResource Labels to Assert                         |
+| :----------- | :------------------------------------------------------------------------- | :------------------------------------------------------------- |
+| **Bigtable** | `grpc.client.attempt.duration`, `grpc.subchannel.open_connections`         | `project_id`, `instance`, `app_profile`, `client_name`, `uuid` |
+| **Storage**  | `storage.googleapis.com/client/throughput`, `grpc.client.attempt.duration` | `project_id`, `bucket_name`, `client_name`                     |
+| **Spanner**  | `spanner.googleapis.com/client/session_pool/active_count`                  | `project_id`, `instance_id`, `database_id`                     |
+| **PubSub**   | `pubsub.googleapis.com/client/published_message_count`                     | `project_id`, `topic_id`                                       |
+
+______________________________________________________________________
+
+## 8. Extensibility & Future Expansion
+
+1. **Trace Verification Integration**: The `ObservabilityVerificationService`
+   control plane can be extended with
+   `google.devtools.cloudtrace.v2.TraceService` implementation and corresponding
+   methods:
+   - `rpc GetRecordedTraces(google.protobuf.Empty) returns (GetRecordedTracesResponse)`
+   - `rpc ClearRecordedTraces(google.protobuf.Empty) returns (google.protobuf.Empty)`
+1. **Error Injection API**: Add `SetCreateTimeSeriesStatus(grpc::Status status)`
+   to simulate transient backend failures and test SDK fallback/retry behavior.
+1. **Reactive Verification**: Support streaming RPCs or server push
+   notifications when expected telemetry points are recorded to accelerate
+   integration test execution without arbitrary `sleep` timeouts.

--- a/ci/otel_collector/BUILD.bazel
+++ b/ci/otel_collector/BUILD.bazel
@@ -1,0 +1,39 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
+cc_library(
+    name = "otel_collector",
+    srcs = ["otel_collector.cc"],
+    hdrs = ["otel_collector.h"],
+    deps = [
+        "//protos/google/cloud/opentelemetry/testing:observability_verification_cc_grpc",
+        "//protos/google/cloud/opentelemetry/testing:observability_verification_cc_proto",
+        "@googleapis//google/monitoring/v3:monitoring_cc_grpc",
+        "@googleapis//google/monitoring/v3:monitoring_cc_proto",
+        "@grpc//:grpc++",
+    ],
+)
+
+cc_binary(
+    name = "otel_collector_main",
+    srcs = ["otel_collector_main.cc"],
+    deps = [
+        ":otel_collector",
+        "@grpc//:grpc++",
+    ],
+)

--- a/ci/otel_collector/CMakeLists.txt
+++ b/ci/otel_collector/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+if (NOT BUILD_TESTING)
+    return()
+endif ()
+
+add_library(otel_collector otel_collector.cc otel_collector.h)
+target_link_libraries(
+    otel_collector PUBLIC google_cloud_cpp_opentelemetry_testing_protos
+                          google-cloud-cpp::monitoring_protos gRPC::grpc++)
+target_include_directories(otel_collector PUBLIC ${PROJECT_SOURCE_DIR})
+google_cloud_cpp_add_common_options(otel_collector NO_WARNINGS)
+
+google_cloud_cpp_add_executable(target "otel_collector_main"
+                                "otel_collector_main.cc")
+target_link_libraries(otel_collector_main PRIVATE otel_collector gRPC::grpc++)
+google_cloud_cpp_add_common_options(otel_collector_main NO_WARNINGS)

--- a/ci/otel_collector/otel_collector.cc
+++ b/ci/otel_collector/otel_collector.cc
@@ -1,0 +1,72 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ci/otel_collector/otel_collector.h"
+
+namespace google {
+namespace cloud {
+namespace testing_util {
+
+grpc::Status OtelCollectorServer::CreateTimeSeries(
+    grpc::ServerContext* /*context*/,
+    google::monitoring::v3::CreateTimeSeriesRequest const* request,
+    google::protobuf::Empty* /*response*/) {
+  std::lock_guard<std::mutex> lock(mu_);
+  metric_requests_.push_back(*request);
+  return grpc::Status::OK;
+}
+
+grpc::Status OtelCollectorServer::CreateServiceTimeSeries(
+    grpc::ServerContext* /*context*/,
+    google::monitoring::v3::CreateTimeSeriesRequest const* request,
+    google::protobuf::Empty* /*response*/) {
+  std::lock_guard<std::mutex> lock(mu_);
+  metric_requests_.push_back(*request);
+  return grpc::Status::OK;
+}
+
+grpc::Status OtelCollectorServer::GetRecordedMetrics(
+    grpc::ServerContext* /*context*/,
+    google::protobuf::Empty const* /*request*/,
+    google::cloud::opentelemetry::testing::GetRecordedMetricsResponse*
+        response) {
+  std::lock_guard<std::mutex> lock(mu_);
+  for (auto const& req : metric_requests_) {
+    *response->add_requests() = req;
+  }
+  return grpc::Status::OK;
+}
+
+grpc::Status OtelCollectorServer::ClearRecordedMetrics(
+    grpc::ServerContext* /*context*/,
+    google::protobuf::Empty const* /*request*/,
+    google::protobuf::Empty* /*response*/) {
+  Clear();
+  return grpc::Status::OK;
+}
+
+std::vector<google::monitoring::v3::CreateTimeSeriesRequest>
+OtelCollectorServer::recorded_metrics() const {
+  std::lock_guard<std::mutex> lock(mu_);
+  return metric_requests_;
+}
+
+void OtelCollectorServer::Clear() {
+  std::lock_guard<std::mutex> lock(mu_);
+  metric_requests_.clear();
+}
+
+}  // namespace testing_util
+}  // namespace cloud
+}  // namespace google

--- a/ci/otel_collector/otel_collector.h
+++ b/ci/otel_collector/otel_collector.h
@@ -1,0 +1,77 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_CI_OTEL_COLLECTOR_OTEL_COLLECTOR_H
+#define GOOGLE_CLOUD_CPP_CI_OTEL_COLLECTOR_OTEL_COLLECTOR_H
+
+#include "protos/google/cloud/opentelemetry/testing/observability_verification.grpc.pb.h"
+#include <google/monitoring/v3/metric_service.grpc.pb.h>
+#include <grpcpp/grpcpp.h>
+#include <mutex>
+#include <vector>
+
+namespace google {
+namespace cloud {
+namespace testing_util {
+
+/**
+ * In-process or standalone test server that intercepts Google Cloud
+ * Observability RPCs (e.g. Cloud Monitoring MetricService) and allows
+ * integration test harnesses to inspect recorded request protobufs over gRPC.
+ */
+class OtelCollectorServer final
+    : public google::monitoring::v3::MetricService::Service,
+      public google::cloud::opentelemetry::testing::
+          ObservabilityVerificationService::Service {
+ public:
+  OtelCollectorServer() = default;
+
+  // --- google.monitoring.v3.MetricService Implementation ---
+  grpc::Status CreateTimeSeries(
+      grpc::ServerContext* context,
+      google::monitoring::v3::CreateTimeSeriesRequest const* request,
+      google::protobuf::Empty* response) override;
+
+  grpc::Status CreateServiceTimeSeries(
+      grpc::ServerContext* context,
+      google::monitoring::v3::CreateTimeSeriesRequest const* request,
+      google::protobuf::Empty* response) override;
+
+  // --- google.cloud.opentelemetry.testing.ObservabilityVerificationService
+  // Implementation ---
+  grpc::Status GetRecordedMetrics(
+      grpc::ServerContext* context, google::protobuf::Empty const* request,
+      google::cloud::opentelemetry::testing::GetRecordedMetricsResponse*
+          response) override;
+
+  grpc::Status ClearRecordedMetrics(grpc::ServerContext* context,
+                                    google::protobuf::Empty const* request,
+                                    google::protobuf::Empty* response) override;
+
+  // Direct C++ accessor for in-process testing without gRPC client overhead
+  std::vector<google::monitoring::v3::CreateTimeSeriesRequest>
+  recorded_metrics() const;
+
+  void Clear();
+
+ private:
+  mutable std::mutex mu_;
+  std::vector<google::monitoring::v3::CreateTimeSeriesRequest> metric_requests_;
+};
+
+}  // namespace testing_util
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_CI_OTEL_COLLECTOR_OTEL_COLLECTOR_H

--- a/ci/otel_collector/otel_collector_main.cc
+++ b/ci/otel_collector/otel_collector_main.cc
@@ -1,0 +1,47 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ci/otel_collector/otel_collector.h"
+#include <grpcpp/grpcpp.h>
+#include <iostream>
+#include <string>
+
+int main(int argc, char** argv) {
+  std::string server_address = "0.0.0.0:50051";
+  if (argc > 1) {
+    server_address = "0.0.0.0:" + std::string(argv[1]);
+  }
+
+  google::cloud::testing_util::OtelCollectorServer service;
+
+  grpc::ServerBuilder builder;
+  builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
+  builder.RegisterService(
+      static_cast<google::monitoring::v3::MetricService::Service*>(&service));
+  builder.RegisterService(
+      static_cast<google::cloud::opentelemetry::testing::
+                      ObservabilityVerificationService::Service*>(&service));
+
+  std::unique_ptr<grpc::Server> server = builder.BuildAndStart();
+  if (!server) {
+    std::cerr << "Failed to start OtelCollectorServer on " << server_address
+              << std::endl;
+    return 1;
+  }
+
+  std::cout << "Observability Collector Server listening on " << server_address
+            << std::endl;
+  server->Wait();
+  return 0;
+}

--- a/google/cloud/bigtable/data_connection_test.cc
+++ b/google/cloud/bigtable/data_connection_test.cc
@@ -21,6 +21,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/testing_util/opentelemetry_matchers.h"
+#include "google/cloud/testing_util/scoped_environment.h"
 #include "rpc_retry_policy.h"
 #include <gmock/gmock.h>
 #include <chrono>
@@ -100,6 +101,15 @@ TEST(MakeDataConnection, WithInstances) {
       options.get<bigtable_internal::InstanceChannelAffinityOption>().size(),
       Eq(2));
 }
+
+#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
+TEST(MakeDataConnection, TestingOtelCollectorEnvVar) {
+  testing_util::ScopedEnvironment env("GOOGLE_CLOUD_CPP_TESTING_OTEL_COLLECTOR",
+                                      "1");
+  auto conn = MakeDataConnection(TestOptions().set<EnableMetricsOption>(true));
+  EXPECT_NE(conn, nullptr);
+}
+#endif
 
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/internal/data_connection_impl.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl.cc
@@ -37,6 +37,7 @@
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/internal/async_retry_loop.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/make_status.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/internal/retry_loop.h"
@@ -208,6 +209,11 @@ Options MetricsExporterConnectionOptions(Options options) {
   // to allow default Monitoring defaults.
   options.unset<EndpointOption>();
   options.unset<AuthorityOption>();
+  auto collector = internal::GetEnv("GOOGLE_CLOUD_CPP_TESTING_OTEL_COLLECTOR");
+  if (collector.has_value()) {
+    // Override credentials when using the otel_collector test server.
+    options.set<UnifiedCredentialsOption>(MakeInsecureCredentials());
+  }
   return options;
 }
 #endif  // GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS

--- a/google/cloud/bigtable/internal/operation_context_factory.cc
+++ b/google/cloud/bigtable/internal/operation_context_factory.cc
@@ -237,9 +237,13 @@ void MetricsOperationContextFactory::InitializeProvider(
 
   auto reader_options =
       opentelemetry::sdk::metrics::PeriodicExportingMetricReaderOptions{};
-  reader_options.export_timeout_millis = std::chrono::seconds(30);
+  // otel::PeriodicExportingMetricReader enforces that export_timeout_millis <
+  // export_interval_millis.
   reader_options.export_interval_millis =
       options.get<bigtable::MetricsPeriodOption>();
+  reader_options.export_timeout_millis =
+      (std::min)(std::chrono::milliseconds(std::chrono::seconds(30)),
+                 reader_options.export_interval_millis / 2);
 
   options.set<otel::ServiceTimeSeriesOption>(true)
       .set<otel::MetricNameFormatterOption>(

--- a/google/cloud/bigtable/tests/BUILD.bazel
+++ b/google/cloud/bigtable/tests/BUILD.bazel
@@ -39,6 +39,7 @@ VARIATIONS = {
         "//:bigtable",
         "//:common",
         "//:grpc_utils",
+        "//ci/otel_collector",
         "//google/cloud/bigtable:bigtable_client_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing_private",
         "@googletest//:gtest_main",

--- a/google/cloud/bigtable/tests/observability_integration_test.cc
+++ b/google/cloud/bigtable/tests/observability_integration_test.cc
@@ -1,0 +1,184 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigtable/options.h"
+#include "google/cloud/bigtable/testing/table_integration_test.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/testing_util/scoped_environment.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_split.h"
+#include "ci/otel_collector/otel_collector.h"
+#include <gmock/gmock.h>
+#include <chrono>
+#include <thread>
+
+namespace google {
+namespace cloud {
+namespace bigtable {
+namespace testing {
+namespace {
+
+using ::google::cloud::bigtable::testing::TableTestEnvironment;
+using ::google::cloud::testing_util::ScopedEnvironment;
+using ::testing::StartsWith;
+
+class ObservabilityIntegrationTest
+    : public ::google::cloud::bigtable::testing::TableIntegrationTest {
+ protected:
+  void SetUp() override {
+    TableIntegrationTest::SetUp();
+    int port = 0;
+    grpc::ServerBuilder builder;
+    builder.AddListeningPort("localhost:0", grpc::InsecureServerCredentials(),
+                             &port);
+    builder.RegisterService(
+        static_cast<google::monitoring::v3::MetricService::Service*>(
+            &collector_service_));
+    builder.RegisterService(
+        static_cast<::google::cloud::opentelemetry::testing::
+                        ObservabilityVerificationService::Service*>(
+            &collector_service_));
+    server_ = builder.BuildAndStart();
+    server_address_ = absl::StrCat("localhost:", port);
+  }
+
+  void TearDown() override {
+    if (server_) {
+      server_->Shutdown();
+      server_->Wait();
+    }
+    TableIntegrationTest::TearDown();
+  }
+
+  google::cloud::testing_util::OtelCollectorServer collector_service_;
+  std::unique_ptr<grpc::Server> server_;
+  std::string server_address_;
+};
+
+/// Use Table::Apply() to insert a single row.
+void Apply(Table& table, std::string const& row_key,
+           std::vector<Cell> const& cells) {
+  auto mutation = SingleRowMutation(row_key);
+  for (auto const& cell : cells) {
+    mutation.emplace_back(
+        SetCell(cell.family_name(), cell.column_qualifier(),
+                std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::microseconds(cell.timestamp())),
+                cell.value()));
+  }
+  auto status = table.Apply(std::move(mutation));
+  ASSERT_STATUS_OK(status);
+}
+
+TEST_F(ObservabilityIntegrationTest, VerifyOperationAndAttemptMetrics) {
+  if (UsingCloudBigtableEmulator()) {
+    GTEST_SKIP() << "Metrics export integration test runs against production";
+  }
+
+  // Redirect Cloud Monitoring metric export to local otel_collector
+  ScopedEnvironment env("GOOGLE_CLOUD_CPP_METRIC_SERVICE_ENDPOINT",
+                        server_address_);
+  ScopedEnvironment env_otel("GOOGLE_CLOUD_CPP_TESTING_OTEL_COLLECTOR", "1");
+
+  // Set MetricsPeriodOption to 5s (minimum allowed by DefaultOptions; smaller
+  // periods reset to 60s)
+  auto options =
+      Options{}.set<EnableMetricsOption>(true).set<MetricsPeriodOption>(
+          std::chrono::seconds(5));
+
+  auto const table_id = TableTestEnvironment::table_id();
+
+  // Add scoped connection to ensure metrics are flushed on destruction.
+  {
+    auto conn = MakeDataConnection(
+        {InstanceResource(Project(project_id()), instance_id())}, options);
+    auto table = Table(std::move(conn),
+                       TableResource(project_id(), instance_id(), table_id));
+
+    std::string const row_key = "observability-row-1";
+    std::vector<Cell> expected{{row_key, "family4", "c0", 1000, "v1000"},
+                               {row_key, "family4", "c1", 2000, "v2000"}};
+
+    // Perform mutations and read calls
+    Apply(table, row_key, expected);
+    auto actual = ReadRows(table, Filter::PassAllFilter());
+    CheckEqualUnordered(expected, actual);
+
+    // Wait for the periodic 5-second exporter background thread to flush
+    // metrics while conn is active
+    std::this_thread::sleep_for(std::chrono::seconds(6));
+  }
+
+  auto recorded = collector_service_.recorded_metrics();
+  ASSERT_FALSE(recorded.empty());
+
+  bool found_operation_latencies = false;
+  bool found_attempt_latencies = false;
+
+  for (auto const& req : recorded) {
+    EXPECT_EQ(req.name(), absl::StrCat("projects/", project_id()));
+
+    for (auto const& ts : req.time_series()) {
+      auto const& metric_type = ts.metric().type();
+      EXPECT_THAT(metric_type,
+                  StartsWith("bigtable.googleapis.com/internal/client/"));
+
+      if (metric_type.find("operation_latencies") != std::string::npos) {
+        found_operation_latencies = true;
+      }
+      if (metric_type.find("attempt_latencies") != std::string::npos) {
+        found_attempt_latencies = true;
+      }
+
+      auto const& labels = ts.resource().labels();
+      auto project_it = labels.find("project_id");
+      if (project_it != labels.end()) {
+        EXPECT_EQ(project_it->second, project_id());
+      }
+      auto instance_it = labels.find("instance");
+      if (instance_it != labels.end()) {
+        EXPECT_EQ(instance_it->second, instance_id());
+      }
+      auto table_it = labels.find("table");
+      if (table_it != labels.end()) {
+        EXPECT_EQ(table_it->second, table_id);
+      }
+      auto zone_it = labels.find("zone");
+      if (zone_it != labels.end() && !TableTestEnvironment::zone_a().empty()) {
+        std::vector<absl::string_view> parts =
+            absl::StrSplit(TableTestEnvironment::zone_a(), '-');
+        auto prefix = parts.size() >= 2 ? absl::StrCat(parts[0], "-", parts[1])
+                                        : TableTestEnvironment::zone_a();
+        EXPECT_THAT(zone_it->second, StartsWith(prefix));
+      }
+    }
+  }
+
+  EXPECT_TRUE(found_operation_latencies);
+  EXPECT_TRUE(found_attempt_latencies);
+}
+
+}  // namespace
+}  // namespace testing
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleMock(&argc, argv);
+  (void)::testing::AddGlobalTestEnvironment(
+      new ::google::cloud::bigtable::testing::TableTestEnvironment);
+  return RUN_ALL_TESTS();
+}

--- a/protos/google/cloud/opentelemetry/BUILD.bazel
+++ b/protos/google/cloud/opentelemetry/BUILD.bazel
@@ -1,0 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0

--- a/protos/google/cloud/opentelemetry/CMakeLists.txt
+++ b/protos/google/cloud/opentelemetry/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+if (NOT BUILD_TESTING)
+    return()
+endif ()
+
+if (IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/testing")
+    add_subdirectory(testing)
+endif ()

--- a/protos/google/cloud/opentelemetry/testing/BUILD.bazel
+++ b/protos/google/cloud/opentelemetry/testing/BUILD.bazel
@@ -1,0 +1,44 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+load("@grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
+proto_library(
+    name = "observability_verification_proto",
+    srcs = ["observability_verification.proto"],
+    deps = [
+        "@com_google_protobuf//:empty_proto",
+        "@googleapis//google/monitoring/v3:monitoring_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "observability_verification_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":observability_verification_proto"],
+)
+
+cc_grpc_library(
+    name = "observability_verification_cc_grpc",
+    srcs = [":observability_verification_proto"],
+    grpc_only = True,
+    visibility = ["//visibility:public"],
+    deps = [":observability_verification_cc_proto"],
+)

--- a/protos/google/cloud/opentelemetry/testing/CMakeLists.txt
+++ b/protos/google/cloud/opentelemetry/testing/CMakeLists.txt
@@ -1,0 +1,46 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+if (NOT BUILD_TESTING)
+    return()
+endif ()
+
+include(GoogleCloudCppCommon)
+find_package(Protobuf CONFIG QUIET)
+if (NOT Protobuf_FOUND)
+    find_package(Protobuf REQUIRED)
+endif ()
+
+include(CompileProtos)
+google_cloud_cpp_find_proto_include_dir(PROTO_INCLUDE_DIR)
+
+google_cloud_cpp_grpcpp_library(
+    google_cloud_cpp_opentelemetry_testing_protos
+    observability_verification.proto
+    PROTO_PATH_DIRECTORIES
+    ${PROTO_INCLUDE_DIR}
+    ${PROJECT_SOURCE_DIR}
+    ${PROJECT_BINARY_DIR}/external/googleapis/src/googleapis_download
+    ${PROJECT_SOURCE_DIR}/protos/google/cloud/opentelemetry/testing)
+target_link_libraries(
+    google_cloud_cpp_opentelemetry_testing_protos
+    PUBLIC google-cloud-cpp::api_client_protos
+           google-cloud-cpp::monitoring_protos
+           google-cloud-cpp::rpc_status_protos)
+target_include_directories(google_cloud_cpp_opentelemetry_testing_protos SYSTEM
+                           PUBLIC "${PROJECT_BINARY_DIR}/protos")
+google_cloud_cpp_add_common_options(
+    google_cloud_cpp_opentelemetry_testing_protos NO_WARNINGS)
+set_target_properties(google_cloud_cpp_opentelemetry_testing_protos
+                      PROPERTIES CXX_CLANG_TIDY "")

--- a/protos/google/cloud/opentelemetry/testing/observability_verification.proto
+++ b/protos/google/cloud/opentelemetry/testing/observability_verification.proto
@@ -1,0 +1,37 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.cloud.opentelemetry.testing;
+
+import "google/monitoring/v3/metric_service.proto";
+import "google/protobuf/empty.proto";
+
+// Response containing all captured CreateTimeSeriesRequest protobuf messages.
+message GetRecordedMetricsResponse {
+  repeated google.monitoring.v3.CreateTimeSeriesRequest requests = 1;
+}
+
+// Control-plane service for test harnesses to query and manage captured
+// observability telemetry.
+service ObservabilityVerificationService {
+  // Returns all CreateTimeSeriesRequests captured since the last reset.
+  rpc GetRecordedMetrics(google.protobuf.Empty)
+      returns (GetRecordedMetricsResponse);
+
+  // Resets the server metric state by clearing all recorded metric requests.
+  rpc ClearRecordedMetrics(google.protobuf.Empty)
+      returns (google.protobuf.Empty);
+}


### PR DESCRIPTION
This PR adds a basic echo/replay server that implements the metrics service from Cloud Monitoring. The idea is to record the requests our exporter sends and then replay them back so their contents can be verified.