### PR TITLE
refactor(bigtable): decouple metric cloning from OperationContext

### DIFF
--- a/google/cloud/bigtable/internal/async_bulk_apply_test.cc
+++ b/google/cloud/bigtable/internal/async_bulk_apply_test.cc
@@ -168,20 +168,6 @@ class MockMetric : public Metric {
               (const, override));
 };
 
-// This class is a vehicle to get a MockMetric into the OperationContext object.
-class CloningMetric : public Metric {
- public:
-  explicit CloningMetric(std::unique_ptr<MockMetric> metric)
-      : metric_(std::move(metric)) {}
-  std::unique_ptr<Metric> clone(TableResourceLabels const&,
-                                TableDataLabels const&) const override {
-    return std::move(metric_);
-  }
-
- private:
-  mutable std::unique_ptr<MockMetric> metric_;
-};
-
 #endif  // GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
 
 TEST_F(AsyncBulkApplyTest, Success) {
@@ -189,19 +175,18 @@ TEST_F(AsyncBulkApplyTest, Success) {
                              IdempotentMutation("r1"));
 
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(1);
   EXPECT_CALL(*mock_metric, PostCall).Times(1);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -263,19 +248,18 @@ TEST_F(AsyncBulkApplyTest, PartialStreamIsRetried) {
                              IdempotentMutation("r1"));
 
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(2);
   EXPECT_CALL(*mock_metric, PostCall).Times(2);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -365,19 +349,18 @@ TEST_F(AsyncBulkApplyTest, IdempotentMutationPolicy) {
       NonIdempotentMutation("fail-with-transient-error"));
 
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(2);
   EXPECT_CALL(*mock_metric, PostCall).Times(2);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -513,19 +496,18 @@ TEST_F(AsyncBulkApplyTest, RetryInfoHeeded) {
   bigtable::BulkMutation mut(IdempotentMutation("r0"));
 
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(2);
   EXPECT_CALL(*mock_metric, PostCall).Times(2);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -586,19 +568,18 @@ TEST_F(AsyncBulkApplyTest, RetryInfoIgnored) {
   bigtable::BulkMutation mut(IdempotentMutation("r0"));
 
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(1);
   EXPECT_CALL(*mock_metric, PostCall).Times(1);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -688,19 +669,18 @@ TEST_F(AsyncBulkApplyTest, CancelAfterSuccess) {
   promise<std::optional<v2::MutateRowsResponse>> p;
 
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(1);
   EXPECT_CALL(*mock_metric, PostCall).Times(1);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -764,19 +744,18 @@ TEST_F(AsyncBulkApplyTest, CancelMidStream) {
   promise<std::optional<v2::MutateRowsResponse>> p;
 
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(1);
   EXPECT_CALL(*mock_metric, PostCall).Times(1);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif

--- a/google/cloud/bigtable/internal/async_row_reader_test.cc
+++ b/google/cloud/bigtable/internal/async_row_reader_test.cc
@@ -120,41 +120,26 @@ class MockMetric : public Metric {
               (const, override));
 };
 
-// This class is a vehicle to get a MockMetric into the OperationContext object.
-class CloningMetric : public Metric {
- public:
-  explicit CloningMetric(std::unique_ptr<MockMetric> metric)
-      : metric_(std::move(metric)) {}
-  std::unique_ptr<Metric> clone(TableResourceLabels const&,
-                                TableDataLabels const&) const override {
-    return std::move(metric_);
-  }
-
- private:
-  mutable std::unique_ptr<MockMetric> metric_;
-};
-
 #endif  // GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
 /// @test Verify that successfully reading rows works.
 TEST_F(AsyncRowReaderTest, Success) {
   CompletionQueue cq;
 
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(1);
   EXPECT_CALL(*mock_metric, PostCall).Times(1);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(3);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(3);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -239,21 +224,20 @@ TEST_F(AsyncRowReaderTest, SuccessDelayedFuture) {
   CompletionQueue cq;
 
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(1);
   EXPECT_CALL(*mock_metric, PostCall).Times(1);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(3);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(3);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -332,21 +316,20 @@ TEST_F(AsyncRowReaderTest, SuccessDelayedFuture) {
 TEST_F(AsyncRowReaderTest, ResponseInMultipleChunks) {
   CompletionQueue cq;
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(1);
   EXPECT_CALL(*mock_metric, PostCall).Times(1);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(1);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(1);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -405,21 +388,20 @@ TEST_F(AsyncRowReaderTest, ResponseInMultipleChunks) {
 TEST_F(AsyncRowReaderTest, ParserEofFailsOnUnfinishedRow) {
   CompletionQueue cq;
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(1);
   EXPECT_CALL(*mock_metric, PostCall).Times(1);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -477,21 +459,20 @@ TEST_F(AsyncRowReaderTest, ParserEofFailsOnUnfinishedRow) {
 TEST_F(AsyncRowReaderTest, ParserEofDoesntFailOnUnfinishedRowIfRowLimit) {
   CompletionQueue cq;
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(1);
   EXPECT_CALL(*mock_metric, PostCall).Times(1);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(1);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(1);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -555,21 +536,20 @@ TEST_F(AsyncRowReaderTest, ParserEofDoesntFailOnUnfinishedRowIfRowLimit) {
 TEST_F(AsyncRowReaderTest, PermanentFailure) {
   CompletionQueue cq;
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(1);
   EXPECT_CALL(*mock_metric, PostCall).Times(1);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -627,21 +607,20 @@ TEST_F(AsyncRowReaderTest, RetryPolicyExhausted) {
       });
   CompletionQueue cq(mock_cq);
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(kNumRetries + 1);
   EXPECT_CALL(*mock_metric, PostCall).Times(kNumRetries + 1);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -793,21 +772,20 @@ TEST_F(AsyncRowReaderTest, RetrySkipsReadRows) {
   });
   CompletionQueue cq(mock_cq);
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(2);
   EXPECT_CALL(*mock_metric, PostCall).Times(2);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(2);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(2);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif

--- a/google/cloud/bigtable/internal/async_row_sampler_test.cc
+++ b/google/cloud/bigtable/internal/async_row_sampler_test.cc
@@ -108,20 +108,6 @@ class MockMetric : public Metric {
               (const, override));
 };
 
-// This class is a vehicle to get a MockMetric into the OperationContext object.
-class CloningMetric : public Metric {
- public:
-  explicit CloningMetric(std::unique_ptr<MockMetric> metric)
-      : metric_(std::move(metric)) {}
-  std::unique_ptr<Metric> clone(TableResourceLabels const&,
-                                TableDataLabels const&) const override {
-    return std::move(metric_);
-  }
-
- private:
-  mutable std::unique_ptr<MockMetric> metric_;
-};
-
 #endif  // GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
 
 class AsyncSampleRowKeysTest : public ::testing::Test {
@@ -131,19 +117,18 @@ class AsyncSampleRowKeysTest : public ::testing::Test {
 
 TEST_F(AsyncSampleRowKeysTest, Simple) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(1);
   EXPECT_CALL(*mock_metric, PostCall).Times(1);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -198,19 +183,18 @@ TEST_F(AsyncSampleRowKeysTest, Simple) {
 
 TEST_F(AsyncSampleRowKeysTest, RetryResetsSamples) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(2);
   EXPECT_CALL(*mock_metric, PostCall).Times(2);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -289,19 +273,18 @@ TEST_F(AsyncSampleRowKeysTest, RetryResetsSamples) {
 
 TEST_F(AsyncSampleRowKeysTest, TooManyFailures) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(kNumRetries + 1);
   EXPECT_CALL(*mock_metric, PostCall).Times(kNumRetries + 1);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -354,19 +337,18 @@ TEST_F(AsyncSampleRowKeysTest, TooManyFailures) {
 
 TEST_F(AsyncSampleRowKeysTest, RetryInfoHeeded) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(2);
   EXPECT_CALL(*mock_metric, PostCall).Times(2);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -426,19 +408,18 @@ TEST_F(AsyncSampleRowKeysTest, RetryInfoHeeded) {
 
 TEST_F(AsyncSampleRowKeysTest, RetryInfoIgnored) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(1);
   EXPECT_CALL(*mock_metric, PostCall).Times(1);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -526,19 +507,18 @@ TEST_F(AsyncSampleRowKeysTest, TimerError) {
 TEST_F(AsyncSampleRowKeysTest, CancelAfterSuccess) {
   promise<std::optional<v2::SampleRowKeysResponse>> p;
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(1);
   EXPECT_CALL(*mock_metric, PostCall).Times(1);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -597,19 +577,18 @@ TEST_F(AsyncSampleRowKeysTest, CancelAfterSuccess) {
 TEST_F(AsyncSampleRowKeysTest, CancelMidStream) {
   promise<std::optional<v2::SampleRowKeysResponse>> p;
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(1);
   EXPECT_CALL(*mock_metric, PostCall).Times(1);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif

--- a/google/cloud/bigtable/internal/bulk_mutator_test.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator_test.cc
@@ -112,21 +112,6 @@ class MockMetric : public bigtable_internal::Metric {
               (const, override));
 };
 
-// This class is a vehicle to get a MockMetric into the OperationContext object.
-class CloningMetric : public bigtable_internal::Metric {
- public:
-  explicit CloningMetric(std::unique_ptr<MockMetric> metric)
-      : metric_(std::move(metric)) {}
-  std::unique_ptr<bigtable_internal::Metric> clone(
-      bigtable_internal::TableResourceLabels const&,
-      bigtable_internal::TableDataLabels const&) const override {
-    return std::move(metric_);
-  }
-
- private:
-  mutable std::unique_ptr<MockMetric> metric_;
-};
-
 #endif  // GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
 
 class BulkMutatorTest : public ::testing::Test {
@@ -137,18 +122,17 @@ class BulkMutatorTest : public ::testing::Test {
 TEST_F(BulkMutatorTest, Simple) {
   BulkMutation mut(IdempotentMutation("r0"), IdempotentMutation("r1"));
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(1);
   EXPECT_CALL(*mock_metric, PostCall).Times(1);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<bigtable_internal::OperationContext>(
-      new bigtable_internal::OperationContext({}, {}, {fake_metric}, clock));
+      new bigtable_internal::OperationContext({mock_metric}, clock));
 #else
   auto operation_context =
       std::make_shared<bigtable_internal::OperationContext>();
@@ -189,18 +173,17 @@ TEST_F(BulkMutatorTest, RetryPartialFailure) {
   // First create the mutation.
   BulkMutation mut(IdempotentMutation("r0"), IdempotentMutation("r1"));
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(2);
   EXPECT_CALL(*mock_metric, PostCall).Times(2);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<bigtable_internal::OperationContext>(
-      new bigtable_internal::OperationContext({}, {}, {fake_metric}, clock));
+      new bigtable_internal::OperationContext({mock_metric}, clock));
 #else
   auto operation_context =
       std::make_shared<bigtable_internal::OperationContext>();
@@ -265,18 +248,17 @@ TEST_F(BulkMutatorTest, PermanentFailure) {
   BulkMutation mut(IdempotentMutation("r0"), IdempotentMutation("r1"));
 
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(2);
   EXPECT_CALL(*mock_metric, PostCall).Times(2);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<bigtable_internal::OperationContext>(
-      new bigtable_internal::OperationContext({}, {}, {fake_metric}, clock));
+      new bigtable_internal::OperationContext({mock_metric}, clock));
 #else
   auto operation_context =
       std::make_shared<bigtable_internal::OperationContext>();
@@ -341,18 +323,17 @@ TEST_F(BulkMutatorTest, PartialStream) {
   BulkMutation mut(IdempotentMutation("r0"), IdempotentMutation("r1"));
 
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(2);
   EXPECT_CALL(*mock_metric, PostCall).Times(2);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<bigtable_internal::OperationContext>(
-      new bigtable_internal::OperationContext({}, {}, {fake_metric}, clock));
+      new bigtable_internal::OperationContext({mock_metric}, clock));
 #else
   auto operation_context =
       std::make_shared<bigtable_internal::OperationContext>();

--- a/google/cloud/bigtable/internal/data_connection_impl_test.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl_test.cc
@@ -16,7 +16,7 @@
 #include "google/cloud/bigtable/data_connection.h"
 #include "google/cloud/bigtable/internal/crc32c.h"
 #include "google/cloud/bigtable/internal/defaults.h"
-#include "google/cloud/bigtable/internal/grpc_metrics_exporter.h"
+#include "google/cloud/bigtable/internal/operation_context.h"
 #include "google/cloud/bigtable/internal/query_plan.h"
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
 #include "google/cloud/bigtable/internal/metrics.h"
@@ -443,8 +443,8 @@ class FakeOperationContextFactory : public OperationContextFactory {
                                            std::string const& app_profile) {
     resource_labels_.table = name;
     data_labels_.app_profile = app_profile;
-    return std::make_shared<OperationContext>(resource_labels_, data_labels_,
-                                              metrics_, clock_);
+    return std::make_shared<OperationContext>(
+        CloneMetrics(resource_labels_, data_labels_, metrics_), clock_);
   }
 
   TableResourceLabels resource_labels_;
@@ -3437,17 +3437,17 @@ TEST_F(DataConnectionTest, PrepareAndExecuteQuerySuccessWithQueryPlanRefresh) {
         std::vector<std::shared_ptr<Metric const>> metrics;
         metrics.push_back(std::make_shared<CloningMetric>(
             std::move(mock_metric_prepared_query_initial)));
-        return std::make_shared<OperationContext>(TableResourceLabels{},
-                                                  TableDataLabels{},
-                                                  std::move(metrics), clock);
+        return std::make_shared<OperationContext>(
+            CloneMetrics(TableResourceLabels{}, TableDataLabels{}, metrics),
+            clock);
       })
       .WillOnce([&](auto const&, auto const&) {
         std::vector<std::shared_ptr<Metric const>> metrics;
         metrics.push_back(std::make_shared<CloningMetric>(
             std::move(mock_metric_prepared_query_refresh)));
-        return std::make_shared<OperationContext>(TableResourceLabels{},
-                                                  TableDataLabels{},
-                                                  std::move(metrics), clock);
+        return std::make_shared<OperationContext>(
+            CloneMetrics(TableResourceLabels{}, TableDataLabels{}, metrics),
+            clock);
       });
 
   auto mock_metric_execute_query = std::make_unique<MockMetric>();
@@ -3462,7 +3462,7 @@ TEST_F(DataConnectionTest, PrepareAndExecuteQuerySuccessWithQueryPlanRefresh) {
     metrics.push_back(
         std::make_shared<CloningMetric>(std::move(mock_metric_execute_query)));
     return std::make_shared<OperationContext>(
-        TableResourceLabels{}, TableDataLabels{}, std::move(metrics), clock);
+        CloneMetrics(TableResourceLabels{}, TableDataLabels{}, metrics), clock);
   });
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();
@@ -3607,17 +3607,17 @@ TEST_F(DataConnectionTest,
         std::vector<std::shared_ptr<Metric const>> metrics;
         metrics.push_back(std::make_shared<CloningMetric>(
             std::move(mock_metric_prepared_query_initial)));
-        return std::make_shared<OperationContext>(TableResourceLabels{},
-                                                  TableDataLabels{},
-                                                  std::move(metrics), clock);
+        return std::make_shared<OperationContext>(
+            CloneMetrics(TableResourceLabels{}, TableDataLabels{}, metrics),
+            clock);
       })
       .WillOnce([&](auto const&, auto const&) {
         std::vector<std::shared_ptr<Metric const>> metrics;
         metrics.push_back(std::make_shared<CloningMetric>(
             std::move(mock_metric_prepared_query_refresh)));
-        return std::make_shared<OperationContext>(TableResourceLabels{},
-                                                  TableDataLabels{},
-                                                  std::move(metrics), clock);
+        return std::make_shared<OperationContext>(
+            CloneMetrics(TableResourceLabels{}, TableDataLabels{}, metrics),
+            clock);
       });
 
   auto mock_metric_execute_query = std::make_unique<MockMetric>();
@@ -3632,7 +3632,7 @@ TEST_F(DataConnectionTest,
     metrics.push_back(
         std::make_shared<CloningMetric>(std::move(mock_metric_execute_query)));
     return std::make_shared<OperationContext>(
-        TableResourceLabels{}, TableDataLabels{}, std::move(metrics), clock);
+        CloneMetrics(TableResourceLabels{}, TableDataLabels{}, metrics), clock);
   });
 #else
   auto factory = std::make_unique<SimpleOperationContextFactory>();

--- a/google/cloud/bigtable/internal/default_row_reader_test.cc
+++ b/google/cloud/bigtable/internal/default_row_reader_test.cc
@@ -131,20 +131,6 @@ class MockMetric : public Metric {
               (const, override));
 };
 
-// This class is a vehicle to get a MockMetric into the OperationContext object.
-class CloningMetric : public Metric {
- public:
-  explicit CloningMetric(std::unique_ptr<MockMetric> metric)
-      : metric_(std::move(metric)) {}
-  std::unique_ptr<Metric> clone(TableResourceLabels const&,
-                                TableDataLabels const&) const override {
-    return std::move(metric_);
-  }
-
- private:
-  mutable std::unique_ptr<MockMetric> metric_;
-};
-
 #endif  // GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
 
 class DefaultRowReaderTest : public ::testing::Test {
@@ -173,21 +159,20 @@ class DefaultRowReaderTest : public ::testing::Test {
 
 TEST_F(DefaultRowReaderTest, EmptyReaderHasNoRows) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(1);
   EXPECT_CALL(*mock_metric, PostCall).Times(1);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -219,21 +204,20 @@ TEST_F(DefaultRowReaderTest, EmptyReaderHasNoRows) {
 
 TEST_F(DefaultRowReaderTest, ReadOneRow) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(1);
   EXPECT_CALL(*mock_metric, PostCall).Times(1);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(1);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(1);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -266,21 +250,20 @@ TEST_F(DefaultRowReaderTest, ReadOneRow) {
 
 TEST_F(DefaultRowReaderTest, StreamIsDrained) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(1);
   EXPECT_CALL(*mock_metric, PostCall).Times(1);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(1);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -332,21 +315,20 @@ TEST_F(DefaultRowReaderTest, StreamIsDrained) {
 
 TEST_F(DefaultRowReaderTest, RetryThenSuccess) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(2);
   EXPECT_CALL(*mock_metric, PostCall).Times(2);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(1);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(1);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -388,21 +370,20 @@ TEST_F(DefaultRowReaderTest, RetryThenSuccess) {
 
 TEST_F(DefaultRowReaderTest, NoRetryOnPermanentError) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(1);
   EXPECT_CALL(*mock_metric, PostCall).Times(1);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -433,21 +414,20 @@ TEST_F(DefaultRowReaderTest, NoRetryOnPermanentError) {
 
 TEST_F(DefaultRowReaderTest, RetryPolicyExhausted) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(kNumRetries + 1);
   EXPECT_CALL(*mock_metric, PostCall).Times(kNumRetries + 1);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -488,21 +468,20 @@ TEST_F(DefaultRowReaderTest, RetryPolicyExhausted) {
 
 TEST_F(DefaultRowReaderTest, RetrySkipsAlreadyReadRows) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(2);
   EXPECT_CALL(*mock_metric, PostCall).Times(2);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(1);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(1);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -548,21 +527,20 @@ TEST_F(DefaultRowReaderTest, RetrySkipsAlreadyReadRows) {
 
 TEST_F(DefaultRowReaderTest, RetrySkipsAlreadyScannedRows) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(2);
   EXPECT_CALL(*mock_metric, PostCall).Times(2);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(1);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(1);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -617,21 +595,20 @@ TEST_F(DefaultRowReaderTest, RetrySkipsAlreadyScannedRows) {
 
 TEST_F(DefaultRowReaderTest, FailedParseIsRetried) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(2);
   EXPECT_CALL(*mock_metric, PostCall).Times(2);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(1);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(1);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -682,21 +659,20 @@ TEST_F(DefaultRowReaderTest, FailedParseIsRetried) {
 
 TEST_F(DefaultRowReaderTest, FailedParseSkipsAlreadyReadRows) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(2);
   EXPECT_CALL(*mock_metric, PostCall).Times(2);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(1);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(1);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -750,21 +726,20 @@ TEST_F(DefaultRowReaderTest, FailedParseSkipsAlreadyReadRows) {
 
 TEST_F(DefaultRowReaderTest, FailedParseSkipsAlreadyScannedRows) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(2);
   EXPECT_CALL(*mock_metric, PostCall).Times(2);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(1);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(1);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -827,21 +802,20 @@ TEST_F(DefaultRowReaderTest, FailedParseSkipsAlreadyScannedRows) {
 
 TEST_F(DefaultRowReaderTest, FailedParseWithPermanentError) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(1);
   EXPECT_CALL(*mock_metric, PostCall).Times(1);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -879,21 +853,20 @@ TEST_F(DefaultRowReaderTest, FailedParseWithPermanentError) {
 
 TEST_F(DefaultRowReaderTest, NoRetryOnEmptyRowSet) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(1);
   EXPECT_CALL(*mock_metric, PostCall).Times(1);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(1);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(1);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -928,21 +901,20 @@ TEST_F(DefaultRowReaderTest, NoRetryOnEmptyRowSet) {
 
 TEST_F(DefaultRowReaderTest, RowLimitIsSent) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(1);
   EXPECT_CALL(*mock_metric, PostCall).Times(1);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -970,21 +942,20 @@ TEST_F(DefaultRowReaderTest, RowLimitIsSent) {
 
 TEST_F(DefaultRowReaderTest, RowLimitIsDecreasedOnRetry) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(2);
   EXPECT_CALL(*mock_metric, PostCall).Times(2);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(1);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(1);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -1026,21 +997,20 @@ TEST_F(DefaultRowReaderTest, RowLimitIsDecreasedOnRetry) {
 
 TEST_F(DefaultRowReaderTest, NoRetryIfRowLimitReached) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(1);
   EXPECT_CALL(*mock_metric, PostCall).Times(1);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(1);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(1);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -1075,21 +1045,20 @@ TEST_F(DefaultRowReaderTest, NoRetryIfRowLimitReached) {
 
 TEST_F(DefaultRowReaderTest, CancelDrainsStream) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(1);
   EXPECT_CALL(*mock_metric, PostCall).Times(1);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(1);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -1146,21 +1115,20 @@ TEST_F(DefaultRowReaderTest, CancelDrainsStream) {
 
 TEST_F(DefaultRowReaderTest, CancelBeforeBegin) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(0);
   EXPECT_CALL(*mock_metric, PostCall).Times(0);
   EXPECT_CALL(*mock_metric, OnDone).Times(0);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -1188,21 +1156,20 @@ TEST_F(DefaultRowReaderTest, CancelBeforeBegin) {
 
 TEST_F(DefaultRowReaderTest, RowReaderConstructorDoesNotCallRpc) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(0);
   EXPECT_CALL(*mock_metric, PostCall).Times(0);
   EXPECT_CALL(*mock_metric, OnDone).Times(0);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -1223,21 +1190,20 @@ TEST_F(DefaultRowReaderTest, RowReaderConstructorDoesNotCallRpc) {
 
 TEST_F(DefaultRowReaderTest, RetryUsesNewContext) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(kNumRetries + 1);
   EXPECT_CALL(*mock_metric, PostCall).Times(kNumRetries + 1);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -1276,21 +1242,20 @@ TEST_F(DefaultRowReaderTest, RetryUsesNewContext) {
 
 TEST_F(DefaultRowReaderTest, ReverseScanSuccess) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(1);
   EXPECT_CALL(*mock_metric, PostCall).Times(1);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(3);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(3);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -1335,21 +1300,20 @@ TEST_F(DefaultRowReaderTest, ReverseScanSuccess) {
 
 TEST_F(DefaultRowReaderTest, ReverseScanFailsOnIncreasingRowKeyOrder) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(1);
   EXPECT_CALL(*mock_metric, PostCall).Times(1);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(1);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(1);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -1394,21 +1358,20 @@ TEST_F(DefaultRowReaderTest, ReverseScanFailsOnIncreasingRowKeyOrder) {
 
 TEST_F(DefaultRowReaderTest, ReverseScanResumption) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(2);
   EXPECT_CALL(*mock_metric, PostCall).Times(2);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(1);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(1);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -1500,21 +1463,20 @@ TEST_F(DefaultRowReaderTest, BigtableCookies) {
 
 TEST_F(DefaultRowReaderTest, RetryInfoHeeded) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(2);
   EXPECT_CALL(*mock_metric, PostCall).Times(2);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(1);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(1);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -1564,21 +1526,20 @@ TEST_F(DefaultRowReaderTest, RetryInfoHeeded) {
 
 TEST_F(DefaultRowReaderTest, RetryInfoIgnored) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(1);
   EXPECT_CALL(*mock_metric, PostCall).Times(1);
   EXPECT_CALL(*mock_metric, OnDone).Times(1);
   EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
 
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif

--- a/google/cloud/bigtable/internal/metrics.cc
+++ b/google/cloud/bigtable/internal/metrics.cc
@@ -553,9 +553,8 @@ std::vector<std::shared_ptr<Metric>> CloneMetrics(
   v.reserve(metrics.size());
   for (auto const& m : metrics) {
     // We should never add a nullptr Metric to the list.
-    assert(m != nullptr);
-    auto clone = m->clone(resource_labels, data_labels);
-    v.emplace_back(std::move(clone));
+    if (m == nullptr) continue;
+    v.push_back(m->clone(resource_labels, data_labels));
   }
   return v;
 }

--- a/google/cloud/bigtable/internal/metrics.cc
+++ b/google/cloud/bigtable/internal/metrics.cc
@@ -545,6 +545,21 @@ std::unique_ptr<Metric> ApplicationBlockingLatency::clone(
   return m;
 }
 
+std::vector<std::shared_ptr<Metric>> CloneMetrics(
+    TableResourceLabels const& resource_labels,
+    TableDataLabels const& data_labels,
+    std::vector<std::shared_ptr<Metric const>> const& metrics) {
+  std::vector<std::shared_ptr<Metric>> v;
+  v.reserve(metrics.size());
+  for (auto const& m : metrics) {
+    // We should never add a nullptr Metric to the list.
+    assert(m != nullptr);
+    auto clone = m->clone(resource_labels, data_labels);
+    v.emplace_back(std::move(clone));
+  }
+  return v;
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable_internal
 }  // namespace cloud

--- a/google/cloud/bigtable/internal/metrics.h
+++ b/google/cloud/bigtable/internal/metrics.h
@@ -123,6 +123,11 @@ class Metric {
                                         TableDataLabels const&) const = 0;
 };
 
+std::vector<std::shared_ptr<Metric>> CloneMetrics(
+    TableResourceLabels const& resource_labels,
+    TableDataLabels const& data_labels,
+    std::vector<std::shared_ptr<Metric const>> const& metrics);
+
 class OperationLatency : public Metric {
  public:
   explicit OperationLatency(

--- a/google/cloud/bigtable/internal/metrics_test.cc
+++ b/google/cloud/bigtable/internal/metrics_test.cc
@@ -38,6 +38,7 @@ using ::google::cloud::testing_util::SetServerMetadata;
 using ::testing::A;
 using ::testing::Eq;
 using ::testing::Pair;
+using ::testing::SizeIs;
 using ::testing::UnorderedElementsAre;
 
 using ::opentelemetry::metrics::Counter;
@@ -2480,6 +2481,28 @@ TEST(ApplicationBlockingLatency, StreamingData) {
   clone->PostCall(otel_context, client_context, {clock->Now(), Status{}});
   clone->OnDone(otel_context, {clock->Now(), Status{}});
 }
+
+class FakeTableMetric : public Metric {
+ public:
+  std::unique_ptr<Metric> clone(TableResourceLabels const&,
+                                TableDataLabels const&) const override {
+    return std::make_unique<FakeTableMetric>(*this);
+  }
+};
+
+TEST(MetricsTest, CloneMetrics) {
+  auto table_metric = std::make_shared<FakeTableMetric>();
+
+  TableResourceLabels resource_labels{"project", "instance", "table", "cluster",
+                                      "zone"};
+  TableDataLabels data_labels{"method", "streaming", "client",
+                              "uid",    "profile",   "status"};
+
+  std::vector<std::shared_ptr<Metric const>> metrics = {table_metric};
+  auto cloned = CloneMetrics(resource_labels, data_labels, metrics);
+  EXPECT_THAT(cloned, SizeIs(1));
+}
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable_internal

--- a/google/cloud/bigtable/internal/metrics_test.cc
+++ b/google/cloud/bigtable/internal/metrics_test.cc
@@ -2081,7 +2081,6 @@ TEST(ConnectivityErrorCount, MissingResourceLabels) {
   auto clone = connectivity_error_count.clone(resource_labels, data_labels);
 
   grpc::ClientContext client_context;
-  google::bigtable::v2::ResponseParams response_params;
   RpcMetadata server_metadata;
   server_metadata.headers.emplace("server-timing", "gfet4t7; dur=15");
   SetServerMetadata(client_context, server_metadata);

--- a/google/cloud/bigtable/internal/operation_context.cc
+++ b/google/cloud/bigtable/internal/operation_context.cc
@@ -25,22 +25,6 @@ namespace cloud {
 namespace bigtable_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-namespace {
-std::vector<std::shared_ptr<Metric>> CloneMetrics(
-    TableResourceLabels const& resource_labels,
-    TableDataLabels const& data_labels,
-    std::vector<std::shared_ptr<Metric const>> const& metrics) {
-  std::vector<std::shared_ptr<Metric>> v;
-  v.reserve(metrics.size());
-  for (auto const& m : metrics) {
-    v.emplace_back(m->clone(resource_labels, data_labels));
-  }
-  return v;
-}
-}  // namespace
-#endif
-
 void OperationContext::ProcessMetadata(
     std::multimap<grpc::string_ref, grpc::string_ref> const& metadata) {
   for (auto const& kv : metadata) {
@@ -54,13 +38,9 @@ void OperationContext::ProcessMetadata(
 
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
 
-OperationContext::OperationContext(
-    TableResourceLabels const& resource_labels,
-    TableDataLabels const& data_labels,
-    std::vector<std::shared_ptr<Metric const>> const& metrics,
-    std::shared_ptr<Clock> clock)
-    : cloned_metrics_(CloneMetrics(resource_labels, data_labels, metrics)),
-      clock_(std::move(clock)) {}
+OperationContext::OperationContext(std::vector<std::shared_ptr<Metric>> metrics,
+                                   std::shared_ptr<Clock> clock)
+    : cloned_metrics_(std::move(metrics)), clock_(std::move(clock)) {}
 
 void OperationContext::PreCall(grpc::ClientContext& client_context) {
   auto otel_context = opentelemetry::context::RuntimeContext::GetCurrent();
@@ -122,10 +102,8 @@ void OperationContext::ElementDelivery(grpc::ClientContext const&) {
 
 #else  // GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
 
-OperationContext::OperationContext(
-    TableResourceLabels const&, TableDataLabels const&,
-    std::vector<std::shared_ptr<Metric const>> const&, std::shared_ptr<Clock>) {
-}
+OperationContext::OperationContext(std::vector<std::shared_ptr<Metric>>,
+                                   std::shared_ptr<Clock>) {}
 
 void OperationContext::PreCall(grpc::ClientContext& client_context) {
   for (auto const& h : cookies_) {

--- a/google/cloud/bigtable/internal/operation_context.h
+++ b/google/cloud/bigtable/internal/operation_context.h
@@ -30,8 +30,6 @@ namespace cloud {
 namespace bigtable_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-struct TableDataLabels;
-struct TableResourceLabels;
 class Metric;
 
 /**
@@ -64,9 +62,7 @@ class OperationContext {
   // The default constructor is used when metric support is unavailable or
   // disabled.
   OperationContext() = default;
-  OperationContext(TableResourceLabels const& resource_labels,
-                   TableDataLabels const& data_labels,
-                   std::vector<std::shared_ptr<Metric const>> const& metrics,
+  OperationContext(std::vector<std::shared_ptr<Metric>> metrics,
                    std::shared_ptr<Clock> clock);
 
   // Called before each RPC attempt.

--- a/google/cloud/bigtable/internal/operation_context_factory.cc
+++ b/google/cloud/bigtable/internal/operation_context_factory.cc
@@ -300,8 +300,9 @@ std::shared_ptr<OperationContext> MetricsOperationContextFactory::ReadRow(
                                  app_profile,
                                  "" /*=status*/};
 
-  return std::make_shared<OperationContext>(resource_labels, data_labels,
-                                            read_row_metrics_.metrics, clock_);
+  return std::make_shared<OperationContext>(
+      CloneMetrics(resource_labels, data_labels, read_row_metrics_.metrics),
+      clock_);
 }
 
 std::shared_ptr<OperationContext> MetricsOperationContextFactory::ReadRows(
@@ -329,8 +330,9 @@ std::shared_ptr<OperationContext> MetricsOperationContextFactory::ReadRows(
                                  app_profile,
                                  "" /*=status*/};
 
-  return std::make_shared<OperationContext>(resource_labels, data_labels,
-                                            read_rows_metrics_.metrics, clock_);
+  return std::make_shared<OperationContext>(
+      CloneMetrics(resource_labels, data_labels, read_rows_metrics_.metrics),
+      clock_);
 }
 
 std::shared_ptr<OperationContext> MetricsOperationContextFactory::MutateRow(
@@ -358,7 +360,8 @@ std::shared_ptr<OperationContext> MetricsOperationContextFactory::MutateRow(
                                  "" /*=status*/};
 
   return std::make_shared<OperationContext>(
-      resource_labels, data_labels, mutate_row_metrics_.metrics, clock_);
+      CloneMetrics(resource_labels, data_labels, mutate_row_metrics_.metrics),
+      clock_);
 }
 
 std::shared_ptr<OperationContext> MetricsOperationContextFactory::MutateRows(
@@ -386,7 +389,8 @@ std::shared_ptr<OperationContext> MetricsOperationContextFactory::MutateRows(
                                  "" /*=status*/};
 
   return std::make_shared<OperationContext>(
-      resource_labels, data_labels, mutate_rows_metrics_.metrics, clock_);
+      CloneMetrics(resource_labels, data_labels, mutate_rows_metrics_.metrics),
+      clock_);
 }
 
 std::shared_ptr<OperationContext>
@@ -415,7 +419,8 @@ MetricsOperationContextFactory::CheckAndMutateRow(
                                  "" /*=status*/};
 
   return std::make_shared<OperationContext>(
-      resource_labels, data_labels, check_and_mutate_row_metrics_.metrics,
+      CloneMetrics(resource_labels, data_labels,
+                   check_and_mutate_row_metrics_.metrics),
       clock_);
 }
 
@@ -444,7 +449,9 @@ std::shared_ptr<OperationContext> MetricsOperationContextFactory::SampleRowKeys(
                                  "" /*=status*/};
 
   return std::make_shared<OperationContext>(
-      resource_labels, data_labels, sample_row_keys_metrics_.metrics, clock_);
+      CloneMetrics(resource_labels, data_labels,
+                   sample_row_keys_metrics_.metrics),
+      clock_);
 }
 
 std::shared_ptr<OperationContext>
@@ -473,7 +480,8 @@ MetricsOperationContextFactory::ReadModifyWriteRow(
                                  "" /*=status*/};
 
   return std::make_shared<OperationContext>(
-      resource_labels, data_labels, read_modify_write_row_metrics_.metrics,
+      CloneMetrics(resource_labels, data_labels,
+                   read_modify_write_row_metrics_.metrics),
       clock_);
 }
 
@@ -500,7 +508,9 @@ std::shared_ptr<OperationContext> MetricsOperationContextFactory::PrepareQuery(
                                  "" /*=status*/};
 
   return std::make_shared<OperationContext>(
-      resource_labels, data_labels, prepare_query_metrics_.metrics, clock_);
+      CloneMetrics(resource_labels, data_labels,
+                   prepare_query_metrics_.metrics),
+      clock_);
 }
 
 std::shared_ptr<OperationContext> MetricsOperationContextFactory::ExecuteQuery(
@@ -529,7 +539,9 @@ std::shared_ptr<OperationContext> MetricsOperationContextFactory::ExecuteQuery(
                                  "" /*=status*/};
 
   return std::make_shared<OperationContext>(
-      resource_labels, data_labels, execute_query_metrics_.metrics, clock_);
+      CloneMetrics(resource_labels, data_labels,
+                   execute_query_metrics_.metrics),
+      clock_);
 }
 
 #endif  // GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS

--- a/google/cloud/bigtable/internal/operation_context_test.cc
+++ b/google/cloud/bigtable/internal/operation_context_test.cc
@@ -146,23 +146,9 @@ class MockMetric : public Metric {
               (const, override));
 };
 
-// This class is a vehicle to get a MockMetric into the OperationContext object.
-class CloningMetric : public Metric {
- public:
-  explicit CloningMetric(std::unique_ptr<MockMetric> metric)
-      : metric_(std::move(metric)) {}
-  std::unique_ptr<Metric> clone(TableResourceLabels const&,
-                                TableDataLabels const&) const override {
-    return std::move(metric_);
-  }
-
- private:
-  mutable std::unique_ptr<MockMetric> metric_;
-};
-
 TEST(OperationContextMetricTest, MetricPreCall) {
   auto expected_first_attempt = std::chrono::steady_clock::now();
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
 
   EXPECT_CALL(*mock_metric, PreCall)
       .WillOnce(
@@ -177,9 +163,8 @@ TEST(OperationContextMetricTest, MetricPreCall) {
         EXPECT_FALSE(p.first_attempt);
       });
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<FakeSteadyClock>();
-  OperationContext operation_context({}, {}, {fake_metric}, clock);
+  OperationContext operation_context({mock_metric}, clock);
   grpc::ClientContext client_context;
 
   clock->SetTime(expected_first_attempt);
@@ -191,7 +176,7 @@ TEST(OperationContextMetricTest, MetricPreCall) {
 TEST(OperationContextMetricTest, MetricPostCall) {
   auto attempt_end = std::chrono::steady_clock::now();
   Status status{StatusCode::kUnavailable, "unavailable"};
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
 
   EXPECT_CALL(*mock_metric, PostCall)
       .WillOnce([&](opentelemetry::context::Context const&,
@@ -200,9 +185,8 @@ TEST(OperationContextMetricTest, MetricPostCall) {
         EXPECT_THAT(p.attempt_status, Eq(status));
       });
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<FakeSteadyClock>();
-  OperationContext operation_context({}, {}, {fake_metric}, clock);
+  OperationContext operation_context({mock_metric}, clock);
 
   testing_util::ValidateMetadataFixture metadata_fixture;
   grpc::ClientContext client_context;
@@ -216,7 +200,7 @@ TEST(OperationContextMetricTest, MetricPostCall) {
 TEST(OperationContextMetricTest, MetricOnDone) {
   auto operation_end = std::chrono::steady_clock::now();
   Status status{StatusCode::kUnavailable, "unavailable"};
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
 
   EXPECT_CALL(*mock_metric, OnDone)
       .WillOnce(
@@ -225,9 +209,8 @@ TEST(OperationContextMetricTest, MetricOnDone) {
             EXPECT_THAT(p.operation_status, Eq(status));
           });
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<FakeSteadyClock>();
-  OperationContext operation_context({}, {}, {fake_metric}, clock);
+  OperationContext operation_context({mock_metric}, clock);
 
   clock->SetTime(operation_end);
   operation_context.OnDone(status);
@@ -235,7 +218,7 @@ TEST(OperationContextMetricTest, MetricOnDone) {
 
 TEST(OperationContextMetricTest, MetricElementRequest) {
   auto element_request = std::chrono::steady_clock::now();
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
 
   EXPECT_CALL(*mock_metric, ElementRequest)
       .WillOnce([&](opentelemetry::context::Context const&,
@@ -243,9 +226,8 @@ TEST(OperationContextMetricTest, MetricElementRequest) {
         EXPECT_THAT(p.element_request, Eq(element_request));
       });
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<FakeSteadyClock>();
-  OperationContext operation_context({}, {}, {fake_metric}, clock);
+  OperationContext operation_context({mock_metric}, clock);
   grpc::ClientContext client_context;
 
   clock->SetTime(element_request);
@@ -254,7 +236,7 @@ TEST(OperationContextMetricTest, MetricElementRequest) {
 
 TEST(OperationContextMetricTest, MetricElementDelivery) {
   auto element_delivery = std::chrono::steady_clock::now();
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
 
   EXPECT_CALL(*mock_metric, ElementDelivery)
       .WillOnce([&](opentelemetry::context::Context const&,
@@ -269,9 +251,8 @@ TEST(OperationContextMetricTest, MetricElementDelivery) {
         EXPECT_FALSE(p.first_response);
       });
 
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<FakeSteadyClock>();
-  OperationContext operation_context({}, {}, {fake_metric}, clock);
+  OperationContext operation_context({mock_metric}, clock);
   grpc::ClientContext client_context;
 
   clock->SetTime(element_delivery);

--- a/google/cloud/bigtable/internal/partial_result_set_source_test.cc
+++ b/google/cloud/bigtable/internal/partial_result_set_source_test.cc
@@ -113,26 +113,12 @@ class MockMetric : public Metric {
                TableDataLabels const& data_labels),
               (const, override));
 };
-
-// This class is a vehicle to get a MockMetric into the OperationContext object.
-class CloningMetric : public Metric {
- public:
-  explicit CloningMetric(std::unique_ptr<MockMetric> metric)
-      : metric_(std::move(metric)) {}
-  std::unique_ptr<Metric> clone(TableResourceLabels const&,
-                                TableDataLabels const&) const override {
-    return std::move(metric_);
-  }
-
- private:
-  mutable std::unique_ptr<MockMetric> metric_;
-};
 #endif  // GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
 
 /// @test Verify the behavior when the initial `Read()` fails.
 TEST(PartialResultSetSourceTest, InitialReadFailure) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(0);
   EXPECT_CALL(*mock_metric, PostCall).Times(0);
   EXPECT_CALL(*mock_metric, OnDone)
@@ -142,13 +128,12 @@ TEST(PartialResultSetSourceTest, InitialReadFailure) {
       });
   EXPECT_CALL(*mock_metric, ElementRequest).Times(0);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(0);
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -173,7 +158,7 @@ TEST(PartialResultSetSourceTest, InitialReadFailure) {
  */
 TEST(PartialResultSetSourceTest, MissingRowTypeNoData) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(0);
   EXPECT_CALL(*mock_metric, PostCall).Times(0);
   EXPECT_CALL(*mock_metric, OnDone)
@@ -183,13 +168,12 @@ TEST(PartialResultSetSourceTest, MissingRowTypeNoData) {
       });
   EXPECT_CALL(*mock_metric, ElementRequest).Times(1);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(1);
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -228,7 +212,7 @@ TEST(PartialResultSetSourceTest, MissingRowTypeNoData) {
 /// @test Verify a single response is handled correctly.
 TEST(PartialResultSetSourceTest, SingleResponse) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(0);
   EXPECT_CALL(*mock_metric, PostCall).Times(0);
   EXPECT_CALL(*mock_metric, OnDone)
@@ -238,13 +222,12 @@ TEST(PartialResultSetSourceTest, SingleResponse) {
       });
   EXPECT_CALL(*mock_metric, ElementRequest).Times(2);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(2);
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -378,7 +361,7 @@ TEST(PartialResultSetSourceTest, ChecksumMismatch) {
  */
 TEST(PartialResultSetSourceTest, MultipleResponses) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(0);
   EXPECT_CALL(*mock_metric, PostCall).Times(0);
   EXPECT_CALL(*mock_metric, OnDone)
@@ -388,13 +371,12 @@ TEST(PartialResultSetSourceTest, MultipleResponses) {
       });
   EXPECT_CALL(*mock_metric, ElementRequest).Times(4);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(4);
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif
@@ -519,7 +501,7 @@ TEST(PartialResultSetSourceTest, MultipleResponses) {
  */
 TEST(PartialResultSetSourceTest, ResponseWithNoValues) {
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  auto mock_metric = std::make_unique<MockMetric>();
+  auto mock_metric = std::make_shared<MockMetric>();
   EXPECT_CALL(*mock_metric, PreCall).Times(0);
   EXPECT_CALL(*mock_metric, PostCall).Times(0);
   EXPECT_CALL(*mock_metric, OnDone)
@@ -529,13 +511,12 @@ TEST(PartialResultSetSourceTest, ResponseWithNoValues) {
       });
   EXPECT_CALL(*mock_metric, ElementRequest).Times(2);
   EXPECT_CALL(*mock_metric, ElementDelivery).Times(2);
-  auto fake_metric = std::make_shared<CloningMetric>(std::move(mock_metric));
   auto clock = std::make_shared<testing_util::FakeSteadyClock>();
   // Normally std::make_shared would be used here, but some weird type deduction
   // is preventing it.
   // NOLINTNEXTLINE(modernize-make-shared)
   auto operation_context = std::shared_ptr<OperationContext>(
-      new OperationContext({}, {}, {fake_metric}, clock));
+      new OperationContext({mock_metric}, clock));
 #else
   auto operation_context = std::make_shared<OperationContext>();
 #endif


### PR DESCRIPTION
This PR decouples ResourceLabels and DataLabels from the OperationContext constructor. This increases the cohesiveness and genericity of the OperationContext class. This will be useful for adding Client Schema metrics to Bigtable and required for metrics support across other libraries.