### PR TITLE
feat(storage): Make PrecomputedChecksumsOption compatible with Options

### DIFF
--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -141,8 +141,14 @@ ObjectWriteStream Client::WriteObjectImpl(
       response->committed_size, std::move(response->metadata), buffer_size,
       internal::CreateHashFunction(request),
       internal::HashValues{
-          request.GetOption<Crc32cChecksumValue>().value_or(""),
-          request.GetOption<MD5HashValue>().value_or(""),
+          request.GetOption<Crc32cChecksumValue>().value_or(
+              current.has<Crc32cChecksumValue>()
+                  ? current.get<Crc32cChecksumValue>()
+                  : ""),
+          request.GetOption<MD5HashValue>().value_or(
+              current.has<MD5HashValue>()
+                  ? current.get<MD5HashValue>()
+                  : ""),
       },
       internal::CreateHashValidator(request),
       request.GetOption<AutoFinalize>().value_or(

--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -142,12 +142,12 @@ ObjectWriteStream Client::WriteObjectImpl(
       internal::CreateHashFunction(request),
       [&]() {
         auto crc = request.GetOption<Crc32cChecksumValue>().value_or("");
-        if (crc.empty() && current.has<PrecomputedChecksumsOption>()) {
-          crc = current.get<PrecomputedChecksumsOption>().crc32c;
-        }
         auto md5 = request.GetOption<MD5HashValue>().value_or("");
-        if (md5.empty() && current.has<PrecomputedChecksumsOption>()) {
-          md5 = current.get<PrecomputedChecksumsOption>().md5;
+        if ((crc.empty() || md5.empty()) &&
+            current.has<PrecomputedChecksumsOption>()) {
+          auto const& checksums = current.get<PrecomputedChecksumsOption>();
+          if (crc.empty()) crc = checksums.crc32c;
+          if (md5.empty()) md5 = checksums.md5;
         }
         return internal::HashValues{std::move(crc), std::move(md5)};
       }(),

--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -140,16 +140,21 @@ ObjectWriteStream Client::WriteObjectImpl(
       connection_, request, std::move(response->upload_id),
       response->committed_size, std::move(response->metadata), buffer_size,
       internal::CreateHashFunction(request),
-      internal::HashValues{
-          request.GetOption<Crc32cChecksumValue>().value_or(
-              current.has<Crc32cChecksumValue>()
-                  ? current.get<Crc32cChecksumValue>()
-                  : ""),
-          request.GetOption<MD5HashValue>().value_or(
-              current.has<MD5HashValue>()
-                  ? current.get<MD5HashValue>()
-                  : ""),
-      },
+      [&]() {
+        auto crc = request.GetOption<Crc32cChecksumValue>().value_or("");
+        if (crc.empty() && current.has<PrecomputedChecksumsOption>()) {
+          auto m = current.get<PrecomputedChecksumsOption>();
+          auto it = m.find(ChecksumAlgorithm::kCrc32c);
+          if (it != m.end()) crc = it->second;
+        }
+        auto md5 = request.GetOption<MD5HashValue>().value_or("");
+        if (md5.empty() && current.has<PrecomputedChecksumsOption>()) {
+          auto m = current.get<PrecomputedChecksumsOption>();
+          auto it = m.find(ChecksumAlgorithm::kMD5);
+          if (it != m.end()) md5 = it->second;
+        }
+        return internal::HashValues{std::move(crc), std::move(md5)};
+      }(),
       internal::CreateHashValidator(request),
       request.GetOption<AutoFinalize>().value_or(
           AutoFinalizeConfig::kEnabled)));

--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -143,15 +143,11 @@ ObjectWriteStream Client::WriteObjectImpl(
       [&]() {
         auto crc = request.GetOption<Crc32cChecksumValue>().value_or("");
         if (crc.empty() && current.has<PrecomputedChecksumsOption>()) {
-          auto m = current.get<PrecomputedChecksumsOption>();
-          auto it = m.find(ChecksumAlgorithm::kCrc32c);
-          if (it != m.end()) crc = it->second;
+          crc = current.get<PrecomputedChecksumsOption>().crc32c;
         }
         auto md5 = request.GetOption<MD5HashValue>().value_or("");
         if (md5.empty() && current.has<PrecomputedChecksumsOption>()) {
-          auto m = current.get<PrecomputedChecksumsOption>();
-          auto it = m.find(ChecksumAlgorithm::kMD5);
-          if (it != m.end()) md5 = it->second;
+          md5 = current.get<PrecomputedChecksumsOption>().md5;
         }
         return internal::HashValues{std::move(crc), std::move(md5)};
       }(),

--- a/google/cloud/storage/hashing_options.h
+++ b/google/cloud/storage/hashing_options.h
@@ -41,6 +41,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct MD5HashValue
     : public internal::ComplexOption<MD5HashValue, std::string> {
   using ComplexOption<MD5HashValue, std::string>::ComplexOption;
+  using Type = std::string;
   // GCC <= 7.0 does not use the inherited default constructor, redeclare it
   // explicitly
   MD5HashValue() = default;
@@ -110,6 +111,7 @@ inline DisableMD5Hash EnableMD5Hash() { return DisableMD5Hash(false); }
 struct Crc32cChecksumValue
     : public internal::ComplexOption<Crc32cChecksumValue, std::string> {
   using ComplexOption<Crc32cChecksumValue, std::string>::ComplexOption;
+  using Type = std::string;
   // GCC <= 7.0 does not use the inherited default constructor, redeclare it
   // explicitly
   Crc32cChecksumValue() = default;

--- a/google/cloud/storage/hashing_options.h
+++ b/google/cloud/storage/hashing_options.h
@@ -41,7 +41,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct MD5HashValue
     : public internal::ComplexOption<MD5HashValue, std::string> {
   using ComplexOption<MD5HashValue, std::string>::ComplexOption;
-  using Type = std::string;
   // GCC <= 7.0 does not use the inherited default constructor, redeclare it
   // explicitly
   MD5HashValue() = default;
@@ -111,7 +110,6 @@ inline DisableMD5Hash EnableMD5Hash() { return DisableMD5Hash(false); }
 struct Crc32cChecksumValue
     : public internal::ComplexOption<Crc32cChecksumValue, std::string> {
   using ComplexOption<Crc32cChecksumValue, std::string>::ComplexOption;
-  using Type = std::string;
   // GCC <= 7.0 does not use the inherited default constructor, redeclare it
   // explicitly
   Crc32cChecksumValue() = default;

--- a/google/cloud/storage/hashing_options.h
+++ b/google/cloud/storage/hashing_options.h
@@ -38,6 +38,17 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * @see
  * https://sigops.org/s/conferences/hotos/2021/papers/hotos21-s01-hochschild.pdf
  */
+
+/**
+ * A structure to hold precomputed hashes.
+ *
+ * @ingroup storage-options
+ */
+struct PrecomputedChecksums {
+  std::string crc32c;
+  std::string md5;
+};
+
 struct MD5HashValue
     : public internal::ComplexOption<MD5HashValue, std::string> {
   using ComplexOption<MD5HashValue, std::string>::ComplexOption;

--- a/google/cloud/storage/internal/hash_function.cc
+++ b/google/cloud/storage/internal/hash_function.cc
@@ -32,8 +32,12 @@ std::unique_ptr<HashFunction> CreateHashFunction(
     Crc32cChecksumValue const& crc32c_value,
     DisableCrc32cChecksum const& crc32c_disabled, MD5HashValue const& md5_value,
     DisableMD5Hash const& md5_disabled) {
+  auto const& options = google::cloud::internal::CurrentOptions();
   auto crc32c = std::unique_ptr<HashFunction>();
-  auto crc32c_v = crc32c_value.value_or("");
+  auto crc32c_v = crc32c_value.value_or(
+      options.has<Crc32cChecksumValue>()
+          ? options.get<Crc32cChecksumValue>()
+          : "");
   if (!crc32c_v.empty()) {
     crc32c = std::make_unique<PrecomputedHashFunction>(
         HashValues{/*.crc32c=*/std::move(crc32c_v), /*md5=*/{}});
@@ -42,7 +46,10 @@ std::unique_ptr<HashFunction> CreateHashFunction(
   }
 
   auto md5 = std::unique_ptr<HashFunction>();
-  auto md5_v = md5_value.value_or("");
+  auto md5_v = md5_value.value_or(
+      options.has<MD5HashValue>()
+          ? options.get<MD5HashValue>()
+          : "");
   if (!md5_v.empty()) {
     md5 = std::make_unique<PrecomputedHashFunction>(
         HashValues{/*.crc32c=*/{}, /*.md5=*/std::move(md5_v)});

--- a/google/cloud/storage/internal/hash_function.cc
+++ b/google/cloud/storage/internal/hash_function.cc
@@ -34,10 +34,15 @@ std::unique_ptr<HashFunction> CreateHashFunction(
     DisableMD5Hash const& md5_disabled) {
   auto const& options = google::cloud::internal::CurrentOptions();
   auto crc32c = std::unique_ptr<HashFunction>();
-  auto crc32c_v = crc32c_value.value_or(
-      options.has<Crc32cChecksumValue>()
-          ? options.get<Crc32cChecksumValue>()
-          : "");
+  auto crc32c_v = crc32c_value.value_or("");
+  if (crc32c_v.empty() && options.has<Crc32cChecksumValue>()) {
+    crc32c_v = options.get<Crc32cChecksumValue>();
+  }
+  if (crc32c_v.empty() && options.has<PrecomputedChecksumsOption>()) {
+    auto m = options.get<PrecomputedChecksumsOption>();
+    auto it = m.find(ChecksumAlgorithm::kCrc32c);
+    if (it != m.end()) crc32c_v = it->second;
+  }
   if (!crc32c_v.empty()) {
     crc32c = std::make_unique<PrecomputedHashFunction>(
         HashValues{/*.crc32c=*/std::move(crc32c_v), /*md5=*/{}});
@@ -46,10 +51,15 @@ std::unique_ptr<HashFunction> CreateHashFunction(
   }
 
   auto md5 = std::unique_ptr<HashFunction>();
-  auto md5_v = md5_value.value_or(
-      options.has<MD5HashValue>()
-          ? options.get<MD5HashValue>()
-          : "");
+  auto md5_v = md5_value.value_or("");
+  if (md5_v.empty() && options.has<MD5HashValue>()) {
+    md5_v = options.get<MD5HashValue>();
+  }
+  if (md5_v.empty() && options.has<PrecomputedChecksumsOption>()) {
+    auto m = options.get<PrecomputedChecksumsOption>();
+    auto it = m.find(ChecksumAlgorithm::kMD5);
+    if (it != m.end()) md5_v = it->second;
+  }
   if (!md5_v.empty()) {
     md5 = std::make_unique<PrecomputedHashFunction>(
         HashValues{/*.crc32c=*/{}, /*.md5=*/std::move(md5_v)});

--- a/google/cloud/storage/internal/hash_function.cc
+++ b/google/cloud/storage/internal/hash_function.cc
@@ -35,9 +35,6 @@ std::unique_ptr<HashFunction> CreateHashFunction(
   auto const& options = google::cloud::internal::CurrentOptions();
   auto crc32c = std::unique_ptr<HashFunction>();
   auto crc32c_v = crc32c_value.value_or("");
-  if (crc32c_v.empty() && options.has<Crc32cChecksumValue>()) {
-    crc32c_v = options.get<Crc32cChecksumValue>();
-  }
   if (crc32c_v.empty() && options.has<PrecomputedChecksumsOption>()) {
     auto m = options.get<PrecomputedChecksumsOption>();
     auto it = m.find(ChecksumAlgorithm::kCrc32c);
@@ -52,9 +49,6 @@ std::unique_ptr<HashFunction> CreateHashFunction(
 
   auto md5 = std::unique_ptr<HashFunction>();
   auto md5_v = md5_value.value_or("");
-  if (md5_v.empty() && options.has<MD5HashValue>()) {
-    md5_v = options.get<MD5HashValue>();
-  }
   if (md5_v.empty() && options.has<PrecomputedChecksumsOption>()) {
     auto m = options.get<PrecomputedChecksumsOption>();
     auto it = m.find(ChecksumAlgorithm::kMD5);

--- a/google/cloud/storage/internal/hash_function.cc
+++ b/google/cloud/storage/internal/hash_function.cc
@@ -36,9 +36,7 @@ std::unique_ptr<HashFunction> CreateHashFunction(
   auto crc32c = std::unique_ptr<HashFunction>();
   auto crc32c_v = crc32c_value.value_or("");
   if (crc32c_v.empty() && options.has<PrecomputedChecksumsOption>()) {
-    auto m = options.get<PrecomputedChecksumsOption>();
-    auto it = m.find(ChecksumAlgorithm::kCrc32c);
-    if (it != m.end()) crc32c_v = it->second;
+    crc32c_v = options.get<PrecomputedChecksumsOption>().crc32c;
   }
   if (!crc32c_v.empty()) {
     crc32c = std::make_unique<PrecomputedHashFunction>(
@@ -50,9 +48,7 @@ std::unique_ptr<HashFunction> CreateHashFunction(
   auto md5 = std::unique_ptr<HashFunction>();
   auto md5_v = md5_value.value_or("");
   if (md5_v.empty() && options.has<PrecomputedChecksumsOption>()) {
-    auto m = options.get<PrecomputedChecksumsOption>();
-    auto it = m.find(ChecksumAlgorithm::kMD5);
-    if (it != m.end()) md5_v = it->second;
+    md5_v = options.get<PrecomputedChecksumsOption>().md5;
   }
   if (!md5_v.empty()) {
     md5 = std::make_unique<PrecomputedHashFunction>(

--- a/google/cloud/storage/internal/hash_function.cc
+++ b/google/cloud/storage/internal/hash_function.cc
@@ -35,20 +35,20 @@ std::unique_ptr<HashFunction> CreateHashFunction(
   auto const& options = google::cloud::internal::CurrentOptions();
   auto crc32c = std::unique_ptr<HashFunction>();
   auto crc32c_v = crc32c_value.value_or("");
-  if (crc32c_v.empty() && options.has<PrecomputedChecksumsOption>()) {
-    crc32c_v = options.get<PrecomputedChecksumsOption>().crc32c;
+  auto md5 = std::unique_ptr<HashFunction>();
+  auto md5_v = md5_value.value_or("");
+
+  if ((crc32c_v.empty() || md5_v.empty()) &&
+      options.has<PrecomputedChecksumsOption>()) {
+    auto const& checksums = options.get<PrecomputedChecksumsOption>();
+    if (crc32c_v.empty()) crc32c_v = checksums.crc32c;
+    if (md5_v.empty()) md5_v = checksums.md5;
   }
   if (!crc32c_v.empty()) {
     crc32c = std::make_unique<PrecomputedHashFunction>(
         HashValues{/*.crc32c=*/std::move(crc32c_v), /*md5=*/{}});
   } else if (!crc32c_disabled.value_or(false)) {
     crc32c = std::make_unique<Crc32cHashFunction>();
-  }
-
-  auto md5 = std::unique_ptr<HashFunction>();
-  auto md5_v = md5_value.value_or("");
-  if (md5_v.empty() && options.has<PrecomputedChecksumsOption>()) {
-    md5_v = options.get<PrecomputedChecksumsOption>().md5;
   }
   if (!md5_v.empty()) {
     md5 = std::make_unique<PrecomputedHashFunction>(

--- a/google/cloud/storage/internal/hash_function_impl_test.cc
+++ b/google/cloud/storage/internal/hash_function_impl_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/internal/object_requests.h"
 #include "google/cloud/storage/testing/mock_hash_function.h"
 #include "google/cloud/storage/testing/upload_hash_cases.h"
+#include "google/cloud/options.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <memory>
@@ -450,10 +451,48 @@ TEST(HashFunctionImplTest, CreateHashFunctionInsertObjectMedia) {
   }
 }
 
+TEST(HashFunctionImplTest, CreateHashFunctionPrecomputedChecksumsOption) {
+  google::cloud::internal::OptionsSpan span(
+      google::cloud::Options{}.set<PrecomputedChecksumsOption>(
+          PrecomputedChecksums{"crc-from-options", "md5-from-options"}));
+
+  ResumableUploadRequest request("bucket", "object");
+  auto function = CreateHashFunction(request);
+  EXPECT_EQ(function->Finish().crc32c, "crc-from-options");
+  EXPECT_EQ(function->Finish().md5, "md5-from-options");
+}
+
+TEST(HashFunctionImplTest,
+     CreateHashFunctionPrecomputedChecksumsOptionPartial) {
+  google::cloud::internal::OptionsSpan span(
+      google::cloud::Options{}.set<PrecomputedChecksumsOption>(
+          PrecomputedChecksums{"crc-from-options", ""}));
+
+  ResumableUploadRequest request("bucket", "object");
+  auto function = CreateHashFunction(request);
+  EXPECT_EQ(function->Finish().crc32c, "crc-from-options");
+  // MD5 is disabled by default for uploads, so it will be empty
+  EXPECT_EQ(function->Finish().md5, "");
+}
+
+TEST(HashFunctionImplTest, CreateHashFunctionPrecedence) {
+  google::cloud::internal::OptionsSpan span(
+      google::cloud::Options{}.set<PrecomputedChecksumsOption>(
+          PrecomputedChecksums{"crc-from-options", "md5-from-options"}));
+
+  ResumableUploadRequest request("bucket", "object");
+  request.set_multiple_options(Crc32cChecksumValue("crc-from-request"),
+                               MD5HashValue("md5-from-request"));
+  auto function = CreateHashFunction(request);
+  // The variadic options provided directly to the request should take
+  // precedence
+  EXPECT_EQ(function->Finish().crc32c, "crc-from-request");
+  EXPECT_EQ(function->Finish().md5, "md5-from-request");
+}
+
 }  // namespace
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
 }  // namespace cloud
 }  // namespace google
-#include "google/cloud/internal/diagnostics_pop.inc"

--- a/google/cloud/storage/internal/rest/stub.cc
+++ b/google/cloud/storage/internal/rest/stub.cc
@@ -714,15 +714,20 @@ StatusOr<CreateResumableUploadResponse> RestStub::CreateResumableUpload(
   }
   if (request.HasOption<Crc32cChecksumValue>()) {
     resource["crc32c"] = request.GetOption<Crc32cChecksumValue>().value();
-  } else if (options.has<PrecomputedChecksumsOption>() &&
-             !options.get<PrecomputedChecksumsOption>().crc32c.empty()) {
-    resource["crc32c"] = options.get<PrecomputedChecksumsOption>().crc32c;
   }
   if (request.HasOption<MD5HashValue>()) {
     resource["md5Hash"] = request.GetOption<MD5HashValue>().value();
-  } else if (options.has<PrecomputedChecksumsOption>() &&
-             !options.get<PrecomputedChecksumsOption>().md5.empty()) {
-    resource["md5Hash"] = options.get<PrecomputedChecksumsOption>().md5;
+  }
+
+  if (options.has<PrecomputedChecksumsOption>()) {
+    auto const& checksums = options.get<PrecomputedChecksumsOption>();
+    if (!request.HasOption<Crc32cChecksumValue>() &&
+        !checksums.crc32c.empty()) {
+      resource["crc32c"] = checksums.crc32c;
+    }
+    if (!request.HasOption<MD5HashValue>() && !checksums.md5.empty()) {
+      resource["md5Hash"] = checksums.md5;
+    }
   }
 
   if (resource.empty()) {

--- a/google/cloud/storage/internal/rest/stub.cc
+++ b/google/cloud/storage/internal/rest/stub.cc
@@ -464,8 +464,7 @@ StatusOr<ObjectMetadata> RestStub::InsertObjectMedia(
       storage::internal::GetUploadChecksumSettings(request, options);
   if (!settings.md5 || !settings.crc32c || request.HasOption<MD5HashValue>() ||
       request.HasOption<Crc32cChecksumValue>() ||
-      options.has<MD5HashValue>() ||
-      options.has<Crc32cChecksumValue>()) {
+      options.has<PrecomputedChecksumsOption>()) {
     return InsertObjectMediaMultipart(context, options, request);
   }
 

--- a/google/cloud/storage/internal/rest/stub.cc
+++ b/google/cloud/storage/internal/rest/stub.cc
@@ -714,17 +714,15 @@ StatusOr<CreateResumableUploadResponse> RestStub::CreateResumableUpload(
   }
   if (request.HasOption<Crc32cChecksumValue>()) {
     resource["crc32c"] = request.GetOption<Crc32cChecksumValue>().value();
-  } else if (options.has<PrecomputedChecksumsOption>()) {
-    auto m = options.get<PrecomputedChecksumsOption>();
-    auto it = m.find(ChecksumAlgorithm::kCrc32c);
-    if (it != m.end()) resource["crc32c"] = it->second;
+  } else if (options.has<PrecomputedChecksumsOption>() &&
+             !options.get<PrecomputedChecksumsOption>().crc32c.empty()) {
+    resource["crc32c"] = options.get<PrecomputedChecksumsOption>().crc32c;
   }
   if (request.HasOption<MD5HashValue>()) {
     resource["md5Hash"] = request.GetOption<MD5HashValue>().value();
-  } else if (options.has<PrecomputedChecksumsOption>()) {
-    auto m = options.get<PrecomputedChecksumsOption>();
-    auto it = m.find(ChecksumAlgorithm::kMD5);
-    if (it != m.end()) resource["md5Hash"] = it->second;
+  } else if (options.has<PrecomputedChecksumsOption>() &&
+             !options.get<PrecomputedChecksumsOption>().md5.empty()) {
+    resource["md5Hash"] = options.get<PrecomputedChecksumsOption>().md5;
   }
 
   if (resource.empty()) {

--- a/google/cloud/storage/internal/rest/stub.cc
+++ b/google/cloud/storage/internal/rest/stub.cc
@@ -717,11 +717,19 @@ StatusOr<CreateResumableUploadResponse> RestStub::CreateResumableUpload(
     resource["crc32c"] = request.GetOption<Crc32cChecksumValue>().value();
   } else if (options.has<Crc32cChecksumValue>()) {
     resource["crc32c"] = options.get<Crc32cChecksumValue>();
+  } else if (options.has<PrecomputedChecksumsOption>()) {
+    auto m = options.get<PrecomputedChecksumsOption>();
+    auto it = m.find(ChecksumAlgorithm::kCrc32c);
+    if (it != m.end()) resource["crc32c"] = it->second;
   }
   if (request.HasOption<MD5HashValue>()) {
     resource["md5Hash"] = request.GetOption<MD5HashValue>().value();
   } else if (options.has<MD5HashValue>()) {
     resource["md5Hash"] = options.get<MD5HashValue>();
+  } else if (options.has<PrecomputedChecksumsOption>()) {
+    auto m = options.get<PrecomputedChecksumsOption>();
+    auto it = m.find(ChecksumAlgorithm::kMD5);
+    if (it != m.end()) resource["md5Hash"] = it->second;
   }
 
   if (resource.empty()) {

--- a/google/cloud/storage/internal/rest/stub.cc
+++ b/google/cloud/storage/internal/rest/stub.cc
@@ -463,7 +463,9 @@ StatusOr<ObjectMetadata> RestStub::InsertObjectMedia(
   auto const settings =
       storage::internal::GetUploadChecksumSettings(request, options);
   if (!settings.md5 || !settings.crc32c || request.HasOption<MD5HashValue>() ||
-      request.HasOption<Crc32cChecksumValue>()) {
+      request.HasOption<Crc32cChecksumValue>() ||
+      options.has<MD5HashValue>() ||
+      options.has<Crc32cChecksumValue>()) {
     return InsertObjectMediaMultipart(context, options, request);
   }
 
@@ -713,9 +715,13 @@ StatusOr<CreateResumableUploadResponse> RestStub::CreateResumableUpload(
   }
   if (request.HasOption<Crc32cChecksumValue>()) {
     resource["crc32c"] = request.GetOption<Crc32cChecksumValue>().value();
+  } else if (options.has<Crc32cChecksumValue>()) {
+    resource["crc32c"] = options.get<Crc32cChecksumValue>();
   }
   if (request.HasOption<MD5HashValue>()) {
     resource["md5Hash"] = request.GetOption<MD5HashValue>().value();
+  } else if (options.has<MD5HashValue>()) {
+    resource["md5Hash"] = options.get<MD5HashValue>();
   }
 
   if (resource.empty()) {

--- a/google/cloud/storage/internal/rest/stub.cc
+++ b/google/cloud/storage/internal/rest/stub.cc
@@ -715,8 +715,6 @@ StatusOr<CreateResumableUploadResponse> RestStub::CreateResumableUpload(
   }
   if (request.HasOption<Crc32cChecksumValue>()) {
     resource["crc32c"] = request.GetOption<Crc32cChecksumValue>().value();
-  } else if (options.has<Crc32cChecksumValue>()) {
-    resource["crc32c"] = options.get<Crc32cChecksumValue>();
   } else if (options.has<PrecomputedChecksumsOption>()) {
     auto m = options.get<PrecomputedChecksumsOption>();
     auto it = m.find(ChecksumAlgorithm::kCrc32c);
@@ -724,8 +722,6 @@ StatusOr<CreateResumableUploadResponse> RestStub::CreateResumableUpload(
   }
   if (request.HasOption<MD5HashValue>()) {
     resource["md5Hash"] = request.GetOption<MD5HashValue>().value();
-  } else if (options.has<MD5HashValue>()) {
-    resource["md5Hash"] = options.get<MD5HashValue>();
   } else if (options.has<PrecomputedChecksumsOption>()) {
     auto m = options.get<PrecomputedChecksumsOption>();
     auto it = m.find(ChecksumAlgorithm::kMD5);

--- a/google/cloud/storage/options.h
+++ b/google/cloud/storage/options.h
@@ -136,7 +136,6 @@ struct PrecomputedChecksumsOption {
   using Type = std::map<ChecksumAlgorithm, std::string>;
 };
 
-
 /**
  * Configure the REST endpoint for the GCS client library.
  *
@@ -393,8 +392,7 @@ using ClientOptionList = ::google::cloud::OptionList<
     TransferStallTimeoutOption, RetryPolicyOption, BackoffPolicyOption,
     IdempotencyPolicyOption, CARootsFilePathOption,
     UploadChecksumValidationOption, DownloadChecksumValidationOption,
-    PrecomputedChecksumsOption,
-    storage_experimental::HttpVersionOption,
+    PrecomputedChecksumsOption, storage_experimental::HttpVersionOption,
     storage_experimental::OTelSpanEnrichmentOption>;
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/options.h
+++ b/google/cloud/storage/options.h
@@ -25,7 +25,6 @@
 #include "google/cloud/options.h"
 #include <chrono>
 #include <cstdint>
-#include <map>
 #include <memory>
 #include <string>
 

--- a/google/cloud/storage/options.h
+++ b/google/cloud/storage/options.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OPTIONS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OPTIONS_H
 
+#include "google/cloud/storage/hashing_options.h"
 #include "google/cloud/storage/idempotency_policy.h"
 #include "google/cloud/storage/retry_policy.h"
 #include "google/cloud/storage/version.h"

--- a/google/cloud/storage/options.h
+++ b/google/cloud/storage/options.h
@@ -133,7 +133,7 @@ struct DownloadChecksumValidationOption {
  * @ingroup storage-options
  */
 struct PrecomputedChecksumsOption {
-  using Type = std::map<ChecksumAlgorithm, std::string>;
+  using Type = PrecomputedChecksums;
 };
 
 /**

--- a/google/cloud/storage/options.h
+++ b/google/cloud/storage/options.h
@@ -25,6 +25,7 @@
 #include "google/cloud/options.h"
 #include <chrono>
 #include <cstdint>
+#include <map>
 #include <memory>
 #include <string>
 
@@ -121,6 +122,20 @@ struct UploadChecksumValidationOption {
 struct DownloadChecksumValidationOption {
   using Type = ChecksumAlgorithm;
 };
+
+/**
+ * Provide precomputed hashes for uploads and downloads.
+ *
+ * If set, the client will use these precomputed hashes instead of computing
+ * them locally. This is useful when the application has already computed the
+ * hash and wants to avoid recomputing it.
+ *
+ * @ingroup storage-options
+ */
+struct PrecomputedChecksumsOption {
+  using Type = std::map<ChecksumAlgorithm, std::string>;
+};
+
 
 /**
  * Configure the REST endpoint for the GCS client library.
@@ -378,6 +393,7 @@ using ClientOptionList = ::google::cloud::OptionList<
     TransferStallTimeoutOption, RetryPolicyOption, BackoffPolicyOption,
     IdempotencyPolicyOption, CARootsFilePathOption,
     UploadChecksumValidationOption, DownloadChecksumValidationOption,
+    PrecomputedChecksumsOption,
     storage_experimental::HttpVersionOption,
     storage_experimental::OTelSpanEnrichmentOption>;
 

--- a/google/cloud/storage/parallel_upload.cc
+++ b/google/cloud/storage/parallel_upload.cc
@@ -43,20 +43,28 @@ class ParallelObjectWriteStreambuf : public ObjectWriteStreambuf {
             std::move(connection), request, std::move(upload_id),
             committed_size, std::move(metadata), max_buffer_size,
             CreateHashFunction(request),
-            internal::HashValues{
-                request.GetOption<Crc32cChecksumValue>().value_or(
-                    google::cloud::internal::CurrentOptions()
-                            .has<Crc32cChecksumValue>()
-                        ? google::cloud::internal::CurrentOptions()
-                              .get<Crc32cChecksumValue>()
-                        : ""),
-                request.GetOption<MD5HashValue>().value_or(
-                    google::cloud::internal::CurrentOptions()
-                            .has<MD5HashValue>()
-                        ? google::cloud::internal::CurrentOptions()
-                              .get<MD5HashValue>()
-                        : ""),
-            },
+            [&request]() {
+              auto const& current = google::cloud::internal::CurrentOptions();
+              auto crc = request.GetOption<Crc32cChecksumValue>().value_or("");
+              if (crc.empty() && current.has<Crc32cChecksumValue>()) {
+                crc = current.get<Crc32cChecksumValue>();
+              }
+              if (crc.empty() && current.has<PrecomputedChecksumsOption>()) {
+                auto m = current.get<PrecomputedChecksumsOption>();
+                auto it = m.find(ChecksumAlgorithm::kCrc32c);
+                if (it != m.end()) crc = it->second;
+              }
+              auto md5 = request.GetOption<MD5HashValue>().value_or("");
+              if (md5.empty() && current.has<MD5HashValue>()) {
+                md5 = current.get<MD5HashValue>();
+              }
+              if (md5.empty() && current.has<PrecomputedChecksumsOption>()) {
+                auto m = current.get<PrecomputedChecksumsOption>();
+                auto it = m.find(ChecksumAlgorithm::kMD5);
+                if (it != m.end()) md5 = it->second;
+              }
+              return internal::HashValues{std::move(crc), std::move(md5)};
+            }(),
             CreateHashValidator(request), AutoFinalizeConfig::kEnabled),
         state_(std::move(state)),
         stream_idx_(stream_idx) {}

--- a/google/cloud/storage/parallel_upload.cc
+++ b/google/cloud/storage/parallel_upload.cc
@@ -47,15 +47,11 @@ class ParallelObjectWriteStreambuf : public ObjectWriteStreambuf {
               auto const& current = google::cloud::internal::CurrentOptions();
               auto crc = request.GetOption<Crc32cChecksumValue>().value_or("");
               if (crc.empty() && current.has<PrecomputedChecksumsOption>()) {
-                auto m = current.get<PrecomputedChecksumsOption>();
-                auto it = m.find(ChecksumAlgorithm::kCrc32c);
-                if (it != m.end()) crc = it->second;
+                crc = current.get<PrecomputedChecksumsOption>().crc32c;
               }
               auto md5 = request.GetOption<MD5HashValue>().value_or("");
               if (md5.empty() && current.has<PrecomputedChecksumsOption>()) {
-                auto m = current.get<PrecomputedChecksumsOption>();
-                auto it = m.find(ChecksumAlgorithm::kMD5);
-                if (it != m.end()) md5 = it->second;
+                md5 = current.get<PrecomputedChecksumsOption>().md5;
               }
               return internal::HashValues{std::move(crc), std::move(md5)};
             }(),

--- a/google/cloud/storage/parallel_upload.cc
+++ b/google/cloud/storage/parallel_upload.cc
@@ -46,12 +46,13 @@ class ParallelObjectWriteStreambuf : public ObjectWriteStreambuf {
             [&request]() {
               auto const& current = google::cloud::internal::CurrentOptions();
               auto crc = request.GetOption<Crc32cChecksumValue>().value_or("");
-              if (crc.empty() && current.has<PrecomputedChecksumsOption>()) {
-                crc = current.get<PrecomputedChecksumsOption>().crc32c;
-              }
               auto md5 = request.GetOption<MD5HashValue>().value_or("");
-              if (md5.empty() && current.has<PrecomputedChecksumsOption>()) {
-                md5 = current.get<PrecomputedChecksumsOption>().md5;
+              if ((crc.empty() || md5.empty()) &&
+                  current.has<PrecomputedChecksumsOption>()) {
+                auto const& checksums =
+                    current.get<PrecomputedChecksumsOption>();
+                if (crc.empty()) crc = checksums.crc32c;
+                if (md5.empty()) md5 = checksums.md5;
               }
               return internal::HashValues{std::move(crc), std::move(md5)};
             }(),

--- a/google/cloud/storage/parallel_upload.cc
+++ b/google/cloud/storage/parallel_upload.cc
@@ -46,18 +46,12 @@ class ParallelObjectWriteStreambuf : public ObjectWriteStreambuf {
             [&request]() {
               auto const& current = google::cloud::internal::CurrentOptions();
               auto crc = request.GetOption<Crc32cChecksumValue>().value_or("");
-              if (crc.empty() && current.has<Crc32cChecksumValue>()) {
-                crc = current.get<Crc32cChecksumValue>();
-              }
               if (crc.empty() && current.has<PrecomputedChecksumsOption>()) {
                 auto m = current.get<PrecomputedChecksumsOption>();
                 auto it = m.find(ChecksumAlgorithm::kCrc32c);
                 if (it != m.end()) crc = it->second;
               }
               auto md5 = request.GetOption<MD5HashValue>().value_or("");
-              if (md5.empty() && current.has<MD5HashValue>()) {
-                md5 = current.get<MD5HashValue>();
-              }
               if (md5.empty() && current.has<PrecomputedChecksumsOption>()) {
                 auto m = current.get<PrecomputedChecksumsOption>();
                 auto it = m.find(ChecksumAlgorithm::kMD5);

--- a/google/cloud/storage/parallel_upload.cc
+++ b/google/cloud/storage/parallel_upload.cc
@@ -44,8 +44,18 @@ class ParallelObjectWriteStreambuf : public ObjectWriteStreambuf {
             committed_size, std::move(metadata), max_buffer_size,
             CreateHashFunction(request),
             internal::HashValues{
-                request.GetOption<Crc32cChecksumValue>().value_or(""),
-                request.GetOption<MD5HashValue>().value_or(""),
+                request.GetOption<Crc32cChecksumValue>().value_or(
+                    google::cloud::internal::CurrentOptions()
+                            .has<Crc32cChecksumValue>()
+                        ? google::cloud::internal::CurrentOptions()
+                              .get<Crc32cChecksumValue>()
+                        : ""),
+                request.GetOption<MD5HashValue>().value_or(
+                    google::cloud::internal::CurrentOptions()
+                            .has<MD5HashValue>()
+                        ? google::cloud::internal::CurrentOptions()
+                              .get<MD5HashValue>()
+                        : ""),
             },
             CreateHashValidator(request), AutoFinalizeConfig::kEnabled),
         state_(std::move(state)),


### PR DESCRIPTION
This pull request updates the Google Cloud Storage C++ client to fall back to the current context options for `Crc32cChecksumValue` and `MD5HashValue` when they are not explicitly provided in the request options. It also introduces a flat `PrecomputedChecksums` struct and `PrecomputedChecksumsOption` to cleanly pass multiple precomputed hashes within the unified `Options` framework.

This enables the same exact conceptual options to be used as both a variadic argument for the synchronous client (e.g. `InsertObject(..., MD5HashValue("hash"))`) and as a modern option for the asynchronous client (e.g. `options.set<PrecomputedChecksumsOption>({..., "hash"})`), while avoiding heap allocations and lookups during hash execution.

This avoids needing any deprecations, any new types leaking into public method signatures, or any duplicate upload/download namespace variants. It is perfectly backward-compatible.