### PR TITLE
impl(bigtable): update dynamic channel selection to return outstanding rpcs

### DIFF
--- a/google/cloud/bigtable/internal/bigtable_random_two_least_used_decorator.cc
+++ b/google/cloud/bigtable/internal/bigtable_random_two_least_used_decorator.cc
@@ -109,10 +109,11 @@ class AsyncStreamingReadWriteRpcTracking
 template <typename Response>
 Response UnaryHelper(std::shared_ptr<DynamicChannelPool<BigtableStub>>& pool,
                      std::function<Response(BigtableStub&)> fn) {
-  auto child = pool->GetChannelRandomTwoLeastUsed();
-  auto stub = child->AcquireStub();
-  auto result = fn(*stub);
-  child->ReleaseStub();
+  SelectedChannel<BigtableStub> selection =
+      pool->GetChannelRandomTwoLeastUsed();
+  std::shared_ptr<BigtableStub> stub = selection.channel->AcquireStub();
+  Response result = fn(*stub);
+  selection.channel->ReleaseStub();
   return result;
 }
 
@@ -123,11 +124,12 @@ StreamingHelper(
     std::function<std::unique_ptr<
         google::cloud::internal::StreamingReadRpc<Response>>(BigtableStub&)>
         fn) {
-  auto child = pool->GetChannelRandomTwoLeastUsed();
-  auto stub = child->AcquireStub();
-  auto result = fn(*stub);
-  auto release_fn = [weak = child->MakeWeak()] {
-    auto child = weak.lock();
+  SelectedChannel<BigtableStub> selection =
+      pool->GetChannelRandomTwoLeastUsed();
+  std::shared_ptr<BigtableStub> stub = selection.channel->AcquireStub();
+  std::unique_ptr<internal::StreamingReadRpc<Response>> result = fn(*stub);
+  auto release_fn = [weak = selection.channel->MakeWeak()] {
+    std::shared_ptr<ChannelUsage<BigtableStub>> child = weak.lock();
     if (child) child->ReleaseStub();
   };
   return std::make_unique<StreamingReadRpcTracking<Response>>(
@@ -142,11 +144,12 @@ AsyncStreamingHelper(
         google::cloud::internal::AsyncStreamingReadRpc<Response>>(
         BigtableStub&)>
         fn) {
-  auto child = pool->GetChannelRandomTwoLeastUsed();
-  auto stub = child->AcquireStub();
-  auto result = fn(*stub);
-  auto release_fn = [weak = child->MakeWeak()] {
-    auto child = weak.lock();
+  SelectedChannel<BigtableStub> selection =
+      pool->GetChannelRandomTwoLeastUsed();
+  std::shared_ptr<BigtableStub> stub = selection.channel->AcquireStub();
+  std::unique_ptr<internal::AsyncStreamingReadRpc<Response>> result = fn(*stub);
+  auto release_fn = [weak = selection.channel->MakeWeak()] {
+    std::shared_ptr<ChannelUsage<BigtableStub>> child = weak.lock();
     if (child) child->ReleaseStub();
   };
   return std::make_unique<AsyncStreamingReadRpcTracking<Response>>(
@@ -160,11 +163,13 @@ AsyncStreamingHelper(
     std::function<std::unique_ptr<google::cloud::AsyncStreamingReadWriteRpc<
         Request, Response>>(BigtableStub&)>
         fn) {
-  auto child = pool->GetChannelRandomTwoLeastUsed();
-  auto stub = child->AcquireStub();
-  auto result = fn(*stub);
-  auto release_fn = [weak = child->MakeWeak()] {
-    auto child = weak.lock();
+  SelectedChannel<BigtableStub> selection =
+      pool->GetChannelRandomTwoLeastUsed();
+  std::shared_ptr<BigtableStub> stub = selection.channel->AcquireStub();
+  std::unique_ptr<AsyncStreamingReadWriteRpc<Request, Response>> result =
+      fn(*stub);
+  auto release_fn = [weak = selection.channel->MakeWeak()] {
+    std::shared_ptr<ChannelUsage<BigtableStub>> child = weak.lock();
     if (child) child->ReleaseStub();
   };
   return std::make_unique<

--- a/google/cloud/bigtable/internal/dynamic_channel_pool.h
+++ b/google/cloud/bigtable/internal/dynamic_channel_pool.h
@@ -36,11 +36,6 @@ namespace cloud {
 namespace bigtable_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-enum class TransportType {
-  kCloudPath,
-  kDirectPath,
-};
-
 //
 // This class manages a pool of Stubs wrapped in a ChannelUsage object, and
 // selects one for use using a "Random Two Least Used" strategy.
@@ -71,12 +66,11 @@ class DynamicChannelPool
       std::vector<std::shared_ptr<ChannelUsage<T>>> initial_channels,
       std::shared_ptr<ConnectionRefreshState> refresh_state,
       StubFactoryFn stub_factory_fn,
-      bigtable::experimental::DynamicChannelPoolSizingPolicy sizing_policy,
-      TransportType transport_type = TransportType::kCloudPath) {
+      bigtable::experimental::DynamicChannelPoolSizingPolicy sizing_policy) {
     auto pool = std::shared_ptr<DynamicChannelPool>(new DynamicChannelPool(
         std::move(instance_name), std::move(cq), std::move(initial_channels),
         std::move(refresh_state), std::move(stub_factory_fn),
-        std::move(sizing_policy), transport_type));
+        std::move(sizing_policy)));
     return pool;
   }
 
@@ -110,8 +104,6 @@ class DynamicChannelPool
       const {
     return sizing_policy_;
   }
-
-  TransportType transport_type() const { return transport_type_; }
 
   // Calls CheckPoolChannelHealth before picking a channel.
   //
@@ -167,8 +159,8 @@ class DynamicChannelPool
       channels_.push_back(stub_factory_fn_(next_channel_id_++, instance_name_,
                                            StubManager::Priming::kNoPriming)
                               .value());
-      auto sor = channels_.front()->instant_outstanding_rpcs();
-      return SelectedChannel<T>{channels_.front(), sor ? *sor : 0};
+      StatusOr<int> rpcs = channels_.front()->instant_outstanding_rpcs();
+      return SelectedChannel<T>{channels_.front(), rpcs ? *rpcs : 0};
     }
     return HandleBadChannels(lk, d);
   }
@@ -181,16 +173,14 @@ class DynamicChannelPool
       std::vector<std::shared_ptr<ChannelUsage<T>>> initial_wrapped_channels,
       std::shared_ptr<ConnectionRefreshState> refresh_state,
       StubFactoryFn stub_factory_fn,
-      bigtable::experimental::DynamicChannelPoolSizingPolicy sizing_policy,
-      TransportType transport_type = TransportType::kCloudPath)
+      bigtable::experimental::DynamicChannelPoolSizingPolicy sizing_policy)
       : instance_name_(std::move(instance_name)),
         cq_(std::move(cq)),
         refresh_state_(std::move(refresh_state)),
         stub_factory_fn_(std::move(stub_factory_fn)),
         channels_(std::move(initial_wrapped_channels)),
         sizing_policy_(std::move(sizing_policy)),
-        next_channel_id_(static_cast<std::uint32_t>(channels_.size())),
-        transport_type_(transport_type) {
+        next_channel_id_(static_cast<std::uint32_t>(channels_.size())) {
     std::scoped_lock lk(mu_);
     SetSizeDecreaseCooldownTimer(lk);
   }
@@ -268,8 +258,8 @@ class DynamicChannelPool
                               .value());
       std::swap(channels_.front(), channels_.back());
       channel = channels_.front();
-      auto sor = channel->instant_outstanding_rpcs();
-      outstanding_rpcs = sor ? *sor : 0;
+      StatusOr<int> rpcs = channel->instant_outstanding_rpcs();
+      outstanding_rpcs = rpcs ? *rpcs : 0;
     }
     ScheduleRemoveChannels(lk);
     return SelectedChannel<T>{std::move(channel), outstanding_rpcs};
@@ -463,7 +453,6 @@ class DynamicChannelPool
   future<StatusOr<std::chrono::system_clock::time_point>>
       pool_size_decrease_cooldown_timer_;
   std::uint32_t next_channel_id_;
-  TransportType const transport_type_ = TransportType::kCloudPath;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/internal/dynamic_channel_pool.h
+++ b/google/cloud/bigtable/internal/dynamic_channel_pool.h
@@ -18,6 +18,8 @@
 #include "google/cloud/bigtable/instance_resource.h"
 #include "google/cloud/bigtable/internal/channel_usage.h"
 #include "google/cloud/bigtable/internal/connection_refresh_state.h"
+#include "google/cloud/bigtable/internal/defaults.h"
+#include "google/cloud/bigtable/internal/metrics.h"
 #include "google/cloud/bigtable/internal/stub_manager.h"
 #include "google/cloud/bigtable/options.h"
 #include "google/cloud/completion_queue.h"
@@ -34,6 +36,11 @@ namespace cloud {
 namespace bigtable_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+enum class TransportType {
+  kCloudPath,
+  kDirectPath,
+};
+
 //
 // This class manages a pool of Stubs wrapped in a ChannelUsage object, and
 // selects one for use using a "Random Two Least Used" strategy.
@@ -42,6 +49,12 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 // remove ChannelUsage<T> objects per the configuration present in the
 // DynamicChannelPoolSizingPolicyOption.
 //
+template <typename T>
+struct SelectedChannel {
+  std::shared_ptr<ChannelUsage<T>> channel;
+  int outstanding_rpcs;
+};
+
 template <typename T>
 class DynamicChannelPool
     : public std::enable_shared_from_this<DynamicChannelPool<T>> {
@@ -58,11 +71,12 @@ class DynamicChannelPool
       std::vector<std::shared_ptr<ChannelUsage<T>>> initial_channels,
       std::shared_ptr<ConnectionRefreshState> refresh_state,
       StubFactoryFn stub_factory_fn,
-      bigtable::experimental::DynamicChannelPoolSizingPolicy sizing_policy) {
+      bigtable::experimental::DynamicChannelPoolSizingPolicy sizing_policy,
+      TransportType transport_type = TransportType::kCloudPath) {
     auto pool = std::shared_ptr<DynamicChannelPool>(new DynamicChannelPool(
         std::move(instance_name), std::move(cq), std::move(initial_channels),
         std::move(refresh_state), std::move(stub_factory_fn),
-        std::move(sizing_policy)));
+        std::move(sizing_policy), transport_type));
     return pool;
   }
 
@@ -97,6 +111,8 @@ class DynamicChannelPool
     return sizing_policy_;
   }
 
+  TransportType transport_type() const { return transport_type_; }
+
   // Calls CheckPoolChannelHealth before picking a channel.
   //
   // Pick two random channels from channels_ and return the channel with the
@@ -111,7 +127,7 @@ class DynamicChannelPool
   //
   // If there are no healthy channels in channels_, create a new channel and
   // use that one. Also call ScheduleAddChannels to replenish channels_.
-  std::shared_ptr<ChannelUsage<T>> GetChannelRandomTwoLeastUsed() {
+  SelectedChannel<T> GetChannelRandomTwoLeastUsed() {
     std::scoped_lock lk(mu_);
     CheckPoolChannelHealth(lk);
 
@@ -136,12 +152,13 @@ class DynamicChannelPool
 
     // This is the most common case so we try it first.
     if (d.channel_1_rpcs.ok() && d.channel_2_rpcs.ok()) {
-      return *d.channel_1_rpcs < *d.channel_2_rpcs ? *d.channel_1_iter
-                                                   : *d.channel_2_iter;
+      return *d.channel_1_rpcs < *d.channel_2_rpcs
+                 ? SelectedChannel<T>{*d.channel_1_iter, *d.channel_1_rpcs}
+                 : SelectedChannel<T>{*d.channel_2_iter, *d.channel_2_rpcs};
     }
     if (d.iterators.size() == 1 && d.channel_1_rpcs.ok()) {
       // Pool contains exactly 1 good channel.
-      return *d.channel_1_iter;
+      return SelectedChannel<T>{*d.channel_1_iter, *d.channel_1_rpcs};
     }
     if (d.iterators.empty()) {
       // Pool is empty, create a channel immediately and return it. While the
@@ -150,7 +167,8 @@ class DynamicChannelPool
       channels_.push_back(stub_factory_fn_(next_channel_id_++, instance_name_,
                                            StubManager::Priming::kNoPriming)
                               .value());
-      return channels_.front();
+      auto sor = channels_.front()->instant_outstanding_rpcs();
+      return SelectedChannel<T>{channels_.front(), sor ? *sor : 0};
     }
     return HandleBadChannels(lk, d);
   }
@@ -163,14 +181,16 @@ class DynamicChannelPool
       std::vector<std::shared_ptr<ChannelUsage<T>>> initial_wrapped_channels,
       std::shared_ptr<ConnectionRefreshState> refresh_state,
       StubFactoryFn stub_factory_fn,
-      bigtable::experimental::DynamicChannelPoolSizingPolicy sizing_policy)
+      bigtable::experimental::DynamicChannelPoolSizingPolicy sizing_policy,
+      TransportType transport_type = TransportType::kCloudPath)
       : instance_name_(std::move(instance_name)),
         cq_(std::move(cq)),
         refresh_state_(std::move(refresh_state)),
         stub_factory_fn_(std::move(stub_factory_fn)),
         channels_(std::move(initial_wrapped_channels)),
         sizing_policy_(std::move(sizing_policy)),
-        next_channel_id_(static_cast<std::uint32_t>(channels_.size())) {
+        next_channel_id_(static_cast<std::uint32_t>(channels_.size())),
+        transport_type_(transport_type) {
     std::scoped_lock lk(mu_);
     SetSizeDecreaseCooldownTimer(lk);
   }
@@ -204,8 +224,8 @@ class DynamicChannelPool
 
   // We have one or more bad channels. Spending time finding a good channel
   // will be cheaper than trying to use a bad channel in the long run.
-  std::shared_ptr<ChannelUsage<T>> HandleBadChannels(
-      std::scoped_lock<std::mutex> const& lk, ChannelSelectionData& d) {
+  SelectedChannel<T> HandleBadChannels(std::scoped_lock<std::mutex> const& lk,
+                                       ChannelSelectionData& d) {
     std::vector<typename ChannelSelectionData::ChannelSelect> bad_channel_iters;
     if (d.shuffle_iter != d.iterators.end()) ++d.shuffle_iter;
     ChannelSelectionData::FindGoodChannel(d.iterators, d.channel_1_iter,
@@ -216,14 +236,22 @@ class DynamicChannelPool
                                           bad_channel_iters);
 
     std::shared_ptr<ChannelUsage<T>> channel;
+    int outstanding_rpcs = 0;
     if (d.channel_1_rpcs.ok() || d.channel_2_rpcs.ok()) {
       if (d.channel_1_rpcs.ok() && d.channel_2_rpcs.ok()) {
-        channel = *d.channel_1_rpcs < *d.channel_2_rpcs ? *d.channel_1_iter
-                                                        : *d.channel_2_iter;
+        if (*d.channel_1_rpcs < *d.channel_2_rpcs) {
+          channel = *d.channel_1_iter;
+          outstanding_rpcs = *d.channel_1_rpcs;
+        } else {
+          channel = *d.channel_2_iter;
+          outstanding_rpcs = *d.channel_2_rpcs;
+        }
       } else if (d.channel_1_rpcs.ok()) {
         channel = *d.channel_1_iter;
+        outstanding_rpcs = *d.channel_1_rpcs;
       } else if (d.channel_2_rpcs.ok()) {
         channel = *d.channel_2_iter;
+        outstanding_rpcs = *d.channel_2_rpcs;
       }
       // Wait until we no longer need valid iterators to call EvictBadChannels.
       EvictBadChannels(lk, bad_channel_iters);
@@ -240,9 +268,11 @@ class DynamicChannelPool
                               .value());
       std::swap(channels_.front(), channels_.back());
       channel = channels_.front();
+      auto sor = channel->instant_outstanding_rpcs();
+      outstanding_rpcs = sor ? *sor : 0;
     }
     ScheduleRemoveChannels(lk);
-    return channel;
+    return SelectedChannel<T>{std::move(channel), outstanding_rpcs};
   }
 
   // Determines the number of channels to add and reserves the channel ids to
@@ -433,6 +463,7 @@ class DynamicChannelPool
   future<StatusOr<std::chrono::system_clock::time_point>>
       pool_size_decrease_cooldown_timer_;
   std::uint32_t next_channel_id_;
+  TransportType const transport_type_ = TransportType::kCloudPath;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/internal/dynamic_channel_pool_test.cc
+++ b/google/cloud/bigtable/internal/dynamic_channel_pool_test.cc
@@ -1,4 +1,3 @@
-#include "google/cloud/bigtable/internal/operation_context.h"
 // Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/internal/dynamic_channel_pool.h"
+#include "google/cloud/bigtable/internal/operation_context.h"
 #include "google/cloud/bigtable/testing/mock_bigtable_stub.h"
 #include "google/cloud/internal/make_status.h"
 #include "google/cloud/testing_util/fake_completion_queue_impl.h"
@@ -36,7 +36,7 @@ class DynamicChannelPoolTestWrapper {
   using ChannelSelectionData =
       DynamicChannelPool<BigtableStub>::ChannelSelectionData;
 
-  std::shared_ptr<ChannelUsage<BigtableStub>> HandleBadChannels(
+  SelectedChannel<BigtableStub> HandleBadChannels(
       std::scoped_lock<std::mutex> const& lk,
       DynamicChannelPool<BigtableStub>::ChannelSelectionData& d) {
     return pool_->HandleBadChannels(lk, d);
@@ -153,14 +153,14 @@ TEST_F(DynamicChannelPoolTest, SelectLeastUsedFromTwoChannels) {
   EXPECT_CALL(*mock_stub_0, CheckAndMutateRow)
       .WillOnce([](grpc::ClientContext&, Options const&,
                    google::bigtable::v2::CheckAndMutateRowRequest const&,
-                   auto&) {
+                   OperationContext&) {
         google::bigtable::v2::CheckAndMutateRowResponse response;
         response.set_predicate_matched(true);
         return response;
       });
   auto mock_stub_1 = std::make_shared<MockBigtableStub>();
   EXPECT_CALL(*mock_stub_1, CheckAndMutateRow).Times(0);
-  int initial_rpc_count = 0;
+  int initial_rpc_count = 5;
   channels.push_back(std::make_shared<ChannelUsage<BigtableStub>>(
       std::move(mock_stub_0), initial_rpc_count++));
   channels.push_back(std::make_shared<ChannelUsage<BigtableStub>>(
@@ -181,11 +181,14 @@ TEST_F(DynamicChannelPoolTest, SelectLeastUsedFromTwoChannels) {
   auto pool = DynamicChannelPool<BigtableStub>::Create(
       instance_name, CompletionQueue(mock_cq_impl_), channels, refresh_state,
       stub_factory_fn, sizing_policy);
-  auto selected_stub = pool->GetChannelRandomTwoLeastUsed();
+  auto selected = pool->GetChannelRandomTwoLeastUsed();
+  EXPECT_THAT(selected.outstanding_rpcs, Eq(5));
   grpc::ClientContext context;
-  OperationContext op_ctx;
-  auto response =
-      selected_stub->AcquireStub()->CheckAndMutateRow(context, {}, {}, op_ctx);
+  OperationContext default_oc;
+  auto response = selected.channel->AcquireStub()->CheckAndMutateRow(
+      context, {}, {}, default_oc);
+  EXPECT_THAT(selected.channel->instant_outstanding_rpcs(),
+              testing_util::IsOkAndHolds(Eq(6)));
   ASSERT_STATUS_OK(response);
   EXPECT_TRUE(response->predicate_matched());
 
@@ -219,7 +222,7 @@ TEST_F(DynamicChannelPoolTest, OneInitialChannel) {
     EXPECT_CALL(*mock_stub_0, CheckAndMutateRow)
         .WillOnce([](grpc::ClientContext&, Options const&,
                      google::bigtable::v2::CheckAndMutateRowRequest const&,
-                     auto&) {
+                     OperationContext&) {
           google::bigtable::v2::CheckAndMutateRowResponse response;
           response.set_predicate_matched(true);
           return response;
@@ -247,11 +250,12 @@ TEST_F(DynamicChannelPoolTest, OneInitialChannel) {
         stub_factory_fn.AsStdFunction(), sizing_policy);
     EXPECT_THAT(pool->size(), Eq(1));
 
-    auto selected_stub = pool->GetChannelRandomTwoLeastUsed();
+    auto selected = pool->GetChannelRandomTwoLeastUsed();
+    EXPECT_THAT(selected.outstanding_rpcs, Eq(0));
     grpc::ClientContext context;
-    OperationContext op_ctx;
-    auto response = selected_stub->AcquireStub()->CheckAndMutateRow(context, {},
-                                                                    {}, op_ctx);
+    OperationContext default_oc;
+    auto response = selected.channel->AcquireStub()->CheckAndMutateRow(
+        context, {}, {}, default_oc);
     ASSERT_STATUS_OK(response);
     EXPECT_TRUE(response->predicate_matched());
   }
@@ -276,7 +280,7 @@ TEST_F(DynamicChannelPoolTest, EmptyInitialPool) {
     EXPECT_CALL(*mock_stub, CheckAndMutateRow)
         .WillOnce([](grpc::ClientContext&, Options const&,
                      google::bigtable::v2::CheckAndMutateRowRequest const&,
-                     auto&) {
+                     OperationContext&) {
           google::bigtable::v2::CheckAndMutateRowResponse response;
           response.set_predicate_matched(true);
           return response;
@@ -310,11 +314,12 @@ TEST_F(DynamicChannelPoolTest, EmptyInitialPool) {
 
     EXPECT_THAT(*pool, ::testing::IsEmpty());
 
-    auto selected_stub = pool->GetChannelRandomTwoLeastUsed();
+    auto selected = pool->GetChannelRandomTwoLeastUsed();
+    EXPECT_THAT(selected.outstanding_rpcs, Eq(0));
     grpc::ClientContext context;
-    OperationContext op_ctx;
-    auto response = selected_stub->AcquireStub()->CheckAndMutateRow(context, {},
-                                                                    {}, op_ctx);
+    OperationContext default_oc;
+    auto response = selected.channel->AcquireStub()->CheckAndMutateRow(
+        context, {}, {}, default_oc);
     ASSERT_STATUS_OK(response);
     EXPECT_TRUE(response->predicate_matched());
 
@@ -751,7 +756,7 @@ TEST_F(DynamicChannelPoolTest, HandleBadChannelsTwoChannelsOneBad) {
   EXPECT_CALL(*mock_stub, CheckAndMutateRow)
       .WillOnce([](grpc::ClientContext&, Options const&,
                    google::bigtable::v2::CheckAndMutateRowRequest const&,
-                   auto&) {
+                   OperationContext&) {
         google::bigtable::v2::CheckAndMutateRowResponse response;
         response.set_predicate_matched(true);
         return response;
@@ -778,7 +783,7 @@ TEST_F(DynamicChannelPoolTest, HandleBadChannelsTwoChannelsOneBad) {
   DynamicChannelPoolTestWrapper wrapper(pool);
   auto draining_channels = wrapper.SetDrainingChannels({});
 
-  std::shared_ptr<ChannelUsage<BigtableStub>> selected_stub;
+  SelectedChannel<BigtableStub> selected_stub;
   {
     auto lock = wrapper.CreateLock();
     selected_stub = wrapper.HandleBadChannels(lock, data);
@@ -786,9 +791,9 @@ TEST_F(DynamicChannelPoolTest, HandleBadChannelsTwoChannelsOneBad) {
   EXPECT_THAT(draining_channels, IsEmpty());
 
   grpc::ClientContext context;
-  OperationContext op_ctx;
-  auto response =
-      selected_stub->AcquireStub()->CheckAndMutateRow(context, {}, {}, op_ctx);
+  OperationContext default_oc;
+  auto response = selected_stub.channel->AcquireStub()->CheckAndMutateRow(
+      context, {}, {}, default_oc);
   ASSERT_STATUS_OK(response);
   EXPECT_TRUE(response->predicate_matched());
   EXPECT_THAT(pool->size(), Eq(1));
@@ -832,7 +837,7 @@ TEST_F(DynamicChannelPoolTest, HandleBadChannelsTwoChannelsOtherOneBad) {
   EXPECT_CALL(*mock_stub, CheckAndMutateRow)
       .WillOnce([](grpc::ClientContext&, Options const&,
                    google::bigtable::v2::CheckAndMutateRowRequest const&,
-                   auto&) {
+                   OperationContext&) {
         google::bigtable::v2::CheckAndMutateRowResponse response;
         response.set_predicate_matched(true);
         return response;
@@ -861,7 +866,7 @@ TEST_F(DynamicChannelPoolTest, HandleBadChannelsTwoChannelsOtherOneBad) {
   DynamicChannelPoolTestWrapper wrapper(pool);
   auto draining_channels = wrapper.SetDrainingChannels({});
 
-  std::shared_ptr<ChannelUsage<BigtableStub>> selected_stub;
+  SelectedChannel<BigtableStub> selected_stub;
   {
     auto lock = wrapper.CreateLock();
     selected_stub = wrapper.HandleBadChannels(lock, data);
@@ -869,9 +874,9 @@ TEST_F(DynamicChannelPoolTest, HandleBadChannelsTwoChannelsOtherOneBad) {
   EXPECT_THAT(draining_channels, IsEmpty());
 
   grpc::ClientContext context;
-  OperationContext op_ctx;
-  auto response =
-      selected_stub->AcquireStub()->CheckAndMutateRow(context, {}, {}, op_ctx);
+  OperationContext default_oc;
+  auto response = selected_stub.channel->AcquireStub()->CheckAndMutateRow(
+      context, {}, {}, default_oc);
   ASSERT_STATUS_OK(response);
   EXPECT_TRUE(response->predicate_matched());
   EXPECT_THAT(pool->size(), Eq(1));
@@ -915,7 +920,7 @@ TEST_F(DynamicChannelPoolTest, HandleBadChannelsThreeChannelsOneBad) {
   EXPECT_CALL(*mock_stub_0, CheckAndMutateRow)
       .WillOnce([](grpc::ClientContext&, Options const&,
                    google::bigtable::v2::CheckAndMutateRowRequest const&,
-                   auto&) {
+                   OperationContext&) {
         google::bigtable::v2::CheckAndMutateRowResponse response;
         response.set_predicate_matched(true);
         return response;
@@ -950,7 +955,7 @@ TEST_F(DynamicChannelPoolTest, HandleBadChannelsThreeChannelsOneBad) {
   DynamicChannelPoolTestWrapper wrapper(pool);
   auto draining_channels = wrapper.SetDrainingChannels({});
 
-  std::shared_ptr<ChannelUsage<BigtableStub>> selected_stub;
+  SelectedChannel<BigtableStub> selected_stub;
   {
     auto lock = wrapper.CreateLock();
     selected_stub = wrapper.HandleBadChannels(lock, data);
@@ -958,9 +963,9 @@ TEST_F(DynamicChannelPoolTest, HandleBadChannelsThreeChannelsOneBad) {
   EXPECT_THAT(draining_channels, IsEmpty());
 
   grpc::ClientContext context;
-  OperationContext op_ctx;
-  auto response =
-      selected_stub->AcquireStub()->CheckAndMutateRow(context, {}, {}, op_ctx);
+  OperationContext default_oc;
+  auto response = selected_stub.channel->AcquireStub()->CheckAndMutateRow(
+      context, {}, {}, default_oc);
   ASSERT_STATUS_OK(response);
   EXPECT_TRUE(response->predicate_matched());
   EXPECT_THAT(pool->size(), Eq(2));
@@ -1004,7 +1009,7 @@ TEST_F(DynamicChannelPoolTest, HandleBadChannelsAllChannelsBad) {
   EXPECT_CALL(*mock_stub, CheckAndMutateRow)
       .WillOnce([](grpc::ClientContext&, Options const&,
                    google::bigtable::v2::CheckAndMutateRowRequest const&,
-                   auto&) {
+                   OperationContext&) {
         google::bigtable::v2::CheckAndMutateRowResponse response;
         response.set_predicate_matched(true);
         return response;
@@ -1049,7 +1054,7 @@ TEST_F(DynamicChannelPoolTest, HandleBadChannelsAllChannelsBad) {
   DynamicChannelPoolTestWrapper wrapper(pool);
   auto draining_channels = wrapper.SetDrainingChannels({});
 
-  std::shared_ptr<ChannelUsage<BigtableStub>> selected_stub;
+  SelectedChannel<BigtableStub> selected_stub;
   {
     auto lock = wrapper.CreateLock();
     selected_stub = wrapper.HandleBadChannels(lock, data);
@@ -1057,9 +1062,9 @@ TEST_F(DynamicChannelPoolTest, HandleBadChannelsAllChannelsBad) {
   EXPECT_THAT(draining_channels, IsEmpty());
 
   grpc::ClientContext context;
-  OperationContext op_ctx;
-  auto response =
-      selected_stub->AcquireStub()->CheckAndMutateRow(context, {}, {}, op_ctx);
+  OperationContext default_oc;
+  auto response = selected_stub.channel->AcquireStub()->CheckAndMutateRow(
+      context, {}, {}, default_oc);
   ASSERT_STATUS_OK(response);
   EXPECT_TRUE(response->predicate_matched());
   EXPECT_THAT(pool->size(), Eq(1));


### PR DESCRIPTION
Preparing for outstanding_rpc metric support, we need to capture the oustanding_rpcs on the channel selected, at the time it was selected.