### PR TITLE
feat(storage): separate read and hedging thread pools

### DIFF
--- a/google/cloud/storage/internal/connection_impl.cc
+++ b/google/cloud/storage/internal/connection_impl.cc
@@ -159,23 +159,29 @@ StorageConnectionImpl::StorageConnectionImpl(
     : stub_(std::move(stub)),
       options_(MergeOptions(std::move(options), stub_->options())) {
   if (options_.get<storage_experimental::EnableReadHedgingOption>()) {
-    // The pool only runs stream-open attempts: one primary and (at most) a few
-    // hedges per stream being opened. Size it to the number of connections the
-    // REST layer can use, falling back to the hardware concurrency when the
-    // connection pool is unbounded (`ConnectionPoolSizeOption == 0`).
-    auto pool_size = options_.get<ConnectionPoolSizeOption>();
-    if (pool_size == 0) {
-      pool_size =
-          (std::max<std::size_t>)(4, std::thread::hardware_concurrency());
-    }
-    auto const max_threads = 2 * pool_size;
-    auto const rate_limit =
-        options_.get<storage_experimental::ReadHedgeRateLimitOption>();
-    auto const max_concurrent =
+    // `DefaultOptions()` normally resolves these, but a connection can be
+    // built without it, in which case the option is left at 0 ("automatic").
+    // A pool sized 0 would accept reads it never runs, hanging the caller.
+    std::size_t read_threads =
+        options_.get<storage_experimental::ReadThreadPoolSizeOption>();
+    if (read_threads == 0) read_threads = DefaultReadThreadPoolSize();
+    // The read pool only ever has one thread per in-flight application read,
+    // and each one blocks inside a synchronous read. Once it saturates, new
+    // primaries queue behind blocked ones and reads degrade to hedge-only.
+    read_pool_ = std::make_shared<ThreadPool>(read_threads);
+
+    std::int64_t const max_concurrent =
         options_.get<storage_experimental::MaxConcurrentHedgesOption>();
+    std::size_t hedge_threads =
+        options_.get<storage_experimental::HedgingThreadPoolSizeOption>();
+    if (hedge_threads == 0) {
+      hedge_threads = DefaultHedgingThreadPoolSize(max_concurrent);
+    }
+    double const rate_limit =
+        options_.get<storage_experimental::ReadHedgeRateLimitOption>();
     // Allow bursts of up to one second worth of hedges.
     hedge_pool_ = std::make_shared<HedgingThreadPool>(
-        max_threads, rate_limit, rate_limit, max_concurrent);
+        hedge_threads, rate_limit, rate_limit, max_concurrent);
   }
 }
 
@@ -435,14 +441,14 @@ StatusOr<std::unique_ptr<ObjectReadSource>> StorageConnectionImpl::ReadObject(
   auto const max_buffer =
       current->get<storage_experimental::MaximumHedgeBufferOption>();
 
-  if (!enable_hedging || max_hedges <= 0 || !hedge_pool_) {
+  if (!enable_hedging || max_hedges <= 0 || !hedge_pool_ || !read_pool_) {
     return retry_source_factory();
   }
 
   // `max_buffer` bounds the size of an individual read, which is only known
   // when the application calls `Read()`; the source applies it there.
   return std::unique_ptr<ObjectReadSource>(
-      std::make_unique<HedgedObjectReadSource>(hedge_pool_,
+      std::make_unique<HedgedObjectReadSource>(read_pool_, hedge_pool_,
                                                std::move(retry_source_factory),
                                                delay, max_hedges, max_buffer));
 }

--- a/google/cloud/storage/internal/connection_impl.h
+++ b/google/cloud/storage/internal/connection_impl.h
@@ -188,6 +188,7 @@ class StorageConnectionImpl
 
   std::unique_ptr<storage_internal::GenericStub> stub_;
   Options options_;
+  std::shared_ptr<ThreadPool> read_pool_;
   std::shared_ptr<HedgingThreadPool> hedge_pool_;
   google::cloud::internal::InvocationIdGenerator invocation_id_generator_;
 };

--- a/google/cloud/storage/internal/hedged_object_read_source.cc
+++ b/google/cloud/storage/internal/hedged_object_read_source.cc
@@ -55,7 +55,7 @@ void RunAttempt(std::shared_ptr<RaceState> const& state,
   auto source = factory();
   if (!source) {
     if (!resolve_on_open_error) return;
-    auto expected = false;
+    bool expected = false;
     if (state->resolved.compare_exchange_strong(expected, true)) {
       state->promise.set_value(
           RaceResult{std::move(source).status(), nullptr, {}});
@@ -65,7 +65,7 @@ void RunAttempt(std::shared_ptr<RaceState> const& state,
   std::unique_ptr<char[]> buffer(new (std::nothrow) char[n]);
   if (!buffer) {
     if (!resolve_on_open_error) return;
-    auto expected = false;
+    bool expected = false;
     if (state->resolved.compare_exchange_strong(expected, true)) {
       state->promise.set_value(RaceResult{
           google::cloud::internal::ResourceExhaustedError(
@@ -76,7 +76,7 @@ void RunAttempt(std::shared_ptr<RaceState> const& state,
     return;
   }
   auto result = (*source)->Read(buffer.get(), n);
-  auto expected = false;
+  bool expected = false;
   if (state->resolved.compare_exchange_strong(expected, true)) {
     state->promise.set_value(
         RaceResult{std::move(result), *std::move(source), std::move(buffer)});
@@ -88,9 +88,11 @@ void RunAttempt(std::shared_ptr<RaceState> const& state,
 }  // namespace
 
 HedgedObjectReadSource::HedgedObjectReadSource(
+    std::shared_ptr<ThreadPool> read_pool,
     std::shared_ptr<HedgingThreadPool> hedge_pool, ChildFactory child_factory,
     std::chrono::milliseconds delay, int max_hedges, std::size_t max_buffer)
-    : hedge_pool_(std::move(hedge_pool)),
+    : read_pool_(std::move(read_pool)),
+      hedge_pool_(std::move(hedge_pool)),
       child_factory_(std::move(child_factory)),
       delay_(delay),
       max_hedges_(max_hedges),
@@ -135,11 +137,12 @@ StatusOr<ReadSourceResult> HedgedObjectReadSource::Read(char* buf,
   auto primary = [state, factory = child_factory_, n] {
     RunAttempt(state, factory, n, /*resolve_on_open_error=*/true, nullptr);
   };
+  // The primary attempt is scheduled on the dedicated read pool.
   // If the pool is shutting down run the attempt inline, the read must
   // complete either way.
-  if (!hedge_pool_->Enqueue(primary)) primary();
+  if (!read_pool_->Enqueue(primary)) primary();
 
-  for (int i = 0; i != max_hedges_; ++i) {
+  for (int hedges_dispatched = 0; hedges_dispatched != max_hedges_;) {
     if (future.wait_for(delay_) != std::future_status::timeout) break;
     if (!hedge_pool_->TryAcquireHedgeToken()) continue;
     auto hedge = [state, factory = child_factory_, n, pool = hedge_pool_] {
@@ -149,6 +152,7 @@ StatusOr<ReadSourceResult> HedgedObjectReadSource::Read(char* buf,
       hedge_pool_->ReleaseHedgeSlot();
       break;
     }
+    ++hedges_dispatched;
   }
 
   auto race = future.get();

--- a/google/cloud/storage/internal/hedged_object_read_source.cc
+++ b/google/cloud/storage/internal/hedged_object_read_source.cc
@@ -45,6 +45,9 @@ void RunAttempt(std::shared_ptr<RaceState> const& state,
                 HedgedObjectReadSource::ChildFactory const& factory,
                 std::size_t n, bool resolve_on_open_error,
                 std::shared_ptr<HedgingThreadPool> release_slot) {
+  // Releases the acquired hedge concurrency slot upon function exit across
+  // all code paths (early return on open/allocation error, race winner, or
+  // race loser). For primary attempts, release_slot is nullptr.
   struct SlotGuard {
     std::shared_ptr<HedgingThreadPool> pool;
     ~SlotGuard() {
@@ -113,7 +116,9 @@ StatusOr<HttpResponse> HedgedObjectReadSource::Close() {
 
 StatusOr<ReadSourceResult> HedgedObjectReadSource::Read(char* buf,
                                                         std::size_t n) {
-  if (is_closed_) return ReadSourceResult{};
+  if (is_closed_) {
+    return ReadSourceResult{0, HttpResponse{HttpStatusCode::kOk, {}, {}}};
+  }
 
   // Only the stream open is hedged. Once a child has won the race all
   // subsequent reads continue on it, at its current offset, without any
@@ -142,9 +147,20 @@ StatusOr<ReadSourceResult> HedgedObjectReadSource::Read(char* buf,
   // complete either way.
   if (!read_pool_->Enqueue(primary)) primary();
 
-  for (int hedges_dispatched = 0; hedges_dispatched != max_hedges_;) {
+  for (int hedges_dispatched = 0; hedges_dispatched < max_hedges_;) {
     if (future.wait_for(delay_) != std::future_status::timeout) break;
-    if (!hedge_pool_->TryAcquireHedgeToken()) continue;
+    if (!hedge_pool_->TryAcquireHedgeToken()) {
+      // When delay_ is 0ms (or token acquisition fails), back off briefly on
+      // the future instead of busy-spinning if tokens or concurrency slots are
+      // temporarily exhausted.
+      if (delay_ == std::chrono::milliseconds::zero()) {
+        if (future.wait_for(std::chrono::milliseconds(10)) !=
+            std::future_status::timeout) {
+          break;
+        }
+      }
+      continue;
+    }
     auto hedge = [state, factory = child_factory_, n, pool = hedge_pool_] {
       RunAttempt(state, factory, n, /*resolve_on_open_error=*/false, pool);
     };

--- a/google/cloud/storage/internal/hedged_object_read_source.h
+++ b/google/cloud/storage/internal/hedged_object_read_source.h
@@ -54,7 +54,8 @@ class HedgedObjectReadSource : public ObjectReadSource {
   using ChildFactory =
       std::function<StatusOr<std::unique_ptr<ObjectReadSource>>()>;
 
-  HedgedObjectReadSource(std::shared_ptr<HedgingThreadPool> hedge_pool,
+  HedgedObjectReadSource(std::shared_ptr<ThreadPool> read_pool,
+                         std::shared_ptr<HedgingThreadPool> hedge_pool,
                          ChildFactory child_factory,
                          std::chrono::milliseconds delay, int max_hedges,
                          std::size_t max_buffer);
@@ -66,6 +67,7 @@ class HedgedObjectReadSource : public ObjectReadSource {
   StatusOr<ReadSourceResult> Read(char* buf, std::size_t n) override;
 
  private:
+  std::shared_ptr<ThreadPool> read_pool_;
   std::shared_ptr<HedgingThreadPool> hedge_pool_;
   ChildFactory child_factory_;
   std::chrono::milliseconds delay_;

--- a/google/cloud/storage/internal/hedged_object_read_source_test.cc
+++ b/google/cloud/storage/internal/hedged_object_read_source_test.cc
@@ -271,6 +271,134 @@ TEST(HedgedObjectReadSourceTest,
   primary_closed->get_future().get();
 }
 
+TEST(HedgedObjectReadSourceTest, HedgeOpenFailureReleasesSlot) {
+  // Verify that if a hedge attempt fails during stream opening (factory()
+  // error), the hedge concurrency slot is released via RAII (SlotGuard) and is
+  // not leaked.
+  auto unblock_primary = std::make_shared<std::promise<void>>();
+  auto calls = std::make_shared<std::atomic<int>>(0);
+  auto factory = [unblock_primary,
+                  calls]() -> StatusOr<std::unique_ptr<ObjectReadSource>> {
+    int call_count = ++*calls;
+    if (call_count == 1) {
+      // Primary attempt: stalls until unblocked.
+      auto mock = std::make_unique<MockObjectReadSource>();
+      EXPECT_CALL(*mock, Read)
+          .WillOnce([unblock_primary](char* buf, std::size_t) {
+            unblock_primary->get_future().get();
+            std::string const payload = "primary";
+            std::copy(payload.begin(), payload.end(), buf);
+            return MakeReadResult(payload);
+          });
+      return std::unique_ptr<ObjectReadSource>(std::move(mock));
+    }
+    // Hedge attempt: fails to open.
+    return Status(StatusCode::kUnavailable, "open failed");
+  };
+
+  auto hedge_pool = std::make_shared<HedgingThreadPool>(
+      /*max_threads=*/2, /*rate_limit=*/0.0, /*capacity=*/0.0,
+      /*max_concurrent=*/1);
+
+  HedgedObjectReadSource source(MakeUnlimitedReadPool(), hedge_pool, factory,
+                                std::chrono::milliseconds(1),
+                                /*max_hedges=*/1, kUnlimitedBuffer);
+
+  std::vector<char> buffer(100);
+  std::thread unblocker([unblock_primary] {
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    unblock_primary->set_value();
+  });
+
+  auto result = source.Read(buffer.data(), buffer.size());
+  unblocker.join();
+
+  ASSERT_THAT(result, IsOk());
+  EXPECT_THAT(std::string(buffer.data(), result->bytes_received),
+              Eq("primary"));
+  EXPECT_THAT(calls->load(), Eq(2));
+
+  // If the slot leaked on open failure, TryAcquireHedgeToken would fail because
+  // max_concurrent is 1.
+  EXPECT_TRUE(hedge_pool->TryAcquireHedgeToken());
+  hedge_pool->ReleaseHedgeSlot();
+}
+
+TEST(HedgedObjectReadSourceTest, ZeroDelayBacksOffOnHedgeTokenExhaustion) {
+  // Verify that when delay_ == 0ms and TryAcquireHedgeToken() returns false,
+  // the hedging loop backs off instead of busy-spinning, allowing the primary
+  // read to complete normally.
+  auto unblock_primary = std::make_shared<std::promise<void>>();
+  auto calls = std::make_shared<std::atomic<int>>(0);
+  auto factory = [unblock_primary,
+                  calls]() -> StatusOr<std::unique_ptr<ObjectReadSource>> {
+    ++*calls;
+    auto mock = std::make_unique<MockObjectReadSource>();
+    EXPECT_CALL(*mock, Read)
+        .WillOnce([unblock_primary](char* buf, std::size_t) {
+          unblock_primary->get_future().get();
+          std::string const payload = "primary_data";
+          std::copy(payload.begin(), payload.end(), buf);
+          return MakeReadResult(payload);
+        });
+    return std::unique_ptr<ObjectReadSource>(std::move(mock));
+  };
+
+  auto hedge_pool = std::make_shared<HedgingThreadPool>(
+      /*max_threads=*/1, /*rate_limit=*/0.0, /*capacity=*/0.0,
+      /*max_concurrent=*/1);
+  // Exhaust all hedge slots so TryAcquireHedgeToken fails.
+  ASSERT_TRUE(hedge_pool->TryAcquireHedgeToken());
+
+  HedgedObjectReadSource source(MakeUnlimitedReadPool(), hedge_pool, factory,
+                                std::chrono::milliseconds(0),
+                                /*max_hedges=*/2, kUnlimitedBuffer);
+
+  std::vector<char> buffer(100);
+  std::thread unblocker([unblock_primary] {
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    unblock_primary->set_value();
+  });
+
+  auto result = source.Read(buffer.data(), buffer.size());
+  unblocker.join();
+
+  ASSERT_THAT(result, IsOk());
+  EXPECT_THAT(std::string(buffer.data(), result->bytes_received),
+              Eq("primary_data"));
+  EXPECT_THAT(calls->load(), Eq(1));
+
+  hedge_pool->ReleaseHedgeSlot();
+}
+
+TEST(HedgedObjectReadSourceTest, NonPositiveMaxHedgesDoesNotHedge) {
+  // Verify that negative or zero max_hedges values defensively result in 0
+  // hedge attempts, running only the primary attempt.
+  auto calls = std::make_shared<std::atomic<int>>(0);
+  auto factory = [calls]() -> StatusOr<std::unique_ptr<ObjectReadSource>> {
+    ++*calls;
+    auto mock = std::make_unique<MockObjectReadSource>();
+    EXPECT_CALL(*mock, Read).WillOnce([](char* buf, std::size_t) {
+      std::string const payload = "primary_only";
+      std::copy(payload.begin(), payload.end(), buf);
+      return MakeReadResult(payload);
+    });
+    return std::unique_ptr<ObjectReadSource>(std::move(mock));
+  };
+
+  HedgedObjectReadSource source(MakeUnlimitedReadPool(),
+                                MakeUnlimitedHedgePool(), factory,
+                                std::chrono::milliseconds(0),
+                                /*max_hedges=*/-1, kUnlimitedBuffer);
+
+  std::vector<char> buffer(100);
+  auto result = source.Read(buffer.data(), buffer.size());
+  ASSERT_THAT(result, IsOk());
+  EXPECT_THAT(std::string(buffer.data(), result->bytes_received),
+              Eq("primary_only"));
+  EXPECT_THAT(calls->load(), Eq(1));
+}
+
 TEST(HedgedObjectReadSourceTest, PrimaryOpenErrorPropagates) {
   auto factory = []() -> StatusOr<std::unique_ptr<ObjectReadSource>> {
     return Status(StatusCode::kPermissionDenied, "uh-oh");

--- a/google/cloud/storage/internal/hedged_object_read_source_test.cc
+++ b/google/cloud/storage/internal/hedged_object_read_source_test.cc
@@ -36,23 +36,53 @@ using ::google::cloud::storage::testing::MockObjectReadSource;
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::Eq;
-using ::testing::Return;
 
 // Large enough that no test read is treated as oversized.
-auto constexpr kUnlimitedBuffer = std::size_t{1} << 30;
+std::size_t constexpr kUnlimitedBuffer = std::size_t{1} << 30;
 
-std::shared_ptr<HedgingThreadPool> MakeUnlimitedPool() {
+std::shared_ptr<ThreadPool> MakeUnlimitedReadPool() {
+  return std::make_shared<ThreadPool>(/*max_threads=*/4);
+}
+
+std::shared_ptr<HedgingThreadPool> MakeUnlimitedHedgePool() {
   return std::make_shared<HedgingThreadPool>(
       /*max_threads=*/4, /*rate_limit=*/0.0, /*capacity=*/0.0,
       /*max_concurrent=*/0);
 }
 
 ReadSourceResult MakeReadResult(std::string const& payload) {
-  auto result =
-      ReadSourceResult{payload.size(), HttpResponse{HttpStatusCode::kOk,
-                                                    /*payload=*/{},
-                                                    /*headers=*/{}}};
-  return result;
+  return ReadSourceResult{payload.size(),
+                          HttpResponse{HttpStatusCode::kOk, {}, {}}};
+}
+
+auto MakeStallingPrimaryFactory(
+    std::shared_ptr<std::promise<void>> const& unblock_primary,
+    std::shared_ptr<std::promise<void>> const& primary_closed,
+    std::shared_ptr<std::atomic<int>> const& calls) {
+  return [unblock_primary, primary_closed,
+          calls]() -> StatusOr<std::unique_ptr<ObjectReadSource>> {
+    auto mock = std::make_unique<MockObjectReadSource>();
+    if (++*calls == 1) {
+      EXPECT_CALL(*mock, Read)
+          .WillOnce([unblock_primary](char* buf, std::size_t) {
+            unblock_primary->get_future().get();
+            std::string const payload = "slow";
+            std::copy(payload.begin(), payload.end(), buf);
+            return MakeReadResult(payload);
+          });
+      EXPECT_CALL(*mock, Close).WillOnce([primary_closed]() {
+        primary_closed->set_value();
+        return make_status_or(HttpResponse{HttpStatusCode::kOk, {}, {}});
+      });
+    } else {
+      EXPECT_CALL(*mock, Read).WillOnce([](char* buf, std::size_t) {
+        std::string const payload = "hedge";
+        std::copy(payload.begin(), payload.end(), buf);
+        return MakeReadResult(payload);
+      });
+    }
+    return std::unique_ptr<ObjectReadSource>(std::move(mock));
+  };
 }
 
 TEST(HedgedObjectReadSourceTest, PrimaryWins) {
@@ -66,7 +96,8 @@ TEST(HedgedObjectReadSourceTest, PrimaryWins) {
     return std::unique_ptr<ObjectReadSource>(std::move(mock));
   };
 
-  HedgedObjectReadSource source(MakeUnlimitedPool(), factory,
+  HedgedObjectReadSource source(MakeUnlimitedReadPool(),
+                                MakeUnlimitedHedgePool(), factory,
                                 std::chrono::milliseconds(500),
                                 /*max_hedges=*/2, kUnlimitedBuffer);
 
@@ -88,12 +119,21 @@ TEST(HedgedObjectReadSourceTest, SubsequentReadsContinueOnWinner) {
     ++*factory_calls;
     auto mock = std::make_unique<MockObjectReadSource>();
     EXPECT_CALL(*mock, Read)
-        .WillOnce(Return(MakeReadResult("chunk-1")))
-        .WillOnce(Return(MakeReadResult("chunk-2")));
+        .WillOnce([](char* buf, std::size_t) {
+          std::string const payload = "chunk-1";
+          std::copy(payload.begin(), payload.end(), buf);
+          return MakeReadResult(payload);
+        })
+        .WillOnce([](char* buf, std::size_t) {
+          std::string const payload = "chunk-2";
+          std::copy(payload.begin(), payload.end(), buf);
+          return MakeReadResult(payload);
+        });
     return std::unique_ptr<ObjectReadSource>(std::move(mock));
   };
 
-  HedgedObjectReadSource source(MakeUnlimitedPool(), factory,
+  HedgedObjectReadSource source(MakeUnlimitedReadPool(),
+                                MakeUnlimitedHedgePool(), factory,
                                 std::chrono::milliseconds(500),
                                 /*max_hedges=*/2, kUnlimitedBuffer);
 
@@ -110,32 +150,122 @@ TEST(HedgedObjectReadSourceTest, HedgeWinsWhenPrimaryStalls) {
   auto unblock_primary = std::make_shared<std::promise<void>>();
   auto primary_closed = std::make_shared<std::promise<void>>();
   auto calls = std::make_shared<std::atomic<int>>(0);
-  auto factory = [unblock_primary, primary_closed,
-                  calls]() -> StatusOr<std::unique_ptr<ObjectReadSource>> {
-    auto mock = std::make_unique<MockObjectReadSource>();
-    if (++*calls == 1) {
-      EXPECT_CALL(*mock, Read).WillOnce([unblock_primary](char*, std::size_t) {
-        unblock_primary->get_future().get();
-        return MakeReadResult("slow");
-      });
-      EXPECT_CALL(*mock, Close).WillOnce([primary_closed]() {
-        primary_closed->set_value();
-        return make_status_or(HttpResponse{HttpStatusCode::kOk, {}, {}});
-      });
-    } else {
-      EXPECT_CALL(*mock, Read).WillOnce(Return(MakeReadResult("hedge")));
-    }
-    return std::unique_ptr<ObjectReadSource>(std::move(mock));
-  };
+  auto factory =
+      MakeStallingPrimaryFactory(unblock_primary, primary_closed, calls);
 
   auto source = std::make_unique<HedgedObjectReadSource>(
-      MakeUnlimitedPool(), factory, std::chrono::milliseconds(1),
+      MakeUnlimitedReadPool(), MakeUnlimitedHedgePool(), factory,
+      std::chrono::milliseconds(1),
       /*max_hedges=*/2, kUnlimitedBuffer);
 
   std::vector<char> buffer(100);
   auto result = source->Read(buffer.data(), buffer.size());
   ASSERT_THAT(result, IsOk());
   EXPECT_THAT(result->bytes_received, Eq(5));
+  EXPECT_THAT(std::string(buffer.data(), result->bytes_received), Eq("hedge"));
+
+  unblock_primary->set_value();
+  primary_closed->get_future().get();
+}
+
+TEST(HedgedObjectReadSourceTest, ReadPoolSaturationDoesNotBlockHedges) {
+  // Verify thread pool isolation: If the read pool is busy with slow reads,
+  // speculative hedge attempts on hedge_pool_ can still execute immediately.
+  auto unblock_primary = std::make_shared<std::promise<void>>();
+  auto primary_closed = std::make_shared<std::promise<void>>();
+  auto calls = std::make_shared<std::atomic<int>>(0);
+  auto factory =
+      MakeStallingPrimaryFactory(unblock_primary, primary_closed, calls);
+
+  HedgedObjectReadSource source(std::make_shared<ThreadPool>(/*max_threads=*/1),
+                                MakeUnlimitedHedgePool(), factory,
+                                std::chrono::milliseconds(1),
+                                /*max_hedges=*/2, kUnlimitedBuffer);
+
+  std::vector<char> buffer(100);
+  auto result = source.Read(buffer.data(), buffer.size());
+  ASSERT_THAT(result, IsOk());
+  EXPECT_THAT(result->bytes_received, Eq(5));
+  EXPECT_THAT(std::string(buffer.data(), result->bytes_received), Eq("hedge"));
+
+  unblock_primary->set_value();
+  primary_closed->get_future().get();
+}
+
+TEST(HedgedObjectReadSourceTest, HedgePoolExhaustionDoesNotBlockPrimary) {
+  // Verify that if the hedge pool is fully exhausted / rate limited (0 tokens),
+  // the primary attempt on read_pool still completes successfully.
+  auto read_pool = MakeUnlimitedReadPool();
+  auto hedge_pool = std::make_shared<HedgingThreadPool>(
+      /*max_threads=*/1, /*rate_limit=*/0.0, /*capacity=*/0.0,
+      /*max_concurrent=*/1);
+  // Acquire the only slot so hedge pool has 0 available capacity.
+  ASSERT_TRUE(hedge_pool->TryAcquireHedgeToken());
+
+  auto calls = std::make_shared<std::atomic<int>>(0);
+  auto factory = [calls]() -> StatusOr<std::unique_ptr<ObjectReadSource>> {
+    ++*calls;
+    auto mock = std::make_unique<MockObjectReadSource>();
+    EXPECT_CALL(*mock, Read).WillOnce([](char* buf, std::size_t) {
+      std::string const payload = "primary_only";
+      std::copy(payload.begin(), payload.end(), buf);
+      return MakeReadResult(payload);
+    });
+    return std::unique_ptr<ObjectReadSource>(std::move(mock));
+  };
+
+  HedgedObjectReadSource source(read_pool, hedge_pool, factory,
+                                std::chrono::milliseconds(10),
+                                /*max_hedges=*/2, kUnlimitedBuffer);
+
+  std::vector<char> buffer(100);
+  auto result = source.Read(buffer.data(), buffer.size());
+  ASSERT_THAT(result, IsOk());
+  EXPECT_THAT(result->bytes_received, Eq(12));
+  EXPECT_THAT(std::string(buffer.data(), result->bytes_received),
+              Eq("primary_only"));
+  EXPECT_THAT(calls->load(), Eq(1));
+
+  hedge_pool->ReleaseHedgeSlot();
+}
+
+TEST(HedgedObjectReadSourceTest,
+     TransientHedgePoolExhaustionDoesNotBurnHedgeAttempt) {
+  // Verify that if TryAcquireHedgeToken() fails on an initial tick due to
+  // transient exhaustion, the hedge attempt slot is not burned and a hedge is
+  // successfully dispatched on a subsequent tick once capacity becomes
+  // available.
+  auto unblock_primary = std::make_shared<std::promise<void>>();
+  auto primary_closed = std::make_shared<std::promise<void>>();
+  auto calls = std::make_shared<std::atomic<int>>(0);
+  auto factory =
+      MakeStallingPrimaryFactory(unblock_primary, primary_closed, calls);
+
+  auto hedge_pool = std::make_shared<HedgingThreadPool>(
+      /*max_threads=*/1, /*rate_limit=*/0.0, /*capacity=*/0.0,
+      /*max_concurrent=*/1);
+  // Acquire the only slot so hedge pool has 0 available capacity initially.
+  ASSERT_TRUE(hedge_pool->TryAcquireHedgeToken());
+
+  // In a background thread, release the slot after a brief delay so it is
+  // available on a subsequent tick.
+  std::thread releaser([hedge_pool] {
+    std::this_thread::sleep_for(std::chrono::milliseconds(25));
+    hedge_pool->ReleaseHedgeSlot();
+  });
+
+  HedgedObjectReadSource source(MakeUnlimitedReadPool(), hedge_pool, factory,
+                                std::chrono::milliseconds(10),
+                                /*max_hedges=*/1, kUnlimitedBuffer);
+
+  std::vector<char> buffer(100);
+  auto result = source.Read(buffer.data(), buffer.size());
+  releaser.join();
+
+  ASSERT_THAT(result, IsOk());
+  EXPECT_THAT(result->bytes_received, Eq(5));
+  EXPECT_THAT(std::string(buffer.data(), result->bytes_received), Eq("hedge"));
+  EXPECT_THAT(calls->load(), Eq(2));
 
   unblock_primary->set_value();
   primary_closed->get_future().get();
@@ -146,7 +276,8 @@ TEST(HedgedObjectReadSourceTest, PrimaryOpenErrorPropagates) {
     return Status(StatusCode::kPermissionDenied, "uh-oh");
   };
 
-  HedgedObjectReadSource source(MakeUnlimitedPool(), factory,
+  HedgedObjectReadSource source(MakeUnlimitedReadPool(),
+                                MakeUnlimitedHedgePool(), factory,
                                 std::chrono::milliseconds(500),
                                 /*max_hedges=*/2, kUnlimitedBuffer);
 
@@ -159,7 +290,8 @@ TEST(HedgedObjectReadSourceTest, CloseWithoutReadSucceeds) {
   auto factory = []() -> StatusOr<std::unique_ptr<ObjectReadSource>> {
     return Status(StatusCode::kUnimplemented, "never called");
   };
-  HedgedObjectReadSource source(MakeUnlimitedPool(), factory,
+  HedgedObjectReadSource source(MakeUnlimitedReadPool(),
+                                MakeUnlimitedHedgePool(), factory,
                                 std::chrono::milliseconds(500),
                                 /*max_hedges=*/2, kUnlimitedBuffer);
   EXPECT_TRUE(source.IsOpen());
@@ -167,19 +299,21 @@ TEST(HedgedObjectReadSourceTest, CloseWithoutReadSucceeds) {
 }
 
 TEST(HedgedObjectReadSourceTest, CloseBeforeRead) {
-  auto pool = std::make_shared<HedgingThreadPool>(1, 0.0, 0.0, 0);
+  auto read_pool = std::make_shared<ThreadPool>(1);
+  auto hedge_pool = std::make_shared<HedgingThreadPool>(1, 0.0, 0.0, 0);
   auto factory = []() {
     return std::unique_ptr<ObjectReadSource>(
         std::make_unique<MockObjectReadSource>());
   };
-  HedgedObjectReadSource source(pool, factory, std::chrono::milliseconds(10), 2,
+  HedgedObjectReadSource source(read_pool, hedge_pool, factory,
+                                std::chrono::milliseconds(10), 2,
                                 kUnlimitedBuffer);
   EXPECT_TRUE(source.IsOpen());
-  EXPECT_STATUS_OK(source.Close());
+  EXPECT_THAT(source.Close(), IsOk());
   EXPECT_FALSE(source.IsOpen());
   auto const res = source.Read(nullptr, 1024);
-  EXPECT_TRUE(res.ok());
-  EXPECT_EQ(res->bytes_received, 0);
+  EXPECT_THAT(res, IsOk());
+  EXPECT_THAT(res->bytes_received, Eq(0));
 }
 
 TEST(HedgedObjectReadSourceTest, OversizedReadIsNotHedged) {
@@ -199,7 +333,8 @@ TEST(HedgedObjectReadSourceTest, OversizedReadIsNotHedged) {
 
   // A zero delay would let a hedge start immediately if the limit were not
   // honored, so any race would be observable as extra factory calls.
-  HedgedObjectReadSource source(MakeUnlimitedPool(), factory,
+  HedgedObjectReadSource source(MakeUnlimitedReadPool(),
+                                MakeUnlimitedHedgePool(), factory,
                                 std::chrono::milliseconds(0),
                                 /*max_hedges=*/2, /*max_buffer=*/8);
 
@@ -216,7 +351,8 @@ TEST(HedgedObjectReadSourceTest, OversizedReadPropagatesOpenError) {
     return Status(StatusCode::kPermissionDenied, "uh-oh");
   };
 
-  HedgedObjectReadSource source(MakeUnlimitedPool(), factory,
+  HedgedObjectReadSource source(MakeUnlimitedReadPool(),
+                                MakeUnlimitedHedgePool(), factory,
                                 std::chrono::milliseconds(0),
                                 /*max_hedges=*/2, /*max_buffer=*/8);
 
@@ -233,12 +369,21 @@ TEST(HedgedObjectReadSourceTest, SubsequentReadsIgnoreBufferLimit) {
     ++*calls;
     auto mock = std::make_unique<MockObjectReadSource>();
     EXPECT_CALL(*mock, Read)
-        .WillOnce(Return(MakeReadResult("small")))
-        .WillOnce(Return(MakeReadResult("large")));
+        .WillOnce([](char* buf, std::size_t) {
+          std::string const payload = "small";
+          std::copy(payload.begin(), payload.end(), buf);
+          return MakeReadResult(payload);
+        })
+        .WillOnce([](char* buf, std::size_t) {
+          std::string const payload = "large";
+          std::copy(payload.begin(), payload.end(), buf);
+          return MakeReadResult(payload);
+        });
     return std::unique_ptr<ObjectReadSource>(std::move(mock));
   };
 
-  HedgedObjectReadSource source(MakeUnlimitedPool(), factory,
+  HedgedObjectReadSource source(MakeUnlimitedReadPool(),
+                                MakeUnlimitedHedgePool(), factory,
                                 std::chrono::milliseconds(500),
                                 /*max_hedges=*/2, /*max_buffer=*/64);
 

--- a/google/cloud/storage/internal/hedging_thread_pool.h
+++ b/google/cloud/storage/internal/hedging_thread_pool.h
@@ -22,6 +22,7 @@
 #include <condition_variable>
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <mutex>
 #include <queue>
 #include <thread>
@@ -35,14 +36,17 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 
 /**
- * A lazy, dynamically-scaling thread pool with integrated hedge throttling.
+ * A lazy, dynamically-scaling thread pool for asynchronous background tasks.
  *
- * The pool starts with no threads and spawns workers on demand, up to
- * @p max_threads. Hedged requests are gated by `TryAcquireHedgeToken()`,
- * which enforces two limits: a maximum number of concurrently active hedges,
- * and a maximum rate of new hedges per second (a token bucket).
+ * The pool starts with no threads and spawns workers on demand up to
+ * @p max_threads. Idle workers wait on a condition variable until tasks arrive
+ * or the pool is shut down.
+ *
+ * @p max_threads is clamped to at least 1. A pool that can never spawn a
+ * worker would accept tasks it silently never runs, and callers that block on
+ * a task's side effects would wait forever.
  */
-class HedgingThreadPool {
+class ThreadPool {
  private:
   struct State {
     std::size_t const max_threads;
@@ -52,24 +56,15 @@ class HedgingThreadPool {
     std::condition_variable cv;
     bool stop = false;
 
-    // Concurrency limiter.
-    std::int64_t const max_concurrent_hedges;
-    std::atomic<std::int64_t> active_concurrent_hedges{0};
-
-    explicit State(std::size_t mt, std::int64_t mc)
-        : max_threads(mt), max_concurrent_hedges(mc) {}
+    explicit State(std::size_t mt) : max_threads(mt) {}
   };
 
  public:
-  HedgingThreadPool(std::size_t max_threads, double rate_limit, double capacity,
-                    std::int64_t max_concurrent)
-      : state_(std::make_shared<State>(max_threads, max_concurrent)),
-        rate_limit_(rate_limit),
-        tokens_capacity_((std::max)(1.0, capacity)),
-        tokens_((std::max)(1.0, capacity)),
-        last_refill_(std::chrono::steady_clock::now()) {}
+  explicit ThreadPool(std::size_t max_threads)
+      : state_(
+            std::make_shared<State>((std::max<std::size_t>)(1, max_threads))) {}
 
-  ~HedgingThreadPool() {
+  ~ThreadPool() {
     {
       std::lock_guard<std::mutex> lock(state_->queue_mutex);
       state_->stop = true;
@@ -85,6 +80,11 @@ class HedgingThreadPool {
       }
     }
   }
+
+  ThreadPool(ThreadPool const&) = delete;
+  ThreadPool& operator=(ThreadPool const&) = delete;
+  ThreadPool(ThreadPool&&) = delete;
+  ThreadPool& operator=(ThreadPool&&) = delete;
 
   /**
    * Schedule @p task to run on a pool thread.
@@ -108,44 +108,7 @@ class HedgingThreadPool {
     return true;
   }
 
-  /**
-   * Try to reserve capacity for one hedged request.
-   *
-   * On success the caller *must* eventually call `ReleaseHedgeSlot()`.
-   */
-  bool TryAcquireHedgeToken() {
-    // Gate 1: the ceiling on concurrently active hedges.
-    if (state_->max_concurrent_hedges > 0) {
-      auto current =
-          state_->active_concurrent_hedges.load(std::memory_order_relaxed);
-      do {
-        if (current >= state_->max_concurrent_hedges) return false;
-      } while (!state_->active_concurrent_hedges.compare_exchange_weak(
-          current, current + 1, std::memory_order_relaxed));
-    }
-
-    // Gate 2: the rate limit on new hedges (token bucket).
-    if (rate_limit_ > 0.0) {
-      std::lock_guard<std::mutex> lock(limiter_mutex_);
-      Refill();
-      if (tokens_ < 1.0) {
-        if (state_->max_concurrent_hedges > 0) {
-          state_->active_concurrent_hedges.fetch_sub(1,
-                                                     std::memory_order_relaxed);
-        }
-        return false;
-      }
-      tokens_ -= 1.0;
-    }
-
-    return true;
-  }
-
-  void ReleaseHedgeSlot() {
-    if (state_->max_concurrent_hedges > 0) {
-      state_->active_concurrent_hedges.fetch_sub(1, std::memory_order_relaxed);
-    }
-  }
+  std::size_t max_threads() const { return state_->max_threads; }
 
  private:
   void SpawnWorker() {
@@ -167,9 +130,88 @@ class HedgingThreadPool {
     });
   }
 
+  std::shared_ptr<State> state_;
+  std::vector<std::thread> workers_;
+};
+
+/**
+ * A dedicated thread pool with integrated hedge throttling.
+ *
+ * Hedged requests are gated by `TryAcquireHedgeToken()`, which enforces two
+ * limits: a maximum number of concurrently active hedges, and a maximum rate of
+ * new hedges per second (a token bucket). Task execution is dispatched onto a
+ * dedicated internal `ThreadPool`.
+ */
+class HedgingThreadPool {
+ public:
+  HedgingThreadPool(std::size_t max_threads, double rate_limit, double capacity,
+                    std::int64_t max_concurrent)
+      : rate_limit_(rate_limit),
+        tokens_capacity_((std::max)(1.0, capacity)),
+        tokens_((std::max)(1.0, capacity)),
+        last_refill_(std::chrono::steady_clock::now()),
+        max_concurrent_hedges_(max_concurrent),
+        pool_(max_threads) {}
+
+  ~HedgingThreadPool() = default;
+
+  HedgingThreadPool(HedgingThreadPool const&) = delete;
+  HedgingThreadPool& operator=(HedgingThreadPool const&) = delete;
+  HedgingThreadPool(HedgingThreadPool&&) = delete;
+  HedgingThreadPool& operator=(HedgingThreadPool&&) = delete;
+
+  /**
+   * Schedule @p task to run on a pool thread.
+   *
+   * Returns false if the pool is shutting down.
+   */
+  bool Enqueue(std::function<void()> task) {
+    return pool_.Enqueue(std::move(task));
+  }
+
+  /**
+   * Try to reserve capacity for one hedged request.
+   *
+   * On success the caller *must* eventually call `ReleaseHedgeSlot()`.
+   */
+  bool TryAcquireHedgeToken() {
+    // Gate 1: the ceiling on concurrently active hedges.
+    if (max_concurrent_hedges_ > 0) {
+      std::int64_t current =
+          active_concurrent_hedges_.load(std::memory_order_relaxed);
+      do {
+        if (current >= max_concurrent_hedges_) return false;
+      } while (!active_concurrent_hedges_.compare_exchange_weak(
+          current, current + 1, std::memory_order_relaxed));
+    }
+
+    // Gate 2: the rate limit on new hedges (token bucket).
+    if (rate_limit_ > 0.0) {
+      std::lock_guard<std::mutex> lock(limiter_mutex_);
+      Refill();
+      if (tokens_ < 1.0) {
+        ReleaseHedgeSlot();
+        return false;
+      }
+      tokens_ -= 1.0;
+    }
+
+    return true;
+  }
+
+  void ReleaseHedgeSlot() {
+    if (max_concurrent_hedges_ > 0) {
+      active_concurrent_hedges_.fetch_sub(1, std::memory_order_relaxed);
+    }
+  }
+
+  std::size_t max_threads() const { return pool_.max_threads(); }
+
+ private:
   void Refill() {
-    auto now = std::chrono::steady_clock::now();
-    auto const elapsed =
+    std::chrono::steady_clock::time_point const now =
+        std::chrono::steady_clock::now();
+    double const elapsed =
         std::chrono::duration_cast<std::chrono::duration<double>>(now -
                                                                   last_refill_)
             .count();
@@ -177,16 +219,53 @@ class HedgingThreadPool {
     tokens_ = (std::min)(tokens_capacity_, tokens_ + elapsed * rate_limit_);
   }
 
-  std::shared_ptr<State> state_;
-  std::vector<std::thread> workers_;
-
   // Token bucket rate limiter.
   double rate_limit_;
   double tokens_capacity_;
   double tokens_;
   std::chrono::steady_clock::time_point last_refill_;
   std::mutex limiter_mutex_;
+
+  // Concurrency limiter.
+  std::int64_t const max_concurrent_hedges_;
+  std::atomic<std::int64_t> active_concurrent_hedges_{0};
+
+  // Declared last so the pool (and its worker threads) is destroyed and joined
+  // first, before any other member variables are torn down.
+  ThreadPool pool_;
 };
+
+/**
+ * The automatic size for the pool running primary read attempts.
+ *
+ * These threads block inside a synchronous read, so the pool needs roughly one
+ * thread per concurrent application read. That has little to do with the core
+ * count; the floor is what serves small hosts.
+ *
+ * Used by `StorageConnectionImpl` when `ReadThreadPoolSizeOption` is unset (0).
+ */
+inline std::size_t DefaultReadThreadPoolSize() {
+  static std::size_t const kCores = std::thread::hardware_concurrency();
+  return (std::max<std::size_t>)(64, 4 * kCores);
+}
+
+/**
+ * The automatic size for the pool running speculative hedge attempts.
+ *
+ * When @p max_concurrent_hedges is set it is already a ceiling on how many
+ * hedges can run at once, so a larger pool could never use the extra threads.
+ *
+ * Used by `StorageConnectionImpl` when `HedgingThreadPoolSizeOption` is
+ * unset (0).
+ */
+inline std::size_t DefaultHedgingThreadPoolSize(
+    std::int64_t max_concurrent_hedges) {
+  if (max_concurrent_hedges > 0) {
+    return static_cast<std::size_t>(max_concurrent_hedges);
+  }
+  static std::size_t const kCores = std::thread::hardware_concurrency();
+  return (std::max<std::size_t>)(16, 2 * kCores);
+}
 
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/hedging_thread_pool.h
+++ b/google/cloud/storage/internal/hedging_thread_pool.h
@@ -135,15 +135,28 @@ class ThreadPool {
 };
 
 /**
- * A dedicated thread pool with integrated hedge throttling.
+ * Coordinates and bounds speculative hedged requests across a storage client.
  *
  * Hedged requests are gated by `TryAcquireHedgeToken()`, which enforces two
- * limits: a maximum number of concurrently active hedges, and a maximum rate of
- * new hedges per second (a token bucket). Task execution is dispatched onto a
- * dedicated internal `ThreadPool`.
+ * limits: a maximum number of concurrently active hedges (when
+ * `max_concurrent > 0`), and a maximum rate of new hedges per second via a
+ * token bucket (when `rate_limit > 0.0`). Setting `rate_limit <= 0.0` disables
+ * rate limiting (unlimited hedges per second). Task execution is dispatched
+ * onto a dedicated internal `ThreadPool`.
  */
 class HedgingThreadPool {
  public:
+  /**
+   * Constructs a `HedgingThreadPool`.
+   *
+   * @param max_threads the worker pool thread limit. Clamped to at least 1.
+   * @param rate_limit the token bucket refill rate in tokens/sec. When <= 0.0,
+   *     rate limiting is disabled (unlimited hedges per second).
+   * @param capacity the maximum burst capacity in tokens. Clamped to at
+   *     least 1.0.
+   * @param max_concurrent the ceiling on concurrently active hedges. When <= 0,
+   *     concurrency limiting is disabled.
+   */
   HedgingThreadPool(std::size_t max_threads, double rate_limit, double capacity,
                     std::int64_t max_concurrent)
       : rate_limit_(rate_limit),
@@ -175,7 +188,8 @@ class HedgingThreadPool {
    * On success the caller *must* eventually call `ReleaseHedgeSlot()`.
    */
   bool TryAcquireHedgeToken() {
-    // Gate 1: the ceiling on concurrently active hedges.
+    // Gate 1: the ceiling on concurrently active hedges. When
+    // max_concurrent_hedges_ <= 0, concurrency limiting is disabled.
     if (max_concurrent_hedges_ > 0) {
       std::int64_t current =
           active_concurrent_hedges_.load(std::memory_order_relaxed);
@@ -185,7 +199,8 @@ class HedgingThreadPool {
           current, current + 1, std::memory_order_relaxed));
     }
 
-    // Gate 2: the rate limit on new hedges (token bucket).
+    // Gate 2: the rate limit on new hedges (token bucket). When
+    // rate_limit_ <= 0.0, rate limiting is disabled.
     if (rate_limit_ > 0.0) {
       std::lock_guard<std::mutex> lock(limiter_mutex_);
       Refill();
@@ -219,14 +234,14 @@ class HedgingThreadPool {
     tokens_ = (std::min)(tokens_capacity_, tokens_ + elapsed * rate_limit_);
   }
 
-  // Token bucket rate limiter.
+  // Token bucket rate limiter. A rate_limit_ <= 0.0 disables rate limiting.
   double rate_limit_;
   double tokens_capacity_;
   double tokens_;
   std::chrono::steady_clock::time_point last_refill_;
   std::mutex limiter_mutex_;
 
-  // Concurrency limiter.
+  // Concurrency limiter. A max_concurrent_hedges_ <= 0 disables limit.
   std::int64_t const max_concurrent_hedges_;
   std::atomic<std::int64_t> active_concurrent_hedges_{0};
 

--- a/google/cloud/storage/internal/hedging_thread_pool_test.cc
+++ b/google/cloud/storage/internal/hedging_thread_pool_test.cc
@@ -179,6 +179,16 @@ TEST(HedgingThreadPoolTest, FractionalRateLimiter) {
   EXPECT_FALSE(pool.TryAcquireHedgeToken());
 }
 
+TEST(HedgingThreadPoolTest, ZeroRateLimitDisablesRateLimiting) {
+  // A rate limit of 0.0 disables rate limiting, allowing unlimited
+  // acquisitions.
+  HedgingThreadPool pool(5, 0.0, 0.0, 0);
+
+  for (int i = 0; i < 100; ++i) {
+    EXPECT_TRUE(pool.TryAcquireHedgeToken());
+  }
+}
+
 TEST(HedgingThreadPoolTest, SafeDestructionOnWorkerThread) {
   TestSafeDestructionOnWorkerThread(
       std::make_shared<HedgingThreadPool>(1, 0.0, 0.0, 0));

--- a/google/cloud/storage/internal/hedging_thread_pool_test.cc
+++ b/google/cloud/storage/internal/hedging_thread_pool_test.cc
@@ -15,9 +15,13 @@
 #include "google/cloud/storage/internal/hedging_thread_pool.h"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <atomic>
 #include <chrono>
+#include <cstddef>
 #include <future>
+#include <memory>
 #include <thread>
+#include <vector>
 
 namespace google {
 namespace cloud {
@@ -26,6 +30,96 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 namespace {
 
+using ::testing::Eq;
+using ::testing::Ge;
+
+TEST(ThreadPoolTest, EnqueueAndExecute) {
+  std::promise<void> p1;
+  std::promise<void> p2;
+  std::future<void> f1 = p1.get_future();
+  std::future<void> f2 = p2.get_future();
+
+  ThreadPool pool(2);
+  EXPECT_TRUE(pool.Enqueue([&p1] { p1.set_value(); }));
+  EXPECT_TRUE(pool.Enqueue([&p2] { p2.set_value(); }));
+
+  f1.get();
+  f2.get();
+}
+
+TEST(ThreadPoolTest, ConcurrentTasks) {
+  std::size_t const task_count = 50;
+  std::atomic<int> completed{0};
+  std::vector<std::promise<void>> promises(task_count);
+  std::vector<std::future<void>> futures;
+  futures.reserve(task_count);
+  // Declare the pool after the promises so workers are joined before the
+  // promises and atomic counter they reference go out of scope.
+  ThreadPool pool(8);
+  for (std::size_t i = 0; i != task_count; ++i) {
+    futures.push_back(promises[i].get_future());
+    EXPECT_TRUE(pool.Enqueue([&promises, &completed, i] {
+      ++completed;
+      promises[i].set_value();
+    }));
+  }
+
+  for (auto& f : futures) {
+    f.get();
+  }
+  EXPECT_THAT(completed.load(), Eq(static_cast<int>(task_count)));
+}
+
+TEST(ThreadPoolTest, ZeroThreadsStillRunsTasks) {
+  // A pool that could never spawn a worker would queue the task, report
+  // success, and leave anyone waiting on the task's side effects blocked
+  // forever. The size is clamped to 1 instead.
+  std::promise<void> p;
+  std::future<void> f = p.get_future();
+  ThreadPool pool(0);
+  EXPECT_THAT(pool.max_threads(), Eq(std::size_t{1}));
+  EXPECT_TRUE(pool.Enqueue([&p] { p.set_value(); }));
+  f.get();
+}
+
+TEST(ThreadPoolTest, DefaultSizes) {
+  // `StorageConnectionImpl` sizes its pools with these when the options are
+  // unset (0), so the floors are the contract.
+  EXPECT_THAT(DefaultReadThreadPoolSize(), Ge(std::size_t{64}));
+  EXPECT_THAT(DefaultHedgingThreadPoolSize(0), Ge(std::size_t{16}));
+  // An explicit hedge ceiling already bounds concurrency, so the pool matches
+  // it rather than the (larger) automatic size.
+  EXPECT_THAT(DefaultHedgingThreadPoolSize(3), Eq(std::size_t{3}));
+  EXPECT_THAT(DefaultHedgingThreadPoolSize(1), Eq(std::size_t{1}));
+}
+
+template <typename Pool>
+void TestSafeDestructionOnWorkerThread(std::shared_ptr<Pool> pool) {
+  auto started = std::make_shared<std::promise<void>>();
+  auto destroyed = std::make_shared<std::promise<void>>();
+  auto release = std::make_shared<std::promise<void>>();
+  std::future<void> started_future = started->get_future();
+  std::future<void> destroyed_future = destroyed->get_future();
+  std::shared_future<void> release_future = release->get_future().share();
+
+  ASSERT_TRUE(pool->Enqueue(
+      [pool_copy = pool, started, destroyed, release_future]() mutable {
+        started->set_value();
+        release_future.wait();
+        pool_copy.reset();
+        destroyed->set_value();
+      }));
+
+  started_future.get();
+  pool.reset();
+  release->set_value();
+  destroyed_future.get();
+}
+
+TEST(ThreadPoolTest, SafeDestructionOnWorkerThread) {
+  TestSafeDestructionOnWorkerThread(std::make_shared<ThreadPool>(1));
+}
+
 TEST(HedgingThreadPoolTest, EnqueueAndExecute) {
   // Declare the promises *before* the pool. `get()` returns as soon as the
   // shared state is ready, which may be before the worker has returned from
@@ -33,8 +127,8 @@ TEST(HedgingThreadPoolTest, EnqueueAndExecute) {
   // means the workers are done before the promises they reference go away.
   std::promise<void> p1;
   std::promise<void> p2;
-  auto f1 = p1.get_future();
-  auto f2 = p2.get_future();
+  std::future<void> f1 = p1.get_future();
+  std::future<void> f2 = p2.get_future();
 
   HedgingThreadPool pool(2, 0.0, 0.0, 0);
   EXPECT_TRUE(pool.Enqueue([&p1] { p1.set_value(); }));
@@ -86,38 +180,8 @@ TEST(HedgingThreadPoolTest, FractionalRateLimiter) {
 }
 
 TEST(HedgingThreadPoolTest, SafeDestructionOnWorkerThread) {
-  // Dropping the last reference to the pool from inside a task runs the pool
-  // destructor on one of its own worker threads. It must detach that thread
-  // rather than join itself.
-  //
-  // Every synchronization object is shared and captured by value: this worker
-  // is detached, so it can still be running after this function returns and
-  // must not reference anything on the test's stack.
-  auto started = std::make_shared<std::promise<void>>();
-  auto destroyed = std::make_shared<std::promise<void>>();
-  auto release = std::make_shared<std::promise<void>>();
-  auto started_future = started->get_future();
-  auto destroyed_future = destroyed->get_future();
-  auto release_future = release->get_future().share();
-
-  auto pool = std::make_shared<HedgingThreadPool>(1, 0.0, 0.0, 0);
-  ASSERT_TRUE(pool->Enqueue(
-      [pool_copy = pool, started, destroyed, release_future]() mutable {
-        started->set_value();
-        release_future.wait();
-        // The test thread has dropped its reference by now, so this is the
-        // last one: the pool destructor runs on this worker thread.
-        pool_copy.reset();
-        destroyed->set_value();
-      }));
-
-  started_future.get();
-  pool.reset();
-  release->set_value();
-  // Wait for the destructor to finish on the worker thread. This replaces a
-  // timing-based sleep: the test cannot return while the pool is still being
-  // destroyed.
-  destroyed_future.get();
+  TestSafeDestructionOnWorkerThread(
+      std::make_shared<HedgingThreadPool>(1, 0.0, 0.0, 0));
 }
 
 }  // namespace

--- a/google/cloud/storage/options.h
+++ b/google/cloud/storage/options.h
@@ -24,6 +24,7 @@
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/options.h"
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -108,6 +109,31 @@ struct ReadHedgeDelayOption {
  */
 struct MaxReadHedgesOption {
   using Type = int;
+};
+
+/**
+ * The maximum number of threads in the thread pool used for primary reads
+ * when `EnableReadHedgingOption` is enabled.
+ *
+ * Sizing defaults to at least 64 threads or 4x hardware concurrency.
+ *
+ * @ingroup storage-options
+ */
+struct ReadThreadPoolSizeOption {
+  using Type = std::size_t;
+};
+
+/**
+ * The maximum number of threads in the thread pool used for speculative
+ * hedged requests when `EnableReadHedgingOption` is enabled.
+ *
+ * Sizing defaults to `MaxConcurrentHedgesOption` if set, or at least 16
+ * threads or 2x hardware concurrency.
+ *
+ * @ingroup storage-options
+ */
+struct HedgingThreadPoolSizeOption {
+  using Type = std::size_t;
 };
 
 /**
@@ -494,6 +520,8 @@ using ClientOptionList = ::google::cloud::OptionList<
     storage_experimental::MaximumHedgeBufferOption,
     storage_experimental::ReadHedgeDelayOption,
     storage_experimental::MaxReadHedgesOption,
+    storage_experimental::ReadThreadPoolSizeOption,
+    storage_experimental::HedgingThreadPoolSizeOption,
     storage_experimental::OTelSpanEnrichmentOption>;
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/options.h
+++ b/google/cloud/storage/options.h
@@ -115,7 +115,8 @@ struct MaxReadHedgesOption {
  * The maximum number of threads in the thread pool used for primary reads
  * when `EnableReadHedgingOption` is enabled.
  *
- * Sizing defaults to at least 64 threads or 4x hardware concurrency.
+ * Set to 0 for automatic sizing (defaults to at least 64 threads or 4x hardware
+ * concurrency).
  *
  * @ingroup storage-options
  */
@@ -127,8 +128,8 @@ struct ReadThreadPoolSizeOption {
  * The maximum number of threads in the thread pool used for speculative
  * hedged requests when `EnableReadHedgingOption` is enabled.
  *
- * Sizing defaults to `MaxConcurrentHedgesOption` if set, or at least 16
- * threads or 2x hardware concurrency.
+ * Set to 0 for automatic sizing (defaults to `MaxConcurrentHedgesOption` if
+ * set, or at least 16 threads or 2x hardware concurrency).
  *
  * @ingroup storage-options
  */


### PR DESCRIPTION
 This PR separates the thread pools used for primary reads and speculative hedged reads in Cloud Storage read hedging.

Previously, both primary reads and speculative hedges shared a single thread pool. This introduced two architectural issues:

  1. Resource Contention / Head-of-Line Blocking: When multiple primary reads stalled or ran concurrently, the shared pool could become saturated. Consequently, speculative hedge
  attempts were blocked from executing, defeating the primary purpose of hedging (tail latency mitigation).
  2. Asymmetric Sizing Needs: Primary reads block synchronously waiting on network I/O and require a higher concurrency ceiling (typically ≥64 threads or 4 × hardware concurrency),
  whereas speculative hedges are gated by rate limits and concurrency controls (typically bounded by MaxConcurrentHedgesOption or 2 × hardware concurrency).

This change introduces a general-purpose, lazily-scaling hedging_thread_pool.h:49 and composes it within hedging_thread_pool.h:145, isolating primary read execution from speculative hedges.


  ## Key Changes

  ### 1. Dedicated ThreadPool and Embedded HedgingThreadPool

**hedging_thread_pool.h:49**:
      • Dynamically scales workers on demand up to max_threads.
      • Workers wait on a condition variable when idle and exit gracefully on shutdown.
      • Automatically clamps max_threads to ≥1 to prevent deadlock/infinite hang if configured with 0.
      • Supports self-destruction from within a worker thread (safely detaches rather than joining itself).
 
**hedging_thread_pool.h:145**:
      • Embeds hedging_thread_pool.h:235 by value as its execution backend (declared last to guarantee worker joining before state teardown).
      • Enforces the token-bucket rate limiter (ReadHedgeRateLimitOption) and maximum concurrent hedge ceiling (MaxConcurrentHedgesOption).


  ### 2. Dual Pool Configuration & Sizing Options

  • Added options.h:122: Defaults to DefaultReadThreadPoolSize() (max (64,4 × cores)).
  • Added options.h:135: Defaults to DefaultHedgingThreadPoolSize() (MaxConcurrentHedgesOption if set, else max (16,2 × cores)).
  • Centralized sizing defaults in DefaultReadThreadPoolSize() and DefaultHedgingThreadPoolSize() so client.cc:604 and connection_impl.cc:165 remain consistent.

  ### 3. Isolation in HedgedObjectReadSource

  • Updated hedged_object_read_source.cc:90 to accept separate read_pool_ and hedge_pool_.
  • Primary attempt opens are scheduled onto read_pool_.
  • Speculative hedged attempts are scheduled onto hedge_pool_.
 