### PR TITLE
impl(generator): add OperationContext to Bigtable stub and decorators

### DIFF
--- a/generator/generator_config.proto
+++ b/generator/generator_config.proto
@@ -182,6 +182,10 @@ message ServiceConfiguration {
   // The implementation for this method in the ConnectionImpl class is not
   // generated and must be handwritten in a separate .cc file.
   repeated BespokeMethod bespoke_methods = 30;
+
+  // If set to `true`, the stub class methods will include an additional
+  // parameter of type `google::cloud::bigtable_internal::OperationContext&`.
+  bool experimental_bigtable_operation_context = 31;
 }
 
 message DiscoveryDocumentDefinedProduct {

--- a/generator/generator_config.textproto
+++ b/generator/generator_config.textproto
@@ -576,6 +576,7 @@ service {
   omit_connection: true
   omit_stub_factory: true
   generate_round_robin_decorator: true
+  experimental_bigtable_operation_context: true
   omitted_rpcs: [
     "GenerateInitialChangeStreamPartitions",
     "ReadChangeStream"

--- a/generator/internal/auth_decorator_generator.cc
+++ b/generator/internal/auth_decorator_generator.cc
@@ -17,6 +17,7 @@
 #include "generator/internal/longrunning.h"
 #include "generator/internal/predicate_utils.h"
 #include "generator/internal/printer.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_split.h"
 #include <google/protobuf/descriptor.h>
 
@@ -130,37 +131,39 @@ $auth_class_name$::$auth_class_name$(
   // Auth decorator class member methods
   for (auto const& method : methods()) {
     if (IsStreamingWrite(method)) {
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
 std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
     $request_type$,
     $response_type$>>
 $auth_class_name$::$method_name$(
     std::shared_ptr<grpc::ClientContext> context,
-    Options const& options) {
+    Options const& options$op_ctx_shared_decl$) {
   using ErrorStream = ::google::cloud::internal::StreamingWriteRpcError<
       $request_type$, $response_type$>;
   auto status = auth_->ConfigureContext(*context);
   if (!status.ok()) return std::make_unique<ErrorStream>(std::move(status));
-  return child_->$method_name$(std::move(context), options);
+  return child_->$method_name$(std::move(context), options$op_ctx_shared_arg$);
 }
 )""");
       continue;
     }
     if (IsBidirStreaming(method)) {
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
     $request_type$,
     $response_type$>>
 $auth_class_name$::Async$method_name$(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
+    google::cloud::internal::ImmutableOptions options$op_ctx_shared_decl$) {
   using StreamAuth = google::cloud::internal::AsyncStreamingReadWriteRpcAuth<
     $request_type$, $response_type$>;
 
-  auto call = [child = child_, cq, options = std::move(options)](
+  auto call = [child = child_, cq, options = std::move(options)$op_ctx_shared_cap$](
                   std::shared_ptr<grpc::ClientContext> ctx) {
-    return child->Async$method_name$(cq, std::move(ctx), options);
+    return child->Async$method_name$(cq, std::move(ctx), options$op_ctx_shared_arg$);
   };
   return std::make_unique<StreamAuth>(
     std::move(context), auth_, StreamAuth::StreamFactory(std::move(call)));
@@ -169,53 +172,56 @@ $auth_class_name$::Async$method_name$(
       continue;
     }
     if (IsLongrunningOperation(method)) {
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
 future<StatusOr<google::longrunning::Operation>>
 $auth_class_name$::Async$method_name$(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      $request_type$ const& request) {
+      $request_type$ const& request$op_ctx_shared_decl$) {
   using ReturnType = StatusOr<google::longrunning::Operation>;
   return auth_->AsyncConfigureContext(std::move(context)).then(
-      [cq, child = child_, options = std::move(options), request](
+      [cq, child = child_, options = std::move(options), request$op_ctx_shared_cap$](
           future<StatusOr<std::shared_ptr<grpc::ClientContext>>> f) mutable {
         auto context = f.get();
         if (!context) {
           return make_ready_future(ReturnType(std::move(context).status()));
         }
         return child->Async$method_name$(
-            cq, *std::move(context), std::move(options), request);
+            cq, *std::move(context), std::move(options), request$op_ctx_shared_arg$);
       });
 }
 )""");
 
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
 StatusOr<google::longrunning::Operation>
 $auth_class_name$::$method_name$(
       grpc::ClientContext& context,
       Options options,
-      $request_type$ const& request) {
+      $request_type$ const& request$op_ctx_decl$) {
   auto status = auth_->ConfigureContext(context);
   if (!status.ok()) return status;
-  return child_->$method_name$(context, options, request);
+  return child_->$method_name$(context, options, request$op_ctx_arg$);
 }
 )""");
 
       continue;
     }
     if (IsStreamingRead(method)) {
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
 std::unique_ptr<google::cloud::internal::StreamingReadRpc<$response_type$>>
 $auth_class_name$::$method_name$(
    std::shared_ptr<grpc::ClientContext> context,
    Options const& options,
-   $request_type$ const& request) {
+   $request_type$ const& request$op_ctx_shared_decl$) {
   using ErrorStream = ::google::cloud::internal::StreamingReadRpcError<
       $response_type$>;
   auto status = auth_->ConfigureContext(*context);
   if (!status.ok()) return std::make_unique<ErrorStream>(std::move(status));
-  return child_->$method_name$(std::move(context), options, request);
+  return child_->$method_name$(std::move(context), options, request$op_ctx_shared_arg$);
 }
 )""");
       continue;
@@ -225,10 +231,10 @@ $auth_class_name$::$method_name$(
                   R"""( $auth_class_name$::$method_name$(
     grpc::ClientContext& context,
     Options const& options,
-    $request_type$ const& request) {
+    $request_type$ const& request$op_ctx_decl$) {
   auto status = auth_->ConfigureContext(context);
   if (!status.ok()) return status;
-  return child_->$method_name$(context, options, request);
+  return child_->$method_name$(context, options, request$op_ctx_arg$);
 }
 )""");
   }
@@ -237,79 +243,81 @@ $auth_class_name$::$method_name$(
     // Nothing to do, these are always asynchronous.
     if (IsBidirStreaming(method) || IsLongrunningOperation(method)) continue;
     if (IsStreamingRead(method)) {
-      auto constexpr kDefinition = R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
 std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
     $response_type$>>
 $auth_class_name$::Async$method_name$(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    $request_type$ const& request) {
+    $request_type$ const& request$op_ctx_shared_decl$) {
   using StreamAuth = google::cloud::internal::AsyncStreamingReadRpcAuth<
     $response_type$>;
 
   auto& child = child_;
-  auto call = [child, cq, opts = std::move(options), request](std::shared_ptr<grpc::ClientContext> ctx) {
-    return child->Async$method_name$(cq, std::move(ctx), opts, request);
+  auto call = [child, cq, opts = std::move(options), request$op_ctx_shared_cap$](std::shared_ptr<grpc::ClientContext> ctx) {
+    return child->Async$method_name$(cq, std::move(ctx), opts, request$op_ctx_shared_arg$);
   };
   return std::make_unique<StreamAuth>(
     std::move(context), auth_, StreamAuth::StreamFactory(std::move(call)));
 }
-)""";
-      CcPrintMethod(method, __FILE__, __LINE__, kDefinition);
+)""");
       continue;
     }
     if (IsStreamingWrite(method)) {
-      auto constexpr kDefinition = R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
 std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
     $request_type$, $response_type$>>
 $auth_class_name$::Async$method_name$(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
+    google::cloud::internal::ImmutableOptions options$op_ctx_shared_decl$) {
   using StreamAuth = google::cloud::internal::AsyncStreamingWriteRpcAuth<
     $request_type$, $response_type$>;
 
-  auto call = [child = child_, cq, options = std::move(options)](
+  auto call = [child = child_, cq, options = std::move(options)$op_ctx_shared_cap$](
                   std::shared_ptr<grpc::ClientContext> ctx) {
-    return child->Async$method_name$(cq, std::move(ctx), options);
+    return child->Async$method_name$(cq, std::move(ctx), options$op_ctx_shared_arg$);
   };
   return std::make_unique<StreamAuth>(
     std::move(context), auth_, StreamAuth::StreamFactory(std::move(call)));
 }
-)""";
-      CcPrintMethod(method, __FILE__, __LINE__, kDefinition);
+)""");
       continue;
     }
     if (IsResponseTypeEmpty(method)) {
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
 future<Status>
 $auth_class_name$::Async$method_name$(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      $request_type$ const& request) {
+      $request_type$ const& request$op_ctx_shared_decl$) {
   return auth_->AsyncConfigureContext(std::move(context)).then(
-      [cq, child = child_, options = std::move(options), request](
+      [cq, child = child_, options = std::move(options), request$op_ctx_shared_cap$](
           future<StatusOr<std::shared_ptr<grpc::ClientContext>>> f) mutable {
         auto context = f.get();
         if (!context) return make_ready_future(std::move(context).status());
         return child->Async$method_name$(
-            cq, *std::move(context), std::move(options), request);
+            cq, *std::move(context), std::move(options), request$op_ctx_shared_arg$);
       });
 }
 )""");
       continue;
     }
-    CcPrintMethod(method, __FILE__, __LINE__, R"""(
+    CcPrintMethod(method, __FILE__, __LINE__,
+                  R"""(
 future<StatusOr<$response_type$>>
 $auth_class_name$::Async$method_name$(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      $request_type$ const& request) {
+      $request_type$ const& request$op_ctx_shared_decl$) {
   return auth_->AsyncConfigureContext(std::move(context)).then(
-      [cq, child = child_, options = std::move(options), request](
+      [cq, child = child_, options = std::move(options), request$op_ctx_shared_cap$](
           future<StatusOr<std::shared_ptr<grpc::ClientContext>>> f) mutable {
         auto context = f.get();
         if (!context) {
@@ -317,7 +325,7 @@ $auth_class_name$::Async$method_name$(
               std::move(context).status()));
         }
         return child->Async$method_name$(
-            cq, *std::move(context), std::move(options), request);
+            cq, *std::move(context), std::move(options), request$op_ctx_shared_arg$);
       });
 }
 )""");
@@ -325,23 +333,24 @@ $auth_class_name$::Async$method_name$(
 
   // long running operation support methods
   if (HasLongrunningMethod()) {
-    CcPrint(R"""(
+    CcPrint(
+        R"""(
 future<StatusOr<google::longrunning::Operation>>
 $auth_class_name$::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::longrunning::GetOperationRequest const& request) {
+    google::longrunning::GetOperationRequest const& request$op_ctx_shared_decl$) {
   using ReturnType = StatusOr<google::longrunning::Operation>;
   return auth_->AsyncConfigureContext(std::move(context)).then(
-      [cq, child = child_, options = std::move(options), request](
+      [cq, child = child_, options = std::move(options), request$op_ctx_shared_cap$](
           future<StatusOr<std::shared_ptr<grpc::ClientContext>>> f) mutable {
         auto context = f.get();
         if (!context) {
           return make_ready_future(ReturnType(std::move(context).status()));
         }
         return child->AsyncGetOperation(
-            cq, *std::move(context), std::move(options), request);
+            cq, *std::move(context), std::move(options), request$op_ctx_shared_arg$);
       });
 }
 
@@ -349,14 +358,14 @@ future<Status> $auth_class_name$::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::longrunning::CancelOperationRequest const& request) {
+    google::longrunning::CancelOperationRequest const& request$op_ctx_shared_decl$) {
   return auth_->AsyncConfigureContext(std::move(context)).then(
-      [cq, child = child_, options = std::move(options), request](
+      [cq, child = child_, options = std::move(options), request$op_ctx_shared_cap$](
           future<StatusOr<std::shared_ptr<grpc::ClientContext>>> f) mutable {
         auto context = f.get();
         if (!context) return make_ready_future(std::move(context).status());
         return child->AsyncCancelOperation(
-            cq, *std::move(context), std::move(options), request);
+            cq, *std::move(context), std::move(options), request$op_ctx_shared_arg$);
       });
 }
 )""");

--- a/generator/internal/codegen_utils_test.cc
+++ b/generator/internal/codegen_utils_test.cc
@@ -323,6 +323,15 @@ TEST(ProcessCommandLineArgs, ProcessExperimental) {
   EXPECT_THAT(*result, Contains(Pair("experimental", "true")));
 }
 
+TEST(ProcessCommandLineArgs, ProcessExperimentalBigtableOperationContext) {
+  auto result = ProcessCommandLineArgs(
+      "product_path=google/cloud/bigtable/"
+      ",experimental_bigtable_operation_context=true");
+  ASSERT_THAT(result, IsOk());
+  EXPECT_THAT(*result, Contains(Pair("experimental_bigtable_operation_context",
+                                     "true")));
+}
+
 TEST(ProcessCommandLineArgs, ProcessServiceNameMapping) {
   auto result = ProcessCommandLineArgs(
       "product_path=google/cloud/pubsub/"

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -851,6 +851,37 @@ VarsDictionary CreateServiceVars(
   SetRetryStatusCodeExpression(vars);
   vars["transient_errors_comment"] = TransientErrorsComment(vars);
   SetLongrunningOperationServiceVars(descriptor, vars);
+  auto const experimental_bigtable_operation_context =
+      vars.find("experimental_bigtable_operation_context");
+  if (experimental_bigtable_operation_context != vars.end() &&
+      experimental_bigtable_operation_context->second == "true") {
+    vars["op_ctx_decl"] =
+        ",\n      google::cloud::bigtable_internal::OperationContext& "
+        "operation_context";
+    vars["op_ctx_arg"] = ", operation_context";
+    vars["op_ctx_cap"] = ", &operation_context";
+    vars["op_ctx_stub_decl"] =
+        ",\n    google::cloud::bigtable_internal::OperationContext&";
+    vars["op_ctx_shared_decl"] =
+        ",\n      "
+        "std::shared_ptr<google::cloud::bigtable_internal::OperationContext> "
+        "operation_context";
+    vars["op_ctx_shared_arg"] = ", std::move(operation_context)";
+    vars["op_ctx_shared_cap"] =
+        ", operation_context = std::move(operation_context)";
+    vars["op_ctx_shared_stub_decl"] =
+        ",\n    "
+        "std::shared_ptr<google::cloud::bigtable_internal::OperationContext>";
+  } else {
+    vars["op_ctx_decl"] = "";
+    vars["op_ctx_arg"] = "";
+    vars["op_ctx_cap"] = "";
+    vars["op_ctx_stub_decl"] = "";
+    vars["op_ctx_shared_decl"] = "";
+    vars["op_ctx_shared_arg"] = "";
+    vars["op_ctx_shared_cap"] = "";
+    vars["op_ctx_shared_stub_decl"] = "";
+  }
   return vars;
 }
 

--- a/generator/internal/logging_decorator_generator.cc
+++ b/generator/internal/logging_decorator_generator.cc
@@ -165,13 +165,13 @@ std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
     $response_type$>>
 $logging_class_name$::$method_name$(
     std::shared_ptr<grpc::ClientContext> context,
-    Options const& options) {
+    Options const& options$op_ctx_shared_decl$) {
   using LoggingStream = ::google::cloud::internal::StreamingWriteRpcLogging<
       $request_type$, $response_type$>;
 
   auto request_id = google::cloud::internal::RequestIdForLogging();
   GCP_LOG(DEBUG) << __func__ << "(" << request_id << ")";
-  auto stream = child_->$method_name$(std::move(context), options);
+  auto stream = child_->$method_name$(std::move(context), options$op_ctx_shared_arg$);
   if (stream_logging_) {
     stream = std::make_unique<LoggingStream>(
         std::move(stream), tracing_options_, std::move(request_id));
@@ -190,14 +190,14 @@ std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
 $logging_class_name$::Async$method_name$(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
+    google::cloud::internal::ImmutableOptions options$op_ctx_shared_decl$) {
   using LoggingStream =
      ::google::cloud::internal::AsyncStreamingReadWriteRpcLogging<$request_type$, $response_type$>;
 
   auto request_id = google::cloud::internal::RequestIdForLogging();
   GCP_LOG(DEBUG) << __func__ << "(" << request_id << ")";
   auto stream = child_->Async$method_name$(
-      cq, std::move(context), std::move(options));
+      cq, std::move(context), std::move(options)$op_ctx_shared_arg$);
   if (stream_logging_) {
     stream = std::make_unique<LoggingStream>(
         std::move(stream), tracing_options_, std::move(request_id));
@@ -208,36 +208,38 @@ $logging_class_name$::Async$method_name$(
       continue;
     }
     if (IsLongrunningOperation(method)) {
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
 future<StatusOr<google::longrunning::Operation>>
 $logging_class_name$::Async$method_name$(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      $request_type$ const& request) {
+      $request_type$ const& request$op_ctx_shared_decl$) {
   return google::cloud::internal::LogWrapper(
-      [this](google::cloud::CompletionQueue& cq,
+      [this$op_ctx_shared_cap$](google::cloud::CompletionQueue& cq,
              std::shared_ptr<grpc::ClientContext> context,
              google::cloud::internal::ImmutableOptions options,
              $request_type$ const& request) {
         return child_->Async$method_name$(
-            cq, std::move(context), std::move(options), request);
+            cq, std::move(context), std::move(options), request$op_ctx_shared_arg$);
       },
       cq, std::move(context), std::move(options), request, __func__,
       tracing_options_);
 }
 )""");
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
 StatusOr<google::longrunning::Operation>
 $logging_class_name$::$method_name$(
       grpc::ClientContext& context,
       Options options,
-      $request_type$ const& request) {
+      $request_type$ const& request$op_ctx_decl$) {
   return google::cloud::internal::LogWrapper(
-      [this](grpc::ClientContext& context,
+      [this$op_ctx_cap$](grpc::ClientContext& context,
              Options const& options,
              $request_type$ const& request) {
-        return child_->$method_name$(context, options, request);
+        return child_->$method_name$(context, options, request$op_ctx_arg$);
       },
       context, options, request, __func__, tracing_options_);
 }
@@ -246,20 +248,21 @@ $logging_class_name$::$method_name$(
       continue;
     }
     if (IsStreamingRead(method)) {
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
 std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     $response_type$>>
 $logging_class_name$::$method_name$(
     std::shared_ptr<grpc::ClientContext> context,
     Options const& options,
-    $request_type$ const& request) {
+    $request_type$ const& request$op_ctx_shared_decl$) {
   return google::cloud::internal::LogWrapper(
-      [this](std::shared_ptr<grpc::ClientContext> context,
+      [this$op_ctx_shared_cap$](std::shared_ptr<grpc::ClientContext> context,
              Options const& options,
              $request_type$ const& request)
           -> std::unique_ptr<google::cloud::internal::StreamingReadRpc<
               $response_type$>> {
-        auto stream = child_->$method_name$(std::move(context), options, request);
+        auto stream = child_->$method_name$(std::move(context), options, request$op_ctx_shared_arg$);
         if (stream_logging_) {
           stream =
               std::make_unique<google::cloud::internal::StreamingReadRpcLogging<
@@ -280,12 +283,12 @@ $logging_class_name$::$method_name$(
 $logging_class_name$::$method_name$(
     grpc::ClientContext& context,
     Options const& options,
-    $request_type$ const& request) {
+    $request_type$ const& request$op_ctx_decl$) {
   return google::cloud::internal::LogWrapper(
-      [this](grpc::ClientContext& context,
+      [this$op_ctx_cap$](grpc::ClientContext& context,
              Options const& options,
              $request_type$ const& request) {
-        return child_->$method_name$(context, options, request);
+        return child_->$method_name$(context, options, request$op_ctx_arg$);
       },
       context, options, request, __func__, tracing_options_);
 }
@@ -296,14 +299,15 @@ $logging_class_name$::$method_name$(
     // Nothing to do, these are always asynchronous.
     if (IsBidirStreaming(method) || IsLongrunningOperation(method)) continue;
     if (IsStreamingRead(method)) {
-      auto constexpr kDefinition = R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
 std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
     $response_type$>>
 $logging_class_name$::Async$method_name$(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    $request_type$ const& request) {
+    $request_type$ const& request$op_ctx_shared_decl$) {
   using LoggingStream =
      ::google::cloud::internal::AsyncStreamingReadRpcLogging<$response_type$>;
 
@@ -312,56 +316,56 @@ $logging_class_name$::Async$method_name$(
       __func__, request_id,
       google::cloud::internal::DebugString(request, tracing_options_));
   auto stream = child_->Async$method_name$(
-      cq, std::move(context), std::move(options), request);
+      cq, std::move(context), std::move(options), request$op_ctx_shared_arg$);
   if (stream_logging_) {
     stream = std::make_unique<LoggingStream>(
         std::move(stream), tracing_options_, std::move(request_id));
   }
   return stream;
 }
-)""";
-      CcPrintMethod(method, __FILE__, __LINE__, kDefinition);
+)""");
       continue;
     }
     if (IsStreamingWrite(method)) {
-      auto constexpr kDefinition = R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
 std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
     $request_type$, $response_type$>>
 $logging_class_name$::Async$method_name$(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
+    google::cloud::internal::ImmutableOptions options$op_ctx_shared_decl$) {
   using LoggingStream = ::google::cloud::internal::AsyncStreamingWriteRpcLogging<
       $request_type$, $response_type$>;
 
   auto request_id = google::cloud::internal::RequestIdForLogging();
   GCP_LOG(DEBUG) << __func__ << "(" << request_id << ")";
   auto stream = child_->Async$method_name$(
-      cq, std::move(context), std::move(options));
+      cq, std::move(context), std::move(options)$op_ctx_shared_arg$);
   if (stream_logging_) {
     stream = std::make_unique<LoggingStream>(
         std::move(stream), tracing_options_, std::move(request_id));
   }
   return stream;
 }
-)""";
-      CcPrintMethod(method, __FILE__, __LINE__, kDefinition);
+)""");
       continue;
     }
     CcPrintMethod(method, __FILE__, __LINE__, "\nfuture<$return_type$>");
-    CcPrintMethod(method, __FILE__, __LINE__, R"""(
+    CcPrintMethod(method, __FILE__, __LINE__,
+                  R"""(
 $logging_class_name$::Async$method_name$(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      $request_type$ const& request) {
+      $request_type$ const& request$op_ctx_shared_decl$) {
   return google::cloud::internal::LogWrapper(
-      [this](google::cloud::CompletionQueue& cq,
+      [this$op_ctx_shared_cap$](google::cloud::CompletionQueue& cq,
              std::shared_ptr<grpc::ClientContext> context,
              google::cloud::internal::ImmutableOptions options,
              $request_type$ const& request) {
         return child_->Async$method_name$(
-            cq, std::move(context), std::move(options), request);
+            cq, std::move(context), std::move(options), request$op_ctx_shared_arg$);
       },
       cq, std::move(context), std::move(options), request, __func__, tracing_options_);
 }
@@ -370,20 +374,21 @@ $logging_class_name$::Async$method_name$(
 
   // long running operation support methods
   if (HasLongrunningMethod()) {
-    CcPrint(R"""(
+    CcPrint(
+        R"""(
 future<StatusOr<google::longrunning::Operation>>
 $logging_class_name$::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::longrunning::GetOperationRequest const& request) {
+    google::longrunning::GetOperationRequest const& request$op_ctx_shared_decl$) {
   return google::cloud::internal::LogWrapper(
-      [this](google::cloud::CompletionQueue& cq,
+      [this$op_ctx_shared_cap$](google::cloud::CompletionQueue& cq,
              std::shared_ptr<grpc::ClientContext> context,
              google::cloud::internal::ImmutableOptions options,
              google::longrunning::GetOperationRequest const& request) {
         return child_->AsyncGetOperation(
-            cq, std::move(context), std::move(options), request);
+            cq, std::move(context), std::move(options), request$op_ctx_shared_arg$);
       },
       cq, std::move(context), std::move(options), request, __func__,
       tracing_options_);
@@ -393,14 +398,14 @@ future<Status> $logging_class_name$::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::longrunning::CancelOperationRequest const& request) {
+    google::longrunning::CancelOperationRequest const& request$op_ctx_shared_decl$) {
   return google::cloud::internal::LogWrapper(
-      [this](google::cloud::CompletionQueue& cq,
+      [this$op_ctx_shared_cap$](google::cloud::CompletionQueue& cq,
              std::shared_ptr<grpc::ClientContext> context,
              google::cloud::internal::ImmutableOptions options,
              google::longrunning::CancelOperationRequest const& request) {
         return child_->AsyncCancelOperation(
-            cq, std::move(context), std::move(options), request);
+            cq, std::move(context), std::move(options), request$op_ctx_shared_arg$);
       },
       cq, std::move(context), std::move(options), request, __func__,
       tracing_options_);

--- a/generator/internal/metadata_decorator_generator.cc
+++ b/generator/internal/metadata_decorator_generator.cc
@@ -218,9 +218,9 @@ std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
     $response_type$>>
 $metadata_class_name$::$method_name$(
     std::shared_ptr<grpc::ClientContext> context,
-    Options const& options) {
+    Options const& options$op_ctx_shared_decl$) {
   SetMetadata(*context, options);
-  return child_->$method_name$(std::move(context), options);
+  return child_->$method_name$(std::move(context), options$op_ctx_shared_arg$);
 }
 )""");
       continue;
@@ -238,72 +238,80 @@ std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
 $metadata_class_name$::Async$method_name$(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
+    google::cloud::internal::ImmutableOptions options$op_ctx_shared_decl$) {
   SetMetadata(*context, *options);
-  return child_->Async$method_name$(cq, std::move(context), std::move(options));
+  return child_->Async$method_name$(cq, std::move(context), std::move(options)$op_ctx_shared_arg$);
 }
 )""");
       continue;
     }
     if (IsLongrunningOperation(method)) {
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
 future<StatusOr<google::longrunning::Operation>>
 $metadata_class_name$::Async$method_name$(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    $request_type$ const& request) {
+    $request_type$ const& request$op_ctx_shared_decl$) {
 )""");
       CcPrintMethod(method, __FILE__, __LINE__,
                     SetMetadataText(method, kPointer, "*options"));
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
   return child_->Async$method_name$(
-      cq, std::move(context), std::move(options), request);
+      cq, std::move(context), std::move(options), request$op_ctx_shared_arg$);
 }
 )""");
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
 StatusOr<google::longrunning::Operation>
 $metadata_class_name$::$method_name$(
     grpc::ClientContext& context,
     Options options,
-    $request_type$ const& request) {
+    $request_type$ const& request$op_ctx_decl$) {
 )""");
       CcPrintMethod(method, __FILE__, __LINE__,
                     SetMetadataText(method, kReference, "options"));
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
-  return child_->$method_name$(context, options, request);
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
+  return child_->$method_name$(context, options, request$op_ctx_arg$);
 }
 )""");
 
       continue;
     }
     if (IsStreamingRead(method)) {
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
 std::unique_ptr<google::cloud::internal::StreamingReadRpc<$response_type$>>
 $metadata_class_name$::$method_name$(
     std::shared_ptr<grpc::ClientContext> context,
     Options const& options,
-    $request_type$ const& request) {
+    $request_type$ const& request$op_ctx_shared_decl$) {
 )""");
       CcPrintMethod(method, __FILE__, __LINE__,
                     SetMetadataText(method, kPointer, "options"));
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
-  return child_->$method_name$(std::move(context), options, request);
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
+  return child_->$method_name$(std::move(context), options, request$op_ctx_shared_arg$);
 }
 )""");
       continue;
     }
     CcPrintMethod(method, __FILE__, __LINE__, "\n$return_type$");
-    CcPrintMethod(method, __FILE__, __LINE__, R"""(
+    CcPrintMethod(method, __FILE__, __LINE__,
+                  R"""(
 $metadata_class_name$::$method_name$(
     grpc::ClientContext& context,
     Options const& options,
-    $request_type$ const& request) {
+    $request_type$ const& request$op_ctx_decl$) {
 )""");
     CcPrintMethod(method, __FILE__, __LINE__,
                   SetMetadataText(method, kReference, "options"));
-    CcPrintMethod(method, __FILE__, __LINE__, R"""(
-  return child_->$method_name$(context, options, request);
+    CcPrintMethod(method, __FILE__, __LINE__,
+                  R"""(
+  return child_->$method_name$(context, options, request$op_ctx_arg$);
 }
 )""");
   }
@@ -320,12 +328,12 @@ $metadata_class_name$::Async$method_name$(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    $request_type$ const& request) {
+    $request_type$ const& request$op_ctx_shared_decl$) {
 )""",
           SetMetadataText(method, kPointer, "*options"),
           R"""(
   return child_->Async$method_name$(
-      cq, std::move(context), std::move(options), request);
+      cq, std::move(context), std::move(options), request$op_ctx_shared_arg$);
 }
 )""");
       CcPrintMethod(method, __FILE__, __LINE__, definition);
@@ -336,62 +344,65 @@ $metadata_class_name$::Async$method_name$(
       // first `Write()` call contains any relevant data to "start" the stream.
       // Thus, the decorator cannot add any routing instructions. The caller
       // should initialize `context` with any such instructions.
-      auto const definition = absl::StrCat(
+      auto const* definition =
           R"""(
 std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
     $request_type$, $response_type$>>
 $metadata_class_name$::Async$method_name$(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
+    google::cloud::internal::ImmutableOptions options$op_ctx_shared_decl$) {
   SetMetadata(*context, *options);
-  return child_->Async$method_name$(cq, std::move(context), std::move(options));
+  return child_->Async$method_name$(cq, std::move(context), std::move(options)$op_ctx_shared_arg$);
 }
-)""");
+)""";
       CcPrintMethod(method, __FILE__, __LINE__, definition);
       continue;
     }
     CcPrintMethod(method, __FILE__, __LINE__, "\nfuture<$return_type$>");
-    CcPrintMethod(method, __FILE__, __LINE__, R"""(
+    CcPrintMethod(method, __FILE__, __LINE__,
+                  R"""(
 $metadata_class_name$::Async$method_name$(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      $request_type$ const& request) {
+      $request_type$ const& request$op_ctx_shared_decl$) {
 )""");
     CcPrintMethod(method, __FILE__, __LINE__,
                   SetMetadataText(method, kPointer, "*options"));
-    CcPrintMethod(method, __FILE__, __LINE__, R"""(
+    CcPrintMethod(method, __FILE__, __LINE__,
+                  R"""(
   return child_->Async$method_name$(
-      cq, std::move(context), std::move(options), request);
+      cq, std::move(context), std::move(options), request$op_ctx_shared_arg$);
 }
 )""");
   }
 
   // long running operation support methods
   if (HasLongrunningMethod()) {
-    CcPrint(R"""(
+    CcPrint(
+        R"""(
 future<StatusOr<google::longrunning::Operation>>
 $metadata_class_name$::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::longrunning::GetOperationRequest const& request) {
+    google::longrunning::GetOperationRequest const& request$op_ctx_shared_decl$) {
   SetMetadata(*context, *options,
               absl::StrCat("name=", internal::UrlEncode(request.name())));
   return child_->AsyncGetOperation(
-      cq, std::move(context), std::move(options), request);
+      cq, std::move(context), std::move(options), request$op_ctx_shared_arg$);
 }
 
 future<Status> $metadata_class_name$::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::longrunning::CancelOperationRequest const& request) {
+    google::longrunning::CancelOperationRequest const& request$op_ctx_shared_decl$) {
   SetMetadata(*context, *options,
               absl::StrCat("name=", internal::UrlEncode(request.name())));
   return child_->AsyncCancelOperation(
-      cq, std::move(context), std::move(options), request);
+      cq, std::move(context), std::move(options), request$op_ctx_shared_arg$);
 }
 )""");
   }

--- a/generator/internal/round_robin_decorator_generator.cc
+++ b/generator/internal/round_robin_decorator_generator.cc
@@ -17,6 +17,7 @@
 #include "generator/internal/longrunning.h"
 #include "generator/internal/predicate_utils.h"
 #include "generator/internal/printer.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_split.h"
 #include <google/protobuf/descriptor.h>
 
@@ -114,75 +115,81 @@ $round_robin_class_name$::$round_robin_class_name$(
 
   for (auto const& method : methods()) {
     if (IsStreamingRead(method)) {
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
 std::unique_ptr<google::cloud::internal::StreamingReadRpc<$response_type$>>
 $round_robin_class_name$::$method_name$(
     std::shared_ptr<grpc::ClientContext> context,
     Options const& options,
-    $request_type$ const& request) {
-  return Child()->$method_name$(std::move(context), options, request);
+    $request_type$ const& request$op_ctx_shared_decl$) {
+  return Child()->$method_name$(std::move(context), options, request$op_ctx_shared_arg$);
 }
 )""");
       continue;
     }
     if (IsStreamingWrite(method)) {
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
 std::unique_ptr<google::cloud::internal::StreamingWriteRpc<
     $request_type$, $response_type$>>
 $round_robin_class_name$::$method_name$(
     std::shared_ptr<grpc::ClientContext> context,
-    Options const& options) {
-  return Child()->$method_name$(std::move(context), options);
+    Options const& options$op_ctx_shared_decl$) {
+  return Child()->$method_name$(std::move(context), options$op_ctx_shared_arg$);
 }
 )""");
       continue;
     }
     if (IsBidirStreaming(method)) {
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
 std::unique_ptr<google::cloud::AsyncStreamingReadWriteRpc<
     $request_type$,
     $response_type$>>
 $round_robin_class_name$::Async$method_name$(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
+    google::cloud::internal::ImmutableOptions options$op_ctx_shared_decl$) {
   return Child()->Async$method_name$(
-      cq, std::move(context), std::move(options));
+      cq, std::move(context), std::move(options)$op_ctx_shared_arg$);
 }
 )""");
       continue;
     }
     if (IsLongrunningOperation(method)) {
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
 future<StatusOr<google::longrunning::Operation>>
 $round_robin_class_name$::Async$method_name$(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    $request_type$ const& request) {
+    $request_type$ const& request$op_ctx_shared_decl$) {
   return Child()->Async$method_name$(
-      cq, std::move(context), std::move(options), request);
+      cq, std::move(context), std::move(options), request$op_ctx_shared_arg$);
 }
 )""");
 
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
 StatusOr<google::longrunning::Operation>
 $round_robin_class_name$::$method_name$(
       grpc::ClientContext& context,
       Options options,
-      $request_type$ const& request) {
-  return Child()->$method_name$(context, options, request);
+      $request_type$ const& request$op_ctx_decl$) {
+  return Child()->$method_name$(context, options, request$op_ctx_arg$);
 }
 )""");
 
       continue;
     }
-    CcPrintMethod(method, __FILE__, __LINE__, R"""(
+    CcPrintMethod(method, __FILE__, __LINE__,
+                  R"""(
 $return_type$ $round_robin_class_name$::$method_name$(
     grpc::ClientContext& context,
     Options const& options,
-    $request_type$ const& request) {
-  return Child()->$method_name$(context, options, request);
+    $request_type$ const& request$op_ctx_decl$) {
+  return Child()->$method_name$(context, options, request$op_ctx_arg$);
 }
 )""");
   }
@@ -191,59 +198,63 @@ $return_type$ $round_robin_class_name$::$method_name$(
     // Nothing to do, these are always asynchronous.
     if (IsBidirStreaming(method) || IsLongrunningOperation(method)) continue;
     if (IsStreamingRead(method)) {
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
 std::unique_ptr<google::cloud::internal::AsyncStreamingReadRpc<
     $response_type$>>
 $round_robin_class_name$::Async$method_name$(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    $request_type$ const& request) {
+    $request_type$ const& request$op_ctx_shared_decl$) {
   return Child()->Async$method_name$(
-      cq, std::move(context), std::move(options), request);
+      cq, std::move(context), std::move(options), request$op_ctx_shared_arg$);
 }
 )""");
       continue;
     }
     if (IsStreamingWrite(method)) {
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
 std::unique_ptr<google::cloud::internal::AsyncStreamingWriteRpc<
     $request_type$,
     $response_type$>>
 $round_robin_class_name$::Async$method_name$(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
+    google::cloud::internal::ImmutableOptions options$op_ctx_shared_decl$) {
   return Child()->Async$method_name$(
-      cq, std::move(context), std::move(options));
+      cq, std::move(context), std::move(options)$op_ctx_shared_arg$);
 }
 )""");
       continue;
     }
     CcPrintMethod(method, __FILE__, __LINE__, "\nfuture<$return_type$>");
-    CcPrintMethod(method, __FILE__, __LINE__, R"""(
+    CcPrintMethod(method, __FILE__, __LINE__,
+                  R"""(
 $round_robin_class_name$::Async$method_name$(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    $request_type$ const& request) {
+    $request_type$ const& request$op_ctx_shared_decl$) {
   return Child()->Async$method_name$(
-      cq, std::move(context), std::move(options), request);
+      cq, std::move(context), std::move(options), request$op_ctx_shared_arg$);
 }
 )""");
   }
 
   // long-running operation support methods
   if (HasLongrunningMethod()) {
-    CcPrint(R"""(
+    CcPrint(
+        R"""(
 future<StatusOr<google::longrunning::Operation>>
 $round_robin_class_name$::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::longrunning::GetOperationRequest const& request) {
+    google::longrunning::GetOperationRequest const& request$op_ctx_shared_decl$) {
   return Child()->AsyncGetOperation(
-      cq, std::move(context), std::move(options), request);
+      cq, std::move(context), std::move(options), request$op_ctx_shared_arg$);
 }
 
 future<Status>
@@ -251,9 +262,9 @@ $round_robin_class_name$::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::longrunning::CancelOperationRequest const& request) {
+    google::longrunning::CancelOperationRequest const& request$op_ctx_shared_decl$) {
   return Child()->AsyncCancelOperation(
-      cq, std::move(context), std::move(options), request);
+      cq, std::move(context), std::move(options), request$op_ctx_shared_arg$);
 }
 )""");
   }

--- a/generator/internal/service_code_generator.cc
+++ b/generator/internal/service_code_generator.cc
@@ -105,6 +105,11 @@ bool ServiceCodeGenerator::IsExperimental() const {
   return iter != vars().end() && iter->second == "true";
 }
 
+bool ServiceCodeGenerator::HasExperimentalBigtableOperationContext() const {
+  auto iter = vars().find("experimental_bigtable_operation_context");
+  return iter != vars().end() && iter->second == "true";
+}
+
 bool ServiceCodeGenerator::HasLongrunningMethod() const {
   return std::any_of(methods_.begin(), methods_.end(),
                      [](google::protobuf::MethodDescriptor const& m) {

--- a/generator/internal/service_code_generator.h
+++ b/generator/internal/service_code_generator.h
@@ -128,6 +128,11 @@ class ServiceCodeGenerator : public GeneratorInterface {
   bool IsExperimental() const;
 
   /**
+   * Determines if the service enables experimental Bigtable OperationContext.
+   */
+  bool HasExperimentalBigtableOperationContext() const;
+
+  /**
    * Determines if the service contains at least one method that requires
    * LRO handling. This could be AIP-151 compatible or something custom.
    */

--- a/generator/internal/stub_generator.cc
+++ b/generator/internal/stub_generator.cc
@@ -90,6 +90,10 @@ Status StubGenerator::GenerateHeader() {
   auto result = HeaderOpenNamespaces(NamespaceType::kInternal);
   if (!result.ok()) return result;
 
+  if (HasExperimentalBigtableOperationContext()) {
+    HeaderPrint("\nclass OperationContext;\n");
+  }
+
   // Abstract interface Stub base class
   HeaderPrint(  // clang-format off
     "\n"
@@ -107,7 +111,7 @@ Status StubGenerator::GenerateHeader() {
       $response_type$>>
   $method_name$(
       std::shared_ptr<grpc::ClientContext> context,
-      Options const& options) = 0;
+      Options const& options$op_ctx_shared_decl$) = 0;
 )""");
       continue;
     }
@@ -120,41 +124,43 @@ Status StubGenerator::GenerateHeader() {
   Async$method_name$(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
-      google::cloud::internal::ImmutableOptions options) = 0;
+      google::cloud::internal::ImmutableOptions options$op_ctx_shared_decl$) = 0;
 )""");
       continue;
     }
     if (IsLongrunningOperation(method)) {
-      HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
+      HeaderPrintMethod(method, __FILE__, __LINE__,
+                        R"""(
   virtual future<StatusOr<google::longrunning::Operation>> Async$method_name$(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      $request_type$ const& request) = 0;
-)""");
-      HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
+      $request_type$ const& request$op_ctx_shared_decl$) = 0;
+
   virtual StatusOr<google::longrunning::Operation> $method_name$(
       grpc::ClientContext& context,
       Options options,
-      $request_type$ const& request) = 0;
+      $request_type$ const& request$op_ctx_decl$) = 0;
 )""");
       continue;
     }
     if (IsStreamingRead(method)) {
-      HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
+      HeaderPrintMethod(method, __FILE__, __LINE__,
+                        R"""(
   virtual std::unique_ptr<google::cloud::internal::StreamingReadRpc<$response_type$>>
   $method_name$(
     std::shared_ptr<grpc::ClientContext> context,
     Options const& options,
-    $request_type$ const& request) = 0;
+    $request_type$ const& request$op_ctx_shared_decl$) = 0;
 )""");
       continue;
     }
-    HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
+    HeaderPrintMethod(method, __FILE__, __LINE__,
+                      R"""(
   virtual $return_type$ $method_name$(
       grpc::ClientContext& context,
       Options const& options,
-      $request_type$ const& request) = 0;
+      $request_type$ const& request$op_ctx_decl$) = 0;
 )""");
   }
 
@@ -162,37 +168,38 @@ Status StubGenerator::GenerateHeader() {
     // Nothing to do, these are always asynchronous.
     if (IsBidirStreaming(method) || IsLongrunningOperation(method)) continue;
     if (IsStreamingRead(method)) {
-      auto constexpr kDeclaration = R"""(
+      HeaderPrintMethod(method, __FILE__, __LINE__,
+                        R"""(
   virtual std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       $response_type$>>
   Async$method_name$(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      $request_type$ const& request) = 0;
-)""";
-      HeaderPrintMethod(method, __FILE__, __LINE__, kDeclaration);
+      $request_type$ const& request$op_ctx_shared_decl$) = 0;
+)""");
       continue;
     }
     if (IsStreamingWrite(method)) {
-      auto constexpr kDeclaration = R"""(
+      HeaderPrintMethod(method, __FILE__, __LINE__,
+                        R"""(
   virtual std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
       $request_type$, $response_type$>>
   Async$method_name$(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) = 0;
-)""";
-      HeaderPrintMethod(method, __FILE__, __LINE__, kDeclaration);
+    google::cloud::internal::ImmutableOptions options$op_ctx_shared_decl$) = 0;
+)""");
       continue;
     }
-    HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
+    HeaderPrintMethod(method, __FILE__, __LINE__,
+                      R"""(
   virtual future<$return_type$>
   Async$method_name$(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    $request_type$ const& request) = 0;
+    $request_type$ const& request$op_ctx_shared_decl$) = 0;
 )""");
   }
 
@@ -204,13 +211,13 @@ Status StubGenerator::GenerateHeader() {
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-      google::longrunning::GetOperationRequest const& request) = 0;
+      google::longrunning::GetOperationRequest const& request$op_ctx_shared_decl$) = 0;
 
   virtual future<Status> AsyncCancelOperation(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::longrunning::CancelOperationRequest const& request) = 0;
+      google::longrunning::CancelOperationRequest const& request$op_ctx_shared_decl$) = 0;
 )""");
   }
   // close abstract interface Stub base class
@@ -345,7 +352,7 @@ std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
     $response_type$>>
 Default$stub_class_name$::$method_name$(
     std::shared_ptr<grpc::ClientContext> context,
-    Options const&) {
+    Options const&$op_ctx_shared_stub_decl$) {
   auto response = std::make_unique<$response_type$>();
   auto stream = $grpc_stub$->$method_name$(context.get(), response.get());
   return std::make_unique<::google::cloud::internal::StreamingWriteRpcImpl<
@@ -364,7 +371,7 @@ std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
 Default$stub_class_name$::Async$method_name$(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
+    google::cloud::internal::ImmutableOptions options$op_ctx_shared_stub_decl$) {
   return google::cloud::internal::MakeStreamingReadWriteRpc<$request_type$, $response_type$>(
       cq, std::move(context), std::move(options),
       [this](grpc::ClientContext* context, grpc::CompletionQueue* cq) {
@@ -382,7 +389,7 @@ Default$stub_class_name$::Async$method_name$(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions,
-      $request_type$ const& request) {
+      $request_type$ const& request$op_ctx_shared_stub_decl$) {
   return internal::MakeUnaryRpcImpl<$request_type$,
                                     google::longrunning::Operation>(
       cq,
@@ -401,7 +408,7 @@ StatusOr<google::longrunning::Operation>
 Default$stub_class_name$::$method_name$(
       grpc::ClientContext& context,
       Options,
-      $request_type$ const& request) {
+      $request_type$ const& request$op_ctx_stub_decl$) {
     $response_type$ response;
     auto status =
         $grpc_stub$->$method_name$(&context, request, &response);
@@ -421,7 +428,7 @@ std::unique_ptr<google::cloud::internal::StreamingReadRpc<$response_type$>>
 Default$stub_class_name$::$method_name$(
     std::shared_ptr<grpc::ClientContext> context,
     Options const&,
-    $request_type$ const& request) {
+    $request_type$ const& request$op_ctx_shared_stub_decl$) {
   auto stream = $grpc_stub$->$method_name$(context.get(), request);
   return std::make_unique<google::cloud::internal::StreamingReadRpcImpl<
       $response_type$>>(
@@ -437,7 +444,7 @@ Default$stub_class_name$::$method_name$(
 Status
 Default$stub_class_name$::$method_name$(
   grpc::ClientContext& context, Options const&,
-  $request_type$ const& request) {
+  $request_type$ const& request$op_ctx_stub_decl$) {
     $response_type$ response;
     auto status =
         $grpc_stub$->$method_name$(&context, request, &response);
@@ -454,7 +461,7 @@ Default$stub_class_name$::$method_name$(
 StatusOr<$response_type$>
 Default$stub_class_name$::$method_name$(
   grpc::ClientContext& context, Options const&,
-  $request_type$ const& request) {
+  $request_type$ const& request$op_ctx_stub_decl$) {
     $response_type$ response;
     auto status =
         $grpc_stub$->$method_name$(&context, request, &response);
@@ -471,14 +478,15 @@ Default$stub_class_name$::$method_name$(
     if (IsBidirStreaming(method) || IsLongrunningOperation(method)) continue;
 
     if (IsStreamingRead(method)) {
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
 std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
     $response_type$>>
 Default$stub_class_name$::Async$method_name$(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    $request_type$ const& request) {
+    $request_type$ const& request$op_ctx_shared_stub_decl$) {
   return google::cloud::internal::MakeStreamingReadRpc<$request_type$, $response_type$>(
     cq, std::move(context), std::move(options), request,
     [this](grpc::ClientContext* context, $request_type$ const& request, grpc::CompletionQueue* cq) {
@@ -489,13 +497,14 @@ Default$stub_class_name$::Async$method_name$(
       continue;
     }
     if (IsStreamingWrite(method)) {
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
 std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
     $request_type$, $response_type$>>
 Default$stub_class_name$::Async$method_name$(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
+    google::cloud::internal::ImmutableOptions options$op_ctx_shared_stub_decl$) {
   return google::cloud::internal::MakeStreamingWriteRpc<$request_type$, $response_type$>(
     cq, std::move(context), std::move(options),
     [this](grpc::ClientContext* context, $response_type$* response, grpc::CompletionQueue* cq) {
@@ -514,7 +523,7 @@ Default$stub_class_name$::Async$method_name$(
     std::shared_ptr<grpc::ClientContext> context,
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
-    $request_type$ const& request) {
+    $request_type$ const& request$op_ctx_shared_stub_decl$) {
   return internal::MakeUnaryRpcImpl<$request_type$,
                                     $response_type$>(
       cq,
@@ -539,7 +548,7 @@ Default$stub_class_name$::Async$method_name$(
     std::shared_ptr<grpc::ClientContext> context,
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
-    $request_type$ const& request) {
+    $request_type$ const& request$op_ctx_shared_stub_decl$) {
   return internal::MakeUnaryRpcImpl<$request_type$,
                                     $response_type$>(
       cq,
@@ -554,14 +563,15 @@ Default$stub_class_name$::Async$method_name$(
   }
 
   if (HasLongrunningMethod()) {
-    CcPrint(R"""(
+    CcPrint(
+        R"""(
 future<StatusOr<google::longrunning::Operation>>
 Default$stub_class_name$::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
-    google::longrunning::GetOperationRequest const& request) {
+    google::longrunning::GetOperationRequest const& request$op_ctx_shared_stub_decl$) {
   return internal::MakeUnaryRpcImpl<google::longrunning::GetOperationRequest,
                                     google::longrunning::Operation>(
       cq,
@@ -578,7 +588,7 @@ future<Status> Default$stub_class_name$::AsyncCancelOperation(
     std::shared_ptr<grpc::ClientContext> context,
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
-    google::longrunning::CancelOperationRequest const& request) {
+    google::longrunning::CancelOperationRequest const& request$op_ctx_shared_stub_decl$) {
   return internal::MakeUnaryRpcImpl<google::longrunning::CancelOperationRequest,
                                     google::protobuf::Empty>(
       cq,

--- a/generator/internal/stub_generator_base.cc
+++ b/generator/internal/stub_generator_base.cc
@@ -15,6 +15,7 @@
 #include "generator/internal/stub_generator_base.h"
 #include "generator/internal/longrunning.h"
 #include "generator/internal/predicate_utils.h"
+#include "absl/strings/str_cat.h"
 #include <google/protobuf/descriptor.h>
 
 namespace google {
@@ -36,59 +37,63 @@ StubGeneratorBase::StubGeneratorBase(
 void StubGeneratorBase::HeaderPrintPublicMethods() {
   for (auto const& method : methods()) {
     if (IsStreamingWrite(method)) {
-      HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
+      HeaderPrintMethod(method, __FILE__, __LINE__,
+                        R"""(
   std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
       $request_type$,
       $response_type$>>
   $method_name$(
       std::shared_ptr<grpc::ClientContext> context,
-      Options const& options) override;
+      Options const& options$op_ctx_shared_decl$) override;
 )""");
       continue;
     }
     if (IsBidirStreaming(method)) {
-      HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
+      HeaderPrintMethod(method, __FILE__, __LINE__,
+                        R"""(
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       $request_type$,
       $response_type$>>
   Async$method_name$(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
-      google::cloud::internal::ImmutableOptions options) override;
+      google::cloud::internal::ImmutableOptions options$op_ctx_shared_decl$) override;
 )""");
       continue;
     }
     if (IsLongrunningOperation(method)) {
-      HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
+      HeaderPrintMethod(method, __FILE__, __LINE__,
+                        R"""(
   future<StatusOr<google::longrunning::Operation>> Async$method_name$(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      $request_type$ const& request) override;
-)""");
-      HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
+      $request_type$ const& request$op_ctx_shared_decl$) override;
+
   StatusOr<google::longrunning::Operation> $method_name$(
       grpc::ClientContext& context,
       Options options,
-      $request_type$ const& request) override;
+      $request_type$ const& request$op_ctx_decl$) override;
 )""");
       continue;
     }
     if (IsStreamingRead(method)) {
-      HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
+      HeaderPrintMethod(method, __FILE__, __LINE__,
+                        R"""(
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<$response_type$>>
   $method_name$(
       std::shared_ptr<grpc::ClientContext> context,
       Options const& options,
-      $request_type$ const& request) override;
+      $request_type$ const& request$op_ctx_shared_decl$) override;
 )""");
       continue;
     }
-    HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
+    HeaderPrintMethod(method, __FILE__, __LINE__,
+                      R"""(
   $return_type$ $method_name$(
       grpc::ClientContext& context,
       Options const& options,
-      $request_type$ const& request) override;
+      $request_type$ const& request$op_ctx_decl$) override;
 )""");
   }
 
@@ -96,52 +101,54 @@ void StubGeneratorBase::HeaderPrintPublicMethods() {
     // Nothing to do, these are always asynchronous.
     if (IsBidirStreaming(method) || IsLongrunningOperation(method)) continue;
     if (IsStreamingRead(method)) {
-      auto constexpr kDeclaration = R"""(
+      HeaderPrintMethod(method, __FILE__, __LINE__,
+                        R"""(
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       $response_type$>>
   Async$method_name$(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      $request_type$ const& request) override;
-)""";
-      HeaderPrintMethod(method, __FILE__, __LINE__, kDeclaration);
+      $request_type$ const& request$op_ctx_shared_decl$) override;
+)""");
       continue;
     }
     if (IsStreamingWrite(method)) {
-      auto constexpr kDeclaration = R"""(
+      HeaderPrintMethod(method, __FILE__, __LINE__,
+                        R"""(
   std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
       $request_type$, $response_type$>>
   Async$method_name$(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
-      google::cloud::internal::ImmutableOptions options) override;
-)""";
-      HeaderPrintMethod(method, __FILE__, __LINE__, kDeclaration);
+      google::cloud::internal::ImmutableOptions options$op_ctx_shared_decl$) override;
+)""");
       continue;
     }
-    HeaderPrintMethod(method, __FILE__, __LINE__, R"""(
+    HeaderPrintMethod(method, __FILE__, __LINE__,
+                      R"""(
   future<$return_type$> Async$method_name$(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      $request_type$ const& request) override;
+      $request_type$ const& request$op_ctx_shared_decl$) override;
 )""");
   }
 
   if (HasLongrunningMethod()) {
-    HeaderPrint(R"""(
+    HeaderPrint(
+        R"""(
   future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::longrunning::GetOperationRequest const& request) override;
+      google::longrunning::GetOperationRequest const& request$op_ctx_shared_decl$) override;
 
   future<Status> AsyncCancelOperation(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::longrunning::CancelOperationRequest const& request) override;
+      google::longrunning::CancelOperationRequest const& request$op_ctx_shared_decl$) override;
 )""");
   }
 }

--- a/generator/internal/tracing_stub_generator.cc
+++ b/generator/internal/tracing_stub_generator.cc
@@ -16,6 +16,7 @@
 #include "generator/internal/codegen_utils.h"
 #include "generator/internal/longrunning.h"
 #include "generator/internal/predicate_utils.h"
+#include "absl/strings/str_cat.h"
 
 namespace google {
 namespace cloud {
@@ -137,15 +138,16 @@ $tracing_stub_class_name$::$tracing_stub_class_name$(
   span->SetAttribute("gl-cpp.request_id", request.$request_id_field_name$());)"""
                                                            : "";
     if (IsStreamingWrite(method)) {
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
 std::unique_ptr<internal::StreamingWriteRpc<$request_type$, $response_type$>>
 $tracing_stub_class_name$::$method_name$(
     std::shared_ptr<grpc::ClientContext> context,
-    Options const& options) {
+    Options const& options$op_ctx_shared_decl$) {
   auto span = internal::MakeSpanGrpc("$grpc_service$", "$method_name$");
   auto scope = opentelemetry::trace::Scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto stream = child_->$method_name$(context, options);
+  auto stream = child_->$method_name$(context, options$op_ctx_shared_arg$);
   return std::make_unique<
       internal::StreamingWriteRpcTracing<$request_type$, $response_type$>>(
       std::move(context), std::move(stream), std::move(span));
@@ -154,17 +156,18 @@ $tracing_stub_class_name$::$method_name$(
       continue;
     }
     if (IsBidirStreaming(method)) {
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
 std::unique_ptr<AsyncStreamingReadWriteRpc<
     $request_type$,
     $response_type$>>
 $tracing_stub_class_name$::Async$method_name$(
     CompletionQueue const& cq, std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
+    google::cloud::internal::ImmutableOptions options$op_ctx_shared_decl$) {
   auto span = internal::MakeSpanGrpc("$grpc_service$", "$method_name$");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto stream = child_->Async$method_name$(cq, context, std::move(options));
+  auto stream = child_->Async$method_name$(cq, context, std::move(options)$op_ctx_shared_arg$);
   return std::make_unique<internal::AsyncStreamingReadWriteRpcTracing<
       $request_type$,
       $response_type$>>(
@@ -174,50 +177,55 @@ $tracing_stub_class_name$::Async$method_name$(
       continue;
     }
     if (IsLongrunningOperation(method)) {
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
 future<StatusOr<google::longrunning::Operation>>
 $tracing_stub_class_name$::Async$method_name$(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      $request_type$ const& request) {
+      $request_type$ const& request$op_ctx_shared_decl$) {
   auto span = internal::MakeSpanGrpc("$grpc_service$", "$method_name$");)""");
       CcPrintMethod(method, __FILE__, __LINE__, request_id_fragment);
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto f = child_->Async$method_name$(cq, context, std::move(options), request);
+  auto f = child_->Async$method_name$(cq, context, std::move(options), request$op_ctx_shared_arg$);
   return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 )""");
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
 StatusOr<google::longrunning::Operation>
 $tracing_stub_class_name$::$method_name$(
       grpc::ClientContext& context,
       Options options,
-      $request_type$ const& request) {
+      $request_type$ const& request$op_ctx_decl$) {
   auto span = internal::MakeSpanGrpc("$grpc_service$", "$method_name$");)""");
       CcPrintMethod(method, __FILE__, __LINE__, request_id_fragment);
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
   auto scope = opentelemetry::trace::Scope(span);
   internal::InjectTraceContext(context, *propagator_);
   return internal::EndSpan(context, *span,
-                           child_->$method_name$(context, options, request));
+                           child_->$method_name$(context, options, request$op_ctx_arg$));
 }
 )""");
       continue;
     }
     if (IsStreamingRead(method)) {
-      CcPrintMethod(method, __FILE__, __LINE__, R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
 std::unique_ptr<google::cloud::internal::StreamingReadRpc<$response_type$>>
 $tracing_stub_class_name$::$method_name$(
     std::shared_ptr<grpc::ClientContext> context,
     Options const& options,
-    $request_type$ const& request) {
+    $request_type$ const& request$op_ctx_shared_decl$) {
   auto span = internal::MakeSpanGrpc("$grpc_service$", "$method_name$");
   auto scope = opentelemetry::trace::Scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto stream = child_->$method_name$(context, options, request);
+  auto stream = child_->$method_name$(context, options, request$op_ctx_shared_arg$);
   return std::make_unique<internal::StreamingReadRpcTracing<$response_type$>>(
       std::move(context), std::move(stream), std::move(span));
 }
@@ -229,14 +237,15 @@ $tracing_stub_class_name$::$method_name$(
                   R"""( $tracing_stub_class_name$::$method_name$(
     grpc::ClientContext& context,
     Options const& options,
-    $request_type$ const& request) {
+    $request_type$ const& request$op_ctx_decl$) {
   auto span = internal::MakeSpanGrpc("$grpc_service$", "$method_name$");)""");
     CcPrintMethod(method, __FILE__, __LINE__, request_id_fragment);
-    CcPrintMethod(method, __FILE__, __LINE__, R"""(
+    CcPrintMethod(method, __FILE__, __LINE__,
+                  R"""(
   auto scope = opentelemetry::trace::Scope(span);
   internal::InjectTraceContext(context, *propagator_);
   return internal::EndSpan(context, *span,
-                           child_->$method_name$(context, options, request));
+                           child_->$method_name$(context, options, request$op_ctx_arg$));
 }
 )""");
   }
@@ -248,59 +257,61 @@ $tracing_stub_class_name$::$method_name$(
     // Nothing to do, these are always asynchronous.
     if (IsBidirStreaming(method) || IsLongrunningOperation(method)) continue;
     if (IsStreamingRead(method)) {
-      auto constexpr kDefinition = R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
 std::unique_ptr<internal::AsyncStreamingReadRpc<$response_type$>>
 $tracing_stub_class_name$::Async$method_name$(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    $request_type$ const& request) {
+    $request_type$ const& request$op_ctx_shared_decl$) {
   auto span = internal::MakeSpanGrpc("$grpc_service$", "$method_name$");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
   auto stream = child_->Async$method_name$(
-      cq, context, std::move(options), request);
+      cq, context, std::move(options), request$op_ctx_shared_arg$);
   return std::make_unique<
       internal::AsyncStreamingReadRpcTracing<$response_type$>>(
       std::move(context), std::move(stream), std::move(span));
 }
-)""";
-      CcPrintMethod(method, __FILE__, __LINE__, kDefinition);
+)""");
       continue;
     }
     if (IsStreamingWrite(method)) {
-      auto constexpr kDefinition = R"""(
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
 std::unique_ptr<
     internal::AsyncStreamingWriteRpc<$request_type$, $response_type$>>
 $tracing_stub_class_name$::Async$method_name$(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
+    google::cloud::internal::ImmutableOptions options$op_ctx_shared_decl$) {
   auto span = internal::MakeSpanGrpc("$grpc_service$", "$method_name$");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto stream = child_->Async$method_name$(cq, context, std::move(options));
+  auto stream = child_->Async$method_name$(cq, context, std::move(options)$op_ctx_shared_arg$);
   return std::make_unique<
       internal::AsyncStreamingWriteRpcTracing<$request_type$, $response_type$>>(
       std::move(context), std::move(stream), std::move(span));
 }
-)""";
-      CcPrintMethod(method, __FILE__, __LINE__, kDefinition);
+)""");
       continue;
     }
     CcPrintMethod(method, __FILE__, __LINE__, "\nfuture<$return_type$>");
-    CcPrintMethod(method, __FILE__, __LINE__, R"""(
+    CcPrintMethod(method, __FILE__, __LINE__,
+                  R"""(
 $tracing_stub_class_name$::Async$method_name$(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      $request_type$ const& request) {
+      $request_type$ const& request$op_ctx_shared_decl$) {
   auto span = internal::MakeSpanGrpc("$grpc_service$", "$method_name$");)""");
     CcPrintMethod(method, __FILE__, __LINE__, request_id_fragment);
-    CcPrintMethod(method, __FILE__, __LINE__, R"""(
+    CcPrintMethod(method, __FILE__, __LINE__,
+                  R"""(
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto f = child_->Async$method_name$(cq, context, std::move(options), request);
+  auto f = child_->Async$method_name$(cq, context, std::move(options), request$op_ctx_shared_arg$);
   return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 )""");
@@ -308,19 +319,20 @@ $tracing_stub_class_name$::Async$method_name$(
 
   // long running operation support methods
   if (HasLongrunningMethod()) {
-    CcPrint(R"""(
+    CcPrint(
+        R"""(
 future<StatusOr<google::longrunning::Operation>>
 $tracing_stub_class_name$::AsyncGetOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::longrunning::GetOperationRequest const& request) {
+    google::longrunning::GetOperationRequest const& request$op_ctx_shared_decl$) {
   auto span =
       internal::MakeSpanGrpc("google.longrunning.Operations", "GetOperation");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
   auto f = child_->AsyncGetOperation(
-      cq, context, std::move(options), request);
+      cq, context, std::move(options), request$op_ctx_shared_arg$);
   return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 
@@ -328,13 +340,13 @@ future<Status> $tracing_stub_class_name$::AsyncCancelOperation(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::longrunning::CancelOperationRequest const& request) {
+    google::longrunning::CancelOperationRequest const& request$op_ctx_shared_decl$) {
   auto span = internal::MakeSpanGrpc("google.longrunning.Operations",
                                      "CancelOperation");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
   auto f = child_->AsyncCancelOperation(
-      cq, context, std::move(options), request);
+      cq, context, std::move(options), request$op_ctx_shared_arg$);
   return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 )""");

--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -303,6 +303,10 @@ std::vector<std::future<google::cloud::Status>> GenerateCodeFromProtos(
       args.emplace_back(
           "--cpp_codegen_opt=generate_round_robin_decorator=true");
     }
+    if (service.experimental_bigtable_operation_context()) {
+      args.emplace_back(
+          "--cpp_codegen_opt=experimental_bigtable_operation_context=true");
+    }
     args.emplace_back("--cpp_codegen_opt=service_endpoint_env_var=" +
                       service.service_endpoint_env_var());
     args.emplace_back("--cpp_codegen_opt=emulator_endpoint_env_var=" +

--- a/google/cloud/bigtable/internal/async_bulk_apply.cc
+++ b/google/cloud/bigtable/internal/async_bulk_apply.cc
@@ -83,7 +83,7 @@ void AsyncBulkApplier::MakeRequest() {
   auto self = this->shared_from_this();
   PerformAsyncStreamingRead(
       stub_->AsyncMutateRows(cq_, client_context_, options_,
-                             state_.BeforeStart()),
+                             state_.BeforeStart(), operation_context_),
       [self](google::bigtable::v2::MutateRowsResponse r) {
         self->OnRead(std::move(r));
         return make_ready_future(self->keep_reading_.load());

--- a/google/cloud/bigtable/internal/async_bulk_apply_test.cc
+++ b/google/cloud/bigtable/internal/async_bulk_apply_test.cc
@@ -207,7 +207,7 @@ TEST_F(AsyncBulkApplyTest, Success) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRows)
       .WillOnce([this](CompletionQueue const&, auto client_context, auto,
-                       v2::MutateRowsRequest const& request) {
+                       v2::MutateRowsRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -281,7 +281,7 @@ TEST_F(AsyncBulkApplyTest, PartialStreamIsRetried) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRows)
       .WillOnce([this](CompletionQueue const&, auto context, auto,
-                       v2::MutateRowsRequest const& request) {
+                       v2::MutateRowsRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -306,7 +306,7 @@ TEST_F(AsyncBulkApplyTest, PartialStreamIsRetried) {
         return stream;
       })
       .WillOnce([this](CompletionQueue const&, auto client_context, auto,
-                       v2::MutateRowsRequest const& request) {
+                       v2::MutateRowsRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -383,7 +383,7 @@ TEST_F(AsyncBulkApplyTest, IdempotentMutationPolicy) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRows)
       .WillOnce([this](CompletionQueue const&, auto client_context, auto,
-                       v2::MutateRowsRequest const& request) {
+                       v2::MutateRowsRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -408,7 +408,7 @@ TEST_F(AsyncBulkApplyTest, IdempotentMutationPolicy) {
         return stream;
       })
       .WillOnce([this](CompletionQueue const&, auto client_context, auto,
-                       v2::MutateRowsRequest const& request) {
+                       v2::MutateRowsRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -464,7 +464,8 @@ TEST_F(AsyncBulkApplyTest, TooManyStreamFailures) {
   EXPECT_CALL(*mock, AsyncMutateRows)
       .Times(kNumRetries + 1)
       .WillRepeatedly([this](CompletionQueue const&, auto context, auto,
-                             v2::MutateRowsRequest const& request) {
+                             v2::MutateRowsRequest const& request,
+                             auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -530,7 +531,7 @@ TEST_F(AsyncBulkApplyTest, RetryInfoHeeded) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRows)
       .WillOnce([this](CompletionQueue const&, auto context, auto,
-                       v2::MutateRowsRequest const&) {
+                       v2::MutateRowsRequest const&, auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         auto stream = std::make_unique<MockAsyncMutateRowsStream>();
         EXPECT_CALL(*stream, Start).WillOnce([] {
@@ -544,7 +545,7 @@ TEST_F(AsyncBulkApplyTest, RetryInfoHeeded) {
         return stream;
       })
       .WillOnce([this](CompletionQueue const&, auto context, auto,
-                       v2::MutateRowsRequest const&) {
+                       v2::MutateRowsRequest const&, auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         auto stream = std::make_unique<MockAsyncMutateRowsStream>();
         EXPECT_CALL(*stream, Start).WillOnce([] {
@@ -603,7 +604,7 @@ TEST_F(AsyncBulkApplyTest, RetryInfoIgnored) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRows)
       .WillOnce([this](CompletionQueue const&, auto context, auto,
-                       v2::MutateRowsRequest const&) {
+                       v2::MutateRowsRequest const&, auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         auto stream = std::make_unique<MockAsyncMutateRowsStream>();
         EXPECT_CALL(*stream, Start).WillOnce([] {
@@ -640,7 +641,7 @@ TEST_F(AsyncBulkApplyTest, TimerError) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRows)
       .WillOnce([this](CompletionQueue const&, auto context, auto,
-                       v2::MutateRowsRequest const& request) {
+                       v2::MutateRowsRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -705,7 +706,7 @@ TEST_F(AsyncBulkApplyTest, CancelAfterSuccess) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRows)
       .WillOnce([&p, this](CompletionQueue const&, auto client_context, auto,
-                           v2::MutateRowsRequest const& request) {
+                           v2::MutateRowsRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -781,7 +782,7 @@ TEST_F(AsyncBulkApplyTest, CancelMidStream) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRows)
       .WillOnce([&p, this](CompletionQueue const&, auto client_context, auto,
-                           v2::MutateRowsRequest const& request) {
+                           v2::MutateRowsRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -849,7 +850,7 @@ TEST_F(AsyncBulkApplyTest, CurrentOptionsContinuedOnRetries) {
   EXPECT_CALL(*mock, AsyncMutateRows)
       .Times(2)
       .WillRepeatedly([this](CompletionQueue const&, auto context, auto,
-                             v2::MutateRowsRequest const&) {
+                             v2::MutateRowsRequest const&, auto const&) {
         EXPECT_EQ(5, internal::CurrentOptions().get<TestOption>());
         metadata_fixture_.SetServerMetadata(*context, {});
         auto stream = std::make_unique<MockAsyncMutateRowsStream>();
@@ -902,7 +903,8 @@ TEST_F(AsyncBulkApplyTest, RetriesOkStreamWithFailedMutations) {
   EXPECT_CALL(*mock, AsyncMutateRows)
       .Times(kNumRetries + 1)
       .WillRepeatedly([this](CompletionQueue const&, auto context, auto,
-                             v2::MutateRowsRequest const& request) {
+                             v2::MutateRowsRequest const& request,
+                             auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -974,7 +976,8 @@ TEST_F(AsyncBulkApplyTest, Throttling) {
   });
   EXPECT_CALL(*mock, AsyncMutateRows)
       .WillOnce([&limiter, this](CompletionQueue const&, auto client_context,
-                                 auto, v2::MutateRowsRequest const&) {
+                                 auto, v2::MutateRowsRequest const&,
+                                 auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         ::testing::InSequence seq2;
         auto stream = std::make_unique<MockAsyncMutateRowsStream>();
@@ -1011,7 +1014,7 @@ TEST_F(AsyncBulkApplyTest, ThrottlingBeforeEachRetry) {
   EXPECT_CALL(*mock, AsyncMutateRows)
       .Times(kNumRetries + 1)
       .WillRepeatedly([this](CompletionQueue const&, auto context, auto,
-                             v2::MutateRowsRequest const&) {
+                             v2::MutateRowsRequest const&, auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         auto stream = std::make_unique<MockAsyncMutateRowsStream>();
         EXPECT_CALL(*stream, Start).WillOnce([] {
@@ -1065,7 +1068,7 @@ TEST_F(AsyncBulkApplyTest, BigtableCookie) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRows)
       .WillOnce([this](CompletionQueue const&, auto context, auto,
-                       v2::MutateRowsRequest const&) {
+                       v2::MutateRowsRequest const&, auto const&) {
         // Return a bigtable cookie in the first request.
         metadata_fixture_.SetServerMetadata(
             *context, {{}, {{"x-goog-cbt-cookie-routing", "routing"}}});
@@ -1079,7 +1082,7 @@ TEST_F(AsyncBulkApplyTest, BigtableCookie) {
         return stream;
       })
       .WillOnce([this](CompletionQueue const&, auto context, auto,
-                       v2::MutateRowsRequest const&) {
+                       v2::MutateRowsRequest const&, auto const&) {
         // Verify that the next request includes the bigtable cookie from above.
         auto headers = metadata_fixture_.GetMetadata(*context);
         EXPECT_THAT(headers,
@@ -1128,10 +1131,11 @@ TEST_F(AsyncBulkApplyTest, TracedBackoff) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRows)
       .Times(kNumRetries + 1)
-      .WillRepeatedly([this](auto&, auto context, auto, auto const&) {
-        metadata_fixture_.SetServerMetadata(*context, {});
-        return std::make_unique<ErrorStream>(TransientError());
-      });
+      .WillRepeatedly(
+          [this](auto&, auto context, auto, auto const&, auto const&) {
+            metadata_fixture_.SetServerMetadata(*context, {});
+            return std::make_unique<ErrorStream>(TransientError());
+          });
 
   internal::AutomaticallyCreatedBackgroundThreads background;
   auto retry = DataLimitedErrorCountRetryPolicy(kNumRetries).clone();
@@ -1160,11 +1164,12 @@ TEST_F(AsyncBulkApplyTest, CallSpanActiveThroughout) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRows)
       .Times(kNumRetries + 1)
-      .WillRepeatedly([this, span](auto&, auto context, auto, auto const&) {
-        metadata_fixture_.SetServerMetadata(*context, {});
-        EXPECT_THAT(span, IsActive());
-        return std::make_unique<ErrorStream>(TransientError());
-      });
+      .WillRepeatedly(
+          [this, span](auto&, auto context, auto, auto const&, auto const&) {
+            metadata_fixture_.SetServerMetadata(*context, {});
+            EXPECT_THAT(span, IsActive());
+            return std::make_unique<ErrorStream>(TransientError());
+          });
 
   internal::AutomaticallyCreatedBackgroundThreads background;
   auto retry = DataLimitedErrorCountRetryPolicy(kNumRetries).clone();

--- a/google/cloud/bigtable/internal/async_row_reader.cc
+++ b/google/cloud/bigtable/internal/async_row_reader.cc
@@ -51,7 +51,8 @@ void AsyncRowReader::MakeRequest() {
 
   auto self = this->shared_from_this();
   PerformAsyncStreamingRead(
-      stub_->AsyncReadRows(cq_, client_context_, options_, request),
+      stub_->AsyncReadRows(cq_, client_context_, options_, request,
+                           operation_context_),
       [self](v2::ReadRowsResponse r) {
         return self->OnDataReceived(std::move(r));
       },

--- a/google/cloud/bigtable/internal/async_row_reader_test.cc
+++ b/google/cloud/bigtable/internal/async_row_reader_test.cc
@@ -160,7 +160,7 @@ TEST_F(AsyncRowReaderTest, Success) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadRows)
       .WillOnce([this](Unused, auto client_context, Unused,
-                       v2::ReadRowsRequest const& request) {
+                       v2::ReadRowsRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -259,7 +259,7 @@ TEST_F(AsyncRowReaderTest, SuccessDelayedFuture) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadRows)
       .WillOnce([this](Unused, auto client_context, Unused,
-                       v2::ReadRowsRequest const& request) {
+                       v2::ReadRowsRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -352,7 +352,7 @@ TEST_F(AsyncRowReaderTest, ResponseInMultipleChunks) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadRows)
       .WillOnce([this](Unused, auto client_context, Unused,
-                       v2::ReadRowsRequest const& request) {
+                       v2::ReadRowsRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -425,7 +425,7 @@ TEST_F(AsyncRowReaderTest, ParserEofFailsOnUnfinishedRow) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadRows)
       .WillOnce([this](Unused, auto client_context, Unused,
-                       v2::ReadRowsRequest const& request) {
+                       v2::ReadRowsRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -497,7 +497,7 @@ TEST_F(AsyncRowReaderTest, ParserEofDoesntFailOnUnfinishedRowIfRowLimit) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadRows)
       .WillOnce([this](Unused, auto client_context, Unused,
-                       v2::ReadRowsRequest const& request) {
+                       v2::ReadRowsRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -575,7 +575,7 @@ TEST_F(AsyncRowReaderTest, PermanentFailure) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadRows)
       .WillOnce([this](Unused, auto client_context, Unused,
-                       v2::ReadRowsRequest const& request) {
+                       v2::ReadRowsRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -648,7 +648,7 @@ TEST_F(AsyncRowReaderTest, RetryPolicyExhausted) {
   EXPECT_CALL(*mock, AsyncReadRows)
       .Times(kNumRetries + 1)
       .WillRepeatedly([this](Unused, auto context, Unused,
-                             v2::ReadRowsRequest const& request) {
+                             v2::ReadRowsRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -698,21 +698,21 @@ TEST_F(AsyncRowReaderTest, RetryInfoHeeded) {
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadRows)
-      .WillOnce(
-          [this](Unused, auto context, Unused, v2::ReadRowsRequest const&) {
-            metadata_fixture_.SetServerMetadata(*context, {});
-            auto stream = std::make_unique<MockAsyncReadRowsStream>();
-            EXPECT_CALL(*stream, Start)
-                .WillOnce(Return(ByMove(make_ready_future(false))));
-            EXPECT_CALL(*stream, Finish).WillOnce([] {
-              auto status = internal::PermissionDeniedError("try again");
-              internal::SetRetryInfo(status, internal::RetryInfo{ms(0)});
-              return make_ready_future(status);
-            });
-            return stream;
-          })
+      .WillOnce([this](Unused, auto context, Unused, v2::ReadRowsRequest const&,
+                       auto const&) {
+        metadata_fixture_.SetServerMetadata(*context, {});
+        auto stream = std::make_unique<MockAsyncReadRowsStream>();
+        EXPECT_CALL(*stream, Start)
+            .WillOnce(Return(ByMove(make_ready_future(false))));
+        EXPECT_CALL(*stream, Finish).WillOnce([] {
+          auto status = internal::PermissionDeniedError("try again");
+          internal::SetRetryInfo(status, internal::RetryInfo{ms(0)});
+          return make_ready_future(status);
+        });
+        return stream;
+      })
       .WillOnce([this](Unused, auto client_context, Unused,
-                       v2::ReadRowsRequest const&) {
+                       v2::ReadRowsRequest const&, auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         auto stream = std::make_unique<MockAsyncReadRowsStream>();
         EXPECT_CALL(*stream, Start)
@@ -749,19 +749,19 @@ TEST_F(AsyncRowReaderTest, RetryInfoIgnored) {
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadRows)
-      .WillOnce(
-          [this](Unused, auto context, Unused, v2::ReadRowsRequest const&) {
-            metadata_fixture_.SetServerMetadata(*context, {});
-            auto stream = std::make_unique<MockAsyncReadRowsStream>();
-            EXPECT_CALL(*stream, Start)
-                .WillOnce(Return(ByMove(make_ready_future(false))));
-            EXPECT_CALL(*stream, Finish).WillOnce([] {
-              auto status = internal::PermissionDeniedError("try again");
-              internal::SetRetryInfo(status, internal::RetryInfo{ms(0)});
-              return make_ready_future(status);
-            });
-            return stream;
-          });
+      .WillOnce([this](Unused, auto context, Unused, v2::ReadRowsRequest const&,
+                       auto const&) {
+        metadata_fixture_.SetServerMetadata(*context, {});
+        auto stream = std::make_unique<MockAsyncReadRowsStream>();
+        EXPECT_CALL(*stream, Start)
+            .WillOnce(Return(ByMove(make_ready_future(false))));
+        EXPECT_CALL(*stream, Finish).WillOnce([] {
+          auto status = internal::PermissionDeniedError("try again");
+          internal::SetRetryInfo(status, internal::RetryInfo{ms(0)});
+          return make_ready_future(status);
+        });
+        return stream;
+      });
 
   MockFunction<future<bool>(bigtable::Row const&)> on_row;
   EXPECT_CALL(on_row, Call).Times(0);
@@ -813,7 +813,7 @@ TEST_F(AsyncRowReaderTest, RetrySkipsReadRows) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadRows)
       .WillOnce([this](Unused, auto context, Unused,
-                       v2::ReadRowsRequest const& request) {
+                       v2::ReadRowsRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -834,7 +834,7 @@ TEST_F(AsyncRowReaderTest, RetrySkipsReadRows) {
         return stream;
       })
       .WillOnce([this](Unused, auto client_context, Unused,
-                       v2::ReadRowsRequest const& request) {
+                       v2::ReadRowsRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -895,7 +895,7 @@ TEST_F(AsyncRowReaderTest, NoRetryIfRowSetIsEmpty) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadRows)
       .WillOnce([this](Unused, auto client_context, Unused,
-                       v2::ReadRowsRequest const& request) {
+                       v2::ReadRowsRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -957,7 +957,7 @@ TEST_F(AsyncRowReaderTest, LastScannedRowKeyIsRespected) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadRows)
       .WillOnce([this](Unused, auto context, Unused,
-                       v2::ReadRowsRequest const& request) {
+                       v2::ReadRowsRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -984,7 +984,7 @@ TEST_F(AsyncRowReaderTest, LastScannedRowKeyIsRespected) {
         return stream;
       })
       .WillOnce([this](Unused, auto client_context, Unused,
-                       v2::ReadRowsRequest const& request) {
+                       v2::ReadRowsRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -1045,7 +1045,7 @@ TEST_F(AsyncRowReaderTest, ParserFailsOnOutOfOrderRowKeys) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadRows)
       .WillOnce([this](Unused, auto client_context, Unused,
-                       v2::ReadRowsRequest const& request) {
+                       v2::ReadRowsRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -1110,7 +1110,7 @@ TEST_P(AsyncRowReaderExceptionTest, CancelMidStream) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadRows)
       .WillOnce([this](Unused, auto client_context, Unused,
-                       v2::ReadRowsRequest const& request) {
+                       v2::ReadRowsRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -1216,7 +1216,7 @@ TEST_F(AsyncRowReaderTest, CancelAfterStreamFinish) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadRows)
       .WillOnce([this](Unused, auto client_context, Unused,
-                       v2::ReadRowsRequest const& request) {
+                       v2::ReadRowsRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -1290,7 +1290,7 @@ TEST_F(AsyncRowReaderTest, DeepStack) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadRows)
       .WillOnce([this](Unused, auto client_context, Unused,
-                       v2::ReadRowsRequest const& request) {
+                       v2::ReadRowsRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -1358,7 +1358,7 @@ TEST_F(AsyncRowReaderTest, TimerErrorEndsLoop) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadRows)
       .WillOnce([this](Unused, auto context, Unused,
-                       v2::ReadRowsRequest const& request) {
+                       v2::ReadRowsRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -1422,7 +1422,7 @@ TEST_F(AsyncRowReaderTest, CurrentOptionsContinuedOnRetries) {
   EXPECT_CALL(*mock, AsyncReadRows)
       .Times(2)
       .WillRepeatedly([this](CompletionQueue const&, auto context, auto,
-                             v2::ReadRowsRequest const&) {
+                             v2::ReadRowsRequest const&, auto const&) {
         EXPECT_EQ(5, internal::CurrentOptions().get<TestOption>());
         metadata_fixture_.SetServerMetadata(*context, {});
         auto stream = std::make_unique<MockAsyncReadRowsStream>();
@@ -1474,7 +1474,7 @@ TEST_F(AsyncRowReaderTest, ReverseScanSuccess) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadRows)
       .WillOnce([this](Unused, auto client_context, Unused,
-                       v2::ReadRowsRequest const& request) {
+                       v2::ReadRowsRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_TRUE(request.reversed());
         auto stream = std::make_unique<MockAsyncReadRowsStream>();
@@ -1533,7 +1533,7 @@ TEST_F(AsyncRowReaderTest, ReverseScanFailsOnIncreasingRowKeyOrder) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadRows)
       .WillOnce([this](Unused, auto client_context, Unused,
-                       v2::ReadRowsRequest const& request) {
+                       v2::ReadRowsRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_TRUE(request.reversed());
         auto stream = std::make_unique<MockAsyncReadRowsStream>();
@@ -1593,7 +1593,7 @@ TEST_F(AsyncRowReaderTest, ReverseScanResumption) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadRows)
       .WillOnce([this](Unused, auto context, Unused,
-                       v2::ReadRowsRequest const& request) {
+                       v2::ReadRowsRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_TRUE(request.reversed());
         // The initial row set contains three rows: "r1", "r2", and "r3".
@@ -1619,7 +1619,7 @@ TEST_F(AsyncRowReaderTest, ReverseScanResumption) {
         return stream;
       })
       .WillOnce([this](Unused, auto client_context, Unused,
-                       v2::ReadRowsRequest const& request) {
+                       v2::ReadRowsRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -1682,36 +1682,36 @@ TEST_F(AsyncRowReaderTest, BigtableCookie) {
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadRows)
-      .WillOnce(
-          [this](Unused, auto context, Unused, v2::ReadRowsRequest const&) {
-            // Return a bigtable cookie in the first request.
-            metadata_fixture_.SetServerMetadata(
-                *context, {{}, {{"x-goog-cbt-cookie-routing", "routing"}}});
-            auto stream = std::make_unique<MockAsyncReadRowsStream>();
-            EXPECT_CALL(*stream, Start).WillOnce([] {
-              return make_ready_future(false);
-            });
-            EXPECT_CALL(*stream, Finish).WillOnce([] {
-              return make_ready_future(TransientError());
-            });
-            return stream;
-          })
-      .WillOnce(
-          [this](Unused, auto context, Unused, v2::ReadRowsRequest const&) {
-            // Verify that the next request includes the bigtable cookie from
-            // above.
-            auto headers = metadata_fixture_.GetMetadata(*context);
-            EXPECT_THAT(headers,
-                        Contains(Pair("x-goog-cbt-cookie-routing", "routing")));
-            auto stream = std::make_unique<MockAsyncReadRowsStream>();
-            EXPECT_CALL(*stream, Start).WillOnce([] {
-              return make_ready_future(false);
-            });
-            EXPECT_CALL(*stream, Finish).WillOnce([] {
-              return make_ready_future(internal::PermissionDeniedError("fail"));
-            });
-            return stream;
-          });
+      .WillOnce([this](Unused, auto context, Unused, v2::ReadRowsRequest const&,
+                       auto const&) {
+        // Return a bigtable cookie in the first request.
+        metadata_fixture_.SetServerMetadata(
+            *context, {{}, {{"x-goog-cbt-cookie-routing", "routing"}}});
+        auto stream = std::make_unique<MockAsyncReadRowsStream>();
+        EXPECT_CALL(*stream, Start).WillOnce([] {
+          return make_ready_future(false);
+        });
+        EXPECT_CALL(*stream, Finish).WillOnce([] {
+          return make_ready_future(TransientError());
+        });
+        return stream;
+      })
+      .WillOnce([this](Unused, auto context, Unused, v2::ReadRowsRequest const&,
+                       auto const&) {
+        // Verify that the next request includes the bigtable cookie from
+        // above.
+        auto headers = metadata_fixture_.GetMetadata(*context);
+        EXPECT_THAT(headers,
+                    Contains(Pair("x-goog-cbt-cookie-routing", "routing")));
+        auto stream = std::make_unique<MockAsyncReadRowsStream>();
+        EXPECT_CALL(*stream, Start).WillOnce([] {
+          return make_ready_future(false);
+        });
+        EXPECT_CALL(*stream, Finish).WillOnce([] {
+          return make_ready_future(internal::PermissionDeniedError("fail"));
+        });
+        return stream;
+      });
 
   MockFunction<future<bool>(bigtable::Row const&)> on_row;
   EXPECT_CALL(on_row, Call).Times(0);
@@ -1747,10 +1747,11 @@ TEST_F(AsyncRowReaderTest, TracedBackoff) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadRows)
       .Times(kNumRetries + 1)
-      .WillRepeatedly([this](auto&, auto context, auto, auto const&) {
-        metadata_fixture_.SetServerMetadata(*context);
-        return std::make_unique<ErrorStream>(TransientError());
-      });
+      .WillRepeatedly(
+          [this](auto&, auto context, auto, auto const&, auto const&) {
+            metadata_fixture_.SetServerMetadata(*context);
+            return std::make_unique<ErrorStream>(TransientError());
+          });
 
   promise<void> p;
   internal::AutomaticallyCreatedBackgroundThreads background;
@@ -1784,11 +1785,12 @@ TEST_F(AsyncRowReaderTest, CallSpanActiveThroughout) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadRows)
       .Times(kNumRetries + 1)
-      .WillRepeatedly([this, span](auto&, auto context, auto, auto const&) {
-        metadata_fixture_.SetServerMetadata(*context);
-        EXPECT_THAT(span, IsActive());
-        return std::make_unique<ErrorStream>(TransientError());
-      });
+      .WillRepeatedly(
+          [this, span](auto&, auto context, auto, auto const&, auto const&) {
+            metadata_fixture_.SetServerMetadata(*context);
+            EXPECT_THAT(span, IsActive());
+            return std::make_unique<ErrorStream>(TransientError());
+          });
 
   promise<void> p;
   internal::AutomaticallyCreatedBackgroundThreads background;

--- a/google/cloud/bigtable/internal/async_row_sampler.cc
+++ b/google/cloud/bigtable/internal/async_row_sampler.cc
@@ -71,7 +71,8 @@ void AsyncRowSampler::StartIteration() {
 
   auto self = this->shared_from_this();
   PerformAsyncStreamingRead<v2::SampleRowKeysResponse>(
-      stub_->AsyncSampleRowKeys(cq_, client_context_, options_, request),
+      stub_->AsyncSampleRowKeys(cq_, client_context_, options_, request,
+                                operation_context_),
       [self](v2::SampleRowKeysResponse response) {
         return self->OnRead(std::move(response));
       },

--- a/google/cloud/bigtable/internal/async_row_sampler_test.cc
+++ b/google/cloud/bigtable/internal/async_row_sampler_test.cc
@@ -148,7 +148,7 @@ TEST_F(AsyncSampleRowKeysTest, Simple) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
       .WillOnce([this](CompletionQueue const&, auto client_context, auto,
-                       v2::SampleRowKeysRequest const& request) {
+                       v2::SampleRowKeysRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -216,7 +216,7 @@ TEST_F(AsyncSampleRowKeysTest, RetryResetsSamples) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
       .WillOnce([this](CompletionQueue const&, auto context, auto,
-                       v2::SampleRowKeysRequest const& request) {
+                       v2::SampleRowKeysRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -238,7 +238,7 @@ TEST_F(AsyncSampleRowKeysTest, RetryResetsSamples) {
         return stream;
       })
       .WillOnce([this](CompletionQueue const&, auto client_context, auto,
-                       v2::SampleRowKeysRequest const& request) {
+                       v2::SampleRowKeysRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -308,7 +308,8 @@ TEST_F(AsyncSampleRowKeysTest, TooManyFailures) {
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
       .Times(kNumRetries + 1)
       .WillRepeatedly([this](CompletionQueue const&, auto context, auto,
-                             v2::SampleRowKeysRequest const& request) {
+                             v2::SampleRowKeysRequest const& request,
+                             auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -371,7 +372,7 @@ TEST_F(AsyncSampleRowKeysTest, RetryInfoHeeded) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
       .WillOnce([this](CompletionQueue const&, auto context, auto,
-                       v2::SampleRowKeysRequest const&) {
+                       v2::SampleRowKeysRequest const&, auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         auto stream = std::make_unique<MockAsyncSampleRowKeysStream>();
         EXPECT_CALL(*stream, Start).WillOnce([] {
@@ -385,7 +386,7 @@ TEST_F(AsyncSampleRowKeysTest, RetryInfoHeeded) {
         return stream;
       })
       .WillOnce([this](CompletionQueue const&, auto context, auto,
-                       v2::SampleRowKeysRequest const&) {
+                       v2::SampleRowKeysRequest const&, auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         auto stream = std::make_unique<MockAsyncSampleRowKeysStream>();
         EXPECT_CALL(*stream, Start).WillOnce([] {
@@ -443,7 +444,7 @@ TEST_F(AsyncSampleRowKeysTest, RetryInfoIgnored) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
       .WillOnce([this](CompletionQueue const&, auto context, auto,
-                       v2::SampleRowKeysRequest const&) {
+                       v2::SampleRowKeysRequest const&, auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         auto stream = std::make_unique<MockAsyncSampleRowKeysStream>();
         EXPECT_CALL(*stream, Start).WillOnce([] {
@@ -476,7 +477,7 @@ TEST_F(AsyncSampleRowKeysTest, TimerError) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
       .WillOnce([this](CompletionQueue const&, auto context, auto,
-                       v2::SampleRowKeysRequest const& request) {
+                       v2::SampleRowKeysRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*context);
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -543,7 +544,8 @@ TEST_F(AsyncSampleRowKeysTest, CancelAfterSuccess) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
       .WillOnce([&p, this](CompletionQueue const&, auto client_context, auto,
-                           v2::SampleRowKeysRequest const& request) {
+                           v2::SampleRowKeysRequest const& request,
+                           auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -613,7 +615,8 @@ TEST_F(AsyncSampleRowKeysTest, CancelMidStream) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
       .WillOnce([&p, this](CompletionQueue const&, auto client_context, auto,
-                           v2::SampleRowKeysRequest const& request) {
+                           v2::SampleRowKeysRequest const& request,
+                           auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -679,7 +682,7 @@ TEST_F(AsyncSampleRowKeysTest, CurrentOptionsContinuedOnRetries) {
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
       .Times(2)
       .WillRepeatedly([this](CompletionQueue const&, auto context, auto,
-                             v2::SampleRowKeysRequest const&) {
+                             v2::SampleRowKeysRequest const&, auto const&) {
         EXPECT_EQ(5, internal::CurrentOptions().get<TestOption>());
         metadata_fixture_.SetServerMetadata(*context);
         auto stream = std::make_unique<MockAsyncSampleRowKeysStream>();
@@ -725,7 +728,7 @@ TEST_F(AsyncSampleRowKeysTest, BigtableCookie) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
       .WillOnce([this](CompletionQueue const&, auto context, auto,
-                       v2::SampleRowKeysRequest const&) {
+                       v2::SampleRowKeysRequest const&, auto const&) {
         // Return a bigtable cookie in the first request.
         metadata_fixture_.SetServerMetadata(
             *context, {{}, {{"x-goog-cbt-cookie-routing", "routing"}}});
@@ -739,7 +742,7 @@ TEST_F(AsyncSampleRowKeysTest, BigtableCookie) {
         return stream;
       })
       .WillOnce([this](CompletionQueue const&, auto context, auto,
-                       v2::SampleRowKeysRequest const&) {
+                       v2::SampleRowKeysRequest const&, auto const&) {
         // Verify that the next request includes the bigtable cookie from above.
         auto headers = metadata_fixture_.GetMetadata(*context);
         EXPECT_THAT(headers,
@@ -787,11 +790,12 @@ TEST_F(AsyncSampleRowKeysTest, TracedBackoff) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
       .Times(kNumRetries + 1)
-      .WillRepeatedly([this](auto&, auto context, auto, auto const&) {
-        metadata_fixture_.SetServerMetadata(*context, {});
-        return std::make_unique<ErrorStream>(
-            internal::UnavailableError("try again"));
-      });
+      .WillRepeatedly(
+          [this](auto&, auto context, auto, auto const&, auto const&) {
+            metadata_fixture_.SetServerMetadata(*context, {});
+            return std::make_unique<ErrorStream>(
+                internal::UnavailableError("try again"));
+          });
 
   internal::AutomaticallyCreatedBackgroundThreads background;
   auto retry = DataLimitedErrorCountRetryPolicy(kNumRetries).clone();
@@ -816,12 +820,13 @@ TEST_F(AsyncSampleRowKeysTest, CallSpanActiveThroughout) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
       .Times(kNumRetries + 1)
-      .WillRepeatedly([this, span](auto&, auto context, auto, auto const&) {
-        metadata_fixture_.SetServerMetadata(*context, {});
-        EXPECT_THAT(span, IsActive());
-        return std::make_unique<ErrorStream>(
-            internal::UnavailableError("try again"));
-      });
+      .WillRepeatedly(
+          [this, span](auto&, auto context, auto, auto const&, auto const&) {
+            metadata_fixture_.SetServerMetadata(*context, {});
+            EXPECT_THAT(span, IsActive());
+            return std::make_unique<ErrorStream>(
+                internal::UnavailableError("try again"));
+          });
 
   internal::AutomaticallyCreatedBackgroundThreads background;
   auto retry = DataLimitedErrorCountRetryPolicy(kNumRetries).clone();

--- a/google/cloud/bigtable/internal/bigtable_auth_decorator.cc
+++ b/google/cloud/bigtable/internal/bigtable_auth_decorator.cc
@@ -38,101 +38,122 @@ BigtableAuth::BigtableAuth(
 
 std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::bigtable::v2::ReadRowsResponse>>
-BigtableAuth::ReadRows(std::shared_ptr<grpc::ClientContext> context,
-                       Options const& options,
-                       google::bigtable::v2::ReadRowsRequest const& request) {
+BigtableAuth::ReadRows(
+    std::shared_ptr<grpc::ClientContext> context, Options const& options,
+    google::bigtable::v2::ReadRowsRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   using ErrorStream = ::google::cloud::internal::StreamingReadRpcError<
       google::bigtable::v2::ReadRowsResponse>;
   auto status = auth_->ConfigureContext(*context);
   if (!status.ok()) return std::make_unique<ErrorStream>(std::move(status));
-  return child_->ReadRows(std::move(context), options, request);
+  return child_->ReadRows(std::move(context), options, request,
+                          std::move(operation_context));
 }
 
 std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::bigtable::v2::SampleRowKeysResponse>>
 BigtableAuth::SampleRowKeys(
     std::shared_ptr<grpc::ClientContext> context, Options const& options,
-    google::bigtable::v2::SampleRowKeysRequest const& request) {
+    google::bigtable::v2::SampleRowKeysRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   using ErrorStream = ::google::cloud::internal::StreamingReadRpcError<
       google::bigtable::v2::SampleRowKeysResponse>;
   auto status = auth_->ConfigureContext(*context);
   if (!status.ok()) return std::make_unique<ErrorStream>(std::move(status));
-  return child_->SampleRowKeys(std::move(context), options, request);
+  return child_->SampleRowKeys(std::move(context), options, request,
+                               std::move(operation_context));
 }
 
 StatusOr<google::bigtable::v2::MutateRowResponse> BigtableAuth::MutateRow(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::MutateRowRequest const& request) {
+    google::bigtable::v2::MutateRowRequest const& request,
+    google::cloud::bigtable_internal::OperationContext& operation_context) {
   auto status = auth_->ConfigureContext(context);
   if (!status.ok()) return status;
-  return child_->MutateRow(context, options, request);
+  return child_->MutateRow(context, options, request, operation_context);
 }
 
 std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::bigtable::v2::MutateRowsResponse>>
 BigtableAuth::MutateRows(
     std::shared_ptr<grpc::ClientContext> context, Options const& options,
-    google::bigtable::v2::MutateRowsRequest const& request) {
+    google::bigtable::v2::MutateRowsRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   using ErrorStream = ::google::cloud::internal::StreamingReadRpcError<
       google::bigtable::v2::MutateRowsResponse>;
   auto status = auth_->ConfigureContext(*context);
   if (!status.ok()) return std::make_unique<ErrorStream>(std::move(status));
-  return child_->MutateRows(std::move(context), options, request);
+  return child_->MutateRows(std::move(context), options, request,
+                            std::move(operation_context));
 }
 
 StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>
 BigtableAuth::CheckAndMutateRow(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::CheckAndMutateRowRequest const& request) {
+    google::bigtable::v2::CheckAndMutateRowRequest const& request,
+    google::cloud::bigtable_internal::OperationContext& operation_context) {
   auto status = auth_->ConfigureContext(context);
   if (!status.ok()) return status;
-  return child_->CheckAndMutateRow(context, options, request);
+  return child_->CheckAndMutateRow(context, options, request,
+                                   operation_context);
 }
 
 StatusOr<google::bigtable::v2::PingAndWarmResponse> BigtableAuth::PingAndWarm(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::PingAndWarmRequest const& request) {
+    google::bigtable::v2::PingAndWarmRequest const& request,
+    google::cloud::bigtable_internal::OperationContext& operation_context) {
   auto status = auth_->ConfigureContext(context);
   if (!status.ok()) return status;
-  return child_->PingAndWarm(context, options, request);
+  return child_->PingAndWarm(context, options, request, operation_context);
 }
 
 StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>
 BigtableAuth::ReadModifyWriteRow(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
+    google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+    google::cloud::bigtable_internal::OperationContext& operation_context) {
   auto status = auth_->ConfigureContext(context);
   if (!status.ok()) return status;
-  return child_->ReadModifyWriteRow(context, options, request);
+  return child_->ReadModifyWriteRow(context, options, request,
+                                    operation_context);
 }
 
 StatusOr<google::bigtable::v2::PrepareQueryResponse> BigtableAuth::PrepareQuery(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::PrepareQueryRequest const& request) {
+    google::bigtable::v2::PrepareQueryRequest const& request,
+    google::cloud::bigtable_internal::OperationContext& operation_context) {
   auto status = auth_->ConfigureContext(context);
   if (!status.ok()) return status;
-  return child_->PrepareQuery(context, options, request);
+  return child_->PrepareQuery(context, options, request, operation_context);
 }
 
 std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::bigtable::v2::ExecuteQueryResponse>>
 BigtableAuth::ExecuteQuery(
     std::shared_ptr<grpc::ClientContext> context, Options const& options,
-    google::bigtable::v2::ExecuteQueryRequest const& request) {
+    google::bigtable::v2::ExecuteQueryRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   using ErrorStream = ::google::cloud::internal::StreamingReadRpcError<
       google::bigtable::v2::ExecuteQueryResponse>;
   auto status = auth_->ConfigureContext(*context);
   if (!status.ok()) return std::make_unique<ErrorStream>(std::move(status));
-  return child_->ExecuteQuery(std::move(context), options, request);
+  return child_->ExecuteQuery(std::move(context), options, request,
+                              std::move(operation_context));
 }
 
 StatusOr<google::bigtable::v2::ClientConfiguration>
 BigtableAuth::GetClientConfiguration(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::GetClientConfigurationRequest const& request) {
+    google::bigtable::v2::GetClientConfigurationRequest const& request,
+    google::cloud::bigtable_internal::OperationContext& operation_context) {
   auto status = auth_->ConfigureContext(context);
   if (!status.ok()) return status;
-  return child_->GetClientConfiguration(context, options, request);
+  return child_->GetClientConfiguration(context, options, request,
+                                        operation_context);
 }
 
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
@@ -141,14 +162,18 @@ std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
 BigtableAuth::AsyncOpenTable(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
+    google::cloud::internal::ImmutableOptions options,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   using StreamAuth = google::cloud::internal::AsyncStreamingReadWriteRpcAuth<
       google::bigtable::v2::SessionRequest,
       google::bigtable::v2::SessionResponse>;
 
-  auto call = [child = child_, cq, options = std::move(options)](
+  auto call = [child = child_, cq, options = std::move(options),
+               operation_context = std::move(operation_context)](
                   std::shared_ptr<grpc::ClientContext> ctx) {
-    return child->AsyncOpenTable(cq, std::move(ctx), options);
+    return child->AsyncOpenTable(cq, std::move(ctx), options,
+                                 std::move(operation_context));
   };
   return std::make_unique<StreamAuth>(
       std::move(context), auth_, StreamAuth::StreamFactory(std::move(call)));
@@ -160,14 +185,18 @@ std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
 BigtableAuth::AsyncOpenAuthorizedView(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
+    google::cloud::internal::ImmutableOptions options,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   using StreamAuth = google::cloud::internal::AsyncStreamingReadWriteRpcAuth<
       google::bigtable::v2::SessionRequest,
       google::bigtable::v2::SessionResponse>;
 
-  auto call = [child = child_, cq, options = std::move(options)](
+  auto call = [child = child_, cq, options = std::move(options),
+               operation_context = std::move(operation_context)](
                   std::shared_ptr<grpc::ClientContext> ctx) {
-    return child->AsyncOpenAuthorizedView(cq, std::move(ctx), options);
+    return child->AsyncOpenAuthorizedView(cq, std::move(ctx), options,
+                                          std::move(operation_context));
   };
   return std::make_unique<StreamAuth>(
       std::move(context), auth_, StreamAuth::StreamFactory(std::move(call)));
@@ -179,14 +208,18 @@ std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
 BigtableAuth::AsyncOpenMaterializedView(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
+    google::cloud::internal::ImmutableOptions options,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   using StreamAuth = google::cloud::internal::AsyncStreamingReadWriteRpcAuth<
       google::bigtable::v2::SessionRequest,
       google::bigtable::v2::SessionResponse>;
 
-  auto call = [child = child_, cq, options = std::move(options)](
+  auto call = [child = child_, cq, options = std::move(options),
+               operation_context = std::move(operation_context)](
                   std::shared_ptr<grpc::ClientContext> ctx) {
-    return child->AsyncOpenMaterializedView(cq, std::move(ctx), options);
+    return child->AsyncOpenMaterializedView(cq, std::move(ctx), options,
+                                            std::move(operation_context));
   };
   return std::make_unique<StreamAuth>(
       std::move(context), auth_, StreamAuth::StreamFactory(std::move(call)));
@@ -198,14 +231,18 @@ BigtableAuth::AsyncReadRows(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::ReadRowsRequest const& request) {
+    google::bigtable::v2::ReadRowsRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   using StreamAuth = google::cloud::internal::AsyncStreamingReadRpcAuth<
       google::bigtable::v2::ReadRowsResponse>;
 
   auto& child = child_;
-  auto call = [child, cq, opts = std::move(options),
-               request](std::shared_ptr<grpc::ClientContext> ctx) {
-    return child->AsyncReadRows(cq, std::move(ctx), opts, request);
+  auto call = [child, cq, opts = std::move(options), request,
+               operation_context = std::move(operation_context)](
+                  std::shared_ptr<grpc::ClientContext> ctx) {
+    return child->AsyncReadRows(cq, std::move(ctx), opts, request,
+                                std::move(operation_context));
   };
   return std::make_unique<StreamAuth>(
       std::move(context), auth_, StreamAuth::StreamFactory(std::move(call)));
@@ -217,14 +254,18 @@ BigtableAuth::AsyncSampleRowKeys(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::SampleRowKeysRequest const& request) {
+    google::bigtable::v2::SampleRowKeysRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   using StreamAuth = google::cloud::internal::AsyncStreamingReadRpcAuth<
       google::bigtable::v2::SampleRowKeysResponse>;
 
   auto& child = child_;
-  auto call = [child, cq, opts = std::move(options),
-               request](std::shared_ptr<grpc::ClientContext> ctx) {
-    return child->AsyncSampleRowKeys(cq, std::move(ctx), opts, request);
+  auto call = [child, cq, opts = std::move(options), request,
+               operation_context = std::move(operation_context)](
+                  std::shared_ptr<grpc::ClientContext> ctx) {
+    return child->AsyncSampleRowKeys(cq, std::move(ctx), opts, request,
+                                     std::move(operation_context));
   };
   return std::make_unique<StreamAuth>(
       std::move(context), auth_, StreamAuth::StreamFactory(std::move(call)));
@@ -235,11 +276,14 @@ BigtableAuth::AsyncMutateRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::MutateRowRequest const& request) {
+    google::bigtable::v2::MutateRowRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   return auth_->AsyncConfigureContext(std::move(context))
-      .then([cq, child = child_, options = std::move(options),
-             request](future<StatusOr<std::shared_ptr<grpc::ClientContext>>>
-                          f) mutable {
+      .then([cq, child = child_, options = std::move(options), request,
+             operation_context = std::move(operation_context)](
+                future<StatusOr<std::shared_ptr<grpc::ClientContext>>>
+                    f) mutable {
         auto context = f.get();
         if (!context) {
           return make_ready_future(
@@ -247,7 +291,8 @@ BigtableAuth::AsyncMutateRow(
                   std::move(context).status()));
         }
         return child->AsyncMutateRow(cq, *std::move(context),
-                                     std::move(options), request);
+                                     std::move(options), request,
+                                     std::move(operation_context));
       });
 }
 
@@ -257,14 +302,18 @@ BigtableAuth::AsyncMutateRows(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::MutateRowsRequest const& request) {
+    google::bigtable::v2::MutateRowsRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   using StreamAuth = google::cloud::internal::AsyncStreamingReadRpcAuth<
       google::bigtable::v2::MutateRowsResponse>;
 
   auto& child = child_;
-  auto call = [child, cq, opts = std::move(options),
-               request](std::shared_ptr<grpc::ClientContext> ctx) {
-    return child->AsyncMutateRows(cq, std::move(ctx), opts, request);
+  auto call = [child, cq, opts = std::move(options), request,
+               operation_context = std::move(operation_context)](
+                  std::shared_ptr<grpc::ClientContext> ctx) {
+    return child->AsyncMutateRows(cq, std::move(ctx), opts, request,
+                                  std::move(operation_context));
   };
   return std::make_unique<StreamAuth>(
       std::move(context), auth_, StreamAuth::StreamFactory(std::move(call)));
@@ -275,11 +324,14 @@ BigtableAuth::AsyncCheckAndMutateRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::CheckAndMutateRowRequest const& request) {
+    google::bigtable::v2::CheckAndMutateRowRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   return auth_->AsyncConfigureContext(std::move(context))
-      .then([cq, child = child_, options = std::move(options),
-             request](future<StatusOr<std::shared_ptr<grpc::ClientContext>>>
-                          f) mutable {
+      .then([cq, child = child_, options = std::move(options), request,
+             operation_context = std::move(operation_context)](
+                future<StatusOr<std::shared_ptr<grpc::ClientContext>>>
+                    f) mutable {
         auto context = f.get();
         if (!context) {
           return make_ready_future(
@@ -287,7 +339,8 @@ BigtableAuth::AsyncCheckAndMutateRow(
                   std::move(context).status()));
         }
         return child->AsyncCheckAndMutateRow(cq, *std::move(context),
-                                             std::move(options), request);
+                                             std::move(options), request,
+                                             std::move(operation_context));
       });
 }
 
@@ -296,11 +349,14 @@ BigtableAuth::AsyncPingAndWarm(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::PingAndWarmRequest const& request) {
+    google::bigtable::v2::PingAndWarmRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   return auth_->AsyncConfigureContext(std::move(context))
-      .then([cq, child = child_, options = std::move(options),
-             request](future<StatusOr<std::shared_ptr<grpc::ClientContext>>>
-                          f) mutable {
+      .then([cq, child = child_, options = std::move(options), request,
+             operation_context = std::move(operation_context)](
+                future<StatusOr<std::shared_ptr<grpc::ClientContext>>>
+                    f) mutable {
         auto context = f.get();
         if (!context) {
           return make_ready_future(
@@ -308,7 +364,8 @@ BigtableAuth::AsyncPingAndWarm(
                   std::move(context).status()));
         }
         return child->AsyncPingAndWarm(cq, *std::move(context),
-                                       std::move(options), request);
+                                       std::move(options), request,
+                                       std::move(operation_context));
       });
 }
 
@@ -317,11 +374,14 @@ BigtableAuth::AsyncReadModifyWriteRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
+    google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   return auth_->AsyncConfigureContext(std::move(context))
-      .then([cq, child = child_, options = std::move(options),
-             request](future<StatusOr<std::shared_ptr<grpc::ClientContext>>>
-                          f) mutable {
+      .then([cq, child = child_, options = std::move(options), request,
+             operation_context = std::move(operation_context)](
+                future<StatusOr<std::shared_ptr<grpc::ClientContext>>>
+                    f) mutable {
         auto context = f.get();
         if (!context) {
           return make_ready_future(
@@ -329,7 +389,8 @@ BigtableAuth::AsyncReadModifyWriteRow(
                   std::move(context).status()));
         }
         return child->AsyncReadModifyWriteRow(cq, *std::move(context),
-                                              std::move(options), request);
+                                              std::move(options), request,
+                                              std::move(operation_context));
       });
 }
 
@@ -338,11 +399,14 @@ BigtableAuth::AsyncPrepareQuery(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::PrepareQueryRequest const& request) {
+    google::bigtable::v2::PrepareQueryRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   return auth_->AsyncConfigureContext(std::move(context))
-      .then([cq, child = child_, options = std::move(options),
-             request](future<StatusOr<std::shared_ptr<grpc::ClientContext>>>
-                          f) mutable {
+      .then([cq, child = child_, options = std::move(options), request,
+             operation_context = std::move(operation_context)](
+                future<StatusOr<std::shared_ptr<grpc::ClientContext>>>
+                    f) mutable {
         auto context = f.get();
         if (!context) {
           return make_ready_future(
@@ -350,7 +414,8 @@ BigtableAuth::AsyncPrepareQuery(
                   std::move(context).status()));
         }
         return child->AsyncPrepareQuery(cq, *std::move(context),
-                                        std::move(options), request);
+                                        std::move(options), request,
+                                        std::move(operation_context));
       });
 }
 

--- a/google/cloud/bigtable/internal/bigtable_auth_decorator.h
+++ b/google/cloud/bigtable/internal/bigtable_auth_decorator.h
@@ -44,57 +44,79 @@ class BigtableAuth : public BigtableStub {
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::ReadRowsResponse>>
   ReadRows(std::shared_ptr<grpc::ClientContext> context, Options const& options,
-           google::bigtable::v2::ReadRowsRequest const& request) override;
+           google::bigtable::v2::ReadRowsRequest const& request,
+           std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+               operation_context) override;
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::SampleRowKeysResponse>>
   SampleRowKeys(
       std::shared_ptr<grpc::ClientContext> context, Options const& options,
-      google::bigtable::v2::SampleRowKeysRequest const& request) override;
+      google::bigtable::v2::SampleRowKeysRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   StatusOr<google::bigtable::v2::MutateRowResponse> MutateRow(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::MutateRowRequest const& request) override;
+      google::bigtable::v2::MutateRowRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
+      override;
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::MutateRowsResponse>>
   MutateRows(std::shared_ptr<grpc::ClientContext> context,
              Options const& options,
-             google::bigtable::v2::MutateRowsRequest const& request) override;
+             google::bigtable::v2::MutateRowsRequest const& request,
+             std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+                 operation_context) override;
 
   StatusOr<google::bigtable::v2::CheckAndMutateRowResponse> CheckAndMutateRow(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::CheckAndMutateRowRequest const& request) override;
+      google::bigtable::v2::CheckAndMutateRowRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
+      override;
 
   StatusOr<google::bigtable::v2::PingAndWarmResponse> PingAndWarm(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::PingAndWarmRequest const& request) override;
+      google::bigtable::v2::PingAndWarmRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
+      override;
 
   StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse> ReadModifyWriteRow(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::ReadModifyWriteRowRequest const& request) override;
+      google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
+      override;
 
   StatusOr<google::bigtable::v2::PrepareQueryResponse> PrepareQuery(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::PrepareQueryRequest const& request) override;
+      google::bigtable::v2::PrepareQueryRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
+      override;
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::ExecuteQueryResponse>>
   ExecuteQuery(
       std::shared_ptr<grpc::ClientContext> context, Options const& options,
-      google::bigtable::v2::ExecuteQueryRequest const& request) override;
+      google::bigtable::v2::ExecuteQueryRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   StatusOr<google::bigtable::v2::ClientConfiguration> GetClientConfiguration(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::GetClientConfigurationRequest const& request)
+      google::bigtable::v2::GetClientConfigurationRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
       override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::bigtable::v2::SessionRequest,
       google::bigtable::v2::SessionResponse>>
-  AsyncOpenTable(google::cloud::CompletionQueue const& cq,
-                 std::shared_ptr<grpc::ClientContext> context,
-                 google::cloud::internal::ImmutableOptions options) override;
+  AsyncOpenTable(
+      google::cloud::CompletionQueue const& cq,
+      std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::bigtable::v2::SessionRequest,
@@ -102,7 +124,9 @@ class BigtableAuth : public BigtableStub {
   AsyncOpenAuthorizedView(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
-      google::cloud::internal::ImmutableOptions options) override;
+      google::cloud::internal::ImmutableOptions options,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::bigtable::v2::SessionRequest,
@@ -110,14 +134,19 @@ class BigtableAuth : public BigtableStub {
   AsyncOpenMaterializedView(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
-      google::cloud::internal::ImmutableOptions options) override;
+      google::cloud::internal::ImmutableOptions options,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::bigtable::v2::ReadRowsResponse>>
-  AsyncReadRows(google::cloud::CompletionQueue const& cq,
-                std::shared_ptr<grpc::ClientContext> context,
-                google::cloud::internal::ImmutableOptions options,
-                google::bigtable::v2::ReadRowsRequest const& request) override;
+  AsyncReadRows(
+      google::cloud::CompletionQueue const& cq,
+      std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
+      google::bigtable::v2::ReadRowsRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::bigtable::v2::SampleRowKeysResponse>>
@@ -125,13 +154,17 @@ class BigtableAuth : public BigtableStub {
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::SampleRowKeysRequest const& request) override;
+      google::bigtable::v2::SampleRowKeysRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   future<StatusOr<google::bigtable::v2::MutateRowResponse>> AsyncMutateRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::MutateRowRequest const& request) override;
+      google::bigtable::v2::MutateRowRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::bigtable::v2::MutateRowsResponse>>
@@ -139,34 +172,44 @@ class BigtableAuth : public BigtableStub {
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::MutateRowsRequest const& request) override;
+      google::bigtable::v2::MutateRowsRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
   AsyncCheckAndMutateRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::CheckAndMutateRowRequest const& request) override;
+      google::bigtable::v2::CheckAndMutateRowRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   future<StatusOr<google::bigtable::v2::PingAndWarmResponse>> AsyncPingAndWarm(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::PingAndWarmRequest const& request) override;
+      google::bigtable::v2::PingAndWarmRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>
   AsyncReadModifyWriteRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::ReadModifyWriteRowRequest const& request) override;
+      google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   future<StatusOr<google::bigtable::v2::PrepareQueryResponse>>
   AsyncPrepareQuery(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::PrepareQueryRequest const& request) override;
+      google::bigtable::v2::PrepareQueryRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
  private:
   std::shared_ptr<google::cloud::internal::GrpcAuthenticationStrategy> auth_;

--- a/google/cloud/bigtable/internal/bigtable_channel_refresh.cc
+++ b/google/cloud/bigtable/internal/bigtable_channel_refresh.cc
@@ -23,67 +23,84 @@ std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::bigtable::v2::ReadRowsResponse>>
 BigtableChannelRefresh::ReadRows(
     std::shared_ptr<grpc::ClientContext> client_context, Options const& options,
-    google::bigtable::v2::ReadRowsRequest const& request) {
-  return child_->ReadRows(std::move(client_context), options, request);
+    google::bigtable::v2::ReadRowsRequest const& request,
+    std::shared_ptr<OperationContext> operation_context) {
+  return child_->ReadRows(std::move(client_context), options, request,
+                          std::move(operation_context));
 }
 
 std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::bigtable::v2::SampleRowKeysResponse>>
 BigtableChannelRefresh::SampleRowKeys(
     std::shared_ptr<grpc::ClientContext> client_context, Options const& options,
-    google::bigtable::v2::SampleRowKeysRequest const& request) {
-  return child_->SampleRowKeys(std::move(client_context), options, request);
+    google::bigtable::v2::SampleRowKeysRequest const& request,
+    std::shared_ptr<OperationContext> operation_context) {
+  return child_->SampleRowKeys(std::move(client_context), options, request,
+                               std::move(operation_context));
 }
 
 StatusOr<google::bigtable::v2::MutateRowResponse>
 BigtableChannelRefresh::MutateRow(
     grpc::ClientContext& client_context, Options const& options,
-    google::bigtable::v2::MutateRowRequest const& request) {
-  return child_->MutateRow(client_context, options, request);
+    google::bigtable::v2::MutateRowRequest const& request,
+    OperationContext& operation_context) {
+  return child_->MutateRow(client_context, options, request, operation_context);
 }
 
 std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::bigtable::v2::MutateRowsResponse>>
 BigtableChannelRefresh::MutateRows(
     std::shared_ptr<grpc::ClientContext> client_context, Options const& options,
-    google::bigtable::v2::MutateRowsRequest const& request) {
-  return child_->MutateRows(std::move(client_context), options, request);
+    google::bigtable::v2::MutateRowsRequest const& request,
+    std::shared_ptr<OperationContext> operation_context) {
+  return child_->MutateRows(std::move(client_context), options, request,
+                            std::move(operation_context));
 }
 
 StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>
 BigtableChannelRefresh::CheckAndMutateRow(
     grpc::ClientContext& client_context, Options const& options,
-    google::bigtable::v2::CheckAndMutateRowRequest const& request) {
-  return child_->CheckAndMutateRow(client_context, options, request);
+    google::bigtable::v2::CheckAndMutateRowRequest const& request,
+    OperationContext& operation_context) {
+  return child_->CheckAndMutateRow(client_context, options, request,
+                                   operation_context);
 }
 
 StatusOr<google::bigtable::v2::PingAndWarmResponse>
 BigtableChannelRefresh::PingAndWarm(
     grpc::ClientContext& client_context, Options const& options,
-    google::bigtable::v2::PingAndWarmRequest const& request) {
-  return child_->PingAndWarm(client_context, options, request);
+    google::bigtable::v2::PingAndWarmRequest const& request,
+    OperationContext& operation_context) {
+  return child_->PingAndWarm(client_context, options, request,
+                             operation_context);
 }
 
 StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>
 BigtableChannelRefresh::ReadModifyWriteRow(
     grpc::ClientContext& client_context, Options const& options,
-    google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
-  return child_->ReadModifyWriteRow(client_context, options, request);
+    google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+    OperationContext& operation_context) {
+  return child_->ReadModifyWriteRow(client_context, options, request,
+                                    operation_context);
 }
 
 StatusOr<google::bigtable::v2::PrepareQueryResponse>
 BigtableChannelRefresh::PrepareQuery(
     grpc::ClientContext& client_context, Options const& options,
-    google::bigtable::v2::PrepareQueryRequest const& request) {
-  return child_->PrepareQuery(client_context, options, request);
+    google::bigtable::v2::PrepareQueryRequest const& request,
+    OperationContext& operation_context) {
+  return child_->PrepareQuery(client_context, options, request,
+                              operation_context);
 }
 
 std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::bigtable::v2::ExecuteQueryResponse>>
 BigtableChannelRefresh::ExecuteQuery(
     std::shared_ptr<grpc::ClientContext> client_context, Options const& options,
-    google::bigtable::v2::ExecuteQueryRequest const& request) {
-  return child_->ExecuteQuery(client_context, options, request);
+    google::bigtable::v2::ExecuteQueryRequest const& request,
+    std::shared_ptr<OperationContext> operation_context) {
+  return child_->ExecuteQuery(std::move(client_context), options, request,
+                              std::move(operation_context));
 }
 
 std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -92,9 +109,10 @@ BigtableChannelRefresh::AsyncReadRows(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::ReadRowsRequest const& request) {
+    google::bigtable::v2::ReadRowsRequest const& request,
+    std::shared_ptr<OperationContext> operation_context) {
   return child_->AsyncReadRows(cq, std::move(context), std::move(options),
-                               request);
+                               request, std::move(operation_context));
 }
 
 std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -103,9 +121,10 @@ BigtableChannelRefresh::AsyncSampleRowKeys(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::SampleRowKeysRequest const& request) {
+    google::bigtable::v2::SampleRowKeysRequest const& request,
+    std::shared_ptr<OperationContext> operation_context) {
   return child_->AsyncSampleRowKeys(cq, std::move(context), std::move(options),
-                                    request);
+                                    request, std::move(operation_context));
 }
 
 future<StatusOr<google::bigtable::v2::MutateRowResponse>>
@@ -113,9 +132,10 @@ BigtableChannelRefresh::AsyncMutateRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::MutateRowRequest const& request) {
+    google::bigtable::v2::MutateRowRequest const& request,
+    std::shared_ptr<OperationContext> operation_context) {
   return child_->AsyncMutateRow(cq, std::move(context), std::move(options),
-                                request);
+                                request, std::move(operation_context));
 }
 
 std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -124,9 +144,10 @@ BigtableChannelRefresh::AsyncMutateRows(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::MutateRowsRequest const& request) {
+    google::bigtable::v2::MutateRowsRequest const& request,
+    std::shared_ptr<OperationContext> operation_context) {
   return child_->AsyncMutateRows(cq, std::move(context), std::move(options),
-                                 request);
+                                 request, std::move(operation_context));
 }
 
 future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
@@ -134,9 +155,11 @@ BigtableChannelRefresh::AsyncCheckAndMutateRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::CheckAndMutateRowRequest const& request) {
+    google::bigtable::v2::CheckAndMutateRowRequest const& request,
+    std::shared_ptr<OperationContext> operation_context) {
   return child_->AsyncCheckAndMutateRow(cq, std::move(context),
-                                        std::move(options), request);
+                                        std::move(options), request,
+                                        std::move(operation_context));
 }
 
 future<StatusOr<google::bigtable::v2::PingAndWarmResponse>>
@@ -144,9 +167,10 @@ BigtableChannelRefresh::AsyncPingAndWarm(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::PingAndWarmRequest const& request) {
+    google::bigtable::v2::PingAndWarmRequest const& request,
+    std::shared_ptr<OperationContext> operation_context) {
   return child_->AsyncPingAndWarm(cq, std::move(context), std::move(options),
-                                  request);
+                                  request, std::move(operation_context));
 }
 
 future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>
@@ -154,9 +178,11 @@ BigtableChannelRefresh::AsyncReadModifyWriteRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
+    google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+    std::shared_ptr<OperationContext> operation_context) {
   return child_->AsyncReadModifyWriteRow(cq, std::move(context),
-                                         std::move(options), request);
+                                         std::move(options), request,
+                                         std::move(operation_context));
 }
 
 future<StatusOr<google::bigtable::v2::PrepareQueryResponse>>
@@ -164,16 +190,19 @@ BigtableChannelRefresh::AsyncPrepareQuery(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::PrepareQueryRequest const& request) {
+    google::bigtable::v2::PrepareQueryRequest const& request,
+    std::shared_ptr<OperationContext> operation_context) {
   return child_->AsyncPrepareQuery(cq, std::move(context), std::move(options),
-                                   request);
+                                   request, std::move(operation_context));
 }
 
 StatusOr<google::bigtable::v2::ClientConfiguration>
 BigtableChannelRefresh::GetClientConfiguration(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::GetClientConfigurationRequest const& request) {
-  return child_->GetClientConfiguration(context, options, request);
+    google::bigtable::v2::GetClientConfigurationRequest const& request,
+    OperationContext& operation_context) {
+  return child_->GetClientConfiguration(context, options, request,
+                                        operation_context);
 }
 
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
@@ -182,8 +211,10 @@ std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
 BigtableChannelRefresh::AsyncOpenTable(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
-  return child_->AsyncOpenTable(cq, std::move(context), std::move(options));
+    google::cloud::internal::ImmutableOptions options,
+    std::shared_ptr<OperationContext> operation_context) {
+  return child_->AsyncOpenTable(cq, std::move(context), std::move(options),
+                                std::move(operation_context));
 }
 
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
@@ -192,9 +223,10 @@ std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
 BigtableChannelRefresh::AsyncOpenAuthorizedView(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
-  return child_->AsyncOpenAuthorizedView(cq, std::move(context),
-                                         std::move(options));
+    google::cloud::internal::ImmutableOptions options,
+    std::shared_ptr<OperationContext> operation_context) {
+  return child_->AsyncOpenAuthorizedView(
+      cq, std::move(context), std::move(options), std::move(operation_context));
 }
 
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
@@ -203,9 +235,10 @@ std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
 BigtableChannelRefresh::AsyncOpenMaterializedView(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
-  return child_->AsyncOpenMaterializedView(cq, std::move(context),
-                                           std::move(options));
+    google::cloud::internal::ImmutableOptions options,
+    std::shared_ptr<OperationContext> operation_context) {
+  return child_->AsyncOpenMaterializedView(
+      cq, std::move(context), std::move(options), std::move(operation_context));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/internal/bigtable_channel_refresh.h
+++ b/google/cloud/bigtable/internal/bigtable_channel_refresh.h
@@ -46,54 +46,62 @@ class BigtableChannelRefresh : public BigtableStub {
       google::bigtable::v2::ReadRowsResponse>>
   ReadRows(std::shared_ptr<grpc::ClientContext> client_context,
            Options const& options,
-           google::bigtable::v2::ReadRowsRequest const& request) override;
+           google::bigtable::v2::ReadRowsRequest const& request,
+           std::shared_ptr<OperationContext> operation_context) override;
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::SampleRowKeysResponse>>
-  SampleRowKeys(
-      std::shared_ptr<grpc::ClientContext> client_context,
-      Options const& options,
-      google::bigtable::v2::SampleRowKeysRequest const& request) override;
+  SampleRowKeys(std::shared_ptr<grpc::ClientContext> client_context,
+                Options const& options,
+                google::bigtable::v2::SampleRowKeysRequest const& request,
+                std::shared_ptr<OperationContext> operation_context) override;
 
   StatusOr<google::bigtable::v2::MutateRowResponse> MutateRow(
       grpc::ClientContext& client_context, Options const& options,
-      google::bigtable::v2::MutateRowRequest const& request) override;
+      google::bigtable::v2::MutateRowRequest const& request,
+      OperationContext& operation_context) override;
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::MutateRowsResponse>>
   MutateRows(std::shared_ptr<grpc::ClientContext> client_context,
              Options const& options,
-             google::bigtable::v2::MutateRowsRequest const& request) override;
+             google::bigtable::v2::MutateRowsRequest const& request,
+             std::shared_ptr<OperationContext> operation_context) override;
 
   StatusOr<google::bigtable::v2::CheckAndMutateRowResponse> CheckAndMutateRow(
       grpc::ClientContext& client_context, Options const& options,
-      google::bigtable::v2::CheckAndMutateRowRequest const& request) override;
+      google::bigtable::v2::CheckAndMutateRowRequest const& request,
+      OperationContext& operation_context) override;
 
   StatusOr<google::bigtable::v2::PingAndWarmResponse> PingAndWarm(
       grpc::ClientContext& client_context, Options const& options,
-      google::bigtable::v2::PingAndWarmRequest const& request) override;
+      google::bigtable::v2::PingAndWarmRequest const& request,
+      OperationContext& operation_context) override;
 
   StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse> ReadModifyWriteRow(
       grpc::ClientContext& client_context, Options const& options,
-      google::bigtable::v2::ReadModifyWriteRowRequest const& request) override;
+      google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+      OperationContext& operation_context) override;
 
   StatusOr<google::bigtable::v2::PrepareQueryResponse> PrepareQuery(
       grpc::ClientContext& client, Options const& options,
-      google::bigtable::v2::PrepareQueryRequest const& request) override;
+      google::bigtable::v2::PrepareQueryRequest const& request,
+      OperationContext& operation_context) override;
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::ExecuteQueryResponse>>
-  ExecuteQuery(
-      std::shared_ptr<grpc::ClientContext> client_context,
-      Options const& options,
-      google::bigtable::v2::ExecuteQueryRequest const& request) override;
+  ExecuteQuery(std::shared_ptr<grpc::ClientContext> client_context,
+               Options const& options,
+               google::bigtable::v2::ExecuteQueryRequest const& request,
+               std::shared_ptr<OperationContext> operation_context) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::bigtable::v2::ReadRowsResponse>>
   AsyncReadRows(google::cloud::CompletionQueue const& cq,
                 std::shared_ptr<grpc::ClientContext> context,
                 google::cloud::internal::ImmutableOptions options,
-                google::bigtable::v2::ReadRowsRequest const& request) override;
+                google::bigtable::v2::ReadRowsRequest const& request,
+                std::shared_ptr<OperationContext> operation_context) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::bigtable::v2::SampleRowKeysResponse>>
@@ -101,60 +109,67 @@ class BigtableChannelRefresh : public BigtableStub {
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::SampleRowKeysRequest const& request) override;
+      google::bigtable::v2::SampleRowKeysRequest const& request,
+      std::shared_ptr<OperationContext> operation_context) override;
 
   future<StatusOr<google::bigtable::v2::MutateRowResponse>> AsyncMutateRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions,
-      google::bigtable::v2::MutateRowRequest const& request) override;
+      google::bigtable::v2::MutateRowRequest const& request,
+      std::shared_ptr<OperationContext> operation_context) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::bigtable::v2::MutateRowsResponse>>
-  AsyncMutateRows(
-      google::cloud::CompletionQueue const& cq,
-      std::shared_ptr<grpc::ClientContext> context,
-      google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::MutateRowsRequest const& request) override;
+  AsyncMutateRows(google::cloud::CompletionQueue const& cq,
+                  std::shared_ptr<grpc::ClientContext> context,
+                  google::cloud::internal::ImmutableOptions options,
+                  google::bigtable::v2::MutateRowsRequest const& request,
+                  std::shared_ptr<OperationContext> operation_context) override;
 
   future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
   AsyncCheckAndMutateRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions,
-      google::bigtable::v2::CheckAndMutateRowRequest const& request) override;
+      google::bigtable::v2::CheckAndMutateRowRequest const& request,
+      std::shared_ptr<OperationContext> operation_context) override;
 
   future<StatusOr<google::bigtable::v2::PingAndWarmResponse>> AsyncPingAndWarm(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::PingAndWarmRequest const& request) override;
+      google::bigtable::v2::PingAndWarmRequest const& request,
+      std::shared_ptr<OperationContext> operation_context) override;
 
   future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>
   AsyncReadModifyWriteRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions,
-      google::bigtable::v2::ReadModifyWriteRowRequest const& request) override;
+      google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+      std::shared_ptr<OperationContext> operation_context) override;
 
   future<StatusOr<google::bigtable::v2::PrepareQueryResponse>>
   AsyncPrepareQuery(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::PrepareQueryRequest const& request) override;
+      google::bigtable::v2::PrepareQueryRequest const& request,
+      std::shared_ptr<OperationContext> operation_context) override;
 
   StatusOr<google::bigtable::v2::ClientConfiguration> GetClientConfiguration(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::GetClientConfigurationRequest const& request)
-      override;
+      google::bigtable::v2::GetClientConfigurationRequest const& request,
+      OperationContext& operation_context) override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::bigtable::v2::SessionRequest,
       google::bigtable::v2::SessionResponse>>
   AsyncOpenTable(google::cloud::CompletionQueue const& cq,
                  std::shared_ptr<grpc::ClientContext> context,
-                 google::cloud::internal::ImmutableOptions options) override;
+                 google::cloud::internal::ImmutableOptions options,
+                 std::shared_ptr<OperationContext> operation_context) override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::bigtable::v2::SessionRequest,
@@ -162,7 +177,8 @@ class BigtableChannelRefresh : public BigtableStub {
   AsyncOpenAuthorizedView(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
-      google::cloud::internal::ImmutableOptions options) override;
+      google::cloud::internal::ImmutableOptions options,
+      std::shared_ptr<OperationContext> operation_context) override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::bigtable::v2::SessionRequest,
@@ -170,7 +186,8 @@ class BigtableChannelRefresh : public BigtableStub {
   AsyncOpenMaterializedView(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
-      google::cloud::internal::ImmutableOptions options) override;
+      google::cloud::internal::ImmutableOptions options,
+      std::shared_ptr<OperationContext> operation_context) override;
 
  private:
   std::shared_ptr<BigtableStub> child_;

--- a/google/cloud/bigtable/internal/bigtable_logging_decorator.cc
+++ b/google/cloud/bigtable/internal/bigtable_logging_decorator.cc
@@ -47,14 +47,17 @@ std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::bigtable::v2::ReadRowsResponse>>
 BigtableLogging::ReadRows(
     std::shared_ptr<grpc::ClientContext> context, Options const& options,
-    google::bigtable::v2::ReadRowsRequest const& request) {
+    google::bigtable::v2::ReadRowsRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   return google::cloud::internal::LogWrapper(
-      [this](std::shared_ptr<grpc::ClientContext> context,
-             Options const& options,
-             google::bigtable::v2::ReadRowsRequest const& request)
+      [this, operation_context = std::move(operation_context)](
+          std::shared_ptr<grpc::ClientContext> context, Options const& options,
+          google::bigtable::v2::ReadRowsRequest const& request)
           -> std::unique_ptr<google::cloud::internal::StreamingReadRpc<
               google::bigtable::v2::ReadRowsResponse>> {
-        auto stream = child_->ReadRows(std::move(context), options, request);
+        auto stream = child_->ReadRows(std::move(context), options, request,
+                                       std::move(operation_context));
         if (stream_logging_) {
           stream =
               std::make_unique<google::cloud::internal::StreamingReadRpcLogging<
@@ -71,15 +74,17 @@ std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::bigtable::v2::SampleRowKeysResponse>>
 BigtableLogging::SampleRowKeys(
     std::shared_ptr<grpc::ClientContext> context, Options const& options,
-    google::bigtable::v2::SampleRowKeysRequest const& request) {
+    google::bigtable::v2::SampleRowKeysRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   return google::cloud::internal::LogWrapper(
-      [this](std::shared_ptr<grpc::ClientContext> context,
-             Options const& options,
-             google::bigtable::v2::SampleRowKeysRequest const& request)
+      [this, operation_context = std::move(operation_context)](
+          std::shared_ptr<grpc::ClientContext> context, Options const& options,
+          google::bigtable::v2::SampleRowKeysRequest const& request)
           -> std::unique_ptr<google::cloud::internal::StreamingReadRpc<
               google::bigtable::v2::SampleRowKeysResponse>> {
-        auto stream =
-            child_->SampleRowKeys(std::move(context), options, request);
+        auto stream = child_->SampleRowKeys(
+            std::move(context), options, request, std::move(operation_context));
         if (stream_logging_) {
           stream =
               std::make_unique<google::cloud::internal::StreamingReadRpcLogging<
@@ -94,11 +99,13 @@ BigtableLogging::SampleRowKeys(
 
 StatusOr<google::bigtable::v2::MutateRowResponse> BigtableLogging::MutateRow(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::MutateRowRequest const& request) {
+    google::bigtable::v2::MutateRowRequest const& request,
+    google::cloud::bigtable_internal::OperationContext& operation_context) {
   return google::cloud::internal::LogWrapper(
-      [this](grpc::ClientContext& context, Options const& options,
-             google::bigtable::v2::MutateRowRequest const& request) {
-        return child_->MutateRow(context, options, request);
+      [this, &operation_context](
+          grpc::ClientContext& context, Options const& options,
+          google::bigtable::v2::MutateRowRequest const& request) {
+        return child_->MutateRow(context, options, request, operation_context);
       },
       context, options, request, __func__, tracing_options_);
 }
@@ -107,14 +114,17 @@ std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::bigtable::v2::MutateRowsResponse>>
 BigtableLogging::MutateRows(
     std::shared_ptr<grpc::ClientContext> context, Options const& options,
-    google::bigtable::v2::MutateRowsRequest const& request) {
+    google::bigtable::v2::MutateRowsRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   return google::cloud::internal::LogWrapper(
-      [this](std::shared_ptr<grpc::ClientContext> context,
-             Options const& options,
-             google::bigtable::v2::MutateRowsRequest const& request)
+      [this, operation_context = std::move(operation_context)](
+          std::shared_ptr<grpc::ClientContext> context, Options const& options,
+          google::bigtable::v2::MutateRowsRequest const& request)
           -> std::unique_ptr<google::cloud::internal::StreamingReadRpc<
               google::bigtable::v2::MutateRowsResponse>> {
-        auto stream = child_->MutateRows(std::move(context), options, request);
+        auto stream = child_->MutateRows(std::move(context), options, request,
+                                         std::move(operation_context));
         if (stream_logging_) {
           stream =
               std::make_unique<google::cloud::internal::StreamingReadRpcLogging<
@@ -130,11 +140,14 @@ BigtableLogging::MutateRows(
 StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>
 BigtableLogging::CheckAndMutateRow(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::CheckAndMutateRowRequest const& request) {
+    google::bigtable::v2::CheckAndMutateRowRequest const& request,
+    google::cloud::bigtable_internal::OperationContext& operation_context) {
   return google::cloud::internal::LogWrapper(
-      [this](grpc::ClientContext& context, Options const& options,
-             google::bigtable::v2::CheckAndMutateRowRequest const& request) {
-        return child_->CheckAndMutateRow(context, options, request);
+      [this, &operation_context](
+          grpc::ClientContext& context, Options const& options,
+          google::bigtable::v2::CheckAndMutateRowRequest const& request) {
+        return child_->CheckAndMutateRow(context, options, request,
+                                         operation_context);
       },
       context, options, request, __func__, tracing_options_);
 }
@@ -142,11 +155,14 @@ BigtableLogging::CheckAndMutateRow(
 StatusOr<google::bigtable::v2::PingAndWarmResponse>
 BigtableLogging::PingAndWarm(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::PingAndWarmRequest const& request) {
+    google::bigtable::v2::PingAndWarmRequest const& request,
+    google::cloud::bigtable_internal::OperationContext& operation_context) {
   return google::cloud::internal::LogWrapper(
-      [this](grpc::ClientContext& context, Options const& options,
-             google::bigtable::v2::PingAndWarmRequest const& request) {
-        return child_->PingAndWarm(context, options, request);
+      [this, &operation_context](
+          grpc::ClientContext& context, Options const& options,
+          google::bigtable::v2::PingAndWarmRequest const& request) {
+        return child_->PingAndWarm(context, options, request,
+                                   operation_context);
       },
       context, options, request, __func__, tracing_options_);
 }
@@ -154,11 +170,14 @@ BigtableLogging::PingAndWarm(
 StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>
 BigtableLogging::ReadModifyWriteRow(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
+    google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+    google::cloud::bigtable_internal::OperationContext& operation_context) {
   return google::cloud::internal::LogWrapper(
-      [this](grpc::ClientContext& context, Options const& options,
-             google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
-        return child_->ReadModifyWriteRow(context, options, request);
+      [this, &operation_context](
+          grpc::ClientContext& context, Options const& options,
+          google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
+        return child_->ReadModifyWriteRow(context, options, request,
+                                          operation_context);
       },
       context, options, request, __func__, tracing_options_);
 }
@@ -166,11 +185,14 @@ BigtableLogging::ReadModifyWriteRow(
 StatusOr<google::bigtable::v2::PrepareQueryResponse>
 BigtableLogging::PrepareQuery(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::PrepareQueryRequest const& request) {
+    google::bigtable::v2::PrepareQueryRequest const& request,
+    google::cloud::bigtable_internal::OperationContext& operation_context) {
   return google::cloud::internal::LogWrapper(
-      [this](grpc::ClientContext& context, Options const& options,
-             google::bigtable::v2::PrepareQueryRequest const& request) {
-        return child_->PrepareQuery(context, options, request);
+      [this, &operation_context](
+          grpc::ClientContext& context, Options const& options,
+          google::bigtable::v2::PrepareQueryRequest const& request) {
+        return child_->PrepareQuery(context, options, request,
+                                    operation_context);
       },
       context, options, request, __func__, tracing_options_);
 }
@@ -179,15 +201,17 @@ std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::bigtable::v2::ExecuteQueryResponse>>
 BigtableLogging::ExecuteQuery(
     std::shared_ptr<grpc::ClientContext> context, Options const& options,
-    google::bigtable::v2::ExecuteQueryRequest const& request) {
+    google::bigtable::v2::ExecuteQueryRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   return google::cloud::internal::LogWrapper(
-      [this](std::shared_ptr<grpc::ClientContext> context,
-             Options const& options,
-             google::bigtable::v2::ExecuteQueryRequest const& request)
+      [this, operation_context = std::move(operation_context)](
+          std::shared_ptr<grpc::ClientContext> context, Options const& options,
+          google::bigtable::v2::ExecuteQueryRequest const& request)
           -> std::unique_ptr<google::cloud::internal::StreamingReadRpc<
               google::bigtable::v2::ExecuteQueryResponse>> {
-        auto stream =
-            child_->ExecuteQuery(std::move(context), options, request);
+        auto stream = child_->ExecuteQuery(std::move(context), options, request,
+                                           std::move(operation_context));
         if (stream_logging_) {
           stream =
               std::make_unique<google::cloud::internal::StreamingReadRpcLogging<
@@ -203,12 +227,14 @@ BigtableLogging::ExecuteQuery(
 StatusOr<google::bigtable::v2::ClientConfiguration>
 BigtableLogging::GetClientConfiguration(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::GetClientConfigurationRequest const& request) {
+    google::bigtable::v2::GetClientConfigurationRequest const& request,
+    google::cloud::bigtable_internal::OperationContext& operation_context) {
   return google::cloud::internal::LogWrapper(
-      [this](
+      [this, &operation_context](
           grpc::ClientContext& context, Options const& options,
           google::bigtable::v2::GetClientConfigurationRequest const& request) {
-        return child_->GetClientConfiguration(context, options, request);
+        return child_->GetClientConfiguration(context, options, request,
+                                              operation_context);
       },
       context, options, request, __func__, tracing_options_);
 }
@@ -219,7 +245,9 @@ std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
 BigtableLogging::AsyncOpenTable(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
+    google::cloud::internal::ImmutableOptions options,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   using LoggingStream =
       ::google::cloud::internal::AsyncStreamingReadWriteRpcLogging<
           google::bigtable::v2::SessionRequest,
@@ -227,8 +255,8 @@ BigtableLogging::AsyncOpenTable(
 
   auto request_id = google::cloud::internal::RequestIdForLogging();
   GCP_LOG(DEBUG) << __func__ << "(" << request_id << ")";
-  auto stream =
-      child_->AsyncOpenTable(cq, std::move(context), std::move(options));
+  auto stream = child_->AsyncOpenTable(
+      cq, std::move(context), std::move(options), std::move(operation_context));
   if (stream_logging_) {
     stream = std::make_unique<LoggingStream>(
         std::move(stream), tracing_options_, std::move(request_id));
@@ -242,7 +270,9 @@ std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
 BigtableLogging::AsyncOpenAuthorizedView(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
+    google::cloud::internal::ImmutableOptions options,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   using LoggingStream =
       ::google::cloud::internal::AsyncStreamingReadWriteRpcLogging<
           google::bigtable::v2::SessionRequest,
@@ -250,8 +280,8 @@ BigtableLogging::AsyncOpenAuthorizedView(
 
   auto request_id = google::cloud::internal::RequestIdForLogging();
   GCP_LOG(DEBUG) << __func__ << "(" << request_id << ")";
-  auto stream = child_->AsyncOpenAuthorizedView(cq, std::move(context),
-                                                std::move(options));
+  auto stream = child_->AsyncOpenAuthorizedView(
+      cq, std::move(context), std::move(options), std::move(operation_context));
   if (stream_logging_) {
     stream = std::make_unique<LoggingStream>(
         std::move(stream), tracing_options_, std::move(request_id));
@@ -265,7 +295,9 @@ std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
 BigtableLogging::AsyncOpenMaterializedView(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
+    google::cloud::internal::ImmutableOptions options,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   using LoggingStream =
       ::google::cloud::internal::AsyncStreamingReadWriteRpcLogging<
           google::bigtable::v2::SessionRequest,
@@ -273,8 +305,8 @@ BigtableLogging::AsyncOpenMaterializedView(
 
   auto request_id = google::cloud::internal::RequestIdForLogging();
   GCP_LOG(DEBUG) << __func__ << "(" << request_id << ")";
-  auto stream = child_->AsyncOpenMaterializedView(cq, std::move(context),
-                                                  std::move(options));
+  auto stream = child_->AsyncOpenMaterializedView(
+      cq, std::move(context), std::move(options), std::move(operation_context));
   if (stream_logging_) {
     stream = std::make_unique<LoggingStream>(
         std::move(stream), tracing_options_, std::move(request_id));
@@ -288,7 +320,9 @@ BigtableLogging::AsyncReadRows(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::ReadRowsRequest const& request) {
+    google::bigtable::v2::ReadRowsRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   using LoggingStream = ::google::cloud::internal::AsyncStreamingReadRpcLogging<
       google::bigtable::v2::ReadRowsResponse>;
 
@@ -296,8 +330,9 @@ BigtableLogging::AsyncReadRows(
   google::cloud::internal::LogRequest(
       __func__, request_id,
       google::cloud::internal::DebugString(request, tracing_options_));
-  auto stream = child_->AsyncReadRows(cq, std::move(context),
-                                      std::move(options), request);
+  auto stream =
+      child_->AsyncReadRows(cq, std::move(context), std::move(options), request,
+                            std::move(operation_context));
   if (stream_logging_) {
     stream = std::make_unique<LoggingStream>(
         std::move(stream), tracing_options_, std::move(request_id));
@@ -311,7 +346,9 @@ BigtableLogging::AsyncSampleRowKeys(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::SampleRowKeysRequest const& request) {
+    google::bigtable::v2::SampleRowKeysRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   using LoggingStream = ::google::cloud::internal::AsyncStreamingReadRpcLogging<
       google::bigtable::v2::SampleRowKeysResponse>;
 
@@ -319,8 +356,9 @@ BigtableLogging::AsyncSampleRowKeys(
   google::cloud::internal::LogRequest(
       __func__, request_id,
       google::cloud::internal::DebugString(request, tracing_options_));
-  auto stream = child_->AsyncSampleRowKeys(cq, std::move(context),
-                                           std::move(options), request);
+  auto stream =
+      child_->AsyncSampleRowKeys(cq, std::move(context), std::move(options),
+                                 request, std::move(operation_context));
   if (stream_logging_) {
     stream = std::make_unique<LoggingStream>(
         std::move(stream), tracing_options_, std::move(request_id));
@@ -333,14 +371,18 @@ BigtableLogging::AsyncMutateRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::MutateRowRequest const& request) {
+    google::bigtable::v2::MutateRowRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   return google::cloud::internal::LogWrapper(
-      [this](google::cloud::CompletionQueue& cq,
-             std::shared_ptr<grpc::ClientContext> context,
-             google::cloud::internal::ImmutableOptions options,
-             google::bigtable::v2::MutateRowRequest const& request) {
+      [this, operation_context = std::move(operation_context)](
+          google::cloud::CompletionQueue& cq,
+          std::shared_ptr<grpc::ClientContext> context,
+          google::cloud::internal::ImmutableOptions options,
+          google::bigtable::v2::MutateRowRequest const& request) {
         return child_->AsyncMutateRow(cq, std::move(context),
-                                      std::move(options), request);
+                                      std::move(options), request,
+                                      std::move(operation_context));
       },
       cq, std::move(context), std::move(options), request, __func__,
       tracing_options_);
@@ -352,7 +394,9 @@ BigtableLogging::AsyncMutateRows(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::MutateRowsRequest const& request) {
+    google::bigtable::v2::MutateRowsRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   using LoggingStream = ::google::cloud::internal::AsyncStreamingReadRpcLogging<
       google::bigtable::v2::MutateRowsResponse>;
 
@@ -360,8 +404,9 @@ BigtableLogging::AsyncMutateRows(
   google::cloud::internal::LogRequest(
       __func__, request_id,
       google::cloud::internal::DebugString(request, tracing_options_));
-  auto stream = child_->AsyncMutateRows(cq, std::move(context),
-                                        std::move(options), request);
+  auto stream =
+      child_->AsyncMutateRows(cq, std::move(context), std::move(options),
+                              request, std::move(operation_context));
   if (stream_logging_) {
     stream = std::make_unique<LoggingStream>(
         std::move(stream), tracing_options_, std::move(request_id));
@@ -374,14 +419,18 @@ BigtableLogging::AsyncCheckAndMutateRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::CheckAndMutateRowRequest const& request) {
+    google::bigtable::v2::CheckAndMutateRowRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   return google::cloud::internal::LogWrapper(
-      [this](google::cloud::CompletionQueue& cq,
-             std::shared_ptr<grpc::ClientContext> context,
-             google::cloud::internal::ImmutableOptions options,
-             google::bigtable::v2::CheckAndMutateRowRequest const& request) {
+      [this, operation_context = std::move(operation_context)](
+          google::cloud::CompletionQueue& cq,
+          std::shared_ptr<grpc::ClientContext> context,
+          google::cloud::internal::ImmutableOptions options,
+          google::bigtable::v2::CheckAndMutateRowRequest const& request) {
         return child_->AsyncCheckAndMutateRow(cq, std::move(context),
-                                              std::move(options), request);
+                                              std::move(options), request,
+                                              std::move(operation_context));
       },
       cq, std::move(context), std::move(options), request, __func__,
       tracing_options_);
@@ -392,14 +441,18 @@ BigtableLogging::AsyncPingAndWarm(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::PingAndWarmRequest const& request) {
+    google::bigtable::v2::PingAndWarmRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   return google::cloud::internal::LogWrapper(
-      [this](google::cloud::CompletionQueue& cq,
-             std::shared_ptr<grpc::ClientContext> context,
-             google::cloud::internal::ImmutableOptions options,
-             google::bigtable::v2::PingAndWarmRequest const& request) {
+      [this, operation_context = std::move(operation_context)](
+          google::cloud::CompletionQueue& cq,
+          std::shared_ptr<grpc::ClientContext> context,
+          google::cloud::internal::ImmutableOptions options,
+          google::bigtable::v2::PingAndWarmRequest const& request) {
         return child_->AsyncPingAndWarm(cq, std::move(context),
-                                        std::move(options), request);
+                                        std::move(options), request,
+                                        std::move(operation_context));
       },
       cq, std::move(context), std::move(options), request, __func__,
       tracing_options_);
@@ -410,14 +463,18 @@ BigtableLogging::AsyncReadModifyWriteRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
+    google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   return google::cloud::internal::LogWrapper(
-      [this](google::cloud::CompletionQueue& cq,
-             std::shared_ptr<grpc::ClientContext> context,
-             google::cloud::internal::ImmutableOptions options,
-             google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
+      [this, operation_context = std::move(operation_context)](
+          google::cloud::CompletionQueue& cq,
+          std::shared_ptr<grpc::ClientContext> context,
+          google::cloud::internal::ImmutableOptions options,
+          google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
         return child_->AsyncReadModifyWriteRow(cq, std::move(context),
-                                               std::move(options), request);
+                                               std::move(options), request,
+                                               std::move(operation_context));
       },
       cq, std::move(context), std::move(options), request, __func__,
       tracing_options_);
@@ -428,14 +485,18 @@ BigtableLogging::AsyncPrepareQuery(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::PrepareQueryRequest const& request) {
+    google::bigtable::v2::PrepareQueryRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   return google::cloud::internal::LogWrapper(
-      [this](google::cloud::CompletionQueue& cq,
-             std::shared_ptr<grpc::ClientContext> context,
-             google::cloud::internal::ImmutableOptions options,
-             google::bigtable::v2::PrepareQueryRequest const& request) {
+      [this, operation_context = std::move(operation_context)](
+          google::cloud::CompletionQueue& cq,
+          std::shared_ptr<grpc::ClientContext> context,
+          google::cloud::internal::ImmutableOptions options,
+          google::bigtable::v2::PrepareQueryRequest const& request) {
         return child_->AsyncPrepareQuery(cq, std::move(context),
-                                         std::move(options), request);
+                                         std::move(options), request,
+                                         std::move(operation_context));
       },
       cq, std::move(context), std::move(options), request, __func__,
       tracing_options_);

--- a/google/cloud/bigtable/internal/bigtable_logging_decorator.h
+++ b/google/cloud/bigtable/internal/bigtable_logging_decorator.h
@@ -44,57 +44,79 @@ class BigtableLogging : public BigtableStub {
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::ReadRowsResponse>>
   ReadRows(std::shared_ptr<grpc::ClientContext> context, Options const& options,
-           google::bigtable::v2::ReadRowsRequest const& request) override;
+           google::bigtable::v2::ReadRowsRequest const& request,
+           std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+               operation_context) override;
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::SampleRowKeysResponse>>
   SampleRowKeys(
       std::shared_ptr<grpc::ClientContext> context, Options const& options,
-      google::bigtable::v2::SampleRowKeysRequest const& request) override;
+      google::bigtable::v2::SampleRowKeysRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   StatusOr<google::bigtable::v2::MutateRowResponse> MutateRow(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::MutateRowRequest const& request) override;
+      google::bigtable::v2::MutateRowRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
+      override;
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::MutateRowsResponse>>
   MutateRows(std::shared_ptr<grpc::ClientContext> context,
              Options const& options,
-             google::bigtable::v2::MutateRowsRequest const& request) override;
+             google::bigtable::v2::MutateRowsRequest const& request,
+             std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+                 operation_context) override;
 
   StatusOr<google::bigtable::v2::CheckAndMutateRowResponse> CheckAndMutateRow(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::CheckAndMutateRowRequest const& request) override;
+      google::bigtable::v2::CheckAndMutateRowRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
+      override;
 
   StatusOr<google::bigtable::v2::PingAndWarmResponse> PingAndWarm(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::PingAndWarmRequest const& request) override;
+      google::bigtable::v2::PingAndWarmRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
+      override;
 
   StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse> ReadModifyWriteRow(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::ReadModifyWriteRowRequest const& request) override;
+      google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
+      override;
 
   StatusOr<google::bigtable::v2::PrepareQueryResponse> PrepareQuery(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::PrepareQueryRequest const& request) override;
+      google::bigtable::v2::PrepareQueryRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
+      override;
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::ExecuteQueryResponse>>
   ExecuteQuery(
       std::shared_ptr<grpc::ClientContext> context, Options const& options,
-      google::bigtable::v2::ExecuteQueryRequest const& request) override;
+      google::bigtable::v2::ExecuteQueryRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   StatusOr<google::bigtable::v2::ClientConfiguration> GetClientConfiguration(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::GetClientConfigurationRequest const& request)
+      google::bigtable::v2::GetClientConfigurationRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
       override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::bigtable::v2::SessionRequest,
       google::bigtable::v2::SessionResponse>>
-  AsyncOpenTable(google::cloud::CompletionQueue const& cq,
-                 std::shared_ptr<grpc::ClientContext> context,
-                 google::cloud::internal::ImmutableOptions options) override;
+  AsyncOpenTable(
+      google::cloud::CompletionQueue const& cq,
+      std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::bigtable::v2::SessionRequest,
@@ -102,7 +124,9 @@ class BigtableLogging : public BigtableStub {
   AsyncOpenAuthorizedView(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
-      google::cloud::internal::ImmutableOptions options) override;
+      google::cloud::internal::ImmutableOptions options,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::bigtable::v2::SessionRequest,
@@ -110,14 +134,19 @@ class BigtableLogging : public BigtableStub {
   AsyncOpenMaterializedView(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
-      google::cloud::internal::ImmutableOptions options) override;
+      google::cloud::internal::ImmutableOptions options,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::bigtable::v2::ReadRowsResponse>>
-  AsyncReadRows(google::cloud::CompletionQueue const& cq,
-                std::shared_ptr<grpc::ClientContext> context,
-                google::cloud::internal::ImmutableOptions options,
-                google::bigtable::v2::ReadRowsRequest const& request) override;
+  AsyncReadRows(
+      google::cloud::CompletionQueue const& cq,
+      std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
+      google::bigtable::v2::ReadRowsRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::bigtable::v2::SampleRowKeysResponse>>
@@ -125,13 +154,17 @@ class BigtableLogging : public BigtableStub {
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::SampleRowKeysRequest const& request) override;
+      google::bigtable::v2::SampleRowKeysRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   future<StatusOr<google::bigtable::v2::MutateRowResponse>> AsyncMutateRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::MutateRowRequest const& request) override;
+      google::bigtable::v2::MutateRowRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::bigtable::v2::MutateRowsResponse>>
@@ -139,34 +172,44 @@ class BigtableLogging : public BigtableStub {
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::MutateRowsRequest const& request) override;
+      google::bigtable::v2::MutateRowsRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
   AsyncCheckAndMutateRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::CheckAndMutateRowRequest const& request) override;
+      google::bigtable::v2::CheckAndMutateRowRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   future<StatusOr<google::bigtable::v2::PingAndWarmResponse>> AsyncPingAndWarm(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::PingAndWarmRequest const& request) override;
+      google::bigtable::v2::PingAndWarmRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>
   AsyncReadModifyWriteRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::ReadModifyWriteRowRequest const& request) override;
+      google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   future<StatusOr<google::bigtable::v2::PrepareQueryResponse>>
   AsyncPrepareQuery(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::PrepareQueryRequest const& request) override;
+      google::bigtable::v2::PrepareQueryRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
  private:
   std::shared_ptr<BigtableStub> child_;

--- a/google/cloud/bigtable/internal/bigtable_metadata_decorator.cc
+++ b/google/cloud/bigtable/internal/bigtable_metadata_decorator.cc
@@ -53,7 +53,9 @@ std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::bigtable::v2::ReadRowsResponse>>
 BigtableMetadata::ReadRows(
     std::shared_ptr<grpc::ClientContext> context, Options const& options,
-    google::bigtable::v2::ReadRowsRequest const& request) {
+    google::bigtable::v2::ReadRowsRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   std::vector<std::string> params;
   params.reserve(3);
 
@@ -101,14 +103,17 @@ BigtableMetadata::ReadRows(
   } else {
     SetMetadata(*context, options, absl::StrJoin(params, "&"));
   }
-  return child_->ReadRows(std::move(context), options, request);
+  return child_->ReadRows(std::move(context), options, request,
+                          std::move(operation_context));
 }
 
 std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::bigtable::v2::SampleRowKeysResponse>>
 BigtableMetadata::SampleRowKeys(
     std::shared_ptr<grpc::ClientContext> context, Options const& options,
-    google::bigtable::v2::SampleRowKeysRequest const& request) {
+    google::bigtable::v2::SampleRowKeysRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   std::vector<std::string> params;
   params.reserve(3);
 
@@ -156,12 +161,14 @@ BigtableMetadata::SampleRowKeys(
   } else {
     SetMetadata(*context, options, absl::StrJoin(params, "&"));
   }
-  return child_->SampleRowKeys(std::move(context), options, request);
+  return child_->SampleRowKeys(std::move(context), options, request,
+                               std::move(operation_context));
 }
 
 StatusOr<google::bigtable::v2::MutateRowResponse> BigtableMetadata::MutateRow(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::MutateRowRequest const& request) {
+    google::bigtable::v2::MutateRowRequest const& request,
+    google::cloud::bigtable_internal::OperationContext& operation_context) {
   std::vector<std::string> params;
   params.reserve(2);
 
@@ -194,14 +201,16 @@ StatusOr<google::bigtable::v2::MutateRowResponse> BigtableMetadata::MutateRow(
   } else {
     SetMetadata(context, options, absl::StrJoin(params, "&"));
   }
-  return child_->MutateRow(context, options, request);
+  return child_->MutateRow(context, options, request, operation_context);
 }
 
 std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::bigtable::v2::MutateRowsResponse>>
 BigtableMetadata::MutateRows(
     std::shared_ptr<grpc::ClientContext> context, Options const& options,
-    google::bigtable::v2::MutateRowsRequest const& request) {
+    google::bigtable::v2::MutateRowsRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   std::vector<std::string> params;
   params.reserve(2);
 
@@ -234,13 +243,15 @@ BigtableMetadata::MutateRows(
   } else {
     SetMetadata(*context, options, absl::StrJoin(params, "&"));
   }
-  return child_->MutateRows(std::move(context), options, request);
+  return child_->MutateRows(std::move(context), options, request,
+                            std::move(operation_context));
 }
 
 StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>
 BigtableMetadata::CheckAndMutateRow(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::CheckAndMutateRowRequest const& request) {
+    google::bigtable::v2::CheckAndMutateRowRequest const& request,
+    google::cloud::bigtable_internal::OperationContext& operation_context) {
   std::vector<std::string> params;
   params.reserve(2);
 
@@ -273,13 +284,15 @@ BigtableMetadata::CheckAndMutateRow(
   } else {
     SetMetadata(context, options, absl::StrJoin(params, "&"));
   }
-  return child_->CheckAndMutateRow(context, options, request);
+  return child_->CheckAndMutateRow(context, options, request,
+                                   operation_context);
 }
 
 StatusOr<google::bigtable::v2::PingAndWarmResponse>
 BigtableMetadata::PingAndWarm(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::PingAndWarmRequest const& request) {
+    google::bigtable::v2::PingAndWarmRequest const& request,
+    google::cloud::bigtable_internal::OperationContext& operation_context) {
   std::vector<std::string> params;
   params.reserve(2);
 
@@ -306,13 +319,14 @@ BigtableMetadata::PingAndWarm(
   } else {
     SetMetadata(context, options, absl::StrJoin(params, "&"));
   }
-  return child_->PingAndWarm(context, options, request);
+  return child_->PingAndWarm(context, options, request, operation_context);
 }
 
 StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>
 BigtableMetadata::ReadModifyWriteRow(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
+    google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+    google::cloud::bigtable_internal::OperationContext& operation_context) {
   std::vector<std::string> params;
   params.reserve(2);
 
@@ -345,13 +359,15 @@ BigtableMetadata::ReadModifyWriteRow(
   } else {
     SetMetadata(context, options, absl::StrJoin(params, "&"));
   }
-  return child_->ReadModifyWriteRow(context, options, request);
+  return child_->ReadModifyWriteRow(context, options, request,
+                                    operation_context);
 }
 
 StatusOr<google::bigtable::v2::PrepareQueryResponse>
 BigtableMetadata::PrepareQuery(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::PrepareQueryRequest const& request) {
+    google::bigtable::v2::PrepareQueryRequest const& request,
+    google::cloud::bigtable_internal::OperationContext& operation_context) {
   std::vector<std::string> params;
   params.reserve(2);
 
@@ -378,14 +394,16 @@ BigtableMetadata::PrepareQuery(
   } else {
     SetMetadata(context, options, absl::StrJoin(params, "&"));
   }
-  return child_->PrepareQuery(context, options, request);
+  return child_->PrepareQuery(context, options, request, operation_context);
 }
 
 std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::bigtable::v2::ExecuteQueryResponse>>
 BigtableMetadata::ExecuteQuery(
     std::shared_ptr<grpc::ClientContext> context, Options const& options,
-    google::bigtable::v2::ExecuteQueryRequest const& request) {
+    google::bigtable::v2::ExecuteQueryRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   std::vector<std::string> params;
   params.reserve(2);
 
@@ -412,15 +430,18 @@ BigtableMetadata::ExecuteQuery(
   } else {
     SetMetadata(*context, options, absl::StrJoin(params, "&"));
   }
-  return child_->ExecuteQuery(std::move(context), options, request);
+  return child_->ExecuteQuery(std::move(context), options, request,
+                              std::move(operation_context));
 }
 
 StatusOr<google::bigtable::v2::ClientConfiguration>
 BigtableMetadata::GetClientConfiguration(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::GetClientConfigurationRequest const& request) {
+    google::bigtable::v2::GetClientConfigurationRequest const& request,
+    google::cloud::bigtable_internal::OperationContext& operation_context) {
   SetMetadata(context, options);
-  return child_->GetClientConfiguration(context, options, request);
+  return child_->GetClientConfiguration(context, options, request,
+                                        operation_context);
 }
 
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
@@ -429,9 +450,12 @@ std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
 BigtableMetadata::AsyncOpenTable(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
+    google::cloud::internal::ImmutableOptions options,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   SetMetadata(*context, *options);
-  return child_->AsyncOpenTable(cq, std::move(context), std::move(options));
+  return child_->AsyncOpenTable(cq, std::move(context), std::move(options),
+                                std::move(operation_context));
 }
 
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
@@ -440,10 +464,12 @@ std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
 BigtableMetadata::AsyncOpenAuthorizedView(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
+    google::cloud::internal::ImmutableOptions options,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   SetMetadata(*context, *options);
-  return child_->AsyncOpenAuthorizedView(cq, std::move(context),
-                                         std::move(options));
+  return child_->AsyncOpenAuthorizedView(
+      cq, std::move(context), std::move(options), std::move(operation_context));
 }
 
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
@@ -452,10 +478,12 @@ std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
 BigtableMetadata::AsyncOpenMaterializedView(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
+    google::cloud::internal::ImmutableOptions options,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   SetMetadata(*context, *options);
-  return child_->AsyncOpenMaterializedView(cq, std::move(context),
-                                           std::move(options));
+  return child_->AsyncOpenMaterializedView(
+      cq, std::move(context), std::move(options), std::move(operation_context));
 }
 
 std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -464,7 +492,9 @@ BigtableMetadata::AsyncReadRows(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::ReadRowsRequest const& request) {
+    google::bigtable::v2::ReadRowsRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   std::vector<std::string> params;
   params.reserve(3);
 
@@ -513,7 +543,7 @@ BigtableMetadata::AsyncReadRows(
     SetMetadata(*context, *options, absl::StrJoin(params, "&"));
   }
   return child_->AsyncReadRows(cq, std::move(context), std::move(options),
-                               request);
+                               request, std::move(operation_context));
 }
 
 std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -522,7 +552,9 @@ BigtableMetadata::AsyncSampleRowKeys(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::SampleRowKeysRequest const& request) {
+    google::bigtable::v2::SampleRowKeysRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   std::vector<std::string> params;
   params.reserve(3);
 
@@ -571,7 +603,7 @@ BigtableMetadata::AsyncSampleRowKeys(
     SetMetadata(*context, *options, absl::StrJoin(params, "&"));
   }
   return child_->AsyncSampleRowKeys(cq, std::move(context), std::move(options),
-                                    request);
+                                    request, std::move(operation_context));
 }
 
 future<StatusOr<google::bigtable::v2::MutateRowResponse>>
@@ -579,7 +611,9 @@ BigtableMetadata::AsyncMutateRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::MutateRowRequest const& request) {
+    google::bigtable::v2::MutateRowRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   std::vector<std::string> params;
   params.reserve(2);
 
@@ -613,7 +647,7 @@ BigtableMetadata::AsyncMutateRow(
     SetMetadata(*context, *options, absl::StrJoin(params, "&"));
   }
   return child_->AsyncMutateRow(cq, std::move(context), std::move(options),
-                                request);
+                                request, std::move(operation_context));
 }
 
 std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
@@ -622,7 +656,9 @@ BigtableMetadata::AsyncMutateRows(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::MutateRowsRequest const& request) {
+    google::bigtable::v2::MutateRowsRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   std::vector<std::string> params;
   params.reserve(2);
 
@@ -656,7 +692,7 @@ BigtableMetadata::AsyncMutateRows(
     SetMetadata(*context, *options, absl::StrJoin(params, "&"));
   }
   return child_->AsyncMutateRows(cq, std::move(context), std::move(options),
-                                 request);
+                                 request, std::move(operation_context));
 }
 
 future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
@@ -664,7 +700,9 @@ BigtableMetadata::AsyncCheckAndMutateRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::CheckAndMutateRowRequest const& request) {
+    google::bigtable::v2::CheckAndMutateRowRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   std::vector<std::string> params;
   params.reserve(2);
 
@@ -698,7 +736,8 @@ BigtableMetadata::AsyncCheckAndMutateRow(
     SetMetadata(*context, *options, absl::StrJoin(params, "&"));
   }
   return child_->AsyncCheckAndMutateRow(cq, std::move(context),
-                                        std::move(options), request);
+                                        std::move(options), request,
+                                        std::move(operation_context));
 }
 
 future<StatusOr<google::bigtable::v2::PingAndWarmResponse>>
@@ -706,7 +745,9 @@ BigtableMetadata::AsyncPingAndWarm(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::PingAndWarmRequest const& request) {
+    google::bigtable::v2::PingAndWarmRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   std::vector<std::string> params;
   params.reserve(2);
 
@@ -734,7 +775,7 @@ BigtableMetadata::AsyncPingAndWarm(
     SetMetadata(*context, *options, absl::StrJoin(params, "&"));
   }
   return child_->AsyncPingAndWarm(cq, std::move(context), std::move(options),
-                                  request);
+                                  request, std::move(operation_context));
 }
 
 future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>
@@ -742,7 +783,9 @@ BigtableMetadata::AsyncReadModifyWriteRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
+    google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   std::vector<std::string> params;
   params.reserve(2);
 
@@ -776,7 +819,8 @@ BigtableMetadata::AsyncReadModifyWriteRow(
     SetMetadata(*context, *options, absl::StrJoin(params, "&"));
   }
   return child_->AsyncReadModifyWriteRow(cq, std::move(context),
-                                         std::move(options), request);
+                                         std::move(options), request,
+                                         std::move(operation_context));
 }
 
 future<StatusOr<google::bigtable::v2::PrepareQueryResponse>>
@@ -784,7 +828,9 @@ BigtableMetadata::AsyncPrepareQuery(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::PrepareQueryRequest const& request) {
+    google::bigtable::v2::PrepareQueryRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   std::vector<std::string> params;
   params.reserve(2);
 
@@ -812,7 +858,7 @@ BigtableMetadata::AsyncPrepareQuery(
     SetMetadata(*context, *options, absl::StrJoin(params, "&"));
   }
   return child_->AsyncPrepareQuery(cq, std::move(context), std::move(options),
-                                   request);
+                                   request, std::move(operation_context));
 }
 
 void BigtableMetadata::SetMetadata(grpc::ClientContext& context,

--- a/google/cloud/bigtable/internal/bigtable_metadata_decorator.h
+++ b/google/cloud/bigtable/internal/bigtable_metadata_decorator.h
@@ -44,57 +44,79 @@ class BigtableMetadata : public BigtableStub {
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::ReadRowsResponse>>
   ReadRows(std::shared_ptr<grpc::ClientContext> context, Options const& options,
-           google::bigtable::v2::ReadRowsRequest const& request) override;
+           google::bigtable::v2::ReadRowsRequest const& request,
+           std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+               operation_context) override;
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::SampleRowKeysResponse>>
   SampleRowKeys(
       std::shared_ptr<grpc::ClientContext> context, Options const& options,
-      google::bigtable::v2::SampleRowKeysRequest const& request) override;
+      google::bigtable::v2::SampleRowKeysRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   StatusOr<google::bigtable::v2::MutateRowResponse> MutateRow(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::MutateRowRequest const& request) override;
+      google::bigtable::v2::MutateRowRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
+      override;
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::MutateRowsResponse>>
   MutateRows(std::shared_ptr<grpc::ClientContext> context,
              Options const& options,
-             google::bigtable::v2::MutateRowsRequest const& request) override;
+             google::bigtable::v2::MutateRowsRequest const& request,
+             std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+                 operation_context) override;
 
   StatusOr<google::bigtable::v2::CheckAndMutateRowResponse> CheckAndMutateRow(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::CheckAndMutateRowRequest const& request) override;
+      google::bigtable::v2::CheckAndMutateRowRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
+      override;
 
   StatusOr<google::bigtable::v2::PingAndWarmResponse> PingAndWarm(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::PingAndWarmRequest const& request) override;
+      google::bigtable::v2::PingAndWarmRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
+      override;
 
   StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse> ReadModifyWriteRow(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::ReadModifyWriteRowRequest const& request) override;
+      google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
+      override;
 
   StatusOr<google::bigtable::v2::PrepareQueryResponse> PrepareQuery(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::PrepareQueryRequest const& request) override;
+      google::bigtable::v2::PrepareQueryRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
+      override;
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::ExecuteQueryResponse>>
   ExecuteQuery(
       std::shared_ptr<grpc::ClientContext> context, Options const& options,
-      google::bigtable::v2::ExecuteQueryRequest const& request) override;
+      google::bigtable::v2::ExecuteQueryRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   StatusOr<google::bigtable::v2::ClientConfiguration> GetClientConfiguration(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::GetClientConfigurationRequest const& request)
+      google::bigtable::v2::GetClientConfigurationRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
       override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::bigtable::v2::SessionRequest,
       google::bigtable::v2::SessionResponse>>
-  AsyncOpenTable(google::cloud::CompletionQueue const& cq,
-                 std::shared_ptr<grpc::ClientContext> context,
-                 google::cloud::internal::ImmutableOptions options) override;
+  AsyncOpenTable(
+      google::cloud::CompletionQueue const& cq,
+      std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::bigtable::v2::SessionRequest,
@@ -102,7 +124,9 @@ class BigtableMetadata : public BigtableStub {
   AsyncOpenAuthorizedView(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
-      google::cloud::internal::ImmutableOptions options) override;
+      google::cloud::internal::ImmutableOptions options,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::bigtable::v2::SessionRequest,
@@ -110,14 +134,19 @@ class BigtableMetadata : public BigtableStub {
   AsyncOpenMaterializedView(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
-      google::cloud::internal::ImmutableOptions options) override;
+      google::cloud::internal::ImmutableOptions options,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::bigtable::v2::ReadRowsResponse>>
-  AsyncReadRows(google::cloud::CompletionQueue const& cq,
-                std::shared_ptr<grpc::ClientContext> context,
-                google::cloud::internal::ImmutableOptions options,
-                google::bigtable::v2::ReadRowsRequest const& request) override;
+  AsyncReadRows(
+      google::cloud::CompletionQueue const& cq,
+      std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
+      google::bigtable::v2::ReadRowsRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::bigtable::v2::SampleRowKeysResponse>>
@@ -125,13 +154,17 @@ class BigtableMetadata : public BigtableStub {
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::SampleRowKeysRequest const& request) override;
+      google::bigtable::v2::SampleRowKeysRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   future<StatusOr<google::bigtable::v2::MutateRowResponse>> AsyncMutateRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::MutateRowRequest const& request) override;
+      google::bigtable::v2::MutateRowRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::bigtable::v2::MutateRowsResponse>>
@@ -139,34 +172,44 @@ class BigtableMetadata : public BigtableStub {
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::MutateRowsRequest const& request) override;
+      google::bigtable::v2::MutateRowsRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
   AsyncCheckAndMutateRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::CheckAndMutateRowRequest const& request) override;
+      google::bigtable::v2::CheckAndMutateRowRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   future<StatusOr<google::bigtable::v2::PingAndWarmResponse>> AsyncPingAndWarm(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::PingAndWarmRequest const& request) override;
+      google::bigtable::v2::PingAndWarmRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>
   AsyncReadModifyWriteRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::ReadModifyWriteRowRequest const& request) override;
+      google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   future<StatusOr<google::bigtable::v2::PrepareQueryResponse>>
   AsyncPrepareQuery(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::PrepareQueryRequest const& request) override;
+      google::bigtable::v2::PrepareQueryRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
  private:
   void SetMetadata(grpc::ClientContext& context, Options const& options,

--- a/google/cloud/bigtable/internal/bigtable_random_two_least_used_decorator.cc
+++ b/google/cloud/bigtable/internal/bigtable_random_two_least_used_decorator.cc
@@ -178,10 +178,14 @@ std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::bigtable::v2::ReadRowsResponse>>
 BigtableRandomTwoLeastUsed::ReadRows(
     std::shared_ptr<grpc::ClientContext> context, Options const& options,
-    google::bigtable::v2::ReadRowsRequest const& request) {
+    google::bigtable::v2::ReadRowsRequest const& request,
+    std::shared_ptr<OperationContext> operation_context) {
   return StreamingHelper<google::bigtable::v2::ReadRowsResponse>(
-      pool_, [&, context = std::move(context)](BigtableStub& stub) mutable {
-        return stub.ReadRows(std::move(context), options, request);
+      pool_, [&, context = std::move(context),
+              operation_context =
+                  std::move(operation_context)](BigtableStub& stub) mutable {
+        return stub.ReadRows(std::move(context), options, request,
+                             std::move(operation_context));
       });
 }
 
@@ -189,20 +193,25 @@ std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::bigtable::v2::SampleRowKeysResponse>>
 BigtableRandomTwoLeastUsed::SampleRowKeys(
     std::shared_ptr<grpc::ClientContext> context, Options const& options,
-    google::bigtable::v2::SampleRowKeysRequest const& request) {
+    google::bigtable::v2::SampleRowKeysRequest const& request,
+    std::shared_ptr<OperationContext> operation_context) {
   return StreamingHelper<google::bigtable::v2::SampleRowKeysResponse>(
-      pool_, [&, context = std::move(context)](BigtableStub& stub) mutable {
-        return stub.SampleRowKeys(std::move(context), options, request);
+      pool_, [&, context = std::move(context),
+              operation_context =
+                  std::move(operation_context)](BigtableStub& stub) mutable {
+        return stub.SampleRowKeys(std::move(context), options, request,
+                                  std::move(operation_context));
       });
 }
 
 StatusOr<google::bigtable::v2::MutateRowResponse>
 BigtableRandomTwoLeastUsed::MutateRow(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::MutateRowRequest const& request) {
+    google::bigtable::v2::MutateRowRequest const& request,
+    OperationContext& operation_context) {
   return UnaryHelper<StatusOr<google::bigtable::v2::MutateRowResponse>>(
       pool_, [&](BigtableStub& stub) {
-        return stub.MutateRow(context, options, request);
+        return stub.MutateRow(context, options, request, operation_context);
       });
 }
 
@@ -210,51 +219,61 @@ std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::bigtable::v2::MutateRowsResponse>>
 BigtableRandomTwoLeastUsed::MutateRows(
     std::shared_ptr<grpc::ClientContext> context, Options const& options,
-    google::bigtable::v2::MutateRowsRequest const& request) {
+    google::bigtable::v2::MutateRowsRequest const& request,
+    std::shared_ptr<OperationContext> operation_context) {
   return StreamingHelper<google::bigtable::v2::MutateRowsResponse>(
-      pool_, [&, context = std::move(context)](BigtableStub& stub) mutable {
-        return stub.MutateRows(std::move(context), options, request);
+      pool_, [&, context = std::move(context),
+              operation_context =
+                  std::move(operation_context)](BigtableStub& stub) mutable {
+        return stub.MutateRows(std::move(context), options, request,
+                               std::move(operation_context));
       });
 }
 
 StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>
 BigtableRandomTwoLeastUsed::CheckAndMutateRow(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::CheckAndMutateRowRequest const& request) {
+    google::bigtable::v2::CheckAndMutateRowRequest const& request,
+    OperationContext& operation_context) {
   return UnaryHelper<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>(
       pool_, [&](BigtableStub& stub) {
-        return stub.CheckAndMutateRow(context, options, request);
+        return stub.CheckAndMutateRow(context, options, request,
+                                      operation_context);
       });
 }
 
 StatusOr<google::bigtable::v2::PingAndWarmResponse>
 BigtableRandomTwoLeastUsed::PingAndWarm(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::PingAndWarmRequest const& request) {
+    google::bigtable::v2::PingAndWarmRequest const& request,
+    OperationContext& operation_context) {
   return UnaryHelper<StatusOr<google::bigtable::v2::PingAndWarmResponse>>(
       pool_, [&](BigtableStub& stub) {
-        return stub.PingAndWarm(context, options, request);
+        return stub.PingAndWarm(context, options, request, operation_context);
       });
 }
 
 StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>
 BigtableRandomTwoLeastUsed::ReadModifyWriteRow(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
+    google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+    OperationContext& operation_context) {
   return UnaryHelper<
       StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>(
       pool_, [&](BigtableStub& stub) {
-        return stub.ReadModifyWriteRow(context, options, request);
+        return stub.ReadModifyWriteRow(context, options, request,
+                                       operation_context);
       });
 }
 
 StatusOr<google::bigtable::v2::PrepareQueryResponse>
 BigtableRandomTwoLeastUsed::PrepareQuery(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::PrepareQueryRequest const& request) {
+    google::bigtable::v2::PrepareQueryRequest const& request,
+    OperationContext& operation_context) {
   return UnaryHelper<StatusOr<google::bigtable::v2::PrepareQueryResponse>>(
       pool_, [&](BigtableStub& stub) {
-        return stub.PrepareQuery(context, options, request);
+        return stub.PrepareQuery(context, options, request, operation_context);
       });
 }
 
@@ -262,10 +281,14 @@ std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::bigtable::v2::ExecuteQueryResponse>>
 BigtableRandomTwoLeastUsed::ExecuteQuery(
     std::shared_ptr<grpc::ClientContext> context, Options const& options,
-    google::bigtable::v2::ExecuteQueryRequest const& request) {
+    google::bigtable::v2::ExecuteQueryRequest const& request,
+    std::shared_ptr<OperationContext> operation_context) {
   return StreamingHelper<google::bigtable::v2::ExecuteQueryResponse>(
-      pool_, [&, context = std::move(context)](BigtableStub& stub) mutable {
-        return stub.ExecuteQuery(std::move(context), options, request);
+      pool_, [&, context = std::move(context),
+              operation_context =
+                  std::move(operation_context)](BigtableStub& stub) mutable {
+        return stub.ExecuteQuery(std::move(context), options, request,
+                                 std::move(operation_context));
       });
 }
 
@@ -275,12 +298,14 @@ BigtableRandomTwoLeastUsed::AsyncReadRows(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::ReadRowsRequest const& request) {
+    google::bigtable::v2::ReadRowsRequest const& request,
+    std::shared_ptr<OperationContext> operation_context) {
   return AsyncStreamingHelper<google::bigtable::v2::ReadRowsResponse>(
-      pool_, [&, context = std::move(context),
-              options = std::move(options)](BigtableStub& stub) mutable {
+      pool_, [&, context = std::move(context), options = std::move(options),
+              operation_context =
+                  std::move(operation_context)](BigtableStub& stub) mutable {
         return stub.AsyncReadRows(cq, std::move(context), std::move(options),
-                                  request);
+                                  request, std::move(operation_context));
       });
 }
 
@@ -290,12 +315,15 @@ BigtableRandomTwoLeastUsed::AsyncSampleRowKeys(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::SampleRowKeysRequest const& request) {
+    google::bigtable::v2::SampleRowKeysRequest const& request,
+    std::shared_ptr<OperationContext> operation_context) {
   return AsyncStreamingHelper<google::bigtable::v2::SampleRowKeysResponse>(
-      pool_, [&, context = std::move(context),
-              options = std::move(options)](BigtableStub& stub) mutable {
+      pool_, [&, context = std::move(context), options = std::move(options),
+              operation_context =
+                  std::move(operation_context)](BigtableStub& stub) mutable {
         return stub.AsyncSampleRowKeys(cq, std::move(context),
-                                       std::move(options), request);
+                                       std::move(options), request,
+                                       std::move(operation_context));
       });
 }
 
@@ -304,12 +332,14 @@ BigtableRandomTwoLeastUsed::AsyncMutateRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::MutateRowRequest const& request) {
+    google::bigtable::v2::MutateRowRequest const& request,
+    std::shared_ptr<OperationContext> operation_context) {
   return UnaryHelper<future<StatusOr<google::bigtable::v2::MutateRowResponse>>>(
-      pool_, [&, context = std::move(context),
-              options = std::move(options)](BigtableStub& stub) mutable {
+      pool_, [&, context = std::move(context), options = std::move(options),
+              operation_context =
+                  std::move(operation_context)](BigtableStub& stub) mutable {
         return stub.AsyncMutateRow(cq, std::move(context), std::move(options),
-                                   request);
+                                   request, std::move(operation_context));
       });
 }
 
@@ -319,12 +349,14 @@ BigtableRandomTwoLeastUsed::AsyncMutateRows(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::MutateRowsRequest const& request) {
+    google::bigtable::v2::MutateRowsRequest const& request,
+    std::shared_ptr<OperationContext> operation_context) {
   return AsyncStreamingHelper<google::bigtable::v2::MutateRowsResponse>(
-      pool_, [&, context = std::move(context),
-              options = std::move(options)](BigtableStub& stub) mutable {
+      pool_, [&, context = std::move(context), options = std::move(options),
+              operation_context =
+                  std::move(operation_context)](BigtableStub& stub) mutable {
         return stub.AsyncMutateRows(cq, std::move(context), std::move(options),
-                                    request);
+                                    request, std::move(operation_context));
       });
 }
 
@@ -333,13 +365,16 @@ BigtableRandomTwoLeastUsed::AsyncCheckAndMutateRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::CheckAndMutateRowRequest const& request) {
+    google::bigtable::v2::CheckAndMutateRowRequest const& request,
+    std::shared_ptr<OperationContext> operation_context) {
   return UnaryHelper<
       future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>>(
-      pool_, [&, context = std::move(context),
-              options = std::move(options)](BigtableStub& stub) mutable {
+      pool_, [&, context = std::move(context), options = std::move(options),
+              operation_context =
+                  std::move(operation_context)](BigtableStub& stub) mutable {
         return stub.AsyncCheckAndMutateRow(cq, std::move(context),
-                                           std::move(options), request);
+                                           std::move(options), request,
+                                           std::move(operation_context));
       });
 }
 
@@ -348,13 +383,15 @@ BigtableRandomTwoLeastUsed::AsyncPingAndWarm(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::PingAndWarmRequest const& request) {
+    google::bigtable::v2::PingAndWarmRequest const& request,
+    std::shared_ptr<OperationContext> operation_context) {
   return UnaryHelper<
       future<StatusOr<google::bigtable::v2::PingAndWarmResponse>>>(
-      pool_, [&, context = std::move(context),
-              options = std::move(options)](BigtableStub& stub) mutable {
+      pool_, [&, context = std::move(context), options = std::move(options),
+              operation_context =
+                  std::move(operation_context)](BigtableStub& stub) mutable {
         return stub.AsyncPingAndWarm(cq, std::move(context), std::move(options),
-                                     request);
+                                     request, std::move(operation_context));
       });
 }
 
@@ -363,13 +400,16 @@ BigtableRandomTwoLeastUsed::AsyncReadModifyWriteRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
+    google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+    std::shared_ptr<OperationContext> operation_context) {
   return UnaryHelper<
       future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>>(
-      pool_, [&, context = std::move(context),
-              options = std::move(options)](BigtableStub& stub) mutable {
+      pool_, [&, context = std::move(context), options = std::move(options),
+              operation_context =
+                  std::move(operation_context)](BigtableStub& stub) mutable {
         return stub.AsyncReadModifyWriteRow(cq, std::move(context),
-                                            std::move(options), request);
+                                            std::move(options), request,
+                                            std::move(operation_context));
       });
 }
 
@@ -378,23 +418,28 @@ BigtableRandomTwoLeastUsed::AsyncPrepareQuery(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::PrepareQueryRequest const& request) {
+    google::bigtable::v2::PrepareQueryRequest const& request,
+    std::shared_ptr<OperationContext> operation_context) {
   return UnaryHelper<
       future<StatusOr<google::bigtable::v2::PrepareQueryResponse>>>(
-      pool_, [&, context = std::move(context),
-              options = std::move(options)](BigtableStub& stub) mutable {
+      pool_, [&, context = std::move(context), options = std::move(options),
+              operation_context =
+                  std::move(operation_context)](BigtableStub& stub) mutable {
         return stub.AsyncPrepareQuery(cq, std::move(context),
-                                      std::move(options), request);
+                                      std::move(options), request,
+                                      std::move(operation_context));
       });
 }
 
 StatusOr<google::bigtable::v2::ClientConfiguration>
 BigtableRandomTwoLeastUsed::GetClientConfiguration(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::GetClientConfigurationRequest const& request) {
+    google::bigtable::v2::GetClientConfigurationRequest const& request,
+    OperationContext& operation_context) {
   return UnaryHelper<StatusOr<google::bigtable::v2::ClientConfiguration>>(
       pool_, [&](BigtableStub& stub) {
-        return stub.GetClientConfiguration(context, options, request);
+        return stub.GetClientConfiguration(context, options, request,
+                                           operation_context);
       });
 }
 
@@ -404,12 +449,15 @@ std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
 BigtableRandomTwoLeastUsed::AsyncOpenTable(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
+    google::cloud::internal::ImmutableOptions options,
+    std::shared_ptr<OperationContext> operation_context) {
   return AsyncStreamingHelper<google::bigtable::v2::SessionRequest,
                               google::bigtable::v2::SessionResponse>(
-      pool_, [&, context = std::move(context),
-              options = std::move(options)](BigtableStub& stub) mutable {
-        return stub.AsyncOpenTable(cq, std::move(context), std::move(options));
+      pool_, [&, context = std::move(context), options = std::move(options),
+              operation_context =
+                  std::move(operation_context)](BigtableStub& stub) mutable {
+        return stub.AsyncOpenTable(cq, std::move(context), std::move(options),
+                                   std::move(operation_context));
       });
 }
 
@@ -419,13 +467,16 @@ std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
 BigtableRandomTwoLeastUsed::AsyncOpenAuthorizedView(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
+    google::cloud::internal::ImmutableOptions options,
+    std::shared_ptr<OperationContext> operation_context) {
   return AsyncStreamingHelper<google::bigtable::v2::SessionRequest,
                               google::bigtable::v2::SessionResponse>(
-      pool_, [&, context = std::move(context),
-              options = std::move(options)](BigtableStub& stub) mutable {
+      pool_, [&, context = std::move(context), options = std::move(options),
+              operation_context =
+                  std::move(operation_context)](BigtableStub& stub) mutable {
         return stub.AsyncOpenAuthorizedView(cq, std::move(context),
-                                            std::move(options));
+                                            std::move(options),
+                                            std::move(operation_context));
       });
 }
 
@@ -435,13 +486,16 @@ std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
 BigtableRandomTwoLeastUsed::AsyncOpenMaterializedView(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
+    google::cloud::internal::ImmutableOptions options,
+    std::shared_ptr<OperationContext> operation_context) {
   return AsyncStreamingHelper<google::bigtable::v2::SessionRequest,
                               google::bigtable::v2::SessionResponse>(
-      pool_, [&, context = std::move(context),
-              options = std::move(options)](BigtableStub& stub) mutable {
+      pool_, [&, context = std::move(context), options = std::move(options),
+              operation_context =
+                  std::move(operation_context)](BigtableStub& stub) mutable {
         return stub.AsyncOpenMaterializedView(cq, std::move(context),
-                                              std::move(options));
+                                              std::move(options),
+                                              std::move(operation_context));
       });
 }
 

--- a/google/cloud/bigtable/internal/bigtable_random_two_least_used_decorator.h
+++ b/google/cloud/bigtable/internal/bigtable_random_two_least_used_decorator.h
@@ -42,52 +42,62 @@ class BigtableRandomTwoLeastUsed : public BigtableStub {
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::ReadRowsResponse>>
   ReadRows(std::shared_ptr<grpc::ClientContext> context, Options const& options,
-           google::bigtable::v2::ReadRowsRequest const& request) override;
+           google::bigtable::v2::ReadRowsRequest const& request,
+           std::shared_ptr<OperationContext> operation_context) override;
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::SampleRowKeysResponse>>
-  SampleRowKeys(
-      std::shared_ptr<grpc::ClientContext> context, Options const& options,
-      google::bigtable::v2::SampleRowKeysRequest const& request) override;
+  SampleRowKeys(std::shared_ptr<grpc::ClientContext> context,
+                Options const& options,
+                google::bigtable::v2::SampleRowKeysRequest const& request,
+                std::shared_ptr<OperationContext> operation_context) override;
 
   StatusOr<google::bigtable::v2::MutateRowResponse> MutateRow(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::MutateRowRequest const& request) override;
+      google::bigtable::v2::MutateRowRequest const& request,
+      OperationContext& operation_context) override;
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::MutateRowsResponse>>
   MutateRows(std::shared_ptr<grpc::ClientContext> context,
              Options const& options,
-             google::bigtable::v2::MutateRowsRequest const& request) override;
+             google::bigtable::v2::MutateRowsRequest const& request,
+             std::shared_ptr<OperationContext> operation_context) override;
 
   StatusOr<google::bigtable::v2::CheckAndMutateRowResponse> CheckAndMutateRow(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::CheckAndMutateRowRequest const& request) override;
+      google::bigtable::v2::CheckAndMutateRowRequest const& request,
+      OperationContext& operation_context) override;
 
   StatusOr<google::bigtable::v2::PingAndWarmResponse> PingAndWarm(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::PingAndWarmRequest const& request) override;
+      google::bigtable::v2::PingAndWarmRequest const& request,
+      OperationContext& operation_context) override;
 
   StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse> ReadModifyWriteRow(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::ReadModifyWriteRowRequest const& request) override;
+      google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+      OperationContext& operation_context) override;
 
   StatusOr<google::bigtable::v2::PrepareQueryResponse> PrepareQuery(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::PrepareQueryRequest const& request) override;
+      google::bigtable::v2::PrepareQueryRequest const& request,
+      OperationContext& operation_context) override;
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::ExecuteQueryResponse>>
-  ExecuteQuery(
-      std::shared_ptr<grpc::ClientContext> context, Options const& options,
-      google::bigtable::v2::ExecuteQueryRequest const& request) override;
+  ExecuteQuery(std::shared_ptr<grpc::ClientContext> context,
+               Options const& options,
+               google::bigtable::v2::ExecuteQueryRequest const& request,
+               std::shared_ptr<OperationContext> operation_context) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::bigtable::v2::ReadRowsResponse>>
   AsyncReadRows(google::cloud::CompletionQueue const& cq,
                 std::shared_ptr<grpc::ClientContext> context,
                 google::cloud::internal::ImmutableOptions options,
-                google::bigtable::v2::ReadRowsRequest const& request) override;
+                google::bigtable::v2::ReadRowsRequest const& request,
+                std::shared_ptr<OperationContext> operation_context) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::bigtable::v2::SampleRowKeysResponse>>
@@ -95,60 +105,67 @@ class BigtableRandomTwoLeastUsed : public BigtableStub {
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::SampleRowKeysRequest const& request) override;
+      google::bigtable::v2::SampleRowKeysRequest const& request,
+      std::shared_ptr<OperationContext> operation_context) override;
 
   future<StatusOr<google::bigtable::v2::MutateRowResponse>> AsyncMutateRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::MutateRowRequest const& request) override;
+      google::bigtable::v2::MutateRowRequest const& request,
+      std::shared_ptr<OperationContext> operation_context) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::bigtable::v2::MutateRowsResponse>>
-  AsyncMutateRows(
-      google::cloud::CompletionQueue const& cq,
-      std::shared_ptr<grpc::ClientContext> context,
-      google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::MutateRowsRequest const& request) override;
+  AsyncMutateRows(google::cloud::CompletionQueue const& cq,
+                  std::shared_ptr<grpc::ClientContext> context,
+                  google::cloud::internal::ImmutableOptions options,
+                  google::bigtable::v2::MutateRowsRequest const& request,
+                  std::shared_ptr<OperationContext> operation_context) override;
 
   future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
   AsyncCheckAndMutateRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::CheckAndMutateRowRequest const& request) override;
+      google::bigtable::v2::CheckAndMutateRowRequest const& request,
+      std::shared_ptr<OperationContext> operation_context) override;
 
   future<StatusOr<google::bigtable::v2::PingAndWarmResponse>> AsyncPingAndWarm(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::PingAndWarmRequest const& request) override;
+      google::bigtable::v2::PingAndWarmRequest const& request,
+      std::shared_ptr<OperationContext> operation_context) override;
 
   future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>
   AsyncReadModifyWriteRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::ReadModifyWriteRowRequest const& request) override;
+      google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+      std::shared_ptr<OperationContext> operation_context) override;
 
   future<StatusOr<google::bigtable::v2::PrepareQueryResponse>>
   AsyncPrepareQuery(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::PrepareQueryRequest const& request) override;
+      google::bigtable::v2::PrepareQueryRequest const& request,
+      std::shared_ptr<OperationContext> operation_context) override;
 
   StatusOr<google::bigtable::v2::ClientConfiguration> GetClientConfiguration(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::GetClientConfigurationRequest const& request)
-      override;
+      google::bigtable::v2::GetClientConfigurationRequest const& request,
+      OperationContext& operation_context) override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::bigtable::v2::SessionRequest,
       google::bigtable::v2::SessionResponse>>
   AsyncOpenTable(google::cloud::CompletionQueue const& cq,
                  std::shared_ptr<grpc::ClientContext> context,
-                 google::cloud::internal::ImmutableOptions options) override;
+                 google::cloud::internal::ImmutableOptions options,
+                 std::shared_ptr<OperationContext> operation_context) override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::bigtable::v2::SessionRequest,
@@ -156,7 +173,8 @@ class BigtableRandomTwoLeastUsed : public BigtableStub {
   AsyncOpenAuthorizedView(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
-      google::cloud::internal::ImmutableOptions options) override;
+      google::cloud::internal::ImmutableOptions options,
+      std::shared_ptr<OperationContext> operation_context) override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::bigtable::v2::SessionRequest,
@@ -164,7 +182,8 @@ class BigtableRandomTwoLeastUsed : public BigtableStub {
   AsyncOpenMaterializedView(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
-      google::cloud::internal::ImmutableOptions options) override;
+      google::cloud::internal::ImmutableOptions options,
+      std::shared_ptr<OperationContext> operation_context) override;
 
  private:
   std::shared_ptr<DynamicChannelPool<BigtableStub>> pool_;

--- a/google/cloud/bigtable/internal/bigtable_random_two_least_used_decorator_test.cc
+++ b/google/cloud/bigtable/internal/bigtable_random_two_least_used_decorator_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/bigtable/internal/bigtable_random_two_least_used_decorator.h"
 #include "google/cloud/bigtable/internal/dynamic_channel_pool.h"
+#include "google/cloud/bigtable/internal/operation_context.h"
 #include "google/cloud/bigtable/testing/mock_bigtable_stub.h"
 #include "google/cloud/testing_util/fake_completion_queue_impl.h"
 #include <gmock/gmock.h>
@@ -63,6 +64,8 @@ class BigtableRandomTwoLeastUsedTest : public ::testing::Test {
       stub_factory_fn_;
   CompletionQueue cq_;
   std::shared_ptr<FakeCompletionQueueImpl> fake_cq_impl_;
+  std::shared_ptr<OperationContext> op_ctx_ =
+      std::make_shared<OperationContext>();
 };
 
 TEST_F(BigtableRandomTwoLeastUsedTest, ReadRows) {
@@ -70,7 +73,7 @@ TEST_F(BigtableRandomTwoLeastUsedTest, ReadRows) {
   auto decorator = std::make_shared<BigtableRandomTwoLeastUsed>(pool_);
   auto client_context = std::make_shared<grpc::ClientContext>();
   google::bigtable::v2::ReadRowsRequest request;
-  auto response = decorator->ReadRows(client_context, {}, request);
+  auto response = decorator->ReadRows(client_context, {}, request, op_ctx_);
 }
 
 TEST_F(BigtableRandomTwoLeastUsedTest, SampleRowKeys) {
@@ -78,7 +81,8 @@ TEST_F(BigtableRandomTwoLeastUsedTest, SampleRowKeys) {
   auto decorator = std::make_shared<BigtableRandomTwoLeastUsed>(pool_);
   auto client_context = std::make_shared<grpc::ClientContext>();
   google::bigtable::v2::SampleRowKeysRequest request;
-  auto response = decorator->SampleRowKeys(client_context, {}, request);
+  auto response =
+      decorator->SampleRowKeys(client_context, {}, request, op_ctx_);
 }
 
 TEST_F(BigtableRandomTwoLeastUsedTest, MutateRow) {
@@ -86,7 +90,7 @@ TEST_F(BigtableRandomTwoLeastUsedTest, MutateRow) {
   auto decorator = std::make_shared<BigtableRandomTwoLeastUsed>(pool_);
   grpc::ClientContext client_context;
   google::bigtable::v2::MutateRowRequest request;
-  auto response = decorator->MutateRow(client_context, {}, request);
+  auto response = decorator->MutateRow(client_context, {}, request, *op_ctx_);
 }
 
 TEST_F(BigtableRandomTwoLeastUsedTest, MutateRows) {
@@ -94,7 +98,7 @@ TEST_F(BigtableRandomTwoLeastUsedTest, MutateRows) {
   auto decorator = std::make_shared<BigtableRandomTwoLeastUsed>(pool_);
   auto client_context = std::make_shared<grpc::ClientContext>();
   google::bigtable::v2::MutateRowsRequest request;
-  auto response = decorator->MutateRows(client_context, {}, request);
+  auto response = decorator->MutateRows(client_context, {}, request, op_ctx_);
 }
 
 TEST_F(BigtableRandomTwoLeastUsedTest, CheckAndMutateRow) {
@@ -102,7 +106,8 @@ TEST_F(BigtableRandomTwoLeastUsedTest, CheckAndMutateRow) {
   auto decorator = std::make_shared<BigtableRandomTwoLeastUsed>(pool_);
   grpc::ClientContext client_context;
   google::bigtable::v2::CheckAndMutateRowRequest request;
-  auto response = decorator->CheckAndMutateRow(client_context, {}, request);
+  auto response =
+      decorator->CheckAndMutateRow(client_context, {}, request, *op_ctx_);
 }
 
 TEST_F(BigtableRandomTwoLeastUsedTest, PingAndWarm) {
@@ -110,7 +115,7 @@ TEST_F(BigtableRandomTwoLeastUsedTest, PingAndWarm) {
   auto decorator = std::make_shared<BigtableRandomTwoLeastUsed>(pool_);
   grpc::ClientContext client_context;
   google::bigtable::v2::PingAndWarmRequest request;
-  auto response = decorator->PingAndWarm(client_context, {}, request);
+  auto response = decorator->PingAndWarm(client_context, {}, request, *op_ctx_);
 }
 
 TEST_F(BigtableRandomTwoLeastUsedTest, ReadModifyWriteRow) {
@@ -118,7 +123,8 @@ TEST_F(BigtableRandomTwoLeastUsedTest, ReadModifyWriteRow) {
   auto decorator = std::make_shared<BigtableRandomTwoLeastUsed>(pool_);
   grpc::ClientContext client_context;
   google::bigtable::v2::ReadModifyWriteRowRequest request;
-  auto response = decorator->ReadModifyWriteRow(client_context, {}, request);
+  auto response =
+      decorator->ReadModifyWriteRow(client_context, {}, request, *op_ctx_);
 }
 
 TEST_F(BigtableRandomTwoLeastUsedTest, PrepareQuery) {
@@ -126,7 +132,8 @@ TEST_F(BigtableRandomTwoLeastUsedTest, PrepareQuery) {
   auto decorator = std::make_shared<BigtableRandomTwoLeastUsed>(pool_);
   grpc::ClientContext client_context;
   google::bigtable::v2::PrepareQueryRequest request;
-  auto response = decorator->PrepareQuery(client_context, {}, request);
+  auto response =
+      decorator->PrepareQuery(client_context, {}, request, *op_ctx_);
 }
 
 TEST_F(BigtableRandomTwoLeastUsedTest, ExecuteQuery) {
@@ -134,7 +141,7 @@ TEST_F(BigtableRandomTwoLeastUsedTest, ExecuteQuery) {
   auto decorator = std::make_shared<BigtableRandomTwoLeastUsed>(pool_);
   auto client_context = std::make_shared<grpc::ClientContext>();
   google::bigtable::v2::ExecuteQueryRequest request;
-  auto response = decorator->ExecuteQuery(client_context, {}, request);
+  auto response = decorator->ExecuteQuery(client_context, {}, request, op_ctx_);
 }
 
 TEST_F(BigtableRandomTwoLeastUsedTest, AsyncReadRows) {
@@ -142,7 +149,8 @@ TEST_F(BigtableRandomTwoLeastUsedTest, AsyncReadRows) {
   auto decorator = std::make_shared<BigtableRandomTwoLeastUsed>(pool_);
   auto client_context = std::make_shared<grpc::ClientContext>();
   google::bigtable::v2::ReadRowsRequest request;
-  auto response = decorator->AsyncReadRows(cq_, client_context, {}, request);
+  auto response =
+      decorator->AsyncReadRows(cq_, client_context, {}, request, op_ctx_);
 }
 
 TEST_F(BigtableRandomTwoLeastUsedTest, AsyncSampleRowKeys) {
@@ -151,7 +159,7 @@ TEST_F(BigtableRandomTwoLeastUsedTest, AsyncSampleRowKeys) {
   auto client_context = std::make_shared<grpc::ClientContext>();
   google::bigtable::v2::SampleRowKeysRequest request;
   auto response =
-      decorator->AsyncSampleRowKeys(cq_, client_context, {}, request);
+      decorator->AsyncSampleRowKeys(cq_, client_context, {}, request, op_ctx_);
 }
 
 TEST_F(BigtableRandomTwoLeastUsedTest, AsyncMutateRow) {
@@ -159,7 +167,8 @@ TEST_F(BigtableRandomTwoLeastUsedTest, AsyncMutateRow) {
   auto decorator = std::make_shared<BigtableRandomTwoLeastUsed>(pool_);
   auto client_context = std::make_shared<grpc::ClientContext>();
   google::bigtable::v2::MutateRowRequest request;
-  auto response = decorator->AsyncMutateRow(cq_, client_context, {}, request);
+  auto response =
+      decorator->AsyncMutateRow(cq_, client_context, {}, request, op_ctx_);
 }
 
 TEST_F(BigtableRandomTwoLeastUsedTest, AsyncMutateRows) {
@@ -167,7 +176,8 @@ TEST_F(BigtableRandomTwoLeastUsedTest, AsyncMutateRows) {
   auto decorator = std::make_shared<BigtableRandomTwoLeastUsed>(pool_);
   auto client_context = std::make_shared<grpc::ClientContext>();
   google::bigtable::v2::MutateRowsRequest request;
-  auto response = decorator->AsyncMutateRows(cq_, client_context, {}, request);
+  auto response =
+      decorator->AsyncMutateRows(cq_, client_context, {}, request, op_ctx_);
 }
 
 TEST_F(BigtableRandomTwoLeastUsedTest, AsyncCheckAndMutateRow) {
@@ -175,8 +185,8 @@ TEST_F(BigtableRandomTwoLeastUsedTest, AsyncCheckAndMutateRow) {
   auto decorator = std::make_shared<BigtableRandomTwoLeastUsed>(pool_);
   auto client_context = std::make_shared<grpc::ClientContext>();
   google::bigtable::v2::CheckAndMutateRowRequest request;
-  auto response =
-      decorator->AsyncCheckAndMutateRow(cq_, client_context, {}, request);
+  auto response = decorator->AsyncCheckAndMutateRow(cq_, client_context, {},
+                                                    request, op_ctx_);
 }
 
 TEST_F(BigtableRandomTwoLeastUsedTest, AsyncPingAndWarm) {
@@ -184,7 +194,8 @@ TEST_F(BigtableRandomTwoLeastUsedTest, AsyncPingAndWarm) {
   auto decorator = std::make_shared<BigtableRandomTwoLeastUsed>(pool_);
   auto client_context = std::make_shared<grpc::ClientContext>();
   google::bigtable::v2::PingAndWarmRequest request;
-  auto response = decorator->AsyncPingAndWarm(cq_, client_context, {}, request);
+  auto response =
+      decorator->AsyncPingAndWarm(cq_, client_context, {}, request, op_ctx_);
 }
 
 TEST_F(BigtableRandomTwoLeastUsedTest, AsyncReadModifyWriteRow) {
@@ -192,8 +203,8 @@ TEST_F(BigtableRandomTwoLeastUsedTest, AsyncReadModifyWriteRow) {
   auto decorator = std::make_shared<BigtableRandomTwoLeastUsed>(pool_);
   auto client_context = std::make_shared<grpc::ClientContext>();
   google::bigtable::v2::ReadModifyWriteRowRequest request;
-  auto response =
-      decorator->AsyncReadModifyWriteRow(cq_, client_context, {}, request);
+  auto response = decorator->AsyncReadModifyWriteRow(cq_, client_context, {},
+                                                     request, op_ctx_);
 }
 
 TEST_F(BigtableRandomTwoLeastUsedTest, AsyncPrepareQuery) {
@@ -202,7 +213,7 @@ TEST_F(BigtableRandomTwoLeastUsedTest, AsyncPrepareQuery) {
   auto client_context = std::make_shared<grpc::ClientContext>();
   google::bigtable::v2::PrepareQueryRequest request;
   auto response =
-      decorator->AsyncPrepareQuery(cq_, client_context, {}, request);
+      decorator->AsyncPrepareQuery(cq_, client_context, {}, request, op_ctx_);
 }
 
 }  // namespace

--- a/google/cloud/bigtable/internal/bigtable_round_robin_decorator.cc
+++ b/google/cloud/bigtable/internal/bigtable_round_robin_decorator.cc
@@ -37,73 +37,94 @@ std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::bigtable::v2::ReadRowsResponse>>
 BigtableRoundRobin::ReadRows(
     std::shared_ptr<grpc::ClientContext> context, Options const& options,
-    google::bigtable::v2::ReadRowsRequest const& request) {
-  return Child()->ReadRows(std::move(context), options, request);
+    google::bigtable::v2::ReadRowsRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
+  return Child()->ReadRows(std::move(context), options, request,
+                           std::move(operation_context));
 }
 
 std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::bigtable::v2::SampleRowKeysResponse>>
 BigtableRoundRobin::SampleRowKeys(
     std::shared_ptr<grpc::ClientContext> context, Options const& options,
-    google::bigtable::v2::SampleRowKeysRequest const& request) {
-  return Child()->SampleRowKeys(std::move(context), options, request);
+    google::bigtable::v2::SampleRowKeysRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
+  return Child()->SampleRowKeys(std::move(context), options, request,
+                                std::move(operation_context));
 }
 
 StatusOr<google::bigtable::v2::MutateRowResponse> BigtableRoundRobin::MutateRow(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::MutateRowRequest const& request) {
-  return Child()->MutateRow(context, options, request);
+    google::bigtable::v2::MutateRowRequest const& request,
+    google::cloud::bigtable_internal::OperationContext& operation_context) {
+  return Child()->MutateRow(context, options, request, operation_context);
 }
 
 std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::bigtable::v2::MutateRowsResponse>>
 BigtableRoundRobin::MutateRows(
     std::shared_ptr<grpc::ClientContext> context, Options const& options,
-    google::bigtable::v2::MutateRowsRequest const& request) {
-  return Child()->MutateRows(std::move(context), options, request);
+    google::bigtable::v2::MutateRowsRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
+  return Child()->MutateRows(std::move(context), options, request,
+                             std::move(operation_context));
 }
 
 StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>
 BigtableRoundRobin::CheckAndMutateRow(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::CheckAndMutateRowRequest const& request) {
-  return Child()->CheckAndMutateRow(context, options, request);
+    google::bigtable::v2::CheckAndMutateRowRequest const& request,
+    google::cloud::bigtable_internal::OperationContext& operation_context) {
+  return Child()->CheckAndMutateRow(context, options, request,
+                                    operation_context);
 }
 
 StatusOr<google::bigtable::v2::PingAndWarmResponse>
 BigtableRoundRobin::PingAndWarm(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::PingAndWarmRequest const& request) {
-  return Child()->PingAndWarm(context, options, request);
+    google::bigtable::v2::PingAndWarmRequest const& request,
+    google::cloud::bigtable_internal::OperationContext& operation_context) {
+  return Child()->PingAndWarm(context, options, request, operation_context);
 }
 
 StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>
 BigtableRoundRobin::ReadModifyWriteRow(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
-  return Child()->ReadModifyWriteRow(context, options, request);
+    google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+    google::cloud::bigtable_internal::OperationContext& operation_context) {
+  return Child()->ReadModifyWriteRow(context, options, request,
+                                     operation_context);
 }
 
 StatusOr<google::bigtable::v2::PrepareQueryResponse>
 BigtableRoundRobin::PrepareQuery(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::PrepareQueryRequest const& request) {
-  return Child()->PrepareQuery(context, options, request);
+    google::bigtable::v2::PrepareQueryRequest const& request,
+    google::cloud::bigtable_internal::OperationContext& operation_context) {
+  return Child()->PrepareQuery(context, options, request, operation_context);
 }
 
 std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::bigtable::v2::ExecuteQueryResponse>>
 BigtableRoundRobin::ExecuteQuery(
     std::shared_ptr<grpc::ClientContext> context, Options const& options,
-    google::bigtable::v2::ExecuteQueryRequest const& request) {
-  return Child()->ExecuteQuery(std::move(context), options, request);
+    google::bigtable::v2::ExecuteQueryRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
+  return Child()->ExecuteQuery(std::move(context), options, request,
+                               std::move(operation_context));
 }
 
 StatusOr<google::bigtable::v2::ClientConfiguration>
 BigtableRoundRobin::GetClientConfiguration(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::GetClientConfigurationRequest const& request) {
-  return Child()->GetClientConfiguration(context, options, request);
+    google::bigtable::v2::GetClientConfigurationRequest const& request,
+    google::cloud::bigtable_internal::OperationContext& operation_context) {
+  return Child()->GetClientConfiguration(context, options, request,
+                                         operation_context);
 }
 
 std::unique_ptr<google::cloud::AsyncStreamingReadWriteRpc<
@@ -112,8 +133,11 @@ std::unique_ptr<google::cloud::AsyncStreamingReadWriteRpc<
 BigtableRoundRobin::AsyncOpenTable(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
-  return Child()->AsyncOpenTable(cq, std::move(context), std::move(options));
+    google::cloud::internal::ImmutableOptions options,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
+  return Child()->AsyncOpenTable(cq, std::move(context), std::move(options),
+                                 std::move(operation_context));
 }
 
 std::unique_ptr<google::cloud::AsyncStreamingReadWriteRpc<
@@ -122,9 +146,11 @@ std::unique_ptr<google::cloud::AsyncStreamingReadWriteRpc<
 BigtableRoundRobin::AsyncOpenAuthorizedView(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
-  return Child()->AsyncOpenAuthorizedView(cq, std::move(context),
-                                          std::move(options));
+    google::cloud::internal::ImmutableOptions options,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
+  return Child()->AsyncOpenAuthorizedView(
+      cq, std::move(context), std::move(options), std::move(operation_context));
 }
 
 std::unique_ptr<google::cloud::AsyncStreamingReadWriteRpc<
@@ -133,9 +159,11 @@ std::unique_ptr<google::cloud::AsyncStreamingReadWriteRpc<
 BigtableRoundRobin::AsyncOpenMaterializedView(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
-  return Child()->AsyncOpenMaterializedView(cq, std::move(context),
-                                            std::move(options));
+    google::cloud::internal::ImmutableOptions options,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
+  return Child()->AsyncOpenMaterializedView(
+      cq, std::move(context), std::move(options), std::move(operation_context));
 }
 
 std::unique_ptr<google::cloud::internal::AsyncStreamingReadRpc<
@@ -144,9 +172,11 @@ BigtableRoundRobin::AsyncReadRows(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::ReadRowsRequest const& request) {
+    google::bigtable::v2::ReadRowsRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   return Child()->AsyncReadRows(cq, std::move(context), std::move(options),
-                                request);
+                                request, std::move(operation_context));
 }
 
 std::unique_ptr<google::cloud::internal::AsyncStreamingReadRpc<
@@ -155,9 +185,11 @@ BigtableRoundRobin::AsyncSampleRowKeys(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::SampleRowKeysRequest const& request) {
+    google::bigtable::v2::SampleRowKeysRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   return Child()->AsyncSampleRowKeys(cq, std::move(context), std::move(options),
-                                     request);
+                                     request, std::move(operation_context));
 }
 
 future<StatusOr<google::bigtable::v2::MutateRowResponse>>
@@ -165,9 +197,11 @@ BigtableRoundRobin::AsyncMutateRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::MutateRowRequest const& request) {
+    google::bigtable::v2::MutateRowRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   return Child()->AsyncMutateRow(cq, std::move(context), std::move(options),
-                                 request);
+                                 request, std::move(operation_context));
 }
 
 std::unique_ptr<google::cloud::internal::AsyncStreamingReadRpc<
@@ -176,9 +210,11 @@ BigtableRoundRobin::AsyncMutateRows(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::MutateRowsRequest const& request) {
+    google::bigtable::v2::MutateRowsRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   return Child()->AsyncMutateRows(cq, std::move(context), std::move(options),
-                                  request);
+                                  request, std::move(operation_context));
 }
 
 future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
@@ -186,9 +222,12 @@ BigtableRoundRobin::AsyncCheckAndMutateRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::CheckAndMutateRowRequest const& request) {
+    google::bigtable::v2::CheckAndMutateRowRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   return Child()->AsyncCheckAndMutateRow(cq, std::move(context),
-                                         std::move(options), request);
+                                         std::move(options), request,
+                                         std::move(operation_context));
 }
 
 future<StatusOr<google::bigtable::v2::PingAndWarmResponse>>
@@ -196,9 +235,11 @@ BigtableRoundRobin::AsyncPingAndWarm(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::PingAndWarmRequest const& request) {
+    google::bigtable::v2::PingAndWarmRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   return Child()->AsyncPingAndWarm(cq, std::move(context), std::move(options),
-                                   request);
+                                   request, std::move(operation_context));
 }
 
 future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>
@@ -206,9 +247,12 @@ BigtableRoundRobin::AsyncReadModifyWriteRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
+    google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   return Child()->AsyncReadModifyWriteRow(cq, std::move(context),
-                                          std::move(options), request);
+                                          std::move(options), request,
+                                          std::move(operation_context));
 }
 
 future<StatusOr<google::bigtable::v2::PrepareQueryResponse>>
@@ -216,9 +260,11 @@ BigtableRoundRobin::AsyncPrepareQuery(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::PrepareQueryRequest const& request) {
+    google::bigtable::v2::PrepareQueryRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   return Child()->AsyncPrepareQuery(cq, std::move(context), std::move(options),
-                                    request);
+                                    request, std::move(operation_context));
 }
 
 std::shared_ptr<BigtableStub> BigtableRoundRobin::Child() {

--- a/google/cloud/bigtable/internal/bigtable_round_robin_decorator.h
+++ b/google/cloud/bigtable/internal/bigtable_round_robin_decorator.h
@@ -42,57 +42,79 @@ class BigtableRoundRobin : public BigtableStub {
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::ReadRowsResponse>>
   ReadRows(std::shared_ptr<grpc::ClientContext> context, Options const& options,
-           google::bigtable::v2::ReadRowsRequest const& request) override;
+           google::bigtable::v2::ReadRowsRequest const& request,
+           std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+               operation_context) override;
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::SampleRowKeysResponse>>
   SampleRowKeys(
       std::shared_ptr<grpc::ClientContext> context, Options const& options,
-      google::bigtable::v2::SampleRowKeysRequest const& request) override;
+      google::bigtable::v2::SampleRowKeysRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   StatusOr<google::bigtable::v2::MutateRowResponse> MutateRow(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::MutateRowRequest const& request) override;
+      google::bigtable::v2::MutateRowRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
+      override;
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::MutateRowsResponse>>
   MutateRows(std::shared_ptr<grpc::ClientContext> context,
              Options const& options,
-             google::bigtable::v2::MutateRowsRequest const& request) override;
+             google::bigtable::v2::MutateRowsRequest const& request,
+             std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+                 operation_context) override;
 
   StatusOr<google::bigtable::v2::CheckAndMutateRowResponse> CheckAndMutateRow(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::CheckAndMutateRowRequest const& request) override;
+      google::bigtable::v2::CheckAndMutateRowRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
+      override;
 
   StatusOr<google::bigtable::v2::PingAndWarmResponse> PingAndWarm(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::PingAndWarmRequest const& request) override;
+      google::bigtable::v2::PingAndWarmRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
+      override;
 
   StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse> ReadModifyWriteRow(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::ReadModifyWriteRowRequest const& request) override;
+      google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
+      override;
 
   StatusOr<google::bigtable::v2::PrepareQueryResponse> PrepareQuery(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::PrepareQueryRequest const& request) override;
+      google::bigtable::v2::PrepareQueryRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
+      override;
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::ExecuteQueryResponse>>
   ExecuteQuery(
       std::shared_ptr<grpc::ClientContext> context, Options const& options,
-      google::bigtable::v2::ExecuteQueryRequest const& request) override;
+      google::bigtable::v2::ExecuteQueryRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   StatusOr<google::bigtable::v2::ClientConfiguration> GetClientConfiguration(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::GetClientConfigurationRequest const& request)
+      google::bigtable::v2::GetClientConfigurationRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
       override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::bigtable::v2::SessionRequest,
       google::bigtable::v2::SessionResponse>>
-  AsyncOpenTable(google::cloud::CompletionQueue const& cq,
-                 std::shared_ptr<grpc::ClientContext> context,
-                 google::cloud::internal::ImmutableOptions options) override;
+  AsyncOpenTable(
+      google::cloud::CompletionQueue const& cq,
+      std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::bigtable::v2::SessionRequest,
@@ -100,7 +122,9 @@ class BigtableRoundRobin : public BigtableStub {
   AsyncOpenAuthorizedView(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
-      google::cloud::internal::ImmutableOptions options) override;
+      google::cloud::internal::ImmutableOptions options,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::bigtable::v2::SessionRequest,
@@ -108,14 +132,19 @@ class BigtableRoundRobin : public BigtableStub {
   AsyncOpenMaterializedView(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
-      google::cloud::internal::ImmutableOptions options) override;
+      google::cloud::internal::ImmutableOptions options,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::bigtable::v2::ReadRowsResponse>>
-  AsyncReadRows(google::cloud::CompletionQueue const& cq,
-                std::shared_ptr<grpc::ClientContext> context,
-                google::cloud::internal::ImmutableOptions options,
-                google::bigtable::v2::ReadRowsRequest const& request) override;
+  AsyncReadRows(
+      google::cloud::CompletionQueue const& cq,
+      std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
+      google::bigtable::v2::ReadRowsRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::bigtable::v2::SampleRowKeysResponse>>
@@ -123,13 +152,17 @@ class BigtableRoundRobin : public BigtableStub {
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::SampleRowKeysRequest const& request) override;
+      google::bigtable::v2::SampleRowKeysRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   future<StatusOr<google::bigtable::v2::MutateRowResponse>> AsyncMutateRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::MutateRowRequest const& request) override;
+      google::bigtable::v2::MutateRowRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::bigtable::v2::MutateRowsResponse>>
@@ -137,34 +170,44 @@ class BigtableRoundRobin : public BigtableStub {
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::MutateRowsRequest const& request) override;
+      google::bigtable::v2::MutateRowsRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
   AsyncCheckAndMutateRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::CheckAndMutateRowRequest const& request) override;
+      google::bigtable::v2::CheckAndMutateRowRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   future<StatusOr<google::bigtable::v2::PingAndWarmResponse>> AsyncPingAndWarm(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::PingAndWarmRequest const& request) override;
+      google::bigtable::v2::PingAndWarmRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>
   AsyncReadModifyWriteRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::ReadModifyWriteRowRequest const& request) override;
+      google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   future<StatusOr<google::bigtable::v2::PrepareQueryResponse>>
   AsyncPrepareQuery(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::PrepareQueryRequest const& request) override;
+      google::bigtable::v2::PrepareQueryRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
  private:
   std::shared_ptr<BigtableStub> Child();

--- a/google/cloud/bigtable/internal/bigtable_stub.cc
+++ b/google/cloud/bigtable/internal/bigtable_stub.cc
@@ -39,7 +39,8 @@ std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::bigtable::v2::ReadRowsResponse>>
 DefaultBigtableStub::ReadRows(
     std::shared_ptr<grpc::ClientContext> context, Options const&,
-    google::bigtable::v2::ReadRowsRequest const& request) {
+    google::bigtable::v2::ReadRowsRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>) {
   auto stream = grpc_stub_->ReadRows(context.get(), request);
   return std::make_unique<google::cloud::internal::StreamingReadRpcImpl<
       google::bigtable::v2::ReadRowsResponse>>(std::move(context),
@@ -50,7 +51,8 @@ std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::bigtable::v2::SampleRowKeysResponse>>
 DefaultBigtableStub::SampleRowKeys(
     std::shared_ptr<grpc::ClientContext> context, Options const&,
-    google::bigtable::v2::SampleRowKeysRequest const& request) {
+    google::bigtable::v2::SampleRowKeysRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>) {
   auto stream = grpc_stub_->SampleRowKeys(context.get(), request);
   return std::make_unique<google::cloud::internal::StreamingReadRpcImpl<
       google::bigtable::v2::SampleRowKeysResponse>>(std::move(context),
@@ -60,7 +62,8 @@ DefaultBigtableStub::SampleRowKeys(
 StatusOr<google::bigtable::v2::MutateRowResponse>
 DefaultBigtableStub::MutateRow(
     grpc::ClientContext& context, Options const&,
-    google::bigtable::v2::MutateRowRequest const& request) {
+    google::bigtable::v2::MutateRowRequest const& request,
+    google::cloud::bigtable_internal::OperationContext&) {
   google::bigtable::v2::MutateRowResponse response;
   auto status = grpc_stub_->MutateRow(&context, request, &response);
   if (!status.ok()) {
@@ -73,7 +76,8 @@ std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::bigtable::v2::MutateRowsResponse>>
 DefaultBigtableStub::MutateRows(
     std::shared_ptr<grpc::ClientContext> context, Options const&,
-    google::bigtable::v2::MutateRowsRequest const& request) {
+    google::bigtable::v2::MutateRowsRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>) {
   auto stream = grpc_stub_->MutateRows(context.get(), request);
   return std::make_unique<google::cloud::internal::StreamingReadRpcImpl<
       google::bigtable::v2::MutateRowsResponse>>(std::move(context),
@@ -83,7 +87,8 @@ DefaultBigtableStub::MutateRows(
 StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>
 DefaultBigtableStub::CheckAndMutateRow(
     grpc::ClientContext& context, Options const&,
-    google::bigtable::v2::CheckAndMutateRowRequest const& request) {
+    google::bigtable::v2::CheckAndMutateRowRequest const& request,
+    google::cloud::bigtable_internal::OperationContext&) {
   google::bigtable::v2::CheckAndMutateRowResponse response;
   auto status = grpc_stub_->CheckAndMutateRow(&context, request, &response);
   if (!status.ok()) {
@@ -95,7 +100,8 @@ DefaultBigtableStub::CheckAndMutateRow(
 StatusOr<google::bigtable::v2::PingAndWarmResponse>
 DefaultBigtableStub::PingAndWarm(
     grpc::ClientContext& context, Options const&,
-    google::bigtable::v2::PingAndWarmRequest const& request) {
+    google::bigtable::v2::PingAndWarmRequest const& request,
+    google::cloud::bigtable_internal::OperationContext&) {
   google::bigtable::v2::PingAndWarmResponse response;
   auto status = grpc_stub_->PingAndWarm(&context, request, &response);
   if (!status.ok()) {
@@ -107,7 +113,8 @@ DefaultBigtableStub::PingAndWarm(
 StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>
 DefaultBigtableStub::ReadModifyWriteRow(
     grpc::ClientContext& context, Options const&,
-    google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
+    google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+    google::cloud::bigtable_internal::OperationContext&) {
   google::bigtable::v2::ReadModifyWriteRowResponse response;
   auto status = grpc_stub_->ReadModifyWriteRow(&context, request, &response);
   if (!status.ok()) {
@@ -119,7 +126,8 @@ DefaultBigtableStub::ReadModifyWriteRow(
 StatusOr<google::bigtable::v2::PrepareQueryResponse>
 DefaultBigtableStub::PrepareQuery(
     grpc::ClientContext& context, Options const&,
-    google::bigtable::v2::PrepareQueryRequest const& request) {
+    google::bigtable::v2::PrepareQueryRequest const& request,
+    google::cloud::bigtable_internal::OperationContext&) {
   google::bigtable::v2::PrepareQueryResponse response;
   auto status = grpc_stub_->PrepareQuery(&context, request, &response);
   if (!status.ok()) {
@@ -132,7 +140,8 @@ std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::bigtable::v2::ExecuteQueryResponse>>
 DefaultBigtableStub::ExecuteQuery(
     std::shared_ptr<grpc::ClientContext> context, Options const&,
-    google::bigtable::v2::ExecuteQueryRequest const& request) {
+    google::bigtable::v2::ExecuteQueryRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>) {
   auto stream = grpc_stub_->ExecuteQuery(context.get(), request);
   return std::make_unique<google::cloud::internal::StreamingReadRpcImpl<
       google::bigtable::v2::ExecuteQueryResponse>>(std::move(context),
@@ -142,7 +151,8 @@ DefaultBigtableStub::ExecuteQuery(
 StatusOr<google::bigtable::v2::ClientConfiguration>
 DefaultBigtableStub::GetClientConfiguration(
     grpc::ClientContext& context, Options const&,
-    google::bigtable::v2::GetClientConfigurationRequest const& request) {
+    google::bigtable::v2::GetClientConfigurationRequest const& request,
+    google::cloud::bigtable_internal::OperationContext&) {
   google::bigtable::v2::ClientConfiguration response;
   auto status =
       grpc_stub_->GetClientConfiguration(&context, request, &response);
@@ -158,7 +168,8 @@ std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
 DefaultBigtableStub::AsyncOpenTable(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
+    google::cloud::internal::ImmutableOptions options,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>) {
   return google::cloud::internal::MakeStreamingReadWriteRpc<
       google::bigtable::v2::SessionRequest,
       google::bigtable::v2::SessionResponse>(
@@ -174,7 +185,8 @@ std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
 DefaultBigtableStub::AsyncOpenAuthorizedView(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
+    google::cloud::internal::ImmutableOptions options,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>) {
   return google::cloud::internal::MakeStreamingReadWriteRpc<
       google::bigtable::v2::SessionRequest,
       google::bigtable::v2::SessionResponse>(
@@ -190,7 +202,8 @@ std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
 DefaultBigtableStub::AsyncOpenMaterializedView(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
+    google::cloud::internal::ImmutableOptions options,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>) {
   return google::cloud::internal::MakeStreamingReadWriteRpc<
       google::bigtable::v2::SessionRequest,
       google::bigtable::v2::SessionResponse>(
@@ -206,7 +219,8 @@ DefaultBigtableStub::AsyncReadRows(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::ReadRowsRequest const& request) {
+    google::bigtable::v2::ReadRowsRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>) {
   return google::cloud::internal::MakeStreamingReadRpc<
       google::bigtable::v2::ReadRowsRequest,
       google::bigtable::v2::ReadRowsResponse>(
@@ -224,7 +238,8 @@ DefaultBigtableStub::AsyncSampleRowKeys(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::SampleRowKeysRequest const& request) {
+    google::bigtable::v2::SampleRowKeysRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>) {
   return google::cloud::internal::MakeStreamingReadRpc<
       google::bigtable::v2::SampleRowKeysRequest,
       google::bigtable::v2::SampleRowKeysResponse>(
@@ -242,7 +257,8 @@ DefaultBigtableStub::AsyncMutateRow(
     std::shared_ptr<grpc::ClientContext> context,
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
-    google::bigtable::v2::MutateRowRequest const& request) {
+    google::bigtable::v2::MutateRowRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>) {
   return internal::MakeUnaryRpcImpl<google::bigtable::v2::MutateRowRequest,
                                     google::bigtable::v2::MutateRowResponse>(
       cq,
@@ -260,7 +276,8 @@ DefaultBigtableStub::AsyncMutateRows(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::MutateRowsRequest const& request) {
+    google::bigtable::v2::MutateRowsRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>) {
   return google::cloud::internal::MakeStreamingReadRpc<
       google::bigtable::v2::MutateRowsRequest,
       google::bigtable::v2::MutateRowsResponse>(
@@ -278,7 +295,8 @@ DefaultBigtableStub::AsyncCheckAndMutateRow(
     std::shared_ptr<grpc::ClientContext> context,
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
-    google::bigtable::v2::CheckAndMutateRowRequest const& request) {
+    google::bigtable::v2::CheckAndMutateRowRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>) {
   return internal::MakeUnaryRpcImpl<
       google::bigtable::v2::CheckAndMutateRowRequest,
       google::bigtable::v2::CheckAndMutateRowResponse>(
@@ -297,7 +315,8 @@ DefaultBigtableStub::AsyncPingAndWarm(
     std::shared_ptr<grpc::ClientContext> context,
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
-    google::bigtable::v2::PingAndWarmRequest const& request) {
+    google::bigtable::v2::PingAndWarmRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>) {
   return internal::MakeUnaryRpcImpl<google::bigtable::v2::PingAndWarmRequest,
                                     google::bigtable::v2::PingAndWarmResponse>(
       cq,
@@ -315,7 +334,8 @@ DefaultBigtableStub::AsyncReadModifyWriteRow(
     std::shared_ptr<grpc::ClientContext> context,
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
-    google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
+    google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>) {
   return internal::MakeUnaryRpcImpl<
       google::bigtable::v2::ReadModifyWriteRowRequest,
       google::bigtable::v2::ReadModifyWriteRowResponse>(
@@ -334,7 +354,8 @@ DefaultBigtableStub::AsyncPrepareQuery(
     std::shared_ptr<grpc::ClientContext> context,
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     google::cloud::internal::ImmutableOptions,
-    google::bigtable::v2::PrepareQueryRequest const& request) {
+    google::bigtable::v2::PrepareQueryRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>) {
   return internal::MakeUnaryRpcImpl<google::bigtable::v2::PrepareQueryRequest,
                                     google::bigtable::v2::PrepareQueryResponse>(
       cq,

--- a/google/cloud/bigtable/internal/bigtable_stub.h
+++ b/google/cloud/bigtable/internal/bigtable_stub.h
@@ -39,6 +39,8 @@ namespace cloud {
 namespace bigtable_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+class OperationContext;
+
 class BigtableStub {
  public:
   virtual ~BigtableStub() = 0;
@@ -46,59 +48,82 @@ class BigtableStub {
   virtual std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::ReadRowsResponse>>
   ReadRows(std::shared_ptr<grpc::ClientContext> context, Options const& options,
-           google::bigtable::v2::ReadRowsRequest const& request) = 0;
+           google::bigtable::v2::ReadRowsRequest const& request,
+           std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+               operation_context) = 0;
 
   virtual std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::SampleRowKeysResponse>>
-  SampleRowKeys(std::shared_ptr<grpc::ClientContext> context,
-                Options const& options,
-                google::bigtable::v2::SampleRowKeysRequest const& request) = 0;
+  SampleRowKeys(
+      std::shared_ptr<grpc::ClientContext> context, Options const& options,
+      google::bigtable::v2::SampleRowKeysRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) = 0;
 
   virtual StatusOr<google::bigtable::v2::MutateRowResponse> MutateRow(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::MutateRowRequest const& request) = 0;
+      google::bigtable::v2::MutateRowRequest const& request,
+      google::cloud::bigtable_internal::OperationContext&
+          operation_context) = 0;
 
   virtual std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::MutateRowsResponse>>
   MutateRows(std::shared_ptr<grpc::ClientContext> context,
              Options const& options,
-             google::bigtable::v2::MutateRowsRequest const& request) = 0;
+             google::bigtable::v2::MutateRowsRequest const& request,
+             std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+                 operation_context) = 0;
 
   virtual StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>
   CheckAndMutateRow(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::CheckAndMutateRowRequest const& request) = 0;
+      google::bigtable::v2::CheckAndMutateRowRequest const& request,
+      google::cloud::bigtable_internal::OperationContext&
+          operation_context) = 0;
 
   virtual StatusOr<google::bigtable::v2::PingAndWarmResponse> PingAndWarm(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::PingAndWarmRequest const& request) = 0;
+      google::bigtable::v2::PingAndWarmRequest const& request,
+      google::cloud::bigtable_internal::OperationContext&
+          operation_context) = 0;
 
   virtual StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>
   ReadModifyWriteRow(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::ReadModifyWriteRowRequest const& request) = 0;
+      google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+      google::cloud::bigtable_internal::OperationContext&
+          operation_context) = 0;
 
   virtual StatusOr<google::bigtable::v2::PrepareQueryResponse> PrepareQuery(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::PrepareQueryRequest const& request) = 0;
+      google::bigtable::v2::PrepareQueryRequest const& request,
+      google::cloud::bigtable_internal::OperationContext&
+          operation_context) = 0;
 
   virtual std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::ExecuteQueryResponse>>
-  ExecuteQuery(std::shared_ptr<grpc::ClientContext> context,
-               Options const& options,
-               google::bigtable::v2::ExecuteQueryRequest const& request) = 0;
+  ExecuteQuery(
+      std::shared_ptr<grpc::ClientContext> context, Options const& options,
+      google::bigtable::v2::ExecuteQueryRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) = 0;
 
   virtual StatusOr<google::bigtable::v2::ClientConfiguration>
   GetClientConfiguration(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::GetClientConfigurationRequest const& request) = 0;
+      google::bigtable::v2::GetClientConfigurationRequest const& request,
+      google::cloud::bigtable_internal::OperationContext&
+          operation_context) = 0;
 
   virtual std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::bigtable::v2::SessionRequest,
       google::bigtable::v2::SessionResponse>>
-  AsyncOpenTable(google::cloud::CompletionQueue const& cq,
-                 std::shared_ptr<grpc::ClientContext> context,
-                 google::cloud::internal::ImmutableOptions options) = 0;
+  AsyncOpenTable(
+      google::cloud::CompletionQueue const& cq,
+      std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) = 0;
 
   virtual std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::bigtable::v2::SessionRequest,
@@ -106,7 +131,9 @@ class BigtableStub {
   AsyncOpenAuthorizedView(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
-      google::cloud::internal::ImmutableOptions options) = 0;
+      google::cloud::internal::ImmutableOptions options,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) = 0;
 
   virtual std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::bigtable::v2::SessionRequest,
@@ -114,14 +141,19 @@ class BigtableStub {
   AsyncOpenMaterializedView(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
-      google::cloud::internal::ImmutableOptions options) = 0;
+      google::cloud::internal::ImmutableOptions options,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) = 0;
 
   virtual std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::bigtable::v2::ReadRowsResponse>>
-  AsyncReadRows(google::cloud::CompletionQueue const& cq,
-                std::shared_ptr<grpc::ClientContext> context,
-                google::cloud::internal::ImmutableOptions options,
-                google::bigtable::v2::ReadRowsRequest const& request) = 0;
+  AsyncReadRows(
+      google::cloud::CompletionQueue const& cq,
+      std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
+      google::bigtable::v2::ReadRowsRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) = 0;
 
   virtual std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::bigtable::v2::SampleRowKeysResponse>>
@@ -129,47 +161,64 @@ class BigtableStub {
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::SampleRowKeysRequest const& request) = 0;
+      google::bigtable::v2::SampleRowKeysRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) = 0;
 
   virtual future<StatusOr<google::bigtable::v2::MutateRowResponse>>
-  AsyncMutateRow(google::cloud::CompletionQueue& cq,
-                 std::shared_ptr<grpc::ClientContext> context,
-                 google::cloud::internal::ImmutableOptions options,
-                 google::bigtable::v2::MutateRowRequest const& request) = 0;
+  AsyncMutateRow(
+      google::cloud::CompletionQueue& cq,
+      std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
+      google::bigtable::v2::MutateRowRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) = 0;
 
   virtual std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::bigtable::v2::MutateRowsResponse>>
-  AsyncMutateRows(google::cloud::CompletionQueue const& cq,
-                  std::shared_ptr<grpc::ClientContext> context,
-                  google::cloud::internal::ImmutableOptions options,
-                  google::bigtable::v2::MutateRowsRequest const& request) = 0;
+  AsyncMutateRows(
+      google::cloud::CompletionQueue const& cq,
+      std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
+      google::bigtable::v2::MutateRowsRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) = 0;
 
   virtual future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
   AsyncCheckAndMutateRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::CheckAndMutateRowRequest const& request) = 0;
+      google::bigtable::v2::CheckAndMutateRowRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) = 0;
 
   virtual future<StatusOr<google::bigtable::v2::PingAndWarmResponse>>
-  AsyncPingAndWarm(google::cloud::CompletionQueue& cq,
-                   std::shared_ptr<grpc::ClientContext> context,
-                   google::cloud::internal::ImmutableOptions options,
-                   google::bigtable::v2::PingAndWarmRequest const& request) = 0;
+  AsyncPingAndWarm(
+      google::cloud::CompletionQueue& cq,
+      std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
+      google::bigtable::v2::PingAndWarmRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) = 0;
 
   virtual future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>
   AsyncReadModifyWriteRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::ReadModifyWriteRowRequest const& request) = 0;
+      google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) = 0;
 
   virtual future<StatusOr<google::bigtable::v2::PrepareQueryResponse>>
   AsyncPrepareQuery(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::PrepareQueryRequest const& request) = 0;
+      google::bigtable::v2::PrepareQueryRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) = 0;
 };
 
 class DefaultBigtableStub : public BigtableStub {
@@ -181,57 +230,79 @@ class DefaultBigtableStub : public BigtableStub {
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::ReadRowsResponse>>
   ReadRows(std::shared_ptr<grpc::ClientContext> context, Options const& options,
-           google::bigtable::v2::ReadRowsRequest const& request) override;
+           google::bigtable::v2::ReadRowsRequest const& request,
+           std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+               operation_context) override;
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::SampleRowKeysResponse>>
   SampleRowKeys(
       std::shared_ptr<grpc::ClientContext> context, Options const& options,
-      google::bigtable::v2::SampleRowKeysRequest const& request) override;
+      google::bigtable::v2::SampleRowKeysRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   StatusOr<google::bigtable::v2::MutateRowResponse> MutateRow(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::MutateRowRequest const& request) override;
+      google::bigtable::v2::MutateRowRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
+      override;
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::MutateRowsResponse>>
   MutateRows(std::shared_ptr<grpc::ClientContext> context,
              Options const& options,
-             google::bigtable::v2::MutateRowsRequest const& request) override;
+             google::bigtable::v2::MutateRowsRequest const& request,
+             std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+                 operation_context) override;
 
   StatusOr<google::bigtable::v2::CheckAndMutateRowResponse> CheckAndMutateRow(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::CheckAndMutateRowRequest const& request) override;
+      google::bigtable::v2::CheckAndMutateRowRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
+      override;
 
   StatusOr<google::bigtable::v2::PingAndWarmResponse> PingAndWarm(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::PingAndWarmRequest const& request) override;
+      google::bigtable::v2::PingAndWarmRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
+      override;
 
   StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse> ReadModifyWriteRow(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::ReadModifyWriteRowRequest const& request) override;
+      google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
+      override;
 
   StatusOr<google::bigtable::v2::PrepareQueryResponse> PrepareQuery(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::PrepareQueryRequest const& request) override;
+      google::bigtable::v2::PrepareQueryRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
+      override;
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::ExecuteQueryResponse>>
   ExecuteQuery(
       std::shared_ptr<grpc::ClientContext> context, Options const& options,
-      google::bigtable::v2::ExecuteQueryRequest const& request) override;
+      google::bigtable::v2::ExecuteQueryRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   StatusOr<google::bigtable::v2::ClientConfiguration> GetClientConfiguration(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::GetClientConfigurationRequest const& request)
+      google::bigtable::v2::GetClientConfigurationRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
       override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::bigtable::v2::SessionRequest,
       google::bigtable::v2::SessionResponse>>
-  AsyncOpenTable(google::cloud::CompletionQueue const& cq,
-                 std::shared_ptr<grpc::ClientContext> context,
-                 google::cloud::internal::ImmutableOptions options) override;
+  AsyncOpenTable(
+      google::cloud::CompletionQueue const& cq,
+      std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::bigtable::v2::SessionRequest,
@@ -239,7 +310,9 @@ class DefaultBigtableStub : public BigtableStub {
   AsyncOpenAuthorizedView(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
-      google::cloud::internal::ImmutableOptions options) override;
+      google::cloud::internal::ImmutableOptions options,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::bigtable::v2::SessionRequest,
@@ -247,14 +320,19 @@ class DefaultBigtableStub : public BigtableStub {
   AsyncOpenMaterializedView(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
-      google::cloud::internal::ImmutableOptions options) override;
+      google::cloud::internal::ImmutableOptions options,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::bigtable::v2::ReadRowsResponse>>
-  AsyncReadRows(google::cloud::CompletionQueue const& cq,
-                std::shared_ptr<grpc::ClientContext> context,
-                google::cloud::internal::ImmutableOptions options,
-                google::bigtable::v2::ReadRowsRequest const& request) override;
+  AsyncReadRows(
+      google::cloud::CompletionQueue const& cq,
+      std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
+      google::bigtable::v2::ReadRowsRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::bigtable::v2::SampleRowKeysResponse>>
@@ -262,13 +340,17 @@ class DefaultBigtableStub : public BigtableStub {
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::SampleRowKeysRequest const& request) override;
+      google::bigtable::v2::SampleRowKeysRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   future<StatusOr<google::bigtable::v2::MutateRowResponse>> AsyncMutateRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::MutateRowRequest const& request) override;
+      google::bigtable::v2::MutateRowRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::bigtable::v2::MutateRowsResponse>>
@@ -276,34 +358,44 @@ class DefaultBigtableStub : public BigtableStub {
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::MutateRowsRequest const& request) override;
+      google::bigtable::v2::MutateRowsRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
   AsyncCheckAndMutateRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::CheckAndMutateRowRequest const& request) override;
+      google::bigtable::v2::CheckAndMutateRowRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   future<StatusOr<google::bigtable::v2::PingAndWarmResponse>> AsyncPingAndWarm(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::PingAndWarmRequest const& request) override;
+      google::bigtable::v2::PingAndWarmRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>
   AsyncReadModifyWriteRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::ReadModifyWriteRowRequest const& request) override;
+      google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   future<StatusOr<google::bigtable::v2::PrepareQueryResponse>>
   AsyncPrepareQuery(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::PrepareQueryRequest const& request) override;
+      google::bigtable::v2::PrepareQueryRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
  private:
   std::unique_ptr<google::bigtable::v2::Bigtable::StubInterface> grpc_stub_;

--- a/google/cloud/bigtable/internal/bigtable_stub_factory.cc
+++ b/google/cloud/bigtable/internal/bigtable_stub_factory.cc
@@ -22,6 +22,7 @@
 #include "google/cloud/bigtable/internal/bigtable_tracing_stub.h"
 #include "google/cloud/bigtable/internal/connection_refresh_state.h"
 #include "google/cloud/bigtable/internal/defaults.h"
+#include "google/cloud/bigtable/internal/operation_context.h"
 #include "google/cloud/bigtable/options.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
@@ -147,8 +148,9 @@ std::shared_ptr<BigtableStub> CreateBigtableStubRandomTwoLeastUsed(
       grpc::ClientContext client_context;
       google::bigtable::v2::PingAndWarmRequest request;
       request.set_name(std::string{instance_name});
-      auto response =
-          stub->PingAndWarm(client_context, options, std::move(request));
+      OperationContext op_ctx;
+      auto response = stub->PingAndWarm(client_context, options,
+                                        std::move(request), op_ctx);
       if (!response.ok()) return response.status();
     }
 

--- a/google/cloud/bigtable/internal/bigtable_stub_factory_test.cc
+++ b/google/cloud/bigtable/internal/bigtable_stub_factory_test.cc
@@ -1,3 +1,4 @@
+#include "google/cloud/bigtable/internal/operation_context.h"
 // Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/bigtable/internal/bigtable_stub_factory.h"
 #include "google/cloud/bigtable/internal/bigtable_random_two_least_used_decorator.h"
+#include "google/cloud/bigtable/internal/bigtable_stub_factory.h"
 #include "google/cloud/bigtable/internal/dynamic_channel_pool.h"
 #include "google/cloud/bigtable/options.h"
 #include "google/cloud/bigtable/testing/mock_bigtable_stub.h"
@@ -109,7 +110,8 @@ TEST(BigtableStubFactory, RoundRobin) {
 
   grpc::ClientContext context;
   for (int i = 0; i != kTestChannels; ++i) {
-    auto response = stub->MutateRow(context, Options{}, {});
+    OperationContext op_ctx;
+    auto response = stub->MutateRow(context, Options{}, {}, op_ctx);
     EXPECT_THAT(response, StatusIs(StatusCode::kAborted, "fail"));
   }
 }
@@ -157,7 +159,8 @@ TEST(BigtableStubFactory, RandomTwoLeastUsed) {
 
   grpc::ClientContext context;
   for (int i = 0; i != kTestChannels; ++i) {
-    auto response = stub->MutateRow(context, Options{}, {});
+    OperationContext op_ctx;
+    auto response = stub->MutateRow(context, Options{}, {}, op_ctx);
     EXPECT_THAT(response, StatusIs(StatusCode::kAborted, "fail"));
   }
 
@@ -247,7 +250,8 @@ TEST(BigtableStubFactory, Auth) {
       factory.AsStdFunction());
 
   grpc::ClientContext context;
-  auto response = stub->MutateRow(context, Options{}, {});
+  OperationContext op_ctx;
+  auto response = stub->MutateRow(context, Options{}, {}, op_ctx);
   EXPECT_THAT(response, StatusIs(StatusCode::kAborted, "fail"));
 }
 
@@ -257,15 +261,15 @@ TEST(BigtableStubFactory, Metadata) {
       .WillOnce([](std::shared_ptr<grpc::Channel> const&) {
         auto mock = std::make_shared<MockBigtableStub>();
         EXPECT_CALL(*mock, MutateRow)
-            .WillOnce(
-                [](grpc::ClientContext& context, Options const&,
-                   google::bigtable::v2::MutateRowRequest const& request) {
-                  ValidateMetadataFixture fixture;
-                  fixture.IsContextMDValid(
-                      context, "google.bigtable.v2.Bigtable.MutateRow", request,
-                      internal::HandCraftedLibClientHeader());
-                  return internal::AbortedError("fail");
-                });
+            .WillOnce([](grpc::ClientContext& context, Options const&,
+                         google::bigtable::v2::MutateRowRequest const& request,
+                         auto const&) {
+              ValidateMetadataFixture fixture;
+              fixture.IsContextMDValid(
+                  context, "google.bigtable.v2.Bigtable.MutateRow", request,
+                  internal::HandCraftedLibClientHeader());
+              return internal::AbortedError("fail");
+            });
         return mock;
       });
 
@@ -280,7 +284,8 @@ TEST(BigtableStubFactory, Metadata) {
       factory.AsStdFunction());
 
   grpc::ClientContext context;
-  auto response = stub->MutateRow(context, Options{}, {});
+  OperationContext op_ctx;
+  auto response = stub->MutateRow(context, Options{}, {}, op_ctx);
   EXPECT_THAT(response, StatusIs(StatusCode::kAborted, "fail"));
 }
 
@@ -308,7 +313,8 @@ TEST(BigtableStubFactory, LoggingEnabled) {
       factory.AsStdFunction());
 
   grpc::ClientContext context;
-  auto response = stub->MutateRow(context, Options{}, {});
+  OperationContext op_ctx;
+  auto response = stub->MutateRow(context, Options{}, {}, op_ctx);
   EXPECT_THAT(response, StatusIs(StatusCode::kAborted, "fail"));
 
   EXPECT_THAT(log.ExtractLines(), Contains(HasSubstr("MutateRow")));
@@ -338,7 +344,8 @@ TEST(BigtableStubFactory, LoggingDisabled) {
       factory.AsStdFunction());
 
   grpc::ClientContext context;
-  auto response = stub->MutateRow(context, Options{}, {});
+  OperationContext op_ctx;
+  auto response = stub->MutateRow(context, Options{}, {}, op_ctx);
   EXPECT_THAT(response, StatusIs(StatusCode::kAborted, "fail"));
 
   EXPECT_THAT(log.ExtractLines(), Not(Contains(HasSubstr("MutateRow"))));
@@ -351,7 +358,8 @@ TEST(BigtableStubFactory, FeaturesFlagsCloudDirectPath) {
         auto mock = std::make_shared<MockBigtableStub>();
         EXPECT_CALL(*mock, MutateRow)
             .WillOnce([](grpc::ClientContext& context, Options const&,
-                         google::bigtable::v2::MutateRowRequest const&) {
+                         google::bigtable::v2::MutateRowRequest const&,
+                         auto const&) {
               ValidateMetadataFixture fixture;
               auto headers = fixture.GetMetadata(context);
               auto it = headers.find("bigtable-features");
@@ -389,7 +397,8 @@ TEST(BigtableStubFactory, FeaturesFlagsCloudDirectPath) {
           .set<UnifiedCredentialsOption>(MakeInsecureCredentials()),
       factory.AsStdFunction());
   grpc::ClientContext context;
-  (void)stub->MutateRow(context, Options{}, {});
+  OperationContext op_ctx;
+  (void)stub->MutateRow(context, Options{}, {}, op_ctx);
   testing_util::UnsetEnv("GOOGLE_CLOUD_ENABLE_DIRECT_PATH");
 }
 
@@ -400,7 +409,8 @@ TEST(BigtableStubFactory, FeaturesFlagsBigtableDirectPath) {
         auto mock = std::make_shared<MockBigtableStub>();
         EXPECT_CALL(*mock, MutateRow)
             .WillOnce([](grpc::ClientContext& context, Options const&,
-                         google::bigtable::v2::MutateRowRequest const&) {
+                         google::bigtable::v2::MutateRowRequest const&,
+                         auto const&) {
               ValidateMetadataFixture fixture;
               auto headers = fixture.GetMetadata(context);
               auto it = headers.find("bigtable-features");
@@ -438,7 +448,8 @@ TEST(BigtableStubFactory, FeaturesFlagsBigtableDirectPath) {
           .set<UnifiedCredentialsOption>(MakeInsecureCredentials()),
       factory.AsStdFunction());
   grpc::ClientContext context;
-  (void)stub->MutateRow(context, Options{}, {});
+  OperationContext op_ctx;
+  (void)stub->MutateRow(context, Options{}, {}, op_ctx);
   testing_util::UnsetEnv("CBT_ENABLE_DIRECTPATH");
 }
 
@@ -449,7 +460,8 @@ TEST(BigtableStubFactory, FeaturesFlags) {
         auto mock = std::make_shared<MockBigtableStub>();
         EXPECT_CALL(*mock, MutateRow)
             .WillOnce([](grpc::ClientContext& context, Options const&,
-                         google::bigtable::v2::MutateRowRequest const&) {
+                         google::bigtable::v2::MutateRowRequest const&,
+                         auto const&) {
               ValidateMetadataFixture fixture;
               auto headers = fixture.GetMetadata(context);
               auto it = headers.find("bigtable-features");
@@ -486,7 +498,8 @@ TEST(BigtableStubFactory, FeaturesFlags) {
           .set<UnifiedCredentialsOption>(MakeInsecureCredentials()),
       factory.AsStdFunction());
   grpc::ClientContext context;
-  (void)stub->MutateRow(context, Options{}, {});
+  OperationContext op_ctx;
+  (void)stub->MutateRow(context, Options{}, {}, op_ctx);
 }
 
 using ::google::cloud::testing_util::DisableTracing;
@@ -505,7 +518,7 @@ TEST(BigtableStubFactory, TracingEnabled) {
       .WillOnce([](std::shared_ptr<grpc::Channel> const&) {
         auto mock = std::make_shared<MockBigtableStub>();
         EXPECT_CALL(*mock, MutateRow)
-            .WillOnce([](auto& context, auto const&, auto const&) {
+            .WillOnce([](auto& context, auto const&, auto const&, auto const&) {
               ValidatePropagator(context);
               return internal::AbortedError("fail");
             });
@@ -523,7 +536,8 @@ TEST(BigtableStubFactory, TracingEnabled) {
               .set<UnifiedCredentialsOption>(MakeInsecureCredentials())),
       factory.AsStdFunction());
   grpc::ClientContext context;
-  (void)stub->MutateRow(context, Options{}, {});
+  OperationContext op_ctx;
+  (void)stub->MutateRow(context, Options{}, {}, op_ctx);
 
   EXPECT_THAT(span_catcher->GetSpans(),
               ElementsAre(SpanNamed("google.bigtable.v2.Bigtable/MutateRow")));
@@ -537,7 +551,7 @@ TEST(BigtableStubFactory, TracingDisabled) {
       .WillOnce([](std::shared_ptr<grpc::Channel> const&) {
         auto mock = std::make_shared<MockBigtableStub>();
         EXPECT_CALL(*mock, MutateRow)
-            .WillOnce([](auto& context, auto const&, auto const&) {
+            .WillOnce([](auto& context, auto const&, auto const&, auto const&) {
               ValidateNoPropagator(context);
               return internal::AbortedError("fail");
             });
@@ -555,7 +569,8 @@ TEST(BigtableStubFactory, TracingDisabled) {
               .set<UnifiedCredentialsOption>(MakeInsecureCredentials())),
       factory.AsStdFunction());
   grpc::ClientContext context;
-  (void)stub->MutateRow(context, Options{}, {});
+  OperationContext op_ctx;
+  (void)stub->MutateRow(context, Options{}, {}, op_ctx);
 
   EXPECT_THAT(span_catcher->GetSpans(), IsEmpty());
 }

--- a/google/cloud/bigtable/internal/bigtable_tracing_stub.cc
+++ b/google/cloud/bigtable/internal/bigtable_tracing_stub.cc
@@ -39,11 +39,14 @@ std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::bigtable::v2::ReadRowsResponse>>
 BigtableTracingStub::ReadRows(
     std::shared_ptr<grpc::ClientContext> context, Options const& options,
-    google::bigtable::v2::ReadRowsRequest const& request) {
+    google::bigtable::v2::ReadRowsRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   auto span = internal::MakeSpanGrpc("google.bigtable.v2.Bigtable", "ReadRows");
   auto scope = opentelemetry::trace::Scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto stream = child_->ReadRows(context, options, request);
+  auto stream =
+      child_->ReadRows(context, options, request, std::move(operation_context));
   return std::make_unique<internal::StreamingReadRpcTracing<
       google::bigtable::v2::ReadRowsResponse>>(
       std::move(context), std::move(stream), std::move(span));
@@ -53,12 +56,15 @@ std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::bigtable::v2::SampleRowKeysResponse>>
 BigtableTracingStub::SampleRowKeys(
     std::shared_ptr<grpc::ClientContext> context, Options const& options,
-    google::bigtable::v2::SampleRowKeysRequest const& request) {
+    google::bigtable::v2::SampleRowKeysRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   auto span =
       internal::MakeSpanGrpc("google.bigtable.v2.Bigtable", "SampleRowKeys");
   auto scope = opentelemetry::trace::Scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto stream = child_->SampleRowKeys(context, options, request);
+  auto stream = child_->SampleRowKeys(context, options, request,
+                                      std::move(operation_context));
   return std::make_unique<internal::StreamingReadRpcTracing<
       google::bigtable::v2::SampleRowKeysResponse>>(
       std::move(context), std::move(stream), std::move(span));
@@ -67,25 +73,30 @@ BigtableTracingStub::SampleRowKeys(
 StatusOr<google::bigtable::v2::MutateRowResponse>
 BigtableTracingStub::MutateRow(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::MutateRowRequest const& request) {
+    google::bigtable::v2::MutateRowRequest const& request,
+    google::cloud::bigtable_internal::OperationContext& operation_context) {
   auto span =
       internal::MakeSpanGrpc("google.bigtable.v2.Bigtable", "MutateRow");
   auto scope = opentelemetry::trace::Scope(span);
   internal::InjectTraceContext(context, *propagator_);
-  return internal::EndSpan(context, *span,
-                           child_->MutateRow(context, options, request));
+  return internal::EndSpan(
+      context, *span,
+      child_->MutateRow(context, options, request, operation_context));
 }
 
 std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::bigtable::v2::MutateRowsResponse>>
 BigtableTracingStub::MutateRows(
     std::shared_ptr<grpc::ClientContext> context, Options const& options,
-    google::bigtable::v2::MutateRowsRequest const& request) {
+    google::bigtable::v2::MutateRowsRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   auto span =
       internal::MakeSpanGrpc("google.bigtable.v2.Bigtable", "MutateRows");
   auto scope = opentelemetry::trace::Scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto stream = child_->MutateRows(context, options, request);
+  auto stream = child_->MutateRows(context, options, request,
+                                   std::move(operation_context));
   return std::make_unique<internal::StreamingReadRpcTracing<
       google::bigtable::v2::MutateRowsResponse>>(
       std::move(context), std::move(stream), std::move(span));
@@ -94,61 +105,72 @@ BigtableTracingStub::MutateRows(
 StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>
 BigtableTracingStub::CheckAndMutateRow(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::CheckAndMutateRowRequest const& request) {
+    google::bigtable::v2::CheckAndMutateRowRequest const& request,
+    google::cloud::bigtable_internal::OperationContext& operation_context) {
   auto span = internal::MakeSpanGrpc("google.bigtable.v2.Bigtable",
                                      "CheckAndMutateRow");
   auto scope = opentelemetry::trace::Scope(span);
   internal::InjectTraceContext(context, *propagator_);
   return internal::EndSpan(
-      context, *span, child_->CheckAndMutateRow(context, options, request));
+      context, *span,
+      child_->CheckAndMutateRow(context, options, request, operation_context));
 }
 
 StatusOr<google::bigtable::v2::PingAndWarmResponse>
 BigtableTracingStub::PingAndWarm(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::PingAndWarmRequest const& request) {
+    google::bigtable::v2::PingAndWarmRequest const& request,
+    google::cloud::bigtable_internal::OperationContext& operation_context) {
   auto span =
       internal::MakeSpanGrpc("google.bigtable.v2.Bigtable", "PingAndWarm");
   auto scope = opentelemetry::trace::Scope(span);
   internal::InjectTraceContext(context, *propagator_);
-  return internal::EndSpan(context, *span,
-                           child_->PingAndWarm(context, options, request));
+  return internal::EndSpan(
+      context, *span,
+      child_->PingAndWarm(context, options, request, operation_context));
 }
 
 StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>
 BigtableTracingStub::ReadModifyWriteRow(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
+    google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+    google::cloud::bigtable_internal::OperationContext& operation_context) {
   auto span = internal::MakeSpanGrpc("google.bigtable.v2.Bigtable",
                                      "ReadModifyWriteRow");
   auto scope = opentelemetry::trace::Scope(span);
   internal::InjectTraceContext(context, *propagator_);
   return internal::EndSpan(
-      context, *span, child_->ReadModifyWriteRow(context, options, request));
+      context, *span,
+      child_->ReadModifyWriteRow(context, options, request, operation_context));
 }
 
 StatusOr<google::bigtable::v2::PrepareQueryResponse>
 BigtableTracingStub::PrepareQuery(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::PrepareQueryRequest const& request) {
+    google::bigtable::v2::PrepareQueryRequest const& request,
+    google::cloud::bigtable_internal::OperationContext& operation_context) {
   auto span =
       internal::MakeSpanGrpc("google.bigtable.v2.Bigtable", "PrepareQuery");
   auto scope = opentelemetry::trace::Scope(span);
   internal::InjectTraceContext(context, *propagator_);
-  return internal::EndSpan(context, *span,
-                           child_->PrepareQuery(context, options, request));
+  return internal::EndSpan(
+      context, *span,
+      child_->PrepareQuery(context, options, request, operation_context));
 }
 
 std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::bigtable::v2::ExecuteQueryResponse>>
 BigtableTracingStub::ExecuteQuery(
     std::shared_ptr<grpc::ClientContext> context, Options const& options,
-    google::bigtable::v2::ExecuteQueryRequest const& request) {
+    google::bigtable::v2::ExecuteQueryRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   auto span =
       internal::MakeSpanGrpc("google.bigtable.v2.Bigtable", "ExecuteQuery");
   auto scope = opentelemetry::trace::Scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto stream = child_->ExecuteQuery(context, options, request);
+  auto stream = child_->ExecuteQuery(context, options, request,
+                                     std::move(operation_context));
   return std::make_unique<internal::StreamingReadRpcTracing<
       google::bigtable::v2::ExecuteQueryResponse>>(
       std::move(context), std::move(stream), std::move(span));
@@ -157,14 +179,15 @@ BigtableTracingStub::ExecuteQuery(
 StatusOr<google::bigtable::v2::ClientConfiguration>
 BigtableTracingStub::GetClientConfiguration(
     grpc::ClientContext& context, Options const& options,
-    google::bigtable::v2::GetClientConfigurationRequest const& request) {
+    google::bigtable::v2::GetClientConfigurationRequest const& request,
+    google::cloud::bigtable_internal::OperationContext& operation_context) {
   auto span = internal::MakeSpanGrpc("google.bigtable.v2.Bigtable",
                                      "GetClientConfiguration");
   auto scope = opentelemetry::trace::Scope(span);
   internal::InjectTraceContext(context, *propagator_);
-  return internal::EndSpan(
-      context, *span,
-      child_->GetClientConfiguration(context, options, request));
+  return internal::EndSpan(context, *span,
+                           child_->GetClientConfiguration(
+                               context, options, request, operation_context));
 }
 
 std::unique_ptr<
@@ -172,12 +195,15 @@ std::unique_ptr<
                                google::bigtable::v2::SessionResponse>>
 BigtableTracingStub::AsyncOpenTable(
     CompletionQueue const& cq, std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
+    google::cloud::internal::ImmutableOptions options,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   auto span =
       internal::MakeSpanGrpc("google.bigtable.v2.Bigtable", "OpenTable");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto stream = child_->AsyncOpenTable(cq, context, std::move(options));
+  auto stream = child_->AsyncOpenTable(cq, context, std::move(options),
+                                       std::move(operation_context));
   return std::make_unique<internal::AsyncStreamingReadWriteRpcTracing<
       google::bigtable::v2::SessionRequest,
       google::bigtable::v2::SessionResponse>>(
@@ -189,13 +215,15 @@ std::unique_ptr<
                                google::bigtable::v2::SessionResponse>>
 BigtableTracingStub::AsyncOpenAuthorizedView(
     CompletionQueue const& cq, std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
+    google::cloud::internal::ImmutableOptions options,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   auto span = internal::MakeSpanGrpc("google.bigtable.v2.Bigtable",
                                      "OpenAuthorizedView");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto stream =
-      child_->AsyncOpenAuthorizedView(cq, context, std::move(options));
+  auto stream = child_->AsyncOpenAuthorizedView(cq, context, std::move(options),
+                                                std::move(operation_context));
   return std::make_unique<internal::AsyncStreamingReadWriteRpcTracing<
       google::bigtable::v2::SessionRequest,
       google::bigtable::v2::SessionResponse>>(
@@ -207,13 +235,15 @@ std::unique_ptr<
                                google::bigtable::v2::SessionResponse>>
 BigtableTracingStub::AsyncOpenMaterializedView(
     CompletionQueue const& cq, std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options) {
+    google::cloud::internal::ImmutableOptions options,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   auto span = internal::MakeSpanGrpc("google.bigtable.v2.Bigtable",
                                      "OpenMaterializedView");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto stream =
-      child_->AsyncOpenMaterializedView(cq, context, std::move(options));
+  auto stream = child_->AsyncOpenMaterializedView(
+      cq, context, std::move(options), std::move(operation_context));
   return std::make_unique<internal::AsyncStreamingReadWriteRpcTracing<
       google::bigtable::v2::SessionRequest,
       google::bigtable::v2::SessionResponse>>(
@@ -226,11 +256,14 @@ BigtableTracingStub::AsyncReadRows(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::ReadRowsRequest const& request) {
+    google::bigtable::v2::ReadRowsRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   auto span = internal::MakeSpanGrpc("google.bigtable.v2.Bigtable", "ReadRows");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto stream = child_->AsyncReadRows(cq, context, std::move(options), request);
+  auto stream = child_->AsyncReadRows(cq, context, std::move(options), request,
+                                      std::move(operation_context));
   return std::make_unique<internal::AsyncStreamingReadRpcTracing<
       google::bigtable::v2::ReadRowsResponse>>(
       std::move(context), std::move(stream), std::move(span));
@@ -242,13 +275,15 @@ BigtableTracingStub::AsyncSampleRowKeys(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::SampleRowKeysRequest const& request) {
+    google::bigtable::v2::SampleRowKeysRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   auto span =
       internal::MakeSpanGrpc("google.bigtable.v2.Bigtable", "SampleRowKeys");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto stream =
-      child_->AsyncSampleRowKeys(cq, context, std::move(options), request);
+  auto stream = child_->AsyncSampleRowKeys(
+      cq, context, std::move(options), request, std::move(operation_context));
   return std::make_unique<internal::AsyncStreamingReadRpcTracing<
       google::bigtable::v2::SampleRowKeysResponse>>(
       std::move(context), std::move(stream), std::move(span));
@@ -259,12 +294,15 @@ BigtableTracingStub::AsyncMutateRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::MutateRowRequest const& request) {
+    google::bigtable::v2::MutateRowRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   auto span =
       internal::MakeSpanGrpc("google.bigtable.v2.Bigtable", "MutateRow");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto f = child_->AsyncMutateRow(cq, context, std::move(options), request);
+  auto f = child_->AsyncMutateRow(cq, context, std::move(options), request,
+                                  std::move(operation_context));
   return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 
@@ -274,13 +312,15 @@ BigtableTracingStub::AsyncMutateRows(
     google::cloud::CompletionQueue const& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::MutateRowsRequest const& request) {
+    google::bigtable::v2::MutateRowsRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   auto span =
       internal::MakeSpanGrpc("google.bigtable.v2.Bigtable", "MutateRows");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto stream =
-      child_->AsyncMutateRows(cq, context, std::move(options), request);
+  auto stream = child_->AsyncMutateRows(cq, context, std::move(options),
+                                        request, std::move(operation_context));
   return std::make_unique<internal::AsyncStreamingReadRpcTracing<
       google::bigtable::v2::MutateRowsResponse>>(
       std::move(context), std::move(stream), std::move(span));
@@ -291,13 +331,15 @@ BigtableTracingStub::AsyncCheckAndMutateRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::CheckAndMutateRowRequest const& request) {
+    google::bigtable::v2::CheckAndMutateRowRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   auto span = internal::MakeSpanGrpc("google.bigtable.v2.Bigtable",
                                      "CheckAndMutateRow");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto f =
-      child_->AsyncCheckAndMutateRow(cq, context, std::move(options), request);
+  auto f = child_->AsyncCheckAndMutateRow(
+      cq, context, std::move(options), request, std::move(operation_context));
   return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 
@@ -306,12 +348,15 @@ BigtableTracingStub::AsyncPingAndWarm(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::PingAndWarmRequest const& request) {
+    google::bigtable::v2::PingAndWarmRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   auto span =
       internal::MakeSpanGrpc("google.bigtable.v2.Bigtable", "PingAndWarm");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto f = child_->AsyncPingAndWarm(cq, context, std::move(options), request);
+  auto f = child_->AsyncPingAndWarm(cq, context, std::move(options), request,
+                                    std::move(operation_context));
   return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 
@@ -320,13 +365,15 @@ BigtableTracingStub::AsyncReadModifyWriteRow(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
+    google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   auto span = internal::MakeSpanGrpc("google.bigtable.v2.Bigtable",
                                      "ReadModifyWriteRow");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto f =
-      child_->AsyncReadModifyWriteRow(cq, context, std::move(options), request);
+  auto f = child_->AsyncReadModifyWriteRow(
+      cq, context, std::move(options), request, std::move(operation_context));
   return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 
@@ -335,12 +382,15 @@ BigtableTracingStub::AsyncPrepareQuery(
     google::cloud::CompletionQueue& cq,
     std::shared_ptr<grpc::ClientContext> context,
     google::cloud::internal::ImmutableOptions options,
-    google::bigtable::v2::PrepareQueryRequest const& request) {
+    google::bigtable::v2::PrepareQueryRequest const& request,
+    std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+        operation_context) {
   auto span =
       internal::MakeSpanGrpc("google.bigtable.v2.Bigtable", "PrepareQuery");
   internal::OTelScope scope(span);
   internal::InjectTraceContext(*context, *propagator_);
-  auto f = child_->AsyncPrepareQuery(cq, context, std::move(options), request);
+  auto f = child_->AsyncPrepareQuery(cq, context, std::move(options), request,
+                                     std::move(operation_context));
   return internal::EndSpan(std::move(context), std::move(span), std::move(f));
 }
 

--- a/google/cloud/bigtable/internal/bigtable_tracing_stub.h
+++ b/google/cloud/bigtable/internal/bigtable_tracing_stub.h
@@ -42,57 +42,79 @@ class BigtableTracingStub : public BigtableStub {
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::ReadRowsResponse>>
   ReadRows(std::shared_ptr<grpc::ClientContext> context, Options const& options,
-           google::bigtable::v2::ReadRowsRequest const& request) override;
+           google::bigtable::v2::ReadRowsRequest const& request,
+           std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+               operation_context) override;
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::SampleRowKeysResponse>>
   SampleRowKeys(
       std::shared_ptr<grpc::ClientContext> context, Options const& options,
-      google::bigtable::v2::SampleRowKeysRequest const& request) override;
+      google::bigtable::v2::SampleRowKeysRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   StatusOr<google::bigtable::v2::MutateRowResponse> MutateRow(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::MutateRowRequest const& request) override;
+      google::bigtable::v2::MutateRowRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
+      override;
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::MutateRowsResponse>>
   MutateRows(std::shared_ptr<grpc::ClientContext> context,
              Options const& options,
-             google::bigtable::v2::MutateRowsRequest const& request) override;
+             google::bigtable::v2::MutateRowsRequest const& request,
+             std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+                 operation_context) override;
 
   StatusOr<google::bigtable::v2::CheckAndMutateRowResponse> CheckAndMutateRow(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::CheckAndMutateRowRequest const& request) override;
+      google::bigtable::v2::CheckAndMutateRowRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
+      override;
 
   StatusOr<google::bigtable::v2::PingAndWarmResponse> PingAndWarm(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::PingAndWarmRequest const& request) override;
+      google::bigtable::v2::PingAndWarmRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
+      override;
 
   StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse> ReadModifyWriteRow(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::ReadModifyWriteRowRequest const& request) override;
+      google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
+      override;
 
   StatusOr<google::bigtable::v2::PrepareQueryResponse> PrepareQuery(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::PrepareQueryRequest const& request) override;
+      google::bigtable::v2::PrepareQueryRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
+      override;
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::ExecuteQueryResponse>>
   ExecuteQuery(
       std::shared_ptr<grpc::ClientContext> context, Options const& options,
-      google::bigtable::v2::ExecuteQueryRequest const& request) override;
+      google::bigtable::v2::ExecuteQueryRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   StatusOr<google::bigtable::v2::ClientConfiguration> GetClientConfiguration(
       grpc::ClientContext& context, Options const& options,
-      google::bigtable::v2::GetClientConfigurationRequest const& request)
+      google::bigtable::v2::GetClientConfigurationRequest const& request,
+      google::cloud::bigtable_internal::OperationContext& operation_context)
       override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::bigtable::v2::SessionRequest,
       google::bigtable::v2::SessionResponse>>
-  AsyncOpenTable(google::cloud::CompletionQueue const& cq,
-                 std::shared_ptr<grpc::ClientContext> context,
-                 google::cloud::internal::ImmutableOptions options) override;
+  AsyncOpenTable(
+      google::cloud::CompletionQueue const& cq,
+      std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::bigtable::v2::SessionRequest,
@@ -100,7 +122,9 @@ class BigtableTracingStub : public BigtableStub {
   AsyncOpenAuthorizedView(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
-      google::cloud::internal::ImmutableOptions options) override;
+      google::cloud::internal::ImmutableOptions options,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::bigtable::v2::SessionRequest,
@@ -108,14 +132,19 @@ class BigtableTracingStub : public BigtableStub {
   AsyncOpenMaterializedView(
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
-      google::cloud::internal::ImmutableOptions options) override;
+      google::cloud::internal::ImmutableOptions options,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::bigtable::v2::ReadRowsResponse>>
-  AsyncReadRows(google::cloud::CompletionQueue const& cq,
-                std::shared_ptr<grpc::ClientContext> context,
-                google::cloud::internal::ImmutableOptions options,
-                google::bigtable::v2::ReadRowsRequest const& request) override;
+  AsyncReadRows(
+      google::cloud::CompletionQueue const& cq,
+      std::shared_ptr<grpc::ClientContext> context,
+      google::cloud::internal::ImmutableOptions options,
+      google::bigtable::v2::ReadRowsRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::bigtable::v2::SampleRowKeysResponse>>
@@ -123,13 +152,17 @@ class BigtableTracingStub : public BigtableStub {
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::SampleRowKeysRequest const& request) override;
+      google::bigtable::v2::SampleRowKeysRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   future<StatusOr<google::bigtable::v2::MutateRowResponse>> AsyncMutateRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::MutateRowRequest const& request) override;
+      google::bigtable::v2::MutateRowRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::bigtable::v2::MutateRowsResponse>>
@@ -137,34 +170,44 @@ class BigtableTracingStub : public BigtableStub {
       google::cloud::CompletionQueue const& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::MutateRowsRequest const& request) override;
+      google::bigtable::v2::MutateRowsRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
   AsyncCheckAndMutateRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::CheckAndMutateRowRequest const& request) override;
+      google::bigtable::v2::CheckAndMutateRowRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   future<StatusOr<google::bigtable::v2::PingAndWarmResponse>> AsyncPingAndWarm(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::PingAndWarmRequest const& request) override;
+      google::bigtable::v2::PingAndWarmRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>
   AsyncReadModifyWriteRow(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::ReadModifyWriteRowRequest const& request) override;
+      google::bigtable::v2::ReadModifyWriteRowRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
   future<StatusOr<google::bigtable::v2::PrepareQueryResponse>>
   AsyncPrepareQuery(
       google::cloud::CompletionQueue& cq,
       std::shared_ptr<grpc::ClientContext> context,
       google::cloud::internal::ImmutableOptions options,
-      google::bigtable::v2::PrepareQueryRequest const& request) override;
+      google::bigtable::v2::PrepareQueryRequest const& request,
+      std::shared_ptr<google::cloud::bigtable_internal::OperationContext>
+          operation_context) override;
 
  private:
   std::shared_ptr<BigtableStub> child_;

--- a/google/cloud/bigtable/internal/bulk_mutator.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator.cc
@@ -212,7 +212,8 @@ Status BulkMutator::MakeOneRequest(BigtableStub& stub,
   limiter.Acquire();
 
   // Read the stream of responses.
-  auto stream = stub.MutateRows(client_context, options, mutations);
+  auto stream =
+      stub.MutateRows(client_context, options, mutations, operation_context_);
   std::optional<Status> status;
   while (true) {
     btproto::MutateRowsResponse response;

--- a/google/cloud/bigtable/internal/bulk_mutator_test.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator_test.cc
@@ -156,7 +156,8 @@ TEST_F(BulkMutatorTest, Simple) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRows)
       .WillOnce([this](auto context, auto const&,
-                       google::bigtable::v2::MutateRowsRequest const& request) {
+                       google::bigtable::v2::MutateRowsRequest const& request,
+                       auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
@@ -210,7 +211,8 @@ TEST_F(BulkMutatorTest, RetryPartialFailure) {
       // Prepare the mocks for the request.  First create a stream response
       // which indicates a partial failure.
       .WillOnce([this](auto context, auto const&,
-                       google::bigtable::v2::MutateRowsRequest const& request) {
+                       google::bigtable::v2::MutateRowsRequest const& request,
+                       auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
@@ -226,7 +228,8 @@ TEST_F(BulkMutatorTest, RetryPartialFailure) {
       // Prepare a second stream response, because the client should retry after
       // the partial failure.
       .WillOnce([this](auto context, auto const&,
-                       google::bigtable::v2::MutateRowsRequest const& request) {
+                       google::bigtable::v2::MutateRowsRequest const& request,
+                       auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
@@ -282,7 +285,8 @@ TEST_F(BulkMutatorTest, PermanentFailure) {
   EXPECT_CALL(*mock, MutateRows)
       // The first RPC return one recoverable and one unrecoverable failure.
       .WillOnce([this](auto context, auto const&,
-                       google::bigtable::v2::MutateRowsRequest const& request) {
+                       google::bigtable::v2::MutateRowsRequest const& request,
+                       auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
@@ -298,7 +302,8 @@ TEST_F(BulkMutatorTest, PermanentFailure) {
       // The BulkMutator should issue a second request, which will return
       // success for the remaining mutation.
       .WillOnce([this](auto context, auto const&,
-                       google::bigtable::v2::MutateRowsRequest const& request) {
+                       google::bigtable::v2::MutateRowsRequest const& request,
+                       auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
@@ -357,7 +362,8 @@ TEST_F(BulkMutatorTest, PartialStream) {
       // This will be the stream returned by the first request.  It is missing
       // information about one of the mutations.
       .WillOnce([this](auto context, auto const&,
-                       google::bigtable::v2::MutateRowsRequest const& request) {
+                       google::bigtable::v2::MutateRowsRequest const& request,
+                       auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
@@ -373,7 +379,8 @@ TEST_F(BulkMutatorTest, PartialStream) {
       // returned by the second request, which indicates success for the missed
       // mutation on r1.
       .WillOnce([this](auto context, auto const&,
-                       google::bigtable::v2::MutateRowsRequest const& request) {
+                       google::bigtable::v2::MutateRowsRequest const& request,
+                       auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
@@ -422,7 +429,8 @@ TEST_F(BulkMutatorTest, RetryOnlyIdempotent) {
       // We will setup the mock to return recoverable transient errors for all
       // mutations.
       .WillOnce([this](auto context, auto const&,
-                       google::bigtable::v2::MutateRowsRequest const& request) {
+                       google::bigtable::v2::MutateRowsRequest const& request,
+                       auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_THAT(request, HasCorrectResourceNames());
         EXPECT_EQ(2, request.entries_size());
@@ -440,7 +448,8 @@ TEST_F(BulkMutatorTest, RetryOnlyIdempotent) {
       // idempotent mutation. Make the mock return success for it.
       .WillOnce([this, expect_r2](
                     auto context, auto const&,
-                    google::bigtable::v2::MutateRowsRequest const& request) {
+                    google::bigtable::v2::MutateRowsRequest const& request,
+                    auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_THAT(request, HasCorrectResourceNames());
         expect_r2(request);
@@ -480,7 +489,8 @@ TEST_F(BulkMutatorTest, RetryInfoHeeded) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRows)
       .WillOnce([this](auto context, auto const&,
-                       google::bigtable::v2::MutateRowsRequest const&) {
+                       google::bigtable::v2::MutateRowsRequest const&,
+                       auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         auto status =
             google::cloud::internal::ResourceExhaustedError("try again");
@@ -494,7 +504,8 @@ TEST_F(BulkMutatorTest, RetryInfoHeeded) {
       // us that it is safe to retry the mutation, even though it is not
       // idempotent.
       .WillOnce([this](auto context, auto const&,
-                       google::bigtable::v2::MutateRowsRequest const& request) {
+                       google::bigtable::v2::MutateRowsRequest const& request,
+                       auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         std::vector<RowKeyType> row_keys;
         for (auto const& entry : request.entries()) {
@@ -533,7 +544,8 @@ TEST_F(BulkMutatorTest, RetryInfoIgnored) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRows)
       .WillOnce([this](auto context, auto const&,
-                       google::bigtable::v2::MutateRowsRequest const&) {
+                       google::bigtable::v2::MutateRowsRequest const&,
+                       auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         auto status =
             google::cloud::internal::ResourceExhaustedError("try again");
@@ -571,7 +583,8 @@ TEST_F(BulkMutatorTest, UnconfirmedAreFailed) {
       // We will setup the mock to return recoverable failures for idempotent
       // mutations.
       .WillOnce([this](auto context, auto const&,
-                       google::bigtable::v2::MutateRowsRequest const& request) {
+                       google::bigtable::v2::MutateRowsRequest const& request,
+                       auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_THAT(request, HasCorrectResourceNames());
         EXPECT_EQ(3, request.entries_size());
@@ -610,7 +623,8 @@ TEST_F(BulkMutatorTest, ConfiguresContext) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRows)
       .WillOnce([this](auto context, auto const&,
-                       google::bigtable::v2::MutateRowsRequest const& request) {
+                       google::bigtable::v2::MutateRowsRequest const& request,
+                       auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
@@ -639,7 +653,8 @@ TEST_F(BulkMutatorTest, MutationStatusReportedOnOkStream) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRows)
       .WillOnce([this](auto context, auto const&,
-                       google::bigtable::v2::MutateRowsRequest const& request) {
+                       google::bigtable::v2::MutateRowsRequest const& request,
+                       auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
@@ -679,7 +694,8 @@ TEST_F(BulkMutatorTest, ReportEitherRetryableMutationFailOrStreamFail) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRows)
       .WillOnce([this](auto context, auto const&,
-                       google::bigtable::v2::MutateRowsRequest const& request) {
+                       google::bigtable::v2::MutateRowsRequest const& request,
+                       auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
@@ -721,7 +737,8 @@ TEST_F(BulkMutatorTest, ReportOnlyLatestMutationStatus) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRows)
       .WillOnce([this](auto context, auto const&,
-                       google::bigtable::v2::MutateRowsRequest const& request) {
+                       google::bigtable::v2::MutateRowsRequest const& request,
+                       auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
@@ -734,7 +751,8 @@ TEST_F(BulkMutatorTest, ReportOnlyLatestMutationStatus) {
         return stream;
       })
       .WillOnce([this](auto context, auto const&,
-                       google::bigtable::v2::MutateRowsRequest const& request) {
+                       google::bigtable::v2::MutateRowsRequest const& request,
+                       auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockMutateRowsStream>();
@@ -771,24 +789,24 @@ TEST_F(BulkMutatorTest, Throttling) {
     ::testing::InSequence seq;
     EXPECT_CALL(*mock_limiter, Acquire);
     EXPECT_CALL(*mock_stub, MutateRows)
-        .WillOnce(
-            [this](auto context, auto const&,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
-              metadata_fixture_.SetServerMetadata(*context, {});
-              EXPECT_THAT(request, HasCorrectResourceNames());
-              auto stream = std::make_unique<MockMutateRowsStream>();
-              EXPECT_CALL(*stream, Read)
-                  .WillOnce([](google::bigtable::v2::MutateRowsResponse* r) {
-                    *r = MakeResponse({{0, grpc::StatusCode::OK}});
-                    return std::nullopt;
-                  })
-                  .WillOnce([](google::bigtable::v2::MutateRowsResponse* r) {
-                    *r = MakeResponse({{1, grpc::StatusCode::OK}});
-                    return std::nullopt;
-                  })
-                  .WillOnce(Return(Status()));
-              return stream;
-            });
+        .WillOnce([this](auto context, auto const&,
+                         google::bigtable::v2::MutateRowsRequest const& request,
+                         auto const&) {
+          metadata_fixture_.SetServerMetadata(*context, {});
+          EXPECT_THAT(request, HasCorrectResourceNames());
+          auto stream = std::make_unique<MockMutateRowsStream>();
+          EXPECT_CALL(*stream, Read)
+              .WillOnce([](google::bigtable::v2::MutateRowsResponse* r) {
+                *r = MakeResponse({{0, grpc::StatusCode::OK}});
+                return std::nullopt;
+              })
+              .WillOnce([](google::bigtable::v2::MutateRowsResponse* r) {
+                *r = MakeResponse({{1, grpc::StatusCode::OK}});
+                return std::nullopt;
+              })
+              .WillOnce(Return(Status()));
+          return stream;
+        });
     EXPECT_CALL(*mock_limiter, Update).Times(2);
   }
 
@@ -811,7 +829,8 @@ TEST_F(BulkMutatorTest, BigtableCookies) {
 
   EXPECT_CALL(*mock, MutateRows)
       .WillOnce([this](auto context, auto const&,
-                       google::bigtable::v2::MutateRowsRequest const&) {
+                       google::bigtable::v2::MutateRowsRequest const&,
+                       auto const&) {
         // Return a bigtable cookie in the first request.
         metadata_fixture_.SetServerMetadata(
             *context, {{}, {{"x-goog-cbt-cookie-routing", "routing"}}});
@@ -822,7 +841,8 @@ TEST_F(BulkMutatorTest, BigtableCookies) {
         return stream;
       })
       .WillOnce([this](auto context, auto const&,
-                       google::bigtable::v2::MutateRowsRequest const&) {
+                       google::bigtable::v2::MutateRowsRequest const&,
+                       auto const&) {
         // Verify that the next request includes the bigtable cookie from above.
         auto headers = metadata_fixture_.GetMetadata(*context);
         EXPECT_THAT(headers,

--- a/google/cloud/bigtable/internal/connection_refresh_state.cc
+++ b/google/cloud/bigtable/internal/connection_refresh_state.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 
 #include "google/cloud/bigtable/internal/connection_refresh_state.h"
+#include "google/cloud/bigtable/internal/operation_context.h"
 #include "google/cloud/log.h"
 #include <chrono>
 
@@ -136,8 +137,9 @@ void ScheduleStubRefresh(
             // AsyncWaitConnectionReady.
             client_context->set_deadline(std::chrono::system_clock::now() +
                                          kConnectionReadyTimeout);
+            auto op_ctx = std::make_shared<OperationContext>();
             stub->AsyncPingAndWarm(cq, client_context, std::move(options),
-                                   request)
+                                   request, std::move(op_ctx))
                 .then(
                     [weak_stub, weak_cq_impl, state, instance_name,
                      connection_status_fn = std::move(connection_status_fn)](

--- a/google/cloud/bigtable/internal/connection_refresh_state_test.cc
+++ b/google/cloud/bigtable/internal/connection_refresh_state_test.cc
@@ -155,7 +155,8 @@ TEST_F(ScheduleStubRefreshTest, RefreshedUsingAsyncPingAndWarm) {
       .WillRepeatedly(
           [&](CompletionQueue&, std::shared_ptr<grpc::ClientContext> const&,
               internal::ImmutableOptions const&,
-              google::bigtable::v2::PingAndWarmRequest const& request)
+              google::bigtable::v2::PingAndWarmRequest const& request,
+              auto const&)
               -> future<StatusOr<google::bigtable::v2::PingAndWarmResponse>> {
             EXPECT_THAT(request.name(), Eq(instance_name));
             return p2.get_future();

--- a/google/cloud/bigtable/internal/data_connection_impl.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl.cc
@@ -268,7 +268,7 @@ Status DataConnectionImpl::Apply(std::string const& table_name,
           grpc::ClientContext& context, Options const& options,
           google::bigtable::v2::MutateRowRequest const& request) {
         operation_context->PreCall(context);
-        auto s = stub->MutateRow(context, options, request);
+        auto s = stub->MutateRow(context, options, request, *operation_context);
         operation_context->PostCall(context, s.status());
         return s;
       },
@@ -311,7 +311,7 @@ future<Status> DataConnectionImpl::AsyncApply(std::string const& table_name,
                  google::bigtable::v2::MutateRowRequest const& request) {
                operation_context->PreCall(*context);
                auto f = stub->AsyncMutateRow(cq, context, std::move(options),
-                                             request);
+                                             request, operation_context);
                return f.then(
                    [operation_context, context = std::move(context)](auto f) {
                      auto s = f.get();
@@ -446,7 +446,8 @@ StatusOr<bigtable::MutationBranch> DataConnectionImpl::CheckAndMutateRow(
           grpc::ClientContext& context, Options const& options,
           google::bigtable::v2::CheckAndMutateRowRequest const& request) {
         operation_context->PreCall(context);
-        auto s = stub->CheckAndMutateRow(context, options, request);
+        auto s = stub->CheckAndMutateRow(context, options, request,
+                                         *operation_context);
         operation_context->PostCall(context, s.status());
         return s;
       },
@@ -496,7 +497,7 @@ DataConnectionImpl::AsyncCheckAndMutateRow(
                      request) {
                operation_context->PreCall(*context);
                auto f = stub->AsyncCheckAndMutateRow(
-                   cq, context, std::move(options), request);
+                   cq, context, std::move(options), request, operation_context);
                return f.then(
                    [operation_context, context = std::move(context)](auto f) {
                      auto s = f.get();
@@ -536,7 +537,8 @@ StatusOr<std::vector<bigtable::RowKeySample>> DataConnectionImpl::SampleRows(
     auto context = std::make_shared<grpc::ClientContext>();
     internal::ConfigureContext(*context, internal::CurrentOptions());
     operation_context->PreCall(*context);
-    auto stream = stub->SampleRowKeys(context, Options{}, request);
+    auto stream =
+        stub->SampleRowKeys(context, Options{}, request, operation_context);
 
     std::optional<Status> status;
     while (true) {
@@ -598,7 +600,8 @@ StatusOr<bigtable::Row> DataConnectionImpl::ReadModifyWriteRow(
           grpc::ClientContext& context, Options const& options,
           google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
         operation_context->PreCall(context);
-        auto result = stub->ReadModifyWriteRow(context, options, request);
+        auto result = stub->ReadModifyWriteRow(context, options, request,
+                                               *operation_context);
         operation_context->PostCall(context, result.status());
         return result;
       },
@@ -628,7 +631,7 @@ future<StatusOr<bigtable::Row>> DataConnectionImpl::AsyncReadModifyWriteRow(
                      request) {
                operation_context->PreCall(*context);
                auto f = stub->AsyncReadModifyWriteRow(
-                   cq, context, std::move(options), request);
+                   cq, context, std::move(options), request, operation_context);
                return f.then(
                    [operation_context, context = std::move(context)](auto f) {
                      auto s = f.get();
@@ -761,7 +764,8 @@ StatusOr<bigtable::PreparedQuery> DataConnectionImpl::PrepareQuery(
           grpc::ClientContext& context, Options const& options,
           google::bigtable::v2::PrepareQueryRequest const& request) {
         operation_context->PreCall(context);
-        auto const& result = stub->PrepareQuery(context, options, request);
+        auto const& result =
+            stub->PrepareQuery(context, options, request, *operation_context);
         operation_context->PostCall(context, result.status());
         return result;
       },
@@ -800,8 +804,9 @@ StatusOr<bigtable::PreparedQuery> DataConnectionImpl::PrepareQuery(
                    google::cloud::internal::ImmutableOptions options,
                    google::bigtable::v2::PrepareQueryRequest const& request) {
                  operation_context->PreCall(*context);
-                 auto f = stub->AsyncPrepareQuery(cq, context,
-                                                  std::move(options), request);
+                 auto f =
+                     stub->AsyncPrepareQuery(cq, context, std::move(options),
+                                             request, operation_context);
                  return f.then(
                      [operation_context, context = std::move(context)](auto f) {
                        auto s = f.get();
@@ -851,7 +856,7 @@ future<StatusOr<bigtable::PreparedQuery>> DataConnectionImpl::AsyncPrepareQuery(
                  google::bigtable::v2::PrepareQueryRequest const& request) {
                operation_context->PreCall(*context);
                auto f = stub->AsyncPrepareQuery(cq, context, std::move(options),
-                                                request);
+                                                request, operation_context);
                return f.then(
                    [operation_context, context = std::move(context)](auto f) {
                      auto s = f.get();
@@ -902,7 +907,8 @@ future<StatusOr<bigtable::PreparedQuery>> DataConnectionImpl::AsyncPrepareQuery(
                              request) {
                        operation_context->PreCall(*context);
                        auto f = stub->AsyncPrepareQuery(
-                           cq, context, std::move(options), request);
+                           cq, context, std::move(options), request,
+                           operation_context);
                        return f.then([operation_context,
                                       context = std::move(context)](auto f) {
                          auto s = f.get();
@@ -1085,7 +1091,8 @@ bigtable::RowStream DataConnectionImpl::ExecuteQuery(
           auto const& options = internal::CurrentOptions();
           internal::ConfigureContext(*context, options);
           operation_context->PreCall(*context);
-          auto stream = stub->ExecuteQuery(context, options, request);
+          auto stream =
+              stub->ExecuteQuery(context, options, request, operation_context);
           std::unique_ptr<PartialResultSetReader> reader =
               std::make_unique<DefaultPartialResultSetReader>(
                   std::move(context), operation_context, std::move(stream));

--- a/google/cloud/bigtable/internal/data_connection_impl_test.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl_test.cc
@@ -510,7 +510,7 @@ TEST_F(DataConnectionTest, ApplySuccess) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRow)
       .WillOnce([](grpc::ClientContext&, Options const&,
-                   v2::MutateRowRequest const& request) {
+                   v2::MutateRowRequest const& request, auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ("row", request.row_key());
@@ -542,7 +542,7 @@ TEST_F(DataConnectionTest, ApplyPermanentFailure) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRow)
       .WillOnce([](grpc::ClientContext&, Options const&,
-                   v2::MutateRowRequest const& request) {
+                   v2::MutateRowRequest const& request, auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ("row", request.row_key());
@@ -574,14 +574,14 @@ TEST_F(DataConnectionTest, ApplyRetryThenSuccess) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRow)
       .WillOnce([](grpc::ClientContext&, Options const&,
-                   v2::MutateRowRequest const& request) {
+                   v2::MutateRowRequest const& request, auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ("row", request.row_key());
         return TransientError();
       })
       .WillOnce([](grpc::ClientContext&, Options const&,
-                   v2::MutateRowRequest const& request) {
+                   v2::MutateRowRequest const& request, auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ("row", request.row_key());
@@ -614,7 +614,7 @@ TEST_F(DataConnectionTest, ApplyRetryExhausted) {
   EXPECT_CALL(*mock, MutateRow)
       .Times(kNumRetries + 1)
       .WillRepeatedly([](grpc::ClientContext&, Options const&,
-                         v2::MutateRowRequest const& request) {
+                         v2::MutateRowRequest const& request, auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ("row", request.row_key());
@@ -639,7 +639,7 @@ TEST_F(DataConnectionTest, ApplyRetryIdempotency) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRow)
       .WillOnce([](grpc::ClientContext&, Options const&,
-                   v2::MutateRowRequest const& request) {
+                   v2::MutateRowRequest const& request, auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ("row", request.row_key());
@@ -680,14 +680,14 @@ TEST_F(DataConnectionTest, ApplyBigtableCookie) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRow)
       .WillOnce([this](grpc::ClientContext& context, Options const&,
-                       v2::MutateRowRequest const&) {
+                       v2::MutateRowRequest const&, auto const&) {
         // Return a bigtable cookie in the first request.
         metadata_fixture_.SetServerMetadata(
             context, {{}, {{"x-goog-cbt-cookie-routing", "routing"}}});
         return TransientError();
       })
       .WillOnce([this](grpc::ClientContext& context, Options const&,
-                       v2::MutateRowRequest const&) {
+                       v2::MutateRowRequest const&, auto const&) {
         // Verify that the next request includes the bigtable cookie from
         // above.
         auto headers = metadata_fixture_.GetMetadata(context);
@@ -730,7 +730,7 @@ TEST_F(DataConnectionTest, AsyncApplySuccess) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRow)
       .WillOnce([](google::cloud::CompletionQueue&, auto, auto,
-                   v2::MutateRowRequest const& request) {
+                   v2::MutateRowRequest const& request, auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ("row", request.row_key());
@@ -747,7 +747,7 @@ TEST_F(DataConnectionTest, AsyncApplyPermanentFailure) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRow)
       .WillOnce([](google::cloud::CompletionQueue&, auto, auto,
-                   v2::MutateRowRequest const& request) {
+                   v2::MutateRowRequest const& request, auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ("row", request.row_key());
@@ -781,7 +781,7 @@ TEST_F(DataConnectionTest, AsyncApplyRetryExhausted) {
   EXPECT_CALL(*mock, AsyncMutateRow)
       .Times(kNumRetries + 1)
       .WillRepeatedly([](google::cloud::CompletionQueue&, auto, auto,
-                         v2::MutateRowRequest const& request) {
+                         v2::MutateRowRequest const& request, auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ("row", request.row_key());
@@ -807,7 +807,7 @@ TEST_F(DataConnectionTest, AsyncApplyRetryIdempotency) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncMutateRow)
       .WillOnce([](google::cloud::CompletionQueue&, auto, auto,
-                   v2::MutateRowRequest const& request) {
+                   v2::MutateRowRequest const& request, auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ("row", request.row_key());
@@ -835,7 +835,7 @@ TEST_F(DataConnectionTest, AsyncApplyBigtableCookie) {
   EXPECT_CALL(*mock, AsyncMutateRow)
       .WillOnce([this](CompletionQueue&,
                        std::shared_ptr<grpc::ClientContext> const& context,
-                       auto, v2::MutateRowRequest const&) {
+                       auto, v2::MutateRowRequest const&, auto const&) {
         // Return a bigtable cookie in the first request.
         metadata_fixture_.SetServerMetadata(
             *context, {{}, {{"x-goog-cbt-cookie-routing", "routing"}}});
@@ -844,7 +844,7 @@ TEST_F(DataConnectionTest, AsyncApplyBigtableCookie) {
       })
       .WillOnce([this](CompletionQueue&,
                        std::shared_ptr<grpc::ClientContext> const& context,
-                       auto, v2::MutateRowRequest const&) {
+                       auto, v2::MutateRowRequest const&, auto const&) {
         // Verify that the next request includes the bigtable cookie from above.
         auto headers = metadata_fixture_.GetMetadata(*context);
         EXPECT_THAT(headers,
@@ -912,7 +912,8 @@ TEST_F(DataConnectionTest, BulkApplySuccess) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRows)
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
+                   google::bigtable::v2::MutateRowsRequest const& request,
+                   auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_THAT(request.entries(), ElementsAre(Entry("r0"), Entry("r1")));
@@ -960,7 +961,8 @@ TEST_F(DataConnectionTest, BulkApplyRetryMutationPolicy) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRows)
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
+                   google::bigtable::v2::MutateRowsRequest const& request,
+                   auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         auto stream = std::make_unique<MockMutateRowsStream>();
@@ -977,7 +979,8 @@ TEST_F(DataConnectionTest, BulkApplyRetryMutationPolicy) {
         return stream;
       })
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
+                   google::bigtable::v2::MutateRowsRequest const& request,
+                   auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_THAT(request.entries(),
@@ -1020,7 +1023,8 @@ TEST_F(DataConnectionTest, BulkApplyIncompleteStreamRetried) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRows)
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
+                   google::bigtable::v2::MutateRowsRequest const& request,
+                   auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         auto stream = std::make_unique<MockMutateRowsStream>();
@@ -1033,7 +1037,8 @@ TEST_F(DataConnectionTest, BulkApplyIncompleteStreamRetried) {
         return stream;
       })
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
+                   google::bigtable::v2::MutateRowsRequest const& request,
+                   auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_THAT(request.entries(), ElementsAre(Entry("forgotten")));
@@ -1074,15 +1079,15 @@ TEST_F(DataConnectionTest, BulkApplyStreamRetryExhausted) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRows)
       .Times(kNumRetries + 1)
-      .WillRepeatedly(
-          [](auto, auto const&,
-             google::bigtable::v2::MutateRowsRequest const& request) {
-            EXPECT_EQ(kAppProfile, request.app_profile_id());
-            EXPECT_EQ(kTableName, request.table_name());
-            auto stream = std::make_unique<MockMutateRowsStream>();
-            EXPECT_CALL(*stream, Read).WillOnce(Return(TransientError()));
-            return stream;
-          });
+      .WillRepeatedly([](auto, auto const&,
+                         google::bigtable::v2::MutateRowsRequest const& request,
+                         auto const&) {
+        EXPECT_EQ(kAppProfile, request.app_profile_id());
+        EXPECT_EQ(kTableName, request.table_name());
+        auto stream = std::make_unique<MockMutateRowsStream>();
+        EXPECT_CALL(*stream, Read).WillOnce(Return(TransientError()));
+        return stream;
+      });
 
   auto mock_b = std::make_unique<MockBackoffPolicy>();
   EXPECT_CALL(*mock_b, clone).WillOnce([]() {
@@ -1120,7 +1125,8 @@ TEST_F(DataConnectionTest, BulkApplyStreamPermanentError) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRows)
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
+                   google::bigtable::v2::MutateRowsRequest const& request,
+                   auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         auto stream = std::make_unique<MockMutateRowsStream>();
@@ -1141,7 +1147,8 @@ TEST_F(DataConnectionTest, BulkApplyNoSleepIfNoPendingMutations) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRows)
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::MutateRowsRequest const& request) {
+                   google::bigtable::v2::MutateRowsRequest const& request,
+                   auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         auto stream = std::make_unique<MockMutateRowsStream>();
@@ -1173,23 +1180,22 @@ TEST_F(DataConnectionTest, BulkApplyRetriesOkStreamWithFailedMutations) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRows)
       .Times(kNumRetries + 1)
-      .WillRepeatedly(
-          [](auto, auto const&,
-             google::bigtable::v2::MutateRowsRequest const& request) {
-            EXPECT_EQ(kAppProfile, request.app_profile_id());
-            EXPECT_EQ(kTableName, request.table_name());
-            auto stream = std::make_unique<MockMutateRowsStream>();
-            // The overall stream succeeds, but it contains failed mutations.
-            // Our retry and backoff policies should take effect.
-            EXPECT_CALL(*stream, Read)
-                .WillOnce([](google::bigtable::v2::MutateRowsResponse* r) {
-                  *r = MakeBulkApplyResponse(
-                      {{0, grpc::StatusCode::UNAVAILABLE}});
-                  return std::nullopt;
-                })
-                .WillOnce(Return(Status()));
-            return stream;
-          });
+      .WillRepeatedly([](auto, auto const&,
+                         google::bigtable::v2::MutateRowsRequest const& request,
+                         auto const&) {
+        EXPECT_EQ(kAppProfile, request.app_profile_id());
+        EXPECT_EQ(kTableName, request.table_name());
+        auto stream = std::make_unique<MockMutateRowsStream>();
+        // The overall stream succeeds, but it contains failed mutations.
+        // Our retry and backoff policies should take effect.
+        EXPECT_CALL(*stream, Read)
+            .WillOnce([](google::bigtable::v2::MutateRowsResponse* r) {
+              *r = MakeBulkApplyResponse({{0, grpc::StatusCode::UNAVAILABLE}});
+              return std::nullopt;
+            })
+            .WillOnce(Return(Status()));
+        return stream;
+      });
 
   auto mock_b = std::make_unique<MockBackoffPolicy>();
   EXPECT_CALL(*mock_b, clone).WillOnce([]() {
@@ -1210,23 +1216,25 @@ TEST_F(DataConnectionTest, BulkApplyRetryInfoHeeded) {
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRows)
-      .WillOnce([](auto, auto const&, v2::MutateRowsRequest const&) {
-        auto status = PermanentError();
-        internal::SetRetryInfo(status, internal::RetryInfo{ms(0)});
-        auto stream = std::make_unique<MockMutateRowsStream>();
-        EXPECT_CALL(*stream, Read).WillOnce(Return(status));
-        return stream;
-      })
-      .WillOnce([](auto, auto const&, v2::MutateRowsRequest const&) {
-        auto stream = std::make_unique<MockMutateRowsStream>();
-        EXPECT_CALL(*stream, Read)
-            .WillOnce([](google::bigtable::v2::MutateRowsResponse* r) {
-              *r = MakeBulkApplyResponse({{0, grpc::StatusCode::OK}});
-              return std::nullopt;
-            })
-            .WillOnce(Return(Status()));
-        return stream;
-      });
+      .WillOnce(
+          [](auto, auto const&, v2::MutateRowsRequest const&, auto const&) {
+            auto status = PermanentError();
+            internal::SetRetryInfo(status, internal::RetryInfo{ms(0)});
+            auto stream = std::make_unique<MockMutateRowsStream>();
+            EXPECT_CALL(*stream, Read).WillOnce(Return(status));
+            return stream;
+          })
+      .WillOnce(
+          [](auto, auto const&, v2::MutateRowsRequest const&, auto const&) {
+            auto stream = std::make_unique<MockMutateRowsStream>();
+            EXPECT_CALL(*stream, Read)
+                .WillOnce([](google::bigtable::v2::MutateRowsResponse* r) {
+                  *r = MakeBulkApplyResponse({{0, grpc::StatusCode::OK}});
+                  return std::nullopt;
+                })
+                .WillOnce(Return(Status()));
+            return stream;
+          });
 
   auto conn = TestConnection(std::move(mock));
   internal::OptionsSpan span(
@@ -1241,13 +1249,14 @@ TEST_F(DataConnectionTest, BulkApplyRetryInfoIgnored) {
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRows)
-      .WillOnce([](auto, auto const&, v2::MutateRowsRequest const&) {
-        auto status = PermanentError();
-        internal::SetRetryInfo(status, internal::RetryInfo{ms(0)});
-        auto stream = std::make_unique<MockMutateRowsStream>();
-        EXPECT_CALL(*stream, Read).WillOnce(Return(status));
-        return stream;
-      });
+      .WillOnce(
+          [](auto, auto const&, v2::MutateRowsRequest const&, auto const&) {
+            auto status = PermanentError();
+            internal::SetRetryInfo(status, internal::RetryInfo{ms(0)});
+            auto stream = std::make_unique<MockMutateRowsStream>();
+            EXPECT_CALL(*stream, Read).WillOnce(Return(status));
+            return stream;
+          });
 
   auto conn = TestConnection(std::move(mock));
   internal::OptionsSpan span(
@@ -1292,7 +1301,7 @@ TEST_F(DataConnectionTest, AsyncBulkApply) {
         .WillOnce(Return(ByMove(make_ready_future())));
     EXPECT_CALL(*mock_stub, AsyncMutateRows)
         .WillOnce([](CompletionQueue const&, auto, auto,
-                     v2::MutateRowsRequest const& request) {
+                     v2::MutateRowsRequest const& request, auto const&) {
           EXPECT_EQ(kAppProfile, request.app_profile_id());
           EXPECT_EQ(kTableName, request.table_name());
           using ErrorStream =
@@ -1313,7 +1322,8 @@ TEST_F(DataConnectionTest, ReadRows) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ(42, request.rows_limit());
@@ -1336,7 +1346,8 @@ TEST_F(DataConnectionTest, ReadRowsReverseScan) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_TRUE(request.reversed());
 
         auto stream = std::make_unique<MockReadRowsStream>();
@@ -1356,7 +1367,8 @@ TEST_F(DataConnectionTest, ReadRowsFull) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ(42, request.rows_limit());
@@ -1379,20 +1391,20 @@ TEST_F(DataConnectionTest, ReadRowsFull) {
 TEST_F(DataConnectionTest, ReadRowsRetryInfoHeeded) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
-      .WillOnce(
-          [](auto, auto const&, google::bigtable::v2::ReadRowsRequest const&) {
-            auto status = PermanentError();
-            internal::SetRetryInfo(status, internal::RetryInfo{ms(0)});
-            auto stream = std::make_unique<MockReadRowsStream>();
-            EXPECT_CALL(*stream, Read).WillOnce(Return(status));
-            return stream;
-          })
-      .WillOnce(
-          [](auto, auto const&, google::bigtable::v2::ReadRowsRequest const&) {
-            auto stream = std::make_unique<MockReadRowsStream>();
-            EXPECT_CALL(*stream, Read).WillOnce(Return(Status()));
-            return stream;
-          });
+      .WillOnce([](auto, auto const&,
+                   google::bigtable::v2::ReadRowsRequest const&, auto const&) {
+        auto status = PermanentError();
+        internal::SetRetryInfo(status, internal::RetryInfo{ms(0)});
+        auto stream = std::make_unique<MockReadRowsStream>();
+        EXPECT_CALL(*stream, Read).WillOnce(Return(status));
+        return stream;
+      })
+      .WillOnce([](auto, auto const&,
+                   google::bigtable::v2::ReadRowsRequest const&, auto const&) {
+        auto stream = std::make_unique<MockReadRowsStream>();
+        EXPECT_CALL(*stream, Read).WillOnce(Return(Status()));
+        return stream;
+      });
 
   auto conn = TestConnection(std::move(mock));
   internal::OptionsSpan span(
@@ -1405,14 +1417,14 @@ TEST_F(DataConnectionTest, ReadRowsRetryInfoHeeded) {
 TEST_F(DataConnectionTest, ReadRowsRetryInfoIgnored) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
-      .WillOnce(
-          [](auto, auto const&, google::bigtable::v2::ReadRowsRequest const&) {
-            auto status = PermanentError();
-            internal::SetRetryInfo(status, internal::RetryInfo{ms(0)});
-            auto stream = std::make_unique<MockReadRowsStream>();
-            EXPECT_CALL(*stream, Read).WillOnce(Return(status));
-            return stream;
-          });
+      .WillOnce([](auto, auto const&,
+                   google::bigtable::v2::ReadRowsRequest const&, auto const&) {
+        auto status = PermanentError();
+        internal::SetRetryInfo(status, internal::RetryInfo{ms(0)});
+        auto stream = std::make_unique<MockReadRowsStream>();
+        EXPECT_CALL(*stream, Read).WillOnce(Return(status));
+        return stream;
+      });
 
   auto conn = TestConnection(std::move(mock));
   internal::OptionsSpan span(
@@ -1443,7 +1455,8 @@ TEST_F(DataConnectionTest, ReadRowEmpty) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ(1, request.rows_limit());
@@ -1481,7 +1494,8 @@ TEST_F(DataConnectionTest, ReadRowSuccess) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ(1, request.rows_limit());
@@ -1531,7 +1545,8 @@ TEST_F(DataConnectionTest, ReadRowFailure) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ(1, request.rows_limit());
@@ -1581,7 +1596,7 @@ TEST_F(DataConnectionTest, CheckAndMutateRowSuccess) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, CheckAndMutateRow)
       .WillOnce([&](grpc::ClientContext&, Options const&,
-                    v2::CheckAndMutateRowRequest const& request) {
+                    v2::CheckAndMutateRowRequest const& request, auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ("row", request.row_key());
@@ -1596,7 +1611,7 @@ TEST_F(DataConnectionTest, CheckAndMutateRowSuccess) {
         return resp;
       })
       .WillOnce([&](grpc::ClientContext&, Options const&,
-                    v2::CheckAndMutateRowRequest const& request) {
+                    v2::CheckAndMutateRowRequest const& request, auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ("row", request.row_key());
@@ -1633,7 +1648,7 @@ TEST_F(DataConnectionTest, CheckAndMutateRowIdempotency) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, CheckAndMutateRow)
       .WillOnce([&](grpc::ClientContext&, Options const&,
-                    v2::CheckAndMutateRowRequest const& request) {
+                    v2::CheckAndMutateRowRequest const& request, auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ("row", request.row_key());
@@ -1686,7 +1701,7 @@ TEST_F(DataConnectionTest, CheckAndMutateRowPermanentError) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, CheckAndMutateRow)
       .WillOnce([&](grpc::ClientContext&, Options const&,
-                    v2::CheckAndMutateRowRequest const& request) {
+                    v2::CheckAndMutateRowRequest const& request, auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ("row", request.row_key());
@@ -1730,7 +1745,8 @@ TEST_F(DataConnectionTest, CheckAndMutateRowRetryExhausted) {
   EXPECT_CALL(*mock, CheckAndMutateRow)
       .Times(kNumRetries + 1)
       .WillRepeatedly([&](grpc::ClientContext&, Options const&,
-                          v2::CheckAndMutateRowRequest const& request) {
+                          v2::CheckAndMutateRowRequest const& request,
+                          auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ("row", request.row_key());
@@ -1769,14 +1785,14 @@ TEST_F(DataConnectionTest, CheckAndMutateRowBigtableCookie) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, CheckAndMutateRow)
       .WillOnce([this](grpc::ClientContext& context, Options const&,
-                       v2::CheckAndMutateRowRequest const&) {
+                       v2::CheckAndMutateRowRequest const&, auto const&) {
         // Return a bigtable cookie in the first request.
         metadata_fixture_.SetServerMetadata(
             context, {{}, {{"x-goog-cbt-cookie-routing", "routing"}}});
         return TransientError();
       })
       .WillOnce([this](grpc::ClientContext& context, Options const&,
-                       v2::CheckAndMutateRowRequest const&) {
+                       v2::CheckAndMutateRowRequest const&, auto const&) {
         // Verify that the next request includes the bigtable cookie from above.
         auto headers = metadata_fixture_.GetMetadata(context);
         EXPECT_THAT(headers,
@@ -1835,7 +1851,7 @@ TEST_F(DataConnectionTest, AsyncCheckAndMutateRowSuccess) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncCheckAndMutateRow)
       .WillOnce([&](google::cloud::CompletionQueue&, auto, auto,
-                    v2::CheckAndMutateRowRequest const& request) {
+                    v2::CheckAndMutateRowRequest const& request, auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ("row", request.row_key());
@@ -1850,7 +1866,7 @@ TEST_F(DataConnectionTest, AsyncCheckAndMutateRowSuccess) {
         return make_ready_future(make_status_or(resp));
       })
       .WillOnce([&](google::cloud::CompletionQueue&, auto, auto,
-                    v2::CheckAndMutateRowRequest const& request) {
+                    v2::CheckAndMutateRowRequest const& request, auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ("row", request.row_key());
@@ -1889,7 +1905,7 @@ TEST_F(DataConnectionTest, AsyncCheckAndMutateRowIdempotency) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncCheckAndMutateRow)
       .WillOnce([&](google::cloud::CompletionQueue&, auto, auto,
-                    v2::CheckAndMutateRowRequest const& request) {
+                    v2::CheckAndMutateRowRequest const& request, auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ("row", request.row_key());
@@ -1943,7 +1959,7 @@ TEST_F(DataConnectionTest, AsyncCheckAndMutateRowPermanentError) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncCheckAndMutateRow)
       .WillOnce([&](google::cloud::CompletionQueue&, auto, auto,
-                    v2::CheckAndMutateRowRequest const& request) {
+                    v2::CheckAndMutateRowRequest const& request, auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ("row", request.row_key());
@@ -1988,7 +2004,8 @@ TEST_F(DataConnectionTest, AsyncCheckAndMutateRowRetryExhausted) {
   EXPECT_CALL(*mock, AsyncCheckAndMutateRow)
       .Times(kNumRetries + 1)
       .WillRepeatedly([&](google::cloud::CompletionQueue&, auto, auto,
-                          v2::CheckAndMutateRowRequest const& request) {
+                          v2::CheckAndMutateRowRequest const& request,
+                          auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ("row", request.row_key());
@@ -2029,7 +2046,7 @@ TEST_F(DataConnectionTest, AsyncCheckAndMutateRowBigtableCookie) {
   EXPECT_CALL(*mock, AsyncCheckAndMutateRow)
       .WillOnce([this](CompletionQueue&,
                        std::shared_ptr<grpc::ClientContext> const& context,
-                       auto, v2::CheckAndMutateRowRequest const&) {
+                       auto, v2::CheckAndMutateRowRequest const&, auto const&) {
         // Return a bigtable cookie in the first request.
         metadata_fixture_.SetServerMetadata(
             *context, {{}, {{"x-goog-cbt-cookie-routing", "routing"}}});
@@ -2038,7 +2055,7 @@ TEST_F(DataConnectionTest, AsyncCheckAndMutateRowBigtableCookie) {
       })
       .WillOnce([this](CompletionQueue&,
                        std::shared_ptr<grpc::ClientContext> const& context,
-                       auto, v2::CheckAndMutateRowRequest const&) {
+                       auto, v2::CheckAndMutateRowRequest const&, auto const&) {
         // Verify that the next request includes the bigtable cookie from above.
         auto headers = metadata_fixture_.GetMetadata(*context);
         EXPECT_THAT(headers,
@@ -2084,7 +2101,7 @@ TEST_F(DataConnectionTest, SampleRowsSuccess) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, SampleRowKeys)
       .WillOnce([this](auto client_context, auto const&,
-                       v2::SampleRowKeysRequest const& request) {
+                       v2::SampleRowKeysRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -2133,7 +2150,8 @@ TEST_F(DataConnectionTest, SampleRowsRetryResetsSamples) {
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, SampleRowKeys)
-      .WillOnce([](auto, auto const&, v2::SampleRowKeysRequest const& request) {
+      .WillOnce([](auto, auto const&, v2::SampleRowKeysRequest const& request,
+                   auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         auto stream = std::make_unique<MockSampleRowKeysStream>();
@@ -2145,7 +2163,8 @@ TEST_F(DataConnectionTest, SampleRowsRetryResetsSamples) {
             .WillOnce(Return(TransientError()));
         return stream;
       })
-      .WillOnce([](auto, auto const&, v2::SampleRowKeysRequest const& request) {
+      .WillOnce([](auto, auto const&, v2::SampleRowKeysRequest const& request,
+                   auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         auto stream = std::make_unique<MockSampleRowKeysStream>();
@@ -2187,7 +2206,8 @@ TEST_F(DataConnectionTest, SampleRowsRetryExhausted) {
   EXPECT_CALL(*mock, SampleRowKeys)
       .Times(kNumRetries + 1)
       .WillRepeatedly([this](auto context, auto const&,
-                             v2::SampleRowKeysRequest const& request) {
+                             v2::SampleRowKeysRequest const& request,
+                             auto const&) {
         metadata_fixture_.SetServerMetadata(*context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -2233,7 +2253,7 @@ TEST_F(DataConnectionTest, SampleRowsPermanentError) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, SampleRowKeys)
       .WillOnce([this](auto client_context, auto const&,
-                       v2::SampleRowKeysRequest const& request) {
+                       v2::SampleRowKeysRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -2255,26 +2275,26 @@ TEST_F(DataConnectionTest, SampleRowsPermanentError) {
 TEST_F(DataConnectionTest, SampleRowsBigtableCookie) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, SampleRowKeys)
-      .WillOnce(
-          [this](auto context, auto const&, v2::SampleRowKeysRequest const&) {
-            // Return a bigtable cookie in the first request.
-            metadata_fixture_.SetServerMetadata(
-                *context, {{}, {{"x-goog-cbt-cookie-routing", "routing"}}});
-            auto stream = std::make_unique<MockSampleRowKeysStream>();
-            EXPECT_CALL(*stream, Read).WillOnce(Return(TransientError()));
-            return stream;
-          })
-      .WillOnce(
-          [this](auto context, auto const&, v2::SampleRowKeysRequest const&) {
-            // Verify that the next request includes the bigtable cookie from
-            // above.
-            auto headers = metadata_fixture_.GetMetadata(*context);
-            EXPECT_THAT(headers,
-                        Contains(Pair("x-goog-cbt-cookie-routing", "routing")));
-            auto stream = std::make_unique<MockSampleRowKeysStream>();
-            EXPECT_CALL(*stream, Read).WillOnce(Return(PermanentError()));
-            return stream;
-          });
+      .WillOnce([this](auto context, auto const&,
+                       v2::SampleRowKeysRequest const&, auto const&) {
+        // Return a bigtable cookie in the first request.
+        metadata_fixture_.SetServerMetadata(
+            *context, {{}, {{"x-goog-cbt-cookie-routing", "routing"}}});
+        auto stream = std::make_unique<MockSampleRowKeysStream>();
+        EXPECT_CALL(*stream, Read).WillOnce(Return(TransientError()));
+        return stream;
+      })
+      .WillOnce([this](auto context, auto const&,
+                       v2::SampleRowKeysRequest const&, auto const&) {
+        // Verify that the next request includes the bigtable cookie from
+        // above.
+        auto headers = metadata_fixture_.GetMetadata(*context);
+        EXPECT_THAT(headers,
+                    Contains(Pair("x-goog-cbt-cookie-routing", "routing")));
+        auto stream = std::make_unique<MockSampleRowKeysStream>();
+        EXPECT_CALL(*stream, Read).WillOnce(Return(PermanentError()));
+        return stream;
+      });
 
   auto mock_b = std::make_unique<MockBackoffPolicy>();
   EXPECT_CALL(*mock_b, clone).WillOnce([]() {
@@ -2294,18 +2314,20 @@ TEST_F(DataConnectionTest, SampleRowsBigtableCookie) {
 TEST_F(DataConnectionTest, SampleRowsRetryInfoHeeded) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, SampleRowKeys)
-      .WillOnce([](auto, auto const&, v2::SampleRowKeysRequest const&) {
-        auto status = PermanentError();
-        internal::SetRetryInfo(status, internal::RetryInfo{ms(0)});
-        auto stream = std::make_unique<MockSampleRowKeysStream>();
-        EXPECT_CALL(*stream, Read).WillOnce(Return(status));
-        return stream;
-      })
-      .WillOnce([](auto, auto const&, v2::SampleRowKeysRequest const&) {
-        auto stream = std::make_unique<MockSampleRowKeysStream>();
-        EXPECT_CALL(*stream, Read).WillOnce(Return(Status()));
-        return stream;
-      });
+      .WillOnce(
+          [](auto, auto const&, v2::SampleRowKeysRequest const&, auto const&) {
+            auto status = PermanentError();
+            internal::SetRetryInfo(status, internal::RetryInfo{ms(0)});
+            auto stream = std::make_unique<MockSampleRowKeysStream>();
+            EXPECT_CALL(*stream, Read).WillOnce(Return(status));
+            return stream;
+          })
+      .WillOnce(
+          [](auto, auto const&, v2::SampleRowKeysRequest const&, auto const&) {
+            auto stream = std::make_unique<MockSampleRowKeysStream>();
+            EXPECT_CALL(*stream, Read).WillOnce(Return(Status()));
+            return stream;
+          });
 
   auto conn = TestConnection(std::move(mock));
   internal::OptionsSpan span(
@@ -2317,13 +2339,14 @@ TEST_F(DataConnectionTest, SampleRowsRetryInfoHeeded) {
 TEST_F(DataConnectionTest, SampleRowsRetryInfoIgnored) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, SampleRowKeys)
-      .WillOnce([](auto, auto const&, v2::SampleRowKeysRequest const&) {
-        auto status = PermanentError();
-        internal::SetRetryInfo(status, internal::RetryInfo{ms(0)});
-        auto stream = std::make_unique<MockSampleRowKeysStream>();
-        EXPECT_CALL(*stream, Read).WillOnce(Return(status));
-        return stream;
-      });
+      .WillOnce(
+          [](auto, auto const&, v2::SampleRowKeysRequest const&, auto const&) {
+            auto status = PermanentError();
+            internal::SetRetryInfo(status, internal::RetryInfo{ms(0)});
+            auto stream = std::make_unique<MockSampleRowKeysStream>();
+            EXPECT_CALL(*stream, Read).WillOnce(Return(status));
+            return stream;
+          });
 
   auto conn = TestConnection(std::move(mock));
   internal::OptionsSpan span(
@@ -2338,7 +2361,7 @@ TEST_F(DataConnectionTest, AsyncSampleRows) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncSampleRowKeys)
       .WillOnce([](CompletionQueue const&, auto, auto,
-                   v2::SampleRowKeysRequest const& request) {
+                   v2::SampleRowKeysRequest const& request, auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         using ErrorStream =
@@ -2385,7 +2408,8 @@ TEST_F(DataConnectionTest, ReadModifyWriteRowSuccess) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadModifyWriteRow)
       .WillOnce([&response](grpc::ClientContext&, Options const&,
-                            v2::ReadModifyWriteRowRequest const& request) {
+                            v2::ReadModifyWriteRowRequest const& request,
+                            auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ("row", request.row_key());
@@ -2426,7 +2450,7 @@ TEST_F(DataConnectionTest, ReadModifyWriteRowPermanentError) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadModifyWriteRow)
       .WillOnce([](grpc::ClientContext&, Options const&,
-                   v2::ReadModifyWriteRowRequest const& request) {
+                   v2::ReadModifyWriteRowRequest const& request, auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ("row", request.row_key());
@@ -2463,7 +2487,7 @@ TEST_F(DataConnectionTest, ReadModifyWriteRowTransientErrorNotRetried) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadModifyWriteRow)
       .WillOnce([](grpc::ClientContext&, Options const&,
-                   v2::ReadModifyWriteRowRequest const& request) {
+                   v2::ReadModifyWriteRowRequest const& request, auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ("row", request.row_key());
@@ -2523,7 +2547,7 @@ TEST_F(DataConnectionTest, AsyncReadModifyWriteRowSuccess) {
   EXPECT_CALL(*mock, AsyncReadModifyWriteRow)
       .WillOnce([&response, this](
                     google::cloud::CompletionQueue&, auto client_context, auto,
-                    v2::ReadModifyWriteRowRequest const& request) {
+                    v2::ReadModifyWriteRowRequest const& request, auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -2569,7 +2593,8 @@ TEST_F(DataConnectionTest, AsyncReadModifyWriteRowPermanentError) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadModifyWriteRow)
       .WillOnce([this](google::cloud::CompletionQueue&, auto client_context,
-                       auto, v2::ReadModifyWriteRowRequest const& request) {
+                       auto, v2::ReadModifyWriteRowRequest const& request,
+                       auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -2597,7 +2622,8 @@ TEST_F(DataConnectionTest, AsyncReadModifyWriteRowTransientErrorNotRetried) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadModifyWriteRow)
       .WillOnce([this](google::cloud::CompletionQueue&, auto client_context,
-                       auto, v2::ReadModifyWriteRowRequest const& request) {
+                       auto, v2::ReadModifyWriteRowRequest const& request,
+                       auto const&) {
         metadata_fixture_.SetServerMetadata(*client_context, {});
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
@@ -2636,7 +2662,7 @@ TEST_F(DataConnectionTest, AsyncReadRows) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadRows)
       .WillOnce([](CompletionQueue const&, auto, auto,
-                   v2::ReadRowsRequest const& request) {
+                   v2::ReadRowsRequest const& request, auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ(42, request.rows_limit());
@@ -2666,7 +2692,7 @@ TEST_F(DataConnectionTest, AsyncReadRowsReverseScan) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadRows)
       .WillOnce([](CompletionQueue const&, auto, auto,
-                   v2::ReadRowsRequest const& request) {
+                   v2::ReadRowsRequest const& request, auto const&) {
         EXPECT_TRUE(request.reversed());
         using ErrorStream =
             internal::AsyncStreamingReadRpcError<v2::ReadRowsResponse>;
@@ -2707,7 +2733,7 @@ TEST_F(DataConnectionTest, AsyncReadRowEmpty) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadRows)
       .WillOnce([](CompletionQueue const&, auto, auto,
-                   v2::ReadRowsRequest const& request) {
+                   v2::ReadRowsRequest const& request, auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ(1, request.rows_limit());
@@ -2753,7 +2779,7 @@ TEST_F(DataConnectionTest, AsyncReadRowSuccess) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadRows)
       .WillOnce([](CompletionQueue const&, auto, auto,
-                   v2::ReadRowsRequest const& request) {
+                   v2::ReadRowsRequest const& request, auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ(1, request.rows_limit());
@@ -2810,7 +2836,7 @@ TEST_F(DataConnectionTest, AsyncReadRowFailure) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncReadRows)
       .WillOnce([](CompletionQueue const&, auto, auto,
-                   v2::ReadRowsRequest const& request) {
+                   v2::ReadRowsRequest const& request, auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_EQ(1, request.rows_limit());
@@ -2864,7 +2890,7 @@ TEST_F(DataConnectionTest, PrepareQuerySuccess) {
       kResultMetadataText, response.mutable_metadata()));
   EXPECT_CALL(*mock, PrepareQuery)
       .WillOnce([&](grpc::ClientContext&, Options const&,
-                    v2::PrepareQueryRequest const& request) {
+                    v2::PrepareQueryRequest const& request, auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ("projects/the-project/instances/the-instance",
                   request.instance_name());
@@ -2911,9 +2937,9 @@ TEST_F(DataConnectionTest, PrepareQueryPermanentError) {
 #endif
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, PrepareQuery)
-      .WillOnce(
-          [](grpc::ClientContext&, Options const&,
-             v2::PrepareQueryRequest const&) { return PermanentError(); });
+      .WillOnce([](grpc::ClientContext&, Options const&,
+                   v2::PrepareQueryRequest const&,
+                   auto const&) { return PermanentError(); });
 
   auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(CallOptions());
@@ -2957,7 +2983,7 @@ TEST_F(DataConnectionTest, AsyncPrepareQuerySuccess) {
       kResultMetadataText, response.mutable_metadata()));
   EXPECT_CALL(*mock, AsyncPrepareQuery)
       .WillOnce([&](CompletionQueue const&, auto, auto,
-                    v2::PrepareQueryRequest const& request) {
+                    v2::PrepareQueryRequest const& request, auto const&) {
         EXPECT_EQ(kAppProfile, request.app_profile_id());
         EXPECT_EQ("projects/the-project/instances/the-instance",
                   request.instance_name());
@@ -3003,11 +3029,11 @@ TEST_F(DataConnectionTest, AsyncPrepareQueryPermanentError) {
 #endif
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncPrepareQuery)
-      .WillOnce(
-          [](CompletionQueue&, auto, auto, v2::PrepareQueryRequest const&) {
-            return make_ready_future<StatusOr<v2::PrepareQueryResponse>>(
-                PermanentError());
-          });
+      .WillOnce([](CompletionQueue&, auto, auto, v2::PrepareQueryRequest const&,
+                   auto const&) {
+        return make_ready_future<StatusOr<v2::PrepareQueryResponse>>(
+            PermanentError());
+      });
 
   auto conn = TestConnection(std::move(mock), std::move(factory));
   internal::OptionsSpan span(CallOptions());
@@ -3068,19 +3094,22 @@ TEST_F(DataConnectionTest, ExecuteQuerySuccessWithTransientErrors) {
   };
   EXPECT_CALL(*mock, ExecuteQuery)
       .WillOnce([&](auto, auto const&,
-                    google::bigtable::v2::ExecuteQueryRequest const&) {
+                    google::bigtable::v2::ExecuteQueryRequest const&,
+                    auto const&) {
         auto error_stream = std::make_unique<MockExecuteQueryStream>();
         EXPECT_CALL(*error_stream, Read).WillOnce(Return(TransientError()));
         return error_stream;
       })
       .WillOnce([&](auto, auto const&,
-                    google::bigtable::v2::ExecuteQueryRequest const&) {
+                    google::bigtable::v2::ExecuteQueryRequest const&,
+                    auto const&) {
         auto error_stream = std::make_unique<MockExecuteQueryStream>();
         EXPECT_CALL(*error_stream, Read).WillOnce(Return(TransientError()));
         return error_stream;
       })
       .WillOnce([&](auto, auto const&,
-                    google::bigtable::v2::ExecuteQueryRequest const& request) {
+                    google::bigtable::v2::ExecuteQueryRequest const& request,
+                    auto const&) {
         EXPECT_EQ(request.app_profile_id(), kAppProfile);
         EXPECT_EQ(request.instance_name(),
                   "projects/test-project/instances/test-instance");
@@ -3168,7 +3197,7 @@ TEST_F(DataConnectionTest, ExecuteQueryFailure) {
                         std::move(refresh_fn));
 
   EXPECT_CALL(*mock, ExecuteQuery)
-      .WillOnce([&](auto, auto const&, auto const&) {
+      .WillOnce([&](auto, auto const&, auto const&, auto const&) {
         auto stream = std::make_unique<MockExecuteQueryStream>();
         EXPECT_CALL(*stream, Read).WillOnce(Return(PermanentError()));
         return stream;
@@ -3223,7 +3252,7 @@ TEST_F(DataConnectionTest, ExecuteQueryOperationRetryExhausted) {
 
   EXPECT_CALL(*mock, ExecuteQuery)
       .Times(3)
-      .WillRepeatedly([&](auto, auto const&, auto const&) {
+      .WillRepeatedly([&](auto, auto const&, auto const&, auto const&) {
         auto stream = std::make_unique<MockExecuteQueryStream>();
         EXPECT_CALL(*stream, Read).WillOnce(Return(TransientError()));
         return stream;
@@ -3322,14 +3351,16 @@ TEST_F(DataConnectionTest, ExecuteQuerySuccessWithQueryPlanRefresh) {
 
   EXPECT_CALL(*mock, ExecuteQuery)
       .WillOnce([&](auto, auto const&,
-                    google::bigtable::v2::ExecuteQueryRequest const& request) {
+                    google::bigtable::v2::ExecuteQueryRequest const& request,
+                    auto const&) {
         EXPECT_EQ(request.prepared_query(), "test-pq-id-initial");
         auto error_stream = std::make_unique<MockExecuteQueryStream>();
         EXPECT_CALL(*error_stream, Read).WillOnce(Return(QueryPlanError()));
         return error_stream;
       })
       .WillOnce([&](auto, auto const&,
-                    google::bigtable::v2::ExecuteQueryRequest const& request) {
+                    google::bigtable::v2::ExecuteQueryRequest const& request,
+                    auto const&) {
         EXPECT_EQ(request.app_profile_id(), kAppProfile);
         EXPECT_EQ(request.instance_name(),
                   "projects/test-project/instances/test-instance");
@@ -3481,22 +3512,24 @@ TEST_F(DataConnectionTest, PrepareAndExecuteQuerySuccessWithQueryPlanRefresh) {
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, PrepareQuery)
-      .WillOnce(
-          [&](grpc::ClientContext&, Options const&,
-              PrepareQueryRequest const&) { return initial_pq_response; });
+      .WillOnce([&](grpc::ClientContext&, Options const&,
+                    PrepareQueryRequest const&,
+                    auto const&) { return initial_pq_response; });
   EXPECT_CALL(*mock, AsyncPrepareQuery)
       .WillOnce([&](CompletionQueue const&, auto, auto,
-                    v2::PrepareQueryRequest const&) {
+                    v2::PrepareQueryRequest const&, auto const&) {
         return make_ready_future(make_status_or(refresh_pq_response));
       });
   EXPECT_CALL(*mock, ExecuteQuery)
-      .WillOnce([&](auto, auto const&, ExecuteQueryRequest const& request) {
+      .WillOnce([&](auto, auto const&, ExecuteQueryRequest const& request,
+                    auto const&) {
         EXPECT_EQ(request.prepared_query(), "test-pq-id-initial");
         auto error_stream = std::make_unique<MockExecuteQueryStream>();
         EXPECT_CALL(*error_stream, Read).WillOnce(Return(QueryPlanError()));
         return error_stream;
       })
-      .WillOnce([&](auto, auto const&, ExecuteQueryRequest const& request) {
+      .WillOnce([&](auto, auto const&, ExecuteQueryRequest const& request,
+                    auto const&) {
         EXPECT_EQ(request.app_profile_id(), kAppProfile);
         EXPECT_EQ(request.instance_name(),
                   "projects/test-project/instances/test-instance");
@@ -3647,22 +3680,24 @@ TEST_F(DataConnectionTest,
 
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, AsyncPrepareQuery)
-      .WillOnce(
-          [&](CompletionQueue const&, auto, auto, PrepareQueryRequest const&) {
-            return make_ready_future(make_status_or(initial_pq_response));
-          })
-      .WillOnce(
-          [&](CompletionQueue const&, auto, auto, PrepareQueryRequest const&) {
-            return make_ready_future(make_status_or(refresh_pq_response));
-          });
+      .WillOnce([&](CompletionQueue const&, auto, auto,
+                    PrepareQueryRequest const&, auto const&) {
+        return make_ready_future(make_status_or(initial_pq_response));
+      })
+      .WillOnce([&](CompletionQueue const&, auto, auto,
+                    PrepareQueryRequest const&, auto const&) {
+        return make_ready_future(make_status_or(refresh_pq_response));
+      });
   EXPECT_CALL(*mock, ExecuteQuery)
-      .WillOnce([&](auto, auto const&, ExecuteQueryRequest const& request) {
+      .WillOnce([&](auto, auto const&, ExecuteQueryRequest const& request,
+                    auto const&) {
         EXPECT_EQ(request.prepared_query(), "test-pq-id-initial");
         auto error_stream = std::make_unique<MockExecuteQueryStream>();
         EXPECT_CALL(*error_stream, Read).WillOnce(Return(QueryPlanError()));
         return error_stream;
       })
-      .WillOnce([&](auto, auto const&, ExecuteQueryRequest const& request) {
+      .WillOnce([&](auto, auto const&, ExecuteQueryRequest const& request,
+                    auto const&) {
         EXPECT_EQ(request.app_profile_id(), kAppProfile);
         EXPECT_EQ(request.instance_name(),
                   "projects/test-project/instances/test-instance");
@@ -3754,7 +3789,8 @@ TEST_F(DataConnectionTest, ExecuteQueryFailureWithSchemaChange) {
   };
   EXPECT_CALL(*mock, ExecuteQuery)
       .WillOnce([&](auto, auto const&,
-                    google::bigtable::v2::ExecuteQueryRequest const& request) {
+                    google::bigtable::v2::ExecuteQueryRequest const& request,
+                    auto const&) {
         EXPECT_EQ(request.app_profile_id(), kAppProfile);
         EXPECT_EQ(request.instance_name(),
                   "projects/test-project/instances/test-instance");
@@ -3819,7 +3855,8 @@ TEST_F(DataConnectionTest, PrepareQueryFailsOnInvalidType) {
 
   EXPECT_CALL(*mock, PrepareQuery)
       .WillOnce([&](grpc::ClientContext&, Options const&,
-                    v2::PrepareQueryRequest const&) { return pq_response; });
+                    v2::PrepareQueryRequest const&,
+                    auto const&) { return pq_response; });
 
   auto conn = TestConnection(std::move(mock));
   internal::OptionsSpan span(CallOptions());
@@ -3863,7 +3900,7 @@ TEST_F(DataConnectionTest, AsyncPrepareQueryFailsOnInvalidType) {
 
   EXPECT_CALL(*mock, AsyncPrepareQuery)
       .WillOnce([&](CompletionQueue const&, auto, auto,
-                    v2::PrepareQueryRequest const&) {
+                    v2::PrepareQueryRequest const&, auto const&) {
         return make_ready_future(make_status_or(pq_response));
       });
 

--- a/google/cloud/bigtable/internal/default_row_reader.cc
+++ b/google/cloud/bigtable/internal/default_row_reader.cc
@@ -68,7 +68,8 @@ void DefaultRowReader::MakeRequest() {
   internal::ConfigureContext(*client_context_, options);
   operation_context_->PreCall(*client_context_);
   called_post_call_ = false;
-  stream_ = stub_->ReadRows(client_context_, options, request);
+  stream_ =
+      stub_->ReadRows(client_context_, options, request, operation_context_);
   stream_is_open_ = true;
 
   parser_ = bigtable::internal::ReadRowsParserFactory().Create(reverse_);

--- a/google/cloud/bigtable/internal/default_row_reader_test.cc
+++ b/google/cloud/bigtable/internal/default_row_reader_test.cc
@@ -193,7 +193,8 @@ TEST_F(DefaultRowReaderTest, EmptyReaderHasNoRows) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockReadRowsStream>();
         EXPECT_CALL(*stream, Read)
@@ -237,7 +238,8 @@ TEST_F(DefaultRowReaderTest, ReadOneRow) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockReadRowsStream>();
         EXPECT_CALL(*stream, Read)
@@ -284,7 +286,8 @@ TEST_F(DefaultRowReaderTest, StreamIsDrained) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockReadRowsStream>();
         ::testing::InSequence s;
@@ -348,7 +351,8 @@ TEST_F(DefaultRowReaderTest, RetryThenSuccess) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockReadRowsStream>();
         EXPECT_CALL(*stream, Read)
@@ -356,7 +360,8 @@ TEST_F(DefaultRowReaderTest, RetryThenSuccess) {
         return stream;
       })
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockReadRowsStream>();
         EXPECT_CALL(*stream, Read)
@@ -403,7 +408,8 @@ TEST_F(DefaultRowReaderTest, NoRetryOnPermanentError) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockReadRowsStream>();
         EXPECT_CALL(*stream, Read)
@@ -448,7 +454,8 @@ TEST_F(DefaultRowReaderTest, RetryPolicyExhausted) {
   EXPECT_CALL(*mock, ReadRows)
       .Times(kNumRetries + 1)
       .WillRepeatedly([](auto, auto const&,
-                         google::bigtable::v2::ReadRowsRequest const& request) {
+                         google::bigtable::v2::ReadRowsRequest const& request,
+                         auto const&) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockReadRowsStream>();
         EXPECT_CALL(*stream, Read)
@@ -501,7 +508,8 @@ TEST_F(DefaultRowReaderTest, RetrySkipsAlreadyReadRows) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         // We should have two rows in the initial request: "r1" and "r2".
         EXPECT_THAT(request.rows().row_keys(), ElementsAre("r1", "r2"));
@@ -515,7 +523,8 @@ TEST_F(DefaultRowReaderTest, RetrySkipsAlreadyReadRows) {
         return stream;
       })
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         // We have read "r1". The new request should only contain: "r2".
         EXPECT_THAT(request.rows().row_keys(), ElementsAre("r2"));
@@ -559,7 +568,8 @@ TEST_F(DefaultRowReaderTest, RetrySkipsAlreadyScannedRows) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         // We start our call with 3 rows in the set: "r1", "r2", "r3".
         EXPECT_THAT(request.rows().row_keys(), ElementsAre("r1", "r2", "r3"));
@@ -580,7 +590,8 @@ TEST_F(DefaultRowReaderTest, RetrySkipsAlreadyScannedRows) {
         return stream;
       })
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         // We retry the remaining rows. We have "r1" returned, but the service
         // has also told us that "r2" was scanned. This means there is only one
@@ -626,7 +637,8 @@ TEST_F(DefaultRowReaderTest, FailedParseIsRetried) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockReadRowsStream>();
         EXPECT_CALL(*stream, Read)
@@ -637,7 +649,8 @@ TEST_F(DefaultRowReaderTest, FailedParseIsRetried) {
         return stream;
       })
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockReadRowsStream>();
         EXPECT_CALL(*stream, Read)
@@ -689,7 +702,8 @@ TEST_F(DefaultRowReaderTest, FailedParseSkipsAlreadyReadRows) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         // We should have two rows in the initial request: "r1" and "r2".
         EXPECT_THAT(request.rows().row_keys(), ElementsAre("r1", "r2"));
@@ -706,7 +720,8 @@ TEST_F(DefaultRowReaderTest, FailedParseSkipsAlreadyReadRows) {
         return stream;
       })
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         // We have read "r1". The new request should only contain: "r2".
         EXPECT_THAT(request.rows().row_keys(), ElementsAre("r2"));
@@ -755,7 +770,8 @@ TEST_F(DefaultRowReaderTest, FailedParseSkipsAlreadyScannedRows) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         // We start our call with 3 rows in the set: "r1", "r2", "r3".
         EXPECT_THAT(request.rows().row_keys(), ElementsAre("r1", "r2", "r3"));
@@ -779,7 +795,8 @@ TEST_F(DefaultRowReaderTest, FailedParseSkipsAlreadyScannedRows) {
         return stream;
       })
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         // We retry the remaining rows. We have "r1" returned, but the service
         // has also told us that "r2" was scanned. This means there is only one
@@ -830,7 +847,8 @@ TEST_F(DefaultRowReaderTest, FailedParseWithPermanentError) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockReadRowsStream>();
         ::testing::InSequence s;
@@ -880,7 +898,8 @@ TEST_F(DefaultRowReaderTest, NoRetryOnEmptyRowSet) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockReadRowsStream>();
         EXPECT_CALL(*stream, Read)
@@ -928,7 +947,8 @@ TEST_F(DefaultRowReaderTest, RowLimitIsSent) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         EXPECT_THAT(request, RequestWithRowsLimit(42));
         auto stream = std::make_unique<MockReadRowsStream>();
@@ -969,7 +989,8 @@ TEST_F(DefaultRowReaderTest, RowLimitIsDecreasedOnRetry) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         EXPECT_THAT(request, RequestWithRowsLimit(42));
         auto stream = std::make_unique<MockReadRowsStream>();
@@ -982,7 +1003,8 @@ TEST_F(DefaultRowReaderTest, RowLimitIsDecreasedOnRetry) {
         return stream;
       })
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         EXPECT_THAT(request, RequestWithRowsLimit(41));
         auto stream = std::make_unique<MockReadRowsStream>();
@@ -1023,7 +1045,8 @@ TEST_F(DefaultRowReaderTest, NoRetryIfRowLimitReached) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         EXPECT_THAT(request, RequestWithRowsLimit(1));
         auto stream = std::make_unique<MockReadRowsStream>();
@@ -1071,7 +1094,8 @@ TEST_F(DefaultRowReaderTest, CancelDrainsStream) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockReadRowsStream>();
         ::testing::InSequence s;
@@ -1220,7 +1244,8 @@ TEST_F(DefaultRowReaderTest, RetryUsesNewContext) {
   EXPECT_CALL(*mock, ReadRows)
       .Times(kNumRetries + 1)
       .WillRepeatedly([](auto context, auto const&,
-                         google::bigtable::v2::ReadRowsRequest const& request) {
+                         google::bigtable::v2::ReadRowsRequest const& request,
+                         auto const&) {
         // This is a hack. A new request will have the default compression
         // algorithm (GRPC_COMPRESS_NONE). We then change the value in this
         // call. If the context is reused, it will no longer have the default
@@ -1271,7 +1296,8 @@ TEST_F(DefaultRowReaderTest, ReverseScanSuccess) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_TRUE(request.reversed());
         auto stream = std::make_unique<MockReadRowsStream>();
         ::testing::InSequence s;
@@ -1329,7 +1355,8 @@ TEST_F(DefaultRowReaderTest, ReverseScanFailsOnIncreasingRowKeyOrder) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_TRUE(request.reversed());
         auto stream = std::make_unique<MockReadRowsStream>();
         ::testing::InSequence s;
@@ -1387,7 +1414,8 @@ TEST_F(DefaultRowReaderTest, ReverseScanResumption) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_TRUE(request.reversed());
         // We start our call with 3 rows in the set: "r1", "r2", "r3".
         EXPECT_THAT(request.rows().row_keys(), ElementsAre("r1", "r2", "r3"));
@@ -1408,7 +1436,8 @@ TEST_F(DefaultRowReaderTest, ReverseScanResumption) {
         return stream;
       })
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_TRUE(request.reversed());
         // We retry the remaining rows. We have "r3" returned, but the service
         // has also told us that "r2" was scanned. This means there is only one
@@ -1434,7 +1463,8 @@ TEST_F(DefaultRowReaderTest, BigtableCookies) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
       .WillOnce([this](auto context, auto const&,
-                       google::bigtable::v2::ReadRowsRequest const&) {
+                       google::bigtable::v2::ReadRowsRequest const&,
+                       auto const&) {
         // Return a bigtable cookie in the first request.
         metadata_fixture_.SetServerMetadata(
             *context, {{}, {{"x-goog-cbt-cookie-routing", "routing"}}});
@@ -1444,7 +1474,8 @@ TEST_F(DefaultRowReaderTest, BigtableCookies) {
         return stream;
       })
       .WillOnce([this](auto context, auto const&,
-                       google::bigtable::v2::ReadRowsRequest const&) {
+                       google::bigtable::v2::ReadRowsRequest const&,
+                       auto const&) {
         // Verify that the next request includes the bigtable cookie from above.
         auto headers = metadata_fixture_.GetMetadata(*context);
         EXPECT_THAT(headers,
@@ -1490,7 +1521,8 @@ TEST_F(DefaultRowReaderTest, RetryInfoHeeded) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
       .WillOnce([delay](auto, auto const&,
-                        google::bigtable::v2::ReadRowsRequest const&) {
+                        google::bigtable::v2::ReadRowsRequest const&,
+                        auto const&) {
         auto stream = std::make_unique<MockReadRowsStream>();
         EXPECT_CALL(*stream, Read)
             .WillOnce([delay](google::bigtable::v2::ReadRowsResponse*) {
@@ -1501,7 +1533,8 @@ TEST_F(DefaultRowReaderTest, RetryInfoHeeded) {
         return stream;
       })
       .WillOnce([](auto, auto const&,
-                   google::bigtable::v2::ReadRowsRequest const& request) {
+                   google::bigtable::v2::ReadRowsRequest const& request,
+                   auto const&) {
         EXPECT_THAT(request, HasCorrectResourceNames());
         auto stream = std::make_unique<MockReadRowsStream>();
         EXPECT_CALL(*stream, Read)
@@ -1552,7 +1585,8 @@ TEST_F(DefaultRowReaderTest, RetryInfoIgnored) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, ReadRows)
       .WillOnce([delay](auto, auto const&,
-                        google::bigtable::v2::ReadRowsRequest const&) {
+                        google::bigtable::v2::ReadRowsRequest const&,
+                        auto const&) {
         auto stream = std::make_unique<MockReadRowsStream>();
         EXPECT_CALL(*stream, Read)
             .WillOnce([delay](google::bigtable::v2::ReadRowsResponse*) {

--- a/google/cloud/bigtable/internal/dynamic_channel_pool_test.cc
+++ b/google/cloud/bigtable/internal/dynamic_channel_pool_test.cc
@@ -1,3 +1,4 @@
+#include "google/cloud/bigtable/internal/operation_context.h"
 // Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -151,7 +152,8 @@ TEST_F(DynamicChannelPoolTest, SelectLeastUsedFromTwoChannels) {
   auto mock_stub_0 = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock_stub_0, CheckAndMutateRow)
       .WillOnce([](grpc::ClientContext&, Options const&,
-                   google::bigtable::v2::CheckAndMutateRowRequest const&) {
+                   google::bigtable::v2::CheckAndMutateRowRequest const&,
+                   auto&) {
         google::bigtable::v2::CheckAndMutateRowResponse response;
         response.set_predicate_matched(true);
         return response;
@@ -181,8 +183,9 @@ TEST_F(DynamicChannelPoolTest, SelectLeastUsedFromTwoChannels) {
       stub_factory_fn, sizing_policy);
   auto selected_stub = pool->GetChannelRandomTwoLeastUsed();
   grpc::ClientContext context;
+  OperationContext op_ctx;
   auto response =
-      selected_stub->AcquireStub()->CheckAndMutateRow(context, {}, {});
+      selected_stub->AcquireStub()->CheckAndMutateRow(context, {}, {}, op_ctx);
   ASSERT_STATUS_OK(response);
   EXPECT_TRUE(response->predicate_matched());
 
@@ -215,7 +218,8 @@ TEST_F(DynamicChannelPoolTest, OneInitialChannel) {
     auto mock_stub_0 = std::make_shared<MockBigtableStub>();
     EXPECT_CALL(*mock_stub_0, CheckAndMutateRow)
         .WillOnce([](grpc::ClientContext&, Options const&,
-                     google::bigtable::v2::CheckAndMutateRowRequest const&) {
+                     google::bigtable::v2::CheckAndMutateRowRequest const&,
+                     auto&) {
           google::bigtable::v2::CheckAndMutateRowResponse response;
           response.set_predicate_matched(true);
           return response;
@@ -245,8 +249,9 @@ TEST_F(DynamicChannelPoolTest, OneInitialChannel) {
 
     auto selected_stub = pool->GetChannelRandomTwoLeastUsed();
     grpc::ClientContext context;
-    auto response =
-        selected_stub->AcquireStub()->CheckAndMutateRow(context, {}, {});
+    OperationContext op_ctx;
+    auto response = selected_stub->AcquireStub()->CheckAndMutateRow(context, {},
+                                                                    {}, op_ctx);
     ASSERT_STATUS_OK(response);
     EXPECT_TRUE(response->predicate_matched());
   }
@@ -270,7 +275,8 @@ TEST_F(DynamicChannelPoolTest, EmptyInitialPool) {
     auto mock_stub = std::make_shared<MockBigtableStub>();
     EXPECT_CALL(*mock_stub, CheckAndMutateRow)
         .WillOnce([](grpc::ClientContext&, Options const&,
-                     google::bigtable::v2::CheckAndMutateRowRequest const&) {
+                     google::bigtable::v2::CheckAndMutateRowRequest const&,
+                     auto&) {
           google::bigtable::v2::CheckAndMutateRowResponse response;
           response.set_predicate_matched(true);
           return response;
@@ -306,8 +312,9 @@ TEST_F(DynamicChannelPoolTest, EmptyInitialPool) {
 
     auto selected_stub = pool->GetChannelRandomTwoLeastUsed();
     grpc::ClientContext context;
-    auto response =
-        selected_stub->AcquireStub()->CheckAndMutateRow(context, {}, {});
+    OperationContext op_ctx;
+    auto response = selected_stub->AcquireStub()->CheckAndMutateRow(context, {},
+                                                                    {}, op_ctx);
     ASSERT_STATUS_OK(response);
     EXPECT_TRUE(response->predicate_matched());
 
@@ -743,7 +750,8 @@ TEST_F(DynamicChannelPoolTest, HandleBadChannelsTwoChannelsOneBad) {
   auto mock_stub = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock_stub, CheckAndMutateRow)
       .WillOnce([](grpc::ClientContext&, Options const&,
-                   google::bigtable::v2::CheckAndMutateRowRequest const&) {
+                   google::bigtable::v2::CheckAndMutateRowRequest const&,
+                   auto&) {
         google::bigtable::v2::CheckAndMutateRowResponse response;
         response.set_predicate_matched(true);
         return response;
@@ -778,8 +786,9 @@ TEST_F(DynamicChannelPoolTest, HandleBadChannelsTwoChannelsOneBad) {
   EXPECT_THAT(draining_channels, IsEmpty());
 
   grpc::ClientContext context;
+  OperationContext op_ctx;
   auto response =
-      selected_stub->AcquireStub()->CheckAndMutateRow(context, {}, {});
+      selected_stub->AcquireStub()->CheckAndMutateRow(context, {}, {}, op_ctx);
   ASSERT_STATUS_OK(response);
   EXPECT_TRUE(response->predicate_matched());
   EXPECT_THAT(pool->size(), Eq(1));
@@ -822,7 +831,8 @@ TEST_F(DynamicChannelPoolTest, HandleBadChannelsTwoChannelsOtherOneBad) {
   auto mock_stub = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock_stub, CheckAndMutateRow)
       .WillOnce([](grpc::ClientContext&, Options const&,
-                   google::bigtable::v2::CheckAndMutateRowRequest const&) {
+                   google::bigtable::v2::CheckAndMutateRowRequest const&,
+                   auto&) {
         google::bigtable::v2::CheckAndMutateRowResponse response;
         response.set_predicate_matched(true);
         return response;
@@ -859,8 +869,9 @@ TEST_F(DynamicChannelPoolTest, HandleBadChannelsTwoChannelsOtherOneBad) {
   EXPECT_THAT(draining_channels, IsEmpty());
 
   grpc::ClientContext context;
+  OperationContext op_ctx;
   auto response =
-      selected_stub->AcquireStub()->CheckAndMutateRow(context, {}, {});
+      selected_stub->AcquireStub()->CheckAndMutateRow(context, {}, {}, op_ctx);
   ASSERT_STATUS_OK(response);
   EXPECT_TRUE(response->predicate_matched());
   EXPECT_THAT(pool->size(), Eq(1));
@@ -903,7 +914,8 @@ TEST_F(DynamicChannelPoolTest, HandleBadChannelsThreeChannelsOneBad) {
   auto mock_stub_0 = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock_stub_0, CheckAndMutateRow)
       .WillOnce([](grpc::ClientContext&, Options const&,
-                   google::bigtable::v2::CheckAndMutateRowRequest const&) {
+                   google::bigtable::v2::CheckAndMutateRowRequest const&,
+                   auto&) {
         google::bigtable::v2::CheckAndMutateRowResponse response;
         response.set_predicate_matched(true);
         return response;
@@ -946,8 +958,9 @@ TEST_F(DynamicChannelPoolTest, HandleBadChannelsThreeChannelsOneBad) {
   EXPECT_THAT(draining_channels, IsEmpty());
 
   grpc::ClientContext context;
+  OperationContext op_ctx;
   auto response =
-      selected_stub->AcquireStub()->CheckAndMutateRow(context, {}, {});
+      selected_stub->AcquireStub()->CheckAndMutateRow(context, {}, {}, op_ctx);
   ASSERT_STATUS_OK(response);
   EXPECT_TRUE(response->predicate_matched());
   EXPECT_THAT(pool->size(), Eq(2));
@@ -990,7 +1003,8 @@ TEST_F(DynamicChannelPoolTest, HandleBadChannelsAllChannelsBad) {
   auto mock_stub = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock_stub, CheckAndMutateRow)
       .WillOnce([](grpc::ClientContext&, Options const&,
-                   google::bigtable::v2::CheckAndMutateRowRequest const&) {
+                   google::bigtable::v2::CheckAndMutateRowRequest const&,
+                   auto&) {
         google::bigtable::v2::CheckAndMutateRowResponse response;
         response.set_predicate_matched(true);
         return response;
@@ -1043,8 +1057,9 @@ TEST_F(DynamicChannelPoolTest, HandleBadChannelsAllChannelsBad) {
   EXPECT_THAT(draining_channels, IsEmpty());
 
   grpc::ClientContext context;
+  OperationContext op_ctx;
   auto response =
-      selected_stub->AcquireStub()->CheckAndMutateRow(context, {}, {});
+      selected_stub->AcquireStub()->CheckAndMutateRow(context, {}, {}, op_ctx);
   ASSERT_STATUS_OK(response);
   EXPECT_TRUE(response->predicate_matched());
   EXPECT_THAT(pool->size(), Eq(1));

--- a/google/cloud/bigtable/internal/stub_manager_test.cc
+++ b/google/cloud/bigtable/internal/stub_manager_test.cc
@@ -1,3 +1,4 @@
+#include "google/cloud/bigtable/internal/operation_context.h"
 // Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/bigtable/internal/stub_manager.h"
 #include "google/cloud/bigtable/instance_resource.h"
+#include "google/cloud/bigtable/internal/stub_manager.h"
 #include "google/cloud/bigtable/table_resource.h"
 #include "google/cloud/bigtable/testing/mock_bigtable_stub.h"
 #include "google/cloud/testing_util/scoped_log.h"
@@ -41,7 +42,8 @@ TEST(StubManagerTest, NoAffinity) {
   auto mock = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock, MutateRow)
       .WillOnce([&](grpc::ClientContext&, Options const&,
-                    google::bigtable::v2::MutateRowRequest const& request) {
+                    google::bigtable::v2::MutateRowRequest const& request,
+                    auto const&) {
         EXPECT_THAT(request.table_name(), Eq(expected_table_name));
         return google::bigtable::v2::MutateRowResponse{};
       });
@@ -52,7 +54,8 @@ TEST(StubManagerTest, NoAffinity) {
   grpc::ClientContext context;
   google::bigtable::v2::MutateRowRequest request;
   request.set_table_name(expected_table_name);
-  auto result = stub->MutateRow(context, {}, request);
+  OperationContext op_ctx;
+  auto result = stub->MutateRow(context, {}, request, op_ctx);
   EXPECT_THAT(result, IsOk());
 }
 
@@ -65,7 +68,8 @@ TEST(StubManagerTest, AffinityToExistingInstance) {
   EXPECT_CALL(*mock_stub, MutateRow)
       .WillOnce([instance_name = instance.FullName()](
                     grpc::ClientContext&, Options const&,
-                    google::bigtable::v2::MutateRowRequest const& request) {
+                    google::bigtable::v2::MutateRowRequest const& request,
+                    auto const&) {
         EXPECT_THAT(request.table_name(), StartsWith(instance_name));
         return google::bigtable::v2::MutateRowResponse{};
       });
@@ -85,7 +89,8 @@ TEST(StubManagerTest, AffinityToExistingInstance) {
   grpc::ClientContext context;
   google::bigtable::v2::MutateRowRequest request;
   request.set_table_name(expected_table_name);
-  auto result = stub->MutateRow(context, {}, request);
+  OperationContext op_ctx;
+  auto result = stub->MutateRow(context, {}, request, op_ctx);
   EXPECT_THAT(result, IsOk());
 }
 
@@ -105,7 +110,8 @@ TEST(StubManagerTest, AffinityToMissingInstance) {
     EXPECT_CALL(*mock_stub, MutateRow)
         .WillOnce([instance_name = std::string{instance_name}](
                       grpc::ClientContext&, Options const&,
-                      google::bigtable::v2::MutateRowRequest const& request) {
+                      google::bigtable::v2::MutateRowRequest const& request,
+                      auto const&) {
           EXPECT_THAT(request.table_name(), StartsWith(instance_name));
           return google::bigtable::v2::MutateRowResponse{};
         });
@@ -121,7 +127,8 @@ TEST(StubManagerTest, AffinityToMissingInstance) {
   grpc::ClientContext context;
   google::bigtable::v2::MutateRowRequest request;
   request.set_table_name(expected_table_name);
-  auto result = stub->MutateRow(context, {}, request);
+  OperationContext op_ctx;
+  auto result = stub->MutateRow(context, {}, request, op_ctx);
   EXPECT_THAT(result, IsOk());
   EXPECT_THAT(log.ExtractLines(),
               Contains(HasSubstr(

--- a/google/cloud/bigtable/testing/mock_bigtable_stub.h
+++ b/google/cloud/bigtable/testing/mock_bigtable_stub.h
@@ -30,112 +30,63 @@ class MockBigtableStub : public bigtable_internal::BigtableStub {
                   google::bigtable::v2::ReadRowsResponse>>,
               ReadRows,
               (std::shared_ptr<grpc::ClientContext>, Options const&,
-               google::bigtable::v2::ReadRowsRequest const&),
+               google::bigtable::v2::ReadRowsRequest const&,
+               std::shared_ptr<bigtable_internal::OperationContext>),
               (override));
   MOCK_METHOD(std::unique_ptr<google::cloud::internal::StreamingReadRpc<
                   google::bigtable::v2::SampleRowKeysResponse>>,
               SampleRowKeys,
               (std::shared_ptr<grpc::ClientContext>, Options const&,
-               google::bigtable::v2::SampleRowKeysRequest const&),
+               google::bigtable::v2::SampleRowKeysRequest const&,
+               std::shared_ptr<bigtable_internal::OperationContext>),
               (override));
   MOCK_METHOD(StatusOr<google::bigtable::v2::MutateRowResponse>, MutateRow,
               (grpc::ClientContext&, Options const&,
-               google::bigtable::v2::MutateRowRequest const&),
+               google::bigtable::v2::MutateRowRequest const&,
+               bigtable_internal::OperationContext&),
               (override));
   MOCK_METHOD(std::unique_ptr<google::cloud::internal::StreamingReadRpc<
                   google::bigtable::v2::MutateRowsResponse>>,
               MutateRows,
               (std::shared_ptr<grpc::ClientContext>, Options const&,
-               google::bigtable::v2::MutateRowsRequest const&),
+               google::bigtable::v2::MutateRowsRequest const&,
+               std::shared_ptr<bigtable_internal::OperationContext>),
               (override));
   MOCK_METHOD(StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>,
               CheckAndMutateRow,
               (grpc::ClientContext&, Options const&,
-               google::bigtable::v2::CheckAndMutateRowRequest const&),
+               google::bigtable::v2::CheckAndMutateRowRequest const&,
+               bigtable_internal::OperationContext&),
               (override));
   MOCK_METHOD(StatusOr<google::bigtable::v2::PingAndWarmResponse>, PingAndWarm,
               (grpc::ClientContext&, Options const&,
-               google::bigtable::v2::PingAndWarmRequest const&),
+               google::bigtable::v2::PingAndWarmRequest const&,
+               bigtable_internal::OperationContext&),
               (override));
   MOCK_METHOD(StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>,
               ReadModifyWriteRow,
               (grpc::ClientContext&, Options const&,
-               google::bigtable::v2::ReadModifyWriteRowRequest const&),
+               google::bigtable::v2::ReadModifyWriteRowRequest const&,
+               bigtable_internal::OperationContext&),
               (override));
   MOCK_METHOD(StatusOr<google::bigtable::v2::PrepareQueryResponse>,
               PrepareQuery,
               (grpc::ClientContext&, Options const&,
-               google::bigtable::v2::PrepareQueryRequest const&),
+               google::bigtable::v2::PrepareQueryRequest const&,
+               bigtable_internal::OperationContext&),
               (override));
   MOCK_METHOD(std::unique_ptr<google::cloud::internal::StreamingReadRpc<
                   google::bigtable::v2::ExecuteQueryResponse>>,
               ExecuteQuery,
               (std::shared_ptr<grpc::ClientContext>, Options const&,
-               google::bigtable::v2::ExecuteQueryRequest const&),
-              (override));
-  MOCK_METHOD(std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
-                  google::bigtable::v2::ReadRowsResponse>>,
-              AsyncReadRows,
-              (google::cloud::CompletionQueue const&,
-               std::shared_ptr<grpc::ClientContext>,
-               google::cloud::internal::ImmutableOptions,
-               google::bigtable::v2::ReadRowsRequest const&),
-              (override));
-  MOCK_METHOD(std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
-                  google::bigtable::v2::SampleRowKeysResponse>>,
-              AsyncSampleRowKeys,
-              (google::cloud::CompletionQueue const&,
-               std::shared_ptr<grpc::ClientContext>,
-               google::cloud::internal::ImmutableOptions,
-               google::bigtable::v2::SampleRowKeysRequest const&),
-              (override));
-  MOCK_METHOD(future<StatusOr<google::bigtable::v2::MutateRowResponse>>,
-              AsyncMutateRow,
-              (google::cloud::CompletionQueue&,
-               std::shared_ptr<grpc::ClientContext>,
-               google::cloud::internal::ImmutableOptions,
-               google::bigtable::v2::MutateRowRequest const&),
-              (override));
-  MOCK_METHOD(std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
-                  google::bigtable::v2::MutateRowsResponse>>,
-              AsyncMutateRows,
-              (google::cloud::CompletionQueue const&,
-               std::shared_ptr<grpc::ClientContext>,
-               google::cloud::internal::ImmutableOptions,
-               google::bigtable::v2::MutateRowsRequest const&),
-              (override));
-  MOCK_METHOD(future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>,
-              AsyncCheckAndMutateRow,
-              (google::cloud::CompletionQueue&,
-               std::shared_ptr<grpc::ClientContext>,
-               google::cloud::internal::ImmutableOptions,
-               google::bigtable::v2::CheckAndMutateRowRequest const&),
-              (override));
-  MOCK_METHOD(future<StatusOr<google::bigtable::v2::PingAndWarmResponse>>,
-              AsyncPingAndWarm,
-              (google::cloud::CompletionQueue&,
-               std::shared_ptr<grpc::ClientContext>,
-               google::cloud::internal::ImmutableOptions,
-               google::bigtable::v2::PingAndWarmRequest const&),
-              (override));
-  MOCK_METHOD(
-      future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>,
-      AsyncReadModifyWriteRow,
-      (google::cloud::CompletionQueue&, std::shared_ptr<grpc::ClientContext>,
-       google::cloud::internal::ImmutableOptions,
-       google::bigtable::v2::ReadModifyWriteRowRequest const&),
-      (override));
-  MOCK_METHOD(future<StatusOr<google::bigtable::v2::PrepareQueryResponse>>,
-              AsyncPrepareQuery,
-              (google::cloud::CompletionQueue&,
-               std::shared_ptr<grpc::ClientContext>,
-               google::cloud::internal::ImmutableOptions,
-               google::bigtable::v2::PrepareQueryRequest const&),
+               google::bigtable::v2::ExecuteQueryRequest const&,
+               std::shared_ptr<bigtable_internal::OperationContext>),
               (override));
   MOCK_METHOD(StatusOr<google::bigtable::v2::ClientConfiguration>,
               GetClientConfiguration,
               (grpc::ClientContext&, Options const&,
-               google::bigtable::v2::GetClientConfigurationRequest const&),
+               google::bigtable::v2::GetClientConfigurationRequest const&,
+               bigtable_internal::OperationContext&),
               (override));
   MOCK_METHOD((std::unique_ptr<google::cloud::AsyncStreamingReadWriteRpc<
                    google::bigtable::v2::SessionRequest,
@@ -143,7 +94,8 @@ class MockBigtableStub : public bigtable_internal::BigtableStub {
               AsyncOpenTable,
               (google::cloud::CompletionQueue const&,
                std::shared_ptr<grpc::ClientContext>,
-               google::cloud::internal::ImmutableOptions),
+               google::cloud::internal::ImmutableOptions,
+               std::shared_ptr<bigtable_internal::OperationContext>),
               (override));
   MOCK_METHOD((std::unique_ptr<google::cloud::AsyncStreamingReadWriteRpc<
                    google::bigtable::v2::SessionRequest,
@@ -151,7 +103,8 @@ class MockBigtableStub : public bigtable_internal::BigtableStub {
               AsyncOpenAuthorizedView,
               (google::cloud::CompletionQueue const&,
                std::shared_ptr<grpc::ClientContext>,
-               google::cloud::internal::ImmutableOptions),
+               google::cloud::internal::ImmutableOptions,
+               std::shared_ptr<bigtable_internal::OperationContext>),
               (override));
   MOCK_METHOD((std::unique_ptr<google::cloud::AsyncStreamingReadWriteRpc<
                    google::bigtable::v2::SessionRequest,
@@ -159,7 +112,75 @@ class MockBigtableStub : public bigtable_internal::BigtableStub {
               AsyncOpenMaterializedView,
               (google::cloud::CompletionQueue const&,
                std::shared_ptr<grpc::ClientContext>,
-               google::cloud::internal::ImmutableOptions),
+               google::cloud::internal::ImmutableOptions,
+               std::shared_ptr<bigtable_internal::OperationContext>),
+              (override));
+  MOCK_METHOD(std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+                  google::bigtable::v2::ReadRowsResponse>>,
+              AsyncReadRows,
+              (google::cloud::CompletionQueue const&,
+               std::shared_ptr<grpc::ClientContext>,
+               google::cloud::internal::ImmutableOptions,
+               google::bigtable::v2::ReadRowsRequest const&,
+               std::shared_ptr<bigtable_internal::OperationContext>),
+              (override));
+  MOCK_METHOD(std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+                  google::bigtable::v2::SampleRowKeysResponse>>,
+              AsyncSampleRowKeys,
+              (google::cloud::CompletionQueue const&,
+               std::shared_ptr<grpc::ClientContext>,
+               google::cloud::internal::ImmutableOptions,
+               google::bigtable::v2::SampleRowKeysRequest const&,
+               std::shared_ptr<bigtable_internal::OperationContext>),
+              (override));
+  MOCK_METHOD(future<StatusOr<google::bigtable::v2::MutateRowResponse>>,
+              AsyncMutateRow,
+              (google::cloud::CompletionQueue&,
+               std::shared_ptr<grpc::ClientContext>,
+               google::cloud::internal::ImmutableOptions,
+               google::bigtable::v2::MutateRowRequest const&,
+               std::shared_ptr<bigtable_internal::OperationContext>),
+              (override));
+  MOCK_METHOD(std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+                  google::bigtable::v2::MutateRowsResponse>>,
+              AsyncMutateRows,
+              (google::cloud::CompletionQueue const&,
+               std::shared_ptr<grpc::ClientContext>,
+               google::cloud::internal::ImmutableOptions,
+               google::bigtable::v2::MutateRowsRequest const&,
+               std::shared_ptr<bigtable_internal::OperationContext>),
+              (override));
+  MOCK_METHOD(future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>,
+              AsyncCheckAndMutateRow,
+              (google::cloud::CompletionQueue&,
+               std::shared_ptr<grpc::ClientContext>,
+               google::cloud::internal::ImmutableOptions,
+               google::bigtable::v2::CheckAndMutateRowRequest const&,
+               std::shared_ptr<bigtable_internal::OperationContext>),
+              (override));
+  MOCK_METHOD(future<StatusOr<google::bigtable::v2::PingAndWarmResponse>>,
+              AsyncPingAndWarm,
+              (google::cloud::CompletionQueue&,
+               std::shared_ptr<grpc::ClientContext>,
+               google::cloud::internal::ImmutableOptions,
+               google::bigtable::v2::PingAndWarmRequest const&,
+               std::shared_ptr<bigtable_internal::OperationContext>),
+              (override));
+  MOCK_METHOD(
+      future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>,
+      AsyncReadModifyWriteRow,
+      (google::cloud::CompletionQueue&, std::shared_ptr<grpc::ClientContext>,
+       google::cloud::internal::ImmutableOptions,
+       google::bigtable::v2::ReadModifyWriteRowRequest const&,
+       std::shared_ptr<bigtable_internal::OperationContext>),
+      (override));
+  MOCK_METHOD(future<StatusOr<google::bigtable::v2::PrepareQueryResponse>>,
+              AsyncPrepareQuery,
+              (google::cloud::CompletionQueue&,
+               std::shared_ptr<grpc::ClientContext>,
+               google::cloud::internal::ImmutableOptions,
+               google::bigtable::v2::PrepareQueryRequest const&,
+               std::shared_ptr<bigtable_internal::OperationContext>),
               (override));
 };
 


### PR DESCRIPTION
As part of ongoing Bigtable metric collection, some additional metrics require data to be collected in a stub decorator. To enable this, we need to plumb the bigtable_internal::OperationContext object into the decorators via the stub RPC methods. This requires a minor but widespread change to how we emit stubs from the generator. For now, we are going to limit this generator change to the bigtable library where it is needed. In the future, as we expand metric collection, we will factor OperationContext out into a common library and make the generator changes service generic instead of specific to bigtable.

The code changes have been grouped into separate commits for clarity.