### PR TITLE
fix(storage): limit retries in InsertObjectWithBadChecksum sample

### DIFF
--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -176,8 +176,11 @@ void InsertObjectWithBadChecksum(google::cloud::storage::Client client,
      std::string const& object_name, std::string contents) {
     auto object_metadata = client.InsertObject(
         bucket_name, object_name, std::move(contents),
-        google::cloud::Options{}.set<gcs::PrecomputedChecksumsOption>(
-            gcs::PrecomputedChecksums{"bad_crc32c"}));
+        google::cloud::Options{}
+            .set<gcs::PrecomputedChecksumsOption>(
+                gcs::PrecomputedChecksums{"bad_crc32c"})
+            .set<gcs::RetryPolicyOption>(
+                gcs::LimitedErrorCountRetryPolicy(2).clone()));
 
     if (!object_metadata) {
       std::cout << "The object was not created because the checksum was bad. "

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <iterator>
 #include <map>
+#include <memory>
 #include <random>
 #include <stdexcept>
 #include <string>
@@ -180,7 +181,7 @@ void InsertObjectWithBadChecksum(google::cloud::storage::Client client,
             .set<gcs::PrecomputedChecksumsOption>(
                 gcs::PrecomputedChecksums{"bad_crc32c"})
             .set<gcs::RetryPolicyOption>(
-                gcs::LimitedErrorCountRetryPolicy(2).clone()));
+                std::make_shared<gcs::LimitedErrorCountRetryPolicy>(2)));
 
     if (!object_metadata) {
       std::cout << "The object was not created because the checksum was bad. "


### PR DESCRIPTION
In `InsertObjectWithBadChecksum`, `client.InsertObject` was called without limiting retries. When executed in CI against the gRPC emulator, checksum errors over gRPC return retryable error statuses, causing the operation to retry until the default 15-minute `LimitedTimeRetryPolicy` expires and timing out the test target (`//google/cloud/storage/examples:storage_object_samples`).

This PR adds `.set<gcs::RetryPolicyOption>(gcs::LimitedErrorCountRetryPolicy(2).clone())` to the per-call options in `InsertObjectWithBadChecksum`. This ensures the operation fails after 2 retries and returns immediately.