### PR TITLE
impl(bigtable): add gRPC metric export validation integration test

### DIFF
--- a/ci/cloudbuild/builds/observability.sh
+++ b/ci/cloudbuild/builds/observability.sh
@@ -26,8 +26,40 @@ export CC=clang
 export CXX=clang++
 
 mapfile -t args < <(bazel::common_args)
-args+=("--//google/cloud/bigtable:enable_metrics=true")
+args+=(
+  "--//google/cloud/bigtable:enable_metrics=true"
+  "--dynamic_mode=off"
+)
+
 mapfile -t integration_args < <(integration::bazel_args)
+
+observability_key_base="observability-key-$(date +"%Y-%m")"
+readonly KEY_DIR="/dev/shm"
+readonly SECRETS_BUCKET="gs://cloud-cpp-testing-resources-secrets"
+gcloud storage cp --quiet "${SECRETS_BUCKET}/${observability_key_base}.json" "${KEY_DIR}/${observability_key_base}.json" >/dev/null 2>&1 || true
+if [[ -r "${KEY_DIR}/${observability_key_base}.json" ]]; then
+  GOOGLE_CLOUD_CPP_TEST_OBSERVABILITY_KEY_FILE_JSON="${KEY_DIR}/${observability_key_base}.json"
+fi
+
+ORIGINAL_ACCOUNT="$(gcloud config get-value account 2>/dev/null || true)"
+
+# Activate dedicated observability service account credentials for GCE VM & GCS management
+KEY_FILE=""
+for candidate in \
+  "${GOOGLE_CLOUD_CPP_TEST_OBSERVABILITY_KEY_FILE_JSON:-}" \
+  "${GOOGLE_APPLICATION_CREDENTIALS:-}"; do
+  if [[ -n "${candidate}" && -r "${candidate}" ]]; then
+    KEY_FILE="${candidate}"
+    break
+  fi
+done
+
+if [[ -n "${KEY_FILE}" ]]; then
+  io::log_h2 "Activating gcloud service account from ${KEY_FILE}"
+  gcloud auth activate-service-account --key-file="${KEY_FILE}" --quiet || true
+else
+  io::log_yellow "No dedicated observability service account keyfile found; using default gcloud auth."
+fi
 
 io::log_h2 "Building OtelCollector targets and Bigtable Observability integration tests"
 io::run bazel build "${args[@]}" \
@@ -35,8 +67,175 @@ io::run bazel build "${args[@]}" \
   //google/cloud/bigtable/tests:observability_integration_test-default \
   //google/cloud/bigtable/tests:observability_integration_test-dynamic-pool
 
-io::log_h2 "Running Bigtable Observability Integration Tests against production endpoint"
-io::run bazel test "${args[@]}" "${integration_args[@]}" \
-  --cache_test_results="auto" \
-  -- //google/cloud/bigtable/tests:observability_integration_test-default \
-  //google/cloud/bigtable/tests:observability_integration_test-dynamic-pool
+BAZEL_BIN="$(bazel info "${args[@]}" bazel-bin)"
+TEST_DEFAULT_BIN="${BAZEL_BIN}/google/cloud/bigtable/tests/observability_integration_test-default"
+TEST_DYNAMIC_BIN="${BAZEL_BIN}/google/cloud/bigtable/tests/observability_integration_test-dynamic-pool"
+
+readonly ZONES=("us-central1-f" "us-central1-a" "us-central1-b" "us-central1-c")
+ZONE="us-central1-f"
+PROJECT_ID="${GOOGLE_CLOUD_PROJECT:-cloud-cpp-testing-resources}"
+BIGTABLE_INSTANCE_ID="${GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID:-test-instance}"
+BIGTABLE_CLUSTER_ID="${GOOGLE_CLOUD_CPP_BIGTABLE_TEST_CLUSTER_ID:-test-cluster}"
+BIGTABLE_ZONE_A="${GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_A:-us-central1-f}"
+BIGTABLE_ZONE_B="${GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_B:-us-central1-b}"
+BUILD_SUFFIX="${BUILD_ID:-local}-${RANDOM}"
+VM_NAME="dp-obs-test-${BUILD_SUFFIX:0:15}"
+GCS_BUCKET="cloud-cpp-testing-resources-observability-logs"
+GCS_PATH="gs://${GCS_BUCKET}/builds/${VM_NAME}"
+VM_CREATED="false"
+
+cleanup() {
+  local exit_code=$?
+  if [[ "${VM_CREATED:-false}" == "true" ]]; then
+    io::log_h2 "Deleting ephemeral DirectPath VM: ${VM_NAME}"
+    gcloud compute instances delete "${VM_NAME}" \
+      --project="${PROJECT_ID}" \
+      --zone="${ZONE}" \
+      --quiet >/dev/null 2>&1 &
+  fi
+
+  if [[ -n "${ORIGINAL_ACCOUNT:-}" ]]; then
+    io::log_h2 "Restoring original gcloud account: ${ORIGINAL_ACCOUNT}"
+    gcloud config set account "${ORIGINAL_ACCOUNT}" --quiet >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT SIGINT SIGTERM
+
+# Ensure GCS bucket and 90-day lifecycle policy exist
+if ! gcloud storage buckets describe "gs://${GCS_BUCKET}" --project="${PROJECT_ID}" >/dev/null 2>&1; then
+  io::log_h2 "Creating GCS bucket gs://${GCS_BUCKET} with 90-day lifecycle policy"
+  gcloud storage buckets create "gs://${GCS_BUCKET}" \
+    --project="${PROJECT_ID}" \
+    --location="us-central1" \
+    --uniform-bucket-level-access || true
+
+  cat <<'EOF' >/tmp/observability_lifecycle.json
+{
+  "rule": [
+    {
+      "action": {
+        "type": "Delete"
+      },
+      "condition": {
+        "age": 90
+      }
+    }
+  ]
+}
+EOF
+  gcloud storage buckets update "gs://${GCS_BUCKET}" \
+    --lifecycle-file=/tmp/observability_lifecycle.json \
+    --project="${PROJECT_ID}" || true
+fi
+
+io::log_h2 "Uploading test binaries to GCS: ${GCS_PATH}/binaries/"
+gcloud storage cp --quiet "${TEST_DEFAULT_BIN}" "${TEST_DYNAMIC_BIN}" "${GCS_PATH}/binaries/" >/dev/null 2>&1 || true
+
+# Prepare Startup Script to run on the ephemeral GCE VM
+STARTUP_SCRIPT=$(
+  cat <<EOF
+#!/bin/bash
+exec > /tmp/startup.log 2>&1
+set -x
+
+export HOME="/tmp"
+export GOOGLE_CLOUD_PROJECT="${PROJECT_ID}"
+export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID="${BIGTABLE_INSTANCE_ID}"
+export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_CLUSTER_ID="${BIGTABLE_CLUSTER_ID}"
+export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_A="${BIGTABLE_ZONE_A}"
+export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_B="${BIGTABLE_ZONE_B}"
+export CBT_ENABLE_DIRECTPATH=true
+export GOOGLE_CLOUD_CPP_TEST_EXPECTED_CLIENT_PROJECT="${PROJECT_ID}"
+export GOOGLE_CLOUD_CPP_TEST_EXPECTED_LOCATION="${ZONE}"
+export GOOGLE_CLOUD_CPP_TEST_EXPECTED_CLOUD_PLATFORM="gcp_compute_engine"
+export GOOGLE_CLOUD_CPP_TEST_EXPECTED_HOSTNAME="\$(hostname)"
+
+echo "Downloading test binaries from GCS..."
+gcloud storage cp --quiet "${GCS_PATH}/binaries/*" /tmp/
+chmod +x /tmp/observability_integration_test-default
+chmod +x /tmp/observability_integration_test-dynamic-pool
+
+TEST_EXIT_CODE=0
+
+echo "Running observability_integration_test-default..."
+/tmp/observability_integration_test-default \
+  --gtest_output=xml:/tmp/test-default.xml > /tmp/test-default.log 2>&1 || TEST_EXIT_CODE=\$?
+
+echo "Running observability_integration_test-dynamic-pool..."
+/tmp/observability_integration_test-dynamic-pool \
+  --gtest_output=xml:/tmp/test-dynamic-pool.xml > /tmp/test-dynamic-pool.log 2>&1 || TEST_EXIT_CODE=\$?
+
+echo "\${TEST_EXIT_CODE}" > /tmp/exit_code.txt
+
+echo "Uploading logs and test results back to GCS..."
+gcloud storage cp --quiet /tmp/startup.log /tmp/*.log /tmp/*.xml /tmp/exit_code.txt "${GCS_PATH}/results/"
+EOF
+)
+
+for candidate_zone in "${ZONES[@]}"; do
+  ZONE="${candidate_zone}"
+  io::log_h2 "Creating ephemeral DirectPath VM instance: ${VM_NAME} in zone ${ZONE}"
+
+  if gcloud compute instances create "${VM_NAME}" \
+    --project="${PROJECT_ID}" \
+    --zone="${ZONE}" \
+    --machine-type="e2-standard-4" \
+    --subnet="projects/${PROJECT_ID}/regions/us-central1/subnetworks/directpath-subnet-ipv6" \
+    --stack-type="IPV4_IPV6" \
+    --image-family="ubuntu-2404-lts-amd64" \
+    --image-project="ubuntu-os-cloud" \
+    --metadata="startup-script=${STARTUP_SCRIPT}" \
+    --scopes="cloud-platform" \
+    --quiet >/tmp/vm_create.log 2>&1; then
+    VM_CREATED="true"
+    break
+  fi
+
+  io::log_yellow "Failed to create ephemeral VM instance in zone ${ZONE}:"
+  cat /tmp/vm_create.log || true
+done
+
+if [[ "${VM_CREATED}" != "true" ]]; then
+  io::log_red "Failed to create ephemeral VM instance ${VM_NAME} in any zone: ${ZONES[*]}"
+  exit 1
+fi
+
+io::log_h2 "Waiting for test execution to complete on VM ${VM_NAME}..."
+TEST_COMPLETED="false"
+for i in {1..90}; do
+  if gcloud storage cp --quiet "${GCS_PATH}/results/exit_code.txt" /tmp/exit_code.txt >/dev/null 2>&1; then
+    TEST_COMPLETED="true"
+    io::log_yellow "Test execution on VM ${VM_NAME} finished."
+    break
+  fi
+  sleep 5
+done
+
+if [[ "${TEST_COMPLETED}" != "true" ]]; then
+  io::log_red "Timed out waiting for test execution on VM ${VM_NAME}."
+  exit 1
+fi
+
+TEST_RESULT_CODE="$(cat /tmp/exit_code.txt 2>/dev/null || echo "1")"
+
+io::log_h2 "Fetching test logs from GCS: ${GCS_PATH}/results/"
+gcloud storage cp --quiet "${GCS_PATH}/results/*.log" /tmp/ 2>/dev/null || true
+
+if [[ "${TEST_RESULT_CODE}" -ne 0 ]]; then
+  for log_file in /tmp/startup.log /tmp/test-default.log /tmp/test-dynamic-pool.log; do
+    if [[ -f "${log_file}" ]]; then
+      io::log_h2 "=== Content of $(basename "${log_file}") ==="
+      cat "${log_file}" || true
+    fi
+  done
+  io::log_red "Observability integration tests failed with exit code: ${TEST_RESULT_CODE}"
+  exit "${TEST_RESULT_CODE}"
+else
+  for log_file in /tmp/test-default.log /tmp/test-dynamic-pool.log; do
+    if [[ -f "${log_file}" ]]; then
+      io::log_h2 "=== Test Summary: $(basename "${log_file}" .log) (Execution: Live Ephemeral VM - Uncached) ==="
+      grep -E '^\[(==========|----------| RUN      |       OK |  PASSED  |  FAILED  |  SKIPPED )\]' "${log_file}" || cat "${log_file}"
+    fi
+  done
+  io::log_green "Observability integration tests PASSED successfully!"
+fi

--- a/ci/cloudbuild/builds/observability.sh
+++ b/ci/cloudbuild/builds/observability.sh
@@ -91,6 +91,7 @@ cleanup() {
     gcloud compute instances delete "${VM_NAME}" \
       --project="${PROJECT_ID}" \
       --zone="${ZONE}" \
+      --async \
       --quiet >/dev/null 2>&1 &
   fi
 

--- a/google/cloud/bigtable/tests/CMakeLists.txt
+++ b/google/cloud/bigtable/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ set(bigtable_client_integration_tests
     filters_integration_test.cc
     instance_admin_integration_test.cc
     mutations_integration_test.cc
+    observability_integration_test.cc
     table_admin_backup_integration_test.cc
     table_admin_iam_policy_integration_test.cc
     table_admin_integration_test.cc
@@ -31,6 +32,11 @@ set(bigtable_client_integration_tests
 include(CreateBazelConfig)
 export_list_to_bazel("bigtable_client_integration_tests.bzl"
                      "bigtable_client_integration_tests" YEAR "2018")
+
+if (NOT TARGET otel_collector)
+    add_subdirectory("${PROJECT_SOURCE_DIR}/ci/otel_collector"
+                     "${CMAKE_BINARY_DIR}/ci/otel_collector")
+endif ()
 
 foreach (fname ${bigtable_client_integration_tests})
     google_cloud_cpp_add_executable(target "bigtable" "${fname}")
@@ -49,6 +55,9 @@ foreach (fname ${bigtable_client_integration_tests})
                 gRPC::grpc++
                 gRPC::grpc
                 protobuf::libprotobuf)
+    if (TARGET otel_collector)
+        target_link_libraries(${target} PRIVATE otel_collector)
+    endif ()
     add_test(NAME ${target} COMMAND ${target})
     set_tests_properties(
         ${target} PROPERTIES LABELS

--- a/google/cloud/bigtable/tests/bigtable_client_integration_tests.bzl
+++ b/google/cloud/bigtable/tests/bigtable_client_integration_tests.bzl
@@ -22,6 +22,7 @@ bigtable_client_integration_tests = [
     "filters_integration_test.cc",
     "instance_admin_integration_test.cc",
     "mutations_integration_test.cc",
+    "observability_integration_test.cc",
     "table_admin_backup_integration_test.cc",
     "table_admin_iam_policy_integration_test.cc",
     "table_admin_integration_test.cc",

--- a/google/cloud/bigtable/tests/observability_integration_test.cc
+++ b/google/cloud/bigtable/tests/observability_integration_test.cc
@@ -12,17 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef _WIN32
+
 #include "google/cloud/bigtable/options.h"
 #include "google/cloud/bigtable/testing/table_integration_test.h"
 #include "google/cloud/credentials.h"
+#include "google/cloud/grpc_options.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/scoped_environment.h"
 #include "google/cloud/testing_util/status_matchers.h"
+#include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_split.h"
 #include "ci/otel_collector/otel_collector.h"
+#include <arpa/inet.h>
 #include <gmock/gmock.h>
+#include <netinet/in.h>
 #include <chrono>
 #include <thread>
+#include <sys/socket.h>
+#include <unistd.h>
 
 namespace google {
 namespace cloud {
@@ -30,15 +39,32 @@ namespace bigtable {
 namespace testing {
 namespace {
 
+bool IsDirectPathReachable() {
+  int s = socket(AF_INET6, SOCK_STREAM, 0);
+  if (s < 0) return false;
+  sockaddr_in6 addr{};
+  addr.sin6_family = AF_INET6;
+  addr.sin6_port = htons(443);
+  inet_pton(AF_INET6, "2607:f8b0:4001:c2f::5f", &addr.sin6_addr);
+  timeval tv{1, 0};
+  setsockopt(s, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+  int res = connect(s, reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
+  close(s);
+  return res == 0;
+}
+
 using ::google::cloud::bigtable::testing::TableTestEnvironment;
 using ::google::cloud::testing_util::ScopedEnvironment;
+using ::testing::Contains;
+using ::testing::Eq;
+using ::testing::IsEmpty;
+using ::testing::Not;
 using ::testing::StartsWith;
 
 class ObservabilityIntegrationTest
     : public ::google::cloud::bigtable::testing::TableIntegrationTest {
  protected:
-  void SetUp() override {
-    TableIntegrationTest::SetUp();
+  static void SetUpTestSuite() {
     int port = 0;
     grpc::ServerBuilder builder;
     builder.AddListeningPort("localhost:0", grpc::InsecureServerCredentials(),
@@ -52,20 +78,41 @@ class ObservabilityIntegrationTest
             &collector_service_));
     server_ = builder.BuildAndStart();
     server_address_ = absl::StrCat("localhost:", port);
+    env_endpoint_ = std::make_unique<ScopedEnvironment>(
+        "GOOGLE_CLOUD_CPP_METRIC_SERVICE_ENDPOINT", server_address_);
+    env_otel_ = std::make_unique<ScopedEnvironment>(
+        "GOOGLE_CLOUD_CPP_TESTING_OTEL_COLLECTOR", "1");
   }
 
-  void TearDown() override {
+  static void TearDownTestSuite() {
+    env_endpoint_.reset();
+    env_otel_.reset();
     if (server_) {
-      server_->Shutdown();
+      server_->Shutdown(std::chrono::system_clock::now() +
+                        std::chrono::seconds(1));
       server_->Wait();
     }
-    TableIntegrationTest::TearDown();
   }
 
-  google::cloud::testing_util::OtelCollectorServer collector_service_;
-  std::unique_ptr<grpc::Server> server_;
-  std::string server_address_;
+  void SetUp() override {
+    TableIntegrationTest::SetUp();
+    data_connection_.reset();
+    collector_service_.Clear();
+  }
+
+  static google::cloud::testing_util::OtelCollectorServer collector_service_;
+  static std::unique_ptr<grpc::Server> server_;
+  static std::string server_address_;
+  static std::unique_ptr<ScopedEnvironment> env_endpoint_;
+  static std::unique_ptr<ScopedEnvironment> env_otel_;
 };
+
+google::cloud::testing_util::OtelCollectorServer
+    ObservabilityIntegrationTest::collector_service_;
+std::unique_ptr<grpc::Server> ObservabilityIntegrationTest::server_;
+std::string ObservabilityIntegrationTest::server_address_;
+std::unique_ptr<ScopedEnvironment> ObservabilityIntegrationTest::env_endpoint_;
+std::unique_ptr<ScopedEnvironment> ObservabilityIntegrationTest::env_otel_;
 
 /// Use Table::Apply() to insert a single row.
 void Apply(Table& table, std::string const& row_key,
@@ -82,21 +129,45 @@ void Apply(Table& table, std::string const& row_key,
   ASSERT_STATUS_OK(status);
 }
 
+void VerifyResourceLabels(google::monitoring::v3::TimeSeries const& ts,
+                          std::string const& expected_project_id,
+                          std::string const& expected_instance_id,
+                          std::string const& expected_table_id) {
+  auto const& labels = ts.resource().labels();
+  auto project_it = labels.find("project_id");
+  if (project_it != labels.end()) {
+    EXPECT_THAT(project_it->second, Eq(expected_project_id));
+  }
+  auto instance_it = labels.find("instance");
+  if (instance_it != labels.end()) {
+    EXPECT_THAT(instance_it->second, Eq(expected_instance_id));
+  }
+  auto table_it = labels.find("table");
+  if (table_it != labels.end()) {
+    EXPECT_THAT(table_it->second, Eq(expected_table_id));
+  }
+  auto zone_it = labels.find("zone");
+  if (zone_it != labels.end() && !TableTestEnvironment::zone_a().empty()) {
+    std::vector<absl::string_view> parts =
+        absl::StrSplit(TableTestEnvironment::zone_a(), '-');
+    auto prefix = parts.size() >= 2 ? absl::StrCat(parts[0], "-", parts[1])
+                                    : TableTestEnvironment::zone_a();
+    EXPECT_THAT(zone_it->second, StartsWith(prefix));
+  }
+}
+
 TEST_F(ObservabilityIntegrationTest, VerifyOperationAndAttemptMetrics) {
   if (UsingCloudBigtableEmulator()) {
     GTEST_SKIP() << "Metrics export integration test runs against production";
   }
 
-  // Redirect Cloud Monitoring metric export to local otel_collector
-  ScopedEnvironment env("GOOGLE_CLOUD_CPP_METRIC_SERVICE_ENDPOINT",
-                        server_address_);
-  ScopedEnvironment env_otel("GOOGLE_CLOUD_CPP_TESTING_OTEL_COLLECTOR", "1");
-
   // Set MetricsPeriodOption to 5s (minimum allowed by DefaultOptions; smaller
   // periods reset to 60s)
-  auto options =
-      Options{}.set<EnableMetricsOption>(true).set<MetricsPeriodOption>(
-          std::chrono::seconds(5));
+  auto options = Options{}
+                     .set<EnableMetricsOption>(true)
+                     .set<MetricsPeriodOption>(std::chrono::seconds(5))
+                     .set<MinConnectionRefreshOption>(std::chrono::hours(1))
+                     .set<MaxConnectionRefreshOption>(std::chrono::hours(1));
 
   auto const table_id = TableTestEnvironment::table_id();
 
@@ -128,46 +199,207 @@ TEST_F(ObservabilityIntegrationTest, VerifyOperationAndAttemptMetrics) {
   bool found_attempt_latencies = false;
 
   for (auto const& req : recorded) {
-    EXPECT_EQ(req.name(), absl::StrCat("projects/", project_id()));
+    EXPECT_THAT(req.name(), Eq(absl::StrCat("projects/", project_id())));
 
     for (auto const& ts : req.time_series()) {
       auto const& metric_type = ts.metric().type();
-      EXPECT_THAT(metric_type,
-                  StartsWith("bigtable.googleapis.com/internal/client/"));
+      // Skip gRPC metrics (which now start with
+      // "bigtable.googleapis.com/internal/client/grpc/") or non-Bigtable client
+      // metrics. This test only validates custom Bigtable client metrics
+      // ("bigtable_client_raw").
+      if (ts.resource().type() != "bigtable_client_raw" ||
+          !absl::StartsWith(metric_type,
+                            "bigtable.googleapis.com/internal/client/")) {
+        continue;
+      }
 
-      if (metric_type.find("operation_latencies") != std::string::npos) {
+      if (absl::StrContains(metric_type, "operation_latencies")) {
         found_operation_latencies = true;
       }
-      if (metric_type.find("attempt_latencies") != std::string::npos) {
+      if (absl::StrContains(metric_type, "attempt_latencies")) {
         found_attempt_latencies = true;
       }
 
-      auto const& labels = ts.resource().labels();
-      auto project_it = labels.find("project_id");
-      if (project_it != labels.end()) {
-        EXPECT_EQ(project_it->second, project_id());
-      }
-      auto instance_it = labels.find("instance");
-      if (instance_it != labels.end()) {
-        EXPECT_EQ(instance_it->second, instance_id());
-      }
-      auto table_it = labels.find("table");
-      if (table_it != labels.end()) {
-        EXPECT_EQ(table_it->second, table_id);
-      }
-      auto zone_it = labels.find("zone");
-      if (zone_it != labels.end() && !TableTestEnvironment::zone_a().empty()) {
-        std::vector<absl::string_view> parts =
-            absl::StrSplit(TableTestEnvironment::zone_a(), '-');
-        auto prefix = parts.size() >= 2 ? absl::StrCat(parts[0], "-", parts[1])
-                                        : TableTestEnvironment::zone_a();
-        EXPECT_THAT(zone_it->second, StartsWith(prefix));
-      }
+      VerifyResourceLabels(ts, project_id(), instance_id(), table_id);
     }
   }
 
   EXPECT_TRUE(found_operation_latencies);
   EXPECT_TRUE(found_attempt_latencies);
+}
+
+bool VerifyDirectPathGrpcResourceLabels(
+    google::monitoring::v3::TimeSeries const& ts,
+    absl::optional<std::string> const& expected_location,
+    absl::optional<std::string> const& expected_cloud_platform,
+    std::string const& expected_client_project,
+    absl::optional<std::string> const& expected_hostname) {
+  if (ts.resource().type() != "bigtable_client") {
+    return false;
+  }
+
+  auto const& labels = ts.resource().labels();
+  auto region_it = labels.find("region");
+  auto platform_it = labels.find("cloud_platform");
+  auto host_id_it = labels.find("host_id");
+  auto client_project_it = labels.find("client_project");
+
+  if (region_it == labels.end() || platform_it == labels.end() ||
+      host_id_it == labels.end() || client_project_it == labels.end()) {
+    return false;
+  }
+
+  EXPECT_THAT(region_it->second, Not(IsEmpty()));
+  if (expected_location.has_value() && !expected_location->empty()) {
+    std::vector<absl::string_view> parts =
+        absl::StrSplit(*expected_location, '-');
+    auto region_prefix = parts.size() >= 2
+                             ? absl::StrCat(parts[0], "-", parts[1])
+                             : *expected_location;
+    EXPECT_THAT(region_it->second, StartsWith(region_prefix));
+  }
+
+  EXPECT_THAT(platform_it->second, Not(IsEmpty()));
+  if (expected_cloud_platform.has_value() &&
+      !expected_cloud_platform->empty()) {
+    EXPECT_THAT(platform_it->second, Eq(*expected_cloud_platform));
+  }
+
+  EXPECT_THAT(host_id_it->second, Not(IsEmpty()));
+
+  EXPECT_THAT(client_project_it->second, Not(IsEmpty()));
+  if (!expected_client_project.empty()) {
+    EXPECT_THAT(client_project_it->second, Eq(expected_client_project));
+  }
+
+  if (expected_hostname.has_value() && !expected_hostname->empty()) {
+    auto hostname_it = labels.find("host_name");
+    if (hostname_it != labels.end()) {
+      EXPECT_THAT(hostname_it->second, Eq(*expected_hostname));
+    }
+  }
+
+  return true;
+}
+
+std::set<std::string> ProcessRecordedGrpcMetrics(
+    std::vector<google::monitoring::v3::CreateTimeSeriesRequest> const&
+        recorded,
+    std::string const& project_id,
+    absl::optional<std::string> const& expected_location,
+    absl::optional<std::string> const& expected_cloud_platform,
+    std::string const& expected_client_project,
+    absl::optional<std::string> const& expected_hostname,
+    bool& verified_resource_labels) {
+  std::set<std::string> grpc_metric_types;
+  for (auto const& req : recorded) {
+    std::cout << "req=" << req.DebugString() << std::endl;
+    EXPECT_THAT(req.name(), Eq(absl::StrCat("projects/", project_id)));
+
+    for (auto const& ts : req.time_series()) {
+      auto const& metric_type = ts.metric().type();
+      if (absl::StartsWith(metric_type,
+                           "bigtable.googleapis.com/internal/client/grpc/")) {
+        grpc_metric_types.insert(metric_type);
+        if (VerifyDirectPathGrpcResourceLabels(
+                ts, expected_location, expected_cloud_platform,
+                expected_client_project, expected_hostname)) {
+          verified_resource_labels = true;
+        }
+      }
+    }
+  }
+  return grpc_metric_types;
+}
+
+TEST_F(ObservabilityIntegrationTest, VerifyDirectPathGrpcMetrics) {
+  if (UsingCloudBigtableEmulator()) {
+    GTEST_SKIP() << "Metrics export integration test runs against production";
+  }
+
+  auto disable_direct_path =
+      google::cloud::internal::GetEnv("GOOGLE_CLOUD_DISABLE_DIRECT_PATH")
+          .value_or("");
+  if (disable_direct_path == "true" || !IsDirectPathReachable()) {
+    GTEST_SKIP() << "DirectPath is disabled or network is unreachable in this "
+                    "test environment";
+  }
+
+  // Set MetricsPeriodOption to 5s (minimum allowed by DefaultOptions; smaller
+  // periods reset to 60s)
+  auto options = Options{}
+                     .set<EnableMetricsOption>(true)
+                     .set<experimental::DirectPathModeOption>(
+                         experimental::DirectPathMode::kEnabled)
+                     .set<MetricsPeriodOption>(std::chrono::seconds(5))
+                     .set<MinConnectionRefreshOption>(std::chrono::hours(1))
+                     .set<MaxConnectionRefreshOption>(std::chrono::hours(1))
+                     .set<GrpcChannelArgumentsOption>({
+                         {"grpc.client_idle_timeout_ms", "1000"},
+                         {"grpc.max_reconnect_backoff_ms", "1000"},
+                     });
+
+  auto const& table_id = TableTestEnvironment::table_id();
+
+  // Add scoped connection to ensure metrics are flushed on destruction.
+  {
+    auto conn = MakeDataConnection(
+        {InstanceResource(Project(project_id()), instance_id())}, options);
+    auto table = Table(std::move(conn),
+                       TableResource(project_id(), instance_id(), table_id));
+
+    std::string const row_key = "observability-directpath-row-1";
+    std::vector<Cell> expected{
+        {row_key, "family4", "c0", 1000, "v1000"},
+        {row_key, "family4", "c1", 2000, "v2000"},
+    };
+
+    // Perform mutations and read calls over DirectPath
+    Apply(table, row_key, expected);
+    auto actual = ReadRows(table, Filter::PassAllFilter());
+    CheckEqualUnordered(expected, actual);
+
+    // Wait for the periodic 5-second exporter background thread to flush
+    // metrics while conn is active
+    std::this_thread::sleep_for(std::chrono::seconds(6));
+  }
+
+  auto recorded = collector_service_.recorded_metrics();
+  ASSERT_FALSE(recorded.empty());
+
+  bool verified_resource_labels = false;
+
+  auto expected_client_project =
+      google::cloud::internal::GetEnv(
+          "GOOGLE_CLOUD_CPP_TEST_EXPECTED_CLIENT_PROJECT")
+          .value_or(project_id());
+  auto expected_location = google::cloud::internal::GetEnv(
+      "GOOGLE_CLOUD_CPP_TEST_EXPECTED_LOCATION");
+  auto expected_cloud_platform = google::cloud::internal::GetEnv(
+      "GOOGLE_CLOUD_CPP_TEST_EXPECTED_CLOUD_PLATFORM");
+  auto expected_hostname = google::cloud::internal::GetEnv(
+      "GOOGLE_CLOUD_CPP_TEST_EXPECTED_HOSTNAME");
+
+  auto grpc_metric_types = ProcessRecordedGrpcMetrics(
+      recorded, project_id(), expected_location, expected_cloud_platform,
+      expected_client_project, expected_hostname, verified_resource_labels);
+
+  EXPECT_TRUE(verified_resource_labels);
+
+  // Verify that specific gRPC client metrics configured in GrpcMetricsExporter
+  // are present. OpenTelemetry metric names are formatted with the
+  // "bigtable.googleapis.com/internal/client/" prefix and slashes ("/") in
+  // place of dots (".").
+  //
+  // Note: Event-driven and failure-driven metrics configured in
+  // GrpcMetricsExporter (such as grpc.lb.rls.*, grpc.xds_client.*, and
+  // grpc.subchannel.* disconnections/failures) are only exported when those
+  // specific events or errors occur during the export window. Therefore, only
+  // RPC attempt duration metric is guaranteed to produce time series during a
+  // healthy test run.
+  EXPECT_THAT(grpc_metric_types,
+              Contains("bigtable.googleapis.com/internal/client/"
+                       "grpc/client/attempt/duration"));
 }
 
 }  // namespace
@@ -182,3 +414,5 @@ int main(int argc, char* argv[]) {
       new ::google::cloud::bigtable::testing::TableTestEnvironment);
   return RUN_ALL_TESTS();
 }
+
+#endif  // _WIN32

--- a/google/cloud/bigtable/tests/observability_integration_test.cc
+++ b/google/cloud/bigtable/tests/observability_integration_test.cc
@@ -28,8 +28,11 @@
 #include <arpa/inet.h>
 #include <gmock/gmock.h>
 #include <netinet/in.h>
+#include <cerrno>
 #include <chrono>
 #include <thread>
+#include <fcntl.h>
+#include <poll.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
@@ -42,13 +45,25 @@ namespace {
 bool IsDirectPathReachable() {
   int s = socket(AF_INET6, SOCK_STREAM, 0);
   if (s < 0) return false;
+  int flags = fcntl(s, F_GETFL, 0);
+  (void)fcntl(s, F_SETFL, flags | O_NONBLOCK);
   sockaddr_in6 addr{};
   addr.sin6_family = AF_INET6;
   addr.sin6_port = htons(443);
   inet_pton(AF_INET6, "2607:f8b0:4001:c2f::5f", &addr.sin6_addr);
-  timeval tv{1, 0};
-  setsockopt(s, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
   int res = connect(s, reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
+  if (res < 0 && errno == EINPROGRESS) {
+    pollfd pfd{s, POLLOUT, 0};
+    res = poll(&pfd, 1, 1000);
+    if (res > 0) {
+      int err = 0;
+      socklen_t len = sizeof(err);
+      (void)getsockopt(s, SOL_SOCKET, SO_ERROR, &err, &len);
+      res = (err == 0) ? 0 : -1;
+    } else {
+      res = -1;
+    }
+  }
   close(s);
   return res == 0;
 }
@@ -293,7 +308,6 @@ std::set<std::string> ProcessRecordedGrpcMetrics(
     bool& verified_resource_labels) {
   std::set<std::string> grpc_metric_types;
   for (auto const& req : recorded) {
-    std::cout << "req=" << req.DebugString() << std::endl;
     EXPECT_THAT(req.name(), Eq(absl::StrCat("projects/", project_id)));
 
     for (auto const& ts : req.time_series()) {


### PR DESCRIPTION
Updates the observability.sh to execute the integration test on an ephemeral compute vm that is directpath enabled.