### PR TITLE
chore(bigtable): fix some formatting and auto issues

### DIFF
--- a/google/cloud/bigtable/internal/bigtable_random_two_least_used_decorator.cc
+++ b/google/cloud/bigtable/internal/bigtable_random_two_least_used_decorator.cc
@@ -28,12 +28,10 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 template <typename T>
-class StreamingReadRpcTracking
-    : public google::cloud::internal::StreamingReadRpc<T> {
+class StreamingReadRpcTracking : public internal::StreamingReadRpc<T> {
  public:
-  StreamingReadRpcTracking(
-      std::unique_ptr<google::cloud::internal::StreamingReadRpc<T>> child,
-      std::function<void(void)> on_destruction)
+  StreamingReadRpcTracking(std::unique_ptr<internal::StreamingReadRpc<T>> child,
+                           std::function<void(void)> on_destruction)
       : child_(std::move(child)), on_destruction_(std::move(on_destruction)) {}
 
   ~StreamingReadRpcTracking() override { on_destruction_(); }
@@ -47,16 +45,16 @@ class StreamingReadRpcTracking
   }
 
  private:
-  std::unique_ptr<google::cloud::internal::StreamingReadRpc<T>> child_;
+  std::unique_ptr<internal::StreamingReadRpc<T>> child_;
   std::function<void(void)> on_destruction_;
 };
 
 template <typename T>
 class AsyncStreamingReadRpcTracking
-    : public google::cloud::internal::AsyncStreamingReadRpc<T> {
+    : public internal::AsyncStreamingReadRpc<T> {
  public:
   AsyncStreamingReadRpcTracking(
-      std::unique_ptr<google::cloud::internal::AsyncStreamingReadRpc<T>> child,
+      std::unique_ptr<internal::AsyncStreamingReadRpc<T>> child,
       std::function<void(void)> on_destruction)
       : child_(std::move(child)), on_destruction_(std::move(on_destruction)) {}
 
@@ -71,18 +69,16 @@ class AsyncStreamingReadRpcTracking
   }
 
  private:
-  std::unique_ptr<google::cloud::internal::AsyncStreamingReadRpc<T>> child_;
+  std::unique_ptr<internal::AsyncStreamingReadRpc<T>> child_;
   std::function<void(void)> on_destruction_;
 };
 
 template <typename Request, typename Response>
 class AsyncStreamingReadWriteRpcTracking
-    : public google::cloud::AsyncStreamingReadWriteRpc<Request, Response> {
+    : public AsyncStreamingReadWriteRpc<Request, Response> {
  public:
   AsyncStreamingReadWriteRpcTracking(
-      std::unique_ptr<
-          google::cloud::AsyncStreamingReadWriteRpc<Request, Response>>
-          child,
+      std::unique_ptr<AsyncStreamingReadWriteRpc<Request, Response>> child,
       std::function<void(void)> on_destruction)
       : child_(std::move(child)), on_destruction_(std::move(on_destruction)) {}
 
@@ -101,8 +97,7 @@ class AsyncStreamingReadWriteRpcTracking
   }
 
  private:
-  std::unique_ptr<google::cloud::AsyncStreamingReadWriteRpc<Request, Response>>
-      child_;
+  std::unique_ptr<AsyncStreamingReadWriteRpc<Request, Response>> child_;
   std::function<void(void)> on_destruction_;
 };
 
@@ -139,12 +134,11 @@ Response AsyncHelper(std::shared_ptr<DynamicChannelPool<BigtableStub>>& pool,
 }
 
 template <typename Response>
-std::unique_ptr<google::cloud::internal::StreamingReadRpc<Response>>
-StreamingHelper(
+std::unique_ptr<internal::StreamingReadRpc<Response>> StreamingHelper(
     std::shared_ptr<DynamicChannelPool<BigtableStub>>& pool,
     std::shared_ptr<OperationContext> const& operation_context,
-    std::function<std::unique_ptr<
-        google::cloud::internal::StreamingReadRpc<Response>>(BigtableStub&)>
+    std::function<
+        std::unique_ptr<internal::StreamingReadRpc<Response>>(BigtableStub&)>
         fn) {
   SelectedChannel<BigtableStub> selection =
       pool->GetChannelRandomTwoLeastUsed();
@@ -164,12 +158,10 @@ StreamingHelper(
 }
 
 template <typename Response>
-std::unique_ptr<google::cloud::internal::AsyncStreamingReadRpc<Response>>
-AsyncStreamingHelper(
+std::unique_ptr<internal::AsyncStreamingReadRpc<Response>> AsyncStreamingHelper(
     std::shared_ptr<DynamicChannelPool<BigtableStub>>& pool,
     std::shared_ptr<OperationContext> const& operation_context,
-    std::function<std::unique_ptr<
-        google::cloud::internal::AsyncStreamingReadRpc<Response>>(
+    std::function<std::unique_ptr<internal::AsyncStreamingReadRpc<Response>>(
         BigtableStub&)>
         fn) {
   SelectedChannel<BigtableStub> selection =
@@ -190,12 +182,12 @@ AsyncStreamingHelper(
 }
 
 template <typename Request, typename Response>
-std::unique_ptr<google::cloud::AsyncStreamingReadWriteRpc<Request, Response>>
+std::unique_ptr<AsyncStreamingReadWriteRpc<Request, Response>>
 AsyncStreamingHelper(
     std::shared_ptr<DynamicChannelPool<BigtableStub>>& pool,
     std::shared_ptr<OperationContext> const& operation_context,
-    std::function<std::unique_ptr<google::cloud::AsyncStreamingReadWriteRpc<
-        Request, Response>>(BigtableStub&)>
+    std::function<std::unique_ptr<
+        AsyncStreamingReadWriteRpc<Request, Response>>(BigtableStub&)>
         fn) {
   SelectedChannel<BigtableStub> selection =
       pool->GetChannelRandomTwoLeastUsed();
@@ -218,8 +210,8 @@ AsyncStreamingHelper(
 
 }  // namespace
 
-std::unique_ptr<google::cloud::internal::StreamingReadRpc<
-    google::bigtable::v2::ReadRowsResponse>>
+std::unique_ptr<
+    internal::StreamingReadRpc<google::bigtable::v2::ReadRowsResponse>>
 BigtableRandomTwoLeastUsed::ReadRows(
     std::shared_ptr<grpc::ClientContext> context, Options const& options,
     google::bigtable::v2::ReadRowsRequest const& request,
@@ -233,8 +225,8 @@ BigtableRandomTwoLeastUsed::ReadRows(
       });
 }
 
-std::unique_ptr<google::cloud::internal::StreamingReadRpc<
-    google::bigtable::v2::SampleRowKeysResponse>>
+std::unique_ptr<
+    internal::StreamingReadRpc<google::bigtable::v2::SampleRowKeysResponse>>
 BigtableRandomTwoLeastUsed::SampleRowKeys(
     std::shared_ptr<grpc::ClientContext> context, Options const& options,
     google::bigtable::v2::SampleRowKeysRequest const& request,
@@ -259,8 +251,8 @@ BigtableRandomTwoLeastUsed::MutateRow(
       });
 }
 
-std::unique_ptr<google::cloud::internal::StreamingReadRpc<
-    google::bigtable::v2::MutateRowsResponse>>
+std::unique_ptr<
+    internal::StreamingReadRpc<google::bigtable::v2::MutateRowsResponse>>
 BigtableRandomTwoLeastUsed::MutateRows(
     std::shared_ptr<grpc::ClientContext> context, Options const& options,
     google::bigtable::v2::MutateRowsRequest const& request,
@@ -321,8 +313,8 @@ BigtableRandomTwoLeastUsed::PrepareQuery(
       });
 }
 
-std::unique_ptr<google::cloud::internal::StreamingReadRpc<
-    google::bigtable::v2::ExecuteQueryResponse>>
+std::unique_ptr<
+    internal::StreamingReadRpc<google::bigtable::v2::ExecuteQueryResponse>>
 BigtableRandomTwoLeastUsed::ExecuteQuery(
     std::shared_ptr<grpc::ClientContext> context, Options const& options,
     google::bigtable::v2::ExecuteQueryRequest const& request,
@@ -336,12 +328,11 @@ BigtableRandomTwoLeastUsed::ExecuteQuery(
       });
 }
 
-std::unique_ptr<google::cloud::internal::AsyncStreamingReadRpc<
-    google::bigtable::v2::ReadRowsResponse>>
+std::unique_ptr<
+    internal::AsyncStreamingReadRpc<google::bigtable::v2::ReadRowsResponse>>
 BigtableRandomTwoLeastUsed::AsyncReadRows(
-    google::cloud::CompletionQueue const& cq,
-    std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options,
+    CompletionQueue const& cq, std::shared_ptr<grpc::ClientContext> context,
+    internal::ImmutableOptions options,
     google::bigtable::v2::ReadRowsRequest const& request,
     std::shared_ptr<OperationContext> operation_context) {
   return AsyncStreamingHelper<google::bigtable::v2::ReadRowsResponse>(
@@ -353,12 +344,11 @@ BigtableRandomTwoLeastUsed::AsyncReadRows(
       });
 }
 
-std::unique_ptr<google::cloud::internal::AsyncStreamingReadRpc<
+std::unique_ptr<internal::AsyncStreamingReadRpc<
     google::bigtable::v2::SampleRowKeysResponse>>
 BigtableRandomTwoLeastUsed::AsyncSampleRowKeys(
-    google::cloud::CompletionQueue const& cq,
-    std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options,
+    CompletionQueue const& cq, std::shared_ptr<grpc::ClientContext> context,
+    internal::ImmutableOptions options,
     google::bigtable::v2::SampleRowKeysRequest const& request,
     std::shared_ptr<OperationContext> operation_context) {
   return AsyncStreamingHelper<google::bigtable::v2::SampleRowKeysResponse>(
@@ -373,9 +363,8 @@ BigtableRandomTwoLeastUsed::AsyncSampleRowKeys(
 
 future<StatusOr<google::bigtable::v2::MutateRowResponse>>
 BigtableRandomTwoLeastUsed::AsyncMutateRow(
-    google::cloud::CompletionQueue& cq,
-    std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options,
+    CompletionQueue& cq, std::shared_ptr<grpc::ClientContext> context,
+    internal::ImmutableOptions options,
     google::bigtable::v2::MutateRowRequest const& request,
     std::shared_ptr<OperationContext> operation_context) {
   return AsyncHelper<future<StatusOr<google::bigtable::v2::MutateRowResponse>>>(
@@ -387,12 +376,11 @@ BigtableRandomTwoLeastUsed::AsyncMutateRow(
       });
 }
 
-std::unique_ptr<google::cloud::internal::AsyncStreamingReadRpc<
-    google::bigtable::v2::MutateRowsResponse>>
+std::unique_ptr<
+    internal::AsyncStreamingReadRpc<google::bigtable::v2::MutateRowsResponse>>
 BigtableRandomTwoLeastUsed::AsyncMutateRows(
-    google::cloud::CompletionQueue const& cq,
-    std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options,
+    CompletionQueue const& cq, std::shared_ptr<grpc::ClientContext> context,
+    internal::ImmutableOptions options,
     google::bigtable::v2::MutateRowsRequest const& request,
     std::shared_ptr<OperationContext> operation_context) {
   return AsyncStreamingHelper<google::bigtable::v2::MutateRowsResponse>(
@@ -406,9 +394,8 @@ BigtableRandomTwoLeastUsed::AsyncMutateRows(
 
 future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
 BigtableRandomTwoLeastUsed::AsyncCheckAndMutateRow(
-    google::cloud::CompletionQueue& cq,
-    std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options,
+    CompletionQueue& cq, std::shared_ptr<grpc::ClientContext> context,
+    internal::ImmutableOptions options,
     google::bigtable::v2::CheckAndMutateRowRequest const& request,
     std::shared_ptr<OperationContext> operation_context) {
   return AsyncHelper<
@@ -424,9 +411,8 @@ BigtableRandomTwoLeastUsed::AsyncCheckAndMutateRow(
 
 future<StatusOr<google::bigtable::v2::PingAndWarmResponse>>
 BigtableRandomTwoLeastUsed::AsyncPingAndWarm(
-    google::cloud::CompletionQueue& cq,
-    std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options,
+    CompletionQueue& cq, std::shared_ptr<grpc::ClientContext> context,
+    internal::ImmutableOptions options,
     google::bigtable::v2::PingAndWarmRequest const& request,
     std::shared_ptr<OperationContext> operation_context) {
   return AsyncHelper<
@@ -441,9 +427,8 @@ BigtableRandomTwoLeastUsed::AsyncPingAndWarm(
 
 future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>
 BigtableRandomTwoLeastUsed::AsyncReadModifyWriteRow(
-    google::cloud::CompletionQueue& cq,
-    std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options,
+    CompletionQueue& cq, std::shared_ptr<grpc::ClientContext> context,
+    internal::ImmutableOptions options,
     google::bigtable::v2::ReadModifyWriteRowRequest const& request,
     std::shared_ptr<OperationContext> operation_context) {
   return AsyncHelper<
@@ -459,9 +444,8 @@ BigtableRandomTwoLeastUsed::AsyncReadModifyWriteRow(
 
 future<StatusOr<google::bigtable::v2::PrepareQueryResponse>>
 BigtableRandomTwoLeastUsed::AsyncPrepareQuery(
-    google::cloud::CompletionQueue& cq,
-    std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options,
+    CompletionQueue& cq, std::shared_ptr<grpc::ClientContext> context,
+    internal::ImmutableOptions options,
     google::bigtable::v2::PrepareQueryRequest const& request,
     std::shared_ptr<OperationContext> operation_context) {
   return AsyncHelper<
@@ -487,13 +471,12 @@ BigtableRandomTwoLeastUsed::GetClientConfiguration(
       });
 }
 
-std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
-    google::bigtable::v2::SessionRequest,
-    google::bigtable::v2::SessionResponse>>
+std::unique_ptr<
+    AsyncStreamingReadWriteRpc<google::bigtable::v2::SessionRequest,
+                               google::bigtable::v2::SessionResponse>>
 BigtableRandomTwoLeastUsed::AsyncOpenTable(
-    google::cloud::CompletionQueue const& cq,
-    std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options,
+    CompletionQueue const& cq, std::shared_ptr<grpc::ClientContext> context,
+    internal::ImmutableOptions options,
     std::shared_ptr<OperationContext> operation_context) {
   return AsyncStreamingHelper<google::bigtable::v2::SessionRequest,
                               google::bigtable::v2::SessionResponse>(
@@ -505,13 +488,12 @@ BigtableRandomTwoLeastUsed::AsyncOpenTable(
       });
 }
 
-std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
-    google::bigtable::v2::SessionRequest,
-    google::bigtable::v2::SessionResponse>>
+std::unique_ptr<
+    AsyncStreamingReadWriteRpc<google::bigtable::v2::SessionRequest,
+                               google::bigtable::v2::SessionResponse>>
 BigtableRandomTwoLeastUsed::AsyncOpenAuthorizedView(
-    google::cloud::CompletionQueue const& cq,
-    std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options,
+    CompletionQueue const& cq, std::shared_ptr<grpc::ClientContext> context,
+    internal::ImmutableOptions options,
     std::shared_ptr<OperationContext> operation_context) {
   return AsyncStreamingHelper<google::bigtable::v2::SessionRequest,
                               google::bigtable::v2::SessionResponse>(
@@ -524,13 +506,12 @@ BigtableRandomTwoLeastUsed::AsyncOpenAuthorizedView(
       });
 }
 
-std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
-    google::bigtable::v2::SessionRequest,
-    google::bigtable::v2::SessionResponse>>
+std::unique_ptr<
+    AsyncStreamingReadWriteRpc<google::bigtable::v2::SessionRequest,
+                               google::bigtable::v2::SessionResponse>>
 BigtableRandomTwoLeastUsed::AsyncOpenMaterializedView(
-    google::cloud::CompletionQueue const& cq,
-    std::shared_ptr<grpc::ClientContext> context,
-    google::cloud::internal::ImmutableOptions options,
+    CompletionQueue const& cq, std::shared_ptr<grpc::ClientContext> context,
+    internal::ImmutableOptions options,
     std::shared_ptr<OperationContext> operation_context) {
   return AsyncStreamingHelper<google::bigtable::v2::SessionRequest,
                               google::bigtable::v2::SessionResponse>(

--- a/google/cloud/bigtable/internal/bigtable_random_two_least_used_decorator.cc
+++ b/google/cloud/bigtable/internal/bigtable_random_two_least_used_decorator.cc
@@ -31,7 +31,7 @@ template <typename T>
 class StreamingReadRpcTracking : public internal::StreamingReadRpc<T> {
  public:
   StreamingReadRpcTracking(std::unique_ptr<internal::StreamingReadRpc<T>> child,
-                           std::function<void(void)> on_destruction)
+                           std::function<void()> on_destruction)
       : child_(std::move(child)), on_destruction_(std::move(on_destruction)) {}
 
   ~StreamingReadRpcTracking() override { on_destruction_(); }
@@ -46,7 +46,7 @@ class StreamingReadRpcTracking : public internal::StreamingReadRpc<T> {
 
  private:
   std::unique_ptr<internal::StreamingReadRpc<T>> child_;
-  std::function<void(void)> on_destruction_;
+  std::function<void()> on_destruction_;
 };
 
 template <typename T>
@@ -55,7 +55,7 @@ class AsyncStreamingReadRpcTracking
  public:
   AsyncStreamingReadRpcTracking(
       std::unique_ptr<internal::AsyncStreamingReadRpc<T>> child,
-      std::function<void(void)> on_destruction)
+      std::function<void()> on_destruction)
       : child_(std::move(child)), on_destruction_(std::move(on_destruction)) {}
 
   ~AsyncStreamingReadRpcTracking() override { on_destruction_(); }
@@ -70,7 +70,7 @@ class AsyncStreamingReadRpcTracking
 
  private:
   std::unique_ptr<internal::AsyncStreamingReadRpc<T>> child_;
-  std::function<void(void)> on_destruction_;
+  std::function<void()> on_destruction_;
 };
 
 template <typename Request, typename Response>
@@ -79,7 +79,7 @@ class AsyncStreamingReadWriteRpcTracking
  public:
   AsyncStreamingReadWriteRpcTracking(
       std::unique_ptr<AsyncStreamingReadWriteRpc<Request, Response>> child,
-      std::function<void(void)> on_destruction)
+      std::function<void()> on_destruction)
       : child_(std::move(child)), on_destruction_(std::move(on_destruction)) {}
 
   ~AsyncStreamingReadWriteRpcTracking() override { on_destruction_(); }
@@ -98,13 +98,13 @@ class AsyncStreamingReadWriteRpcTracking
 
  private:
   std::unique_ptr<AsyncStreamingReadWriteRpc<Request, Response>> child_;
-  std::function<void(void)> on_destruction_;
+  std::function<void()> on_destruction_;
 };
 
 template <typename Response>
 Response UnaryHelper(std::shared_ptr<DynamicChannelPool<BigtableStub>>& pool,
                      OperationContext& oc,
-                     std::function<Response(BigtableStub&)> fn) {
+                     std::function<Response(BigtableStub&)> const& fn) {
   SelectedChannel<BigtableStub> selection =
       pool->GetChannelRandomTwoLeastUsed();
   oc.StubSelection(StubSelectionParams{
@@ -119,7 +119,7 @@ Response UnaryHelper(std::shared_ptr<DynamicChannelPool<BigtableStub>>& pool,
 template <typename Response>
 Response AsyncHelper(std::shared_ptr<DynamicChannelPool<BigtableStub>>& pool,
                      std::shared_ptr<OperationContext> const& operation_context,
-                     std::function<Response(BigtableStub&)> fn) {
+                     std::function<Response(BigtableStub&)> const& fn) {
   SelectedChannel<BigtableStub> selection =
       pool->GetChannelRandomTwoLeastUsed();
   if (operation_context != nullptr) {
@@ -137,9 +137,8 @@ template <typename Response>
 std::unique_ptr<internal::StreamingReadRpc<Response>> StreamingHelper(
     std::shared_ptr<DynamicChannelPool<BigtableStub>>& pool,
     std::shared_ptr<OperationContext> const& operation_context,
-    std::function<
-        std::unique_ptr<internal::StreamingReadRpc<Response>>(BigtableStub&)>
-        fn) {
+    std::function<std::unique_ptr<internal::StreamingReadRpc<Response>>(
+        BigtableStub&)> const& fn) {
   SelectedChannel<BigtableStub> selection =
       pool->GetChannelRandomTwoLeastUsed();
   if (operation_context != nullptr) {
@@ -162,8 +161,7 @@ std::unique_ptr<internal::AsyncStreamingReadRpc<Response>> AsyncStreamingHelper(
     std::shared_ptr<DynamicChannelPool<BigtableStub>>& pool,
     std::shared_ptr<OperationContext> const& operation_context,
     std::function<std::unique_ptr<internal::AsyncStreamingReadRpc<Response>>(
-        BigtableStub&)>
-        fn) {
+        BigtableStub&)> const& fn) {
   SelectedChannel<BigtableStub> selection =
       pool->GetChannelRandomTwoLeastUsed();
   if (operation_context != nullptr) {
@@ -183,12 +181,10 @@ std::unique_ptr<internal::AsyncStreamingReadRpc<Response>> AsyncStreamingHelper(
 
 template <typename Request, typename Response>
 std::unique_ptr<AsyncStreamingReadWriteRpc<Request, Response>>
-AsyncStreamingHelper(
-    std::shared_ptr<DynamicChannelPool<BigtableStub>>& pool,
-    std::shared_ptr<OperationContext> const& operation_context,
-    std::function<std::unique_ptr<
-        AsyncStreamingReadWriteRpc<Request, Response>>(BigtableStub&)>
-        fn) {
+AsyncStreamingHelper(std::shared_ptr<DynamicChannelPool<BigtableStub>>& pool,
+                     std::shared_ptr<OperationContext> const& operation_context,
+                     std::function<std::unique_ptr<AsyncStreamingReadWriteRpc<
+                         Request, Response>>(BigtableStub&)> const& fn) {
   SelectedChannel<BigtableStub> selection =
       pool->GetChannelRandomTwoLeastUsed();
   if (operation_context != nullptr) {

--- a/google/cloud/bigtable/internal/bigtable_random_two_least_used_decorator.h
+++ b/google/cloud/bigtable/internal/bigtable_random_two_least_used_decorator.h
@@ -39,14 +39,14 @@ class BigtableRandomTwoLeastUsed : public BigtableStub {
     return pool_;
   }
 
-  std::unique_ptr<google::cloud::internal::StreamingReadRpc<
-      google::bigtable::v2::ReadRowsResponse>>
+  std::unique_ptr<
+      internal::StreamingReadRpc<google::bigtable::v2::ReadRowsResponse>>
   ReadRows(std::shared_ptr<grpc::ClientContext> context, Options const& options,
            google::bigtable::v2::ReadRowsRequest const& request,
            std::shared_ptr<OperationContext> operation_context) override;
 
-  std::unique_ptr<google::cloud::internal::StreamingReadRpc<
-      google::bigtable::v2::SampleRowKeysResponse>>
+  std::unique_ptr<
+      internal::StreamingReadRpc<google::bigtable::v2::SampleRowKeysResponse>>
   SampleRowKeys(std::shared_ptr<grpc::ClientContext> context,
                 Options const& options,
                 google::bigtable::v2::SampleRowKeysRequest const& request,
@@ -57,8 +57,8 @@ class BigtableRandomTwoLeastUsed : public BigtableStub {
       google::bigtable::v2::MutateRowRequest const& request,
       OperationContext& operation_context) override;
 
-  std::unique_ptr<google::cloud::internal::StreamingReadRpc<
-      google::bigtable::v2::MutateRowsResponse>>
+  std::unique_ptr<
+      internal::StreamingReadRpc<google::bigtable::v2::MutateRowsResponse>>
   MutateRows(std::shared_ptr<grpc::ClientContext> context,
              Options const& options,
              google::bigtable::v2::MutateRowsRequest const& request,
@@ -84,73 +84,67 @@ class BigtableRandomTwoLeastUsed : public BigtableStub {
       google::bigtable::v2::PrepareQueryRequest const& request,
       OperationContext& operation_context) override;
 
-  std::unique_ptr<google::cloud::internal::StreamingReadRpc<
-      google::bigtable::v2::ExecuteQueryResponse>>
+  std::unique_ptr<
+      internal::StreamingReadRpc<google::bigtable::v2::ExecuteQueryResponse>>
   ExecuteQuery(std::shared_ptr<grpc::ClientContext> context,
                Options const& options,
                google::bigtable::v2::ExecuteQueryRequest const& request,
                std::shared_ptr<OperationContext> operation_context) override;
 
-  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
-      google::bigtable::v2::ReadRowsResponse>>
-  AsyncReadRows(google::cloud::CompletionQueue const& cq,
+  std::unique_ptr<
+      internal::AsyncStreamingReadRpc<google::bigtable::v2::ReadRowsResponse>>
+  AsyncReadRows(CompletionQueue const& cq,
                 std::shared_ptr<grpc::ClientContext> context,
-                google::cloud::internal::ImmutableOptions options,
+                internal::ImmutableOptions options,
                 google::bigtable::v2::ReadRowsRequest const& request,
                 std::shared_ptr<OperationContext> operation_context) override;
 
-  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+  std::unique_ptr<internal::AsyncStreamingReadRpc<
       google::bigtable::v2::SampleRowKeysResponse>>
   AsyncSampleRowKeys(
-      google::cloud::CompletionQueue const& cq,
-      std::shared_ptr<grpc::ClientContext> context,
-      google::cloud::internal::ImmutableOptions options,
+      CompletionQueue const& cq, std::shared_ptr<grpc::ClientContext> context,
+      internal::ImmutableOptions options,
       google::bigtable::v2::SampleRowKeysRequest const& request,
       std::shared_ptr<OperationContext> operation_context) override;
 
   future<StatusOr<google::bigtable::v2::MutateRowResponse>> AsyncMutateRow(
-      google::cloud::CompletionQueue& cq,
-      std::shared_ptr<grpc::ClientContext> context,
-      google::cloud::internal::ImmutableOptions options,
+      CompletionQueue& cq, std::shared_ptr<grpc::ClientContext> context,
+      internal::ImmutableOptions options,
       google::bigtable::v2::MutateRowRequest const& request,
       std::shared_ptr<OperationContext> operation_context) override;
 
-  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
-      google::bigtable::v2::MutateRowsResponse>>
-  AsyncMutateRows(google::cloud::CompletionQueue const& cq,
+  std::unique_ptr<
+      internal::AsyncStreamingReadRpc<google::bigtable::v2::MutateRowsResponse>>
+  AsyncMutateRows(CompletionQueue const& cq,
                   std::shared_ptr<grpc::ClientContext> context,
-                  google::cloud::internal::ImmutableOptions options,
+                  internal::ImmutableOptions options,
                   google::bigtable::v2::MutateRowsRequest const& request,
                   std::shared_ptr<OperationContext> operation_context) override;
 
   future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
   AsyncCheckAndMutateRow(
-      google::cloud::CompletionQueue& cq,
-      std::shared_ptr<grpc::ClientContext> context,
-      google::cloud::internal::ImmutableOptions options,
+      CompletionQueue& cq, std::shared_ptr<grpc::ClientContext> context,
+      internal::ImmutableOptions options,
       google::bigtable::v2::CheckAndMutateRowRequest const& request,
       std::shared_ptr<OperationContext> operation_context) override;
 
   future<StatusOr<google::bigtable::v2::PingAndWarmResponse>> AsyncPingAndWarm(
-      google::cloud::CompletionQueue& cq,
-      std::shared_ptr<grpc::ClientContext> context,
-      google::cloud::internal::ImmutableOptions options,
+      CompletionQueue& cq, std::shared_ptr<grpc::ClientContext> context,
+      internal::ImmutableOptions options,
       google::bigtable::v2::PingAndWarmRequest const& request,
       std::shared_ptr<OperationContext> operation_context) override;
 
   future<StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>>
   AsyncReadModifyWriteRow(
-      google::cloud::CompletionQueue& cq,
-      std::shared_ptr<grpc::ClientContext> context,
-      google::cloud::internal::ImmutableOptions options,
+      CompletionQueue& cq, std::shared_ptr<grpc::ClientContext> context,
+      internal::ImmutableOptions options,
       google::bigtable::v2::ReadModifyWriteRowRequest const& request,
       std::shared_ptr<OperationContext> operation_context) override;
 
   future<StatusOr<google::bigtable::v2::PrepareQueryResponse>>
   AsyncPrepareQuery(
-      google::cloud::CompletionQueue& cq,
-      std::shared_ptr<grpc::ClientContext> context,
-      google::cloud::internal::ImmutableOptions options,
+      CompletionQueue& cq, std::shared_ptr<grpc::ClientContext> context,
+      internal::ImmutableOptions options,
       google::bigtable::v2::PrepareQueryRequest const& request,
       std::shared_ptr<OperationContext> operation_context) override;
 
@@ -159,30 +153,28 @@ class BigtableRandomTwoLeastUsed : public BigtableStub {
       google::bigtable::v2::GetClientConfigurationRequest const& request,
       OperationContext& operation_context) override;
 
-  std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
-      google::bigtable::v2::SessionRequest,
-      google::bigtable::v2::SessionResponse>>
-  AsyncOpenTable(google::cloud::CompletionQueue const& cq,
+  std::unique_ptr<
+      AsyncStreamingReadWriteRpc<google::bigtable::v2::SessionRequest,
+                                 google::bigtable::v2::SessionResponse>>
+  AsyncOpenTable(CompletionQueue const& cq,
                  std::shared_ptr<grpc::ClientContext> context,
-                 google::cloud::internal::ImmutableOptions options,
+                 internal::ImmutableOptions options,
                  std::shared_ptr<OperationContext> operation_context) override;
 
-  std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
-      google::bigtable::v2::SessionRequest,
-      google::bigtable::v2::SessionResponse>>
+  std::unique_ptr<
+      AsyncStreamingReadWriteRpc<google::bigtable::v2::SessionRequest,
+                                 google::bigtable::v2::SessionResponse>>
   AsyncOpenAuthorizedView(
-      google::cloud::CompletionQueue const& cq,
-      std::shared_ptr<grpc::ClientContext> context,
-      google::cloud::internal::ImmutableOptions options,
+      CompletionQueue const& cq, std::shared_ptr<grpc::ClientContext> context,
+      internal::ImmutableOptions options,
       std::shared_ptr<OperationContext> operation_context) override;
 
-  std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
-      google::bigtable::v2::SessionRequest,
-      google::bigtable::v2::SessionResponse>>
+  std::unique_ptr<
+      AsyncStreamingReadWriteRpc<google::bigtable::v2::SessionRequest,
+                                 google::bigtable::v2::SessionResponse>>
   AsyncOpenMaterializedView(
-      google::cloud::CompletionQueue const& cq,
-      std::shared_ptr<grpc::ClientContext> context,
-      google::cloud::internal::ImmutableOptions options,
+      CompletionQueue const& cq, std::shared_ptr<grpc::ClientContext> context,
+      internal::ImmutableOptions options,
       std::shared_ptr<OperationContext> operation_context) override;
 
  private:

--- a/google/cloud/bigtable/internal/stub_manager_test.cc
+++ b/google/cloud/bigtable/internal/stub_manager_test.cc
@@ -1,4 +1,3 @@
-#include "google/cloud/bigtable/internal/operation_context.h"
 // Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/bigtable/instance_resource.h"
 #include "google/cloud/bigtable/internal/stub_manager.h"
+#include "google/cloud/bigtable/instance_resource.h"
+#include "google/cloud/bigtable/internal/operation_context.h"
 #include "google/cloud/bigtable/table_resource.h"
 #include "google/cloud/bigtable/testing/mock_bigtable_stub.h"
 #include "google/cloud/testing_util/scoped_log.h"
@@ -43,7 +43,7 @@ TEST(StubManagerTest, NoAffinity) {
   EXPECT_CALL(*mock, MutateRow)
       .WillOnce([&](grpc::ClientContext&, Options const&,
                     google::bigtable::v2::MutateRowRequest const& request,
-                    auto const&) {
+                    OperationContext&) {
         EXPECT_THAT(request.table_name(), Eq(expected_table_name));
         return google::bigtable::v2::MutateRowResponse{};
       });
@@ -69,7 +69,7 @@ TEST(StubManagerTest, AffinityToExistingInstance) {
       .WillOnce([instance_name = instance.FullName()](
                     grpc::ClientContext&, Options const&,
                     google::bigtable::v2::MutateRowRequest const& request,
-                    auto const&) {
+                    OperationContext&) {
         EXPECT_THAT(request.table_name(), StartsWith(instance_name));
         return google::bigtable::v2::MutateRowResponse{};
       });
@@ -111,7 +111,7 @@ TEST(StubManagerTest, AffinityToMissingInstance) {
         .WillOnce([instance_name = std::string{instance_name}](
                       grpc::ClientContext&, Options const&,
                       google::bigtable::v2::MutateRowRequest const& request,
-                      auto const&) {
+                      OperationContext&) {
           EXPECT_THAT(request.table_name(), StartsWith(instance_name));
           return google::bigtable::v2::MutateRowResponse{};
         });

--- a/google/cloud/geminidataanalytics/CMakeLists.txt
+++ b/google/cloud/geminidataanalytics/CMakeLists.txt
@@ -31,8 +31,6 @@ if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
             $<TARGET_FILE:geminidataanalytics_quickstart> GOOGLE_CLOUD_PROJECT
             GOOGLE_CLOUD_CPP_TEST_REGION)
     set_tests_properties(
-        geminidataanalytics_quickstart
-        PROPERTIES
-            LABELS "integration-test;quickstart" PASS_REGULAR_EXPRESSION
-            "Permanent error.*gcloud-cpp.retry.function=ListConversations")
+        geminidataanalytics_quickstart PROPERTIES DISABLED "True" LABELS
+                                                  "integration-test;quickstart")
 endif ()


### PR DESCRIPTION
Cleans up some full explicit namespace usage where it wasn't needed as well as switching some uses of `auto` to explicit types.