### PR TITLE
chore: upgrade some builds to grpc 1.83.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -29,7 +29,7 @@ bazel_dep(name = "abseil-cpp", version = "20250814.2")
 # The name "com_google_protobuf" is internally used by @bazel_tools,
 # a native repository we cannot override.
 # See https://github.com/googleapis/google-cloud-cpp/issues/15393
-bazel_dep(name = "protobuf", version = "33.6", repo_name = "com_google_protobuf")
+bazel_dep(name = "protobuf", version = "35.1", repo_name = "com_google_protobuf")
 bazel_dep(name = "boringssl", version = "0.20251124.0")
 bazel_dep(name = "nlohmann_json", version = "3.12.0.bcr.1")
 bazel_dep(name = "curl", version = "8.8.0.bcr.3")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -52,7 +52,7 @@ python.toolchain(
     python_version = "3.11",
 )
 
-bazel_dep(name = "grpc", version = "1.81.0")
+bazel_dep(name = "grpc", version = "1.83.0")
 bazel_dep(name = "googleapis", version = "0.0.0-20260623-b6f9ff05")
 bazel_dep(name = "googleapis-cc", version = "1.1.5")
 bazel_dep(name = "googleapis-grpc-cc", version = "1.1.5")

--- a/ci/cloudbuild/builds/bazel-oldest.sh
+++ b/ci/cloudbuild/builds/bazel-oldest.sh
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-export USE_BAZEL_VERSION=7.7.1
+export USE_BAZEL_VERSION=8.7.0
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/bazel.sh

--- a/ci/cloudbuild/builds/bazel-oldest.sh
+++ b/ci/cloudbuild/builds/bazel-oldest.sh
@@ -16,7 +16,8 @@
 
 set -euo pipefail
 
-export USE_BAZEL_VERSION=8.7.0
+export USE_BAZEL_VERSION=7.7.1
+export GOOGLE_CLOUD_CPP_CI_BAZEL_USE_WORKSPACE=true
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/bazel.sh

--- a/ci/cloudbuild/builds/lib/bazel.sh
+++ b/ci/cloudbuild/builds/lib/bazel.sh
@@ -28,25 +28,13 @@ source module ci/lib/io.sh
 io::log "Using bazelisk version"
 bazelisk version
 
-io::log "Prefetching bazel deps..."
-# Bazel downloads all the dependencies of a project, as well as a number of
-# development tools during startup. In automated builds these downloads fail
-# from time to time due to transient network problems. Running `bazel fetch` at
-# the beginning of the build prevents such transient failures from flaking the
-# build.
-TIMEFORMAT="==> 🕑 prefetching done in %R seconds"
-time {
-  "ci/retry-command.sh" 3 120 bazel fetch ...
-}
-echo >&2
-
 # Outputs a list of args that should be given to all bazel invocations. To read
 # this into an array use `mapfile -t my_array < <(bazel::common_args)`
 function bazel::common_args() {
   function should_cache_test_results() {
     # Disables test caching on ci and daily builds to surface flaky tests.
     # Enables test caching on other builds to avoid surfacing unrelated flakes.
-    case "${TRIGGER_TYPE}" in
+    case "${TRIGGER_TYPE:-}" in
       ci | daily)
         echo no
         ;;
@@ -73,3 +61,27 @@ function bazel::common_args() {
   fi
   printf "%s\n" "${args[@]}"
 }
+
+# Bazel downloads all the dependencies of a project, as well as a number of
+# development tools during startup. In automated builds these downloads fail
+# from time to time due to transient network problems. Running `bazel fetch` at
+# the beginning of the build prevents such transient failures from flaking the
+# build.
+function bazel::prefetch() {
+  local args
+  mapfile -t args < <(bazel::common_args)
+  if [[ "${GOOGLE_CLOUD_CPP_CI_BAZEL_USE_WORKSPACE:-}" == "true" ]]; then
+    args+=(
+      "--noenable_bzlmod"
+      "--enable_workspace"
+    )
+  fi
+  "ci/retry-command.sh" 3 120 bazel fetch "${args[@]}" ...
+}
+
+io::log "Prefetching bazel deps..."
+TIMEFORMAT="==> 🕑 prefetching done in %R seconds"
+time {
+  bazel::prefetch
+}
+echo >&2

--- a/ci/cloudbuild/dockerfiles/fedora-latest-cmake.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-latest-cmake.Dockerfile
@@ -160,7 +160,7 @@ RUN curl -fsSL https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.24
 
 WORKDIR /var/tmp/build/grpc
 RUN dnf makecache && dnf install -y c-ares-devel re2-devel
-RUN curl -fsSL https://github.com/grpc/grpc/archive/v1.81.0.tar.gz | \
+RUN curl -fsSL https://github.com/grpc/grpc/archive/v1.83.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \

--- a/ci/cloudbuild/dockerfiles/fedora-latest-cxx20.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-latest-cxx20.Dockerfile
@@ -157,7 +157,7 @@ RUN curl -fsSL https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.24
 
 WORKDIR /var/tmp/build/grpc
 RUN dnf makecache && dnf install -y c-ares-devel re2-devel
-RUN curl -fsSL https://github.com/grpc/grpc/archive/v1.81.0.tar.gz | \
+RUN curl -fsSL https://github.com/grpc/grpc/archive/v1.83.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_CXX_STANDARD=20 \

--- a/ci/cloudbuild/dockerfiles/fedora-latest-publish-docs.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-latest-publish-docs.Dockerfile
@@ -102,7 +102,7 @@ RUN curl -fsSL https://github.com/protocolbuffers/protobuf/archive/v33.6.tar.gz 
 
 WORKDIR /var/tmp/build/grpc
 RUN dnf makecache && dnf install -y c-ares-devel re2-devel
-RUN curl -fsSL https://github.com/grpc/grpc/archive/v1.81.0.tar.gz | \
+RUN curl -fsSL https://github.com/grpc/grpc/archive/v1.83.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \

--- a/ci/cloudbuild/dockerfiles/gcc-oldest.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/gcc-oldest.Dockerfile
@@ -117,7 +117,7 @@ RUN curl -fsSL https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.24
     ldconfig && cd /var/tmp && rm -fr build
 
 WORKDIR /var/tmp/build/grpc
-RUN curl -fsSL https://github.com/grpc/grpc/archive/v1.83.0.tar.gz | \
+RUN curl -fsSL https://github.com/grpc/grpc/archive/v1.81.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \

--- a/ci/cloudbuild/dockerfiles/gcc-oldest.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/gcc-oldest.Dockerfile
@@ -117,7 +117,7 @@ RUN curl -fsSL https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.24
     ldconfig && cd /var/tmp && rm -fr build
 
 WORKDIR /var/tmp/build/grpc
-RUN curl -fsSL https://github.com/grpc/grpc/archive/v1.81.0.tar.gz | \
+RUN curl -fsSL https://github.com/grpc/grpc/archive/v1.83.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \

--- a/ci/cloudbuild/dockerfiles/ubuntu-20.04-install.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/ubuntu-20.04-install.Dockerfile
@@ -163,7 +163,7 @@ RUN curl -fsSL https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.24
     ldconfig && cd /var/tmp && rm -fr build
 
 WORKDIR /var/tmp/build/grpc
-RUN curl -fsSL https://github.com/grpc/grpc/archive/v1.81.0.tar.gz | \
+RUN curl -fsSL https://github.com/grpc/grpc/archive/v1.83.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \

--- a/ci/cloudbuild/dockerfiles/ubuntu-22.04-install.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/ubuntu-22.04-install.Dockerfile
@@ -162,7 +162,7 @@ RUN curl -fsSL https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.24
     ldconfig && cd /var/tmp && rm -fr build
 
 WORKDIR /var/tmp/build/grpc
-RUN curl -fsSL https://github.com/grpc/grpc/archive/v1.81.0.tar.gz | \
+RUN curl -fsSL https://github.com/grpc/grpc/archive/v1.83.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \

--- a/ci/gha/builds/lib/bazel.sh
+++ b/ci/gha/builds/lib/bazel.sh
@@ -103,6 +103,12 @@ function bazel::integration_test_args() {
 function bazel::prefetch() {
   local args
   mapfile -t args < <(bazel::common_args)
+  if [[ "${GOOGLE_CLOUD_CPP_CI_BAZEL_USE_WORKSPACE:-}" == "true" ]]; then
+    args+=(
+      "--noenable_bzlmod"
+      "--enable_workspace"
+    )
+  fi
   local common_rules=(
     "..."
   )

--- a/google/cloud/aiplatform/v1/dataset_client.h
+++ b/google/cloud/aiplatform/v1/dataset_client.h
@@ -287,7 +287,7 @@ class DatasetServiceClient {
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.aiplatform.v1.Dataset]: @googleapis_reference_link{google/cloud/aiplatform/v1/dataset.proto#L36}
   /// [google.cloud.aiplatform.v1.UpdateDatasetRequest]: @googleapis_reference_link{google/cloud/aiplatform/v1/dataset_service.proto#L312}
-  /// [google.protobuf.FieldMask]: @googleapis_reference_link{google/protobuf/field_mask.proto#L242}
+  /// [google.protobuf.FieldMask]: @googleapis_reference_link{google/protobuf/field_mask.proto#L240}
   ///
   // clang-format on
   StatusOr<google::cloud::aiplatform::v1::Dataset> UpdateDataset(
@@ -909,7 +909,7 @@ class DatasetServiceClient {
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.aiplatform.v1.DatasetVersion]: @googleapis_reference_link{google/cloud/aiplatform/v1/dataset_version.proto#L33}
   /// [google.cloud.aiplatform.v1.UpdateDatasetVersionRequest]: @googleapis_reference_link{google/cloud/aiplatform/v1/dataset_service.proto#L329}
-  /// [google.protobuf.FieldMask]: @googleapis_reference_link{google/protobuf/field_mask.proto#L242}
+  /// [google.protobuf.FieldMask]: @googleapis_reference_link{google/protobuf/field_mask.proto#L240}
   ///
   // clang-format on
   StatusOr<google::cloud::aiplatform::v1::DatasetVersion> UpdateDatasetVersion(

--- a/google/cloud/aiplatform/v1/endpoint_client.h
+++ b/google/cloud/aiplatform/v1/endpoint_client.h
@@ -427,7 +427,7 @@ class EndpointServiceClient {
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.aiplatform.v1.Endpoint]: @googleapis_reference_link{google/cloud/aiplatform/v1/endpoint.proto#L39}
   /// [google.cloud.aiplatform.v1.UpdateEndpointRequest]: @googleapis_reference_link{google/cloud/aiplatform/v1/endpoint_service.proto#L293}
-  /// [google.protobuf.FieldMask]: @googleapis_reference_link{google/protobuf/field_mask.proto#L242}
+  /// [google.protobuf.FieldMask]: @googleapis_reference_link{google/protobuf/field_mask.proto#L240}
   ///
   // clang-format on
   StatusOr<google::cloud::aiplatform::v1::Endpoint> UpdateEndpoint(
@@ -1028,7 +1028,7 @@ class EndpointServiceClient {
   /// [google.cloud.aiplatform.v1.DedicatedResources.autoscaling_metric_specs]: @googleapis_reference_link{google/cloud/aiplatform/v1/machine_resources.proto#L153}
   /// [google.cloud.aiplatform.v1.MutateDeployedModelRequest]: @googleapis_reference_link{google/cloud/aiplatform/v1/endpoint_service.proto#L426}
   /// [google.cloud.aiplatform.v1.MutateDeployedModelResponse]: @googleapis_reference_link{google/cloud/aiplatform/v1/endpoint_service.proto#L461}
-  /// [google.protobuf.FieldMask]: @googleapis_reference_link{google/protobuf/field_mask.proto#L242}
+  /// [google.protobuf.FieldMask]: @googleapis_reference_link{google/protobuf/field_mask.proto#L240}
   ///
   // clang-format on
   future<StatusOr<google::cloud::aiplatform::v1::MutateDeployedModelResponse>>

--- a/google/cloud/aiplatform/v1/index_client.h
+++ b/google/cloud/aiplatform/v1/index_client.h
@@ -367,7 +367,7 @@ class IndexServiceClient {
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.aiplatform.v1.Index]: @googleapis_reference_link{google/cloud/aiplatform/v1/index.proto#L36}
   /// [google.cloud.aiplatform.v1.UpdateIndexRequest]: @googleapis_reference_link{google/cloud/aiplatform/v1/index_service.proto#L205}
-  /// [google.protobuf.FieldMask]: @googleapis_reference_link{google/protobuf/field_mask.proto#L242}
+  /// [google.protobuf.FieldMask]: @googleapis_reference_link{google/protobuf/field_mask.proto#L240}
   ///
   // clang-format on
   future<StatusOr<google::cloud::aiplatform::v1::Index>> UpdateIndex(

--- a/google/cloud/aiplatform/v1/index_endpoint_client.h
+++ b/google/cloud/aiplatform/v1/index_endpoint_client.h
@@ -366,7 +366,7 @@ class IndexEndpointServiceClient {
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.aiplatform.v1.IndexEndpoint]: @googleapis_reference_link{google/cloud/aiplatform/v1/index_endpoint.proto#L36}
   /// [google.cloud.aiplatform.v1.UpdateIndexEndpointRequest]: @googleapis_reference_link{google/cloud/aiplatform/v1/index_endpoint_service.proto#L241}
-  /// [google.protobuf.FieldMask]: @googleapis_reference_link{google/protobuf/field_mask.proto#L242}
+  /// [google.protobuf.FieldMask]: @googleapis_reference_link{google/protobuf/field_mask.proto#L240}
   ///
   // clang-format on
   StatusOr<google::cloud::aiplatform::v1::IndexEndpoint> UpdateIndexEndpoint(

--- a/google/cloud/aiplatform/v1/model_client.h
+++ b/google/cloud/aiplatform/v1/model_client.h
@@ -543,7 +543,7 @@ class ModelServiceClient {
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.aiplatform.v1.Model]: @googleapis_reference_link{google/cloud/aiplatform/v1/model.proto#L38}
   /// [google.cloud.aiplatform.v1.UpdateModelRequest]: @googleapis_reference_link{google/cloud/aiplatform/v1/model_service.proto#L540}
-  /// [google.protobuf.FieldMask]: @googleapis_reference_link{google/protobuf/field_mask.proto#L242}
+  /// [google.protobuf.FieldMask]: @googleapis_reference_link{google/protobuf/field_mask.proto#L240}
   ///
   // clang-format on
   StatusOr<google::cloud::aiplatform::v1::Model> UpdateModel(

--- a/google/cloud/aiplatform/v1/notebook_client.h
+++ b/google/cloud/aiplatform/v1/notebook_client.h
@@ -496,7 +496,7 @@ class NotebookServiceClient {
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.aiplatform.v1.NotebookRuntimeTemplate]: @googleapis_reference_link{google/cloud/aiplatform/v1/notebook_runtime.proto#L54}
   /// [google.cloud.aiplatform.v1.UpdateNotebookRuntimeTemplateRequest]: @googleapis_reference_link{google/cloud/aiplatform/v1/notebook_service.proto#L385}
-  /// [google.protobuf.FieldMask]: @googleapis_reference_link{google/protobuf/field_mask.proto#L242}
+  /// [google.protobuf.FieldMask]: @googleapis_reference_link{google/protobuf/field_mask.proto#L240}
   ///
   // clang-format on
   StatusOr<google::cloud::aiplatform::v1::NotebookRuntimeTemplate>

--- a/google/cloud/aiplatform/v1/schedule_client.h
+++ b/google/cloud/aiplatform/v1/schedule_client.h
@@ -600,7 +600,7 @@ class ScheduleServiceClient {
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.aiplatform.v1.Schedule]: @googleapis_reference_link{google/cloud/aiplatform/v1/schedule.proto#L35}
   /// [google.cloud.aiplatform.v1.UpdateScheduleRequest]: @googleapis_reference_link{google/cloud/aiplatform/v1/schedule_service.proto#L298}
-  /// [google.protobuf.FieldMask]: @googleapis_reference_link{google/protobuf/field_mask.proto#L242}
+  /// [google.protobuf.FieldMask]: @googleapis_reference_link{google/protobuf/field_mask.proto#L240}
   ///
   // clang-format on
   StatusOr<google::cloud::aiplatform::v1::Schedule> UpdateSchedule(

--- a/google/cloud/config/v1/config_client.h
+++ b/google/cloud/config/v1/config_client.h
@@ -2197,7 +2197,7 @@ class ConfigClient {
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.config.v1.AutoMigrationConfig]: @googleapis_reference_link{google/cloud/config/v1/config.proto#L2630}
   /// [google.cloud.config.v1.UpdateAutoMigrationConfigRequest]: @googleapis_reference_link{google/cloud/config/v1/config.proto#L2652}
-  /// [google.protobuf.FieldMask]: @googleapis_reference_link{google/protobuf/field_mask.proto#L242}
+  /// [google.protobuf.FieldMask]: @googleapis_reference_link{google/protobuf/field_mask.proto#L240}
   ///
   // clang-format on
   future<StatusOr<google::cloud::config::v1::AutoMigrationConfig>>

--- a/google/cloud/dialogflow_cx/agents_client.h
+++ b/google/cloud/dialogflow_cx/agents_client.h
@@ -529,7 +529,7 @@ class AgentsClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.dialogflow.cx.v3.RestoreAgentRequest]: @googleapis_reference_link{google/cloud/dialogflow/cx/v3/agent.proto#L618}
-  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L51}
+  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L56}
   ///
   // clang-format on
   future<StatusOr<google::protobuf::Struct>> RestoreAgent(

--- a/google/cloud/dialogflow_cx/flows_client.h
+++ b/google/cloud/dialogflow_cx/flows_client.h
@@ -449,7 +449,7 @@ class FlowsClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.dialogflow.cx.v3.TrainFlowRequest]: @googleapis_reference_link{google/cloud/dialogflow/cx/v3/flow.proto#L526}
-  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L51}
+  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L56}
   ///
   // clang-format on
   future<StatusOr<google::protobuf::Struct>> TrainFlow(std::string const& name,
@@ -515,7 +515,7 @@ class FlowsClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.dialogflow.cx.v3.TrainFlowRequest]: @googleapis_reference_link{google/cloud/dialogflow/cx/v3/flow.proto#L526}
-  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L51}
+  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L56}
   ///
   // clang-format on
   future<StatusOr<google::protobuf::Struct>> TrainFlow(

--- a/google/cloud/dialogflow_cx/versions_client.h
+++ b/google/cloud/dialogflow_cx/versions_client.h
@@ -518,7 +518,7 @@ class VersionsClient {
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.dialogflow.cx.v3.LoadVersionRequest]: @googleapis_reference_link{google/cloud/dialogflow/cx/v3/version.proto#L286}
   /// [google.cloud.dialogflow.cx.v3.Version]: @googleapis_reference_link{google/cloud/dialogflow/cx/v3/version.proto#L147}
-  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L51}
+  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L56}
   ///
   // clang-format on
   future<StatusOr<google::protobuf::Struct>> LoadVersion(
@@ -579,7 +579,7 @@ class VersionsClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.dialogflow.cx.v3.LoadVersionRequest]: @googleapis_reference_link{google/cloud/dialogflow/cx/v3/version.proto#L286}
-  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L51}
+  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L56}
   ///
   // clang-format on
   future<StatusOr<google::protobuf::Struct>> LoadVersion(

--- a/google/cloud/dialogflow_es/agents_client.h
+++ b/google/cloud/dialogflow_es/agents_client.h
@@ -387,7 +387,7 @@ class AgentsClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.dialogflow.v2.TrainAgentRequest]: @googleapis_reference_link{google/cloud/dialogflow/v2/agent.proto#L447}
-  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L51}
+  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L56}
   ///
   // clang-format on
   future<StatusOr<google::protobuf::Struct>> TrainAgent(
@@ -452,7 +452,7 @@ class AgentsClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.dialogflow.v2.TrainAgentRequest]: @googleapis_reference_link{google/cloud/dialogflow/v2/agent.proto#L447}
-  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L51}
+  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L56}
   ///
   // clang-format on
   future<StatusOr<google::protobuf::Struct>> TrainAgent(
@@ -677,7 +677,7 @@ class AgentsClient {
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.dialogflow.v2.Agents.TrainAgent]: @googleapis_reference_link{google/cloud/dialogflow/v2/agent.proto#L111}
   /// [google.cloud.dialogflow.v2.ImportAgentRequest]: @googleapis_reference_link{google/cloud/dialogflow/v2/agent.proto#L499}
-  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L51}
+  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L56}
   ///
   // clang-format on
   future<StatusOr<google::protobuf::Struct>> ImportAgent(
@@ -768,7 +768,7 @@ class AgentsClient {
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.dialogflow.v2.Agents.TrainAgent]: @googleapis_reference_link{google/cloud/dialogflow/v2/agent.proto#L111}
   /// [google.cloud.dialogflow.v2.RestoreAgentRequest]: @googleapis_reference_link{google/cloud/dialogflow/v2/agent.proto#L528}
-  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L51}
+  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L56}
   ///
   // clang-format on
   future<StatusOr<google::protobuf::Struct>> RestoreAgent(

--- a/google/cloud/dialogflow_es/entity_types_client.h
+++ b/google/cloud/dialogflow_es/entity_types_client.h
@@ -687,7 +687,7 @@ class EntityTypesClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.dialogflow.v2.BatchDeleteEntityTypesRequest]: @googleapis_reference_link{google/cloud/dialogflow/v2/entity_type.proto#L546}
-  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L51}
+  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L56}
   ///
   // clang-format on
   future<StatusOr<google::protobuf::Struct>> BatchDeleteEntityTypes(
@@ -753,7 +753,7 @@ class EntityTypesClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.dialogflow.v2.BatchDeleteEntityTypesRequest]: @googleapis_reference_link{google/cloud/dialogflow/v2/entity_type.proto#L546}
-  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L51}
+  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L56}
   ///
   // clang-format on
   future<StatusOr<google::protobuf::Struct>> BatchDeleteEntityTypes(
@@ -831,7 +831,7 @@ class EntityTypesClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.dialogflow.v2.BatchCreateEntitiesRequest]: @googleapis_reference_link{google/cloud/dialogflow/v2/entity_type.proto#L564}
-  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L51}
+  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L56}
   ///
   // clang-format on
   future<StatusOr<google::protobuf::Struct>> BatchCreateEntities(
@@ -903,7 +903,7 @@ class EntityTypesClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.dialogflow.v2.BatchCreateEntitiesRequest]: @googleapis_reference_link{google/cloud/dialogflow/v2/entity_type.proto#L564}
-  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L51}
+  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L56}
   ///
   // clang-format on
   future<StatusOr<google::protobuf::Struct>> BatchCreateEntities(
@@ -973,7 +973,7 @@ class EntityTypesClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.dialogflow.v2.BatchCreateEntitiesRequest]: @googleapis_reference_link{google/cloud/dialogflow/v2/entity_type.proto#L564}
-  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L51}
+  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L56}
   ///
   // clang-format on
   future<StatusOr<google::protobuf::Struct>> BatchCreateEntities(
@@ -1052,7 +1052,7 @@ class EntityTypesClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.dialogflow.v2.BatchUpdateEntitiesRequest]: @googleapis_reference_link{google/cloud/dialogflow/v2/entity_type.proto#L588}
-  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L51}
+  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L56}
   ///
   // clang-format on
   future<StatusOr<google::protobuf::Struct>> BatchUpdateEntities(
@@ -1127,7 +1127,7 @@ class EntityTypesClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.dialogflow.v2.BatchUpdateEntitiesRequest]: @googleapis_reference_link{google/cloud/dialogflow/v2/entity_type.proto#L588}
-  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L51}
+  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L56}
   ///
   // clang-format on
   future<StatusOr<google::protobuf::Struct>> BatchUpdateEntities(
@@ -1200,7 +1200,7 @@ class EntityTypesClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.dialogflow.v2.BatchUpdateEntitiesRequest]: @googleapis_reference_link{google/cloud/dialogflow/v2/entity_type.proto#L588}
-  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L51}
+  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L56}
   ///
   // clang-format on
   future<StatusOr<google::protobuf::Struct>> BatchUpdateEntities(
@@ -1278,7 +1278,7 @@ class EntityTypesClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.dialogflow.v2.BatchDeleteEntitiesRequest]: @googleapis_reference_link{google/cloud/dialogflow/v2/entity_type.proto#L616}
-  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L51}
+  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L56}
   ///
   // clang-format on
   future<StatusOr<google::protobuf::Struct>> BatchDeleteEntities(
@@ -1348,7 +1348,7 @@ class EntityTypesClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.dialogflow.v2.BatchDeleteEntitiesRequest]: @googleapis_reference_link{google/cloud/dialogflow/v2/entity_type.proto#L616}
-  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L51}
+  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L56}
   ///
   // clang-format on
   future<StatusOr<google::protobuf::Struct>> BatchDeleteEntities(
@@ -1415,7 +1415,7 @@ class EntityTypesClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.dialogflow.v2.BatchDeleteEntitiesRequest]: @googleapis_reference_link{google/cloud/dialogflow/v2/entity_type.proto#L616}
-  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L51}
+  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L56}
   ///
   // clang-format on
   future<StatusOr<google::protobuf::Struct>> BatchDeleteEntities(

--- a/google/cloud/dialogflow_es/intents_client.h
+++ b/google/cloud/dialogflow_es/intents_client.h
@@ -831,7 +831,7 @@ class IntentsClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.dialogflow.v2.BatchDeleteIntentsRequest]: @googleapis_reference_link{google/cloud/dialogflow/v2/intent.proto#L1117}
-  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L51}
+  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L56}
   ///
   // clang-format on
   future<StatusOr<google::protobuf::Struct>> BatchDeleteIntents(
@@ -899,7 +899,7 @@ class IntentsClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.dialogflow.v2.BatchDeleteIntentsRequest]: @googleapis_reference_link{google/cloud/dialogflow/v2/intent.proto#L1117}
-  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L51}
+  /// [google.protobuf.Struct]: @googleapis_reference_link{google/protobuf/struct.proto#L56}
   ///
   // clang-format on
   future<StatusOr<google::protobuf::Struct>> BatchDeleteIntents(

--- a/google/cloud/logging/v2/config_service_v2_client.h
+++ b/google/cloud/logging/v2/config_service_v2_client.h
@@ -2030,7 +2030,7 @@ class ConfigServiceV2Client {
   /// [google.logging.v2.ConfigServiceV2.UpdateSettings]: @googleapis_reference_link{google/logging/v2/logging_config.proto#L747}
   /// [google.logging.v2.Settings]: @googleapis_reference_link{google/logging/v2/logging_config.proto#L2086}
   /// [google.logging.v2.UpdateSettingsRequest]: @googleapis_reference_link{google/logging/v2/logging_config.proto#L2052}
-  /// [google.protobuf.FieldMask]: @googleapis_reference_link{google/protobuf/field_mask.proto#L242}
+  /// [google.protobuf.FieldMask]: @googleapis_reference_link{google/protobuf/field_mask.proto#L240}
   ///
   // clang-format on
   StatusOr<google::logging::v2::Settings> UpdateSettings(

--- a/google/cloud/redis/cluster/v1/cloud_redis_cluster_client.h
+++ b/google/cloud/redis/cluster/v1/cloud_redis_cluster_client.h
@@ -413,7 +413,7 @@ class CloudRedisClusterClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.redis.cluster.v1.DeleteClusterRequest]: @googleapis_reference_link{google/cloud/redis/cluster/v1/cloud_redis_cluster.proto#L484}
-  /// [google.protobuf.Any]: @googleapis_reference_link{google/protobuf/any.proto#L128}
+  /// [google.protobuf.Any]: @googleapis_reference_link{google/protobuf/any.proto#L72}
   ///
   // clang-format on
   future<StatusOr<google::protobuf::Any>> DeleteCluster(std::string const& name,
@@ -465,7 +465,7 @@ class CloudRedisClusterClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.redis.cluster.v1.DeleteClusterRequest]: @googleapis_reference_link{google/cloud/redis/cluster/v1/cloud_redis_cluster.proto#L484}
-  /// [google.protobuf.Any]: @googleapis_reference_link{google/protobuf/any.proto#L128}
+  /// [google.protobuf.Any]: @googleapis_reference_link{google/protobuf/any.proto#L72}
   ///
   // clang-format on
   future<StatusOr<google::protobuf::Any>> DeleteCluster(
@@ -1201,7 +1201,7 @@ class CloudRedisClusterClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.redis.cluster.v1.DeleteBackupRequest]: @googleapis_reference_link{google/cloud/redis/cluster/v1/cloud_redis_cluster.proto#L622}
-  /// [google.protobuf.Any]: @googleapis_reference_link{google/protobuf/any.proto#L128}
+  /// [google.protobuf.Any]: @googleapis_reference_link{google/protobuf/any.proto#L72}
   ///
   // clang-format on
   future<StatusOr<google::protobuf::Any>> DeleteBackup(std::string const& name,
@@ -1253,7 +1253,7 @@ class CloudRedisClusterClient {
   /// [`StatusOr`]: @ref google::cloud::StatusOr
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.redis.cluster.v1.DeleteBackupRequest]: @googleapis_reference_link{google/cloud/redis/cluster/v1/cloud_redis_cluster.proto#L622}
-  /// [google.protobuf.Any]: @googleapis_reference_link{google/protobuf/any.proto#L128}
+  /// [google.protobuf.Any]: @googleapis_reference_link{google/protobuf/any.proto#L72}
   ///
   // clang-format on
   future<StatusOr<google::protobuf::Any>> DeleteBackup(

--- a/google/cloud/vectorsearch/v1/data_object_client.h
+++ b/google/cloud/vectorsearch/v1/data_object_client.h
@@ -265,7 +265,7 @@ class DataObjectServiceClient {
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.vectorsearch.v1.DataObject]: @googleapis_reference_link{google/cloud/vectorsearch/v1/data_object.proto#L33}
   /// [google.cloud.vectorsearch.v1.UpdateDataObjectRequest]: @googleapis_reference_link{google/cloud/vectorsearch/v1/data_object_service.proto#L173}
-  /// [google.protobuf.FieldMask]: @googleapis_reference_link{google/protobuf/field_mask.proto#L242}
+  /// [google.protobuf.FieldMask]: @googleapis_reference_link{google/protobuf/field_mask.proto#L240}
   ///
   // clang-format on
   StatusOr<google::cloud::vectorsearch::v1::DataObject> UpdateDataObject(

--- a/google/cloud/vision/v1/product_search_client.h
+++ b/google/cloud/vision/v1/product_search_client.h
@@ -369,7 +369,7 @@ class ProductSearchClient {
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.vision.v1.ProductSet]: @googleapis_reference_link{google/cloud/vision/v1/product_search_service.proto#L437}
   /// [google.cloud.vision.v1.UpdateProductSetRequest]: @googleapis_reference_link{google/cloud/vision/v1/product_search_service.proto#L661}
-  /// [google.protobuf.FieldMask]: @googleapis_reference_link{google/protobuf/field_mask.proto#L242}
+  /// [google.protobuf.FieldMask]: @googleapis_reference_link{google/protobuf/field_mask.proto#L240}
   ///
   // clang-format on
   StatusOr<google::cloud::vision::v1::ProductSet> UpdateProductSet(
@@ -744,7 +744,7 @@ class ProductSearchClient {
   /// [`Status`]: @ref google::cloud::Status
   /// [google.cloud.vision.v1.Product]: @googleapis_reference_link{google/cloud/vision/v1/product_search_service.proto#L378}
   /// [google.cloud.vision.v1.UpdateProductRequest]: @googleapis_reference_link{google/cloud/vision/v1/product_search_service.proto#L570}
-  /// [google.protobuf.FieldMask]: @googleapis_reference_link{google/protobuf/field_mask.proto#L242}
+  /// [google.protobuf.FieldMask]: @googleapis_reference_link{google/protobuf/field_mask.proto#L240}
   ///
   // clang-format on
   StatusOr<google::cloud::vision::v1::Product> UpdateProduct(


### PR DESCRIPTION
In order to maintain existing coverage in our test matrix, only some CI builds are being updated with gRPC v1.83.0.