### PR TITLE
impl(bigtable): client schema metric updates from testing

### DIFF
--- a/google/cloud/bigtable/internal/client_schema_metrics.cc
+++ b/google/cloud/bigtable/internal/client_schema_metrics.cc
@@ -156,9 +156,9 @@ ClientResourceLabels MakeClientResourceLabels(
     client_project = project_id;
   }
 
-  auto region = by_name(sc::cloud::kCloudRegion);
+  std::string region = by_name(sc::cloud::kCloudRegion);
   if (region.empty()) {
-    auto zone = by_name(sc::cloud::kCloudAvailabilityZone);
+    std::string zone = by_name(sc::cloud::kCloudAvailabilityZone);
     std::vector<std::string_view> parts = absl::StrSplit(zone, '-');
     if (parts.size() >= 3 && parts.back().size() == 1) {
       parts.pop_back();
@@ -245,7 +245,7 @@ void DirectAccessCompatibility::Record(
     opentelemetry::context::Context const& context, std::int64_t value,
     DirectAccessCompatibilityLabels const& data_labels) {
   if (gauge_ == nullptr) return;
-  auto const labels = IntoLabelMap(resource_labels_, data_labels, {});
+  LabelMap const labels = IntoLabelMap(resource_labels_, data_labels, {});
   gauge_->Record(value, labels, context);
 }
 #else
@@ -304,9 +304,10 @@ DirectAccessCompatibility::DirectAccessCompatibility(
 void DirectAccessCompatibility::Record(
     opentelemetry::context::Context const&, std::int64_t value,
     DirectAccessCompatibilityLabels const& data_labels) {
+  LabelMap labels = IntoLabelMap(resource_labels_, data_labels, {});
   std::lock_guard<std::mutex> lk(state_->mu);
   state_->value = value;
-  state_->labels = IntoLabelMap(resource_labels_, data_labels, {});
+  state_->labels = std::move(labels);
   state_->has_value = true;
 }
 #endif

--- a/google/cloud/bigtable/internal/client_schema_metrics.cc
+++ b/google/cloud/bigtable/internal/client_schema_metrics.cc
@@ -18,6 +18,8 @@
 #include "google/cloud/bigtable/internal/data_connection_impl.h"
 #include "google/cloud/bigtable/options.h"
 #include "google/cloud/bigtable/version.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/str_split.h"
 #include <opentelemetry/metrics/meter.h>
 #include <opentelemetry/semconv/incubating/cloud_attributes.h>
 #include <opentelemetry/semconv/incubating/faas_attributes.h>
@@ -66,8 +68,8 @@ LabelMap BaseLabels(ClientResourceLabels const& r) {
   return {{"project_id", r.project_id},   {"instance", r.instance},
           {"app_profile", r.app_profile}, {"client_name", r.client_name},
           {"client_uid", r.client_uid},   {"client_project", r.client_project},
-          {"location", r.location},       {"cloud_platform", r.cloud_platform},
-          {"host_id", r.host_id},         {"hostname", r.hostname}};
+          {"region", r.region},           {"cloud_platform", r.cloud_platform},
+          {"host_id", r.host_id},         {"host_name", r.host_name}};
 }
 }  // namespace
 
@@ -154,6 +156,21 @@ ClientResourceLabels MakeClientResourceLabels(
     client_project = project_id;
   }
 
+  auto region = by_name(sc::cloud::kCloudRegion);
+  if (region.empty()) {
+    auto zone = by_name(sc::cloud::kCloudAvailabilityZone);
+    std::vector<std::string_view> parts = absl::StrSplit(zone, '-');
+    if (parts.size() >= 3 && parts.back().size() == 1) {
+      parts.pop_back();
+      region = absl::StrJoin(parts, "-");
+    } else {
+      region = std::move(zone);
+    }
+  }
+  if (region.empty()) {
+    region = "global";
+  }
+
   ClientResourceLabels labels;
   labels.project_id = std::move(project_id);
   labels.instance = std::move(instance);
@@ -161,16 +178,13 @@ ClientResourceLabels MakeClientResourceLabels(
   labels.client_name = "cpp.Bigtable/" + bigtable::version_string();
   labels.client_uid = client_uid;
   labels.client_project = std::move(client_project);
-  labels.location = by_name(sc::cloud::kCloudAvailabilityZone);
-  if (labels.location.empty()) {
-    labels.location = by_name(sc::cloud::kCloudRegion, "global");
-  }
+  labels.region = std::move(region);
   labels.cloud_platform = by_name(sc::cloud::kCloudPlatform, "unknown");
   labels.host_id = by_name("faas.id");
   if (labels.host_id.empty()) {
     labels.host_id = by_name(sc::host::kHostId, "unknown");
   }
-  labels.hostname = by_name(sc::host::kHostName);
+  labels.host_name = by_name(sc::host::kHostName);
   return labels;
 }
 
@@ -193,9 +207,16 @@ void OutstandingRpcs::StubSelection(
     StubSelectionParams const& p) {
   ClientOutstandingRpcLabels data_labels{p.transport_type,
                                          p.channel_pool_lb_policy, p.streaming};
-  outstanding_rpcs_->Record(static_cast<double>(p.outstanding_rpcs),
-                            IntoLabelMap(resource_labels_, data_labels, {}),
-                            context);
+  // `channel_pool_lb_policy` is filtered out because the Cloud Monitoring
+  // metric descriptor for
+  // `bigtable.googleapis.com/internal/client/connection_pool/outstanding_rpcs`
+  // does not recognize this label.
+  static auto const* const kFilteredDataLabels =
+      new std::set<std::string>{"channel_pool_lb_policy"};
+  outstanding_rpcs_->Record(
+      static_cast<double>(p.outstanding_rpcs),
+      IntoLabelMap(resource_labels_, data_labels, *kFilteredDataLabels),
+      context);
 }
 
 std::unique_ptr<ClientSchemaMetric> OutstandingRpcs::clone(
@@ -205,40 +226,90 @@ std::unique_ptr<ClientSchemaMetric> OutstandingRpcs::clone(
   return m;
 }
 
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
 DirectAccessCompatibility::DirectAccessCompatibility(
     std::string const& instrumentation_scope,
     opentelemetry::nostd::shared_ptr<
-        opentelemetry::metrics::MeterProvider> const& provider)
-    : gauge_(
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
-          provider
-              ->GetMeter(instrumentation_scope,
-                         kMeterInstrumentationScopeVersion)
-              ->CreateInt64Gauge(
-                  "direct_access/compatible",
-                  "Compatibility check result for Bigtable DirectPath.", "1")
-#else
-          provider
-              ->GetMeter(instrumentation_scope,
-                         kMeterInstrumentationScopeVersion)
-              ->CreateDoubleHistogram(
-                  "direct_access/compatible",
-                  "Compatibility check result for Bigtable DirectPath.", "1")
-#endif
-      ) {
-}
+        opentelemetry::metrics::MeterProvider> const& provider,
+    ClientResourceLabels resource_labels)
+    : resource_labels_(std::move(resource_labels)),
+      gauge_(provider
+                 ->GetMeter(instrumentation_scope,
+                            kMeterInstrumentationScopeVersion)
+                 ->CreateInt64Gauge(
+                     "direct_access/compatible",
+                     "Compatibility check result for Bigtable DirectPath.",
+                     "1")) {}
 
 void DirectAccessCompatibility::Record(
     opentelemetry::context::Context const& context, std::int64_t value,
     DirectAccessCompatibilityLabels const& data_labels) {
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
-  gauge_->Record(value, IntoLabelMap(resource_labels_, data_labels, {}),
-                 context);
-#else
-  gauge_->Record(static_cast<double>(value),
-                 IntoLabelMap(resource_labels_, data_labels, {}), context);
-#endif
+  if (gauge_ == nullptr) return;
+  auto const labels = IntoLabelMap(resource_labels_, data_labels, {});
+  gauge_->Record(value, labels, context);
 }
+#else
+void DirectAccessCompatibility::ObserveCallback(
+    opentelemetry::metrics::ObserverResult observer_result, void* state_ptr) {
+  auto* state = static_cast<State*>(state_ptr);
+  if (state == nullptr) return;
+  std::lock_guard<std::mutex> lk(state->mu);
+  if (!state->has_value) return;
+
+  if (opentelemetry::nostd::holds_alternative<opentelemetry::nostd::shared_ptr<
+          opentelemetry::metrics::ObserverResultT<std::int64_t> > >(
+          observer_result)) {
+    auto observer = opentelemetry::nostd::get<opentelemetry::nostd::shared_ptr<
+        opentelemetry::metrics::ObserverResultT<std::int64_t> > >(
+        observer_result);
+    observer->Observe(state->value, state->labels);
+  }
+}
+
+DirectAccessCompatibility::DirectAccessCompatibility(
+    std::string const& instrumentation_scope,
+    opentelemetry::nostd::shared_ptr<
+        opentelemetry::metrics::MeterProvider> const& provider,
+    ClientResourceLabels resource_labels)
+    : resource_labels_(std::move(resource_labels)),
+      state_(std::make_shared<State>()),
+      gauge_(provider
+                 ->GetMeter(instrumentation_scope,
+                            kMeterInstrumentationScopeVersion)
+                 ->CreateInt64ObservableGauge(
+                     "direct_access/compatible",
+                     "Compatibility check result for Bigtable DirectPath.",
+                     "1")) {
+  if (gauge_ != nullptr) {
+    gauge_->AddCallback(ObserveCallback, state_.get());
+  }
+}
+
+DirectAccessCompatibility::~DirectAccessCompatibility() {
+  if (gauge_ != nullptr) {
+    gauge_->RemoveCallback(ObserveCallback, state_.get());
+  }
+}
+
+DirectAccessCompatibility::DirectAccessCompatibility(
+    DirectAccessCompatibility const& other)
+    : resource_labels_(other.resource_labels_),
+      state_(std::make_shared<State>()),
+      gauge_(other.gauge_) {
+  if (gauge_ != nullptr) {
+    gauge_->AddCallback(ObserveCallback, state_.get());
+  }
+}
+
+void DirectAccessCompatibility::Record(
+    opentelemetry::context::Context const&, std::int64_t value,
+    DirectAccessCompatibilityLabels const& data_labels) {
+  std::lock_guard<std::mutex> lk(state_->mu);
+  state_->value = value;
+  state_->labels = IntoLabelMap(resource_labels_, data_labels, {});
+  state_->has_value = true;
+}
+#endif
 
 std::unique_ptr<ClientSchemaMetric> DirectAccessCompatibility::clone(
     ClientResourceLabels const& resource_labels) const {

--- a/google/cloud/bigtable/internal/client_schema_metrics.h
+++ b/google/cloud/bigtable/internal/client_schema_metrics.h
@@ -19,10 +19,13 @@
 
 #include "google/cloud/bigtable/internal/metrics.h"
 #include "google/cloud/options.h"
+#include <opentelemetry/metrics/async_instruments.h>
 #include <opentelemetry/metrics/meter_provider.h>
+#include <opentelemetry/metrics/observer_result.h>
 #include <opentelemetry/metrics/sync_instruments.h>
 #include <opentelemetry/sdk/resource/resource.h>
 #include <memory>
+#include <mutex>
 #include <set>
 #include <string>
 #include <unordered_map>
@@ -39,10 +42,10 @@ struct ClientResourceLabels {
   std::string client_name;
   std::string client_uid;
   std::string client_project;
-  std::string location;
+  std::string region;
   std::string cloud_platform;
   std::string host_id;
-  std::string hostname;
+  std::string host_name;
 };
 
 struct ClientOutstandingRpcLabels {
@@ -95,10 +98,29 @@ class OutstandingRpcs : public ClientSchemaMetric {
 
 class DirectAccessCompatibility : public ClientSchemaMetric {
  public:
+#if OPENTELEMETRY_ABI_VERSION_NO < 2
+  struct State {
+    std::mutex mu;
+    bool has_value = false;
+    std::int64_t value = 0;
+    LabelMap labels;
+  };
+#endif
+
   DirectAccessCompatibility(
       std::string const& instrumentation_scope,
       opentelemetry::nostd::shared_ptr<
-          opentelemetry::metrics::MeterProvider> const& provider);
+          opentelemetry::metrics::MeterProvider> const& provider,
+      ClientResourceLabels resource_labels);
+#if OPENTELEMETRY_ABI_VERSION_NO < 2
+  ~DirectAccessCompatibility() override;
+
+  DirectAccessCompatibility(DirectAccessCompatibility const& other);
+  DirectAccessCompatibility& operator=(DirectAccessCompatibility const&) =
+      delete;
+  DirectAccessCompatibility(DirectAccessCompatibility&&) = delete;
+  DirectAccessCompatibility& operator=(DirectAccessCompatibility&&) = delete;
+#endif
 
   void Record(opentelemetry::context::Context const& context,
               std::int64_t value,
@@ -108,12 +130,17 @@ class DirectAccessCompatibility : public ClientSchemaMetric {
       ClientResourceLabels const& resource_labels) const override;
 
  private:
-  ClientResourceLabels resource_labels_;
 #if OPENTELEMETRY_ABI_VERSION_NO >= 2
+  ClientResourceLabels resource_labels_;
   opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Gauge<std::int64_t>>
       gauge_;
 #else
-  opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Histogram<double>>
+  static void ObserveCallback(
+      opentelemetry::metrics::ObserverResult observer_result, void* state_ptr);
+
+  ClientResourceLabels resource_labels_;
+  std::shared_ptr<State> state_;
+  opentelemetry::nostd::shared_ptr<opentelemetry::metrics::ObservableInstrument>
       gauge_;
 #endif
 };

--- a/google/cloud/bigtable/internal/client_schema_metrics_test.cc
+++ b/google/cloud/bigtable/internal/client_schema_metrics_test.cc
@@ -35,6 +35,7 @@ namespace {
 using ::google::cloud::testing_util::MakeAttributesMap;
 #if OPENTELEMETRY_ABI_VERSION_NO >= 2
 using ::google::cloud::testing_util::MockGauge;
+using ::testing::_;
 #endif
 using ::google::cloud::testing_util::MockHistogram;
 using ::google::cloud::testing_util::MockMeter;

--- a/google/cloud/bigtable/internal/client_schema_metrics_test.cc
+++ b/google/cloud/bigtable/internal/client_schema_metrics_test.cc
@@ -39,9 +39,13 @@ using ::google::cloud::testing_util::MockGauge;
 using ::google::cloud::testing_util::MockHistogram;
 using ::google::cloud::testing_util::MockMeter;
 using ::google::cloud::testing_util::MockMeterProvider;
+using ::google::cloud::testing_util::MockObservableInstrument;
+using ::google::cloud::testing_util::MockObserverResult;
 using ::testing::A;
+using ::testing::AnyNumber;
 using ::testing::Eq;
 using ::testing::IsEmpty;
+using ::testing::NotNull;
 using ::testing::Pair;
 using ::testing::UnorderedElementsAre;
 
@@ -58,8 +62,8 @@ TEST(ClientSchemaMetricsTest, IntoLabelMapClient) {
                   Pair("project_id", "p-1"), Pair("instance", "i-1"),
                   Pair("app_profile", "app-1"), Pair("client_name", "client-1"),
                   Pair("client_uid", "uid-1"), Pair("client_project", "cp-1"),
-                  Pair("location", "loc-1"), Pair("cloud_platform", "cloud-1"),
-                  Pair("host_id", "host-1"), Pair("hostname", "hostname-1"),
+                  Pair("region", "loc-1"), Pair("cloud_platform", "cloud-1"),
+                  Pair("host_id", "host-1"), Pair("host_name", "hostname-1"),
                   Pair("transport_type", "DirectPath"),
                   Pair("channel_pool_lb_policy", "RANDOM_TWO_LEAST_USED"),
                   Pair("streaming", "true")));
@@ -78,8 +82,8 @@ TEST(ClientSchemaMetricsTest, IntoLabelMapClientRoundRobinCloudPathUnary) {
                   Pair("project_id", "p-1"), Pair("instance", "i-1"),
                   Pair("app_profile", "app-1"), Pair("client_name", "client-1"),
                   Pair("client_uid", "uid-1"), Pair("client_project", "cp-1"),
-                  Pair("location", "loc-1"), Pair("cloud_platform", "cloud-1"),
-                  Pair("host_id", "host-1"), Pair("hostname", "hostname-1"),
+                  Pair("region", "loc-1"), Pair("cloud_platform", "cloud-1"),
+                  Pair("host_id", "host-1"), Pair("host_name", "hostname-1"),
                   Pair("transport_type", "CloudPath"),
                   Pair("channel_pool_lb_policy", "ROUND_ROBIN"),
                   Pair("streaming", "false")));
@@ -98,8 +102,8 @@ TEST(ClientSchemaMetricsTest, IntoLabelMapFilteredDataLabels) {
                   Pair("project_id", "p-1"), Pair("instance", "i-1"),
                   Pair("app_profile", "app-1"), Pair("client_name", "client-1"),
                   Pair("client_uid", "uid-1"), Pair("client_project", "cp-1"),
-                  Pair("location", "loc-1"), Pair("cloud_platform", "cloud-1"),
-                  Pair("host_id", "host-1"), Pair("hostname", "hostname-1"),
+                  Pair("region", "loc-1"), Pair("cloud_platform", "cloud-1"),
+                  Pair("host_id", "host-1"), Pair("host_name", "hostname-1"),
                   Pair("transport_type", "DirectPath"),
                   Pair("channel_pool_lb_policy", "RANDOM_TWO_LEAST_USED")));
 }
@@ -123,10 +127,9 @@ TEST(ClientSchemaMetricsTest, OutstandingRpcsMetric) {
                 Pair("client_name", "my-client-name"),
                 Pair("client_uid", "my-uid"),
                 Pair("client_project", "my-client-project"),
-                Pair("location", "us-east1"), Pair("cloud_platform", "gcp"),
-                Pair("host_id", "my-host"), Pair("hostname", "my-hostname"),
+                Pair("region", "us-east1"), Pair("cloud_platform", "gcp"),
+                Pair("host_id", "my-host"), Pair("host_name", "my-hostname"),
                 Pair("transport_type", "DirectPath"),
-                Pair("channel_pool_lb_policy", "RANDOM_TWO_LEAST_USED"),
                 Pair("streaming", "false")));
       });
 
@@ -189,10 +192,10 @@ TEST(ClientSchemaMetricsTest, MakeClientResourceLabels) {
               Eq("cpp.Bigtable/" + bigtable::version_string()));
   EXPECT_THAT(labels.client_uid, Eq("test-client-uid"));
   EXPECT_THAT(labels.client_project, Eq("test-project"));
-  EXPECT_THAT(labels.location, Eq("global"));
+  EXPECT_THAT(labels.region, Eq("global"));
   EXPECT_THAT(labels.cloud_platform, Eq("unknown"));
   EXPECT_THAT(labels.host_id, Eq("unknown"));
-  EXPECT_THAT(labels.hostname, IsEmpty());
+  EXPECT_THAT(labels.host_name, IsEmpty());
 }
 
 TEST(ClientSchemaMetricsTest, IntoLabelMapDirectAccessCompatibility) {
@@ -207,8 +210,8 @@ TEST(ClientSchemaMetricsTest, IntoLabelMapDirectAccessCompatibility) {
           Pair("project_id", "p-1"), Pair("instance", "i-1"),
           Pair("app_profile", "app-1"), Pair("client_name", "client-1"),
           Pair("client_uid", "uid-1"), Pair("client_project", "cp-1"),
-          Pair("location", "loc-1"), Pair("cloud_platform", "cloud-1"),
-          Pair("host_id", "host-1"), Pair("hostname", "hostname-1"),
+          Pair("region", "loc-1"), Pair("cloud_platform", "cloud-1"),
+          Pair("host_id", "host-1"), Pair("host_name", "hostname-1"),
           Pair("ip_preference", "ipv4"), Pair("reason", "test_reason")));
 }
 
@@ -223,18 +226,18 @@ TEST(ClientSchemaMetricsTest, IntoLabelMapDirectAccessCompatibilityFiltered) {
                   Pair("project_id", "p-1"), Pair("instance", "i-1"),
                   Pair("app_profile", "app-1"), Pair("client_name", "client-1"),
                   Pair("client_uid", "uid-1"), Pair("client_project", "cp-1"),
-                  Pair("location", "loc-1"), Pair("cloud_platform", "cloud-1"),
-                  Pair("host_id", "host-1"), Pair("hostname", "hostname-1"),
+                  Pair("region", "loc-1"), Pair("cloud_platform", "cloud-1"),
+                  Pair("host_id", "host-1"), Pair("host_name", "hostname-1"),
                   Pair("ip_preference", "ipv6")));
 }
 
-TEST(ClientSchemaMetricsTest, DirectAccessCompatibilityMetric) {
 #if OPENTELEMETRY_ABI_VERSION_NO >= 2
+TEST(ClientSchemaMetricsTest, DirectAccessCompatibilityMetric) {
   auto mock_gauge = std::make_unique<MockGauge<std::int64_t>>();
-  EXPECT_CALL(*mock_gauge,
-              Record(A<std::int64_t>(),
-                     A<opentelemetry::common::KeyValueIterable const&>(),
-                     A<opentelemetry::context::Context const&>()))
+  auto* mock_gauge_ptr = mock_gauge.get();
+  EXPECT_CALL(
+      *mock_gauge_ptr,
+      Record(Eq(1), A<opentelemetry::common::KeyValueIterable const&>(), _))
       .WillOnce([](std::int64_t value,
                    opentelemetry::common::KeyValueIterable const& attrs,
                    opentelemetry::context::Context const&) {
@@ -248,13 +251,12 @@ TEST(ClientSchemaMetricsTest, DirectAccessCompatibilityMetric) {
                 Pair("client_name", "my-client-name"),
                 Pair("client_uid", "my-uid"),
                 Pair("client_project", "my-client-project"),
-                Pair("location", "us-east1"), Pair("cloud_platform", "gcp"),
-                Pair("host_id", "my-host"), Pair("hostname", "my-hostname"),
+                Pair("region", "us-east1"), Pair("cloud_platform", "gcp"),
+                Pair("host_id", "my-host"), Pair("host_name", "my-hostname"),
                 Pair("ip_preference", "ipv4"), Pair("reason", "")));
       });
 
-  opentelemetry::nostd::shared_ptr<MockMeter> mock_meter =
-      std::make_shared<MockMeter>();
+  auto mock_meter = std::make_shared<MockMeter>();
   EXPECT_CALL(*mock_meter, CreateInt64Gauge)
       .WillOnce([mock = std::move(mock_gauge)](
                     opentelemetry::nostd::string_view name,
@@ -263,61 +265,20 @@ TEST(ClientSchemaMetricsTest, DirectAccessCompatibilityMetric) {
         EXPECT_THAT(name, Eq("direct_access/compatible"));
         return std::move(mock);
       });
-#else
-  auto mock_histogram = std::make_unique<MockHistogram<double>>();
-  EXPECT_CALL(
-      *mock_histogram,
-      Record(A<double>(), A<opentelemetry::common::KeyValueIterable const&>(),
-             A<opentelemetry::context::Context const&>()))
-      .WillOnce([](double value,
-                   opentelemetry::common::KeyValueIterable const& attrs,
-                   opentelemetry::context::Context const&) {
-        EXPECT_THAT(value, Eq(1.0));
-        EXPECT_THAT(
-            MakeAttributesMap(attrs),
-            UnorderedElementsAre(
-                Pair("project_id", "my-project"),
-                Pair("instance", "my-instance"),
-                Pair("app_profile", "my-app-profile"),
-                Pair("client_name", "my-client-name"),
-                Pair("client_uid", "my-uid"),
-                Pair("client_project", "my-client-project"),
-                Pair("location", "us-east1"), Pair("cloud_platform", "gcp"),
-                Pair("host_id", "my-host"), Pair("hostname", "my-hostname"),
-                Pair("ip_preference", "ipv4"), Pair("reason", "")));
-      });
 
-  opentelemetry::nostd::shared_ptr<MockMeter> mock_meter =
-      std::make_shared<MockMeter>();
-  EXPECT_CALL(*mock_meter, CreateDoubleHistogram)
-      .WillOnce([mock = std::move(mock_histogram)](
-                    opentelemetry::nostd::string_view name,
-                    opentelemetry::nostd::string_view,
-                    opentelemetry::nostd::string_view) mutable {
-        EXPECT_THAT(name, Eq("direct_access/compatible"));
-        return std::move(mock);
-      });
-#endif
-
-  opentelemetry::nostd::shared_ptr<MockMeterProvider> mock_provider =
-      std::make_shared<MockMeterProvider>();
+  auto mock_provider = std::make_shared<MockMeterProvider>();
   EXPECT_CALL(*mock_provider, GetMeter)
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
       .WillOnce([&](opentelemetry::nostd::string_view scope,
                     opentelemetry::nostd::string_view scope_version,
                     opentelemetry::nostd::string_view,
                     opentelemetry::common::KeyValueIterable const*) mutable {
-#else
-      .WillOnce([&](opentelemetry::nostd::string_view scope,
-                    opentelemetry::nostd::string_view scope_version,
-                    opentelemetry::nostd::string_view) mutable {
-#endif
         EXPECT_THAT(scope, Eq("my-instrument-scope"));
         EXPECT_THAT(scope_version, Eq("v1"));
         return mock_meter;
       });
 
-  DirectAccessCompatibility compatibility("my-instrument-scope", mock_provider);
+  DirectAccessCompatibility compatibility("my-instrument-scope", mock_provider,
+                                          ClientResourceLabels{});
   ClientResourceLabels resource_labels{
       "my-project", "my-instance",       "my-app-profile", "my-client-name",
       "my-uid",     "my-client-project", "us-east1",       "gcp",
@@ -329,6 +290,80 @@ TEST(ClientSchemaMetricsTest, DirectAccessCompatibilityMetric) {
   static_cast<DirectAccessCompatibility*>(clone.get())
       ->Record(otel_context, 1, DirectAccessCompatibilityLabels{"ipv4", ""});
 }
+#else
+TEST(ClientSchemaMetricsTest, DirectAccessCompatibilityMetric) {
+  auto mock_observable_gauge = std::make_shared<MockObservableInstrument>();
+  opentelemetry::metrics::ObservableCallbackPtr saved_callback = nullptr;
+  void* saved_state = nullptr;
+  EXPECT_CALL(*mock_observable_gauge, AddCallback)
+      .WillRepeatedly(
+          [&](opentelemetry::metrics::ObservableCallbackPtr cb, void* state) {
+            saved_callback = cb;
+            saved_state = state;
+          });
+  EXPECT_CALL(*mock_observable_gauge, RemoveCallback).Times(AnyNumber());
+
+  auto mock_meter = std::make_shared<MockMeter>();
+  EXPECT_CALL(*mock_meter, CreateInt64ObservableGauge)
+      .WillOnce([mock = mock_observable_gauge](
+                    opentelemetry::nostd::string_view name,
+                    opentelemetry::nostd::string_view,
+                    opentelemetry::nostd::string_view) mutable {
+        EXPECT_THAT(name, Eq("direct_access/compatible"));
+        return mock;
+      });
+
+  auto mock_provider = std::make_shared<MockMeterProvider>();
+  EXPECT_CALL(*mock_provider, GetMeter)
+      .WillOnce([&](opentelemetry::nostd::string_view scope,
+                    opentelemetry::nostd::string_view scope_version,
+                    opentelemetry::nostd::string_view) mutable {
+        EXPECT_THAT(scope, Eq("my-instrument-scope"));
+        EXPECT_THAT(scope_version, Eq("v1"));
+        return mock_meter;
+      });
+
+  DirectAccessCompatibility compatibility("my-instrument-scope", mock_provider,
+                                          ClientResourceLabels{});
+  ClientResourceLabels resource_labels{
+      "my-project", "my-instance",       "my-app-profile", "my-client-name",
+      "my-uid",     "my-client-project", "us-east1",       "gcp",
+      "my-host",    "my-hostname"};
+  auto clone = compatibility.clone(resource_labels);
+
+  auto const otel_context =
+      opentelemetry::context::RuntimeContext::GetCurrent();
+  static_cast<DirectAccessCompatibility*>(clone.get())
+      ->Record(otel_context, 1, DirectAccessCompatibilityLabels{"ipv4", ""});
+
+  auto mock_observer = std::make_shared<MockObserverResult<std::int64_t>>();
+  EXPECT_CALL(
+      *mock_observer,
+      Observe(Eq(1), A<opentelemetry::common::KeyValueIterable const&>()))
+      .WillOnce([](std::int64_t value,
+                   opentelemetry::common::KeyValueIterable const& attrs) {
+        EXPECT_THAT(value, Eq(1));
+        EXPECT_THAT(
+            MakeAttributesMap(attrs),
+            UnorderedElementsAre(
+                Pair("project_id", "my-project"),
+                Pair("instance", "my-instance"),
+                Pair("app_profile", "my-app-profile"),
+                Pair("client_name", "my-client-name"),
+                Pair("client_uid", "my-uid"),
+                Pair("client_project", "my-client-project"),
+                Pair("region", "us-east1"), Pair("cloud_platform", "gcp"),
+                Pair("host_id", "my-host"), Pair("host_name", "my-hostname"),
+                Pair("ip_preference", "ipv4"), Pair("reason", "")));
+      });
+
+  ASSERT_THAT(saved_callback, NotNull());
+  opentelemetry::metrics::ObserverResult observer_result =
+      opentelemetry::nostd::shared_ptr<
+          opentelemetry::metrics::ObserverResultT<std::int64_t>>(mock_observer);
+  saved_callback(observer_result, saved_state);
+}
+#endif
 
 TEST(ClientSchemaMetricsTest, MakeClientResourceLabelsExtractsFromOptions) {
   Options options;

--- a/google/cloud/bigtable/internal/directpath_diagnostics_test.cc
+++ b/google/cloud/bigtable/internal/directpath_diagnostics_test.cc
@@ -55,6 +55,7 @@ using ::testing::Eq;
 using ::google::cloud::testing_util::MakeAttributesMap;
 #if OPENTELEMETRY_ABI_VERSION_NO >= 2
 using ::google::cloud::testing_util::MockGauge;
+using ::testing::_;
 #endif
 using ::google::cloud::testing_util::MockMeter;
 using ::google::cloud::testing_util::MockMeterProvider;

--- a/google/cloud/bigtable/internal/directpath_diagnostics_test.cc
+++ b/google/cloud/bigtable/internal/directpath_diagnostics_test.cc
@@ -56,12 +56,15 @@ using ::google::cloud::testing_util::MakeAttributesMap;
 #if OPENTELEMETRY_ABI_VERSION_NO >= 2
 using ::google::cloud::testing_util::MockGauge;
 #endif
-using ::google::cloud::testing_util::MockHistogram;
 using ::google::cloud::testing_util::MockMeter;
 using ::google::cloud::testing_util::MockMeterProvider;
+using ::google::cloud::testing_util::MockObservableInstrument;
+using ::google::cloud::testing_util::MockObserverResult;
 using ::testing::A;
+using ::testing::AnyNumber;
 using ::testing::Contains;
 using ::testing::Key;
+using ::testing::NotNull;
 using ::testing::Pair;
 #endif
 #endif
@@ -334,19 +337,17 @@ TEST(DirectPathDiagnosticsTest, RunAsyncRecordsDiagnosticMetric) {
 
 #if OPENTELEMETRY_ABI_VERSION_NO >= 2
   auto mock_gauge = std::make_unique<MockGauge<std::int64_t>>();
-  EXPECT_CALL(*mock_gauge,
-              Record(A<std::int64_t>(),
-                     A<opentelemetry::common::KeyValueIterable const&>(),
-                     A<opentelemetry::context::Context const&>()))
-      .WillOnce([&recorded_promise](
-                    std::int64_t value,
-                    opentelemetry::common::KeyValueIterable const& attrs,
-                    opentelemetry::context::Context const&) {
+  auto* mock_gauge_ptr = mock_gauge.get();
+  EXPECT_CALL(
+      *mock_gauge_ptr,
+      Record(Eq(0), A<opentelemetry::common::KeyValueIterable const&>(), _))
+      .WillOnce([](std::int64_t value,
+                   opentelemetry::common::KeyValueIterable const& attrs,
+                   opentelemetry::context::Context const&) {
         EXPECT_THAT(value, Eq(0));
         auto const map = MakeAttributesMap(attrs);
         EXPECT_THAT(map, Contains(Key("reason")));
         EXPECT_THAT(map, Contains(Pair("ip_preference", "")));
-        recorded_promise.set_value();
       });
 
   auto mock_meter = std::make_shared<MockMeter>();
@@ -358,37 +359,9 @@ TEST(DirectPathDiagnosticsTest, RunAsyncRecordsDiagnosticMetric) {
         EXPECT_THAT(name, Eq("direct_access/compatible"));
         return std::move(mock);
       });
-#else
-  auto mock_histogram = std::make_unique<MockHistogram<double>>();
-  EXPECT_CALL(
-      *mock_histogram,
-      Record(A<double>(), A<opentelemetry::common::KeyValueIterable const&>(),
-             A<opentelemetry::context::Context const&>()))
-      .WillOnce([&recorded_promise](
-                    double value,
-                    opentelemetry::common::KeyValueIterable const& attrs,
-                    opentelemetry::context::Context const&) {
-        EXPECT_THAT(value, Eq(0.0));
-        auto const map = MakeAttributesMap(attrs);
-        EXPECT_THAT(map, Contains(Key("reason")));
-        EXPECT_THAT(map, Contains(Pair("ip_preference", "")));
-        recorded_promise.set_value();
-      });
-
-  auto mock_meter = std::make_shared<MockMeter>();
-  EXPECT_CALL(*mock_meter, CreateDoubleHistogram)
-      .WillOnce([mock = std::move(mock_histogram)](
-                    opentelemetry::nostd::string_view name,
-                    opentelemetry::nostd::string_view,
-                    opentelemetry::nostd::string_view) mutable {
-        EXPECT_THAT(name, Eq("direct_access/compatible"));
-        return std::move(mock);
-      });
-#endif
 
   auto mock_provider = std::make_shared<MockMeterProvider>();
   EXPECT_CALL(*mock_provider, GetMeter)
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
       .WillOnce([&mock_meter](opentelemetry::nostd::string_view,
                               opentelemetry::nostd::string_view,
                               opentelemetry::nostd::string_view,
@@ -396,6 +369,29 @@ TEST(DirectPathDiagnosticsTest, RunAsyncRecordsDiagnosticMetric) {
         return mock_meter;
       });
 #else
+  auto mock_observable_gauge = std::make_shared<MockObservableInstrument>();
+  opentelemetry::metrics::ObservableCallbackPtr saved_callback = nullptr;
+  void* saved_state = nullptr;
+  EXPECT_CALL(*mock_observable_gauge, AddCallback)
+      .WillRepeatedly(
+          [&](opentelemetry::metrics::ObservableCallbackPtr cb, void* state) {
+            saved_callback = cb;
+            saved_state = state;
+          });
+  EXPECT_CALL(*mock_observable_gauge, RemoveCallback).Times(AnyNumber());
+
+  auto mock_meter = std::make_shared<MockMeter>();
+  EXPECT_CALL(*mock_meter, CreateInt64ObservableGauge)
+      .WillOnce([mock = mock_observable_gauge](
+                    opentelemetry::nostd::string_view name,
+                    opentelemetry::nostd::string_view,
+                    opentelemetry::nostd::string_view) mutable {
+        EXPECT_THAT(name, Eq("direct_access/compatible"));
+        return mock;
+      });
+
+  auto mock_provider = std::make_shared<MockMeterProvider>();
+  EXPECT_CALL(*mock_provider, GetMeter)
       .WillOnce([&mock_meter](opentelemetry::nostd::string_view,
                               opentelemetry::nostd::string_view,
                               opentelemetry::nostd::string_view) {
@@ -404,7 +400,7 @@ TEST(DirectPathDiagnosticsTest, RunAsyncRecordsDiagnosticMetric) {
 #endif
 
   auto direct_access = std::make_shared<DirectAccessCompatibility>(
-      "test-instrumentation-scope", mock_provider);
+      "test-instrumentation-scope", mock_provider, ClientResourceLabels{});
 
   Options const options =
       Options{}.set<bigtable::experimental::DirectPathDiagnosticsTimeoutOption>(
@@ -414,6 +410,7 @@ TEST(DirectPathDiagnosticsTest, RunAsyncRecordsDiagnosticMetric) {
   std::thread t([&cq] { cq.Run(); });
 
   DirectPathDiagnostics::RunAsync(cq, options, direct_access);
+  cq.RunAsync([&recorded_promise] { recorded_promise.set_value(); });
 
   ASSERT_THAT(recorded_future.wait_for(std::chrono::seconds(10)),
               Eq(std::future_status::ready));
@@ -421,6 +418,26 @@ TEST(DirectPathDiagnosticsTest, RunAsyncRecordsDiagnosticMetric) {
   cq.CancelAll();
   cq.Shutdown();
   t.join();
+
+#if OPENTELEMETRY_ABI_VERSION_NO < 2
+  auto mock_observer = std::make_shared<MockObserverResult<std::int64_t>>();
+  EXPECT_CALL(
+      *mock_observer,
+      Observe(Eq(0), A<opentelemetry::common::KeyValueIterable const&>()))
+      .WillOnce([](std::int64_t value,
+                   opentelemetry::common::KeyValueIterable const& attrs) {
+        EXPECT_THAT(value, Eq(0));
+        auto const map = MakeAttributesMap(attrs);
+        EXPECT_THAT(map, Contains(Key("reason")));
+        EXPECT_THAT(map, Contains(Pair("ip_preference", "")));
+      });
+
+  ASSERT_THAT(saved_callback, NotNull());
+  opentelemetry::metrics::ObserverResult observer_result =
+      opentelemetry::nostd::shared_ptr<
+          opentelemetry::metrics::ObserverResultT<std::int64_t>>(mock_observer);
+  saved_callback(observer_result, saved_state);
+#endif
 }
 
 TEST(DirectPathDiagnosticsTest, RunAsyncRecordsMetadataUnreachableReason) {
@@ -436,19 +453,17 @@ TEST(DirectPathDiagnosticsTest, RunAsyncRecordsMetadataUnreachableReason) {
 
 #if OPENTELEMETRY_ABI_VERSION_NO >= 2
   auto mock_gauge = std::make_unique<MockGauge<std::int64_t>>();
-  EXPECT_CALL(*mock_gauge,
-              Record(A<std::int64_t>(),
-                     A<opentelemetry::common::KeyValueIterable const&>(),
-                     A<opentelemetry::context::Context const&>()))
-      .WillOnce([&recorded_promise](
-                    std::int64_t value,
-                    opentelemetry::common::KeyValueIterable const& attrs,
-                    opentelemetry::context::Context const&) {
+  auto* mock_gauge_ptr = mock_gauge.get();
+  EXPECT_CALL(
+      *mock_gauge_ptr,
+      Record(Eq(0), A<opentelemetry::common::KeyValueIterable const&>(), _))
+      .WillOnce([](std::int64_t value,
+                   opentelemetry::common::KeyValueIterable const& attrs,
+                   opentelemetry::context::Context const&) {
         EXPECT_THAT(value, Eq(0));
         auto const map = MakeAttributesMap(attrs);
         EXPECT_THAT(map, Contains(Pair("reason", "metadata_unreachable")));
         EXPECT_THAT(map, Contains(Pair("ip_preference", "")));
-        recorded_promise.set_value();
       });
 
   auto mock_meter = std::make_shared<MockMeter>();
@@ -460,37 +475,9 @@ TEST(DirectPathDiagnosticsTest, RunAsyncRecordsMetadataUnreachableReason) {
         EXPECT_THAT(name, Eq("direct_access/compatible"));
         return std::move(mock);
       });
-#else
-  auto mock_histogram = std::make_unique<MockHistogram<double>>();
-  EXPECT_CALL(
-      *mock_histogram,
-      Record(A<double>(), A<opentelemetry::common::KeyValueIterable const&>(),
-             A<opentelemetry::context::Context const&>()))
-      .WillOnce([&recorded_promise](
-                    double value,
-                    opentelemetry::common::KeyValueIterable const& attrs,
-                    opentelemetry::context::Context const&) {
-        EXPECT_THAT(value, Eq(0.0));
-        auto const map = MakeAttributesMap(attrs);
-        EXPECT_THAT(map, Contains(Pair("reason", "metadata_unreachable")));
-        EXPECT_THAT(map, Contains(Pair("ip_preference", "")));
-        recorded_promise.set_value();
-      });
-
-  auto mock_meter = std::make_shared<MockMeter>();
-  EXPECT_CALL(*mock_meter, CreateDoubleHistogram)
-      .WillOnce([mock = std::move(mock_histogram)](
-                    opentelemetry::nostd::string_view name,
-                    opentelemetry::nostd::string_view,
-                    opentelemetry::nostd::string_view) mutable {
-        EXPECT_THAT(name, Eq("direct_access/compatible"));
-        return std::move(mock);
-      });
-#endif
 
   auto mock_provider = std::make_shared<MockMeterProvider>();
   EXPECT_CALL(*mock_provider, GetMeter)
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
       .WillOnce([&mock_meter](opentelemetry::nostd::string_view,
                               opentelemetry::nostd::string_view,
                               opentelemetry::nostd::string_view,
@@ -498,6 +485,29 @@ TEST(DirectPathDiagnosticsTest, RunAsyncRecordsMetadataUnreachableReason) {
         return mock_meter;
       });
 #else
+  auto mock_observable_gauge = std::make_shared<MockObservableInstrument>();
+  opentelemetry::metrics::ObservableCallbackPtr saved_callback = nullptr;
+  void* saved_state = nullptr;
+  EXPECT_CALL(*mock_observable_gauge, AddCallback)
+      .WillRepeatedly(
+          [&](opentelemetry::metrics::ObservableCallbackPtr cb, void* state) {
+            saved_callback = cb;
+            saved_state = state;
+          });
+  EXPECT_CALL(*mock_observable_gauge, RemoveCallback).Times(AnyNumber());
+
+  auto mock_meter = std::make_shared<MockMeter>();
+  EXPECT_CALL(*mock_meter, CreateInt64ObservableGauge)
+      .WillOnce([mock = mock_observable_gauge](
+                    opentelemetry::nostd::string_view name,
+                    opentelemetry::nostd::string_view,
+                    opentelemetry::nostd::string_view) mutable {
+        EXPECT_THAT(name, Eq("direct_access/compatible"));
+        return mock;
+      });
+
+  auto mock_provider = std::make_shared<MockMeterProvider>();
+  EXPECT_CALL(*mock_provider, GetMeter)
       .WillOnce([&mock_meter](opentelemetry::nostd::string_view,
                               opentelemetry::nostd::string_view,
                               opentelemetry::nostd::string_view) {
@@ -506,7 +516,7 @@ TEST(DirectPathDiagnosticsTest, RunAsyncRecordsMetadataUnreachableReason) {
 #endif
 
   auto direct_access = std::make_shared<DirectAccessCompatibility>(
-      "test-instrumentation-scope", mock_provider);
+      "test-instrumentation-scope", mock_provider, ClientResourceLabels{});
 
   Options const options =
       Options{}.set<bigtable::experimental::DirectPathDiagnosticsTimeoutOption>(
@@ -518,6 +528,7 @@ TEST(DirectPathDiagnosticsTest, RunAsyncRecordsMetadataUnreachableReason) {
   DirectPathDiagnostics::RunAsync(cq, options, direct_access, mock_detector,
                                   mock_network, "127.0.0.1",
                                   static_cast<std::uint16_t>(80));
+  cq.RunAsync([&recorded_promise] { recorded_promise.set_value(); });
 
   ASSERT_THAT(recorded_future.wait_for(std::chrono::seconds(10)),
               Eq(std::future_status::ready));
@@ -525,6 +536,26 @@ TEST(DirectPathDiagnosticsTest, RunAsyncRecordsMetadataUnreachableReason) {
   cq.CancelAll();
   cq.Shutdown();
   t.join();
+
+#if OPENTELEMETRY_ABI_VERSION_NO < 2
+  auto mock_observer = std::make_shared<MockObserverResult<std::int64_t>>();
+  EXPECT_CALL(
+      *mock_observer,
+      Observe(Eq(0), A<opentelemetry::common::KeyValueIterable const&>()))
+      .WillOnce([](std::int64_t value,
+                   opentelemetry::common::KeyValueIterable const& attrs) {
+        EXPECT_THAT(value, Eq(0));
+        auto const map = MakeAttributesMap(attrs);
+        EXPECT_THAT(map, Contains(Pair("reason", "metadata_unreachable")));
+        EXPECT_THAT(map, Contains(Pair("ip_preference", "")));
+      });
+
+  ASSERT_THAT(saved_callback, NotNull());
+  opentelemetry::metrics::ObserverResult observer_result =
+      opentelemetry::nostd::shared_ptr<
+          opentelemetry::metrics::ObserverResultT<std::int64_t>>(mock_observer);
+  saved_callback(observer_result, saved_state);
+#endif
 }
 
 TEST(DirectPathDiagnosticsTest, RunAsyncRecordsLoopbackMisconfiguredReason) {
@@ -543,20 +574,18 @@ TEST(DirectPathDiagnosticsTest, RunAsyncRecordsLoopbackMisconfiguredReason) {
 
 #if OPENTELEMETRY_ABI_VERSION_NO >= 2
   auto mock_gauge = std::make_unique<MockGauge<std::int64_t>>();
-  EXPECT_CALL(*mock_gauge,
-              Record(A<std::int64_t>(),
-                     A<opentelemetry::common::KeyValueIterable const&>(),
-                     A<opentelemetry::context::Context const&>()))
-      .WillOnce([&recorded_promise](
-                    std::int64_t value,
-                    opentelemetry::common::KeyValueIterable const& attrs,
-                    opentelemetry::context::Context const&) {
+  auto* mock_gauge_ptr = mock_gauge.get();
+  EXPECT_CALL(
+      *mock_gauge_ptr,
+      Record(Eq(0), A<opentelemetry::common::KeyValueIterable const&>(), _))
+      .WillOnce([](std::int64_t value,
+                   opentelemetry::common::KeyValueIterable const& attrs,
+                   opentelemetry::context::Context const&) {
         EXPECT_THAT(value, Eq(0));
         auto const map = MakeAttributesMap(attrs);
         EXPECT_THAT(map,
                     Contains(Pair("reason", "loopback_misconfigured_ipv6")));
         EXPECT_THAT(map, Contains(Pair("ip_preference", "")));
-        recorded_promise.set_value();
       });
 
   auto mock_meter = std::make_shared<MockMeter>();
@@ -568,38 +597,9 @@ TEST(DirectPathDiagnosticsTest, RunAsyncRecordsLoopbackMisconfiguredReason) {
         EXPECT_THAT(name, Eq("direct_access/compatible"));
         return std::move(mock);
       });
-#else
-  auto mock_histogram = std::make_unique<MockHistogram<double>>();
-  EXPECT_CALL(
-      *mock_histogram,
-      Record(A<double>(), A<opentelemetry::common::KeyValueIterable const&>(),
-             A<opentelemetry::context::Context const&>()))
-      .WillOnce([&recorded_promise](
-                    double value,
-                    opentelemetry::common::KeyValueIterable const& attrs,
-                    opentelemetry::context::Context const&) {
-        EXPECT_THAT(value, Eq(0.0));
-        auto const map = MakeAttributesMap(attrs);
-        EXPECT_THAT(map,
-                    Contains(Pair("reason", "loopback_misconfigured_ipv6")));
-        EXPECT_THAT(map, Contains(Pair("ip_preference", "")));
-        recorded_promise.set_value();
-      });
-
-  auto mock_meter = std::make_shared<MockMeter>();
-  EXPECT_CALL(*mock_meter, CreateDoubleHistogram)
-      .WillOnce([mock = std::move(mock_histogram)](
-                    opentelemetry::nostd::string_view name,
-                    opentelemetry::nostd::string_view,
-                    opentelemetry::nostd::string_view) mutable {
-        EXPECT_THAT(name, Eq("direct_access/compatible"));
-        return std::move(mock);
-      });
-#endif
 
   auto mock_provider = std::make_shared<MockMeterProvider>();
   EXPECT_CALL(*mock_provider, GetMeter)
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
       .WillOnce([&mock_meter](opentelemetry::nostd::string_view,
                               opentelemetry::nostd::string_view,
                               opentelemetry::nostd::string_view,
@@ -607,6 +607,29 @@ TEST(DirectPathDiagnosticsTest, RunAsyncRecordsLoopbackMisconfiguredReason) {
         return mock_meter;
       });
 #else
+  auto mock_observable_gauge = std::make_shared<MockObservableInstrument>();
+  opentelemetry::metrics::ObservableCallbackPtr saved_callback = nullptr;
+  void* saved_state = nullptr;
+  EXPECT_CALL(*mock_observable_gauge, AddCallback)
+      .WillRepeatedly(
+          [&](opentelemetry::metrics::ObservableCallbackPtr cb, void* state) {
+            saved_callback = cb;
+            saved_state = state;
+          });
+  EXPECT_CALL(*mock_observable_gauge, RemoveCallback).Times(AnyNumber());
+
+  auto mock_meter = std::make_shared<MockMeter>();
+  EXPECT_CALL(*mock_meter, CreateInt64ObservableGauge)
+      .WillOnce([mock = mock_observable_gauge](
+                    opentelemetry::nostd::string_view name,
+                    opentelemetry::nostd::string_view,
+                    opentelemetry::nostd::string_view) mutable {
+        EXPECT_THAT(name, Eq("direct_access/compatible"));
+        return mock;
+      });
+
+  auto mock_provider = std::make_shared<MockMeterProvider>();
+  EXPECT_CALL(*mock_provider, GetMeter)
       .WillOnce([&mock_meter](opentelemetry::nostd::string_view,
                               opentelemetry::nostd::string_view,
                               opentelemetry::nostd::string_view) {
@@ -615,7 +638,7 @@ TEST(DirectPathDiagnosticsTest, RunAsyncRecordsLoopbackMisconfiguredReason) {
 #endif
 
   auto direct_access = std::make_shared<DirectAccessCompatibility>(
-      "test-instrumentation-scope", mock_provider);
+      "test-instrumentation-scope", mock_provider, ClientResourceLabels{});
 
   Options const options =
       Options{}.set<bigtable::experimental::DirectPathDiagnosticsTimeoutOption>(
@@ -627,6 +650,7 @@ TEST(DirectPathDiagnosticsTest, RunAsyncRecordsLoopbackMisconfiguredReason) {
   DirectPathDiagnostics::RunAsync(cq, options, direct_access, mock_detector,
                                   mock_network, "127.0.0.1",
                                   static_cast<std::uint16_t>(80));
+  cq.RunAsync([&recorded_promise] { recorded_promise.set_value(); });
 
   ASSERT_THAT(recorded_future.wait_for(std::chrono::seconds(10)),
               Eq(std::future_status::ready));
@@ -634,6 +658,27 @@ TEST(DirectPathDiagnosticsTest, RunAsyncRecordsLoopbackMisconfiguredReason) {
   cq.CancelAll();
   cq.Shutdown();
   t.join();
+
+#if OPENTELEMETRY_ABI_VERSION_NO < 2
+  auto mock_observer = std::make_shared<MockObserverResult<std::int64_t>>();
+  EXPECT_CALL(
+      *mock_observer,
+      Observe(Eq(0), A<opentelemetry::common::KeyValueIterable const&>()))
+      .WillOnce([](std::int64_t value,
+                   opentelemetry::common::KeyValueIterable const& attrs) {
+        EXPECT_THAT(value, Eq(0));
+        auto const map = MakeAttributesMap(attrs);
+        EXPECT_THAT(map,
+                    Contains(Pair("reason", "loopback_misconfigured_ipv6")));
+        EXPECT_THAT(map, Contains(Pair("ip_preference", "")));
+      });
+
+  ASSERT_THAT(saved_callback, NotNull());
+  opentelemetry::metrics::ObserverResult observer_result =
+      opentelemetry::nostd::shared_ptr<
+          opentelemetry::metrics::ObserverResultT<std::int64_t>>(mock_observer);
+  saved_callback(observer_result, saved_state);
+#endif
 }
 
 #endif  // GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS

--- a/google/cloud/bigtable/internal/grpc_metrics_exporter.cc
+++ b/google/cloud/bigtable/internal/grpc_metrics_exporter.cc
@@ -323,7 +323,9 @@ GrpcMetricsPluginConfig MakeGrpcMetricsPluginConfig(
       "service.instance.id",
   };
   auto resource_filter_fn =
-      [excluded_labels = std::move(excluded_labels)](std::string const& key) {
+      [excluded_labels = std::move(excluded_labels)](
+          std::string const& key,
+          opentelemetry::sdk::metrics::PointAttributes const&) {
         return internal::Contains(excluded_labels, key);
       };
 
@@ -367,6 +369,7 @@ GrpcMetricsPluginConfig MakeGrpcMetricsPluginConfig(
   };
 
   auto disable_metrics = std::vector<std::string_view>{
+      std::string_view{"grpc.client.attempt.started"},
       std::string_view{
           "grpc.client.attempt.sent_total_compressed_message_size"},
       std::string_view{

--- a/google/cloud/bigtable/internal/grpc_metrics_exporter_test.cc
+++ b/google/cloud/bigtable/internal/grpc_metrics_exporter_test.cc
@@ -434,7 +434,8 @@ TEST(GrpcMetricsExporterTest, ValidatePluginConfigArguments) {
 
   EXPECT_THAT(
       config.disabled_metrics,
-      ElementsAre("grpc.client.attempt.sent_total_compressed_message_size",
+      ElementsAre("grpc.client.attempt.started",
+                  "grpc.client.attempt.sent_total_compressed_message_size",
                   "grpc.client.attempt.rcvd_total_compressed_message_size"));
 
   ASSERT_TRUE(config.generic_method_filter);

--- a/google/cloud/bigtable/internal/operation_context_factory.cc
+++ b/google/cloud/bigtable/internal/operation_context_factory.cc
@@ -246,7 +246,8 @@ MetricsOperationContextFactory::MetricsOperationContextFactory(
 void MetricsOperationContextFactory::InitializeProvider(
     std::shared_ptr<monitoring_v3::MetricServiceConnection> conn,
     Options options) {
-  auto constexpr kResourceType = "bigtable_client_raw";
+  auto constexpr kTableResourceType = "bigtable_client_raw";
+  auto constexpr kClientResourceType = "bigtable_client";
   auto constexpr kBigtableMetricNamePath =
       "bigtable.googleapis.com/internal/client/";
   auto constexpr kProjectLabel = "project_id";
@@ -259,10 +260,10 @@ void MetricsOperationContextFactory::InitializeProvider(
   auto constexpr kClientUidAttribute = "client_uid";
   auto constexpr kUuidLabel = "uuid";
   auto constexpr kClientProjectLabel = "client_project";
-  auto constexpr kLocationLabel = "location";
+  auto constexpr kRegionLabel = "region";
   auto constexpr kCloudPlatformLabel = "cloud_platform";
   auto constexpr kHostIdLabel = "host_id";
-  auto constexpr kHostnameLabel = "hostname";
+  auto constexpr kHostNameLabel = "host_name";
 
   auto dynamic_resource_fn =
       [=](opentelemetry::sdk::metrics::PointDataAttributes const& pda) {
@@ -278,18 +279,19 @@ void MetricsOperationContextFactory::InitializeProvider(
         };
 
         google::api::MonitoredResource resource;
-        resource.set_type(kResourceType);
         auto& labels = *resource.mutable_labels();
         labels[kProjectLabel] = get_attr(kProjectLabel);
         labels[kInstanceLabel] = get_attr(kInstanceLabel);
 
         if (attributes.find(kTableLabel) != attributes.end()) {
+          resource.set_type(kTableResourceType);
           labels[kTableLabel] = get_attr(kTableLabel);
           labels[kClusterLabel] = get_attr(kClusterLabel);
           labels[kZoneLabel] = get_attr(kZoneLabel);
           return std::make_pair(labels[kProjectLabel], resource);
         }
 
+        resource.set_type(kClientResourceType);
         labels[kAppProfileLabel] = get_attr(kAppProfileLabel);
         labels[kClientNameLabel] = get_attr(kClientNameLabel);
         labels[kUuidLabel] = get_attr(kClientUidAttribute);
@@ -297,24 +299,33 @@ void MetricsOperationContextFactory::InitializeProvider(
         if (!client_project.empty()) {
           labels[kClientProjectLabel] = std::move(client_project);
         }
-        labels[kLocationLabel] = get_attr(kLocationLabel);
+        labels[kRegionLabel] = get_attr(kRegionLabel);
         labels[kCloudPlatformLabel] = get_attr(kCloudPlatformLabel);
         labels[kHostIdLabel] = get_attr(kHostIdLabel);
-        std::string hostname = get_attr(kHostnameLabel);
-        if (!hostname.empty()) {
-          labels[kHostnameLabel] = std::move(hostname);
+        std::string host_name = get_attr(kHostNameLabel);
+        if (!host_name.empty()) {
+          labels[kHostNameLabel] = std::move(host_name);
         }
         return std::make_pair(labels[kProjectLabel], resource);
       };
 
-  std::set<std::string> resource_labels{
-      kProjectLabel, kInstanceLabel,      kTableLabel,      kClusterLabel,
-      kZoneLabel,    kAppProfileLabel,    kClientNameLabel, kClientUidAttribute,
-      kUuidLabel,    kClientProjectLabel, kLocationLabel,   kCloudPlatformLabel,
-      kHostIdLabel,  kHostnameLabel};
+  std::set<std::string> table_resource_labels{
+      kProjectLabel, kInstanceLabel, kTableLabel, kClusterLabel, kZoneLabel};
+  std::set<std::string> client_resource_labels{
+      kProjectLabel,       kInstanceLabel,      kAppProfileLabel,
+      kClientNameLabel,    kClientUidAttribute, kUuidLabel,
+      kClientProjectLabel, kRegionLabel,        kCloudPlatformLabel,
+      kHostIdLabel,        kHostNameLabel};
+
   auto resource_filter_fn =
-      [resource_labels = std::move(resource_labels)](std::string const& key) {
-        return internal::Contains(resource_labels, key);
+      [table_resource_labels = std::move(table_resource_labels),
+       client_resource_labels = std::move(client_resource_labels)](
+          std::string const& key,
+          opentelemetry::sdk::metrics::PointAttributes const& attributes) {
+        if (attributes.find(kTableLabel) != attributes.end()) {
+          return internal::Contains(table_resource_labels, key);
+        }
+        return internal::Contains(client_resource_labels, key);
       };
 
   auto reader_options =

--- a/google/cloud/bigtable/internal/operation_context_factory.cc
+++ b/google/cloud/bigtable/internal/operation_context_factory.cc
@@ -318,8 +318,12 @@ void MetricsOperationContextFactory::InitializeProvider(
       kHostIdLabel,        kHostNameLabel};
 
   auto resource_filter_fn =
-      [table_resource_labels = std::move(table_resource_labels),
-       client_resource_labels = std::move(client_resource_labels)](
+      [
+#ifdef _WIN32
+          kTableLabel,
+#endif
+          table_resource_labels = std::move(table_resource_labels),
+          client_resource_labels = std::move(client_resource_labels)](
           std::string const& key,
           opentelemetry::sdk::metrics::PointAttributes const& attributes) {
         if (attributes.find(kTableLabel) != attributes.end()) {

--- a/google/cloud/bigtable/internal/operation_context_factory_test.cc
+++ b/google/cloud/bigtable/internal/operation_context_factory_test.cc
@@ -309,7 +309,7 @@ TEST(MetricsOperationContextFactoryTest, CloneMetricsWithClientResourceLabels) {
                               "uid",    "profile",   "status"};
   ClientResourceLabels client_labels{
       "project",     "instance", "profile", "client", "uid",
-      "client-proj", "location", "gcp",     "host",   "hostname"};
+      "client-proj", "region",   "gcp",     "host",   "hostname"};
 
   std::vector<std::shared_ptr<Metric const>> metrics = {table_metric,
                                                         client_metric};
@@ -339,15 +339,16 @@ TEST(MetricsOperationContextFactoryTest,
           [](google::monitoring::v3::CreateTimeSeriesRequest const& request) {
             EXPECT_THAT(request.name(), Eq("projects/my-project"));
             for (auto const& ts : request.time_series()) {
-              EXPECT_THAT(ts.resource().type(), Eq("bigtable_client_raw"));
               if (ts.resource().labels().find("table") !=
                   ts.resource().labels().end()) {
+                EXPECT_THAT(ts.resource().type(), Eq("bigtable_client_raw"));
                 EXPECT_THAT(ts.resource().labels().at("project_id"),
                             Eq("my-project"));
                 EXPECT_THAT(ts.resource().labels().at("instance"),
                             Eq("my-instance"));
                 EXPECT_THAT(ts.resource().labels().at("table"), Eq("my-table"));
               } else {
+                EXPECT_THAT(ts.resource().type(), Eq("bigtable_client"));
                 EXPECT_THAT(ts.resource().labels().at("project_id"),
                             Eq("my-project"));
                 EXPECT_THAT(ts.resource().labels().at("instance"),
@@ -364,12 +365,20 @@ TEST(MetricsOperationContextFactoryTest,
                           ts.metric().labels().end());
               EXPECT_TRUE(ts.metric().labels().find("instance") ==
                           ts.metric().labels().end());
-              EXPECT_TRUE(ts.metric().labels().find("table") ==
-                          ts.metric().labels().end());
-              EXPECT_TRUE(ts.metric().labels().find("app_profile") ==
-                          ts.metric().labels().end());
-              EXPECT_TRUE(ts.metric().labels().find("uuid") ==
-                          ts.metric().labels().end());
+              if (ts.resource().labels().find("table") !=
+                  ts.resource().labels().end()) {
+                EXPECT_TRUE(ts.metric().labels().find("table") ==
+                            ts.metric().labels().end());
+                EXPECT_TRUE(ts.metric().labels().find("app_profile") !=
+                            ts.metric().labels().end());
+                EXPECT_TRUE(ts.metric().labels().find("client_uid") !=
+                            ts.metric().labels().end());
+              } else {
+                EXPECT_TRUE(ts.metric().labels().find("app_profile") ==
+                            ts.metric().labels().end());
+                EXPECT_TRUE(ts.metric().labels().find("client_uid") ==
+                            ts.metric().labels().end());
+              }
             }
             return Status();
           });

--- a/google/cloud/opentelemetry/internal/monitoring_exporter.cc
+++ b/google/cloud/opentelemetry/internal/monitoring_exporter.cc
@@ -43,7 +43,9 @@ otel_internal::ResourceFilterDataFn MakeResourceFilterFn(
   if (excluded.empty()) return nullptr;
 
   // Capture by value to avoid dangling reference in the lambda.
-  return [excluded = std::move(excluded)](std::string const& key) -> bool {
+  return [excluded = std::move(excluded)](
+             std::string const& key,
+             opentelemetry::sdk::metrics::PointAttributes const&) -> bool {
     return excluded.count(key) > 0;
   };
 }

--- a/google/cloud/opentelemetry/internal/monitoring_exporter.h
+++ b/google/cloud/opentelemetry/internal/monitoring_exporter.h
@@ -43,7 +43,8 @@ using MonitoredResourceFromDataFn =
 // For use with dynamic monitored resources, this function is used in ToMetric
 // to indicate which labels should be skipped when populating the labels field
 // of the google::api::Metric proto.
-using ResourceFilterDataFn = std::function<bool(std::string const&)>;
+using ResourceFilterDataFn = std::function<bool(
+    std::string const&, opentelemetry::sdk::metrics::PointAttributes const&)>;
 
 // Filter resource labels. A set of OpenTelemetry resource attribute keys to
 // exclude from metric labels when exporting metrics.

--- a/google/cloud/opentelemetry/internal/monitoring_exporter_test.cc
+++ b/google/cloud/opentelemetry/internal/monitoring_exporter_test.cc
@@ -146,9 +146,11 @@ TEST(MonitoringExporter, ExportSuccess) {
         return std::make_pair(labels["project_id"], resource);
       };
 
-  auto filter_fn = [resources = std::set<std::string>{
-                        "project_id", "instance", "cluster", "table",
-                        "zone"}](std::string const& l) {
+  auto filter_fn = [resources =
+                        std::set<std::string>{"project_id", "instance",
+                                              "cluster", "table", "zone"}](
+                       std::string const& l,
+                       opentelemetry::sdk::metrics::PointAttributes const&) {
     return internal::Contains(resources, l);
   };
 

--- a/google/cloud/opentelemetry/internal/time_series.cc
+++ b/google/cloud/opentelemetry/internal/time_series.cc
@@ -144,8 +144,8 @@ google::api::Metric ToMetric(
     opentelemetry::sdk::resource::Resource const* resource,
     std::function<std::string(std::string)> const& name_formatter,
     ResourceFilterDataFn const& resource_filter_fn) {
-  auto add_label = [&resource_filter_fn](auto& labels, auto key,
-                                         auto const& value) {
+  auto add_label = [&resource_filter_fn, &attributes](auto& labels, auto key,
+                                                      auto const& value) {
     // GCM labels match on the regex: R"([a-zA-Z_][a-zA-Z0-9_]*)".
     if (key.empty()) return;
     if (!std::isalpha(key[0]) && key[0] != '_') {
@@ -157,7 +157,7 @@ google::api::Metric ToMetric(
     for (auto& c : key) {
       if (!std::isalnum(c)) c = '_';
     }
-    if (resource_filter_fn && resource_filter_fn(key)) return;
+    if (resource_filter_fn && resource_filter_fn(key, attributes)) return;
     labels[std::move(key)] = AsString(value);
   };
 

--- a/google/cloud/opentelemetry/internal/time_series_test.cc
+++ b/google/cloud/opentelemetry/internal/time_series_test.cc
@@ -343,9 +343,12 @@ TEST(ToMetric, ResourceFilter) {
   auto resource = opentelemetry::sdk::resource::Resource::Create({});
 
   auto resource_filter_fn =
-      [resource_labels = std::set<std::string>{
-           sc::service::kServiceName, sc::service::kServiceNamespace,
-           sc::service::kServiceInstanceId}](std::string const& l) {
+      [resource_labels =
+           std::set<std::string>{sc::service::kServiceName,
+                                 sc::service::kServiceNamespace,
+                                 sc::service::kServiceInstanceId}](
+          std::string const& l,
+          opentelemetry::sdk::metrics::PointAttributes const&) {
         return internal::Contains(resource_labels, l);
       };
 

--- a/google/cloud/testing_util/mock_opentelemetry_metrics.h
+++ b/google/cloud/testing_util/mock_opentelemetry_metrics.h
@@ -22,6 +22,7 @@
 #include <opentelemetry/metrics/async_instruments.h>
 #include <opentelemetry/metrics/meter.h>
 #include <opentelemetry/metrics/meter_provider.h>
+#include <opentelemetry/metrics/observer_result.h>
 #include <opentelemetry/metrics/sync_instruments.h>
 #include <opentelemetry/nostd/shared_ptr.h>
 #include <opentelemetry/nostd/span.h>
@@ -90,6 +91,27 @@ class MockCounter : public opentelemetry::metrics::Counter<T> {
   MOCK_METHOD(void, Add,  // NOLINT(bugprone-exception-escape)
               (T value, opentelemetry::common::KeyValueIterable const&,
                opentelemetry::context::Context const&),
+              (noexcept, override));
+};
+
+class MockObservableInstrument
+    : public opentelemetry::metrics::ObservableInstrument {
+ public:
+  MOCK_METHOD(void, AddCallback,  // NOLINT(bugprone-exception-escape)
+              (opentelemetry::metrics::ObservableCallbackPtr, void*),
+              (noexcept, override));
+  MOCK_METHOD(void, RemoveCallback,  // NOLINT(bugprone-exception-escape)
+              (opentelemetry::metrics::ObservableCallbackPtr, void*),
+              (noexcept, override));
+};
+
+template <typename T>
+class MockObserverResult : public opentelemetry::metrics::ObserverResultT<T> {
+ public:
+  MOCK_METHOD(void, Observe,  // NOLINT(bugprone-exception-escape)
+              (T), (noexcept, override));
+  MOCK_METHOD(void, Observe,  // NOLINT(bugprone-exception-escape)
+              (T, opentelemetry::common::KeyValueIterable const&),
               (noexcept, override));
 };
 


### PR DESCRIPTION
Testing against prod services has illuminated some issues:

- direct_access/compatible is expected to be a Gauge by Cloud Monitoring; refactored OTel ABI 1 to use an ObservableInstrument
- not all of the default gRPC metrics were being disabled that needed to be
- a more nuanced handling of table schema vs client schema labels was required when exporting so the filtering functions required some introspection into which schema was being used