### PR TITLE
fix(storage): do not close object descriptor span on reader completion

### DIFF
--- a/google/cloud/storage/internal/async/object_descriptor_connection_tracing.cc
+++ b/google/cloud/storage/internal/async/object_descriptor_connection_tracing.cc
@@ -55,7 +55,6 @@ class AsyncObjectDescriptorConnectionTracing
                      {"read-start", p.start},
                      {"read-length", p.length}});
     return impl_->Read(p);
-    ;
   }
 
   void MakeSubsequentStream() override {

--- a/google/cloud/storage/internal/async/object_descriptor_connection_tracing.cc
+++ b/google/cloud/storage/internal/async/object_descriptor_connection_tracing.cc
@@ -50,12 +50,12 @@ class AsyncObjectDescriptorConnectionTracing
 
   std::unique_ptr<storage::AsyncReaderConnection> Read(ReadParams p) override {
     internal::OTelScope scope(span_);
-    auto result = impl_->Read(p);
     span_->AddEvent("gl-cpp.open.read",
                     {{sc::thread::kThreadId, internal::CurrentThreadId()},
                      {"read-start", p.start},
                      {"read-length", p.length}});
-    return MakeTracingReaderConnection(span_, std::move(result));
+    return impl_->Read(p);
+    ;
   }
 
   void MakeSubsequentStream() override {

--- a/google/cloud/storage/internal/async/object_descriptor_connection_tracing.cc
+++ b/google/cloud/storage/internal/async/object_descriptor_connection_tracing.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/storage/internal/async/object_descriptor_connection_tracing.h"
 #include "google/cloud/storage/async/reader_connection.h"
-#include "google/cloud/storage/internal/async/reader_connection_tracing.h"
 #include "google/cloud/internal/opentelemetry.h"
 #include "google/cloud/version.h"
 #include <opentelemetry/semconv/incubating/thread_attributes.h>

--- a/google/cloud/storage/internal/async/object_descriptor_connection_tracing_test.cc
+++ b/google/cloud/storage/internal/async/object_descriptor_connection_tracing_test.cc
@@ -98,7 +98,8 @@ TEST(ObjectDescriptorConnectionTracing, Read) {
                   OTelAttribute<std::string>(sc::thread::kThreadId, _)))))));
 }
 
-TEST(ObjectDescriptorConnectionTracing, ReadThenRead) {
+TEST(ObjectDescriptorConnectionTracing,
+     SingleReadRangeCompletedDoesNotEndOpenSpan) {
   namespace sc = ::opentelemetry::semconv;
   auto span_catcher = InstallSpanCatcher();
 
@@ -106,20 +107,73 @@ TEST(ObjectDescriptorConnectionTracing, ReadThenRead) {
       std::make_shared<MockAsyncObjectDescriptorConnection>();
   auto* mock_reader_ptr = new MockAsyncReaderConnection;
   PromiseWithOTelContext<ReadResponse> p;
-  EXPECT_CALL(*mock_reader_ptr, Read).WillOnce(expect_context(p));
+  EXPECT_CALL(*mock_reader_ptr, Read).WillOnce([&p] { return p.get_future(); });
 
   EXPECT_CALL(*mock_connection, Read)
-      .WillOnce([&](ObjectDescriptorConnection::ReadParams) {
+      .WillOnce([&](ObjectDescriptorConnection::ReadParams p) {
+        EXPECT_EQ(p.start, 100);
+        EXPECT_EQ(p.length, 200);
         return std::unique_ptr<storage::AsyncReaderConnection>(mock_reader_ptr);
       });
 
   auto connection = MakeTracingObjectDescriptorConnection(
       internal::MakeSpan("test-span"), std::move(mock_connection));
 
-  auto reader = connection->Read({});
-  auto f = reader->Read().then(expect_no_context);
-  p.set_value(ReadPayload("test-payload").set_offset(123));
+  auto reader = connection->Read({100, 200});
+  auto f = reader->Read();
+  // Simulate stream completion (EOF)
+  p.set_value(Status{});
   (void)f.get();
+
+  // Before resetting the connection, the Open span must NOT be ended yet.
+  EXPECT_THAT(span_catcher->GetSpans(), ::testing::IsEmpty());
+
+  connection.reset();  // End the span now
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(
+      spans,
+      ElementsAre(AllOf(
+          SpanNamed("test-span"),
+          SpanWithStatus(opentelemetry::trace::StatusCode::kOk),
+          SpanHasInstrumentationScope(), SpanKindIsClient(),
+          SpanEventsAre(AllOf(
+              EventNamed("gl-cpp.open.read"),
+              SpanEventAttributesAre(
+                  OTelAttribute<std::int64_t>("read-length", 200),
+                  OTelAttribute<std::int64_t>("read-start", 100),
+                  OTelAttribute<std::string>(sc::thread::kThreadId, _)))))));
+}
+
+TEST(ObjectDescriptorConnectionTracing, MultipleReadRanges) {
+  namespace sc = ::opentelemetry::semconv;
+  auto span_catcher = InstallSpanCatcher();
+
+  auto mock_connection =
+      std::make_shared<MockAsyncObjectDescriptorConnection>();
+  auto mock_reader1 = std::make_unique<MockAsyncReaderConnection>();
+  auto mock_reader2 = std::make_unique<MockAsyncReaderConnection>();
+
+  EXPECT_CALL(*mock_connection, Read)
+      .WillOnce([&](ObjectDescriptorConnection::ReadParams p) {
+        EXPECT_EQ(p.start, 0);
+        EXPECT_EQ(p.length, 100);
+        return std::move(mock_reader1);
+      })
+      .WillOnce([&](ObjectDescriptorConnection::ReadParams p) {
+        EXPECT_EQ(p.start, 100);
+        EXPECT_EQ(p.length, 200);
+        return std::move(mock_reader2);
+      });
+
+  auto connection = MakeTracingObjectDescriptorConnection(
+      internal::MakeSpan("test-span"), std::move(mock_connection));
+
+  auto reader1 = connection->Read({0, 100});
+  auto reader2 = connection->Read({100, 200});
+
+  // Span is still active and not ended yet
+  EXPECT_THAT(span_catcher->GetSpans(), ::testing::IsEmpty());
 
   connection.reset();  // End the span
 
@@ -133,18 +187,15 @@ TEST(ObjectDescriptorConnectionTracing, ReadThenRead) {
           SpanEventsAre(
               AllOf(EventNamed("gl-cpp.open.read"),
                     SpanEventAttributesAre(
-                        OTelAttribute<std::int64_t>("read-length", 0),
+                        OTelAttribute<std::int64_t>("read-length", 100),
                         OTelAttribute<std::int64_t>("read-start", 0),
                         OTelAttribute<std::string>(sc::thread::kThreadId, _))),
-              AllOf(EventNamed("gl-cpp.read"),
+              AllOf(EventNamed("gl-cpp.open.read"),
                     SpanEventAttributesAre(
-                        OTelAttribute<std::int64_t>("message.starting_offset",
-                                                    123),
-                        OTelAttribute<std::string>(sc::thread::kThreadId, _),
-                        OTelAttribute<std::int64_t>("rpc.message.id", 1),
-                        // THIS WAS THE MISSING ATTRIBUTE:
-                        OTelAttribute<std::string>("rpc.message.type",
-                                                   "RECEIVED")))))));
+                        OTelAttribute<std::int64_t>("read-length", 200),
+                        OTelAttribute<std::int64_t>("read-start", 100),
+                        OTelAttribute<std::string>(sc::thread::kThreadId,
+                                                   _)))))));
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/async/object_descriptor_connection_tracing_test.cc
+++ b/google/cloud/storage/internal/async/object_descriptor_connection_tracing_test.cc
@@ -32,7 +32,6 @@ namespace {
 using ReadResponse =
     ::google::cloud::storage::AsyncReaderConnection::ReadResponse;
 using ::google::cloud::storage::ObjectDescriptorConnection;
-using ::google::cloud::storage::ReadPayload;
 using ::google::cloud::storage_mocks::MockAsyncObjectDescriptorConnection;
 using ::google::cloud::storage_mocks::MockAsyncReaderConnection;
 using ::google::cloud::testing_util::EventNamed;

--- a/google/cloud/storage/internal/async/object_descriptor_connection_tracing_test.cc
+++ b/google/cloud/storage/internal/async/object_descriptor_connection_tracing_test.cc
@@ -38,34 +38,13 @@ using ::google::cloud::storage_mocks::MockAsyncReaderConnection;
 using ::google::cloud::testing_util::EventNamed;
 using ::google::cloud::testing_util::InstallSpanCatcher;
 using ::google::cloud::testing_util::OTelAttribute;
-using ::google::cloud::testing_util::OTelContextCaptured;
 using ::google::cloud::testing_util::PromiseWithOTelContext;
 using ::google::cloud::testing_util::SpanEventAttributesAre;
 using ::google::cloud::testing_util::SpanHasInstrumentationScope;
 using ::google::cloud::testing_util::SpanKindIsClient;
 using ::google::cloud::testing_util::SpanNamed;
 using ::google::cloud::testing_util::SpanWithStatus;
-using ::google::cloud::testing_util::ThereIsAnActiveSpan;
 using ::testing::_;
-
-// A helper to set expectations on a mock async reader. It captures the OTel
-// context and returns a future that can be controlled by the test.
-auto expect_context = [](auto& p) {
-  return [&p] {
-    EXPECT_TRUE(ThereIsAnActiveSpan());
-    EXPECT_TRUE(OTelContextCaptured());
-    return p.get_future();
-  };
-};
-
-// A helper to be used in a `.then()` clause. It verifies the OTel context
-// has been detached before the user receives the result.
-auto expect_no_context = [](auto f) {
-  auto t = f.get();
-  EXPECT_FALSE(ThereIsAnActiveSpan());
-  EXPECT_FALSE(OTelContextCaptured());
-  return t;
-};
 
 TEST(ObjectDescriptorConnectionTracing, Read) {
   namespace sc = ::opentelemetry::semconv;
@@ -105,15 +84,16 @@ TEST(ObjectDescriptorConnectionTracing,
 
   auto mock_connection =
       std::make_shared<MockAsyncObjectDescriptorConnection>();
-  auto* mock_reader_ptr = new MockAsyncReaderConnection;
+  auto mock_reader = std::make_unique<MockAsyncReaderConnection>();
   PromiseWithOTelContext<ReadResponse> p;
-  EXPECT_CALL(*mock_reader_ptr, Read).WillOnce([&p] { return p.get_future(); });
+  EXPECT_CALL(*mock_reader, Read).WillOnce([&p] { return p.get_future(); });
 
   EXPECT_CALL(*mock_connection, Read)
-      .WillOnce([&](ObjectDescriptorConnection::ReadParams p) {
+      .WillOnce([&, r = std::move(mock_reader)](
+                    ObjectDescriptorConnection::ReadParams p) mutable {
         EXPECT_EQ(p.start, 100);
         EXPECT_EQ(p.length, 200);
-        return std::unique_ptr<storage::AsyncReaderConnection>(mock_reader_ptr);
+        return std::move(r);
       });
 
   auto connection = MakeTracingObjectDescriptorConnection(

--- a/google/cloud/storage/internal/async/object_descriptor_reader_tracing.cc
+++ b/google/cloud/storage/internal/async/object_descriptor_reader_tracing.cc
@@ -32,17 +32,23 @@ namespace sc = ::opentelemetry::semconv;
 class ObjectDescriptorReaderTracing : public ObjectDescriptorReader {
  public:
   explicit ObjectDescriptorReaderTracing(std::shared_ptr<ReadRange> impl,
-                                         absl::string_view cache_status)
-      : ObjectDescriptorReader(std::move(impl)), cache_status_(cache_status) {}
+                                         absl::string_view cache_status,
+                                         opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> parent_span)
+      : ObjectDescriptorReader(std::move(impl)), cache_status_(cache_status), parent_span_(std::move(parent_span)) {}
 
   ~ObjectDescriptorReaderTracing() override = default;
 
   future<ObjectDescriptorReader::ReadResponse> Read() override {
+    opentelemetry::trace::StartSpanOptions options;
+    if (parent_span_ && parent_span_->GetContext().IsValid()) {
+      options.parent = parent_span_->GetContext();
+    }
     auto span = internal::MakeSpan("storage::AsyncConnection::ReadRange");
     if (!cache_status_.empty()) {
       span->SetAttribute("gl-cpp.initial-read-ranges.cache-status",
                          std::string(cache_status_));
     }
+
     internal::OTelScope scope(span);
     return ObjectDescriptorReader::Read().then(
         [span = std::move(span),
@@ -72,15 +78,18 @@ class ObjectDescriptorReaderTracing : public ObjectDescriptorReader {
 
  private:
   absl::string_view cache_status_;
+  opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> parent_span_;
 };
 
 }  // namespace
 
 std::unique_ptr<storage::AsyncReaderConnection>
 MakeTracingObjectDescriptorReader(std::shared_ptr<ReadRange> impl,
-                                  absl::string_view cache_status) {
+                                  absl::string_view cache_status,
+                                  opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> parent_span) {
   return std::make_unique<ObjectDescriptorReaderTracing>(std::move(impl),
-                                                         cache_status);
+                                                         cache_status,
+                                                        std::move(parent_span));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/async/object_descriptor_reader_tracing.cc
+++ b/google/cloud/storage/internal/async/object_descriptor_reader_tracing.cc
@@ -31,10 +31,12 @@ namespace sc = ::opentelemetry::semconv;
 
 class ObjectDescriptorReaderTracing : public ObjectDescriptorReader {
  public:
-  explicit ObjectDescriptorReaderTracing(std::shared_ptr<ReadRange> impl,
-                                         absl::string_view cache_status,
-                                         opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> parent_span)
-      : ObjectDescriptorReader(std::move(impl)), cache_status_(cache_status), parent_span_(std::move(parent_span)) {}
+  explicit ObjectDescriptorReaderTracing(
+      std::shared_ptr<ReadRange> impl, absl::string_view cache_status,
+      opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> parent_span)
+      : ObjectDescriptorReader(std::move(impl)),
+        cache_status_(cache_status),
+        parent_span_(std::move(parent_span)) {}
 
   ~ObjectDescriptorReaderTracing() override = default;
 
@@ -43,7 +45,8 @@ class ObjectDescriptorReaderTracing : public ObjectDescriptorReader {
     if (parent_span_ && parent_span_->GetContext().IsValid()) {
       options.parent = parent_span_->GetContext();
     }
-    auto span = internal::MakeSpan("storage::AsyncConnection::ReadRange");
+    auto span =
+        internal::MakeSpan("storage::AsyncConnection::ReadRange", options);
     if (!cache_status_.empty()) {
       span->SetAttribute("gl-cpp.initial-read-ranges.cache-status",
                          std::string(cache_status_));
@@ -84,12 +87,11 @@ class ObjectDescriptorReaderTracing : public ObjectDescriptorReader {
 }  // namespace
 
 std::unique_ptr<storage::AsyncReaderConnection>
-MakeTracingObjectDescriptorReader(std::shared_ptr<ReadRange> impl,
-                                  absl::string_view cache_status,
-                                  opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> parent_span) {
-  return std::make_unique<ObjectDescriptorReaderTracing>(std::move(impl),
-                                                         cache_status,
-                                                        std::move(parent_span));
+MakeTracingObjectDescriptorReader(
+    std::shared_ptr<ReadRange> impl, absl::string_view cache_status,
+    opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> parent_span) {
+  return std::make_unique<ObjectDescriptorReaderTracing>(
+      std::move(impl), cache_status, std::move(parent_span));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/async/object_descriptor_reader_tracing.cc
+++ b/google/cloud/storage/internal/async/object_descriptor_reader_tracing.cc
@@ -31,13 +31,21 @@ namespace sc = ::opentelemetry::semconv;
 
 class ObjectDescriptorReaderTracing : public ObjectDescriptorReader {
  public:
-  explicit ObjectDescriptorReaderTracing(std::shared_ptr<ReadRange> impl)
-      : ObjectDescriptorReader(std::move(impl)) {}
+  explicit ObjectDescriptorReaderTracing(
+      std::shared_ptr<ReadRange> impl,
+      opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> parent_span)
+      : ObjectDescriptorReader(std::move(impl)),
+        parent_span_(std::move(parent_span)) {}
 
   ~ObjectDescriptorReaderTracing() override = default;
 
   future<ObjectDescriptorReader::ReadResponse> Read() override {
-    auto span = internal::MakeSpan("storage::AsyncConnection::ReadRange");
+    opentelemetry::trace::StartSpanOptions options;
+    if (parent_span_ && parent_span_->GetContext().IsValid()) {
+      options.parent = parent_span_->GetContext();
+    }
+    auto span =
+        internal::MakeSpan("storage::AsyncConnection::ReadRange", options);
     internal::OTelScope scope(span);
     return ObjectDescriptorReader::Read().then(
         [span = std::move(span),
@@ -64,13 +72,19 @@ class ObjectDescriptorReaderTracing : public ObjectDescriptorReader {
           return result;
         });
   }
+
+ private:
+  opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> parent_span_;
 };
 
 }  // namespace
 
 std::unique_ptr<storage::AsyncReaderConnection>
-MakeTracingObjectDescriptorReader(std::shared_ptr<ReadRange> impl) {
-  return std::make_unique<ObjectDescriptorReaderTracing>(std::move(impl));
+MakeTracingObjectDescriptorReader(
+    std::shared_ptr<ReadRange> impl,
+    opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> parent_span) {
+  return std::make_unique<ObjectDescriptorReaderTracing>(
+      std::move(impl), std::move(parent_span));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/async/object_descriptor_reader_tracing.h
+++ b/google/cloud/storage/internal/async/object_descriptor_reader_tracing.h
@@ -25,7 +25,10 @@ namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 std::unique_ptr<storage::AsyncReaderConnection>
-MakeTracingObjectDescriptorReader(std::shared_ptr<ReadRange> impl);
+MakeTracingObjectDescriptorReader(
+    std::shared_ptr<ReadRange> impl,
+    opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> parent_span =
+        opentelemetry::trace::Tracer::GetCurrentSpan());
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage_internal

--- a/google/cloud/storage/internal/async/object_descriptor_reader_tracing.h
+++ b/google/cloud/storage/internal/async/object_descriptor_reader_tracing.h
@@ -26,7 +26,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 std::unique_ptr<storage::AsyncReaderConnection>
 MakeTracingObjectDescriptorReader(std::shared_ptr<ReadRange> impl,
-                                  absl::string_view cache_status);
+                                  absl::string_view cache_status,
+                                opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> parent_span =
+        opentelemetry::trace::Tracer::GetCurrentSpan());
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage_internal

--- a/google/cloud/storage/internal/async/object_descriptor_reader_tracing.h
+++ b/google/cloud/storage/internal/async/object_descriptor_reader_tracing.h
@@ -25,9 +25,9 @@ namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 std::unique_ptr<storage::AsyncReaderConnection>
-MakeTracingObjectDescriptorReader(std::shared_ptr<ReadRange> impl,
-                                  absl::string_view cache_status,
-                                opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> parent_span =
+MakeTracingObjectDescriptorReader(
+    std::shared_ptr<ReadRange> impl, absl::string_view cache_status,
+    opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> parent_span =
         opentelemetry::trace::Tracer::GetCurrentSpan());
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/async/object_descriptor_reader_tracing_test.cc
+++ b/google/cloud/storage/internal/async/object_descriptor_reader_tracing_test.cc
@@ -156,11 +156,9 @@ TEST(ObjectDescriptorReaderTracing, ReadWithParentSpan) {
 
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(
-      spans,
-      ElementsAre(
-          AllOf(SpanNamed("storage::AsyncConnection::ReadRange"),
-                SpanWithParent(parent_span)),
-          SpanNamed("test-parent-span")));
+      spans, ElementsAre(AllOf(SpanNamed("storage::AsyncConnection::ReadRange"),
+                               SpanWithParent(parent_span)),
+                         SpanNamed("test-parent-span")));
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/async/object_descriptor_reader_tracing_test.cc
+++ b/google/cloud/storage/internal/async/object_descriptor_reader_tracing_test.cc
@@ -140,7 +140,8 @@ TEST(ObjectDescriptorReaderTracing, ReadWithParentSpan) {
 
   auto parent_span = internal::MakeSpan("test-parent-span");
   auto impl = std::make_shared<ReadRange>(10000, 30);
-  auto reader = MakeTracingObjectDescriptorReader(impl, parent_span);
+  auto reader =
+      MakeTracingObjectDescriptorReader(impl, /*cache_status=*/"", parent_span);
 
   auto data = google::storage::v2::ObjectRangeData{};
   auto constexpr kData0 = R"pb(

--- a/google/cloud/storage/internal/async/object_descriptor_reader_tracing_test.cc
+++ b/google/cloud/storage/internal/async/object_descriptor_reader_tracing_test.cc
@@ -36,8 +36,11 @@ using ::google::cloud::testing_util::SpanEventAttributesAre;
 using ::google::cloud::testing_util::SpanHasAttributes;
 using ::google::cloud::testing_util::SpanHasEvents;
 using ::google::cloud::testing_util::SpanNamed;
+using ::google::cloud::testing_util::SpanWithParent;
 using ::google::protobuf::TextFormat;
 using ::testing::_;
+using ::testing::AllOf;
+using ::testing::ElementsAre;
 
 namespace sc = ::opentelemetry::semconv;
 
@@ -130,6 +133,34 @@ TEST(ObjectDescriptorReaderTracing, ReadWithCacheStatuses) {
                     SpanHasAttributes(OTelAttribute<std::string>(
                         "gl-cpp.initial-read-ranges.cache-status", status)))));
   }
+}
+
+TEST(ObjectDescriptorReaderTracing, ReadWithParentSpan) {
+  auto span_catcher = InstallSpanCatcher();
+
+  auto parent_span = internal::MakeSpan("test-parent-span");
+  auto impl = std::make_shared<ReadRange>(10000, 30);
+  auto reader = MakeTracingObjectDescriptorReader(impl, parent_span);
+
+  auto data = google::storage::v2::ObjectRangeData{};
+  auto constexpr kData0 = R"pb(
+    checksummed_data { content: "0123456789" }
+    read_range { read_offset: 10000 read_length: 10 read_id: 7 }
+    range_end: false
+  )pb";
+  EXPECT_TRUE(TextFormat::ParseFromString(kData0, &data));
+  impl->OnRead(std::move(data), /*is_transcoded=*/false);
+
+  auto actual = reader->Read().get();
+  internal::EndSpan(*parent_span);
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(
+      spans,
+      ElementsAre(
+          AllOf(SpanNamed("storage::AsyncConnection::ReadRange"),
+                SpanWithParent(parent_span)),
+          SpanNamed("test-parent-span")));
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/async/object_descriptor_reader_tracing_test.cc
+++ b/google/cloud/storage/internal/async/object_descriptor_reader_tracing_test.cc
@@ -116,11 +116,9 @@ TEST(ObjectDescriptorReaderTracing, ReadWithParentSpan) {
 
   auto spans = span_catcher->GetSpans();
   EXPECT_THAT(
-      spans,
-      ElementsAre(
-          AllOf(SpanNamed("storage::AsyncConnection::ReadRange"),
-                SpanWithParent(parent_span)),
-          SpanNamed("test-parent-span")));
+      spans, ElementsAre(AllOf(SpanNamed("storage::AsyncConnection::ReadRange"),
+                               SpanWithParent(parent_span)),
+                         SpanNamed("test-parent-span")));
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/async/object_descriptor_reader_tracing_test.cc
+++ b/google/cloud/storage/internal/async/object_descriptor_reader_tracing_test.cc
@@ -36,8 +36,11 @@ using ::google::cloud::testing_util::SpanEventAttributesAre;
 using ::google::cloud::testing_util::SpanHasAttributes;
 using ::google::cloud::testing_util::SpanHasEvents;
 using ::google::cloud::testing_util::SpanNamed;
+using ::google::cloud::testing_util::SpanWithParent;
 using ::google::protobuf::TextFormat;
 using ::testing::_;
+using ::testing::AllOf;
+using ::testing::ElementsAre;
 
 namespace sc = ::opentelemetry::semconv;
 
@@ -90,6 +93,34 @@ TEST(ObjectDescriptorReaderTracing, ReadError) {
                           OTelAttribute<std::string>(sc::thread::kThreadId, _),
                           OTelAttribute<std::string>("rpc.message.type",
                                                      "RECEIVED")))))));
+}
+
+TEST(ObjectDescriptorReaderTracing, ReadWithParentSpan) {
+  auto span_catcher = InstallSpanCatcher();
+
+  auto parent_span = internal::MakeSpan("test-parent-span");
+  auto impl = std::make_shared<ReadRange>(10000, 30);
+  auto reader = MakeTracingObjectDescriptorReader(impl, parent_span);
+
+  auto data = google::storage::v2::ObjectRangeData{};
+  auto constexpr kData0 = R"pb(
+    checksummed_data { content: "0123456789" }
+    read_range { read_offset: 10000 read_length: 10 read_id: 7 }
+    range_end: false
+  )pb";
+  EXPECT_TRUE(TextFormat::ParseFromString(kData0, &data));
+  impl->OnRead(std::move(data), /*is_transcoded=*/false);
+
+  auto actual = reader->Read().get();
+  internal::EndSpan(*parent_span);
+
+  auto spans = span_catcher->GetSpans();
+  EXPECT_THAT(
+      spans,
+      ElementsAre(
+          AllOf(SpanNamed("storage::AsyncConnection::ReadRange"),
+                SpanWithParent(parent_span)),
+          SpanNamed("test-parent-span")));
 }
 
 }  // namespace


### PR DESCRIPTION
**Problem**
`AsyncObjectDescriptorConnectionTracing::Read()` was wrapping the returned reader in `MakeTracingReaderConnection(span_, ...)`. `AsyncReaderConnectionTracing` ends the span as soon as the reader stream finishes. Because `span_` represents the `storage::AsyncConnection::Open` span, it was ending prematurely on the first range completion instead of staying active for the lifetime of `ObjectDescriptorConnection`.

**Fix**
Returned `impl_->Read(p)` directly in `AsyncObjectDescriptorConnectionTracing::Read()`. Individual range reads are already traced by `ObjectDescriptorImpl::Read()`, which creates `MakeTracingObjectDescriptorReader()` when tracing is enabled.
