### PR TITLE
chore: update markdown files disallowing internal default params

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -83,3 +83,16 @@ to avoid typing an explicit type.
   - When a reference or pointer is intended, always explicitly qualify as
     `auto const&`, `auto&`, or `auto*` to prevent accidental copies (since bare
     `auto` deduces by value) and to make ownership and mutability unambiguous.
+
+## Default Arguments in Internal Namespaces
+
+- **Avoid Default Parameters in `internal` Namespaces:**
+  - Functions, member functions, and constructors declared in `internal`
+    namespaces (e.g., `google::cloud::*::internal`, `google::cloud::*_internal`)
+    must not specify default parameter values.
+  - Require all internal callers and unit tests to explicitly specify all
+    arguments.
+  - *Why:* Default arguments in internal implementation code obscure
+    dependencies at call sites, make it easy to inadvertently omit required
+    configuration, and can mask untested branches in unit tests. If a simpler
+    calling convention is genuinely needed, provide an explicit overload.

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -32,7 +32,12 @@ https://google.github.io/styleguide/cppguide.html with the following variances:
   files.
 - Encourage duplication of salient setup and expectations in test cases to
   increase readability.
-- Discourage default parameters for functions in an internal namespace.
+- **Disallow Default Parameters in `internal` Namespaces:** Reject default
+  argument values in functions, member functions, and constructors declared in
+  `internal` namespaces (e.g., `google::cloud::*::internal`,
+  `google::cloud::*_internal`). Require all internal callers and unit tests to
+  explicitly supply all arguments. Suggest explicit function overloads if a
+  simpler calling syntax is needed.
 
 Do not make comments of suggestions on ordering of includes as a script formats
 them.


### PR DESCRIPTION
Update and/or emphasize that internal functions should not have default parameters.