### PR TITLE
impl(bigtable): add directpath metric

### DIFF
--- a/google/cloud/bigtable/internal/client_schema_metrics.cc
+++ b/google/cloud/bigtable/internal/client_schema_metrics.cc
@@ -85,9 +85,36 @@ LabelMap IntoLabelMap(ClientResourceLabels const& r,
       {"streaming", std::string(IsStreamingAsString(d.streaming))},
   };
 
-  for (auto& item : data) {
-    if (filtered_data_labels.find(item.key) == filtered_data_labels.end()) {
-      labels.emplace(std::move(item.key), std::move(item.value));
+  for (auto& [key, value] : data) {
+    if (filtered_data_labels.find(key) == filtered_data_labels.end()) {
+      labels.emplace(std::move(key), std::move(value));
+    }
+  }
+
+  return labels;
+}
+
+LabelMap IntoLabelMap(ClientResourceLabels const& r,
+                      DirectAccessCompatibilityLabels const& d,
+                      std::set<std::string> const& filtered_data_labels) {
+  LabelMap labels = {
+      {"project_id", r.project_id},   {"instance", r.instance},
+      {"app_profile", r.app_profile}, {"client_name", r.client_name},
+      {"client_uid", r.client_uid},   {"client_project", r.client_project},
+      {"location", r.location},       {"cloud_platform", r.cloud_platform},
+      {"host_id", r.host_id},         {"hostname", r.hostname}};
+
+  struct {
+    std::string key;
+    std::string value;
+  } data[] = {
+      {"ip_preference", d.ip_preference},
+      {"reason", d.reason},
+  };
+
+  for (auto& [key, value] : data) {
+    if (filtered_data_labels.find(key) == filtered_data_labels.end()) {
+      labels.emplace(std::move(key), std::move(value));
     }
   }
 
@@ -119,6 +146,19 @@ ClientResourceLabels MakeClientResourceLabels(
   }
   if (project_id.empty()) {
     project_id = by_name(sc::cloud::kCloudAccountId);
+  }
+
+  if (instance.empty() &&
+      options.has<bigtable_internal::InstanceChannelAffinityOption>()) {
+    auto const& instances =
+        options.get<bigtable_internal::InstanceChannelAffinityOption>();
+    if (!instances.empty()) {
+      instance = instances[0].instance_id();
+    }
+  }
+
+  if (app_profile.empty() && options.has<bigtable::AppProfileIdOption>()) {
+    app_profile = options.get<bigtable::AppProfileIdOption>();
   }
 
   std::string client_project = by_name(sc::cloud::kCloudAccountId);
@@ -173,6 +213,47 @@ void OutstandingRpcs::StubSelection(
 std::unique_ptr<ClientSchemaMetric> OutstandingRpcs::clone(
     ClientResourceLabels const& resource_labels) const {
   auto m = std::make_unique<OutstandingRpcs>(*this);
+  m->resource_labels_ = resource_labels;
+  return m;
+}
+
+DirectAccessCompatibility::DirectAccessCompatibility(
+    std::string const& instrumentation_scope,
+    opentelemetry::nostd::shared_ptr<
+        opentelemetry::metrics::MeterProvider> const& provider)
+    : gauge_(
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+          provider
+              ->GetMeter(instrumentation_scope,
+                         kMeterInstrumentationScopeVersion)
+              ->CreateInt64Gauge(
+                  "direct_access/compatible",
+                  "Compatibility check result for Bigtable DirectPath.", "1")
+#else
+          provider
+              ->GetMeter(instrumentation_scope,
+                         kMeterInstrumentationScopeVersion)
+              ->CreateDoubleHistogram(
+                  "direct_access/compatible",
+                  "Compatibility check result for Bigtable DirectPath.", "1")
+#endif
+      ) {
+}
+
+void DirectAccessCompatibility::Record(
+    opentelemetry::context::Context const& context, std::int64_t value,
+    DirectAccessCompatibilityLabels const& data_labels) {
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+  gauge_->Record(value, IntoLabelMap(resource_labels_, data_labels), context);
+#else
+  gauge_->Record(static_cast<double>(value),
+                 IntoLabelMap(resource_labels_, data_labels), context);
+#endif
+}
+
+std::unique_ptr<ClientSchemaMetric> DirectAccessCompatibility::clone(
+    ClientResourceLabels const& resource_labels) const {
+  auto m = std::make_unique<DirectAccessCompatibility>(*this);
   m->resource_labels_ = resource_labels;
   return m;
 }

--- a/google/cloud/bigtable/internal/client_schema_metrics.cc
+++ b/google/cloud/bigtable/internal/client_schema_metrics.cc
@@ -22,8 +22,6 @@
 #include <opentelemetry/semconv/incubating/cloud_attributes.h>
 #include <opentelemetry/semconv/incubating/faas_attributes.h>
 #include <opentelemetry/semconv/incubating/host_attributes.h>
-#include <algorithm>
-#include <map>
 #include <set>
 #include <string_view>
 
@@ -63,33 +61,33 @@ std::string_view IsStreamingAsString(RpcType type) {
   }
   return "false";
 }
+
+LabelMap BaseLabels(ClientResourceLabels const& r) {
+  return {{"project_id", r.project_id},   {"instance", r.instance},
+          {"app_profile", r.app_profile}, {"client_name", r.client_name},
+          {"client_uid", r.client_uid},   {"client_project", r.client_project},
+          {"location", r.location},       {"cloud_platform", r.cloud_platform},
+          {"host_id", r.host_id},         {"hostname", r.hostname}};
+}
 }  // namespace
 
 LabelMap IntoLabelMap(ClientResourceLabels const& r,
                       ClientOutstandingRpcLabels const& d,
                       std::set<std::string> const& filtered_data_labels) {
-  LabelMap labels = {
-      {"project_id", r.project_id},   {"instance", r.instance},
-      {"app_profile", r.app_profile}, {"client_name", r.client_name},
-      {"client_uid", r.client_uid},   {"client_project", r.client_project},
-      {"location", r.location},       {"cloud_platform", r.cloud_platform},
-      {"host_id", r.host_id},         {"hostname", r.hostname}};
+  LabelMap labels = BaseLabels(r);
 
-  struct {
-    std::string key;
-    std::string value;
-  } data[] = {
-      {"transport_type", std::string(ToString(d.transport_type))},
-      {"channel_pool_lb_policy",
-       std::string(ToString(d.channel_pool_lb_policy))},
-      {"streaming", std::string(IsStreamingAsString(d.streaming))},
-  };
-
-  for (auto& [key, value] : data) {
+  auto emplace_if_not_filtered = [&](std::string key, std::string value) {
     if (filtered_data_labels.find(key) == filtered_data_labels.end()) {
       labels.emplace(std::move(key), std::move(value));
     }
-  }
+  };
+
+  emplace_if_not_filtered("transport_type",
+                          std::string(ToString(d.transport_type)));
+  emplace_if_not_filtered("channel_pool_lb_policy",
+                          std::string(ToString(d.channel_pool_lb_policy)));
+  emplace_if_not_filtered("streaming",
+                          std::string(IsStreamingAsString(d.streaming)));
 
   return labels;
 }
@@ -97,26 +95,16 @@ LabelMap IntoLabelMap(ClientResourceLabels const& r,
 LabelMap IntoLabelMap(ClientResourceLabels const& r,
                       DirectAccessCompatibilityLabels const& d,
                       std::set<std::string> const& filtered_data_labels) {
-  LabelMap labels = {
-      {"project_id", r.project_id},   {"instance", r.instance},
-      {"app_profile", r.app_profile}, {"client_name", r.client_name},
-      {"client_uid", r.client_uid},   {"client_project", r.client_project},
-      {"location", r.location},       {"cloud_platform", r.cloud_platform},
-      {"host_id", r.host_id},         {"hostname", r.hostname}};
+  LabelMap labels = BaseLabels(r);
 
-  struct {
-    std::string key;
-    std::string value;
-  } data[] = {
-      {"ip_preference", d.ip_preference},
-      {"reason", d.reason},
-  };
-
-  for (auto& [key, value] : data) {
+  auto emplace_if_not_filtered = [&](std::string key, std::string value) {
     if (filtered_data_labels.find(key) == filtered_data_labels.end()) {
       labels.emplace(std::move(key), std::move(value));
     }
-  }
+  };
+
+  emplace_if_not_filtered("ip_preference", d.ip_preference);
+  emplace_if_not_filtered("reason", d.reason);
 
   return labels;
 }
@@ -136,10 +124,8 @@ ClientResourceLabels MakeClientResourceLabels(
     return opentelemetry::nostd::get<std::string>(l->second);
   };
 
-  if (project_id.empty() &&
-      options.has<bigtable_internal::InstanceChannelAffinityOption>()) {
-    auto const& instances =
-        options.get<bigtable_internal::InstanceChannelAffinityOption>();
+  if (project_id.empty() && options.has<InstanceChannelAffinityOption>()) {
+    auto const& instances = options.get<InstanceChannelAffinityOption>();
     if (!instances.empty()) {
       project_id = instances[0].project_id();
     }
@@ -148,10 +134,8 @@ ClientResourceLabels MakeClientResourceLabels(
     project_id = by_name(sc::cloud::kCloudAccountId);
   }
 
-  if (instance.empty() &&
-      options.has<bigtable_internal::InstanceChannelAffinityOption>()) {
-    auto const& instances =
-        options.get<bigtable_internal::InstanceChannelAffinityOption>();
+  if (instance.empty() && options.has<InstanceChannelAffinityOption>()) {
+    auto const& instances = options.get<InstanceChannelAffinityOption>();
     if (!instances.empty()) {
       instance = instances[0].instance_id();
     }

--- a/google/cloud/bigtable/internal/client_schema_metrics.cc
+++ b/google/cloud/bigtable/internal/client_schema_metrics.cc
@@ -76,18 +76,19 @@ LabelMap IntoLabelMap(ClientResourceLabels const& r,
                       std::set<std::string> const& filtered_data_labels) {
   LabelMap labels = BaseLabels(r);
 
-  auto emplace_if_not_filtered = [&](std::string key, std::string value) {
-    if (filtered_data_labels.find(key) == filtered_data_labels.end()) {
-      labels.emplace(std::move(key), std::move(value));
+  auto emplace_if_not_filtered = [&](std::string_view key,
+                                     std::string_view value) {
+    if (filtered_data_labels.empty() ||
+        filtered_data_labels.find(std::string(key)) ==
+            filtered_data_labels.end()) {
+      labels.emplace(key, value);
     }
   };
 
-  emplace_if_not_filtered("transport_type",
-                          std::string(ToString(d.transport_type)));
+  emplace_if_not_filtered("transport_type", ToString(d.transport_type));
   emplace_if_not_filtered("channel_pool_lb_policy",
-                          std::string(ToString(d.channel_pool_lb_policy)));
-  emplace_if_not_filtered("streaming",
-                          std::string(IsStreamingAsString(d.streaming)));
+                          ToString(d.channel_pool_lb_policy));
+  emplace_if_not_filtered("streaming", IsStreamingAsString(d.streaming));
 
   return labels;
 }
@@ -97,9 +98,12 @@ LabelMap IntoLabelMap(ClientResourceLabels const& r,
                       std::set<std::string> const& filtered_data_labels) {
   LabelMap labels = BaseLabels(r);
 
-  auto emplace_if_not_filtered = [&](std::string key, std::string value) {
-    if (filtered_data_labels.find(key) == filtered_data_labels.end()) {
-      labels.emplace(std::move(key), std::move(value));
+  auto emplace_if_not_filtered = [&](std::string_view key,
+                                     std::string_view value) {
+    if (filtered_data_labels.empty() ||
+        filtered_data_labels.find(std::string(key)) ==
+            filtered_data_labels.end()) {
+      labels.emplace(key, value);
     }
   };
 
@@ -190,7 +194,7 @@ void OutstandingRpcs::StubSelection(
   ClientOutstandingRpcLabels data_labels{p.transport_type,
                                          p.channel_pool_lb_policy, p.streaming};
   outstanding_rpcs_->Record(static_cast<double>(p.outstanding_rpcs),
-                            IntoLabelMap(resource_labels_, data_labels),
+                            IntoLabelMap(resource_labels_, data_labels, {}),
                             context);
 }
 
@@ -228,10 +232,11 @@ void DirectAccessCompatibility::Record(
     opentelemetry::context::Context const& context, std::int64_t value,
     DirectAccessCompatibilityLabels const& data_labels) {
 #if OPENTELEMETRY_ABI_VERSION_NO >= 2
-  gauge_->Record(value, IntoLabelMap(resource_labels_, data_labels), context);
+  gauge_->Record(value, IntoLabelMap(resource_labels_, data_labels, {}),
+                 context);
 #else
   gauge_->Record(static_cast<double>(value),
-                 IntoLabelMap(resource_labels_, data_labels), context);
+                 IntoLabelMap(resource_labels_, data_labels, {}), context);
 #endif
 }
 

--- a/google/cloud/bigtable/internal/client_schema_metrics.h
+++ b/google/cloud/bigtable/internal/client_schema_metrics.h
@@ -56,6 +56,15 @@ LabelMap IntoLabelMap(ClientResourceLabels const& r,
                       ClientOutstandingRpcLabels const& d,
                       std::set<std::string> const& filtered_data_labels = {});
 
+struct DirectAccessCompatibilityLabels {
+  std::string ip_preference;
+  std::string reason;
+};
+
+LabelMap IntoLabelMap(ClientResourceLabels const& r,
+                      DirectAccessCompatibilityLabels const& d,
+                      std::set<std::string> const& filtered_data_labels = {});
+
 ClientResourceLabels MakeClientResourceLabels(
     std::string project_id, std::string instance, std::string app_profile,
     Options const& options, std::string const& client_uid,
@@ -82,6 +91,31 @@ class OutstandingRpcs : public ClientSchemaMetric {
   ClientResourceLabels resource_labels_;
   opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Histogram<double>>
       outstanding_rpcs_;
+};
+
+class DirectAccessCompatibility : public ClientSchemaMetric {
+ public:
+  DirectAccessCompatibility(
+      std::string const& instrumentation_scope,
+      opentelemetry::nostd::shared_ptr<
+          opentelemetry::metrics::MeterProvider> const& provider);
+
+  void Record(opentelemetry::context::Context const& context,
+              std::int64_t value,
+              DirectAccessCompatibilityLabels const& data_labels);
+
+  std::unique_ptr<ClientSchemaMetric> clone(
+      ClientResourceLabels const& resource_labels) const override;
+
+ private:
+  ClientResourceLabels resource_labels_;
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+  opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Gauge<std::int64_t>>
+      gauge_;
+#else
+  opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Histogram<double>>
+      gauge_;
+#endif
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/internal/client_schema_metrics.h
+++ b/google/cloud/bigtable/internal/client_schema_metrics.h
@@ -54,7 +54,7 @@ struct ClientOutstandingRpcLabels {
 using LabelMap = std::unordered_map<std::string, std::string>;
 LabelMap IntoLabelMap(ClientResourceLabels const& r,
                       ClientOutstandingRpcLabels const& d,
-                      std::set<std::string> const& filtered_data_labels = {});
+                      std::set<std::string> const& filtered_data_labels);
 
 struct DirectAccessCompatibilityLabels {
   std::string ip_preference;
@@ -63,7 +63,7 @@ struct DirectAccessCompatibilityLabels {
 
 LabelMap IntoLabelMap(ClientResourceLabels const& r,
                       DirectAccessCompatibilityLabels const& d,
-                      std::set<std::string> const& filtered_data_labels = {});
+                      std::set<std::string> const& filtered_data_labels);
 
 ClientResourceLabels MakeClientResourceLabels(
     std::string project_id, std::string instance, std::string app_profile,

--- a/google/cloud/bigtable/internal/client_schema_metrics_test.cc
+++ b/google/cloud/bigtable/internal/client_schema_metrics_test.cc
@@ -18,6 +18,7 @@
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
 
 #include "google/cloud/bigtable/internal/client_schema_metrics.h"
+#include "google/cloud/bigtable/internal/data_connection_impl.h"
 #include "google/cloud/bigtable/options.h"
 #include "google/cloud/bigtable/version.h"
 #include "google/cloud/testing_util/mock_opentelemetry_metrics.h"
@@ -189,6 +190,157 @@ TEST(ClientSchemaMetricsTest, MakeClientResourceLabels) {
   EXPECT_THAT(labels.cloud_platform, Eq("unknown"));
   EXPECT_THAT(labels.host_id, Eq("unknown"));
   EXPECT_THAT(labels.hostname, IsEmpty());
+}
+
+TEST(ClientSchemaMetricsTest, IntoLabelMapDirectAccessCompatibility) {
+  ClientResourceLabels resource{"p-1",    "i-1",       "app-1", "client-1",
+                                "uid-1",  "cp-1",      "loc-1", "cloud-1",
+                                "host-1", "hostname-1"};
+  DirectAccessCompatibilityLabels data{"ipv4", "test_reason"};
+  LabelMap actual = IntoLabelMap(resource, data);
+  EXPECT_THAT(
+      actual,
+      UnorderedElementsAre(
+          Pair("project_id", "p-1"), Pair("instance", "i-1"),
+          Pair("app_profile", "app-1"), Pair("client_name", "client-1"),
+          Pair("client_uid", "uid-1"), Pair("client_project", "cp-1"),
+          Pair("location", "loc-1"), Pair("cloud_platform", "cloud-1"),
+          Pair("host_id", "host-1"), Pair("hostname", "hostname-1"),
+          Pair("ip_preference", "ipv4"), Pair("reason", "test_reason")));
+}
+
+TEST(ClientSchemaMetricsTest, IntoLabelMapDirectAccessCompatibilityFiltered) {
+  ClientResourceLabels resource{"p-1",    "i-1",       "app-1", "client-1",
+                                "uid-1",  "cp-1",      "loc-1", "cloud-1",
+                                "host-1", "hostname-1"};
+  DirectAccessCompatibilityLabels data{"ipv6", ""};
+  LabelMap actual = IntoLabelMap(resource, data, {"reason"});
+  EXPECT_THAT(actual,
+              UnorderedElementsAre(
+                  Pair("project_id", "p-1"), Pair("instance", "i-1"),
+                  Pair("app_profile", "app-1"), Pair("client_name", "client-1"),
+                  Pair("client_uid", "uid-1"), Pair("client_project", "cp-1"),
+                  Pair("location", "loc-1"), Pair("cloud_platform", "cloud-1"),
+                  Pair("host_id", "host-1"), Pair("hostname", "hostname-1"),
+                  Pair("ip_preference", "ipv6")));
+}
+
+TEST(ClientSchemaMetricsTest, DirectAccessCompatibilityMetric) {
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+  auto mock_gauge = std::make_unique<MockGauge<std::int64_t>>();
+  EXPECT_CALL(*mock_gauge,
+              Record(A<std::int64_t>(),
+                     A<opentelemetry::common::KeyValueIterable const&>(),
+                     A<opentelemetry::context::Context const&>()))
+      .WillOnce([](std::int64_t value,
+                   opentelemetry::common::KeyValueIterable const& attrs,
+                   opentelemetry::context::Context const&) {
+        EXPECT_THAT(value, Eq(1));
+        EXPECT_THAT(
+            MakeAttributesMap(attrs),
+            UnorderedElementsAre(
+                Pair("project_id", "my-project"),
+                Pair("instance", "my-instance"),
+                Pair("app_profile", "my-app-profile"),
+                Pair("client_name", "my-client-name"),
+                Pair("client_uid", "my-uid"),
+                Pair("client_project", "my-client-project"),
+                Pair("location", "us-east1"), Pair("cloud_platform", "gcp"),
+                Pair("host_id", "my-host"), Pair("hostname", "my-hostname"),
+                Pair("ip_preference", "ipv4"), Pair("reason", "")));
+      });
+
+  opentelemetry::nostd::shared_ptr<MockMeter> mock_meter =
+      std::make_shared<MockMeter>();
+  EXPECT_CALL(*mock_meter, CreateInt64Gauge)
+      .WillOnce([mock = std::move(mock_gauge)](
+                    opentelemetry::nostd::string_view name,
+                    opentelemetry::nostd::string_view,
+                    opentelemetry::nostd::string_view) mutable {
+        EXPECT_THAT(name, Eq("direct_access/compatible"));
+        return std::move(mock);
+      });
+#else
+  auto mock_histogram = std::make_unique<MockHistogram<double>>();
+  EXPECT_CALL(
+      *mock_histogram,
+      Record(A<double>(), A<opentelemetry::common::KeyValueIterable const&>(),
+             A<opentelemetry::context::Context const&>()))
+      .WillOnce([](double value,
+                   opentelemetry::common::KeyValueIterable const& attrs,
+                   opentelemetry::context::Context const&) {
+        EXPECT_THAT(value, Eq(1.0));
+        EXPECT_THAT(
+            MakeAttributesMap(attrs),
+            UnorderedElementsAre(
+                Pair("project_id", "my-project"),
+                Pair("instance", "my-instance"),
+                Pair("app_profile", "my-app-profile"),
+                Pair("client_name", "my-client-name"),
+                Pair("client_uid", "my-uid"),
+                Pair("client_project", "my-client-project"),
+                Pair("location", "us-east1"), Pair("cloud_platform", "gcp"),
+                Pair("host_id", "my-host"), Pair("hostname", "my-hostname"),
+                Pair("ip_preference", "ipv4"), Pair("reason", "")));
+      });
+
+  opentelemetry::nostd::shared_ptr<MockMeter> mock_meter =
+      std::make_shared<MockMeter>();
+  EXPECT_CALL(*mock_meter, CreateDoubleHistogram)
+      .WillOnce([mock = std::move(mock_histogram)](
+                    opentelemetry::nostd::string_view name,
+                    opentelemetry::nostd::string_view,
+                    opentelemetry::nostd::string_view) mutable {
+        EXPECT_THAT(name, Eq("direct_access/compatible"));
+        return std::move(mock);
+      });
+#endif
+
+  opentelemetry::nostd::shared_ptr<MockMeterProvider> mock_provider =
+      std::make_shared<MockMeterProvider>();
+  EXPECT_CALL(*mock_provider, GetMeter)
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+      .WillOnce([&](opentelemetry::nostd::string_view scope,
+                    opentelemetry::nostd::string_view scope_version,
+                    opentelemetry::nostd::string_view,
+                    opentelemetry::common::KeyValueIterable const*) mutable {
+#else
+      .WillOnce([&](opentelemetry::nostd::string_view scope,
+                    opentelemetry::nostd::string_view scope_version,
+                    opentelemetry::nostd::string_view) mutable {
+#endif
+        EXPECT_THAT(scope, Eq("my-instrument-scope"));
+        EXPECT_THAT(scope_version, Eq("v1"));
+        return mock_meter;
+      });
+
+  DirectAccessCompatibility compatibility("my-instrument-scope", mock_provider);
+  ClientResourceLabels resource_labels{
+      "my-project", "my-instance",       "my-app-profile", "my-client-name",
+      "my-uid",     "my-client-project", "us-east1",       "gcp",
+      "my-host",    "my-hostname"};
+  auto clone = compatibility.clone(resource_labels);
+
+  auto const otel_context =
+      opentelemetry::context::RuntimeContext::GetCurrent();
+  static_cast<DirectAccessCompatibility*>(clone.get())
+      ->Record(otel_context, 1, DirectAccessCompatibilityLabels{"ipv4", ""});
+}
+
+TEST(ClientSchemaMetricsTest, MakeClientResourceLabelsExtractsFromOptions) {
+  Options options;
+  options.set<bigtable_internal::InstanceChannelAffinityOption>(
+      {bigtable::InstanceResource(Project("proj-1"), "inst-1")});
+  options.set<bigtable::AppProfileIdOption>("profile-1");
+
+  ClientResourceLabels const labels = MakeClientResourceLabels(
+      /*project_id=*/"", /*instance=*/"", /*app_profile=*/"", options,
+      "test-uid", opentelemetry::sdk::resource::Resource::GetEmpty());
+
+  EXPECT_THAT(labels.project_id, Eq("proj-1"));
+  EXPECT_THAT(labels.instance, Eq("inst-1"));
+  EXPECT_THAT(labels.app_profile, Eq("profile-1"));
+  EXPECT_THAT(labels.client_uid, Eq("test-uid"));
 }
 
 }  // namespace

--- a/google/cloud/bigtable/internal/client_schema_metrics_test.cc
+++ b/google/cloud/bigtable/internal/client_schema_metrics_test.cc
@@ -52,7 +52,7 @@ TEST(ClientSchemaMetricsTest, IntoLabelMapClient) {
   ClientOutstandingRpcLabels data{TransportType::kDirectPath,
                                   ChannelPoolLbPolicy::kRandomTwoLeastUsed,
                                   RpcType::kStreaming};
-  LabelMap actual = IntoLabelMap(resource, data);
+  LabelMap actual = IntoLabelMap(resource, data, {});
   EXPECT_THAT(actual,
               UnorderedElementsAre(
                   Pair("project_id", "p-1"), Pair("instance", "i-1"),
@@ -72,7 +72,7 @@ TEST(ClientSchemaMetricsTest, IntoLabelMapClientRoundRobinCloudPathUnary) {
   ClientOutstandingRpcLabels data{TransportType::kCloudPath,
                                   ChannelPoolLbPolicy::kRoundRobin,
                                   RpcType::kUnary};
-  LabelMap actual = IntoLabelMap(resource, data);
+  LabelMap actual = IntoLabelMap(resource, data, {});
   EXPECT_THAT(actual,
               UnorderedElementsAre(
                   Pair("project_id", "p-1"), Pair("instance", "i-1"),
@@ -200,7 +200,7 @@ TEST(ClientSchemaMetricsTest, IntoLabelMapDirectAccessCompatibility) {
                                 "uid-1",  "cp-1",      "loc-1", "cloud-1",
                                 "host-1", "hostname-1"};
   DirectAccessCompatibilityLabels data{"ipv4", "test_reason"};
-  LabelMap actual = IntoLabelMap(resource, data);
+  LabelMap actual = IntoLabelMap(resource, data, {});
   EXPECT_THAT(
       actual,
       UnorderedElementsAre(

--- a/google/cloud/bigtable/internal/client_schema_metrics_test.cc
+++ b/google/cloud/bigtable/internal/client_schema_metrics_test.cc
@@ -33,6 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::google::cloud::testing_util::MakeAttributesMap;
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+using ::google::cloud::testing_util::MockGauge;
+#endif
 using ::google::cloud::testing_util::MockHistogram;
 using ::google::cloud::testing_util::MockMeter;
 using ::google::cloud::testing_util::MockMeterProvider;

--- a/google/cloud/testing_util/mock_opentelemetry_metrics.h
+++ b/google/cloud/testing_util/mock_opentelemetry_metrics.h
@@ -56,6 +56,26 @@ class MockHistogram : public opentelemetry::metrics::Histogram<T> {
               (noexcept, override));
 };
 
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+template <typename T>
+class MockGauge : public opentelemetry::metrics::Gauge<T> {
+ public:
+  MOCK_METHOD(void, Record,  // NOLINT(bugprone-exception-escape)
+              (T value), (noexcept, override));
+  MOCK_METHOD(void, Record,  // NOLINT(bugprone-exception-escape)
+              (T value, opentelemetry::context::Context const& context),
+              (noexcept, override));
+  MOCK_METHOD(void, Record,  // NOLINT(bugprone-exception-escape)
+              (T, opentelemetry::common::KeyValueIterable const&),
+              (noexcept, override));
+  MOCK_METHOD(void, Record,  // NOLINT(bugprone-exception-escape)
+              (T value,
+               opentelemetry::common::KeyValueIterable const& attributes,
+               opentelemetry::context::Context const& context),
+              (noexcept, override));
+};
+#endif
+
 template <typename T>
 class MockCounter : public opentelemetry::metrics::Counter<T> {
  public:


### PR DESCRIPTION
This PR adds the client schema metric used to report the result of attempting to use DirectPath.