### PR TITLE
fix!: require minimum libcurl 8.7.1 to fix curl bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ for details on updating existing applications using v1.x.y or v2.x.y.
 
 ## v3.9.0 - TBD
 
+### Dependency version update
+
+- Updated minimum version of libcurl from 7.74.0 to 8.7.1. This was done primarily to avoid a known bug introduced in libcurl 8.5.0. For more information, see [Issue #16343](https://github.com/googleapis/google-cloud-cpp/issues/16343).
+
 ### New Libraries
 
 We are happy to announce the following GA libraries. Unless specifically noted,

--- a/ci/cloudbuild/dockerfiles/demo-debian-bookworm.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-debian-bookworm.Dockerfile
@@ -56,7 +56,9 @@ ENV PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/local/lib/pkgconfig
 # ```
 
 # #### curl
-
+#
+# Install curl from source to avoid a libcurl bug present in older versions.
+#
 # ```bash
 WORKDIR /var/tmp/build/curl
 RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \

--- a/ci/cloudbuild/dockerfiles/demo-debian-bookworm.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-debian-bookworm.Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && \
 # ```bash
 RUN apt-get update && \
     apt-get --no-install-recommends install -y \
-        libcurl4-openssl-dev libssl-dev nlohmann-json3-dev
+        libnghttp2-dev libssl-dev nlohmann-json3-dev
 # ```
 
 # #### Patching pkg-config
@@ -53,6 +53,24 @@ RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     make install && \
     ldconfig && cd /var/tmp && rm -fr build
 ENV PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/local/lib/pkgconfig
+# ```
+
+# #### curl
+
+# ```bash
+WORKDIR /var/tmp/build/curl
+RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Debug \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCURL_USE_OPENSSL=ON \
+        -DBUILD_CURL_EXE=OFF \
+        -DBUILD_TESTING=OFF \
+        -GNinja -S . -B cmake-out && \
+    cmake --build cmake-out --target install && \
+    ldconfig && cd /var/tmp && rm -fr build
 # ```
 
 # #### Abseil

--- a/ci/cloudbuild/dockerfiles/demo-debian-bookworm.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-debian-bookworm.Dockerfile
@@ -58,6 +58,8 @@ ENV PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/local/lib/pkgconfig
 # #### curl
 #
 # Install curl from source to avoid a libcurl bug present in older versions.
+# See https://github.com/googleapis/google-cloud-cpp/issues/16343 for more
+# details.
 #
 # ```bash
 WORKDIR /var/tmp/build/curl

--- a/ci/cloudbuild/dockerfiles/demo-debian-bullseye.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-debian-bullseye.Dockerfile
@@ -36,6 +36,8 @@ RUN curl -fsSL https://github.com/Kitware/cmake/archive/v3.31.12.tar.gz | \
 # #### curl
 #
 # Install curl from source to avoid a libcurl bug present in older versions.
+# See https://github.com/googleapis/google-cloud-cpp/issues/16343 for more
+# details.
 #
 # ```bash
 WORKDIR /var/tmp/build/curl

--- a/ci/cloudbuild/dockerfiles/demo-debian-bullseye.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-debian-bullseye.Dockerfile
@@ -17,13 +17,13 @@ ARG NCPU=4
 
 ## [BEGIN packaging.md]
 
-# Install the minimal development tools, libcurl, and OpenSSL:
+# Install the minimal development tools, OpenSSL, and libnghttp2:
 
 # ```bash
 RUN apt-get update && \
     apt-get --no-install-recommends install -y apt-transport-https apt-utils \
         automake build-essential ca-certificates curl git \
-        gcc g++ libc-ares-dev libc-ares2 libcurl4-openssl-dev \
+        gcc g++ libc-ares-dev libc-ares2 libnghttp2-dev \
         libssl-dev m4 make ninja-build pkg-config tar wget zlib1g-dev libc6-dbg
 # ```
 
@@ -32,6 +32,24 @@ WORKDIR /var/tmp/build/cmake
 RUN curl -fsSL https://github.com/Kitware/cmake/archive/v3.31.12.tar.gz | \
     tar -xzf - --strip-components=1 && \
     ./bootstrap && make -j ${NCPU:-4} && make install
+
+# #### curl
+
+# ```bash
+WORKDIR /var/tmp/build/curl
+RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Debug \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCURL_USE_OPENSSL=ON \
+        -DBUILD_CURL_EXE=OFF \
+        -DBUILD_TESTING=OFF \
+        -GNinja -S . -B cmake-out && \
+    cmake --build cmake-out --target install && \
+    ldconfig && cd /var/tmp && rm -fr build
+# ```
 
 # #### Abseil
 

--- a/ci/cloudbuild/dockerfiles/demo-debian-bullseye.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-debian-bullseye.Dockerfile
@@ -34,7 +34,9 @@ RUN curl -fsSL https://github.com/Kitware/cmake/archive/v3.31.12.tar.gz | \
     ./bootstrap && make -j ${NCPU:-4} && make install
 
 # #### curl
-
+#
+# Install curl from source to avoid a libcurl bug present in older versions.
+#
 # ```bash
 WORKDIR /var/tmp/build/curl
 RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \

--- a/ci/cloudbuild/dockerfiles/demo-fedora.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-fedora.Dockerfile
@@ -65,6 +65,8 @@ ENV PKG_CONFIG_PATH=/usr/local/share/pkgconfig:/usr/lib64/pkgconfig:/usr/local/l
 # #### curl
 #
 # Install curl from source to avoid a libcurl bug present in older versions.
+# See https://github.com/googleapis/google-cloud-cpp/issues/16343 for more
+# details.
 #
 # ```bash
 WORKDIR /var/tmp/build/curl

--- a/ci/cloudbuild/dockerfiles/demo-fedora.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-fedora.Dockerfile
@@ -31,7 +31,7 @@ RUN dnf makecache && dnf debuginfo-install -y glibc
 
 # ```bash
 RUN dnf makecache && \
-    dnf install -y json-devel libcurl-devel openssl-devel
+    dnf install -y json-devel libnghttp2-devel openssl-devel
 # ```
 
 # #### Patching pkg-config
@@ -60,6 +60,24 @@ RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
 
 # ```bash
 ENV PKG_CONFIG_PATH=/usr/local/share/pkgconfig:/usr/lib64/pkgconfig:/usr/local/lib64/pkgconfig
+# ```
+
+# #### curl
+
+# ```bash
+WORKDIR /var/tmp/build/curl
+RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCURL_USE_OPENSSL=ON \
+        -DBUILD_CURL_EXE=OFF \
+        -DBUILD_TESTING=OFF \
+        -GNinja -S . -B cmake-out && \
+    cmake --build cmake-out --target install && \
+    ldconfig && cd /var/tmp && rm -fr build
 # ```
 
 # #### Protobuf

--- a/ci/cloudbuild/dockerfiles/demo-fedora.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-fedora.Dockerfile
@@ -63,7 +63,9 @@ ENV PKG_CONFIG_PATH=/usr/local/share/pkgconfig:/usr/lib64/pkgconfig:/usr/local/l
 # ```
 
 # #### curl
-
+#
+# Install curl from source to avoid a libcurl bug present in older versions.
+#
 # ```bash
 WORKDIR /var/tmp/build/curl
 RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \

--- a/ci/cloudbuild/dockerfiles/demo-rockylinux-9.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-rockylinux-9.Dockerfile
@@ -17,7 +17,7 @@ ARG NCPU=4
 
 ## [BEGIN packaging.md]
 
-# Install the minimal development tools, libcurl, OpenSSL, and the c-ares
+# Install the minimal development tools, OpenSSL, and the c-ares
 # library (required by gRPC):
 
 # ```bash
@@ -26,7 +26,7 @@ RUN dnf makecache && \
     dnf install -y epel-release && \
     dnf makecache && \
     dnf install -y cmake findutils gcc-c++ git make openssl-devel \
-        patch zlib-devel libcurl-devel c-ares-devel tar wget which \
+        patch zlib-devel libnghttp2-devel c-ares-devel tar wget which \
         autoconf automake libtool binutils dnf-utils
 RUN dnf makecache && dnf debuginfo-install -y glibc
 
@@ -66,6 +66,24 @@ RUN (echo "/usr/local/lib" ; echo "/usr/local/lib64") | \
     tee /etc/ld.so.conf.d/usrlocal.conf
 ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig:/usr/lib64/pkgconfig
 ENV PATH=/usr/local/bin:${PATH}
+# ```
+
+# #### curl
+
+# ```bash
+WORKDIR /var/tmp/build/curl
+RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Debug \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCURL_USE_OPENSSL=ON \
+        -DBUILD_CURL_EXE=OFF \
+        -DBUILD_TESTING=OFF \
+        -S . -B cmake-out && \
+    cmake --build cmake-out --target install && \
+    ldconfig && cd /var/tmp && rm -fr build
 # ```
 
 # #### Abseil

--- a/ci/cloudbuild/dockerfiles/demo-rockylinux-9.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-rockylinux-9.Dockerfile
@@ -24,6 +24,7 @@ ARG NCPU=4
 RUN dnf makecache && \
     dnf update -y && \
     dnf install -y epel-release && \
+    dnf config-manager --set-enabled crb && \
     dnf makecache && \
     dnf install -y cmake findutils gcc-c++ git make openssl-devel \
         patch zlib-devel libnghttp2-devel c-ares-devel tar wget which \

--- a/ci/cloudbuild/dockerfiles/demo-rockylinux-9.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-rockylinux-9.Dockerfile
@@ -70,7 +70,9 @@ ENV PATH=/usr/local/bin:${PATH}
 # ```
 
 # #### curl
-
+#
+# Install curl from source to avoid a libcurl bug present in older versions.
+#
 # ```bash
 WORKDIR /var/tmp/build/curl
 RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \

--- a/ci/cloudbuild/dockerfiles/demo-rockylinux-9.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-rockylinux-9.Dockerfile
@@ -72,6 +72,8 @@ ENV PATH=/usr/local/bin:${PATH}
 # #### curl
 #
 # Install curl from source to avoid a libcurl bug present in older versions.
+# See https://github.com/googleapis/google-cloud-cpp/issues/16343 for more
+# details.
 #
 # ```bash
 WORKDIR /var/tmp/build/curl

--- a/ci/cloudbuild/dockerfiles/demo-ubuntu-24.04.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-ubuntu-24.04.Dockerfile
@@ -60,7 +60,9 @@ RUN ln -s /usr/bin/pkgconf /usr/bin/pkg-config
 # ```
 
 # #### curl
-
+#
+# Install curl from source to avoid a libcurl bug present in older versions.
+#
 # ```bash
 WORKDIR /var/tmp/build/curl
 RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \

--- a/ci/cloudbuild/dockerfiles/demo-ubuntu-24.04.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-ubuntu-24.04.Dockerfile
@@ -62,6 +62,8 @@ RUN ln -s /usr/bin/pkgconf /usr/bin/pkg-config
 # #### curl
 #
 # Install curl from source to avoid a libcurl bug present in older versions.
+# See https://github.com/googleapis/google-cloud-cpp/issues/16343 for more
+# details.
 #
 # ```bash
 WORKDIR /var/tmp/build/curl

--- a/ci/cloudbuild/dockerfiles/demo-ubuntu-24.04.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-ubuntu-24.04.Dockerfile
@@ -17,7 +17,7 @@ ARG NCPU=4
 
 ## [BEGIN packaging.md]
 
-# Install the minimal development tools, libcurl, OpenSSL and libc-ares:
+# Install the minimal development tools, OpenSSL and libc-ares:
 
 # ```bash
 ENV DEBIAN_FRONTEND=noninteractive
@@ -33,7 +33,7 @@ RUN apt-get update && \
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get --no-install-recommends install -y  \
-        libssl-dev libcurl4-openssl-dev nlohmann-json3-dev zlib1g-dev \
+        libssl-dev libnghttp2-dev nlohmann-json3-dev zlib1g-dev \
         libsystemd-dev
 # ```
 
@@ -57,6 +57,24 @@ RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
     make install && \
     ldconfig && cd /var/tmp && rm -fr build
 RUN ln -s /usr/bin/pkgconf /usr/bin/pkg-config
+# ```
+
+# #### curl
+
+# ```bash
+WORKDIR /var/tmp/build/curl
+RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Debug \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCURL_USE_OPENSSL=ON \
+        -DBUILD_CURL_EXE=OFF \
+        -DBUILD_TESTING=OFF \
+        -S . -B cmake-out && \
+    cmake --build cmake-out --target install && \
+    ldconfig && cd /var/tmp && rm -fr build
 # ```
 
 # #### Abseil

--- a/ci/cloudbuild/dockerfiles/demo-ubuntu-jammy.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-ubuntu-jammy.Dockerfile
@@ -29,7 +29,9 @@ RUN apt-get update && \
 # ```
 
 # #### curl
-
+#
+# Install curl from source to avoid a libcurl bug present in older versions.
+#
 # ```bash
 WORKDIR /var/tmp/build/curl
 RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \

--- a/ci/cloudbuild/dockerfiles/demo-ubuntu-jammy.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-ubuntu-jammy.Dockerfile
@@ -31,6 +31,8 @@ RUN apt-get update && \
 # #### curl
 #
 # Install curl from source to avoid a libcurl bug present in older versions.
+# See https://github.com/googleapis/google-cloud-cpp/issues/16343 for more
+# details.
 #
 # ```bash
 WORKDIR /var/tmp/build/curl

--- a/ci/cloudbuild/dockerfiles/demo-ubuntu-jammy.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-ubuntu-jammy.Dockerfile
@@ -17,15 +17,33 @@ ARG NCPU=4
 
 ## [BEGIN packaging.md]
 
-# Install the minimal development tools, libcurl, OpenSSL and libc-ares:
+# Install the minimal development tools, OpenSSL and libc-ares:
 
 # ```bash
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get --no-install-recommends install -y apt-transport-https apt-utils \
         automake build-essential cmake ca-certificates curl git \
-        gcc g++ libc-ares-dev libc-ares2 libcurl4-openssl-dev libre2-dev \
+        gcc g++ libc-ares-dev libc-ares2 libnghttp2-dev libre2-dev \
         libssl-dev m4 make pkg-config tar wget zlib1g-dev libc6-dbg
+# ```
+
+# #### curl
+
+# ```bash
+WORKDIR /var/tmp/build/curl
+RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Debug \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCURL_USE_OPENSSL=ON \
+        -DBUILD_CURL_EXE=OFF \
+        -DBUILD_TESTING=OFF \
+        -S . -B cmake-out && \
+    cmake --build cmake-out --target install && \
+    ldconfig && cd /var/tmp && rm -fr build
 # ```
 
 # #### Abseil

--- a/ci/cloudbuild/dockerfiles/fedora-cmake-quickstart.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-cmake-quickstart.Dockerfile
@@ -81,6 +81,7 @@ RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
 # set the search path.
 ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/lib64/pkgconfig
 
+# Install curl from source to avoid a libcurl bug present in older versions.
 WORKDIR /var/tmp/build/curl
 RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
     tar -xzf - --strip-components=1 && \

--- a/ci/cloudbuild/dockerfiles/fedora-cmake-quickstart.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-cmake-quickstart.Dockerfile
@@ -82,6 +82,8 @@ RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
 ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/lib64/pkgconfig
 
 # Install curl from source to avoid a libcurl bug present in older versions.
+# See https://github.com/googleapis/google-cloud-cpp/issues/16343 for more
+# details.
 WORKDIR /var/tmp/build/curl
 RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
     tar -xzf - --strip-components=1 && \

--- a/ci/cloudbuild/dockerfiles/fedora-cmake-quickstart.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-cmake-quickstart.Dockerfile
@@ -16,14 +16,14 @@ FROM fedora:40
 ARG NCPU=4
 ARG ARCH=amd64
 
-# Fedora includes packages for libcurl and OpenSSL that are recent enough
+# Fedora includes packages for OpenSSL that are recent enough
 # for `google-cloud-cpp`. Install these packages and additional development
 # tools to compile the dependencies:
 RUN dnf makecache && \
     dnf install -y abi-compliance-checker autoconf automake \
         clang clang-analyzer clang-tools-extra \
         cmake diffutils findutils gcc-c++ git \
-        libcurl-devel llvm make ninja-build \
+        libnghttp2-devel llvm make ninja-build \
         openssl-devel patch python python3 \
         python-pip tar unzip w3m wget which zip zlib-devel
 
@@ -80,6 +80,20 @@ RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
 # default, pkgconf does not search in these directories. We need to explicitly
 # set the search path.
 ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/lib64/pkgconfig
+
+WORKDIR /var/tmp/build/curl
+RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCURL_USE_OPENSSL=ON \
+        -DBUILD_CURL_EXE=OFF \
+        -DBUILD_TESTING=OFF \
+        -GNinja -S . -B cmake-out && \
+    cmake --build cmake-out --target install && \
+    ldconfig && cd /var/tmp && rm -fr build
 
 # We disable the inline namespace because otherwise Abseil LTS updates break our
 # `check-api` build.

--- a/ci/cloudbuild/dockerfiles/fedora-latest-cmake.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-latest-cmake.Dockerfile
@@ -81,6 +81,7 @@ RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
 # set the search path.
 ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/lib64/pkgconfig
 
+# Install curl from source to avoid a libcurl bug present in older versions.
 WORKDIR /var/tmp/build/curl
 RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
     tar -xzf - --strip-components=1 && \

--- a/ci/cloudbuild/dockerfiles/fedora-latest-cmake.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-latest-cmake.Dockerfile
@@ -16,14 +16,14 @@ FROM fedora:40
 ARG NCPU=4
 ARG ARCH=amd64
 
-# Fedora includes packages for libcurl and OpenSSL that are recent enough
+# Fedora includes packages for OpenSSL that are recent enough
 # for `google-cloud-cpp`. Install these packages and additional development
 # tools to compile the dependencies:
 RUN dnf makecache && \
     dnf install -y abi-compliance-checker autoconf automake \
         clang clang-analyzer clang-tools-extra \
         cmake diffutils findutils gcc-c++ git \
-        libcurl-devel llvm make ninja-build \
+        llvm make ninja-build \
         openssl-devel patch python python3 \
         python-pip tar unzip w3m wget which zip zlib-devel
 
@@ -80,6 +80,20 @@ RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
 # default, pkgconf does not search in these directories. We need to explicitly
 # set the search path.
 ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/lib64/pkgconfig
+
+WORKDIR /var/tmp/build/curl
+RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCURL_USE_OPENSSL=ON \
+        -DBUILD_CURL_EXE=OFF \
+        -DBUILD_TESTING=OFF \
+        -GNinja -S . -B cmake-out && \
+    cmake --build cmake-out --target install && \
+    ldconfig && cd /var/tmp && rm -fr build
 
 # We disable the inline namespace because otherwise Abseil LTS updates break our
 # `check-api` build.

--- a/ci/cloudbuild/dockerfiles/fedora-latest-cmake.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-latest-cmake.Dockerfile
@@ -23,7 +23,7 @@ RUN dnf makecache && \
     dnf install -y abi-compliance-checker autoconf automake \
         clang clang-analyzer clang-tools-extra \
         cmake diffutils findutils gcc-c++ git \
-        llvm make ninja-build \
+        libnghttp2-devel llvm make ninja-build \
         openssl-devel patch python python3 \
         python-pip tar unzip w3m wget which zip zlib-devel
 

--- a/ci/cloudbuild/dockerfiles/fedora-latest-cmake.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-latest-cmake.Dockerfile
@@ -82,6 +82,8 @@ RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
 ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/lib64/pkgconfig
 
 # Install curl from source to avoid a libcurl bug present in older versions.
+# See https://github.com/googleapis/google-cloud-cpp/issues/16343 for more
+# details.
 WORKDIR /var/tmp/build/curl
 RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
     tar -xzf - --strip-components=1 && \

--- a/ci/cloudbuild/dockerfiles/fedora-latest-cxx20.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-latest-cxx20.Dockerfile
@@ -68,6 +68,8 @@ RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
 ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/lib64/pkgconfig
 
 # Install curl from source to avoid a libcurl bug present in older versions.
+# See https://github.com/googleapis/google-cloud-cpp/issues/16343 for more
+# details.
 WORKDIR /var/tmp/build/curl
 RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
     tar -xzf - --strip-components=1 && \

--- a/ci/cloudbuild/dockerfiles/fedora-latest-cxx20.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-latest-cxx20.Dockerfile
@@ -16,7 +16,7 @@ FROM fedora:40
 ARG NCPU=4
 ARG ARCH=amd64
 
-# Fedora includes packages for gRPC, libcurl, and OpenSSL that are recent enough
+# Fedora includes packages for gRPC and OpenSSL that are recent enough
 # for `google-cloud-cpp`. Install these packages and additional development
 # tools to compile the dependencies:
 RUN dnf makecache && \
@@ -25,10 +25,10 @@ RUN dnf makecache && \
         make ninja-build patch python3 \
         python-pip tar unzip wget which zip zlib-devel
 
-# Install the development packages for libcurl and OpenSSL. Neither are affected
+# Install the development packages for OpenSSL and libnghttp2. Neither are affected
 # by the C++ version, so we can use the pre-built binaries.
 RUN dnf makecache && \
-    dnf install -y libcurl-devel openssl-devel
+    dnf install -y libnghttp2-devel openssl-devel
 
 # Install the Python modules needed to run the storage emulator
 RUN dnf makecache && dnf install -y python3-devel
@@ -66,6 +66,20 @@ RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
 # default, pkgconf does not search in these directories. We need to explicitly
 # set the search path.
 ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/lib64/pkgconfig
+
+WORKDIR /var/tmp/build/curl
+RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_CXX_STANDARD=20 \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCURL_USE_OPENSSL=ON \
+        -DBUILD_CURL_EXE=OFF \
+        -DBUILD_TESTING=OFF \
+        -GNinja -S . -B cmake-out && \
+    cmake --build cmake-out --target install && \
+    ldconfig && cd /var/tmp && rm -fr build
 
 # Download and install direct dependencies of `google-cloud-cpp`. Including
 # development dependencies.  In each case, remove the downloaded files and the

--- a/ci/cloudbuild/dockerfiles/fedora-latest-cxx20.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-latest-cxx20.Dockerfile
@@ -67,6 +67,7 @@ RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
 # set the search path.
 ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/lib64/pkgconfig
 
+# Install curl from source to avoid a libcurl bug present in older versions.
 WORKDIR /var/tmp/build/curl
 RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
     tar -xzf - --strip-components=1 && \

--- a/ci/cloudbuild/dockerfiles/fedora-latest-publish-docs.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-latest-publish-docs.Dockerfile
@@ -29,7 +29,7 @@ RUN dnf makecache && \
         google-benchmark-devel \
         gtest-devel \
         json-devel \
-        libcurl-devel \
+        libnghttp2-devel \
         openssl-devel \
         pugixml-devel
 
@@ -51,6 +51,20 @@ RUN curl -fsSL https://github.com/jbeder/yaml-cpp/archive/refs/tags/yaml-cpp-0.9
         -DBUILD_SHARED_LIBS=ON \
         -DBUILD_TESTING=OFF \
         -S . -B cmake-out -GNinja && \
+    cmake --build cmake-out --target install && \
+    ldconfig && cd /var/tmp && rm -fr build
+
+WORKDIR /var/tmp/build/curl
+RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCURL_USE_OPENSSL=ON \
+        -DBUILD_CURL_EXE=OFF \
+        -DBUILD_TESTING=OFF \
+        -GNinja -S . -B cmake-out && \
     cmake --build cmake-out --target install && \
     ldconfig && cd /var/tmp && rm -fr build
 

--- a/ci/cloudbuild/dockerfiles/fedora-latest-publish-docs.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-latest-publish-docs.Dockerfile
@@ -55,6 +55,8 @@ RUN curl -fsSL https://github.com/jbeder/yaml-cpp/archive/refs/tags/yaml-cpp-0.9
     ldconfig && cd /var/tmp && rm -fr build
 
 # Install curl from source to avoid a libcurl bug present in older versions.
+# See https://github.com/googleapis/google-cloud-cpp/issues/16343 for more
+# details.
 WORKDIR /var/tmp/build/curl
 RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
     tar -xzf - --strip-components=1 && \

--- a/ci/cloudbuild/dockerfiles/fedora-latest-publish-docs.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-latest-publish-docs.Dockerfile
@@ -54,6 +54,7 @@ RUN curl -fsSL https://github.com/jbeder/yaml-cpp/archive/refs/tags/yaml-cpp-0.9
     cmake --build cmake-out --target install && \
     ldconfig && cd /var/tmp && rm -fr build
 
+# Install curl from source to avoid a libcurl bug present in older versions.
 WORKDIR /var/tmp/build/curl
 RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
     tar -xzf - --strip-components=1 && \

--- a/ci/cloudbuild/dockerfiles/fedora-m32.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-m32.Dockerfile
@@ -78,6 +78,7 @@ RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
 # uses /lib/ in contrast to most Fedora-based build that use /lib64/
 ENV PKG_CONFIG_PATH=/usr/local/share/pkgconfig:/usr/lib/pkgconfig
 
+# Install curl from source to avoid a libcurl bug present in older versions.
 WORKDIR /var/tmp/build/curl
 RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
     tar -xzf - --strip-components=1 && \

--- a/ci/cloudbuild/dockerfiles/fedora-m32.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-m32.Dockerfile
@@ -79,6 +79,8 @@ RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
 ENV PKG_CONFIG_PATH=/usr/local/share/pkgconfig:/usr/lib/pkgconfig
 
 # Install curl from source to avoid a libcurl bug present in older versions.
+# See https://github.com/googleapis/google-cloud-cpp/issues/16343 for more
+# details.
 WORKDIR /var/tmp/build/curl
 RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
     tar -xzf - --strip-components=1 && \

--- a/ci/cloudbuild/dockerfiles/fedora-m32.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-m32.Dockerfile
@@ -38,7 +38,7 @@ RUN dnf makecache && \
         google-benchmark-devel.i686 \
         grpc-devel.i686 \
         gtest-devel.i686 \
-        libcurl-devel.i686 \
+        libnghttp2-devel.i686 \
         libstdc++-devel.i686 \
         openssl-devel.i686 \
         protobuf-devel.i686 \
@@ -77,6 +77,25 @@ RUN curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
 # default, pkg-config does not search in these directories. Note how this build
 # uses /lib/ in contrast to most Fedora-based build that use /lib64/
 ENV PKG_CONFIG_PATH=/usr/local/share/pkgconfig:/usr/lib/pkgconfig
+
+WORKDIR /var/tmp/build/curl
+RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+        -DCMAKE_C_FLAGS=-m32 \
+        -DCMAKE_FIND_ROOT_PATH=/usr/ \
+        -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=NEVER \
+        -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY \
+        -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCURL_USE_OPENSSL=ON \
+        -DBUILD_CURL_EXE=OFF \
+        -DBUILD_TESTING=OFF \
+        -S . -B cmake-out && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig && cd /var/tmp && rm -fr build
 
 # The project depends on the nlohmann_json library. We use CMake to
 # install it as this installs the necessary CMake configuration files.

--- a/ci/cloudbuild/dockerfiles/ubuntu-20.04-install.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/ubuntu-20.04-install.Dockerfile
@@ -58,6 +58,7 @@ RUN apt update && apt install -y openjdk-13-jre
 # files and any temporary artifacts after a successful build to keep the
 # image smaller (and with fewer layers)
 
+# Install curl from source to avoid a libcurl bug present in older versions.
 WORKDIR /var/tmp/build/curl
 RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
     tar -xzf - --strip-components=1 && \

--- a/ci/cloudbuild/dockerfiles/ubuntu-20.04-install.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/ubuntu-20.04-install.Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && \
         gcc \
         g++ \
         cmake \
-        libcurl4-openssl-dev \
+        libnghttp2-dev \
         libssl-dev \
         libtool \
         lsb-release \
@@ -57,6 +57,21 @@ RUN apt update && apt install -y openjdk-13-jre
 # Use a different directory for each build, and remove the downloaded
 # files and any temporary artifacts after a successful build to keep the
 # image smaller (and with fewer layers)
+
+WORKDIR /var/tmp/build/curl
+RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE="Release" \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCURL_USE_OPENSSL=ON \
+        -DBUILD_CURL_EXE=OFF \
+        -DBUILD_TESTING=OFF \
+        -S . -B cmake-out -GNinja && \
+    cmake --build cmake-out --target install && \
+    ldconfig && \
+    cd /var/tmp && rm -fr build
 
 WORKDIR /var/tmp/build/abseil-cpp
 RUN curl -fsSL https://github.com/abseil/abseil-cpp/archive/20250814.2.tar.gz | \

--- a/ci/cloudbuild/dockerfiles/ubuntu-20.04-install.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/ubuntu-20.04-install.Dockerfile
@@ -59,6 +59,8 @@ RUN apt update && apt install -y openjdk-13-jre
 # image smaller (and with fewer layers)
 
 # Install curl from source to avoid a libcurl bug present in older versions.
+# See https://github.com/googleapis/google-cloud-cpp/issues/16343 for more
+# details.
 WORKDIR /var/tmp/build/curl
 RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
     tar -xzf - --strip-components=1 && \

--- a/ci/cloudbuild/dockerfiles/ubuntu-22.04-install.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/ubuntu-22.04-install.Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && \
         git \
         gcc \
         g++ \
-        libcurl4-openssl-dev \
+        libnghttp2-dev \
         libssl-dev \
         libtool \
         lsb-release \
@@ -56,6 +56,21 @@ RUN apt update && apt install -y openjdk-11-jre
 # Use a different directory for each build, and remove the downloaded
 # files and any temporary artifacts after a successful build to keep the
 # image smaller (and with fewer layers)
+
+WORKDIR /var/tmp/build/curl
+RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE="Release" \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCURL_USE_OPENSSL=ON \
+        -DBUILD_CURL_EXE=OFF \
+        -DBUILD_TESTING=OFF \
+        -S . -B cmake-out -GNinja && \
+    cmake --build cmake-out --target install && \
+    ldconfig && \
+    cd /var/tmp && rm -fr build
 
 WORKDIR /var/tmp/build/abseil-cpp
 RUN curl -fsSL https://github.com/abseil/abseil-cpp/archive/20250814.2.tar.gz | \

--- a/ci/cloudbuild/dockerfiles/ubuntu-22.04-install.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/ubuntu-22.04-install.Dockerfile
@@ -57,6 +57,7 @@ RUN apt update && apt install -y openjdk-11-jre
 # files and any temporary artifacts after a successful build to keep the
 # image smaller (and with fewer layers)
 
+# Install curl from source to avoid a libcurl bug present in older versions.
 WORKDIR /var/tmp/build/curl
 RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
     tar -xzf - --strip-components=1 && \

--- a/ci/cloudbuild/dockerfiles/ubuntu-22.04-install.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/ubuntu-22.04-install.Dockerfile
@@ -58,6 +58,8 @@ RUN apt update && apt install -y openjdk-11-jre
 # image smaller (and with fewer layers)
 
 # Install curl from source to avoid a libcurl bug present in older versions.
+# See https://github.com/googleapis/google-cloud-cpp/issues/16343 for more
+# details.
 WORKDIR /var/tmp/build/curl
 RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
     tar -xzf - --strip-components=1 && \

--- a/ci/cloudbuild/dockerfiles/ubuntu-22.04.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/ubuntu-22.04.Dockerfile
@@ -47,6 +47,8 @@ RUN apt-get update && \
         apt-transport-https
 
 # Install curl from source to avoid a libcurl bug present in older versions.
+# See https://github.com/googleapis/google-cloud-cpp/issues/16343 for more
+# details.
 WORKDIR /var/tmp/build/curl
 RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
     tar -xzf - --strip-components=1 && \

--- a/ci/cloudbuild/dockerfiles/ubuntu-22.04.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/ubuntu-22.04.Dockerfile
@@ -46,6 +46,7 @@ RUN apt-get update && \
         ca-certificates \
         apt-transport-https
 
+# Install curl from source to avoid a libcurl bug present in older versions.
 WORKDIR /var/tmp/build/curl
 RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
     tar -xzf - --strip-components=1 && \

--- a/ci/cloudbuild/dockerfiles/ubuntu-22.04.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/ubuntu-22.04.Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && \
         git \
         gcc \
         g++ \
-        libcurl4-openssl-dev \
+        libnghttp2-dev \
         libssl-dev \
         libtool \
         lsb-release \
@@ -45,6 +45,20 @@ RUN apt-get update && \
         apt-utils \
         ca-certificates \
         apt-transport-https
+
+WORKDIR /var/tmp/build/curl
+RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCURL_USE_OPENSSL=ON \
+        -DBUILD_CURL_EXE=OFF \
+        -DBUILD_TESTING=OFF \
+        -GNinja -S . -B cmake-out && \
+    cmake --build cmake-out --target install && \
+    ldconfig && cd /var/tmp && rm -fr build
 
 # Install Python packages used in the integration tests.
 RUN update-alternatives --install /usr/bin/python python $(which python3) 10

--- a/ci/cloudbuild/dockerfiles/ubuntu-24.04.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/ubuntu-24.04.Dockerfile
@@ -51,6 +51,8 @@ RUN apt-get update && \
         apt-transport-https
 
 # Install curl from source to avoid a libcurl bug present in older versions.
+# See https://github.com/googleapis/google-cloud-cpp/issues/16343 for more
+# details.
 WORKDIR /var/tmp/build/curl
 RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
     tar -xzf - --strip-components=1 && \

--- a/ci/cloudbuild/dockerfiles/ubuntu-24.04.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/ubuntu-24.04.Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
         gcc \
         g++ \
         cmake \
-        libcurl4-openssl-dev \
+        libnghttp2-dev \
         libssl-dev \
         libtool \
         llvm \
@@ -49,6 +49,20 @@ RUN apt-get update && \
         apt-utils \
         ca-certificates \
         apt-transport-https
+
+WORKDIR /var/tmp/build/curl
+RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCURL_USE_OPENSSL=ON \
+        -DBUILD_CURL_EXE=OFF \
+        -DBUILD_TESTING=OFF \
+        -GNinja -S . -B cmake-out && \
+    cmake --build cmake-out --target install && \
+    ldconfig && cd /var/tmp && rm -fr build
 
 # Install Python packages used in the integration tests.
 RUN update-alternatives --install /usr/bin/python python $(which python3) 10

--- a/ci/cloudbuild/dockerfiles/ubuntu-24.04.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/ubuntu-24.04.Dockerfile
@@ -50,6 +50,7 @@ RUN apt-get update && \
         ca-certificates \
         apt-transport-https
 
+# Install curl from source to avoid a libcurl bug present in older versions.
 WORKDIR /var/tmp/build/curl
 RUN curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
     tar -xzf - --strip-components=1 && \

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -277,6 +277,12 @@ export PKG_CONFIG_PATH=/usr/local/share/pkgconfig:/usr/lib64/pkgconfig:/usr/loca
 
 #### curl
 
+# 
+
+Install curl from source to avoid a libcurl bug present in older versions.
+
+# 
+
 ```bash
 mkdir -p $HOME/Downloads/curl && cd $HOME/Downloads/curl
 curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
@@ -595,6 +601,12 @@ ln -s /usr/bin/pkgconf /usr/bin/pkg-config
 
 #### curl
 
+# 
+
+Install curl from source to avoid a libcurl bug present in older versions.
+
+# 
+
 ```bash
 mkdir -p $HOME/Downloads/curl && cd $HOME/Downloads/curl
 curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
@@ -753,6 +765,12 @@ sudo apt-get --no-install-recommends install -y apt-transport-https apt-utils \
 ```
 
 #### curl
+
+# 
+
+Install curl from source to avoid a libcurl bug present in older versions.
+
+# 
 
 ```bash
 mkdir -p $HOME/Downloads/curl && cd $HOME/Downloads/curl
@@ -942,6 +960,12 @@ export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/local/lib/pkgcon
 
 #### curl
 
+# 
+
+Install curl from source to avoid a libcurl bug present in older versions.
+
+# 
+
 ```bash
 mkdir -p $HOME/Downloads/curl && cd $HOME/Downloads/curl
 curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
@@ -1109,6 +1133,12 @@ tar -xzf - --strip-components=1 && \
 ./bootstrap && make -j ${NCPU:-4} && sudo make install
 
 #### curl
+
+# 
+
+Install curl from source to avoid a libcurl bug present in older versions.
+
+# 
 
 ```bash
 mkdir -p $HOME/Downloads/curl && cd $HOME/Downloads/curl
@@ -1316,6 +1346,12 @@ export PATH=/usr/local/bin:${PATH}
 ```
 
 #### curl
+
+# 
+
+Install curl from source to avoid a libcurl bug present in older versions.
+
+# 
 
 ```bash
 mkdir -p $HOME/Downloads/curl && cd $HOME/Downloads/curl

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -150,8 +150,8 @@ apk update && \
 
 Alpine's version of `pkg-config` (https://github.com/pkgconf/pkgconf) is slow
 when handling `.pc` files with lots of `Requires:` deps, which happens with
-Abseil, so we use the normal `pkg-config` binary, which seems to not suffer
-from this bottleneck. For more details see
+Abseil, so we use the normal `pkg-config` binary, which seems to not suffer from
+this bottleneck. For more details see
 https://github.com/pkgconf/pkgconf/issues/229 and
 https://github.com/googleapis/google-cloud-cpp/issues/7052
 
@@ -166,8 +166,8 @@ sudo make install && \
 ```
 
 The following steps will install libraries and tools in `/usr/local`. By
-default, pkgconf does not search in these directories. We need to explicitly
-set the search path.
+default, pkgconf does not search in these directories. We need to explicitly set
+the search path.
 
 ```bash
 export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/lib/pkgconfig
@@ -175,9 +175,9 @@ export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/lib/pkgconfig
 
 #### Dependencies
 
-The versions of Abseil, Protobuf, gRPC, OpenSSL, and nlohmann-json included
-with Alpine >= 3.19 meet `google-cloud-cpp`'s requirements. We can simply
-install the development packages
+The versions of Abseil, Protobuf, gRPC, OpenSSL, and nlohmann-json included with
+Alpine >= 3.19 meet `google-cloud-cpp`'s requirements. We can simply install the
+development packages
 
 ```bash
 apk update && \
@@ -239,8 +239,8 @@ sudo dnf install -y cmake curl findutils gcc-c++ git make ninja-build \
 sudo dnf makecache && sudo dnf debuginfo-install -y glibc
 ```
 
-Fedora:40 includes packages, with recent enough versions, for most of the
-direct dependencies of `google-cloud-cpp`.
+Fedora:40 includes packages, with recent enough versions, for most of the direct
+dependencies of `google-cloud-cpp`.
 
 ```bash
 sudo dnf makecache && \
@@ -253,9 +253,9 @@ If you are not planning to use `pkg-config(1)` you can skip these steps.
 
 Fedora's version of `pkg-config` (https://github.com/pkgconf/pkgconf) is slow
 when handling `.pc` files with lots of `Requires:` deps, which happens with
-Abseil. If you plan to use `pkg-config` with any of the installed artifacts,
-you may want to use a recent version of the standard `pkg-config` binary. If
-not, `sudo dnf install pkgconfig` should work.
+Abseil. If you plan to use `pkg-config` with any of the installed artifacts, you
+may want to use a recent version of the standard `pkg-config` binary. If not,
+`sudo dnf install pkgconfig` should work.
 
 ```bash
 mkdir -p $HOME/Downloads/pkgconf && cd $HOME/Downloads/pkgconf
@@ -268,8 +268,8 @@ sudo ldconfig && cd /var/tmp && rm -fr build
 ```
 
 The following steps will install libraries and tools in `/usr/local`. By
-default, pkgconf does not search in these directories. We need to explicitly
-set the search path.
+default, pkgconf does not search in these directories. We need to explicitly set
+the search path.
 
 ```bash
 export PKG_CONFIG_PATH=/usr/local/share/pkgconfig:/usr/lib64/pkgconfig:/usr/local/lib64/pkgconfig
@@ -405,8 +405,8 @@ sudo zypper install --allow-downgrade -y \
 ```
 
 The following steps will install libraries and tools in `/usr/local`. openSUSE
-does not search for shared libraries in these directories by default. There
-are multiple ways to solve this problem, the following steps are one solution:
+does not search for shared libraries in these directories by default. There are
+multiple ways to solve this problem, the following steps are one solution:
 
 ```bash
 (echo "/usr/local/lib" ; echo "/usr/local/lib64") | \
@@ -415,10 +415,8 @@ export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
 export PATH=/usr/local/bin:${PATH}
 ```
 
-Use the following environment variables to configure the compiler used by
-CMake.
-export CC=gcc
-export CXX=g++
+Use the following environment variables to configure the compiler used by CMake.
+export CC=gcc export CXX=g++
 
 #### Abseil
 
@@ -553,7 +551,7 @@ cmake --build cmake-out --target install
 <summary>Ubuntu (24.04 LTS - Noble Numbat)</summary>
 <br>
 
-Install the minimal development tools, libcurl, OpenSSL and libc-ares:
+Install the minimal development tools, OpenSSL and libc-ares:
 
 ```bash
 export DEBIAN_FRONTEND=noninteractive
@@ -569,7 +567,7 @@ Ubuntu:24 includes packages for most of the direct dependencies of
 export DEBIAN_FRONTEND=noninteractive
 sudo apt-get update && \
 sudo apt-get --no-install-recommends install -y  \
-        libssl-dev libcurl4-openssl-dev nlohmann-json3-dev zlib1g-dev \
+        libssl-dev libnghttp2-dev nlohmann-json3-dev zlib1g-dev \
         libsystemd-dev
 ```
 
@@ -579,9 +577,9 @@ If you are not planning to use `pkg-config(1)` you can skip these steps.
 
 Ubuntu's version of `pkg-config` (https://github.com/pkgconf/pkgconf) is slow
 when handling `.pc` files with lots of `Requires:` deps, which happens with
-Abseil. If you plan to use `pkg-config` with any of the installed artifacts,
-you may want to use a recent version of the standard `pkg-config` binary. If
-not, `sudo dnf install pkgconfig` should work.
+Abseil. If you plan to use `pkg-config` with any of the installed artifacts, you
+may want to use a recent version of the standard `pkg-config` binary. If not,
+`sudo dnf install pkgconfig` should work.
 
 ```bash
 mkdir -p $HOME/Downloads/pkgconf && cd $HOME/Downloads/pkgconf
@@ -593,6 +591,24 @@ curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
 sudo make install && \
 sudo ldconfig && cd /var/tmp && rm -fr build
 ln -s /usr/bin/pkgconf /usr/bin/pkg-config
+```
+
+#### curl
+
+```bash
+mkdir -p $HOME/Downloads/curl && cd $HOME/Downloads/curl
+curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Debug \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCURL_USE_OPENSSL=ON \
+        -DBUILD_CURL_EXE=OFF \
+        -DBUILD_TESTING=OFF \
+        -S . -B cmake-out && \
+sudo cmake --build cmake-out --target install && \
+sudo ldconfig && cd /var/tmp && rm -fr build
 ```
 
 #### Abseil
@@ -725,15 +741,33 @@ cmake --build cmake-out --target install
 <summary>Ubuntu (22.04 LTS - Jammy Jellyfish)</summary>
 <br>
 
-Install the minimal development tools, libcurl, OpenSSL and libc-ares:
+Install the minimal development tools, OpenSSL and libc-ares:
 
 ```bash
 export DEBIAN_FRONTEND=noninteractive
 sudo apt-get update && \
 sudo apt-get --no-install-recommends install -y apt-transport-https apt-utils \
         automake build-essential cmake ca-certificates curl git \
-        gcc g++ libc-ares-dev libc-ares2 libcurl4-openssl-dev libre2-dev \
+        gcc g++ libc-ares-dev libc-ares2 libnghttp2-dev libre2-dev \
         libssl-dev m4 make pkg-config tar wget zlib1g-dev libc6-dbg
+```
+
+#### curl
+
+```bash
+mkdir -p $HOME/Downloads/curl && cd $HOME/Downloads/curl
+curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Debug \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCURL_USE_OPENSSL=ON \
+        -DBUILD_CURL_EXE=OFF \
+        -DBUILD_TESTING=OFF \
+        -S . -B cmake-out && \
+sudo cmake --build cmake-out --target install && \
+sudo ldconfig && cd /var/tmp && rm -fr build
 ```
 
 #### Abseil
@@ -776,8 +810,8 @@ sudo ldconfig
 
 #### gRPC
 
-We also need a version of gRPC that is recent enough to support the Google
-Cloud Platform proto files. We install it using:
+We also need a version of gRPC that is recent enough to support the Google Cloud
+Platform proto files. We install it using:
 
 ```bash
 mkdir -p $HOME/Downloads/grpc && cd $HOME/Downloads/grpc
@@ -803,10 +837,10 @@ sudo ldconfig
 
 #### nlohmann_json library
 
-The project depends on the nlohmann_json library. We use CMake to
-install it as this installs the necessary CMake configuration files.
-Note that this is a header-only library, and often installed manually.
-This leaves your environment without support for CMake pkg-config.
+The project depends on the nlohmann_json library. We use CMake to install it as
+this installs the necessary CMake configuration files. Note that this is a
+header-only library, and often installed manually. This leaves your environment
+without support for CMake pkg-config.
 
 ```bash
 mkdir -p $HOME/Downloads/json && cd $HOME/Downloads/json
@@ -891,9 +925,9 @@ If you are not planning to use `pkg-config(1)` you can skip these steps.
 
 Debian's version of `pkg-config` (https://github.com/pkgconf/pkgconf) is slow
 when handling `.pc` files with lots of `Requires:` deps, which happens with
-Abseil. If you plan to use `pkg-config` with any of the installed artifacts,
-you may want to use a recent version of the standard `pkg-config` binary. If
-not, `sudo dnf install pkgconfig` should work.
+Abseil. If you plan to use `pkg-config` with any of the installed artifacts, you
+may want to use a recent version of the standard `pkg-config` binary. If not,
+`sudo dnf install pkgconfig` should work.
 
 ```bash
 mkdir -p $HOME/Downloads/pkgconf && cd $HOME/Downloads/pkgconf
@@ -1068,10 +1102,11 @@ sudo apt-get --no-install-recommends install -y apt-transport-https apt-utils \
 ```
 
 #### Install CMake v3.22
-mkdir -p $HOME/Downloads/cmake && cd $HOME/Downloads/cmake
-curl -fsSL https://github.com/Kitware/cmake/archive/v3.31.12.tar.gz | \
-    tar -xzf - --strip-components=1 && \
-    ./bootstrap && make -j ${NCPU:-4} && sudo make install
+
+mkdir -p $HOME/Downloads/cmake && cd $HOME/Downloads/cmake curl -fsSL
+https://github.com/Kitware/cmake/archive/v3.31.12.tar.gz | \
+tar -xzf - --strip-components=1 && \
+./bootstrap && make -j ${NCPU:-4} && sudo make install
 
 #### curl
 
@@ -1110,7 +1145,8 @@ sudo ldconfig
 
 #### nlohmann_json library
 
-Debian 11 also ships with nlohmann-json==3.9.1, which is recent enough for our needs:
+Debian 11 also ships with nlohmann-json==3.9.1, which is recent enough for our
+needs:
 
 ```bash
 sudo apt-get update && \
@@ -1119,10 +1155,10 @@ sudo apt-get --no-install-recommends install -y nlohmann-json3-dev
 
 #### Protobuf
 
-Unless you are only using the Google Cloud Storage library the project
-needs Protobuf and gRPC. Unfortunately the version of Protobuf that ships
-with Debian 11 is not recent enough to support the protos published by
-Google Cloud. We need to build from source:
+Unless you are only using the Google Cloud Storage library the project needs
+Protobuf and gRPC. Unfortunately the version of Protobuf that ships with Debian
+11 is not recent enough to support the protos published by Google Cloud. We need
+to build from source:
 
 ```bash
 mkdir -p $HOME/Downloads/protobuf && cd $HOME/Downloads/protobuf
@@ -1141,9 +1177,9 @@ sudo ldconfig
 
 #### RE2
 
-The version of RE2 included with this distro hard-codes C++11 in its
-pkg-config file. You can skip this build and use the system's package if
-you are not planning to use pkg-config.
+The version of RE2 included with this distro hard-codes C++11 in its pkg-config
+file. You can skip this build and use the system's package if you are not
+planning to use pkg-config.
 
 ```bash
 mkdir -p $HOME/Downloads/re2 && cd $HOME/Downloads/re2
@@ -1227,8 +1263,8 @@ cmake --build cmake-out --target install
 <summary>Rocky Linux (9)</summary>
 <br>
 
-Install the minimal development tools, libcurl, OpenSSL, and the c-ares
-library (required by gRPC):
+Install the minimal development tools, OpenSSL, and the c-ares library (required
+by gRPC):
 
 ```bash
 sudo dnf makecache && \
@@ -1236,7 +1272,7 @@ sudo dnf update -y && \
 sudo dnf install -y epel-release && \
 sudo dnf makecache && \
 sudo dnf install -y cmake findutils gcc-c++ git make openssl-devel \
-        patch zlib-devel libcurl-devel c-ares-devel tar wget which \
+        patch zlib-devel libnghttp2-devel c-ares-devel tar wget which \
         autoconf automake libtool binutils dnf-utils
 sudo dnf makecache && sudo dnf debuginfo-install -y glibc
 
@@ -1251,10 +1287,10 @@ export CXX=/usr/bin/g++
 ```
 
 Rocky Linux's version of `pkg-config` (https://github.com/pkgconf/pkgconf) is
-slow when handling `.pc` files with lots of `Requires:` deps, which happens
-with Abseil. If you plan to use `pkg-config` with any of the installed
-artifacts, you may want to use a recent version of the standard `pkg-config`
-binary. If not, `sudo dnf install pkgconfig` should work.
+slow when handling `.pc` files with lots of `Requires:` deps, which happens with
+Abseil. If you plan to use `pkg-config` with any of the installed artifacts, you
+may want to use a recent version of the standard `pkg-config` binary. If not,
+`sudo dnf install pkgconfig` should work.
 
 ```bash
 mkdir -p $HOME/Downloads/pkgconf && cd $HOME/Downloads/pkgconf
@@ -1268,14 +1304,32 @@ sudo ldconfig && cd /var/tmp && rm -fr build
 
 The following steps will install libraries and tools in `/usr/local`. By
 default, Rocky Linux 9 does not search for shared libraries in these
-directories, there are multiple ways to solve this problem, the following
-steps are one solution:
+directories, there are multiple ways to solve this problem, the following steps
+are one solution:
 
 ```bash
 (echo "/usr/local/lib" ; echo "/usr/local/lib64") | \
 sudo tee /etc/ld.so.conf.d/usrlocal.conf
 export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig:/usr/lib64/pkgconfig
 export PATH=/usr/local/bin:${PATH}
+```
+
+#### curl
+
+```bash
+mkdir -p $HOME/Downloads/curl && cd $HOME/Downloads/curl
+curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Debug \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCURL_USE_OPENSSL=ON \
+        -DBUILD_CURL_EXE=OFF \
+        -DBUILD_TESTING=OFF \
+        -S . -B cmake-out && \
+sudo cmake --build cmake-out --target install && \
+sudo ldconfig && cd /var/tmp && rm -fr build
 ```
 
 #### Abseil
@@ -1297,8 +1351,8 @@ sudo ldconfig
 
 #### Protobuf
 
-Rocky Linux ships with Protobuf 3.14.x.  Some of the libraries in
-`google-cloud-cpp` require Protobuf >= 3.15.8.  For simplicity, we will just
+Rocky Linux ships with Protobuf 3.14.x. Some of the libraries in
+`google-cloud-cpp` require Protobuf >= 3.15.8. For simplicity, we will just
 install Protobuf (and any downstream packages) from source.
 
 ```bash
@@ -1319,9 +1373,9 @@ sudo ldconfig
 
 #### RE2
 
-The version of RE2 included with this distro hard-codes C++11 in its
-pkg-config file. You can skip this build and use the system's package if
-you are not planning to use pkg-config.
+The version of RE2 included with this distro hard-codes C++11 in its pkg-config
+file. You can skip this build and use the system's package if you are not
+planning to use pkg-config.
 
 ```bash
 mkdir -p $HOME/Downloads/re2 && cd $HOME/Downloads/re2
@@ -1338,10 +1392,10 @@ sudo ldconfig
 
 #### gRPC
 
-We also need a version of gRPC that is recent enough to support the Google
-Cloud Platform proto files. Note that gRPC overrides the default C++ standard
-version to C++14, we need to configure it to use the platform's default. We
-manually install it using:
+We also need a version of gRPC that is recent enough to support the Google Cloud
+Platform proto files. Note that gRPC overrides the default C++ standard version
+to C++14, we need to configure it to use the platform's default. We manually
+install it using:
 
 ```bash
 mkdir -p $HOME/Downloads/grpc && cd $HOME/Downloads/grpc
@@ -1367,10 +1421,10 @@ sudo ldconfig
 
 #### nlohmann_json library
 
-The project depends on the nlohmann_json library. We use CMake to
-install it as this installs the necessary CMake configuration files.
-Note that this is a header-only library, and often installed manually.
-This leaves your environment without support for CMake pkg-config.
+The project depends on the nlohmann_json library. We use CMake to install it as
+this installs the necessary CMake configuration files. Note that this is a
+header-only library, and often installed manually. This leaves your environment
+without support for CMake pkg-config.
 
 ```bash
 mkdir -p $HOME/Downloads/json && cd $HOME/Downloads/json

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -1270,6 +1270,7 @@ by gRPC):
 sudo dnf makecache && \
 sudo dnf update -y && \
 sudo dnf install -y epel-release && \
+sudo dnf config-manager --set-enabled crb && \
 sudo dnf makecache && \
 sudo dnf install -y cmake findutils gcc-c++ git make openssl-devel \
         patch zlib-devel libnghttp2-devel c-ares-devel tar wget which \

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -150,8 +150,8 @@ apk update && \
 
 Alpine's version of `pkg-config` (https://github.com/pkgconf/pkgconf) is slow
 when handling `.pc` files with lots of `Requires:` deps, which happens with
-Abseil, so we use the normal `pkg-config` binary, which seems to not suffer from
-this bottleneck. For more details see
+Abseil, so we use the normal `pkg-config` binary, which seems to not suffer
+from this bottleneck. For more details see
 https://github.com/pkgconf/pkgconf/issues/229 and
 https://github.com/googleapis/google-cloud-cpp/issues/7052
 
@@ -166,8 +166,8 @@ sudo make install && \
 ```
 
 The following steps will install libraries and tools in `/usr/local`. By
-default, pkgconf does not search in these directories. We need to explicitly set
-the search path.
+default, pkgconf does not search in these directories. We need to explicitly
+set the search path.
 
 ```bash
 export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/lib/pkgconfig
@@ -175,9 +175,9 @@ export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/lib/pkgconfig
 
 #### Dependencies
 
-The versions of Abseil, Protobuf, gRPC, OpenSSL, and nlohmann-json included with
-Alpine >= 3.19 meet `google-cloud-cpp`'s requirements. We can simply install the
-development packages
+The versions of Abseil, Protobuf, gRPC, OpenSSL, and nlohmann-json included
+with Alpine >= 3.19 meet `google-cloud-cpp`'s requirements. We can simply
+install the development packages
 
 ```bash
 apk update && \
@@ -239,8 +239,8 @@ sudo dnf install -y cmake curl findutils gcc-c++ git make ninja-build \
 sudo dnf makecache && sudo dnf debuginfo-install -y glibc
 ```
 
-Fedora:40 includes packages, with recent enough versions, for most of the direct
-dependencies of `google-cloud-cpp`.
+Fedora:40 includes packages, with recent enough versions, for most of the
+direct dependencies of `google-cloud-cpp`.
 
 ```bash
 sudo dnf makecache && \
@@ -253,9 +253,9 @@ If you are not planning to use `pkg-config(1)` you can skip these steps.
 
 Fedora's version of `pkg-config` (https://github.com/pkgconf/pkgconf) is slow
 when handling `.pc` files with lots of `Requires:` deps, which happens with
-Abseil. If you plan to use `pkg-config` with any of the installed artifacts, you
-may want to use a recent version of the standard `pkg-config` binary. If not,
-`sudo dnf install pkgconfig` should work.
+Abseil. If you plan to use `pkg-config` with any of the installed artifacts,
+you may want to use a recent version of the standard `pkg-config` binary. If
+not, `sudo dnf install pkgconfig` should work.
 
 ```bash
 mkdir -p $HOME/Downloads/pkgconf && cd $HOME/Downloads/pkgconf
@@ -268,8 +268,8 @@ sudo ldconfig && cd /var/tmp && rm -fr build
 ```
 
 The following steps will install libraries and tools in `/usr/local`. By
-default, pkgconf does not search in these directories. We need to explicitly set
-the search path.
+default, pkgconf does not search in these directories. We need to explicitly
+set the search path.
 
 ```bash
 export PKG_CONFIG_PATH=/usr/local/share/pkgconfig:/usr/lib64/pkgconfig:/usr/local/lib64/pkgconfig
@@ -405,8 +405,8 @@ sudo zypper install --allow-downgrade -y \
 ```
 
 The following steps will install libraries and tools in `/usr/local`. openSUSE
-does not search for shared libraries in these directories by default. There are
-multiple ways to solve this problem, the following steps are one solution:
+does not search for shared libraries in these directories by default. There
+are multiple ways to solve this problem, the following steps are one solution:
 
 ```bash
 (echo "/usr/local/lib" ; echo "/usr/local/lib64") | \
@@ -415,8 +415,10 @@ export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
 export PATH=/usr/local/bin:${PATH}
 ```
 
-Use the following environment variables to configure the compiler used by CMake.
-export CC=gcc export CXX=g++
+Use the following environment variables to configure the compiler used by
+CMake.
+export CC=gcc
+export CXX=g++
 
 #### Abseil
 
@@ -577,9 +579,9 @@ If you are not planning to use `pkg-config(1)` you can skip these steps.
 
 Ubuntu's version of `pkg-config` (https://github.com/pkgconf/pkgconf) is slow
 when handling `.pc` files with lots of `Requires:` deps, which happens with
-Abseil. If you plan to use `pkg-config` with any of the installed artifacts, you
-may want to use a recent version of the standard `pkg-config` binary. If not,
-`sudo dnf install pkgconfig` should work.
+Abseil. If you plan to use `pkg-config` with any of the installed artifacts,
+you may want to use a recent version of the standard `pkg-config` binary. If
+not, `sudo dnf install pkgconfig` should work.
 
 ```bash
 mkdir -p $HOME/Downloads/pkgconf && cd $HOME/Downloads/pkgconf
@@ -774,8 +776,8 @@ sudo ldconfig
 
 #### gRPC
 
-We also need a version of gRPC that is recent enough to support the Google Cloud
-Platform proto files. We install it using:
+We also need a version of gRPC that is recent enough to support the Google
+Cloud Platform proto files. We install it using:
 
 ```bash
 mkdir -p $HOME/Downloads/grpc && cd $HOME/Downloads/grpc
@@ -801,10 +803,10 @@ sudo ldconfig
 
 #### nlohmann_json library
 
-The project depends on the nlohmann_json library. We use CMake to install it as
-this installs the necessary CMake configuration files. Note that this is a
-header-only library, and often installed manually. This leaves your environment
-without support for CMake pkg-config.
+The project depends on the nlohmann_json library. We use CMake to
+install it as this installs the necessary CMake configuration files.
+Note that this is a header-only library, and often installed manually.
+This leaves your environment without support for CMake pkg-config.
 
 ```bash
 mkdir -p $HOME/Downloads/json && cd $HOME/Downloads/json
@@ -880,7 +882,7 @@ Install the development packages for direct `google-cloud-cpp` dependencies:
 ```bash
 sudo apt-get update && \
 sudo apt-get --no-install-recommends install -y \
-        libcurl4-openssl-dev libssl-dev nlohmann-json3-dev
+        libnghttp2-dev libssl-dev nlohmann-json3-dev
 ```
 
 #### Patching pkg-config
@@ -889,9 +891,9 @@ If you are not planning to use `pkg-config(1)` you can skip these steps.
 
 Debian's version of `pkg-config` (https://github.com/pkgconf/pkgconf) is slow
 when handling `.pc` files with lots of `Requires:` deps, which happens with
-Abseil. If you plan to use `pkg-config` with any of the installed artifacts, you
-may want to use a recent version of the standard `pkg-config` binary. If not,
-`sudo dnf install pkgconfig` should work.
+Abseil. If you plan to use `pkg-config` with any of the installed artifacts,
+you may want to use a recent version of the standard `pkg-config` binary. If
+not, `sudo dnf install pkgconfig` should work.
 
 ```bash
 mkdir -p $HOME/Downloads/pkgconf && cd $HOME/Downloads/pkgconf
@@ -902,6 +904,24 @@ curl -fsSL https://distfiles.ariadne.space/pkgconf/pkgconf-2.2.0.tar.gz | \
 sudo make install && \
 sudo ldconfig && cd /var/tmp && rm -fr build
 export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/local/lib/pkgconfig
+```
+
+#### curl
+
+```bash
+mkdir -p $HOME/Downloads/curl && cd $HOME/Downloads/curl
+curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Debug \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCURL_USE_OPENSSL=ON \
+        -DBUILD_CURL_EXE=OFF \
+        -DBUILD_TESTING=OFF \
+        -GNinja -S . -B cmake-out && \
+sudo cmake --build cmake-out --target install && \
+sudo ldconfig && cd /var/tmp && rm -fr build
 ```
 
 #### Abseil
@@ -1037,22 +1057,39 @@ cmake --build cmake-out --target install
 <summary>Debian (11 - Bullseye)</summary>
 <br>
 
-Install the minimal development tools, libcurl, and OpenSSL:
+Install the minimal development tools, OpenSSL, and libnghttp2:
 
 ```bash
 sudo apt-get update && \
 sudo apt-get --no-install-recommends install -y apt-transport-https apt-utils \
         automake build-essential ca-certificates curl git \
-        gcc g++ libc-ares-dev libc-ares2 libcurl4-openssl-dev \
+        gcc g++ libc-ares-dev libc-ares2 libnghttp2-dev \
         libssl-dev m4 make ninja-build pkg-config tar wget zlib1g-dev libc6-dbg
 ```
 
 #### Install CMake v3.22
+mkdir -p $HOME/Downloads/cmake && cd $HOME/Downloads/cmake
+curl -fsSL https://github.com/Kitware/cmake/archive/v3.31.12.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    ./bootstrap && make -j ${NCPU:-4} && sudo make install
 
-mkdir -p $HOME/Downloads/cmake && cd $HOME/Downloads/cmake curl -fsSL
-https://github.com/Kitware/cmake/archive/v3.31.12.tar.gz | \
-tar -xzf - --strip-components=1 && \
-./bootstrap && make -j ${NCPU:-4} && sudo make install
+#### curl
+
+```bash
+mkdir -p $HOME/Downloads/curl && cd $HOME/Downloads/curl
+curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Debug \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCURL_USE_OPENSSL=ON \
+        -DBUILD_CURL_EXE=OFF \
+        -DBUILD_TESTING=OFF \
+        -GNinja -S . -B cmake-out && \
+sudo cmake --build cmake-out --target install && \
+sudo ldconfig && cd /var/tmp && rm -fr build
+```
 
 #### Abseil
 
@@ -1073,8 +1110,7 @@ sudo ldconfig
 
 #### nlohmann_json library
 
-Debian 11 also ships with nlohmann-json==3.9.1, which is recent enough for our
-needs:
+Debian 11 also ships with nlohmann-json==3.9.1, which is recent enough for our needs:
 
 ```bash
 sudo apt-get update && \
@@ -1083,10 +1119,10 @@ sudo apt-get --no-install-recommends install -y nlohmann-json3-dev
 
 #### Protobuf
 
-Unless you are only using the Google Cloud Storage library the project needs
-Protobuf and gRPC. Unfortunately the version of Protobuf that ships with Debian
-11 is not recent enough to support the protos published by Google Cloud. We need
-to build from source:
+Unless you are only using the Google Cloud Storage library the project
+needs Protobuf and gRPC. Unfortunately the version of Protobuf that ships
+with Debian 11 is not recent enough to support the protos published by
+Google Cloud. We need to build from source:
 
 ```bash
 mkdir -p $HOME/Downloads/protobuf && cd $HOME/Downloads/protobuf
@@ -1105,9 +1141,9 @@ sudo ldconfig
 
 #### RE2
 
-The version of RE2 included with this distro hard-codes C++11 in its pkg-config
-file. You can skip this build and use the system's package if you are not
-planning to use pkg-config.
+The version of RE2 included with this distro hard-codes C++11 in its
+pkg-config file. You can skip this build and use the system's package if
+you are not planning to use pkg-config.
 
 ```bash
 mkdir -p $HOME/Downloads/re2 && cd $HOME/Downloads/re2
@@ -1191,8 +1227,8 @@ cmake --build cmake-out --target install
 <summary>Rocky Linux (9)</summary>
 <br>
 
-Install the minimal development tools, libcurl, OpenSSL, and the c-ares library
-(required by gRPC):
+Install the minimal development tools, libcurl, OpenSSL, and the c-ares
+library (required by gRPC):
 
 ```bash
 sudo dnf makecache && \
@@ -1215,10 +1251,10 @@ export CXX=/usr/bin/g++
 ```
 
 Rocky Linux's version of `pkg-config` (https://github.com/pkgconf/pkgconf) is
-slow when handling `.pc` files with lots of `Requires:` deps, which happens with
-Abseil. If you plan to use `pkg-config` with any of the installed artifacts, you
-may want to use a recent version of the standard `pkg-config` binary. If not,
-`sudo dnf install pkgconfig` should work.
+slow when handling `.pc` files with lots of `Requires:` deps, which happens
+with Abseil. If you plan to use `pkg-config` with any of the installed
+artifacts, you may want to use a recent version of the standard `pkg-config`
+binary. If not, `sudo dnf install pkgconfig` should work.
 
 ```bash
 mkdir -p $HOME/Downloads/pkgconf && cd $HOME/Downloads/pkgconf
@@ -1232,8 +1268,8 @@ sudo ldconfig && cd /var/tmp && rm -fr build
 
 The following steps will install libraries and tools in `/usr/local`. By
 default, Rocky Linux 9 does not search for shared libraries in these
-directories, there are multiple ways to solve this problem, the following steps
-are one solution:
+directories, there are multiple ways to solve this problem, the following
+steps are one solution:
 
 ```bash
 (echo "/usr/local/lib" ; echo "/usr/local/lib64") | \
@@ -1261,8 +1297,8 @@ sudo ldconfig
 
 #### Protobuf
 
-Rocky Linux ships with Protobuf 3.14.x. Some of the libraries in
-`google-cloud-cpp` require Protobuf >= 3.15.8. For simplicity, we will just
+Rocky Linux ships with Protobuf 3.14.x.  Some of the libraries in
+`google-cloud-cpp` require Protobuf >= 3.15.8.  For simplicity, we will just
 install Protobuf (and any downstream packages) from source.
 
 ```bash
@@ -1283,9 +1319,9 @@ sudo ldconfig
 
 #### RE2
 
-The version of RE2 included with this distro hard-codes C++11 in its pkg-config
-file. You can skip this build and use the system's package if you are not
-planning to use pkg-config.
+The version of RE2 included with this distro hard-codes C++11 in its
+pkg-config file. You can skip this build and use the system's package if
+you are not planning to use pkg-config.
 
 ```bash
 mkdir -p $HOME/Downloads/re2 && cd $HOME/Downloads/re2
@@ -1302,10 +1338,10 @@ sudo ldconfig
 
 #### gRPC
 
-We also need a version of gRPC that is recent enough to support the Google Cloud
-Platform proto files. Note that gRPC overrides the default C++ standard version
-to C++14, we need to configure it to use the platform's default. We manually
-install it using:
+We also need a version of gRPC that is recent enough to support the Google
+Cloud Platform proto files. Note that gRPC overrides the default C++ standard
+version to C++14, we need to configure it to use the platform's default. We
+manually install it using:
 
 ```bash
 mkdir -p $HOME/Downloads/grpc && cd $HOME/Downloads/grpc
@@ -1331,10 +1367,10 @@ sudo ldconfig
 
 #### nlohmann_json library
 
-The project depends on the nlohmann_json library. We use CMake to install it as
-this installs the necessary CMake configuration files. Note that this is a
-header-only library, and often installed manually. This leaves your environment
-without support for CMake pkg-config.
+The project depends on the nlohmann_json library. We use CMake to
+install it as this installs the necessary CMake configuration files.
+Note that this is a header-only library, and often installed manually.
+This leaves your environment without support for CMake pkg-config.
 
 ```bash
 mkdir -p $HOME/Downloads/json && cd $HOME/Downloads/json

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -279,7 +279,8 @@ export PKG_CONFIG_PATH=/usr/local/share/pkgconfig:/usr/lib64/pkgconfig:/usr/loca
 
 # 
 
-Install curl from source to avoid a libcurl bug present in older versions.
+Install curl from source to avoid a libcurl bug present in older versions. See
+https://github.com/googleapis/google-cloud-cpp/issues/16343 for more details.
 
 # 
 
@@ -603,7 +604,8 @@ ln -s /usr/bin/pkgconf /usr/bin/pkg-config
 
 # 
 
-Install curl from source to avoid a libcurl bug present in older versions.
+Install curl from source to avoid a libcurl bug present in older versions. See
+https://github.com/googleapis/google-cloud-cpp/issues/16343 for more details.
 
 # 
 
@@ -768,7 +770,8 @@ sudo apt-get --no-install-recommends install -y apt-transport-https apt-utils \
 
 # 
 
-Install curl from source to avoid a libcurl bug present in older versions.
+Install curl from source to avoid a libcurl bug present in older versions. See
+https://github.com/googleapis/google-cloud-cpp/issues/16343 for more details.
 
 # 
 
@@ -962,7 +965,8 @@ export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/local/lib/pkgcon
 
 # 
 
-Install curl from source to avoid a libcurl bug present in older versions.
+Install curl from source to avoid a libcurl bug present in older versions. See
+https://github.com/googleapis/google-cloud-cpp/issues/16343 for more details.
 
 # 
 
@@ -1136,7 +1140,8 @@ tar -xzf - --strip-components=1 && \
 
 # 
 
-Install curl from source to avoid a libcurl bug present in older versions.
+Install curl from source to avoid a libcurl bug present in older versions. See
+https://github.com/googleapis/google-cloud-cpp/issues/16343 for more details.
 
 # 
 
@@ -1349,7 +1354,8 @@ export PATH=/usr/local/bin:${PATH}
 
 # 
 
-Install curl from source to avoid a libcurl bug present in older versions.
+Install curl from source to avoid a libcurl bug present in older versions. See
+https://github.com/googleapis/google-cloud-cpp/issues/16343 for more details.
 
 # 
 

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -244,7 +244,7 @@ dependencies of `google-cloud-cpp`.
 
 ```bash
 sudo dnf makecache && \
-sudo dnf install -y json-devel libcurl-devel openssl-devel
+sudo dnf install -y json-devel libnghttp2-devel openssl-devel
 ```
 
 #### Patching pkg-config
@@ -273,6 +273,24 @@ the search path.
 
 ```bash
 export PKG_CONFIG_PATH=/usr/local/share/pkgconfig:/usr/lib64/pkgconfig:/usr/local/lib64/pkgconfig
+```
+
+#### curl
+
+```bash
+mkdir -p $HOME/Downloads/curl && cd $HOME/Downloads/curl
+curl -fsSL https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCURL_USE_OPENSSL=ON \
+        -DBUILD_CURL_EXE=OFF \
+        -DBUILD_TESTING=OFF \
+        -GNinja -S . -B cmake-out && \
+sudo cmake --build cmake-out --target install && \
+sudo ldconfig && cd /var/tmp && rm -fr build
 ```
 
 #### Protobuf

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -117,7 +117,7 @@ quickstart guides also cover this use-case.
 | --------------------------------- | ----------------: | ---------------------------------------------------------- |
 | [Abseil][abseil-gh]               | 20250814, Patch 1 | Abseil C++ common library [^1]                             |
 | [gRPC][grpc-gh]                   |            1.76.x | An RPC library and framework [^2]                          |
-| [libcurl][libcurl-gh]             |            7.74.0 | HTTP client library [^3]                                   |
+| [libcurl][libcurl-gh]             |             8.7.1 | HTTP client library [^3]                                   |
 | [OpenSSL][openssl-gh]             |            3.0.17 | Crypto functions for [^3]                                  |
 | [nlohmann/json][nlohmann-json-gh] |            3.12.0 | JSON for Modern C++ [^3]                                   |
 | [protobuf][protobuf-gh]           |            6.33.x | Protobuf is needed for any library based on gRPC [^5] [^6] |

--- a/google/cloud/google_cloud_cpp_rest_internal.cmake
+++ b/google/cloud/google_cloud_cpp_rest_internal.cmake
@@ -15,15 +15,7 @@
 # ~~~
 
 find_package(nlohmann_json CONFIG REQUIRED)
-find_package(CURL REQUIRED)
-
-if (CURL_VERSION_STRING VERSION_LESS "8.7.1")
-    message(
-        FATAL_ERROR
-            "cURL version ${CURL_VERSION_STRING} is too old and unsupported. "
-            "Minimum required version is 8.7.1.")
-endif ()
-
+find_package(CURL 8.7.1 REQUIRED)
 if (NOT WIN32)
     find_package(OpenSSL REQUIRED)
 endif ()

--- a/google/cloud/google_cloud_cpp_rest_internal.cmake
+++ b/google/cloud/google_cloud_cpp_rest_internal.cmake
@@ -16,6 +16,14 @@
 
 find_package(nlohmann_json CONFIG REQUIRED)
 find_package(CURL REQUIRED)
+
+if (CURL_VERSION_STRING VERSION_LESS "8.7.1")
+    message(
+        FATAL_ERROR
+            "cURL version ${CURL_VERSION_STRING} is too old and unsupported. "
+            "Minimum required version is 8.7.1.")
+endif ()
+
 if (NOT WIN32)
     find_package(OpenSSL REQUIRED)
 endif ()

--- a/google/cloud/storage/google_cloud_cpp_storage.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage.cmake
@@ -15,6 +15,14 @@
 # ~~~
 
 find_package(CURL REQUIRED)
+
+if (CURL_VERSION_STRING VERSION_LESS "8.7.1")
+    message(
+        FATAL_ERROR
+            "cURL version ${CURL_VERSION_STRING} is too old and unsupported. "
+            "Minimum required version is 8.7.1.")
+endif ()
+
 if (NOT WIN32)
     find_package(OpenSSL REQUIRED)
 endif ()

--- a/google/cloud/storage/google_cloud_cpp_storage.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage.cmake
@@ -14,15 +14,7 @@
 # limitations under the License.
 # ~~~
 
-find_package(CURL REQUIRED)
-
-if (CURL_VERSION_STRING VERSION_LESS "8.7.1")
-    message(
-        FATAL_ERROR
-            "cURL version ${CURL_VERSION_STRING} is too old and unsupported. "
-            "Minimum required version is 8.7.1.")
-endif ()
-
+find_package(CURL 8.7.1 REQUIRED)
 if (NOT WIN32)
     find_package(OpenSSL REQUIRED)
 endif ()


### PR DESCRIPTION
Previous versions of libcurl contained a bug in curl_retry_request. 

fixes #16343 