### PR TITLE
docs(storage): add samples for PrecomputedChecksumsOption

### DIFF
--- a/google/cloud/storage/examples/storage_async_samples.cc
+++ b/google/cloud/storage/examples/storage_async_samples.cc
@@ -753,8 +753,7 @@ void CreateAndWriteAppendableObjectWithChecksum(
     // just before calling Finalize().
     google::cloud::internal::OptionsSpan span(
         google::cloud::Options{}.set<gcs::PrecomputedChecksumsOption>(
-            gcs::PrecomputedChecksums{
-                gcs::ComputeCrc32cChecksum("Some data\n"), ""}));
+            gcs::PrecomputedChecksums{gcs::ComputeCrc32cChecksum("Some data\n")}));
     co_return (co_await writer.Finalize(std::move(token))).value();
   };
   // [END storage_create_and_write_appendable_object_with_checksum]

--- a/google/cloud/storage/examples/storage_async_samples.cc
+++ b/google/cloud/storage/examples/storage_async_samples.cc
@@ -751,10 +751,10 @@ void CreateAndWriteAppendableObjectWithChecksum(
 
     // Set the expected CRC32C checksum in the current options scope
     // just before calling Finalize().
-    // Note: 548262564U is the pre-computed CRC32C checksum for the string "Some
-    // data\n". If the data changes, this checksum must be updated to match.
     google::cloud::internal::OptionsSpan span(
-        google::cloud::Options{}.set<gcs::UseCrc32cValueOption>(548262564U));
+        google::cloud::Options{}.set<gcs::PrecomputedChecksumsOption>(
+            gcs::PrecomputedChecksums{
+                gcs::ComputeCrc32cChecksum("Some data\n"), ""}));
     co_return (co_await writer.Finalize(std::move(token))).value();
   };
   // [END storage_create_and_write_appendable_object_with_checksum]

--- a/google/cloud/storage/examples/storage_async_samples.cc
+++ b/google/cloud/storage/examples/storage_async_samples.cc
@@ -753,7 +753,8 @@ void CreateAndWriteAppendableObjectWithChecksum(
     // just before calling Finalize().
     google::cloud::internal::OptionsSpan span(
         google::cloud::Options{}.set<gcs::PrecomputedChecksumsOption>(
-            gcs::PrecomputedChecksums{gcs::ComputeCrc32cChecksum("Some data\n")}));
+            gcs::PrecomputedChecksums{
+                gcs::ComputeCrc32cChecksum("Some data\n")}));
     co_return (co_await writer.Finalize(std::move(token))).value();
   };
   // [END storage_create_and_write_appendable_object_with_checksum]

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -145,6 +145,29 @@ void InsertObject(google::cloud::storage::Client client,
   (std::move(client), argv.at(0), argv.at(1), argv.at(2));
 }
 
+void InsertObjectWithChecksum(google::cloud::storage::Client client,
+                              std::vector<std::string> const& argv) {
+  //! [insert-object-with-checksum]
+  namespace gcs = ::google::cloud::storage;
+  using ::google::cloud::StatusOr;
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, std::string const& contents) {
+    StatusOr<gcs::ObjectMetadata> object_metadata = client.InsertObject(
+        bucket_name, object_name, std::move(contents),
+        google::cloud::Options{}.set<gcs::PrecomputedChecksumsOption>(
+            gcs::PrecomputedChecksums{
+                gcs::ComputeCrc32cChecksum(contents), ""}));
+
+    if (!object_metadata) throw std::move(object_metadata).status();
+
+    std::cout << "The object " << object_metadata->name()
+              << " was created in bucket " << object_metadata->bucket()
+              << " with precomputed checksums.\n";
+  }
+  //! [insert-object-with-checksum]
+  (std::move(client), argv.at(0), argv.at(1), argv.at(2));
+}
+
 // NOLINTNEXTLINE(performance-unnecessary-value-param)
 void InsertObjectStrictIdempotency(google::cloud::storage::Client,
                                    std::vector<std::string> const& argv) {
@@ -392,6 +415,34 @@ void WriteObject(google::cloud::storage::Client client,
   }
   //! [write object] [END storage_stream_file_upload]
   (std::move(client), argv.at(0), argv.at(1), std::stoi(argv.at(2)));
+}
+
+void WriteObjectWithChecksum(google::cloud::storage::Client client,
+                             std::vector<std::string> const& argv) {
+  //! [write-object-with-checksum]
+  namespace gcs = ::google::cloud::storage;
+  using ::google::cloud::StatusOr;
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name) {
+    std::string const text = "Some data\n";
+    gcs::ObjectWriteStream stream = client.WriteObject(
+        bucket_name, object_name,
+        google::cloud::Options{}.set<gcs::PrecomputedChecksumsOption>(
+            gcs::PrecomputedChecksums{
+                gcs::ComputeCrc32cChecksum(text), ""}));
+
+    stream << text;
+    stream.Close();
+
+    StatusOr<gcs::ObjectMetadata> metadata = std::move(stream).metadata();
+    if (!metadata) throw std::move(metadata).status();
+
+    std::cout << "The object " << metadata->name()
+              << " was created in bucket " << metadata->bucket()
+              << " with precomputed checksums.\n";
+  }
+  //! [write-object-with-checksum]
+  (std::move(client), argv.at(0), argv.at(1));
 }
 
 void WriteObjectFromMemory(google::cloud::storage::Client client,
@@ -677,6 +728,9 @@ void RunAll(std::vector<std::string> const& argv) {
   std::cout << "\nRunning InsertObject() example [1]" << std::endl;
   InsertObject(client, {bucket_name, object_name, object_media});
 
+  std::cout << "\nRunning InsertObjectWithChecksum() example" << std::endl;
+  InsertObjectWithChecksum(client, {bucket_name, object_name + "_with_checksum", object_media});
+
   std::cout << "\nRunning ListObjects() example" << std::endl;
   ListObjects(client, {bucket_name});
 
@@ -724,6 +778,9 @@ void RunAll(std::vector<std::string> const& argv) {
 
   std::cout << "\nRunning WriteObject() example" << std::endl;
   WriteObject(client, {bucket_name, object_name, "100000"});
+
+  std::cout << "\nRunning WriteObjectWithChecksum() example" << std::endl;
+  WriteObjectWithChecksum(client, {bucket_name, object_name + "_write_checksum"});
 
   std::cout << "\nRunning ReadObjectRange() example" << std::endl;
   ReadObjectRange(client, {bucket_name, object_name, "1000", "2000"});
@@ -830,6 +887,9 @@ int main(int argc, char* argv[]) {
                  ListObjectsAndFolders),
       make_entry("insert-object",
                  {"<object-name>", "<object-contents (string)>"}, InsertObject),
+      make_entry("insert-object-with-checksum",
+                 {"<object-name>", "<object-contents (string)>"},
+                 InsertObjectWithChecksum),
       make_entry("insert-object-strict-idempotency",
                  {"<object-name>", "<object-contents (string)>"},
                  InsertObjectStrictIdempotency),
@@ -855,6 +915,8 @@ int main(int argc, char* argv[]) {
       make_entry("delete-object", {"<object-name>"}, DeleteObject),
       make_entry("write-object",
                  {"<object-name>", "<target-object-line-count>"}, WriteObject),
+      make_entry("write-object-with-checksum", {"<object-name>"},
+                 WriteObjectWithChecksum),
       make_entry("write-object-from-memory", {"<object-name>"},
                  WriteObjectFromMemory),
       make_entry("update-object-metadata",

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -155,8 +155,7 @@ void InsertObjectWithChecksum(google::cloud::storage::Client client,
     StatusOr<gcs::ObjectMetadata> object_metadata = client.InsertObject(
         bucket_name, object_name, std::move(contents),
         google::cloud::Options{}.set<gcs::PrecomputedChecksumsOption>(
-            gcs::PrecomputedChecksums{
-                gcs::ComputeCrc32cChecksum(contents), ""}));
+            gcs::PrecomputedChecksums{gcs::ComputeCrc32cChecksum(contents)}));
 
     if (!object_metadata) throw std::move(object_metadata).status();
 
@@ -165,6 +164,26 @@ void InsertObjectWithChecksum(google::cloud::storage::Client client,
               << " with precomputed checksums.\n";
   }
   //! [insert-object-with-checksum]
+  (std::move(client), argv.at(0), argv.at(1), argv.at(2));
+}
+
+void InsertObjectWithBadChecksum(google::cloud::storage::Client client,
+                                 std::vector<std::string> const& argv) {
+  //! [insert-object-with-bad-checksum]
+  namespace gcs = ::google::cloud::storage;
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, std::string const& contents) {
+    try {
+      client.InsertObject(
+          bucket_name, object_name, std::move(contents),
+          google::cloud::Options{}.set<gcs::PrecomputedChecksumsOption>(
+              gcs::PrecomputedChecksums{"bad_crc32c"}));
+    } catch (google::cloud::Status const& status) {
+      std::cout << "The object was not created because the checksum was bad. "
+                << "Status: " << status << "\n";
+    }
+  }
+  //! [insert-object-with-bad-checksum]
   (std::move(client), argv.at(0), argv.at(1), argv.at(2));
 }
 
@@ -428,8 +447,7 @@ void WriteObjectWithChecksum(google::cloud::storage::Client client,
     gcs::ObjectWriteStream stream = client.WriteObject(
         bucket_name, object_name,
         google::cloud::Options{}.set<gcs::PrecomputedChecksumsOption>(
-            gcs::PrecomputedChecksums{
-                gcs::ComputeCrc32cChecksum(text), ""}));
+            gcs::PrecomputedChecksums{gcs::ComputeCrc32cChecksum(text)}));
 
     stream << text;
     stream.Close();
@@ -437,9 +455,8 @@ void WriteObjectWithChecksum(google::cloud::storage::Client client,
     StatusOr<gcs::ObjectMetadata> metadata = std::move(stream).metadata();
     if (!metadata) throw std::move(metadata).status();
 
-    std::cout << "The object " << metadata->name()
-              << " was created in bucket " << metadata->bucket()
-              << " with precomputed checksums.\n";
+    std::cout << "The object " << metadata->name() << " was created in bucket "
+              << metadata->bucket() << " with precomputed checksums.\n";
   }
   //! [write-object-with-checksum]
   (std::move(client), argv.at(0), argv.at(1));
@@ -729,7 +746,12 @@ void RunAll(std::vector<std::string> const& argv) {
   InsertObject(client, {bucket_name, object_name, object_media});
 
   std::cout << "\nRunning InsertObjectWithChecksum() example" << std::endl;
-  InsertObjectWithChecksum(client, {bucket_name, object_name + "_with_checksum", object_media});
+  InsertObjectWithChecksum(
+      client, {bucket_name, object_name + "_with_checksum", object_media});
+
+  std::cout << "\nRunning InsertObjectWithBadChecksum() example" << std::endl;
+  InsertObjectWithBadChecksum(
+      client, {bucket_name, object_name + "_with_bad_checksum", object_media});
 
   std::cout << "\nRunning ListObjects() example" << std::endl;
   ListObjects(client, {bucket_name});
@@ -780,7 +802,8 @@ void RunAll(std::vector<std::string> const& argv) {
   WriteObject(client, {bucket_name, object_name, "100000"});
 
   std::cout << "\nRunning WriteObjectWithChecksum() example" << std::endl;
-  WriteObjectWithChecksum(client, {bucket_name, object_name + "_write_checksum"});
+  WriteObjectWithChecksum(client,
+                          {bucket_name, object_name + "_write_checksum"});
 
   std::cout << "\nRunning ReadObjectRange() example" << std::endl;
   ReadObjectRange(client, {bucket_name, object_name, "1000", "2000"});
@@ -890,6 +913,9 @@ int main(int argc, char* argv[]) {
       make_entry("insert-object-with-checksum",
                  {"<object-name>", "<object-contents (string)>"},
                  InsertObjectWithChecksum),
+      make_entry("insert-object-with-bad-checksum",
+                 {"<object-name>", "<object-contents (string)>"},
+                 InsertObjectWithBadChecksum),
       make_entry("insert-object-strict-idempotency",
                  {"<object-name>", "<object-contents (string)>"},
                  InsertObjectStrictIdempotency),

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -224,7 +224,7 @@ void InsertObjectModifiedRetry(google::cloud::storage::Client,
   namespace gcs = ::google::cloud::storage;
   using ::google::cloud::StatusOr;
   [](std::string const& bucket_name, std::string const& object_name,
-     std::string const& contents) {
+     std::string contents) {
     // Create a client that only gives up on the third error. The default policy
     // is to retry for several minutes.
     auto client =
@@ -251,7 +251,7 @@ void InsertObjectMultipart(google::cloud::storage::Client client,
   using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string const& bucket_name,
      std::string const& object_name, std::string const& content_type,
-     std::string const& contents) {
+     std::string contents) {
     // Setting the object metadata (via the `gcs::WithObjectMadata` option)
     // requires a multipart upload, the library prefers simple uploads unless
     // required as in this case.

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -132,7 +132,7 @@ void InsertObject(google::cloud::storage::Client client,
   namespace gcs = ::google::cloud::storage;
   using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string const& bucket_name,
-     std::string const& object_name, std::string const& contents) {
+     std::string const& object_name, std::string contents) {
     StatusOr<gcs::ObjectMetadata> object_metadata =
         client.InsertObject(bucket_name, object_name, std::move(contents));
     if (!object_metadata) throw std::move(object_metadata).status();
@@ -151,11 +151,12 @@ void InsertObjectWithChecksum(google::cloud::storage::Client client,
   namespace gcs = ::google::cloud::storage;
   using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string const& bucket_name,
-     std::string const& object_name, std::string const& contents) {
+     std::string const& object_name, std::string contents) {
+    auto checksum = gcs::ComputeCrc32cChecksum(contents);
     StatusOr<gcs::ObjectMetadata> object_metadata = client.InsertObject(
         bucket_name, object_name, std::move(contents),
         google::cloud::Options{}.set<gcs::PrecomputedChecksumsOption>(
-            gcs::PrecomputedChecksums{gcs::ComputeCrc32cChecksum(contents)}));
+            gcs::PrecomputedChecksums{std::move(checksum)}));
 
     if (!object_metadata) throw std::move(object_metadata).status();
 
@@ -172,16 +173,19 @@ void InsertObjectWithBadChecksum(google::cloud::storage::Client client,
   //! [insert-object-with-bad-checksum]
   namespace gcs = ::google::cloud::storage;
   [](gcs::Client client, std::string const& bucket_name,
-     std::string const& object_name, std::string const& contents) {
-    try {
-      client.InsertObject(
-          bucket_name, object_name, std::move(contents),
-          google::cloud::Options{}.set<gcs::PrecomputedChecksumsOption>(
-              gcs::PrecomputedChecksums{"bad_crc32c"}));
-    } catch (google::cloud::Status const& status) {
+     std::string const& object_name, std::string contents) {
+    auto object_metadata = client.InsertObject(
+        bucket_name, object_name, std::move(contents),
+        google::cloud::Options{}.set<gcs::PrecomputedChecksumsOption>(
+            gcs::PrecomputedChecksums{"bad_crc32c"}));
+
+    if (!object_metadata) {
       std::cout << "The object was not created because the checksum was bad. "
-                << "Status: " << status << "\n";
+                << "Status: " << object_metadata.status() << "\n";
+      return;
     }
+    throw std::runtime_error(
+        "The object was created, but it shouldn't have been!");
   }
   //! [insert-object-with-bad-checksum]
   (std::move(client), argv.at(0), argv.at(1), argv.at(2));
@@ -194,7 +198,7 @@ void InsertObjectStrictIdempotency(google::cloud::storage::Client,
   namespace gcs = ::google::cloud::storage;
   using ::google::cloud::StatusOr;
   [](std::string const& bucket_name, std::string const& object_name,
-     std::string const& contents) {
+     std::string contents) {
     // Create a client that only retries idempotent operations, the default is
     // to retry all operations.
     auto client =


### PR DESCRIPTION
This PR updates the examples to demonstrate how to use `PrecomputedChecksumsOption`.

- **Async Sample**: Replaced the old `UseCrc32cValueOption` in `storage_async_samples.cc` with `PrecomputedChecksumsOption`.
- **Sync Sample**: Added `InsertObjectWithChecksum` and `WriteObjectWithChecksum` to `storage_object_samples.cc` to demonstrate providing precomputed hashes to synchronous client calls.

These changes are a follow-up to the previously merged PR that introduced `PrecomputedChecksumsOption`.