### PR TITLE
doc(oauth2): name the constructor parameter these classes actually take

### DIFF
--- a/google/cloud/internal/oauth2_authorized_user_credentials.h
+++ b/google/cloud/internal/oauth2_authorized_user_credentials.h
@@ -71,8 +71,8 @@ class AuthorizedUserCredentials : public Credentials {
   /**
    * Creates an instance of AuthorizedUserCredentials.
    *
-   * @param rest_client a dependency injection point. It makes it possible to
-   *     mock internal REST types. This should generally not be overridden
+   * @param client_factory a dependency injection point. It makes it possible
+   *     to mock internal REST types. This should generally not be overridden
    *     except for testing.
    */
   explicit AuthorizedUserCredentials(AuthorizedUserCredentialsInfo info,

--- a/google/cloud/internal/oauth2_compute_engine_credentials.h
+++ b/google/cloud/internal/oauth2_compute_engine_credentials.h
@@ -83,9 +83,9 @@ class ComputeEngineCredentials : public Credentials {
   /**
    * Creates an instance of ComputeEngineCredentials.
    *
-   * @param rest_client a dependency injection point. It makes it possible to
-   *     mock internal libcurl wrappers. This should generally not be overridden
-   *     except for testing.
+   * @param client_factory a dependency injection point. It makes it possible
+   *     to mock internal libcurl wrappers. This should generally not be
+   *     overridden except for testing.
    */
   explicit ComputeEngineCredentials(std::string service_account_email,
                                     Options options,

--- a/google/cloud/internal/oauth2_impersonate_service_account_credentials.h
+++ b/google/cloud/internal/oauth2_impersonate_service_account_credentials.h
@@ -49,8 +49,9 @@ class ImpersonateServiceAccountCredentials
   /**
    * Creates an instance of ImpersonateServiceAccountCredentials.
    *
-   * @param current_time_fn a dependency injection point to fetch the current
-   *     time. This should generally not be overridden except for testing.
+   * @param client_factory a dependency injection point. It makes it possible
+   *     to mock internal REST types. This should generally not be overridden
+   *     except for testing.
    */
   explicit ImpersonateServiceAccountCredentials(
       google::cloud::internal::ImpersonateServiceAccountConfig const& config,

--- a/google/cloud/internal/oauth2_service_account_credentials.h
+++ b/google/cloud/internal/oauth2_service_account_credentials.h
@@ -252,11 +252,9 @@ class ServiceAccountCredentials : public oauth2_internal::Credentials {
   /**
    * Creates an instance of ServiceAccountCredentials.
    *
-   * @param rest_client a dependency injection point. It makes it possible to
-   *     mock internal REST types. This should generally not be overridden
+   * @param client_factory a dependency injection point. It makes it possible
+   *     to mock internal REST types. This should generally not be overridden
    *     except for testing.
-   * @param current_time_fn a dependency injection point to fetch the current
-   *     time. This should generally not be overridden except for testing.
    */
   explicit ServiceAccountCredentials(ServiceAccountCredentialsInfo info,
                                      Options options,


### PR DESCRIPTION
Four credential constructors document parameters they do not take:

```cpp
/**
 * Creates an instance of AuthorizedUserCredentials.
 *
 * @param rest_client a dependency injection point. It makes it possible to
 *     mock internal REST types. This should generally not be overridden
 *     except for testing.
 */
explicit AuthorizedUserCredentials(AuthorizedUserCredentialsInfo info,
                                   Options options,
                                   HttpClientFactory client_factory);
```

`rest_client` is gone, and so is `current_time_fn` in the other two. The injection point they describe is now `client_factory`, so Doxygen drops the description as belonging to nothing and the parameter that is actually there ends up undocumented.

Same shape in `AuthorizedUserCredentials`, `ComputeEngineCredentials`, `ImpersonateServiceAccountCredentials` and `ServiceAccountCredentials`. Renamed the names, kept the wording each file already used, no behaviour touched.
