### PR TITLE
cleanup(storage): fix GCS tracing test on macOS

### DIFF
--- a/google/cloud/storage/internal/async/connection_tracing_test.cc
+++ b/google/cloud/storage/internal/async/connection_tracing_test.cc
@@ -675,7 +675,7 @@ TEST(ConnectionTracing, OpenSuccessWithInitialReadRanges) {
   EXPECT_THAT(
       spans, ElementsAre(
                  AllOf(SpanNamed("storage::AsyncConnection::Open"),
-                       SpanHasAttributes(OTelAttribute<std::size_t>(
+                       SpanHasAttributes(OTelAttribute<std::uint64_t>(
                            "gl-cpp.initial-read-ranges.ranges-count", 2)),
                        SpanWithStatus(opentelemetry::trace::StatusCode::kOk))));
 }


### PR DESCRIPTION
```
  The Root Cause: LP64 Type Aliasing Mismatch

  The compilation error occurs during the template instantiation of google::cloud::testing_util::OTelAttribute<std::size_t> at line 678 in
  google/cloud/storage/internal/async/connection_tracing_test.cc.

  Under the standard LP64 data model used by both 64-bit Linux and 64-bit macOS:
   - std::size_t is defined as unsigned long on both systems.
   - However, how std::uint64_t (from <cstdint>) is defined differs:
     - On 64-bit Linux (GCC/Clang): std::uint64_t is defined as unsigned long. Thus, std::size_t and std::uint64_t are the exact same type.
     - On 64-bit macOS (Clang): std::uint64_t is defined as unsigned long long. Thus, std::size_t (unsigned long) and std::uint64_t
       (unsigned long long) are distinct and different types, even though both are 64-bit.

  Why this breaks OpenTelemetry's Matcher
  The OpenTelemetry SDK's OwnedAttributeValue is a std::variant that holds supported attribute types, including std::uint64_t and
  std::int64_t. 

  In the test helper opentelemetry_matchers.h, OTelAttribute<T> utilizes GoogleTest's ::testing::VariantWith<T>(matcher), which internally
  checks:

   1 std::holds_alternative<T>(value)
   - On Linux: Since T = std::size_t resolves to unsigned long (which matches the variant's std::uint64_t type), the variant contains this
     type, and it compiles.
   - On macOS: Since T = std::size_t resolves to unsigned long, but the variant only contains std::uint64_t (which is unsigned long long),
     unsigned long is not in the variant. This triggers the static_assert failure in std::variant: type not found in type list.

  ---

  The Solution

  The solution is to use std::uint64_t instead of std::size_t in connection_tracing_test.cc. 

  Because std::uint64_t is guaranteed to be one of the types in the OpenTelemetry variant on both platforms (mapping to unsigned long on
  Linux and unsigned long long on macOS), using it resolves the compilation failure.

  Proposed Change

  In google/cloud/storage/internal/async/connection_tracing_test.cc:

   1 // Change this:
   2                        SpanHasAttributes(OTelAttribute<std::size_t>(
   3                            "gl-cpp.initial-read-ranges.ranges-count", 2)),
   4
   5 // To this:
   6                        SpanHasAttributes(OTelAttribute<std::uint64_t>(
   7                            "gl-cpp.initial-read-ranges.ranges-count", 2)),
```