### PR TITLE
refactor(bigtable): rename metric Labels types to indicate Table schema

### DIFF
--- a/google/cloud/bigtable/internal/async_bulk_apply_test.cc
+++ b/google/cloud/bigtable/internal/async_bulk_apply_test.cc
@@ -163,7 +163,8 @@ class MockMetric : public Metric {
                ElementDeliveryParams const&),
               (override));
   MOCK_METHOD(std::unique_ptr<Metric>, clone,
-              (ResourceLabels resource_labels, DataLabels data_labels),
+              (TableResourceLabels const& resource_labels,
+               TableDataLabels const& data_labels),
               (const, override));
 };
 
@@ -172,7 +173,8 @@ class CloningMetric : public Metric {
  public:
   explicit CloningMetric(std::unique_ptr<MockMetric> metric)
       : metric_(std::move(metric)) {}
-  std::unique_ptr<Metric> clone(ResourceLabels, DataLabels) const override {
+  std::unique_ptr<Metric> clone(TableResourceLabels const&,
+                                TableDataLabels const&) const override {
     return std::move(metric_);
   }
 

--- a/google/cloud/bigtable/internal/async_row_reader_test.cc
+++ b/google/cloud/bigtable/internal/async_row_reader_test.cc
@@ -115,7 +115,8 @@ class MockMetric : public Metric {
                ElementDeliveryParams const&),
               (override));
   MOCK_METHOD(std::unique_ptr<Metric>, clone,
-              (ResourceLabels resource_labels, DataLabels data_labels),
+              (TableResourceLabels const& resource_labels,
+               TableDataLabels const& data_labels),
               (const, override));
 };
 
@@ -124,7 +125,8 @@ class CloningMetric : public Metric {
  public:
   explicit CloningMetric(std::unique_ptr<MockMetric> metric)
       : metric_(std::move(metric)) {}
-  std::unique_ptr<Metric> clone(ResourceLabels, DataLabels) const override {
+  std::unique_ptr<Metric> clone(TableResourceLabels const&,
+                                TableDataLabels const&) const override {
     return std::move(metric_);
   }
 

--- a/google/cloud/bigtable/internal/async_row_sampler_test.cc
+++ b/google/cloud/bigtable/internal/async_row_sampler_test.cc
@@ -103,7 +103,8 @@ class MockMetric : public Metric {
                ElementDeliveryParams const&),
               (override));
   MOCK_METHOD(std::unique_ptr<Metric>, clone,
-              (ResourceLabels resource_labels, DataLabels data_labels),
+              (TableResourceLabels const& resource_labels,
+               TableDataLabels const& data_labels),
               (const, override));
 };
 
@@ -112,7 +113,8 @@ class CloningMetric : public Metric {
  public:
   explicit CloningMetric(std::unique_ptr<MockMetric> metric)
       : metric_(std::move(metric)) {}
-  std::unique_ptr<Metric> clone(ResourceLabels, DataLabels) const override {
+  std::unique_ptr<Metric> clone(TableResourceLabels const&,
+                                TableDataLabels const&) const override {
     return std::move(metric_);
   }
 

--- a/google/cloud/bigtable/internal/bulk_mutator_test.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator_test.cc
@@ -107,8 +107,8 @@ class MockMetric : public bigtable_internal::Metric {
                bigtable_internal::ElementDeliveryParams const&),
               (override));
   MOCK_METHOD(std::unique_ptr<Metric>, clone,
-              (bigtable_internal::ResourceLabels resource_labels,
-               bigtable_internal::DataLabels data_labels),
+              (bigtable_internal::TableResourceLabels const& resource_labels,
+               bigtable_internal::TableDataLabels const& data_labels),
               (const, override));
 };
 
@@ -118,8 +118,8 @@ class CloningMetric : public bigtable_internal::Metric {
   explicit CloningMetric(std::unique_ptr<MockMetric> metric)
       : metric_(std::move(metric)) {}
   std::unique_ptr<bigtable_internal::Metric> clone(
-      bigtable_internal::ResourceLabels,
-      bigtable_internal::DataLabels) const override {
+      bigtable_internal::TableResourceLabels const&,
+      bigtable_internal::TableDataLabels const&) const override {
     return std::move(metric_);
   }
 

--- a/google/cloud/bigtable/internal/data_connection_impl_test.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl_test.cc
@@ -361,7 +361,8 @@ class MockMetric : public Metric {
                ElementDeliveryParams const&),
               (override));
   MOCK_METHOD(std::unique_ptr<Metric>, clone,
-              (ResourceLabels resource_labels, DataLabels data_labels),
+              (TableResourceLabels const& resource_labels,
+               TableDataLabels const& data_labels),
               (const, override));
 };
 
@@ -376,7 +377,8 @@ class CloningMetric : public Metric {
     std::reverse(metrics_.begin(), metrics_.end());
   }
 
-  std::unique_ptr<Metric> clone(ResourceLabels, DataLabels) const override {
+  std::unique_ptr<Metric> clone(TableResourceLabels const&,
+                                TableDataLabels const&) const override {
     auto m = std::move(metrics_.back());
     metrics_.pop_back();
     return m;
@@ -388,7 +390,7 @@ class CloningMetric : public Metric {
 
 class FakeOperationContextFactory : public OperationContextFactory {
  public:
-  FakeOperationContextFactory(ResourceLabels r, DataLabels d,
+  FakeOperationContextFactory(TableResourceLabels r, TableDataLabels d,
                               std::shared_ptr<Metric> metric,
                               std::shared_ptr<OperationContext::Clock> clock)
       : resource_labels_(std::move(r)),
@@ -445,8 +447,8 @@ class FakeOperationContextFactory : public OperationContextFactory {
                                               metrics_, clock_);
   }
 
-  ResourceLabels resource_labels_;
-  DataLabels data_labels_;
+  TableResourceLabels resource_labels_;
+  TableDataLabels data_labels_;
   std::vector<std::shared_ptr<Metric const>> metrics_;
   std::shared_ptr<OperationContext::Clock> clock_;
 };
@@ -502,7 +504,7 @@ TEST_F(DataConnectionTest, ApplySuccess) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -534,7 +536,7 @@ TEST_F(DataConnectionTest, ApplyPermanentFailure) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -566,7 +568,7 @@ TEST_F(DataConnectionTest, ApplyRetryThenSuccess) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -605,7 +607,7 @@ TEST_F(DataConnectionTest, ApplyRetryExhausted) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -672,7 +674,7 @@ TEST_F(DataConnectionTest, ApplyBigtableCookie) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -722,7 +724,7 @@ TEST_F(DataConnectionTest, AsyncApplySuccess) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -772,7 +774,7 @@ TEST_F(DataConnectionTest, AsyncApplyRetryExhausted) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -879,7 +881,7 @@ TEST_F(DataConnectionTest, BulkApplyEmpty) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -901,7 +903,7 @@ TEST_F(DataConnectionTest, BulkApplySuccess) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -945,7 +947,7 @@ TEST_F(DataConnectionTest, BulkApplyRetryMutationPolicy) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -1012,7 +1014,7 @@ TEST_F(DataConnectionTest, BulkApplyIncompleteStreamRetried) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -1069,7 +1071,7 @@ TEST_F(DataConnectionTest, BulkApplyStreamRetryExhausted) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -1114,7 +1116,7 @@ TEST_F(DataConnectionTest, BulkApplyStreamPermanentError) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -1447,7 +1449,7 @@ TEST_F(DataConnectionTest, ReadRowEmpty) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -1486,7 +1488,7 @@ TEST_F(DataConnectionTest, ReadRowSuccess) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -1537,7 +1539,7 @@ TEST_F(DataConnectionTest, ReadRowFailure) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -1584,7 +1586,7 @@ TEST_F(DataConnectionTest, CheckAndMutateRowSuccess) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(v));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -1688,7 +1690,7 @@ TEST_F(DataConnectionTest, CheckAndMutateRowPermanentError) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -1731,7 +1733,7 @@ TEST_F(DataConnectionTest, CheckAndMutateRowRetryExhausted) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -1838,7 +1840,7 @@ TEST_F(DataConnectionTest, AsyncCheckAndMutateRowSuccess) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(v));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -1946,7 +1948,7 @@ TEST_F(DataConnectionTest, AsyncCheckAndMutateRowPermanentError) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -1990,7 +1992,7 @@ TEST_F(DataConnectionTest, AsyncCheckAndMutateRowRetryExhausted) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -2093,7 +2095,7 @@ TEST_F(DataConnectionTest, SampleRowsSuccess) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -2143,7 +2145,7 @@ TEST_F(DataConnectionTest, SampleRowsRetryResetsSamples) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -2197,7 +2199,7 @@ TEST_F(DataConnectionTest, SampleRowsRetryExhausted) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -2245,7 +2247,7 @@ TEST_F(DataConnectionTest, SampleRowsPermanentError) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -2386,7 +2388,7 @@ TEST_F(DataConnectionTest, ReadModifyWriteRowSuccess) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -2442,7 +2444,7 @@ TEST_F(DataConnectionTest, ReadModifyWriteRowPermanentError) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -2479,7 +2481,7 @@ TEST_F(DataConnectionTest, ReadModifyWriteRowTransientErrorNotRetried) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -2524,7 +2526,7 @@ TEST_F(DataConnectionTest, AsyncReadModifyWriteRowSuccess) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -2585,7 +2587,7 @@ TEST_F(DataConnectionTest, AsyncReadModifyWriteRowPermanentError) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -2725,7 +2727,7 @@ TEST_F(DataConnectionTest, AsyncReadRowEmpty) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -2771,7 +2773,7 @@ TEST_F(DataConnectionTest, AsyncReadRowSuccess) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -2828,7 +2830,7 @@ TEST_F(DataConnectionTest, AsyncReadRowFailure) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -2865,7 +2867,7 @@ TEST_F(DataConnectionTest, PrepareQuerySuccess) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -2931,7 +2933,7 @@ TEST_F(DataConnectionTest, PrepareQueryPermanentError) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -2961,7 +2963,7 @@ TEST_F(DataConnectionTest, AsyncPrepareQuerySuccess) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -3023,7 +3025,7 @@ TEST_F(DataConnectionTest, AsyncPrepareQueryPermanentError) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -3057,7 +3059,7 @@ TEST_F(DataConnectionTest, ExecuteQuerySuccessWithTransientErrors) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -3175,7 +3177,7 @@ TEST_F(DataConnectionTest, ExecuteQueryFailure) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -3229,7 +3231,7 @@ TEST_F(DataConnectionTest, ExecuteQueryOperationRetryExhausted) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -3284,7 +3286,7 @@ TEST_F(DataConnectionTest, ExecuteQuerySuccessWithQueryPlanRefresh) {
   auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   auto factory = std::make_unique<FakeOperationContextFactory>(
-      ResourceLabels{}, DataLabels{}, fake_metric, clock);
+      TableResourceLabels{}, TableDataLabels{}, fake_metric, clock);
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
 #endif
@@ -3435,15 +3437,17 @@ TEST_F(DataConnectionTest, PrepareAndExecuteQuerySuccessWithQueryPlanRefresh) {
         std::vector<std::shared_ptr<Metric const>> metrics;
         metrics.push_back(std::make_shared<CloningMetric>(
             std::move(mock_metric_prepared_query_initial)));
-        return std::make_shared<OperationContext>(
-            ResourceLabels{}, DataLabels{}, std::move(metrics), clock);
+        return std::make_shared<OperationContext>(TableResourceLabels{},
+                                                  TableDataLabels{},
+                                                  std::move(metrics), clock);
       })
       .WillOnce([&](auto const&, auto const&) {
         std::vector<std::shared_ptr<Metric const>> metrics;
         metrics.push_back(std::make_shared<CloningMetric>(
             std::move(mock_metric_prepared_query_refresh)));
-        return std::make_shared<OperationContext>(
-            ResourceLabels{}, DataLabels{}, std::move(metrics), clock);
+        return std::make_shared<OperationContext>(TableResourceLabels{},
+                                                  TableDataLabels{},
+                                                  std::move(metrics), clock);
       });
 
   auto mock_metric_execute_query = std::make_unique<MockMetric>();
@@ -3457,8 +3461,8 @@ TEST_F(DataConnectionTest, PrepareAndExecuteQuerySuccessWithQueryPlanRefresh) {
     std::vector<std::shared_ptr<Metric const>> metrics;
     metrics.push_back(
         std::make_shared<CloningMetric>(std::move(mock_metric_execute_query)));
-    return std::make_shared<OperationContext>(ResourceLabels{}, DataLabels{},
-                                              std::move(metrics), clock);
+    return std::make_shared<OperationContext>(
+        TableResourceLabels{}, TableDataLabels{}, std::move(metrics), clock);
   });
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
@@ -3603,15 +3607,17 @@ TEST_F(DataConnectionTest,
         std::vector<std::shared_ptr<Metric const>> metrics;
         metrics.push_back(std::make_shared<CloningMetric>(
             std::move(mock_metric_prepared_query_initial)));
-        return std::make_shared<OperationContext>(
-            ResourceLabels{}, DataLabels{}, std::move(metrics), clock);
+        return std::make_shared<OperationContext>(TableResourceLabels{},
+                                                  TableDataLabels{},
+                                                  std::move(metrics), clock);
       })
       .WillOnce([&](auto const&, auto const&) {
         std::vector<std::shared_ptr<Metric const>> metrics;
         metrics.push_back(std::make_shared<CloningMetric>(
             std::move(mock_metric_prepared_query_refresh)));
-        return std::make_shared<OperationContext>(
-            ResourceLabels{}, DataLabels{}, std::move(metrics), clock);
+        return std::make_shared<OperationContext>(TableResourceLabels{},
+                                                  TableDataLabels{},
+                                                  std::move(metrics), clock);
       });
 
   auto mock_metric_execute_query = std::make_unique<MockMetric>();
@@ -3625,8 +3631,8 @@ TEST_F(DataConnectionTest,
     std::vector<std::shared_ptr<Metric const>> metrics;
     metrics.push_back(
         std::make_shared<CloningMetric>(std::move(mock_metric_execute_query)));
-    return std::make_shared<OperationContext>(ResourceLabels{}, DataLabels{},
-                                              std::move(metrics), clock);
+    return std::make_shared<OperationContext>(
+        TableResourceLabels{}, TableDataLabels{}, std::move(metrics), clock);
   });
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();

--- a/google/cloud/bigtable/internal/default_row_reader_test.cc
+++ b/google/cloud/bigtable/internal/default_row_reader_test.cc
@@ -126,7 +126,8 @@ class MockMetric : public Metric {
                ElementDeliveryParams const&),
               (override));
   MOCK_METHOD(std::unique_ptr<Metric>, clone,
-              (ResourceLabels resource_labels, DataLabels data_labels),
+              (TableResourceLabels const& resource_labels,
+               TableDataLabels const& data_labels),
               (const, override));
 };
 
@@ -135,7 +136,8 @@ class CloningMetric : public Metric {
  public:
   explicit CloningMetric(std::unique_ptr<MockMetric> metric)
       : metric_(std::move(metric)) {}
-  std::unique_ptr<Metric> clone(ResourceLabels, DataLabels) const override {
+  std::unique_ptr<Metric> clone(TableResourceLabels const&,
+                                TableDataLabels const&) const override {
     return std::move(metric_);
   }
 

--- a/google/cloud/bigtable/internal/metrics.cc
+++ b/google/cloud/bigtable/internal/metrics.cc
@@ -540,8 +540,8 @@ std::unique_ptr<Metric> ApplicationBlockingLatency::clone(
     TableResourceLabels const& resource_labels,
     TableDataLabels const& data_labels) const {
   auto m = std::make_unique<ApplicationBlockingLatency>(*this);
-  m->resource_labels_ = std::move(resource_labels);
-  m->data_labels_ = std::move(data_labels);
+  m->resource_labels_ = resource_labels;
+  m->data_labels_ = data_labels;
   return m;
 }
 

--- a/google/cloud/bigtable/internal/metrics.cc
+++ b/google/cloud/bigtable/internal/metrics.cc
@@ -35,10 +35,10 @@ auto constexpr kMeterInstrumentationScopeVersion = "v1";
 }  // namespace
 
 // TODO(#15329): Refactor how we're handling different data labels for
-// the various RPCs. Adding a function to each metric type to add its DataLabels
-// to the map should be more performant than performing a set_difference every
-// time.
-LabelMap IntoLabelMap(ResourceLabels const& r, DataLabels const& d,
+// the various RPCs. Adding a function to each metric type to add its
+// TableDataLabels to the map should be more performant than performing a
+// set_difference every time.
+LabelMap IntoLabelMap(TableResourceLabels const& r, TableDataLabels const& d,
                       std::set<std::string> const& filtered_data_labels,
                       std::optional<PeerInfoLabels> const& peer_info_labels) {
   LabelMap labels = {
@@ -219,11 +219,12 @@ void OperationLatency::OnDone(opentelemetry::context::Context const& context,
                                context);
 }
 
-std::unique_ptr<Metric> OperationLatency::clone(ResourceLabels resource_labels,
-                                                DataLabels data_labels) const {
+std::unique_ptr<Metric> OperationLatency::clone(
+    TableResourceLabels const& resource_labels,
+    TableDataLabels const& data_labels) const {
   auto m = std::make_unique<OperationLatency>(*this);
-  m->resource_labels_ = std::move(resource_labels);
-  m->data_labels_ = std::move(data_labels);
+  m->resource_labels_ = resource_labels;
+  m->data_labels_ = data_labels;
   return m;
 }
 
@@ -256,11 +257,12 @@ void AttemptLatency::PostCall(opentelemetry::context::Context const& context,
   attempt_latencies_->Record(attempt_elapsed.count(), std::move(m), context);
 }
 
-std::unique_ptr<Metric> AttemptLatency::clone(ResourceLabels resource_labels,
-                                              DataLabels data_labels) const {
+std::unique_ptr<Metric> AttemptLatency::clone(
+    TableResourceLabels const& resource_labels,
+    TableDataLabels const& data_labels) const {
   auto m = std::make_unique<AttemptLatency>(*this);
-  m->resource_labels_ = std::move(resource_labels);
-  m->data_labels_ = std::move(data_labels);
+  m->resource_labels_ = resource_labels;
+  m->data_labels_ = data_labels;
   return m;
 }
 
@@ -306,11 +308,12 @@ void AttemptLatency2::PostCall(opentelemetry::context::Context const& context,
   attempt_latencies2_->Record(attempt_elapsed.count(), std::move(m), context);
 }
 
-std::unique_ptr<Metric> AttemptLatency2::clone(ResourceLabels resource_labels,
-                                               DataLabels data_labels) const {
+std::unique_ptr<Metric> AttemptLatency2::clone(
+    TableResourceLabels const& resource_labels,
+    TableDataLabels const& data_labels) const {
   auto m = std::make_unique<AttemptLatency2>(*this);
-  m->resource_labels_ = std::move(resource_labels);
-  m->data_labels_ = std::move(data_labels);
+  m->resource_labels_ = resource_labels;
+  m->data_labels_ = data_labels;
   return m;
 }
 
@@ -350,11 +353,12 @@ void RetryCount::OnDone(opentelemetry::context::Context const& context,
                     context);
 }
 
-std::unique_ptr<Metric> RetryCount::clone(ResourceLabels resource_labels,
-                                          DataLabels data_labels) const {
+std::unique_ptr<Metric> RetryCount::clone(
+    TableResourceLabels const& resource_labels,
+    TableDataLabels const& data_labels) const {
   auto m = std::make_unique<RetryCount>(*this);
-  m->resource_labels_ = std::move(resource_labels);
-  m->data_labels_ = std::move(data_labels);
+  m->resource_labels_ = resource_labels;
+  m->data_labels_ = data_labels;
   return m;
 }
 
@@ -405,10 +409,11 @@ void FirstResponseLatency::OnDone(
 }
 
 std::unique_ptr<Metric> FirstResponseLatency::clone(
-    ResourceLabels resource_labels, DataLabels data_labels) const {
+    TableResourceLabels const& resource_labels,
+    TableDataLabels const& data_labels) const {
   auto m = std::make_unique<FirstResponseLatency>(*this);
-  m->resource_labels_ = std::move(resource_labels);
-  m->data_labels_ = std::move(data_labels);
+  m->resource_labels_ = resource_labels;
+  m->data_labels_ = data_labels;
   return m;
 }
 
@@ -437,11 +442,12 @@ void ServerLatency::PostCall(opentelemetry::context::Context const& context,
   }
 }
 
-std::unique_ptr<Metric> ServerLatency::clone(ResourceLabels resource_labels,
-                                             DataLabels data_labels) const {
+std::unique_ptr<Metric> ServerLatency::clone(
+    TableResourceLabels const& resource_labels,
+    TableDataLabels const& data_labels) const {
   auto m = std::make_unique<ServerLatency>(*this);
-  m->resource_labels_ = std::move(resource_labels);
-  m->data_labels_ = std::move(data_labels);
+  m->resource_labels_ = resource_labels;
+  m->data_labels_ = data_labels;
   return m;
 }
 
@@ -480,10 +486,11 @@ void ConnectivityErrorCount::OnDone(
 }
 
 std::unique_ptr<Metric> ConnectivityErrorCount::clone(
-    ResourceLabels resource_labels, DataLabels data_labels) const {
+    TableResourceLabels const& resource_labels,
+    TableDataLabels const& data_labels) const {
   auto m = std::make_unique<ConnectivityErrorCount>(*this);
-  m->resource_labels_ = std::move(resource_labels);
-  m->data_labels_ = std::move(data_labels);
+  m->resource_labels_ = resource_labels;
+  m->data_labels_ = data_labels;
   return m;
 }
 
@@ -530,7 +537,8 @@ void ApplicationBlockingLatency::OnDone(
 }
 
 std::unique_ptr<Metric> ApplicationBlockingLatency::clone(
-    ResourceLabels resource_labels, DataLabels data_labels) const {
+    TableResourceLabels const& resource_labels,
+    TableDataLabels const& data_labels) const {
   auto m = std::make_unique<ApplicationBlockingLatency>(*this);
   m->resource_labels_ = std::move(resource_labels);
   m->data_labels_ = std::move(data_labels);

--- a/google/cloud/bigtable/internal/metrics.h
+++ b/google/cloud/bigtable/internal/metrics.h
@@ -36,7 +36,7 @@ namespace cloud {
 namespace bigtable_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-struct ResourceLabels {
+struct TableResourceLabels {
   std::string project_id;
   std::string instance;
   std::string table;
@@ -44,7 +44,7 @@ struct ResourceLabels {
   std::string zone;
 };
 
-struct DataLabels {
+struct TableDataLabels {
   std::string method;
   std::string streaming;
   std::string client_name;
@@ -63,7 +63,7 @@ struct PeerInfoLabels {
 using LabelMap = std::unordered_map<std::string, std::string>;
 // `peer_info_labels` is optional because only AttemptLatency2 populates it.
 LabelMap IntoLabelMap(
-    ResourceLabels const& r, DataLabels const& d,
+    TableResourceLabels const& r, TableDataLabels const& d,
     std::set<std::string> const& filtered_data_labels = {},
     std::optional<PeerInfoLabels> const& peer_info_labels = std::nullopt);
 
@@ -119,8 +119,10 @@ class Metric {
                               ElementRequestParams const&) {}
   virtual void ElementDelivery(opentelemetry::context::Context const&,
                                ElementDeliveryParams const&) {}
-  virtual std::unique_ptr<Metric> clone(ResourceLabels resource_labels,
-                                        DataLabels data_labels) const = 0;
+  virtual std::unique_ptr<Metric> clone(TableResourceLabels const&,
+                                        TableDataLabels const&) const {
+    return nullptr;
+  }
 };
 
 class OperationLatency : public Metric {
@@ -136,12 +138,13 @@ class OperationLatency : public Metric {
                 PostCallParams const& p) override;
   void OnDone(opentelemetry::context::Context const& context,
               OnDoneParams const& p) override;
-  std::unique_ptr<Metric> clone(ResourceLabels resource_labels,
-                                DataLabels data_labels) const override;
+  std::unique_ptr<Metric> clone(
+      TableResourceLabels const& resource_labels,
+      TableDataLabels const& data_labels) const override;
 
  private:
-  ResourceLabels resource_labels_;
-  DataLabels data_labels_;
+  TableResourceLabels resource_labels_;
+  TableDataLabels data_labels_;
   opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Histogram<double>>
       operation_latencies_;
   OperationContext::Clock::time_point operation_start_;
@@ -157,12 +160,13 @@ class AttemptLatency : public Metric {
   void PostCall(opentelemetry::context::Context const& context,
                 grpc::ClientContext const& client_context,
                 PostCallParams const& p) override;
-  std::unique_ptr<Metric> clone(ResourceLabels resource_labels,
-                                DataLabels data_labels) const override;
+  std::unique_ptr<Metric> clone(
+      TableResourceLabels const& resource_labels,
+      TableDataLabels const& data_labels) const override;
 
  private:
-  ResourceLabels resource_labels_;
-  DataLabels data_labels_;
+  TableResourceLabels resource_labels_;
+  TableDataLabels data_labels_;
   opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Histogram<double>>
       attempt_latencies_;
   OperationContext::Clock::time_point attempt_start_;
@@ -179,12 +183,13 @@ class AttemptLatency2 : public Metric {
   void PostCall(opentelemetry::context::Context const& context,
                 grpc::ClientContext const& client_context,
                 PostCallParams const& p) override;
-  std::unique_ptr<Metric> clone(ResourceLabels resource_labels,
-                                DataLabels data_labels) const override;
+  std::unique_ptr<Metric> clone(
+      TableResourceLabels const& resource_labels,
+      TableDataLabels const& data_labels) const override;
 
  private:
-  ResourceLabels resource_labels_;
-  DataLabels data_labels_;
+  TableResourceLabels resource_labels_;
+  TableDataLabels data_labels_;
   PeerInfoLabels peer_info_labels_;
   opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Histogram<double>>
       attempt_latencies2_;
@@ -203,12 +208,13 @@ class RetryCount : public Metric {
                 PostCallParams const& p) override;
   void OnDone(opentelemetry::context::Context const& context,
               OnDoneParams const& p) override;
-  std::unique_ptr<Metric> clone(ResourceLabels resource_labels,
-                                DataLabels data_labels) const override;
+  std::unique_ptr<Metric> clone(
+      TableResourceLabels const& resource_labels,
+      TableDataLabels const& data_labels) const override;
 
  private:
-  ResourceLabels resource_labels_;
-  DataLabels data_labels_;
+  TableResourceLabels resource_labels_;
+  TableDataLabels data_labels_;
   std::uint64_t num_retries_ = 0;
   opentelemetry::nostd::shared_ptr<
       opentelemetry::metrics::Counter<std::uint64_t>>
@@ -231,12 +237,13 @@ class FirstResponseLatency : public Metric {
   void OnDone(opentelemetry::context::Context const& context,
               OnDoneParams const& p) override;
 
-  std::unique_ptr<Metric> clone(ResourceLabels resource_labels,
-                                DataLabels data_labels) const override;
+  std::unique_ptr<Metric> clone(
+      TableResourceLabels const& resource_labels,
+      TableDataLabels const& data_labels) const override;
 
  private:
-  ResourceLabels resource_labels_;
-  DataLabels data_labels_;
+  TableResourceLabels resource_labels_;
+  TableDataLabels data_labels_;
   opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Histogram<double>>
       first_response_latencies_;
   OperationContext::Clock::time_point operation_start_;
@@ -252,12 +259,13 @@ class ServerLatency : public Metric {
                 grpc::ClientContext const& client_context,
                 PostCallParams const& p) override;
 
-  std::unique_ptr<Metric> clone(ResourceLabels resource_labels,
-                                DataLabels data_labels) const override;
+  std::unique_ptr<Metric> clone(
+      TableResourceLabels const& resource_labels,
+      TableDataLabels const& data_labels) const override;
 
  private:
-  ResourceLabels resource_labels_;
-  DataLabels data_labels_;
+  TableResourceLabels resource_labels_;
+  TableDataLabels data_labels_;
   opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Histogram<double>>
       server_latencies_;
 };
@@ -278,12 +286,13 @@ class ApplicationBlockingLatency : public Metric {
   void OnDone(opentelemetry::context::Context const& context,
               OnDoneParams const&) override;
 
-  std::unique_ptr<Metric> clone(ResourceLabels resource_labels,
-                                DataLabels data_labels) const override;
+  std::unique_ptr<Metric> clone(
+      TableResourceLabels const& resource_labels,
+      TableDataLabels const& data_labels) const override;
 
  private:
-  ResourceLabels resource_labels_;
-  DataLabels data_labels_;
+  TableResourceLabels resource_labels_;
+  TableDataLabels data_labels_;
   opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Histogram<double>>
       application_blocking_latencies_;
   OperationContext::Clock::time_point element_delivery_time_;
@@ -301,12 +310,13 @@ class ConnectivityErrorCount : public Metric {
                 PostCallParams const& p) override;
   void OnDone(opentelemetry::context::Context const& context,
               OnDoneParams const&) override;
-  std::unique_ptr<Metric> clone(ResourceLabels resource_labels,
-                                DataLabels data_labels) const override;
+  std::unique_ptr<Metric> clone(
+      TableResourceLabels const& resource_labels,
+      TableDataLabels const& data_labels) const override;
 
  private:
-  ResourceLabels resource_labels_;
-  DataLabels data_labels_;
+  TableResourceLabels resource_labels_;
+  TableDataLabels data_labels_;
   std::uint64_t num_errors_ = 0;
   opentelemetry::nostd::shared_ptr<
       opentelemetry::metrics::Counter<std::uint64_t>>

--- a/google/cloud/bigtable/internal/metrics.h
+++ b/google/cloud/bigtable/internal/metrics.h
@@ -120,9 +120,7 @@ class Metric {
   virtual void ElementDelivery(opentelemetry::context::Context const&,
                                ElementDeliveryParams const&) {}
   virtual std::unique_ptr<Metric> clone(TableResourceLabels const&,
-                                        TableDataLabels const&) const {
-    return nullptr;
-  }
+                                        TableDataLabels const&) const = 0;
 };
 
 class OperationLatency : public Metric {

--- a/google/cloud/bigtable/internal/metrics_test.cc
+++ b/google/cloud/bigtable/internal/metrics_test.cc
@@ -228,10 +228,10 @@ class MockMeterProvider : public opentelemetry::metrics::MeterProvider {
 };
 
 TEST(LabelMap, IntoLabelMap) {
-  ResourceLabels r{"my-project", "my-instance", "my-table", "my-cluster",
-                   "my-zone"};
-  DataLabels d{"my-method",     "my-streaming",   "my-client-name",
-               "my-client-uid", "my-app-profile", "my-status"};
+  TableResourceLabels r{"my-project", "my-instance", "my-table", "my-cluster",
+                        "my-zone"};
+  TableDataLabels d{"my-method",     "my-streaming",   "my-client-name",
+                    "my-client-uid", "my-app-profile", "my-status"};
   auto label_map = IntoLabelMap(r, d);
   EXPECT_THAT(
       label_map,
@@ -246,9 +246,9 @@ TEST(LabelMap, IntoLabelMap) {
 }
 
 TEST(LabelMap, IntoLabelMapWithDefaults) {
-  ResourceLabels r{"my-project", "my-instance", "my-table", "", ""};
-  DataLabels d{"my-method",     "my-streaming",   "my-client-name",
-               "my-client-uid", "my-app-profile", "my-status"};
+  TableResourceLabels r{"my-project", "my-instance", "my-table", "", ""};
+  TableDataLabels d{"my-method",     "my-streaming",   "my-client-name",
+                    "my-client-uid", "my-app-profile", "my-status"};
   auto label_map = IntoLabelMap(r, d);
   EXPECT_THAT(
       label_map,
@@ -510,10 +510,11 @@ TEST(OperationLatencyTest, FirstAttemptSuccess) {
       });
 
   OperationLatency operation_latency("my-instrument-scope", mock_provider);
-  ResourceLabels resource_labels{"my-project-id", "my-instance", "my-table", "",
-                                 ""};
-  DataLabels data_labels{"my-method",     "my-streaming",   "my-client-name",
-                         "my-client-uid", "my-app-profile", ""};
+  TableResourceLabels resource_labels{"my-project-id", "my-instance",
+                                      "my-table", "", ""};
+  TableDataLabels data_labels{"my-method",      "my-streaming",
+                              "my-client-name", "my-client-uid",
+                              "my-app-profile", ""};
   auto clone = operation_latency.clone(resource_labels, data_labels);
 
   grpc::ClientContext client_context;
@@ -583,10 +584,11 @@ TEST(OperationLatencyTest, ThirdAttemptSuccess) {
       });
 
   OperationLatency operation_latency("my-instrument-scope", mock_provider);
-  ResourceLabels resource_labels{"my-project-id", "my-instance", "my-table", "",
-                                 ""};
-  DataLabels data_labels{"my-method",     "my-streaming",   "my-client-name",
-                         "my-client-uid", "my-app-profile", ""};
+  TableResourceLabels resource_labels{"my-project-id", "my-instance",
+                                      "my-table", "", ""};
+  TableDataLabels data_labels{"my-method",      "my-streaming",
+                              "my-client-name", "my-client-uid",
+                              "my-app-profile", ""};
   auto clone = operation_latency.clone(resource_labels, data_labels);
 
   grpc::ClientContext client_context;
@@ -671,10 +673,11 @@ TEST(OperationLatencyTest, UsesDefaultClusterAndZone) {
       });
 
   OperationLatency operation_latency("my-instrument-scope", mock_provider);
-  ResourceLabels resource_labels{"my-project-id", "my-instance", "my-table", "",
-                                 ""};
-  DataLabels data_labels{"my-method",     "my-streaming",   "my-client-name",
-                         "my-client-uid", "my-app-profile", ""};
+  TableResourceLabels resource_labels{"my-project-id", "my-instance",
+                                      "my-table", "", ""};
+  TableDataLabels data_labels{"my-method",      "my-streaming",
+                              "my-client-name", "my-client-uid",
+                              "my-app-profile", ""};
   auto clone = operation_latency.clone(resource_labels, data_labels);
 
   grpc::ClientContext client_context;
@@ -743,10 +746,11 @@ TEST(AttemptLatencyTest, NoRetry) {
       });
 
   AttemptLatency attempt_latency("my-instrument-scope", mock_provider);
-  ResourceLabels resource_labels{"my-project-id", "my-instance", "my-table", "",
-                                 ""};
-  DataLabels data_labels{"my-method",     "my-streaming",   "my-client-name",
-                         "my-client-uid", "my-app-profile", ""};
+  TableResourceLabels resource_labels{"my-project-id", "my-instance",
+                                      "my-table", "", ""};
+  TableDataLabels data_labels{"my-method",      "my-streaming",
+                              "my-client-name", "my-client-uid",
+                              "my-app-profile", ""};
   auto clone = attempt_latency.clone(resource_labels, data_labels);
 
   grpc::ClientContext client_context;
@@ -846,10 +850,11 @@ TEST(AttemptLatencyTest, ThreeAttempts) {
       });
 
   AttemptLatency attempt_latency("my-instrument-scope", mock_provider);
-  ResourceLabels resource_labels{"my-project-id", "my-instance", "my-table", "",
-                                 ""};
-  DataLabels data_labels{"my-method",     "my-streaming",   "my-client-name",
-                         "my-client-uid", "my-app-profile", ""};
+  TableResourceLabels resource_labels{"my-project-id", "my-instance",
+                                      "my-table", "", ""};
+  TableDataLabels data_labels{"my-method",      "my-streaming",
+                              "my-client-name", "my-client-uid",
+                              "my-app-profile", ""};
   auto clone = attempt_latency.clone(resource_labels, data_labels);
 
   grpc::ClientContext client_context;
@@ -929,10 +934,11 @@ TEST(AttemptLatencyTest, UsesDefaultClusterAndZone) {
       });
 
   AttemptLatency attempt_latency("my-instrument-scope", mock_provider);
-  ResourceLabels resource_labels{"my-project-id", "my-instance", "my-table", "",
-                                 ""};
-  DataLabels data_labels{"my-method",     "my-streaming",   "my-client-name",
-                         "my-client-uid", "my-app-profile", ""};
+  TableResourceLabels resource_labels{"my-project-id", "my-instance",
+                                      "my-table", "", ""};
+  TableDataLabels data_labels{"my-method",      "my-streaming",
+                              "my-client-name", "my-client-uid",
+                              "my-app-profile", ""};
   auto clone = attempt_latency.clone(resource_labels, data_labels);
 
   grpc::ClientContext client_context;
@@ -1004,10 +1010,11 @@ TEST(AttemptLatency2Test, NoRetry) {
       });
 
   AttemptLatency2 attempt_latency("my-instrument-scope", mock_provider);
-  ResourceLabels resource_labels{"my-project-id", "my-instance", "my-table", "",
-                                 ""};
-  DataLabels data_labels{"my-method",     "my-streaming",   "my-client-name",
-                         "my-client-uid", "my-app-profile", ""};
+  TableResourceLabels resource_labels{"my-project-id", "my-instance",
+                                      "my-table", "", ""};
+  TableDataLabels data_labels{"my-method",      "my-streaming",
+                              "my-client-name", "my-client-uid",
+                              "my-app-profile", ""};
   auto clone = attempt_latency.clone(resource_labels, data_labels);
 
   grpc::ClientContext client_context;
@@ -1114,10 +1121,11 @@ TEST(AttemptLatency2Test, ThreeAttempts) {
       });
 
   AttemptLatency2 attempt_latency("my-instrument-scope", mock_provider);
-  ResourceLabels resource_labels{"my-project-id", "my-instance", "my-table", "",
-                                 ""};
-  DataLabels data_labels{"my-method",     "my-streaming",   "my-client-name",
-                         "my-client-uid", "my-app-profile", ""};
+  TableResourceLabels resource_labels{"my-project-id", "my-instance",
+                                      "my-table", "", ""};
+  TableDataLabels data_labels{"my-method",      "my-streaming",
+                              "my-client-name", "my-client-uid",
+                              "my-app-profile", ""};
   auto clone = attempt_latency.clone(resource_labels, data_labels);
 
   grpc::ClientContext client_context;
@@ -1198,10 +1206,11 @@ TEST(AttemptLatency2Test, UsesDefaultClusterAndZone) {
       });
 
   AttemptLatency2 attempt_latency("my-instrument-scope", mock_provider);
-  ResourceLabels resource_labels{"my-project-id", "my-instance", "my-table", "",
-                                 ""};
-  DataLabels data_labels{"my-method",     "my-streaming",   "my-client-name",
-                         "my-client-uid", "my-app-profile", ""};
+  TableResourceLabels resource_labels{"my-project-id", "my-instance",
+                                      "my-table", "", ""};
+  TableDataLabels data_labels{"my-method",      "my-streaming",
+                              "my-client-name", "my-client-uid",
+                              "my-app-profile", ""};
   auto clone = attempt_latency.clone(resource_labels, data_labels);
 
   grpc::ClientContext client_context;
@@ -1270,10 +1279,11 @@ TEST(RetryCountTest, NoRetry) {
       });
 
   RetryCount retry_count("my-instrument-scope", mock_provider);
-  ResourceLabels resource_labels{"my-project-id", "my-instance", "my-table", "",
-                                 ""};
-  DataLabels data_labels{"my-method",     "my-streaming",   "my-client-name",
-                         "my-client-uid", "my-app-profile", ""};
+  TableResourceLabels resource_labels{"my-project-id", "my-instance",
+                                      "my-table", "", ""};
+  TableDataLabels data_labels{"my-method",      "my-streaming",
+                              "my-client-name", "my-client-uid",
+                              "my-app-profile", ""};
   auto clone = retry_count.clone(resource_labels, data_labels);
 
   grpc::ClientContext client_context;
@@ -1343,10 +1353,11 @@ TEST(RetryCountTest, ThreeAttempts) {
       });
 
   RetryCount retry_count("my-instrument-scope", mock_provider);
-  ResourceLabels resource_labels{"my-project-id", "my-instance", "my-table", "",
-                                 ""};
-  DataLabels data_labels{"my-method",     "my-streaming",   "my-client-name",
-                         "my-client-uid", "my-app-profile", ""};
+  TableResourceLabels resource_labels{"my-project-id", "my-instance",
+                                      "my-table", "", ""};
+  TableDataLabels data_labels{"my-method",      "my-streaming",
+                              "my-client-name", "my-client-uid",
+                              "my-app-profile", ""};
   auto clone = retry_count.clone(resource_labels, data_labels);
 
   grpc::ClientContext client_context;
@@ -1426,10 +1437,11 @@ TEST(RetryCountTest, UsesDefaultClusterAndZone) {
       });
 
   RetryCount retry_count("my-instrument-scope", mock_provider);
-  ResourceLabels resource_labels{"my-project-id", "my-instance", "my-table", "",
-                                 ""};
-  DataLabels data_labels{"my-method",     "my-streaming",   "my-client-name",
-                         "my-client-uid", "my-app-profile", ""};
+  TableResourceLabels resource_labels{"my-project-id", "my-instance",
+                                      "my-table", "", ""};
+  TableDataLabels data_labels{"my-method",      "my-streaming",
+                              "my-client-name", "my-client-uid",
+                              "my-app-profile", ""};
   auto clone = retry_count.clone(resource_labels, data_labels);
 
   grpc::ClientContext client_context;
@@ -1499,10 +1511,11 @@ TEST(FirstResponseLatency, Success) {
 
   FirstResponseLatency first_response_latency("my-instrument-scope",
                                               mock_provider);
-  ResourceLabels resource_labels{"my-project-id", "my-instance", "my-table", "",
-                                 ""};
-  DataLabels data_labels{"my-method",     "my-streaming",   "my-client-name",
-                         "my-client-uid", "my-app-profile", ""};
+  TableResourceLabels resource_labels{"my-project-id", "my-instance",
+                                      "my-table", "", ""};
+  TableDataLabels data_labels{"my-method",      "my-streaming",
+                              "my-client-name", "my-client-uid",
+                              "my-app-profile", ""};
   auto clone = first_response_latency.clone(resource_labels, data_labels);
 
   grpc::ClientContext client_context;
@@ -1564,10 +1577,11 @@ TEST(FirstResponseLatency, NoDataReceived) {
 
   FirstResponseLatency first_response_latency("my-instrument-scope",
                                               mock_provider);
-  ResourceLabels resource_labels{"my-project-id", "my-instance", "my-table", "",
-                                 ""};
-  DataLabels data_labels{"my-method",     "my-streaming",   "my-client-name",
-                         "my-client-uid", "my-app-profile", ""};
+  TableResourceLabels resource_labels{"my-project-id", "my-instance",
+                                      "my-table", "", ""};
+  TableDataLabels data_labels{"my-method",      "my-streaming",
+                              "my-client-name", "my-client-uid",
+                              "my-app-profile", ""};
   auto clone = first_response_latency.clone(resource_labels, data_labels);
 
   grpc::ClientContext client_context;
@@ -1642,10 +1656,11 @@ TEST(FirstResponseLatency, UsesDefaultClusterAndZone) {
 
   FirstResponseLatency first_response_latency("my-instrument-scope",
                                               mock_provider);
-  ResourceLabels resource_labels{"my-project-id", "my-instance", "my-table", "",
-                                 ""};
-  DataLabels data_labels{"my-method",     "my-streaming",   "my-client-name",
-                         "my-client-uid", "my-app-profile", ""};
+  TableResourceLabels resource_labels{"my-project-id", "my-instance",
+                                      "my-table", "", ""};
+  TableDataLabels data_labels{"my-method",      "my-streaming",
+                              "my-client-name", "my-client-uid",
+                              "my-app-profile", ""};
   auto clone = first_response_latency.clone(resource_labels, data_labels);
 
   grpc::ClientContext client_context;
@@ -1756,10 +1771,11 @@ TEST(ServerLatency, SingleSuccess) {
       });
 
   ServerLatency server_latency("my-instrument-scope", mock_provider);
-  ResourceLabels resource_labels{"my-project-id", "my-instance", "my-table", "",
-                                 ""};
-  DataLabels data_labels{"my-method",     "my-streaming",   "my-client-name",
-                         "my-client-uid", "my-app-profile", ""};
+  TableResourceLabels resource_labels{"my-project-id", "my-instance",
+                                      "my-table", "", ""};
+  TableDataLabels data_labels{"my-method",      "my-streaming",
+                              "my-client-name", "my-client-uid",
+                              "my-app-profile", ""};
   auto clone = server_latency.clone(resource_labels, data_labels);
 
   grpc::ClientContext client_context;
@@ -1831,10 +1847,11 @@ TEST(ServerLatency, UsesDefaultClusterAndZone) {
       });
 
   ServerLatency server_latency("my-instrument-scope", mock_provider);
-  ResourceLabels resource_labels{"my-project-id", "my-instance", "my-table", "",
-                                 ""};
-  DataLabels data_labels{"my-method",     "my-streaming",   "my-client-name",
-                         "my-client-uid", "my-app-profile", ""};
+  TableResourceLabels resource_labels{"my-project-id", "my-instance",
+                                      "my-table", "", ""};
+  TableDataLabels data_labels{"my-method",      "my-streaming",
+                              "my-client-name", "my-client-uid",
+                              "my-app-profile", ""};
   auto clone = server_latency.clone(resource_labels, data_labels);
 
   grpc::ClientContext client_context;
@@ -1916,10 +1933,11 @@ TEST(ServerLatency, TwoAttempts) {
       });
 
   ServerLatency server_latency("my-instrument-scope", mock_provider);
-  ResourceLabels resource_labels{"my-project-id", "my-instance", "my-table", "",
-                                 ""};
-  DataLabels data_labels{"my-method",     "my-streaming",   "my-client-name",
-                         "my-client-uid", "my-app-profile", ""};
+  TableResourceLabels resource_labels{"my-project-id", "my-instance",
+                                      "my-table", "", ""};
+  TableDataLabels data_labels{"my-method",      "my-streaming",
+                              "my-client-name", "my-client-uid",
+                              "my-app-profile", ""};
   auto clone = server_latency.clone(resource_labels, data_labels);
 
   grpc::ClientContext client_context;
@@ -1986,10 +2004,11 @@ TEST(ServerLatency, NoServerTiming) {
       });
 
   ServerLatency server_latency("my-instrument-scope", mock_provider);
-  ResourceLabels resource_labels{"my-project-id", "my-instance", "my-table", "",
-                                 ""};
-  DataLabels data_labels{"my-method",     "my-streaming",   "my-client-name",
-                         "my-client-uid", "my-app-profile", ""};
+  TableResourceLabels resource_labels{"my-project-id", "my-instance",
+                                      "my-table", "", ""};
+  TableDataLabels data_labels{"my-method",      "my-streaming",
+                              "my-client-name", "my-client-uid",
+                              "my-app-profile", ""};
   auto clone = server_latency.clone(resource_labels, data_labels);
 
   grpc::ClientContext client_context;
@@ -2053,10 +2072,11 @@ TEST(ConnectivityErrorCount, MissingResourceLabels) {
 
   ConnectivityErrorCount connectivity_error_count("my-instrument-scope",
                                                   mock_provider);
-  ResourceLabels resource_labels{"my-project-id", "my-instance", "my-table", "",
-                                 ""};
-  DataLabels data_labels{"my-method",     "my-streaming",   "my-client-name",
-                         "my-client-uid", "my-app-profile", ""};
+  TableResourceLabels resource_labels{"my-project-id", "my-instance",
+                                      "my-table", "", ""};
+  TableDataLabels data_labels{"my-method",      "my-streaming",
+                              "my-client-name", "my-client-uid",
+                              "my-app-profile", ""};
   auto clone = connectivity_error_count.clone(resource_labels, data_labels);
 
   grpc::ClientContext client_context;
@@ -2133,10 +2153,11 @@ TEST(ConnectivityErrorCount, Success) {
 
   ConnectivityErrorCount connectivity_error_count("my-instrument-scope",
                                                   mock_provider);
-  ResourceLabels resource_labels{"my-project-id", "my-instance", "my-table", "",
-                                 ""};
-  DataLabels data_labels{"my-method",     "my-streaming",   "my-client-name",
-                         "my-client-uid", "my-app-profile", ""};
+  TableResourceLabels resource_labels{"my-project-id", "my-instance",
+                                      "my-table", "", ""};
+  TableDataLabels data_labels{"my-method",      "my-streaming",
+                              "my-client-name", "my-client-uid",
+                              "my-app-profile", ""};
   auto clone = connectivity_error_count.clone(resource_labels, data_labels);
 
   grpc::ClientContext client_context;
@@ -2209,10 +2230,11 @@ TEST(ConnectivityErrorCount, OkAndMissingServerTiming) {
 
   ConnectivityErrorCount connectivity_error_count("my-instrument-scope",
                                                   mock_provider);
-  ResourceLabels resource_labels{"my-project-id", "my-instance", "my-table", "",
-                                 ""};
-  DataLabels data_labels{"my-method",     "my-streaming",   "my-client-name",
-                         "my-client-uid", "my-app-profile", ""};
+  TableResourceLabels resource_labels{"my-project-id", "my-instance",
+                                      "my-table", "", ""};
+  TableDataLabels data_labels{"my-method",      "my-streaming",
+                              "my-client-name", "my-client-uid",
+                              "my-app-profile", ""};
   auto clone = connectivity_error_count.clone(resource_labels, data_labels);
 
   grpc::ClientContext client_context;
@@ -2278,10 +2300,11 @@ TEST(ConnectivityErrorCount, DeadlineExceededAndMissingServerTiming) {
 
   ConnectivityErrorCount connectivity_error_count("my-instrument-scope",
                                                   mock_provider);
-  ResourceLabels resource_labels{"my-project-id", "my-instance", "my-table", "",
-                                 ""};
-  DataLabels data_labels{"my-method",     "my-streaming",   "my-client-name",
-                         "my-client-uid", "my-app-profile", ""};
+  TableResourceLabels resource_labels{"my-project-id", "my-instance",
+                                      "my-table", "", ""};
+  TableDataLabels data_labels{"my-method",      "my-streaming",
+                              "my-client-name", "my-client-uid",
+                              "my-app-profile", ""};
   auto clone = connectivity_error_count.clone(resource_labels, data_labels);
 
   grpc::ClientContext client_context;
@@ -2346,10 +2369,11 @@ TEST(ApplicationBlockingLatency, Success) {
 
   ApplicationBlockingLatency application_blocking_latency("my-instrument-scope",
                                                           mock_provider);
-  ResourceLabels resource_labels{"my-project-id", "my-instance", "my-table", "",
-                                 ""};
-  DataLabels data_labels{"my-method",     "my-streaming",   "my-client-name",
-                         "my-client-uid", "my-app-profile", ""};
+  TableResourceLabels resource_labels{"my-project-id", "my-instance",
+                                      "my-table", "", ""};
+  TableDataLabels data_labels{"my-method",      "my-streaming",
+                              "my-client-name", "my-client-uid",
+                              "my-app-profile", ""};
   auto clone = application_blocking_latency.clone(resource_labels, data_labels);
 
   grpc::ClientContext client_context;
@@ -2433,10 +2457,11 @@ TEST(ApplicationBlockingLatency, StreamingData) {
 
   ApplicationBlockingLatency application_blocking_latency("my-instrument-scope",
                                                           mock_provider);
-  ResourceLabels resource_labels{"my-project-id", "my-instance", "my-table", "",
-                                 ""};
-  DataLabels data_labels{"my-method",     "my-streaming",   "my-client-name",
-                         "my-client-uid", "my-app-profile", ""};
+  TableResourceLabels resource_labels{"my-project-id", "my-instance",
+                                      "my-table", "", ""};
+  TableDataLabels data_labels{"my-method",      "my-streaming",
+                              "my-client-name", "my-client-uid",
+                              "my-app-profile", ""};
   auto clone = application_blocking_latency.clone(resource_labels, data_labels);
 
   grpc::ClientContext client_context;

--- a/google/cloud/bigtable/internal/operation_context.cc
+++ b/google/cloud/bigtable/internal/operation_context.cc
@@ -28,7 +28,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
 namespace {
 std::vector<std::shared_ptr<Metric>> CloneMetrics(
-    ResourceLabels const& resource_labels, DataLabels const& data_labels,
+    TableResourceLabels const& resource_labels,
+    TableDataLabels const& data_labels,
     std::vector<std::shared_ptr<Metric const>> const& metrics) {
   std::vector<std::shared_ptr<Metric>> v;
   v.reserve(metrics.size());
@@ -54,7 +55,8 @@ void OperationContext::ProcessMetadata(
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
 
 OperationContext::OperationContext(
-    ResourceLabels const& resource_labels, DataLabels const& data_labels,
+    TableResourceLabels const& resource_labels,
+    TableDataLabels const& data_labels,
     std::vector<std::shared_ptr<Metric const>> const& metrics,
     std::shared_ptr<Clock> clock)
     : cloned_metrics_(CloneMetrics(resource_labels, data_labels, metrics)),
@@ -121,7 +123,7 @@ void OperationContext::ElementDelivery(grpc::ClientContext const&) {
 #else  // GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
 
 OperationContext::OperationContext(
-    ResourceLabels const&, DataLabels const&,
+    TableResourceLabels const&, TableDataLabels const&,
     std::vector<std::shared_ptr<Metric const>> const&, std::shared_ptr<Clock>) {
 }
 

--- a/google/cloud/bigtable/internal/operation_context.h
+++ b/google/cloud/bigtable/internal/operation_context.h
@@ -30,8 +30,8 @@ namespace cloud {
 namespace bigtable_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-struct DataLabels;
-struct ResourceLabels;
+struct TableDataLabels;
+struct TableResourceLabels;
 class Metric;
 
 /**
@@ -64,8 +64,8 @@ class OperationContext {
   // The default constructor is used when metric support is unavailable or
   // disabled.
   OperationContext() = default;
-  OperationContext(ResourceLabels const& resource_labels,
-                   DataLabels const& data_labels,
+  OperationContext(TableResourceLabels const& resource_labels,
+                   TableDataLabels const& data_labels,
                    std::vector<std::shared_ptr<Metric const>> const& metrics,
                    std::shared_ptr<Clock> clock);
 

--- a/google/cloud/bigtable/internal/operation_context_factory.cc
+++ b/google/cloud/bigtable/internal/operation_context_factory.cc
@@ -37,27 +37,28 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 #if GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
 namespace {
 
-ResourceLabels ResourceLabelsFromTableName(std::string const& table_name) {
+TableResourceLabels TableResourceLabelsFromTableName(
+    std::string const& table_name) {
   // split table_name into component pieces
   // projects/<project>/instances/<instance>/tables/<table>
   std::vector<absl::string_view> name_parts = absl::StrSplit(table_name, '/');
   if (name_parts.size() < 6) return {};
-  ResourceLabels resource_labels = {
+  TableResourceLabels resource_labels = {
       std::string(name_parts[1]), std::string(name_parts[3]),
       std::string(name_parts[5]), "" /*=cluster*/, "" /*=zone*/};
   return resource_labels;
 }
 
-ResourceLabels ResourceLabelsFromInstanceName(
+TableResourceLabels TableResourceLabelsFromInstanceName(
     std::string const& instance_name) {
   // split instance_name into component pieces
   // projects/<project>/instances/<instance>
   std::vector<absl::string_view> name_parts =
       absl::StrSplit(instance_name, '/');
   if (name_parts.size() < 4) return {};
-  ResourceLabels resource_labels = {std::string(name_parts[1]),
-                                    std::string(name_parts[3]), "",
-                                    "" /*=cluster*/, "" /*=zone*/};
+  TableResourceLabels resource_labels = {std::string(name_parts[1]),
+                                         std::string(name_parts[3]), "",
+                                         "" /*=cluster*/, "" /*=zone*/};
   return resource_labels;
 }
 
@@ -291,13 +292,13 @@ std::shared_ptr<OperationContext> MetricsOperationContextFactory::ReadRow(
     swap(read_row_metrics_.metrics, v);
   });
 
-  auto resource_labels = ResourceLabelsFromTableName(table_name);
-  DataLabels data_labels = {kRpc,
-                            "true", /*=streaming*/
-                            "cpp.Bigtable/" + version_string(),
-                            client_uid_,
-                            app_profile,
-                            "" /*=status*/};
+  auto resource_labels = TableResourceLabelsFromTableName(table_name);
+  TableDataLabels data_labels = {kRpc,
+                                 "true", /*=streaming*/
+                                 "cpp.Bigtable/" + version_string(),
+                                 client_uid_,
+                                 app_profile,
+                                 "" /*=status*/};
 
   return std::make_shared<OperationContext>(resource_labels, data_labels,
                                             read_row_metrics_.metrics, clock_);
@@ -320,13 +321,13 @@ std::shared_ptr<OperationContext> MetricsOperationContextFactory::ReadRows(
     swap(read_rows_metrics_.metrics, v);
   });
 
-  auto resource_labels = ResourceLabelsFromTableName(table_name);
-  DataLabels data_labels = {kRpc,
-                            "true", /*=streaming*/
-                            "cpp.Bigtable/" + version_string(),
-                            client_uid_,
-                            app_profile,
-                            "" /*=status*/};
+  auto resource_labels = TableResourceLabelsFromTableName(table_name);
+  TableDataLabels data_labels = {kRpc,
+                                 "true", /*=streaming*/
+                                 "cpp.Bigtable/" + version_string(),
+                                 client_uid_,
+                                 app_profile,
+                                 "" /*=status*/};
 
   return std::make_shared<OperationContext>(resource_labels, data_labels,
                                             read_rows_metrics_.metrics, clock_);
@@ -348,13 +349,13 @@ std::shared_ptr<OperationContext> MetricsOperationContextFactory::MutateRow(
     swap(mutate_row_metrics_.metrics, v);
   });
 
-  auto resource_labels = ResourceLabelsFromTableName(table_name);
-  DataLabels data_labels = {kRpc,
-                            "false", /*=streaming*/
-                            "cpp.Bigtable/" + version_string(),
-                            client_uid_,
-                            app_profile,
-                            "" /*=status*/};
+  auto resource_labels = TableResourceLabelsFromTableName(table_name);
+  TableDataLabels data_labels = {kRpc,
+                                 "false", /*=streaming*/
+                                 "cpp.Bigtable/" + version_string(),
+                                 client_uid_,
+                                 app_profile,
+                                 "" /*=status*/};
 
   return std::make_shared<OperationContext>(
       resource_labels, data_labels, mutate_row_metrics_.metrics, clock_);
@@ -376,13 +377,13 @@ std::shared_ptr<OperationContext> MetricsOperationContextFactory::MutateRows(
     swap(mutate_rows_metrics_.metrics, v);
   });
 
-  auto resource_labels = ResourceLabelsFromTableName(table_name);
-  DataLabels data_labels = {kRpc,
-                            "true", /*=streaming*/
-                            "cpp.Bigtable/" + version_string(),
-                            client_uid_,
-                            app_profile,
-                            "" /*=status*/};
+  auto resource_labels = TableResourceLabelsFromTableName(table_name);
+  TableDataLabels data_labels = {kRpc,
+                                 "true", /*=streaming*/
+                                 "cpp.Bigtable/" + version_string(),
+                                 client_uid_,
+                                 app_profile,
+                                 "" /*=status*/};
 
   return std::make_shared<OperationContext>(
       resource_labels, data_labels, mutate_rows_metrics_.metrics, clock_);
@@ -405,13 +406,13 @@ MetricsOperationContextFactory::CheckAndMutateRow(
     swap(check_and_mutate_row_metrics_.metrics, v);
   });
 
-  auto resource_labels = ResourceLabelsFromTableName(table_name);
-  DataLabels data_labels = {kRpc,
-                            "false", /*=streaming*/
-                            "cpp.Bigtable/" + version_string(),
-                            client_uid_,
-                            app_profile,
-                            "" /*=status*/};
+  auto resource_labels = TableResourceLabelsFromTableName(table_name);
+  TableDataLabels data_labels = {kRpc,
+                                 "false", /*=streaming*/
+                                 "cpp.Bigtable/" + version_string(),
+                                 client_uid_,
+                                 app_profile,
+                                 "" /*=status*/};
 
   return std::make_shared<OperationContext>(
       resource_labels, data_labels, check_and_mutate_row_metrics_.metrics,
@@ -434,13 +435,13 @@ std::shared_ptr<OperationContext> MetricsOperationContextFactory::SampleRowKeys(
     swap(sample_row_keys_metrics_.metrics, v);
   });
 
-  auto resource_labels = ResourceLabelsFromTableName(table_name);
-  DataLabels data_labels = {kRpc,
-                            "true", /*=streaming*/
-                            "cpp.Bigtable/" + version_string(),
-                            client_uid_,
-                            app_profile,
-                            "" /*=status*/};
+  auto resource_labels = TableResourceLabelsFromTableName(table_name);
+  TableDataLabels data_labels = {kRpc,
+                                 "true", /*=streaming*/
+                                 "cpp.Bigtable/" + version_string(),
+                                 client_uid_,
+                                 app_profile,
+                                 "" /*=status*/};
 
   return std::make_shared<OperationContext>(
       resource_labels, data_labels, sample_row_keys_metrics_.metrics, clock_);
@@ -463,13 +464,13 @@ MetricsOperationContextFactory::ReadModifyWriteRow(
     swap(read_modify_write_row_metrics_.metrics, v);
   });
 
-  auto resource_labels = ResourceLabelsFromTableName(table_name);
-  DataLabels data_labels = {kRpc,
-                            "false", /*=streaming*/
-                            "cpp.Bigtable/" + version_string(),
-                            client_uid_,
-                            app_profile,
-                            "" /*=status*/};
+  auto resource_labels = TableResourceLabelsFromTableName(table_name);
+  TableDataLabels data_labels = {kRpc,
+                                 "false", /*=streaming*/
+                                 "cpp.Bigtable/" + version_string(),
+                                 client_uid_,
+                                 app_profile,
+                                 "" /*=status*/};
 
   return std::make_shared<OperationContext>(
       resource_labels, data_labels, read_modify_write_row_metrics_.metrics,
@@ -490,13 +491,13 @@ std::shared_ptr<OperationContext> MetricsOperationContextFactory::PrepareQuery(
     swap(prepare_query_metrics_.metrics, v);
   });
 
-  auto resource_labels = ResourceLabelsFromInstanceName(instance_name);
-  DataLabels data_labels = {kRpc,
-                            "false", /*=streaming*/
-                            "cpp.Bigtable/" + version_string(),
-                            client_uid_,
-                            app_profile,
-                            "" /*=status*/};
+  auto resource_labels = TableResourceLabelsFromInstanceName(instance_name);
+  TableDataLabels data_labels = {kRpc,
+                                 "false", /*=streaming*/
+                                 "cpp.Bigtable/" + version_string(),
+                                 client_uid_,
+                                 app_profile,
+                                 "" /*=status*/};
 
   return std::make_shared<OperationContext>(
       resource_labels, data_labels, prepare_query_metrics_.metrics, clock_);
@@ -519,13 +520,13 @@ std::shared_ptr<OperationContext> MetricsOperationContextFactory::ExecuteQuery(
     swap(execute_query_metrics_.metrics, v);
   });
 
-  auto resource_labels = ResourceLabelsFromInstanceName(instance_name);
-  DataLabels data_labels = {kRpc,
-                            "true", /*=streaming*/
-                            "cpp.Bigtable/" + version_string(),
-                            client_uid_,
-                            app_profile,
-                            "" /*=status*/};
+  auto resource_labels = TableResourceLabelsFromInstanceName(instance_name);
+  TableDataLabels data_labels = {kRpc,
+                                 "true", /*=streaming*/
+                                 "cpp.Bigtable/" + version_string(),
+                                 client_uid_,
+                                 app_profile,
+                                 "" /*=status*/};
 
   return std::make_shared<OperationContext>(
       resource_labels, data_labels, execute_query_metrics_.metrics, clock_);

--- a/google/cloud/bigtable/internal/operation_context_factory_test.cc
+++ b/google/cloud/bigtable/internal/operation_context_factory_test.cc
@@ -29,7 +29,8 @@ using ::testing::IsEmpty;
 
 class MockMetric : public Metric {
  public:
-  MOCK_METHOD(std::unique_ptr<Metric>, clone, (ResourceLabels, DataLabels),
+  MOCK_METHOD(std::unique_ptr<Metric>, clone,
+              (TableResourceLabels const&, TableDataLabels const&),
               (const, override));
 };
 
@@ -40,8 +41,8 @@ TEST(MetricsOperationContextFactoryTest, ReadRow) {
 
   auto mock_metric = std::make_shared<MockMetric const>();
   EXPECT_CALL(*mock_metric, clone)
-      .WillOnce([&](ResourceLabels const& resource_labels,
-                    DataLabels const& data_labels) {
+      .WillOnce([&](TableResourceLabels const& resource_labels,
+                    TableDataLabels const& data_labels) {
         EXPECT_THAT(resource_labels.project_id, Eq("my-project"));
         EXPECT_THAT(resource_labels.instance, Eq("my-instance"));
         EXPECT_THAT(resource_labels.table, Eq("my-table"));
@@ -68,11 +69,12 @@ TEST(MetricsOperationContextFactoryTest, ReadRows) {
 
   auto mock_metric = std::make_shared<MockMetric const>();
   EXPECT_CALL(*mock_metric, clone)
-      .WillOnce([&](ResourceLabels const&, DataLabels const& data_labels) {
-        EXPECT_THAT(data_labels.method, Eq("ReadRows"));
-        EXPECT_THAT(data_labels.streaming, Eq("true"));
-        return std::make_unique<MockMetric>();
-      });
+      .WillOnce(
+          [&](TableResourceLabels const&, TableDataLabels const& data_labels) {
+            EXPECT_THAT(data_labels.method, Eq("ReadRows"));
+            EXPECT_THAT(data_labels.streaming, Eq("true"));
+            return std::make_unique<MockMetric>();
+          });
 
   MetricsOperationContextFactory factory({}, mock_metric);
   auto operation_context = factory.ReadRows(table_full_name, app_profile);
@@ -85,11 +87,12 @@ TEST(MetricsOperationContextFactoryTest, MutateRow) {
 
   auto mock_metric = std::make_shared<MockMetric const>();
   EXPECT_CALL(*mock_metric, clone)
-      .WillOnce([&](ResourceLabels const&, DataLabels const& data_labels) {
-        EXPECT_THAT(data_labels.method, Eq("MutateRow"));
-        EXPECT_THAT(data_labels.streaming, Eq("false"));
-        return std::make_unique<MockMetric>();
-      });
+      .WillOnce(
+          [&](TableResourceLabels const&, TableDataLabels const& data_labels) {
+            EXPECT_THAT(data_labels.method, Eq("MutateRow"));
+            EXPECT_THAT(data_labels.streaming, Eq("false"));
+            return std::make_unique<MockMetric>();
+          });
 
   MetricsOperationContextFactory factory({}, mock_metric);
   auto operation_context = factory.MutateRow(table_full_name, app_profile);
@@ -102,11 +105,12 @@ TEST(MetricsOperationContextFactoryTest, MutateRows) {
 
   auto mock_metric = std::make_shared<MockMetric const>();
   EXPECT_CALL(*mock_metric, clone)
-      .WillOnce([&](ResourceLabels const&, DataLabels const& data_labels) {
-        EXPECT_THAT(data_labels.method, Eq("MutateRows"));
-        EXPECT_THAT(data_labels.streaming, Eq("true"));
-        return std::make_unique<MockMetric>();
-      });
+      .WillOnce(
+          [&](TableResourceLabels const&, TableDataLabels const& data_labels) {
+            EXPECT_THAT(data_labels.method, Eq("MutateRows"));
+            EXPECT_THAT(data_labels.streaming, Eq("true"));
+            return std::make_unique<MockMetric>();
+          });
 
   MetricsOperationContextFactory factory({}, mock_metric);
   auto operation_context = factory.MutateRows(table_full_name, app_profile);
@@ -119,11 +123,12 @@ TEST(MetricsOperationContextFactoryTest, CheckAndMutateRow) {
 
   auto mock_metric = std::make_shared<MockMetric const>();
   EXPECT_CALL(*mock_metric, clone)
-      .WillOnce([&](ResourceLabels const&, DataLabels const& data_labels) {
-        EXPECT_THAT(data_labels.method, Eq("CheckAndMutateRow"));
-        EXPECT_THAT(data_labels.streaming, Eq("false"));
-        return std::make_unique<MockMetric>();
-      });
+      .WillOnce(
+          [&](TableResourceLabels const&, TableDataLabels const& data_labels) {
+            EXPECT_THAT(data_labels.method, Eq("CheckAndMutateRow"));
+            EXPECT_THAT(data_labels.streaming, Eq("false"));
+            return std::make_unique<MockMetric>();
+          });
 
   MetricsOperationContextFactory factory({}, mock_metric);
   auto operation_context =
@@ -137,11 +142,12 @@ TEST(MetricsOperationContextFactoryTest, SampleRowKeys) {
 
   auto mock_metric = std::make_shared<MockMetric const>();
   EXPECT_CALL(*mock_metric, clone)
-      .WillOnce([&](ResourceLabels const&, DataLabels const& data_labels) {
-        EXPECT_THAT(data_labels.method, Eq("SampleRowKeys"));
-        EXPECT_THAT(data_labels.streaming, Eq("true"));
-        return std::make_unique<MockMetric>();
-      });
+      .WillOnce(
+          [&](TableResourceLabels const&, TableDataLabels const& data_labels) {
+            EXPECT_THAT(data_labels.method, Eq("SampleRowKeys"));
+            EXPECT_THAT(data_labels.streaming, Eq("true"));
+            return std::make_unique<MockMetric>();
+          });
 
   MetricsOperationContextFactory factory({}, mock_metric);
   auto operation_context = factory.SampleRowKeys(table_full_name, app_profile);
@@ -154,11 +160,12 @@ TEST(MetricsOperationContextFactoryTest, ReadModifyWriteRow) {
 
   auto mock_metric = std::make_shared<MockMetric const>();
   EXPECT_CALL(*mock_metric, clone)
-      .WillOnce([&](ResourceLabels const&, DataLabels const& data_labels) {
-        EXPECT_THAT(data_labels.method, Eq("ReadModifyWriteRow"));
-        EXPECT_THAT(data_labels.streaming, Eq("false"));
-        return std::make_unique<MockMetric>();
-      });
+      .WillOnce(
+          [&](TableResourceLabels const&, TableDataLabels const& data_labels) {
+            EXPECT_THAT(data_labels.method, Eq("ReadModifyWriteRow"));
+            EXPECT_THAT(data_labels.streaming, Eq("false"));
+            return std::make_unique<MockMetric>();
+          });
 
   MetricsOperationContextFactory factory({}, mock_metric);
   auto operation_context =
@@ -171,11 +178,12 @@ TEST(MetricsOperationContextFactoryTest, PrepareQuery) {
 
   auto mock_metric = std::make_shared<MockMetric const>();
   EXPECT_CALL(*mock_metric, clone)
-      .WillOnce([&](ResourceLabels const&, DataLabels const& data_labels) {
-        EXPECT_THAT(data_labels.method, Eq("PrepareQuery"));
-        EXPECT_THAT(data_labels.streaming, Eq("false"));
-        return std::make_unique<MockMetric>();
-      });
+      .WillOnce(
+          [&](TableResourceLabels const&, TableDataLabels const& data_labels) {
+            EXPECT_THAT(data_labels.method, Eq("PrepareQuery"));
+            EXPECT_THAT(data_labels.streaming, Eq("false"));
+            return std::make_unique<MockMetric>();
+          });
 
   MetricsOperationContextFactory factory({}, mock_metric);
   auto operation_context =
@@ -188,11 +196,12 @@ TEST(MetricsOperationContextFactoryTest, ExecuteQuery) {
 
   auto mock_metric = std::make_shared<MockMetric const>();
   EXPECT_CALL(*mock_metric, clone)
-      .WillOnce([&](ResourceLabels const&, DataLabels const& data_labels) {
-        EXPECT_THAT(data_labels.method, Eq("ExecuteQuery"));
-        EXPECT_THAT(data_labels.streaming, Eq("true"));
-        return std::make_unique<MockMetric>();
-      });
+      .WillOnce(
+          [&](TableResourceLabels const&, TableDataLabels const& data_labels) {
+            EXPECT_THAT(data_labels.method, Eq("ExecuteQuery"));
+            EXPECT_THAT(data_labels.streaming, Eq("true"));
+            return std::make_unique<MockMetric>();
+          });
 
   MetricsOperationContextFactory factory({}, mock_metric);
   auto operation_context =

--- a/google/cloud/bigtable/internal/operation_context_test.cc
+++ b/google/cloud/bigtable/internal/operation_context_test.cc
@@ -141,7 +141,8 @@ class MockMetric : public Metric {
                ElementDeliveryParams const&),
               (override));
   MOCK_METHOD(std::unique_ptr<Metric>, clone,
-              (ResourceLabels resource_labels, DataLabels data_labels),
+              (TableResourceLabels const& resource_labels,
+               TableDataLabels const& data_labels),
               (const, override));
 };
 
@@ -150,7 +151,8 @@ class CloningMetric : public Metric {
  public:
   explicit CloningMetric(std::unique_ptr<MockMetric> metric)
       : metric_(std::move(metric)) {}
-  std::unique_ptr<Metric> clone(ResourceLabels, DataLabels) const override {
+  std::unique_ptr<Metric> clone(TableResourceLabels const&,
+                                TableDataLabels const&) const override {
     return std::move(metric_);
   }
 

--- a/google/cloud/bigtable/internal/partial_result_set_source_test.cc
+++ b/google/cloud/bigtable/internal/partial_result_set_source_test.cc
@@ -109,7 +109,8 @@ class MockMetric : public Metric {
                ElementDeliveryParams const&),
               (override));
   MOCK_METHOD(std::unique_ptr<Metric>, clone,
-              (ResourceLabels resource_labels, DataLabels data_labels),
+              (TableResourceLabels const& resource_labels,
+               TableDataLabels const& data_labels),
               (const, override));
 };
 
@@ -118,7 +119,8 @@ class CloningMetric : public Metric {
  public:
   explicit CloningMetric(std::unique_ptr<MockMetric> metric)
       : metric_(std::move(metric)) {}
-  std::unique_ptr<Metric> clone(ResourceLabels, DataLabels) const override {
+  std::unique_ptr<Metric> clone(TableResourceLabels const&,
+                                TableDataLabels const&) const override {
     return std::move(metric_);
   }
 


### PR DESCRIPTION
With the upcoming introduction of Client schema metric labels, this helps differentiate.