### PR TITLE
chore: migrate from deprecated absl types to std equivalents

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -23,7 +23,7 @@ module(
 bazel_dep(name = "platforms", version = "1.1.0")
 bazel_dep(name = "bazel_skylib", version = "1.9.2")
 bazel_dep(name = "rules_cc", version = "0.2.17")
-bazel_dep(name = "abseil-cpp", version = "20250814.2")
+bazel_dep(name = "abseil-cpp", version = "20260526.0")
 
 # For backwards compatibility with WORKSPACE.
 # The name "com_google_protobuf" is internally used by @bazel_tools,

--- a/examples/api_key.cc
+++ b/examples/api_key.cc
@@ -33,6 +33,7 @@
 #include "absl/strings/str_split.h"
 #include <chrono>
 #include <iostream>
+#include <optional>
 #include <string>
 #include <thread>
 #include <vector>
@@ -147,7 +148,7 @@ void AutoRun(std::vector<std::string> const& argv) {
     // When we authenticate with an API key, we do not have (or need)
     // credentials. Using a quota project requires credentials, so disable it.
     google::cloud::testing_util::ScopedEnvironment overlay(
-        "GOOGLE_CLOUD_CPP_USER_PROJECT", absl::nullopt);
+        "GOOGLE_CLOUD_CPP_USER_PROJECT", std::nullopt);
 
     try {
       AuthenticateWithApiKey({project_id, key.key_string()});

--- a/generator/integration_tests/golden/v1/golden_kitchen_sink_connection.cc
+++ b/generator/integration_tests/golden/v1/golden_kitchen_sink_connection.cc
@@ -84,7 +84,7 @@ StreamRange<google::test::admin::database::v1::Response> GoldenKitchenSinkConnec
     google::test::admin::database::v1::Request const&) {
   return google::cloud::internal::MakeStreamRange<
       google::test::admin::database::v1::Response>(
-      []() -> absl::variant<Status,
+      []() -> std::variant<Status,
       google::test::admin::database::v1::Response>{
         return Status(StatusCode::kUnimplemented, "not implemented");}
       );

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_connection_impl.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_connection_impl.cc
@@ -184,7 +184,7 @@ GoldenKitchenSinkConnectionImpl::StreamingRead(google::test::admin::database::v1
           GoldenKitchenSinkStreamingReadStreamingUpdater, request);
   return internal::MakeStreamRange<google::test::admin::database::v1::Response>(
       [resumable = std::move(resumable)]()
-          -> absl::variant<
+          -> std::variant<
               Status,
               google::test::admin::database::v1::Response> {
         google::test::admin::database::v1::Response response;

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_metadata_decorator.cc
@@ -175,7 +175,7 @@ GoldenKitchenSinkMetadata::ExplicitRouting1(
       {[](google::test::admin::database::v1::ExplicitRoutingRequest const& request) -> std::string const& {
         return request.app_profile_id();
       },
-      absl::nullopt},
+      std::nullopt},
       {[](google::test::admin::database::v1::ExplicitRoutingRequest const& request) -> std::string const& {
         return request.table_name();
       },

--- a/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_metadata_decorator.cc
+++ b/generator/integration_tests/golden/v1/internal/golden_kitchen_sink_rest_metadata_decorator.cc
@@ -120,7 +120,7 @@ GoldenKitchenSinkRestMetadata::ExplicitRouting1(
       {[](google::test::admin::database::v1::ExplicitRoutingRequest const& request) -> std::string const& {
         return request.app_profile_id();
       },
-      absl::nullopt},
+      std::nullopt},
       {[](google::test::admin::database::v1::ExplicitRoutingRequest const& request) -> std::string const& {
         return request.table_name();
       },

--- a/generator/integration_tests/tests/golden_kitchen_sink_client_test.cc
+++ b/generator/integration_tests/tests/golden_kitchen_sink_client_test.cc
@@ -239,7 +239,7 @@ TEST(GoldenKitchenSinkClientTest, StreamingRead) {
                     Contains("test-only/1.0"));
         EXPECT_THAT(request.stream(), "test-only-stream-name");
         return google::cloud::internal::MakeStreamRange<Response>(
-            []() -> absl::variant<Status, Response> {
+            []() -> std::variant<Status, Response> {
               return Status(StatusCode::kPermissionDenied, "uh-oh");
             });
       });

--- a/generator/internal/connection_generator.cc
+++ b/generator/internal/connection_generator.cc
@@ -460,7 +460,7 @@ $connection_class_name$::Async$method_name$() {
     "    $request_type$ const&) {\n"
     "  return google::cloud::internal::MakeStreamRange<\n"
     "      $response_type$>(\n"
-    "      []() -> absl::variant<Status,\n"
+    "      []() -> std::variant<Status,\n"
     "      $response_type$>{\n"
     "        return Status(StatusCode::kUnimplemented, \"not implemented\");}\n"
     "      );\n"

--- a/generator/internal/connection_impl_generator.cc
+++ b/generator/internal/connection_impl_generator.cc
@@ -363,7 +363,7 @@ $connection_class_name$Impl::$method_name$($request_type$ const& request) {
           $service_name$$method_name$StreamingUpdater, request);
   return internal::MakeStreamRange<$response_type$>(
       [resumable = std::move(resumable)]()
-          -> absl::variant<
+          -> std::variant<
               Status,
               $response_type$> {
         $response_type$ response;

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -34,7 +34,6 @@
 #include "absl/strings/str_replace.h"
 #include "absl/strings/str_split.h"
 #include "absl/strings/strip.h"
-#include "absl/types/variant.h"
 #include "google/api/annotations.pb.h"
 #include "google/api/http.pb.h"
 #include "google/api/routing.pb.h"

--- a/generator/internal/descriptor_utils.h
+++ b/generator/internal/descriptor_utils.h
@@ -19,7 +19,6 @@
 #include "generator/internal/mixin_utils.h"
 #include "generator/internal/predicate_utils.h"
 #include "generator/internal/printer.h"
-#include "absl/types/variant.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <yaml-cpp/yaml.h>

--- a/generator/internal/http_annotation_parser.cc
+++ b/generator/internal/http_annotation_parser.cc
@@ -19,6 +19,7 @@
 #include "absl/strings/str_cat.h"
 #include <cassert>
 #include <functional>
+#include <variant>
 
 namespace google {
 namespace cloud {
@@ -246,7 +247,7 @@ StatusOr<PathTemplate> ParsePathTemplate(absl::string_view input) {
     return MakeParseError(input, v->end, " end of input", GCP_ERROR_INFO());
   }
   return PathTemplate{std::move(s->value),
-                      absl::get<std::string>(v->value.value)};
+                      std::get<std::string>(v->value.value)};
 }
 
 std::ostream& operator<<(std::ostream& os, PathTemplate::Segment const& rhs) {
@@ -263,7 +264,7 @@ std::ostream& operator<<(std::ostream& os, PathTemplate::Segment const& rhs) {
     }
   };
   os << "{";
-  absl::visit(Visitor{os}, rhs.value);
+  std::visit(Visitor{os}, rhs.value);
   os << "}";
   return os;
 }

--- a/generator/internal/http_annotation_parser.h
+++ b/generator/internal/http_annotation_parser.h
@@ -17,8 +17,8 @@
 
 #include "google/cloud/status_or.h"
 #include "absl/strings/string_view.h"
-#include "absl/types/variant.h"
 #include <memory>
+#include <variant>
 #include <vector>
 
 namespace google {
@@ -86,7 +86,7 @@ struct PathTemplate {
     std::vector<std::shared_ptr<Segment>> segments;
   };
   struct Segment {
-    absl::variant<Match, MatchRecursive, std::string, Variable> value;
+    std::variant<Match, MatchRecursive, std::string, Variable> value;
   };
   using Segments = std::vector<std::shared_ptr<Segment>>;
 

--- a/generator/internal/http_annotation_parser_test.cc
+++ b/generator/internal/http_annotation_parser_test.cc
@@ -17,6 +17,7 @@
 #include <gmock/gmock.h>
 #include <algorithm>
 #include <sstream>
+#include <variant>
 
 namespace google {
 namespace cloud {
@@ -65,21 +66,21 @@ bool SameValues(PathTemplate::Segment const& a,
   struct Visitor {
     PathTemplate::Segment const& a;
     bool operator()(PathTemplate::Match const&) {
-      return absl::holds_alternative<PathTemplate::Match>(a.value);
+      return std::holds_alternative<PathTemplate::Match>(a.value);
     }
     bool operator()(PathTemplate::MatchRecursive const&) {
-      return absl::holds_alternative<PathTemplate::MatchRecursive>(a.value);
+      return std::holds_alternative<PathTemplate::MatchRecursive>(a.value);
     }
     bool operator()(std::string const& s) {
-      return absl::holds_alternative<std::string>(a.value) &&
-             absl::get<std::string>(a.value) == s;
+      return std::holds_alternative<std::string>(a.value) &&
+             std::get<std::string>(a.value) == s;
     }
     bool operator()(PathTemplate::Variable const& v) {
-      return absl::holds_alternative<PathTemplate::Variable>(a.value) &&
-             SameValues(absl::get<PathTemplate::Variable>(a.value), v);
+      return std::holds_alternative<PathTemplate::Variable>(a.value) &&
+             SameValues(std::get<PathTemplate::Variable>(a.value), v);
     }
   };
-  return absl::visit(Visitor{a}, b.value);
+  return std::visit(Visitor{a}, b.value);
 }
 
 bool SameValues(PathTemplate const& a, PathTemplate const& b) {

--- a/generator/internal/http_option_utils.cc
+++ b/generator/internal/http_option_utils.cc
@@ -30,6 +30,7 @@
 #include <google/protobuf/descriptor.h>
 #include <optional>
 #include <regex>
+#include <variant>
 #include <vector>
 
 using ::google::protobuf::MethodDescriptor;
@@ -96,7 +97,7 @@ struct RestPathVisitor {
 void RestPathVisitorHelper(
     std::optional<std::string> api_version, PathTemplate::Segment const& s,
     std::vector<HttpExtensionInfo::RestPathPiece>& path) {
-  absl::visit(RestPathVisitor{std::move(api_version), path}, s.value);
+  std::visit(RestPathVisitor{std::move(api_version), path}, s.value);
 }
 
 std::string FormatQueryParameterCode(
@@ -319,15 +320,15 @@ HttpExtensionInfo ParseHttpExtension(google::api::HttpRule const& http_rule) {
   };
   auto segment_formatter = [](std::string* out,
                               std::shared_ptr<PathTemplate::Segment> const& s) {
-    out->append(absl::visit(SegmentAsStringVisitor{}, s->value));
+    out->append(std::visit(SegmentAsStringVisitor{}, s->value));
   };
 
   auto api_version = FormatApiVersionFromUrlPattern(info.url_path);
   auto rest_path_visitor =
       RestPathVisitor(std::move(api_version), info.rest_path);
   for (auto const& s : parsed_http_rule->segments) {
-    if (absl::holds_alternative<PathTemplate::Variable>(s->value)) {
-      auto v = absl::get<PathTemplate::Variable>(s->value);
+    if (std::holds_alternative<PathTemplate::Variable>(s->value)) {
+      auto v = std::get<PathTemplate::Variable>(s->value);
       if (v.segments.empty()) {
         info.field_substitutions.emplace_back(v.field_path, v.field_path);
       } else {
@@ -336,7 +337,7 @@ HttpExtensionInfo ParseHttpExtension(google::api::HttpRule const& http_rule) {
       }
     }
 
-    absl::visit(rest_path_visitor, s->value);
+    std::visit(rest_path_visitor, s->value);
   }
 
   info.rest_path_verb = parsed_http_rule->verb;

--- a/generator/internal/longrunning.cc
+++ b/generator/internal/longrunning.cc
@@ -19,9 +19,9 @@
 #include "google/cloud/extended_operations.pb.h"
 #include "google/cloud/log.h"
 #include "absl/strings/str_cat.h"
-#include "absl/types/variant.h"
 #include "google/longrunning/operations.pb.h"
 #include <string>
+#include <variant>
 
 using ::google::protobuf::Descriptor;
 using ::google::protobuf::MethodDescriptor;
@@ -31,7 +31,7 @@ namespace cloud {
 namespace generator_internal {
 namespace {
 
-absl::variant<std::string, Descriptor const*> FullyQualifyMessageType(
+std::variant<std::string, Descriptor const*> FullyQualifyMessageType(
     MethodDescriptor const& method, std::string message_type) {
   Descriptor const* output_type =
       method.file()->pool()->FindMessageTypeByName(message_type);
@@ -63,7 +63,7 @@ struct FormatDoxygenLinkVisitor {
   }
 };
 
-absl::variant<std::string, Descriptor const*>
+std::variant<std::string, Descriptor const*>
 DeduceLongrunningOperationResponseType(
     MethodDescriptor const& method,
     google::longrunning::OperationInfo const& operation_info) {
@@ -100,36 +100,36 @@ void SetLongrunningOperationMethodVars(
   if (IsGRPCLongrunningOperation(method)) {
     auto operation_info =
         method.options().GetExtension(google::longrunning::operation_info);
-    method_vars["longrunning_metadata_type"] = ProtoNameToCppName(absl::visit(
+    method_vars["longrunning_metadata_type"] = ProtoNameToCppName(std::visit(
         FullyQualifiedMessageTypeVisitor(),
         FullyQualifyMessageType(method, operation_info.metadata_type())));
-    method_vars["longrunning_response_type"] = ProtoNameToCppName(absl::visit(
+    method_vars["longrunning_response_type"] = ProtoNameToCppName(std::visit(
         FullyQualifiedMessageTypeVisitor(),
         FullyQualifyMessageType(method, operation_info.response_type())));
     auto deduced_response_type =
         DeduceLongrunningOperationResponseType(method, operation_info);
     method_vars["longrunning_deduced_response_message_type"] =
-        absl::visit(FullyQualifiedMessageTypeVisitor(), deduced_response_type);
+        std::visit(FullyQualifiedMessageTypeVisitor(), deduced_response_type);
     method_vars["longrunning_deduced_response_type"] = ProtoNameToCppName(
         method_vars["longrunning_deduced_response_message_type"]);
     method_vars["method_longrunning_deduced_return_doxygen_link"] =
-        absl::visit(FormatDoxygenLinkVisitor{}, deduced_response_type);
+        std::visit(FormatDoxygenLinkVisitor{}, deduced_response_type);
     return;
   }
 
   if (IsHttpLongrunningOperation(method)) {
-    method_vars["longrunning_response_type"] = ProtoNameToCppName(absl::visit(
+    method_vars["longrunning_response_type"] = ProtoNameToCppName(std::visit(
         FullyQualifiedMessageTypeVisitor(),
         FullyQualifyMessageType(
             method, std::string{method.output_type()->full_name()})));
-    absl::variant<std::string, google::protobuf::Descriptor const*>
+    std::variant<std::string, google::protobuf::Descriptor const*>
         deduced_response_type = method.output_type();
     method_vars["longrunning_deduced_response_message_type"] =
-        absl::visit(FullyQualifiedMessageTypeVisitor(), deduced_response_type);
+        std::visit(FullyQualifiedMessageTypeVisitor(), deduced_response_type);
     method_vars["longrunning_deduced_response_type"] = ProtoNameToCppName(
         method_vars["longrunning_deduced_response_message_type"]);
     method_vars["method_longrunning_deduced_return_doxygen_link"] =
-        absl::visit(FormatDoxygenLinkVisitor{}, deduced_response_type);
+        std::visit(FormatDoxygenLinkVisitor{}, deduced_response_type);
   }
 }
 
@@ -169,11 +169,10 @@ void SetLongrunningOperationServiceVars(
       return;
     }
     if (IsHttpLongrunningOperation(*method)) {
-      service_vars["longrunning_response_type"] =
-          ProtoNameToCppName(absl::visit(
-              FullyQualifiedMessageTypeVisitor(),
-              FullyQualifyMessageType(
-                  *method, std::string{method->output_type()->full_name()})));
+      service_vars["longrunning_response_type"] = ProtoNameToCppName(std::visit(
+          FullyQualifiedMessageTypeVisitor(),
+          FullyQualifyMessageType(
+              *method, std::string{method->output_type()->full_name()})));
       auto operation_service_extension =
           method->options().GetExtension(google::cloud::operation_service);
 

--- a/generator/internal/metadata_decorator_generator.cc
+++ b/generator/internal/metadata_decorator_generator.cc
@@ -82,7 +82,7 @@ std::string SetMetadataText(google::protobuf::MethodDescriptor const& method,
       text += "      },\n";
       // In the special match-all case, we do not bother to set a regex.
       if (rp.pattern == "(.*)") {
-        text += "      absl::nullopt},\n";
+        text += "      std::nullopt},\n";
       } else {
         text += "      std::regex{\"" + rp.pattern + "\", std::regex::optimize}},\n";
       }

--- a/generator/internal/metadata_decorator_rest_generator.cc
+++ b/generator/internal/metadata_decorator_rest_generator.cc
@@ -74,7 +74,7 @@ std::string SetMetadataText(google::protobuf::MethodDescriptor const& method,
       text += "      },\n";
       // In the special match-all case, we do not bother to set a regex.
       if (rp.pattern == "(.*)") {
-        text += "      absl::nullopt},\n";
+        text += "      std::nullopt},\n";
       } else {
         text += "      std::regex{\"" + rp.pattern + "\", std::regex::optimize}},\n";
       }

--- a/google/cloud/BUILD.bazel
+++ b/google/cloud/BUILD.bazel
@@ -78,7 +78,6 @@ cc_library(
         "@abseil-cpp//absl/strings:str_format",
         "@abseil-cpp//absl/time",
         "@abseil-cpp//absl/types:span",
-        "@abseil-cpp//absl/types:variant",
         "@opentelemetry-cpp//api",
     ] + select({
         "@platforms//os:windows": [],

--- a/google/cloud/aiplatform/v1/featurestore_online_serving_connection.cc
+++ b/google/cloud/aiplatform/v1/featurestore_online_serving_connection.cc
@@ -50,7 +50,7 @@ FeaturestoreOnlineServingServiceConnection::StreamingReadFeatureValues(
     google::cloud::aiplatform::v1::StreamingReadFeatureValuesRequest const&) {
   return google::cloud::internal::MakeStreamRange<
       google::cloud::aiplatform::v1::ReadFeatureValuesResponse>(
-      []() -> absl::variant<
+      []() -> std::variant<
                Status,
                google::cloud::aiplatform::v1::ReadFeatureValuesResponse> {
         return Status(StatusCode::kUnimplemented, "not implemented");

--- a/google/cloud/aiplatform/v1/internal/featurestore_online_serving_connection_impl.cc
+++ b/google/cloud/aiplatform/v1/internal/featurestore_online_serving_connection_impl.cc
@@ -111,7 +111,7 @@ FeaturestoreOnlineServingServiceConnectionImpl::StreamingReadFeatureValues(
   return internal::MakeStreamRange<
       google::cloud::aiplatform::v1::ReadFeatureValuesResponse>(
       [resumable = std::move(resumable)]()
-          -> absl::variant<
+          -> std::variant<
               Status,
               google::cloud::aiplatform::v1::ReadFeatureValuesResponse> {
         google::cloud::aiplatform::v1::ReadFeatureValuesResponse response;

--- a/google/cloud/aiplatform/v1/internal/prediction_connection_impl.cc
+++ b/google/cloud/aiplatform/v1/internal/prediction_connection_impl.cc
@@ -120,7 +120,7 @@ PredictionServiceConnectionImpl::StreamRawPredict(
       PredictionServiceStreamRawPredictStreamingUpdater, request);
   return internal::MakeStreamRange<google::api::HttpBody>(
       [resumable = std::move(
-           resumable)]() -> absl::variant<Status, google::api::HttpBody> {
+           resumable)]() -> std::variant<Status, google::api::HttpBody> {
         google::api::HttpBody response;
         auto status = resumable->Read(&response);
         if (status.has_value()) return *status;
@@ -204,7 +204,7 @@ PredictionServiceConnectionImpl::ServerStreamingPredict(
   return internal::MakeStreamRange<
       google::cloud::aiplatform::v1::StreamingPredictResponse>(
       [resumable = std::move(resumable)]()
-          -> absl::variant<
+          -> std::variant<
               Status, google::cloud::aiplatform::v1::StreamingPredictResponse> {
         google::cloud::aiplatform::v1::StreamingPredictResponse response;
         auto status = resumable->Read(&response);
@@ -270,7 +270,7 @@ PredictionServiceConnectionImpl::StreamGenerateContent(
   return internal::MakeStreamRange<
       google::cloud::aiplatform::v1::GenerateContentResponse>(
       [resumable = std::move(resumable)]()
-          -> absl::variant<
+          -> std::variant<
               Status, google::cloud::aiplatform::v1::GenerateContentResponse> {
         google::cloud::aiplatform::v1::GenerateContentResponse response;
         auto status = resumable->Read(&response);

--- a/google/cloud/aiplatform/v1/internal/tensorboard_connection_impl.cc
+++ b/google/cloud/aiplatform/v1/internal/tensorboard_connection_impl.cc
@@ -1057,7 +1057,7 @@ TensorboardServiceConnectionImpl::ReadTensorboardBlobData(
   return internal::MakeStreamRange<
       google::cloud::aiplatform::v1::ReadTensorboardBlobDataResponse>(
       [resumable = std::move(resumable)]()
-          -> absl::variant<
+          -> std::variant<
               Status,
               google::cloud::aiplatform::v1::ReadTensorboardBlobDataResponse> {
         google::cloud::aiplatform::v1::ReadTensorboardBlobDataResponse response;

--- a/google/cloud/aiplatform/v1/prediction_connection.cc
+++ b/google/cloud/aiplatform/v1/prediction_connection.cc
@@ -53,7 +53,7 @@ StreamRange<google::api::HttpBody>
 PredictionServiceConnection::StreamRawPredict(
     google::cloud::aiplatform::v1::StreamRawPredictRequest const&) {
   return google::cloud::internal::MakeStreamRange<google::api::HttpBody>(
-      []() -> absl::variant<Status, google::api::HttpBody> {
+      []() -> std::variant<Status, google::api::HttpBody> {
         return Status(StatusCode::kUnimplemented, "not implemented");
       });
 }
@@ -109,7 +109,7 @@ PredictionServiceConnection::ServerStreamingPredict(
   return google::cloud::internal::MakeStreamRange<
       google::cloud::aiplatform::v1::StreamingPredictResponse>(
       []()
-          -> absl::variant<
+          -> std::variant<
               Status, google::cloud::aiplatform::v1::StreamingPredictResponse> {
         return Status(StatusCode::kUnimplemented, "not implemented");
       });
@@ -143,7 +143,7 @@ PredictionServiceConnection::StreamGenerateContent(
     google::cloud::aiplatform::v1::GenerateContentRequest const&) {
   return google::cloud::internal::MakeStreamRange<
       google::cloud::aiplatform::v1::GenerateContentResponse>(
-      []() -> absl::variant<
+      []() -> std::variant<
                Status, google::cloud::aiplatform::v1::GenerateContentResponse> {
         return Status(StatusCode::kUnimplemented, "not implemented");
       });

--- a/google/cloud/aiplatform/v1/tensorboard_connection.cc
+++ b/google/cloud/aiplatform/v1/tensorboard_connection.cc
@@ -320,7 +320,7 @@ TensorboardServiceConnection::ReadTensorboardBlobData(
     google::cloud::aiplatform::v1::ReadTensorboardBlobDataRequest const&) {
   return google::cloud::internal::MakeStreamRange<
       google::cloud::aiplatform::v1::ReadTensorboardBlobDataResponse>(
-      []() -> absl::variant<
+      []() -> std::variant<
                Status,
                google::cloud::aiplatform::v1::ReadTensorboardBlobDataResponse> {
         return Status(StatusCode::kUnimplemented, "not implemented");

--- a/google/cloud/biglake/hive/v1/hive_metastore_connection.cc
+++ b/google/cloud/biglake/hive/v1/hive_metastore_connection.cc
@@ -153,7 +153,7 @@ HiveMetastoreServiceConnection::ListPartitions(
     google::cloud::biglake::hive::v1::ListPartitionsRequest const&) {
   return google::cloud::internal::MakeStreamRange<
       google::cloud::biglake::hive::v1::ListPartitionsResponse>(
-      []() -> absl::variant<
+      []() -> std::variant<
                Status,
                google::cloud::biglake::hive::v1::ListPartitionsResponse> {
         return Status(StatusCode::kUnimplemented, "not implemented");

--- a/google/cloud/biglake/hive/v1/internal/hive_metastore_connection_impl.cc
+++ b/google/cloud/biglake/hive/v1/internal/hive_metastore_connection_impl.cc
@@ -426,7 +426,7 @@ HiveMetastoreServiceConnectionImpl::ListPartitions(
   return internal::MakeStreamRange<
       google::cloud::biglake::hive::v1::ListPartitionsResponse>(
       [resumable = std::move(resumable)]()
-          -> absl::variant<
+          -> std::variant<
               Status,
               google::cloud::biglake::hive::v1::ListPartitionsResponse> {
         google::cloud::biglake::hive::v1::ListPartitionsResponse response;

--- a/google/cloud/bigquery/storage/v1/bigquery_read_connection.cc
+++ b/google/cloud/bigquery/storage/v1/bigquery_read_connection.cc
@@ -48,7 +48,7 @@ BigQueryReadConnection::ReadRows(
     google::cloud::bigquery::storage::v1::ReadRowsRequest const&) {
   return google::cloud::internal::MakeStreamRange<
       google::cloud::bigquery::storage::v1::ReadRowsResponse>(
-      []() -> absl::variant<
+      []() -> std::variant<
                Status, google::cloud::bigquery::storage::v1::ReadRowsResponse> {
         return Status(StatusCode::kUnimplemented, "not implemented");
       });

--- a/google/cloud/bigquery/storage/v1/internal/bigquery_read_connection_impl.cc
+++ b/google/cloud/bigquery/storage/v1/internal/bigquery_read_connection_impl.cc
@@ -98,7 +98,7 @@ BigQueryReadConnectionImpl::ReadRows(
   return internal::MakeStreamRange<
       google::cloud::bigquery::storage::v1::ReadRowsResponse>(
       [resumable = std::move(resumable)]()
-          -> absl::variant<
+          -> std::variant<
               Status, google::cloud::bigquery::storage::v1::ReadRowsResponse> {
         google::cloud::bigquery::storage::v1::ReadRowsResponse response;
         auto status = resumable->Read(&response);

--- a/google/cloud/bigquery/v2/minimal/internal/common_v2_resources.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/common_v2_resources.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/internal/debug_string.h"
 #include "google/cloud/internal/format_time_point.h"
 #include "google/cloud/log.h"
+#include <variant>
 
 namespace google {
 namespace cloud {
@@ -133,7 +134,7 @@ void to_json(nlohmann::json& j, StandardSqlDataType const& t) {
     TypeKind type_kind;
     nlohmann::json& j;
 
-    void operator()(absl::monostate const&) {
+    void operator()(std::monostate const&) {
       j = nlohmann::json{{"typeKind", std::move(type_kind.value)}};
     }
     void operator()(std::shared_ptr<StandardSqlDataType> const& type) {
@@ -148,7 +149,7 @@ void to_json(nlohmann::json& j, StandardSqlDataType const& t) {
     }
   };
 
-  absl::visit(Visitor{t.type_kind, j}, t.sub_type);
+  std::visit(Visitor{t.type_kind, j}, t.sub_type);
 }
 
 void from_json(nlohmann::json const& j, StandardSqlDataType& t) {
@@ -185,7 +186,7 @@ void to_json(nlohmann::json& j, Value const& v) {
   struct Visitor {
     nlohmann::json& j;
 
-    void operator()(absl::monostate const&) {
+    void operator()(std::monostate const&) {
       // Nothing to do.
     }
     void operator()(double const& val) {
@@ -205,7 +206,7 @@ void to_json(nlohmann::json& j, Value const& v) {
     }
   };
 
-  absl::visit(Visitor{j}, v.value_kind);
+  std::visit(Visitor{j}, v.value_kind);
 }
 
 void from_json(nlohmann::json const& j, Value& v) {
@@ -493,7 +494,7 @@ std::string StandardSqlDataType::DebugString(absl::string_view name,
 std::string Value::DebugString(absl::string_view name,
                                TracingOptions const& options,
                                int indent) const {
-  return absl::visit(ValueKindDebugString{name, options, indent}, value_kind);
+  return std::visit(ValueKindDebugString{name, options, indent}, value_kind);
 }
 
 std::string SystemVariables::DebugString(absl::string_view name,

--- a/google/cloud/bigquery/v2/minimal/internal/common_v2_resources.h
+++ b/google/cloud/bigquery/v2/minimal/internal/common_v2_resources.h
@@ -18,10 +18,10 @@
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
 #include "absl/strings/string_view.h"
-#include "absl/types/variant.h"
 #include <nlohmann/json.hpp>
 #include <chrono>
 #include <string>
+#include <variant>
 
 namespace google {
 namespace cloud {
@@ -255,8 +255,8 @@ bool operator==(StandardSqlStructType const& lhs,
 // https://cloud.google.com/bigquery/docs/reference/rest/v2/StandardSqlDataType
 struct StandardSqlDataType {
   using ValueType =
-      absl::variant<absl::monostate, std::shared_ptr<StandardSqlDataType>,
-                    StandardSqlStructType>;
+      std::variant<std::monostate, std::shared_ptr<StandardSqlDataType>,
+                   StandardSqlStructType>;
   TypeKind type_kind;
 
   ValueType sub_type;
@@ -286,8 +286,8 @@ struct Struct;
 // For more details, please see:
 // https://protobuf.dev/reference/protobuf/google.protobuf/#value
 struct Value {
-  using KindType = absl::variant<absl::monostate, double, std::string, bool,
-                                 std::shared_ptr<Struct>, std::vector<Value>>;
+  using KindType = std::variant<std::monostate, double, std::string, bool,
+                                std::shared_ptr<Struct>, std::vector<Value>>;
   KindType value_kind;
 
   std::string DebugString(absl::string_view name,

--- a/google/cloud/bigquery/v2/minimal/internal/dataset_connection.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/dataset_connection.cc
@@ -33,7 +33,7 @@ StatusOr<Dataset> DatasetConnection::GetDataset(GetDatasetRequest const&) {
 StreamRange<ListFormatDataset> DatasetConnection::ListDatasets(
     ListDatasetsRequest const&) {
   return google::cloud::internal::MakeStreamRange<ListFormatDataset>(
-      []() -> absl::variant<Status, ListFormatDataset> {
+      []() -> std::variant<Status, ListFormatDataset> {
         return Status(StatusCode::kUnimplemented, "not implemented");
       });
 }

--- a/google/cloud/bigquery/v2/minimal/internal/job_connection.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_connection.cc
@@ -33,7 +33,7 @@ StatusOr<Job> BigQueryJobConnection::GetJob(GetJobRequest const&) {
 StreamRange<ListFormatJob> BigQueryJobConnection::ListJobs(
     ListJobsRequest const&) {
   return google::cloud::internal::MakeStreamRange<ListFormatJob>(
-      []() -> absl::variant<Status, ListFormatJob> {
+      []() -> std::variant<Status, ListFormatJob> {
         return Status(StatusCode::kUnimplemented, "not implemented");
       });
 }

--- a/google/cloud/bigquery/v2/minimal/internal/project_connection.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/project_connection.cc
@@ -30,7 +30,7 @@ ProjectConnection::~ProjectConnection() = default;
 StreamRange<Project> ProjectConnection::ListProjects(
     ListProjectsRequest const&) {
   return google::cloud::internal::MakeStreamRange<Project>(
-      []() -> absl::variant<Status, Project> {
+      []() -> std::variant<Status, Project> {
         return Status(StatusCode::kUnimplemented, "not implemented");
       });
 }

--- a/google/cloud/bigquery/v2/minimal/internal/table_connection.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/table_connection.cc
@@ -33,7 +33,7 @@ StatusOr<Table> TableConnection::GetTable(GetTableRequest const&) {
 StreamRange<ListFormatTable> TableConnection::ListTables(
     ListTablesRequest const&) {
   return google::cloud::internal::MakeStreamRange<ListFormatTable>(
-      []() -> absl::variant<Status, ListFormatTable> {
+      []() -> std::variant<Status, ListFormatTable> {
         return Status(StatusCode::kUnimplemented, "not implemented");
       });
 }

--- a/google/cloud/bigtable/column_family.h
+++ b/google/cloud/bigtable/column_family.h
@@ -16,13 +16,13 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_COLUMN_FAMILY_H
 
 #include "google/cloud/bigtable/version.h"
-#include "absl/meta/type_traits.h"
 #include "google/bigtable/admin/v2/bigtable_table_admin.pb.h"
 #include "google/bigtable/admin/v2/table.pb.h"
 #include <google/protobuf/util/message_differencer.h>
 #include <chrono>
 #include <memory>
 #include <string>
+#include <type_traits>
 
 namespace google {
 namespace cloud {
@@ -96,7 +96,7 @@ class GcRule {
     // letting the compiler figure things out N levels deep as it recurses on
     // `add_intersection()`.
     static_assert(
-        absl::conjunction<std::is_convertible<GcRuleTypes, GcRule>...>::value,
+        std::conjunction<std::is_convertible<GcRuleTypes, GcRule>...>::value,
         "The arguments to Intersection must be convertible to GcRule");
     GcRule tmp;
     auto& intersection = *tmp.gc_rule_.mutable_intersection();
@@ -121,7 +121,7 @@ class GcRule {
     // letting the compiler figure things out N levels deep as it recurses on
     // `add_intersection()`.
     static_assert(
-        absl::conjunction<std::is_convertible<GcRuleTypes, GcRule>...>::value,
+        std::conjunction<std::is_convertible<GcRuleTypes, GcRule>...>::value,
         "The arguments to Union must be convertible to GcRule");
     GcRule tmp;
     auto& gc_rule_union = *tmp.gc_rule_.mutable_union_();

--- a/google/cloud/bigtable/filters.h
+++ b/google/cloud/bigtable/filters.h
@@ -16,11 +16,11 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_FILTERS_H
 
 #include "google/cloud/bigtable/version.h"
-#include "absl/meta/type_traits.h"
 #include "google/bigtable/v2/data.pb.h"
 #include <google/protobuf/util/message_differencer.h>
 #include <chrono>
 #include <string>
+#include <type_traits>
 
 namespace google {
 namespace cloud {
@@ -572,7 +572,7 @@ class Filter {
     // just letting the compiler figure things out 3 levels deep
     // as it recurses on append_types().
     static_assert(
-        absl::conjunction<std::is_convertible<FilterTypes, Filter>...>::value,
+        std::conjunction<std::is_convertible<FilterTypes, Filter>...>::value,
         "The arguments passed to Chain(...) must be convertible to Filter");
     Filter tmp;
     auto& chain = *tmp.filter_.mutable_chain();
@@ -636,7 +636,7 @@ class Filter {
   template <typename... FilterTypes>
   static Filter Interleave(FilterTypes&&... streams) {
     static_assert(
-        absl::conjunction<std::is_convertible<FilterTypes, Filter>...>::value,
+        std::conjunction<std::is_convertible<FilterTypes, Filter>...>::value,
         "The arguments passed to Interleave(...) must be convertible"
         " to Filter");
     Filter tmp;

--- a/google/cloud/bigtable/internal/async_streaming_read.h
+++ b/google/cloud/bigtable/internal/async_streaming_read.h
@@ -16,7 +16,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_STREAMING_READ_H
 
 #include "google/cloud/internal/async_streaming_read_rpc.h"
-#include "absl/types/variant.h"
 #include <memory>
 #include <string>
 

--- a/google/cloud/bigtable/internal/default_row_reader.cc
+++ b/google/cloud/bigtable/internal/default_row_reader.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/make_status.h"
 #include "google/cloud/internal/retry_loop_helpers.h"
+#include <variant>
 
 namespace google {
 namespace cloud {
@@ -94,7 +95,7 @@ bool DefaultRowReader::NextChunk() {
   return true;
 }
 
-absl::variant<Status, bigtable::Row> DefaultRowReader::Advance() {
+std::variant<Status, bigtable::Row> DefaultRowReader::Advance() {
   // We only want to call ElementRequest if an RPC has previously been
   // made.
   if (stream_is_open_) {
@@ -107,12 +108,12 @@ absl::variant<Status, bigtable::Row> DefaultRowReader::Advance() {
   }
   while (true) {
     auto variant = AdvanceOrFail();
-    if (absl::holds_alternative<bigtable::Row>(variant)) {
+    if (std::holds_alternative<bigtable::Row>(variant)) {
       operation_context_->ElementDelivery(*client_context_);
-      return absl::get<bigtable::Row>(std::move(variant));
+      return std::get<bigtable::Row>(std::move(variant));
     }
 
-    auto status = absl::get<Status>(std::move(variant));
+    auto status = std::get<Status>(std::move(variant));
     if (status.ok()) return Status{};
 
     // In the unlikely case when we have already reached the requested
@@ -151,7 +152,7 @@ absl::variant<Status, bigtable::Row> DefaultRowReader::Advance() {
   }
 }
 
-absl::variant<Status, bigtable::Row> DefaultRowReader::AdvanceOrFail() {
+std::variant<Status, bigtable::Row> DefaultRowReader::AdvanceOrFail() {
   grpc::Status grpc_status;
   if (!stream_) MakeRequest();
   while (!parser_->HasNext()) {

--- a/google/cloud/bigtable/internal/default_row_reader.h
+++ b/google/cloud/bigtable/internal/default_row_reader.h
@@ -26,13 +26,13 @@
 #include "google/cloud/bigtable/rpc_backoff_policy.h"
 #include "google/cloud/bigtable/rpc_retry_policy.h"
 #include "google/cloud/bigtable/version.h"
-#include "absl/types/variant.h"
 #include <grpcpp/grpcpp.h>
 #include <chrono>
 #include <cinttypes>
 #include <functional>
 #include <string>
 #include <thread>
+#include <variant>
 
 namespace google {
 namespace cloud {
@@ -68,11 +68,11 @@ class DefaultRowReader : public RowReaderImpl {
    *
    * This call possibly blocks waiting for data until a full row is available.
    */
-  absl::variant<Status, bigtable::Row> Advance() override;
+  std::variant<Status, bigtable::Row> Advance() override;
 
  private:
   /// Called by Advance(), does not handle retries.
-  absl::variant<Status, bigtable::Row> AdvanceOrFail();
+  std::variant<Status, bigtable::Row> AdvanceOrFail();
 
   /**
    * Move the `processed_chunks_count_` index to the next chunk,

--- a/google/cloud/bigtable/internal/row_reader_impl.h
+++ b/google/cloud/bigtable/internal/row_reader_impl.h
@@ -16,7 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ROW_READER_IMPL_H
 
 #include "google/cloud/bigtable/row.h"
-#include "absl/types/variant.h"
+#include <variant>
 
 namespace google {
 namespace cloud {
@@ -30,7 +30,7 @@ class RowReaderImpl {
 
   virtual void Cancel() = 0;
 
-  virtual absl::variant<Status, bigtable::Row> Advance() = 0;
+  virtual std::variant<Status, bigtable::Row> Advance() = 0;
 };
 
 /**
@@ -45,7 +45,7 @@ class StatusOnlyRowReader : public RowReaderImpl {
 
   void Cancel() override {}
 
-  absl::variant<Status, bigtable::Row> Advance() override { return status_; }
+  std::variant<Status, bigtable::Row> Advance() override { return status_; }
 
  private:
   Status status_;

--- a/google/cloud/bigtable/internal/traced_row_reader.cc
+++ b/google/cloud/bigtable/internal/traced_row_reader.cc
@@ -41,7 +41,7 @@ class TracedRowReader : public bigtable_internal::RowReaderImpl {
     reader_.Cancel();
   };
 
-  absl::variant<Status, bigtable::Row> Advance() override {
+  std::variant<Status, bigtable::Row> Advance() override {
     if (it_ == reader_.end()) return End(Status());
     auto row = *it_;
     ++it_;

--- a/google/cloud/bigtable/mocks/mock_row_reader.cc
+++ b/google/cloud/bigtable/mocks/mock_row_reader.cc
@@ -38,7 +38,7 @@ bigtable::RowReader MakeRowReader(std::vector<bigtable::Row> rows,
     /// Skips remaining rows and invalidates current iterator.
     void Cancel() override { iter_ = rows_.cend(); };
 
-    absl::variant<Status, bigtable::Row> Advance() override {
+    std::variant<Status, bigtable::Row> Advance() override {
       if (iter_ == rows_.cend()) return final_status_;
       return *iter_++;
     }

--- a/google/cloud/bigtable/mutations.h
+++ b/google/cloud/bigtable/mutations.h
@@ -22,7 +22,6 @@
 #include "google/cloud/internal/big_endian.h"
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
-#include "absl/meta/type_traits.h"
 #include "google/bigtable/v2/bigtable.pb.h"
 #include "google/bigtable/v2/data.pb.h"
 #include <google/protobuf/util/message_differencer.h>
@@ -325,7 +324,7 @@ class SingleRowMutation {
             >
   explicit SingleRowMutation(RowKey&& row_key, M&&... m) {
     static_assert(
-        absl::conjunction<std::is_convertible<M, Mutation>...>::value,
+        std::conjunction<std::is_convertible<M, Mutation>...>::value,
         "The arguments passed to SingleRowMutation(std::string, ...) must be "
         "convertible to Mutation");
     request_.set_row_key(std::forward<RowKey>(row_key));
@@ -521,13 +520,14 @@ class BulkMutation {
   }
 
   /// Create a multi-row mutation from a variadic list.
-  template <typename... M,
-            /// @cond implementation_details
-            std::enable_if_t<absl::conjunction<std::is_convertible<
-                                 M, SingleRowMutation>...>::value,
-                             int> = 0
-            /// @endcond
-            >
+  template <
+      typename... M,
+      /// @cond implementation_details
+      std::enable_if_t<
+          std::conjunction<std::is_convertible<M, SingleRowMutation>...>::value,
+          int> = 0
+      /// @endcond
+      >
   // NOLINTNEXTLINE(google-explicit-constructor)
   BulkMutation(M&&... m) : BulkMutation() {
     emplace_many(std::forward<M>(m)...);

--- a/google/cloud/bigtable/row_reader_test.cc
+++ b/google/cloud/bigtable/row_reader_test.cc
@@ -61,7 +61,7 @@ TEST(RowReaderTest, IteratorPostincrement) {
 class MockRowReader : public bigtable_internal::RowReaderImpl {
  public:
   MOCK_METHOD(void, Cancel, (), (override));
-  MOCK_METHOD((absl::variant<Status, bigtable::Row>), Advance, (), (override));
+  MOCK_METHOD((std::variant<Status, bigtable::Row>), Advance, (), (override));
 };
 
 TEST(RowReaderTest, OptionsSpan) {

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -40,8 +40,8 @@
 #include "google/cloud/options.h"
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
-#include "absl/meta/type_traits.h"
 #include <string>
+#include <type_traits>
 #include <vector>
 
 namespace google {
@@ -157,13 +157,13 @@ class Table {
   /// A meta function to check if @p P is a valid Policy type.
   template <typename P>
   struct ValidPolicy
-      : absl::disjunction<std::is_base_of<RPCBackoffPolicy, P>,
-                          std::is_base_of<RPCRetryPolicy, P>,
-                          std::is_base_of<IdempotentMutationPolicy, P>> {};
+      : std::disjunction<std::is_base_of<RPCBackoffPolicy, P>,
+                         std::is_base_of<RPCRetryPolicy, P>,
+                         std::is_base_of<IdempotentMutationPolicy, P>> {};
 
   /// A meta function to check if all the @p Policies are valid policy types.
   template <typename... Policies>
-  struct ValidPolicies : absl::conjunction<ValidPolicy<Policies>...> {};
+  struct ValidPolicies : std::conjunction<ValidPolicy<Policies>...> {};
 
  public:
   /**
@@ -589,7 +589,7 @@ class Table {
     // Generate a better compile time error message than the default one
     // if the types do not match
     static_assert(
-        absl::conjunction<absl::disjunction<
+        std::conjunction<std::disjunction<
             std::is_convertible<Args, bigtable::ReadModifyWriteRule>,
             std::is_same<std::decay_t<Args>, Options>>...>::value,
         "The arguments passed to ReadModifyWriteRow(row_key,...) must be "
@@ -643,7 +643,7 @@ class Table {
     // Generate a better compile time error message than the default one
     // if the types do not match
     static_assert(
-        absl::conjunction<absl::disjunction<
+        std::conjunction<std::disjunction<
             std::is_convertible<Args, bigtable::ReadModifyWriteRule>,
             std::is_same<std::decay_t<Args>, Options>>...>::value,
         "The arguments passed to AsyncReadModifyWriteRow(row_key,...) must be "

--- a/google/cloud/bigtable/value_test.cc
+++ b/google/cloud/bigtable/value_test.cc
@@ -305,8 +305,8 @@ template <
         std::is_same<std::remove_cv_t<std::remove_reference_t<U>>,
                      absl::Cord>::value>::type* = nullptr,
     typename std::enable_if_t<
-        absl::disjunction<std::is_same<T, std::string>,
-                          std::is_same<T, std::optional<std::string>>>::value,
+        std::disjunction<std::is_same<T, std::string>,
+                         std::is_same<T, std::optional<std::string>>>::value,
         int> = 0>
 
 StatusOr<T> MovedFromString(Value const&) {

--- a/google/cloud/ces/v1/internal/session_connection_impl.cc
+++ b/google/cloud/ces/v1/internal/session_connection_impl.cc
@@ -93,7 +93,7 @@ SessionServiceConnectionImpl::StreamRunSession(
       SessionServiceStreamRunSessionStreamingUpdater, request);
   return internal::MakeStreamRange<google::cloud::ces::v1::RunSessionResponse>(
       [resumable = std::move(resumable)]()
-          -> absl::variant<Status, google::cloud::ces::v1::RunSessionResponse> {
+          -> std::variant<Status, google::cloud::ces::v1::RunSessionResponse> {
         google::cloud::ces::v1::RunSessionResponse response;
         auto status = resumable->Read(&response);
         if (status.has_value()) return *status;

--- a/google/cloud/ces/v1/session_connection.cc
+++ b/google/cloud/ces/v1/session_connection.cc
@@ -49,8 +49,7 @@ SessionServiceConnection::StreamRunSession(
     google::cloud::ces::v1::RunSessionRequest const&) {
   return google::cloud::internal::MakeStreamRange<
       google::cloud::ces::v1::RunSessionResponse>(
-      []()
-          -> absl::variant<Status, google::cloud::ces::v1::RunSessionResponse> {
+      []() -> std::variant<Status, google::cloud::ces::v1::RunSessionResponse> {
         return Status(StatusCode::kUnimplemented, "not implemented");
       });
 }

--- a/google/cloud/datacatalog/lineage/v1/internal/lineage_connection_impl.cc
+++ b/google/cloud/datacatalog/lineage/v1/internal/lineage_connection_impl.cc
@@ -636,8 +636,8 @@ LineageConnectionImpl::SearchLineageStreaming(
   return internal::MakeStreamRange<
       google::cloud::datacatalog::lineage::v1::SearchLineageStreamingResponse>(
       [resumable = std::move(resumable)]()
-          -> absl::variant<Status, google::cloud::datacatalog::lineage::v1::
-                                       SearchLineageStreamingResponse> {
+          -> std::variant<Status, google::cloud::datacatalog::lineage::v1::
+                                      SearchLineageStreamingResponse> {
         google::cloud::datacatalog::lineage::v1::SearchLineageStreamingResponse
             response;
         auto status = resumable->Read(&response);

--- a/google/cloud/datacatalog/lineage/v1/lineage_connection.cc
+++ b/google/cloud/datacatalog/lineage/v1/lineage_connection.cc
@@ -190,8 +190,8 @@ LineageConnection::SearchLineageStreaming(
         SearchLineageStreamingRequest const&) {
   return google::cloud::internal::MakeStreamRange<
       google::cloud::datacatalog::lineage::v1::SearchLineageStreamingResponse>(
-      []() -> absl::variant<Status, google::cloud::datacatalog::lineage::v1::
-                                        SearchLineageStreamingResponse> {
+      []() -> std::variant<Status, google::cloud::datacatalog::lineage::v1::
+                                       SearchLineageStreamingResponse> {
         return Status(StatusCode::kUnimplemented, "not implemented");
       });
 }

--- a/google/cloud/dialogflow_cx/internal/sessions_connection_impl.cc
+++ b/google/cloud/dialogflow_cx/internal/sessions_connection_impl.cc
@@ -98,7 +98,7 @@ SessionsConnectionImpl::ServerStreamingDetectIntent(
   return internal::MakeStreamRange<
       google::cloud::dialogflow::cx::v3::DetectIntentResponse>(
       [resumable = std::move(resumable)]()
-          -> absl::variant<
+          -> std::variant<
               Status, google::cloud::dialogflow::cx::v3::DetectIntentResponse> {
         google::cloud::dialogflow::cx::v3::DetectIntentResponse response;
         auto status = resumable->Read(&response);

--- a/google/cloud/dialogflow_cx/sessions_connection.cc
+++ b/google/cloud/dialogflow_cx/sessions_connection.cc
@@ -50,7 +50,7 @@ SessionsConnection::ServerStreamingDetectIntent(
   return google::cloud::internal::MakeStreamRange<
       google::cloud::dialogflow::cx::v3::DetectIntentResponse>(
       []()
-          -> absl::variant<
+          -> std::variant<
               Status, google::cloud::dialogflow::cx::v3::DetectIntentResponse> {
         return Status(StatusCode::kUnimplemented, "not implemented");
       });

--- a/google/cloud/discoveryengine/v1/conversational_search_connection.cc
+++ b/google/cloud/discoveryengine/v1/conversational_search_connection.cc
@@ -88,7 +88,7 @@ ConversationalSearchServiceConnection::StreamAnswerQuery(
   return google::cloud::internal::MakeStreamRange<
       google::cloud::discoveryengine::v1::AnswerQueryResponse>(
       []()
-          -> absl::variant<
+          -> std::variant<
               Status, google::cloud::discoveryengine::v1::AnswerQueryResponse> {
         return Status(StatusCode::kUnimplemented, "not implemented");
       });

--- a/google/cloud/discoveryengine/v1/internal/conversational_search_connection_impl.cc
+++ b/google/cloud/discoveryengine/v1/internal/conversational_search_connection_impl.cc
@@ -227,7 +227,7 @@ ConversationalSearchServiceConnectionImpl::StreamAnswerQuery(
   return internal::MakeStreamRange<
       google::cloud::discoveryengine::v1::AnswerQueryResponse>(
       [resumable = std::move(resumable)]()
-          -> absl::variant<
+          -> std::variant<
               Status, google::cloud::discoveryengine::v1::AnswerQueryResponse> {
         google::cloud::discoveryengine::v1::AnswerQueryResponse response;
         auto status = resumable->Read(&response);

--- a/google/cloud/future_generic.h
+++ b/google/cloud/future_generic.h
@@ -20,7 +20,6 @@
 #include "google/cloud/internal/future_impl.h"
 #include "google/cloud/internal/invoke_result.h"
 #include "google/cloud/version.h"
-#include "absl/meta/type_traits.h"
 #include <future>
 #include <type_traits>
 
@@ -64,7 +63,7 @@ class future final : private internal::future_base<T> {
    * future's result type.
    */
   template <class U, typename Enable =
-                         absl::enable_if_t<std::is_constructible<T, U>::value>>
+                         std::enable_if_t<std::is_constructible<T, U>::value>>
   explicit future(future<U>&& rhs);
 
   /**

--- a/google/cloud/geminidataanalytics/v1/data_chat_connection.cc
+++ b/google/cloud/geminidataanalytics/v1/data_chat_connection.cc
@@ -43,8 +43,8 @@ DataChatServiceConnection::Chat(
     google::cloud::geminidataanalytics::v1::ChatRequest const&) {
   return google::cloud::internal::MakeStreamRange<
       google::cloud::geminidataanalytics::v1::Message>(
-      []() -> absl::variant<Status,
-                            google::cloud::geminidataanalytics::v1::Message> {
+      []() -> std::variant<Status,
+                           google::cloud::geminidataanalytics::v1::Message> {
         return Status(StatusCode::kUnimplemented, "not implemented");
       });
 }

--- a/google/cloud/geminidataanalytics/v1/internal/data_chat_connection_impl.cc
+++ b/google/cloud/geminidataanalytics/v1/internal/data_chat_connection_impl.cc
@@ -89,8 +89,8 @@ DataChatServiceConnectionImpl::Chat(
   return internal::MakeStreamRange<
       google::cloud::geminidataanalytics::v1::Message>(
       [resumable = std::move(resumable)]()
-          -> absl::variant<Status,
-                           google::cloud::geminidataanalytics::v1::Message> {
+          -> std::variant<Status,
+                          google::cloud::geminidataanalytics::v1::Message> {
         google::cloud::geminidataanalytics::v1::Message response;
         auto status = resumable->Read(&response);
         if (status.has_value()) return *status;

--- a/google/cloud/google_cloud_cpp_common.cmake
+++ b/google/cloud/google_cloud_cpp_common.cmake
@@ -184,11 +184,9 @@ target_link_libraries(
     google_cloud_cpp_common
     PUBLIC absl::base
            absl::memory
-           absl::optional
            absl::span
            absl::str_format
            absl::time
-           absl::variant
            Threads::Threads)
 if (WIN32)
     target_compile_definitions(google_cloud_cpp_common
@@ -255,12 +253,10 @@ google_cloud_cpp_add_pkgconfig(
     "common"
     "Google Cloud C++ Client Library Common Components"
     "Common Components used by the Google Cloud C++ Client Libraries."
-    "absl_optional"
     "absl_span"
     "absl_strings"
     "absl_time"
     "absl_time_zone"
-    "absl_variant"
     "${GOOGLE_CLOUD_CPP_OPENTELEMETRY_API}"
     NON_WIN32_REQUIRES
     openssl
@@ -428,7 +424,6 @@ if (BUILD_TESTING)
             PRIVATE google_cloud_cpp_testing
                     google-cloud-cpp::common
                     google-cloud-cpp::mocks
-                    absl::variant
                     GTest::gmock_main
                     GTest::gmock
                     GTest::gtest)

--- a/google/cloud/google_cloud_cpp_common.cmake
+++ b/google/cloud/google_cloud_cpp_common.cmake
@@ -181,13 +181,8 @@ add_library(
     version.cc
     version.h)
 target_link_libraries(
-    google_cloud_cpp_common
-    PUBLIC absl::base
-           absl::memory
-           absl::span
-           absl::str_format
-           absl::time
-           Threads::Threads)
+    google_cloud_cpp_common PUBLIC absl::base absl::memory absl::span
+                                   absl::str_format absl::time Threads::Threads)
 if (WIN32)
     target_compile_definitions(google_cloud_cpp_common
                                PRIVATE WIN32_LEAN_AND_MEAN)
@@ -421,11 +416,8 @@ if (BUILD_TESTING)
         google_cloud_cpp_add_executable(target "common" "${fname}")
         target_link_libraries(
             ${target}
-            PRIVATE google_cloud_cpp_testing
-                    google-cloud-cpp::common
-                    google-cloud-cpp::mocks
-                    GTest::gmock_main
-                    GTest::gmock
+            PRIVATE google_cloud_cpp_testing google-cloud-cpp::common
+                    google-cloud-cpp::mocks GTest::gmock_main GTest::gmock
                     GTest::gtest)
         google_cloud_cpp_add_common_options(${target})
         add_test(NAME ${target} COMMAND ${target})

--- a/google/cloud/google_cloud_cpp_grpc_utils.cmake
+++ b/google/cloud/google_cloud_cpp_grpc_utils.cmake
@@ -112,7 +112,6 @@ target_link_libraries(
     PUBLIC absl::function_ref
            absl::memory
            absl::time
-           absl::variant
            google-cloud-cpp::iam_credentials_v1_iamcredentials_protos
            google-cloud-cpp::iam_v1_policy_protos
            google-cloud-cpp::longrunning_operations_protos
@@ -183,7 +182,6 @@ google_cloud_cpp_add_pkgconfig(
     "absl_strings"
     "absl_time"
     "absl_time_zone"
-    "absl_variant"
     "openssl")
 # Create and install the CMake configuration files.
 configure_file("config-grpc-utils.cmake.in"
@@ -208,7 +206,6 @@ function (google_cloud_cpp_grpc_utils_add_test fname labels)
                 google_cloud_cpp_testing_grpc
                 google_cloud_cpp_testing
                 google-cloud-cpp::common
-                absl::variant
                 GTest::gmock_main
                 GTest::gmock
                 GTest::gtest
@@ -308,7 +305,6 @@ if (BUILD_TESTING)
                     google_cloud_cpp_testing
                     google-cloud-cpp::common
                     google-cloud-cpp::iam_credentials_v1_iamcredentials_protos
-                    absl::variant
                     GTest::gmock_main
                     GTest::gmock
                     GTest::gtest

--- a/google/cloud/google_cloud_cpp_rest_protobuf_internal.cmake
+++ b/google/cloud/google_cloud_cpp_rest_protobuf_internal.cmake
@@ -106,7 +106,6 @@ function (google_cloud_cpp_rest_protobuf_internal_add_test fname labels)
                 google_cloud_cpp_testing_grpc
                 google_cloud_cpp_testing
                 google-cloud-cpp::common
-                absl::variant
                 GTest::gmock_main
                 GTest::gmock
                 GTest::gtest)

--- a/google/cloud/google_cloud_cpp_universe_domain.cmake
+++ b/google/cloud/google_cloud_cpp_universe_domain.cmake
@@ -85,7 +85,7 @@ function (google_cloud_cpp_universe_domain_add_test fname labels)
     target_link_libraries(
         ${target}
         PRIVATE google-cloud-cpp::universe_domain google_cloud_cpp_testing
-                absl::variant GTest::gmock_main GTest::gmock GTest::gtest)
+                GTest::gmock_main GTest::gmock GTest::gtest)
     google_cloud_cpp_add_common_options(${target})
     add_test(NAME ${target} COMMAND ${target})
     set_tests_properties(${target} PROPERTIES LABELS "${labels}")

--- a/google/cloud/internal/future_impl.h
+++ b/google/cloud/internal/future_impl.h
@@ -18,7 +18,6 @@
 #include "google/cloud/internal/future_fwd.h"
 #include "google/cloud/terminate_handler.h"
 #include "google/cloud/version.h"
-#include "absl/types/variant.h"
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
@@ -26,6 +25,7 @@
 #include <future>
 #include <mutex>
 #include <utility>
+#include <variant>
 
 namespace google {
 namespace cloud {
@@ -49,7 +49,7 @@ class future_shared_state;
 /**
  * A monostate for `future<void>`.
  *
- * The implementation already uses `absl::monostate` to represent "future<void>
+ * The implementation already uses `std::monostate` to represent "future<void>
  * is **not** set". We need a distinct type to represent "`future<void>` value
  * is set".
  */
@@ -159,7 +159,7 @@ class future_shared_state final {  // NOLINT(readability-identifier-naming)
   /**
    * The different states of the shared state.
    *
-   * The shared state is initialized with `absl::monostate`, this represents
+   * The shared state is initialized with `std::monostate`, this represents
    * an unsatisfied future.
    *
    * The future may be satisfied with an exception, stored as a
@@ -171,8 +171,8 @@ class future_shared_state final {  // NOLINT(readability-identifier-naming)
    * Finally, the value and/or exception may be retrieved as part of invoking
    * any continuation. We store this as a `FutureValueRetrieved`.
    */
-  using ValueType = absl::variant<absl::monostate, std::exception_ptr, T,
-                                  FutureValueRetrieved>;
+  using ValueType =
+      std::variant<std::monostate, std::exception_ptr, T, FutureValueRetrieved>;
 
 #if __clang__
 #elif __GNUC__
@@ -212,7 +212,7 @@ class future_shared_state final {  // NOLINT(readability-identifier-naming)
         ThrowFutureError(std::future_errc::no_state,
                          "future<T>::get() - already retrieved");
       }
-      T operator()(absl::monostate) {
+      T operator()(std::monostate) {
         ThrowFutureError(std::future_errc::no_state,
                          "future<T>::get() - not set");
       }
@@ -222,7 +222,7 @@ class future_shared_state final {  // NOLINT(readability-identifier-naming)
     // future, so new calls will fail.
     ValueType tmp(FutureValueRetrieved{});
     tmp.swap(value_);
-    return absl::visit(Visitor{}, std::move(tmp));
+    return std::visit(Visitor{}, std::move(tmp));
   }
 
   /**
@@ -421,7 +421,7 @@ class future_shared_state final {  // NOLINT(readability-identifier-naming)
 
  protected:
   bool is_ready_unlocked() const {
-    return !absl::holds_alternative<absl::monostate>(value_);
+    return !std::holds_alternative<std::monostate>(value_);
   }
 
   /// Satisfy the shared state using an exception.
@@ -468,7 +468,7 @@ class future_shared_state final {  // NOLINT(readability-identifier-naming)
 
   /// Synchronize changes to `value_` and `cv_`.
   mutable std::mutex mu_;
-  /// Used to wait until `value_` does not contain `absl::monostate`.
+  /// Used to wait until `value_` does not contain `std::monostate`.
   std::condition_variable cv_;
   /// The value of the shared state.
   ValueType value_;

--- a/google/cloud/internal/future_then_impl.h
+++ b/google/cloud/internal/future_then_impl.h
@@ -22,6 +22,7 @@
 #include "absl/functional/function_ref.h"
 #include <exception>
 #include <type_traits>
+#include <variant>
 
 namespace google {
 namespace cloud {
@@ -97,14 +98,14 @@ struct FutureThenImpl {
         struct Visitor {
           std::shared_ptr<future_shared_state<U>> output;
 
-          void operator()(absl::monostate) { output->abandon(); }
+          void operator()(std::monostate) { output->abandon(); }
           void operator()(std::exception_ptr e) {
             output->set_exception(std::move(e));
           }
           void operator()(FutureValueRetrieved) { output->abandon(); }
           void operator()(T v) { set_value(*output, std::move(v)); }
         };
-        return absl::visit(Visitor{std::move(output_)}, s.value());
+        return std::visit(Visitor{std::move(output_)}, s.value());
       }
 
      private:
@@ -131,7 +132,7 @@ struct FutureThenImpl {
         struct Visitor {
           std::shared_ptr<future_shared_state<U>> output;
 
-          void operator()(absl::monostate) { output->abandon(); }
+          void operator()(std::monostate) { output->abandon(); }
           void operator()(std::exception_ptr e) {
             output->set_exception(std::move(e));
           }
@@ -140,7 +141,7 @@ struct FutureThenImpl {
             unwrap(std::move(output), std::move(v.shared_state_));
           }
         };
-        return absl::visit(Visitor{std::move(output_)}, s.value());
+        return std::visit(Visitor{std::move(output_)}, s.value());
       }
 
      private:

--- a/google/cloud/internal/streaming_read_rpc_logging_test.cc
+++ b/google/cloud/internal/streaming_read_rpc_logging_test.cc
@@ -16,7 +16,6 @@
 #include "google/cloud/status.h"
 #include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/tracing_options.h"
-#include "absl/types/variant.h"
 #include "google/protobuf/duration.pb.h"
 #include <gmock/gmock.h>
 

--- a/google/cloud/internal/traced_stream_range.h
+++ b/google/cloud/internal/traced_stream_range.h
@@ -39,7 +39,7 @@ class TracedStreamRange {
     (void)End(Status());
   }
 
-  absl::variant<Status, T> Advance() {
+  std::variant<Status, T> Advance() {
     if (it_ == sr_.end()) return End(Status());
     auto sor = *it_;
     ++it_;

--- a/google/cloud/internal/type_list.h
+++ b/google/cloud/internal/type_list.h
@@ -16,7 +16,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_TYPE_LIST_H
 
 #include "google/cloud/version.h"
-#include "absl/meta/type_traits.h"
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -93,7 +92,7 @@ struct TypeListHasType;
 
 template <typename... Us, typename T>
 struct TypeListHasType<TypeList<Us...>, T>
-    : absl::disjunction<std::is_same<T, Us>...> {};
+    : std::disjunction<std::is_same<T, Us>...> {};
 
 template <template <typename> class Predicate, typename List>
 struct TypeListFilter;

--- a/google/cloud/mocks/mock_stream_range.h
+++ b/google/cloud/mocks/mock_stream_range.h
@@ -55,7 +55,7 @@ StreamRange<T> MakeStreamRange(std::vector<T> values,
   auto iter = values.begin();
   auto reader =
       [v = std::move(values), it = std::move(iter),
-       s = std::move(final_status)]() mutable -> absl::variant<Status, T> {
+       s = std::move(final_status)]() mutable -> std::variant<Status, T> {
     if (it == v.end()) return s;
     return *it++;
   };

--- a/google/cloud/opentelemetry/internal/monitored_resource.cc
+++ b/google/cloud/opentelemetry/internal/monitored_resource.cc
@@ -16,8 +16,6 @@
 #include "google/cloud/version.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
-#include "absl/types/optional.h"
-#include "absl/types/variant.h"
 #include <opentelemetry/common/attribute_value.h>
 #include <opentelemetry/sdk/resource/resource.h>
 #include <opentelemetry/semconv/incubating/cloud_attributes.h>

--- a/google/cloud/opentelemetry/internal/monitored_resource_test.cc
+++ b/google/cloud/opentelemetry/internal/monitored_resource_test.cc
@@ -14,13 +14,13 @@
 
 #include "google/cloud/opentelemetry/internal/monitored_resource.h"
 #include "google/cloud/version.h"
-#include "absl/types/optional.h"
 #include <gmock/gmock.h>
 #include <opentelemetry/semconv/incubating/cloud_attributes.h>
 #include <opentelemetry/semconv/incubating/faas_attributes.h>
 #include <opentelemetry/semconv/incubating/host_attributes.h>
 #include <opentelemetry/semconv/incubating/k8s_attributes.h>
 #include <opentelemetry/semconv/incubating/service_attributes.h>
+#include <optional>
 
 namespace google {
 namespace cloud {
@@ -87,14 +87,14 @@ TEST(MonitoredResource, GceInstance) {
 
 TEST(MonitoredResource, K8sContainer) {
   struct TestCase {
-    absl::optional<std::string> zone;
-    absl::optional<std::string> region;
+    std::optional<std::string> zone;
+    std::optional<std::string> region;
     std::string expected_location;
   };
   auto tests = std::vector<TestCase>{
       {"us-central1-a", "us-central1", "us-central1-a"},
-      {"us-central1-a", absl::nullopt, "us-central1-a"},
-      {absl::nullopt, "us-central1", "us-central1"},
+      {"us-central1-a", std::nullopt, "us-central1-a"},
+      {std::nullopt, "us-central1", "us-central1"},
   };
   for (auto const& test : tests) {
     auto attributes = opentelemetry::sdk::resource::ResourceAttributes{
@@ -120,14 +120,14 @@ TEST(MonitoredResource, K8sContainer) {
 
 TEST(MonitoredResource, K8sPod) {
   struct TestCase {
-    absl::optional<std::string> zone;
-    absl::optional<std::string> region;
+    std::optional<std::string> zone;
+    std::optional<std::string> region;
     std::string expected_location;
   };
   auto tests = std::vector<TestCase>{
       {"us-central1-a", "us-central1", "us-central1-a"},
-      {"us-central1-a", absl::nullopt, "us-central1-a"},
-      {absl::nullopt, "us-central1", "us-central1"},
+      {"us-central1-a", std::nullopt, "us-central1-a"},
+      {std::nullopt, "us-central1", "us-central1"},
   };
   for (auto const& test : tests) {
     auto attributes = opentelemetry::sdk::resource::ResourceAttributes{
@@ -151,14 +151,14 @@ TEST(MonitoredResource, K8sPod) {
 
 TEST(MonitoredResource, K8sNode) {
   struct TestCase {
-    absl::optional<std::string> zone;
-    absl::optional<std::string> region;
+    std::optional<std::string> zone;
+    std::optional<std::string> region;
     std::string expected_location;
   };
   auto tests = std::vector<TestCase>{
       {"us-central1-a", "us-central1", "us-central1-a"},
-      {"us-central1-a", absl::nullopt, "us-central1-a"},
-      {absl::nullopt, "us-central1", "us-central1"},
+      {"us-central1-a", std::nullopt, "us-central1-a"},
+      {std::nullopt, "us-central1", "us-central1"},
   };
   for (auto const& test : tests) {
     auto attributes = opentelemetry::sdk::resource::ResourceAttributes{
@@ -180,14 +180,14 @@ TEST(MonitoredResource, K8sNode) {
 
 TEST(MonitoredResource, K8sCluster) {
   struct TestCase {
-    absl::optional<std::string> zone;
-    absl::optional<std::string> region;
+    std::optional<std::string> zone;
+    std::optional<std::string> region;
     std::string expected_location;
   };
   auto tests = std::vector<TestCase>{
       {"us-central1-a", "us-central1", "us-central1-a"},
-      {"us-central1-a", absl::nullopt, "us-central1-a"},
-      {absl::nullopt, "us-central1", "us-central1"},
+      {"us-central1-a", std::nullopt, "us-central1-a"},
+      {std::nullopt, "us-central1", "us-central1"},
   };
   for (auto const& test : tests) {
     auto attributes = opentelemetry::sdk::resource::ResourceAttributes{
@@ -207,14 +207,14 @@ TEST(MonitoredResource, K8sCluster) {
 
 TEST(MonitoredResource, GaeInstance) {
   struct TestCase {
-    absl::optional<std::string> zone;
-    absl::optional<std::string> region;
+    std::optional<std::string> zone;
+    std::optional<std::string> region;
     std::string expected_location;
   };
   auto tests = std::vector<TestCase>{
       {"us-central1-a", "us-central1", "us-central1-a"},
-      {"us-central1-a", absl::nullopt, "us-central1-a"},
-      {absl::nullopt, "us-central1", "us-central1"},
+      {"us-central1-a", std::nullopt, "us-central1-a"},
+      {std::nullopt, "us-central1", "us-central1"},
   };
   for (auto const& test : tests) {
     auto attributes = opentelemetry::sdk::resource::ResourceAttributes{
@@ -238,14 +238,14 @@ TEST(MonitoredResource, GaeInstance) {
 
 TEST(MonitoredResource, AwsEc2Instance) {
   struct TestCase {
-    absl::optional<std::string> zone;
-    absl::optional<std::string> region;
+    std::optional<std::string> zone;
+    std::optional<std::string> region;
     std::string expected_region;
   };
   auto tests = std::vector<TestCase>{
       {"test-zone", "test-region", "test-zone"},
-      {"test-zone", absl::nullopt, "test-zone"},
-      {absl::nullopt, "test-region", "test-region"},
+      {"test-zone", std::nullopt, "test-zone"},
+      {std::nullopt, "test-region", "test-region"},
   };
   for (auto const& test : tests) {
     auto attributes = opentelemetry::sdk::resource::ResourceAttributes{
@@ -267,15 +267,15 @@ TEST(MonitoredResource, AwsEc2Instance) {
 
 TEST(MonitoredResource, GenericTaskFaas) {
   struct TestCase {
-    absl::optional<std::string> zone;
-    absl::optional<std::string> region;
+    std::optional<std::string> zone;
+    std::optional<std::string> region;
     std::string expected_location;
   };
   auto tests = std::vector<TestCase>{
       {"us-central1-a", "us-central1", "us-central1-a"},
-      {"us-central1-a", absl::nullopt, "us-central1-a"},
-      {absl::nullopt, "us-central1", "us-central1"},
-      {absl::nullopt, absl::nullopt, "global"},
+      {"us-central1-a", std::nullopt, "us-central1-a"},
+      {std::nullopt, "us-central1", "us-central1"},
+      {std::nullopt, std::nullopt, "global"},
   };
   for (auto const& test : tests) {
     auto attributes = opentelemetry::sdk::resource::ResourceAttributes{
@@ -297,15 +297,15 @@ TEST(MonitoredResource, GenericTaskFaas) {
 
 TEST(MonitoredResource, GenericTaskService) {
   struct TestCase {
-    absl::optional<std::string> zone;
-    absl::optional<std::string> region;
+    std::optional<std::string> zone;
+    std::optional<std::string> region;
     std::string expected_location;
   };
   auto tests = std::vector<TestCase>{
       {"us-central1-a", "us-central1", "us-central1-a"},
-      {"us-central1-a", absl::nullopt, "us-central1-a"},
-      {absl::nullopt, "us-central1", "us-central1"},
-      {absl::nullopt, absl::nullopt, "global"},
+      {"us-central1-a", std::nullopt, "us-central1-a"},
+      {std::nullopt, "us-central1", "us-central1"},
+      {std::nullopt, std::nullopt, "global"},
   };
   for (auto const& test : tests) {
     auto attributes = opentelemetry::sdk::resource::ResourceAttributes{
@@ -328,15 +328,15 @@ TEST(MonitoredResource, GenericTaskService) {
 
 TEST(MonitoredResource, GenericNode) {
   struct LocationTestCase {
-    absl::optional<std::string> zone;
-    absl::optional<std::string> region;
+    std::optional<std::string> zone;
+    std::optional<std::string> region;
     std::string expected_location;
   };
   auto location_tests = std::vector<LocationTestCase>{
       {"us-central1-a", "us-central1", "us-central1-a"},
-      {"us-central1-a", absl::nullopt, "us-central1-a"},
-      {absl::nullopt, "us-central1", "us-central1"},
-      {absl::nullopt, absl::nullopt, "global"},
+      {"us-central1-a", std::nullopt, "us-central1-a"},
+      {std::nullopt, "us-central1", "us-central1"},
+      {std::nullopt, std::nullopt, "global"},
   };
   for (auto const& test : location_tests) {
     auto attributes = opentelemetry::sdk::resource::ResourceAttributes{
@@ -355,12 +355,12 @@ TEST(MonitoredResource, GenericNode) {
   }
 
   struct NodeIDTestCase {
-    absl::optional<std::string> host_id;
+    std::optional<std::string> host_id;
     std::string expected_node_id;
   };
   auto node_id_tests = std::vector<NodeIDTestCase>{
       {"test-instance", "test-instance"},
-      {absl::nullopt, "test-name"},
+      {std::nullopt, "test-name"},
   };
   for (auto const& test : node_id_tests) {
     auto attributes = opentelemetry::sdk::resource::ResourceAttributes{

--- a/google/cloud/opentelemetry/internal/monitoring_exporter.cc
+++ b/google/cloud/opentelemetry/internal/monitoring_exporter.cc
@@ -51,8 +51,8 @@ otel_internal::ResourceFilterDataFn MakeResourceFilterFn(
 }
 
 otel_internal::MonitoredResourceFromDataFn MakeDynamicResourceFn(
-    Options const& options, absl::optional<Project> const& project,
-    absl::optional<google::api::MonitoredResource> const& mr_proto) {
+    Options const& options, std::optional<Project> const& project,
+    std::optional<google::api::MonitoredResource> const& mr_proto) {
   if (!options.has<otel_internal::ResourceFilterDataFnOption>()) {
     return nullptr;
   }

--- a/google/cloud/opentelemetry/internal/monitoring_exporter.h
+++ b/google/cloud/opentelemetry/internal/monitoring_exporter.h
@@ -20,12 +20,12 @@
 #include "google/cloud/opentelemetry/monitoring_exporter.h"
 #include "google/cloud/project.h"
 #include "google/cloud/version.h"
-#include "absl/types/optional.h"
 #include <opentelemetry/sdk/metrics/data/metric_data.h>
 #include <opentelemetry/sdk/metrics/push_metric_exporter.h>
 #include <chrono>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace google {
@@ -86,11 +86,11 @@ class MonitoringExporter final
       std::vector<google::monitoring::v3::CreateTimeSeriesRequest> const&
           requests);
 
-  absl::optional<Project> project_;
+  std::optional<Project> project_;
   monitoring_v3::MetricServiceClient client_;
   otel::MetricNameFormatterOption::Type formatter_;
   bool use_service_time_series_;
-  absl::optional<google::api::MonitoredResource> mr_proto_;
+  std::optional<google::api::MonitoredResource> mr_proto_;
   otel_internal::MonitoredResourceFromDataFn dynamic_resource_fn_;
   otel_internal::ResourceFilterDataFn resource_filter_fn_;
 };

--- a/google/cloud/opentelemetry/internal/recordable.cc
+++ b/google/cloud/opentelemetry/internal/recordable.cc
@@ -19,7 +19,6 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
 #include "absl/time/time.h"
-#include "absl/types/variant.h"
 #include <grpcpp/grpcpp.h>
 #include <iterator>
 

--- a/google/cloud/opentelemetry/internal/resource_detector_impl_test.cc
+++ b/google/cloud/opentelemetry/internal/resource_detector_impl_test.cc
@@ -348,7 +348,7 @@ TEST(ResourceDetector, GkeZone) {
 }
 
 TEST(ResourceDetector, CloudFunctions) {
-  testing_util::ScopedEnvironment e1("KUBERNETES_SERVICE_HOST", absl::nullopt);
+  testing_util::ScopedEnvironment e1("KUBERNETES_SERVICE_HOST", std::nullopt);
   testing_util::ScopedEnvironment e2("FUNCTION_TARGET", "set");
   testing_util::ScopedEnvironment e3("K_SERVICE", "test-service");
   testing_util::ScopedEnvironment e4("K_REVISION", "test-version");
@@ -381,8 +381,8 @@ TEST(ResourceDetector, CloudFunctions) {
 }
 
 TEST(ResourceDetector, CloudRun) {
-  testing_util::ScopedEnvironment e1("KUBERNETES_SERVICE_HOST", absl::nullopt);
-  testing_util::ScopedEnvironment e2("FUNCTION_TARGET", absl::nullopt);
+  testing_util::ScopedEnvironment e1("KUBERNETES_SERVICE_HOST", std::nullopt);
+  testing_util::ScopedEnvironment e2("FUNCTION_TARGET", std::nullopt);
   testing_util::ScopedEnvironment e3("K_CONFIGURATION", "set");
   testing_util::ScopedEnvironment e4("K_SERVICE", "test-service");
   testing_util::ScopedEnvironment e5("K_REVISION", "test-version");
@@ -415,9 +415,9 @@ TEST(ResourceDetector, CloudRun) {
 }
 
 TEST(ResourceDetector, Gae) {
-  testing_util::ScopedEnvironment e1("KUBERNETES_SERVICE_HOST", absl::nullopt);
-  testing_util::ScopedEnvironment e2("FUNCTION_TARGET", absl::nullopt);
-  testing_util::ScopedEnvironment e3("K_CONFIGURATION", absl::nullopt);
+  testing_util::ScopedEnvironment e1("KUBERNETES_SERVICE_HOST", std::nullopt);
+  testing_util::ScopedEnvironment e2("FUNCTION_TARGET", std::nullopt);
+  testing_util::ScopedEnvironment e3("K_CONFIGURATION", std::nullopt);
   testing_util::ScopedEnvironment e4("GAE_SERVICE", "test-service");
   testing_util::ScopedEnvironment e5("GAE_VERSION", "test-version");
   testing_util::ScopedEnvironment e6("GAE_INSTANCE", "test-instance");
@@ -452,10 +452,10 @@ TEST(ResourceDetector, Gae) {
 }
 
 TEST(ResourceDetector, Gce) {
-  testing_util::ScopedEnvironment e1("KUBERNETES_SERVICE_HOST", absl::nullopt);
-  testing_util::ScopedEnvironment e2("FUNCTION_TARGET", absl::nullopt);
-  testing_util::ScopedEnvironment e3("K_CONFIGURATION", absl::nullopt);
-  testing_util::ScopedEnvironment e4("GAE_SERVICE", absl::nullopt);
+  testing_util::ScopedEnvironment e1("KUBERNETES_SERVICE_HOST", std::nullopt);
+  testing_util::ScopedEnvironment e2("FUNCTION_TARGET", std::nullopt);
+  testing_util::ScopedEnvironment e3("K_CONFIGURATION", std::nullopt);
+  testing_util::ScopedEnvironment e4("GAE_SERVICE", std::nullopt);
   auto constexpr kPayload = R"json({
   "instance": {
     "id": 1020304050607080900,
@@ -490,10 +490,10 @@ TEST(ResourceDetector, Gce) {
 }
 
 TEST(ResourceDetector, CachesAttributes) {
-  testing_util::ScopedEnvironment e1("KUBERNETES_SERVICE_HOST", absl::nullopt);
-  testing_util::ScopedEnvironment e2("FUNCTION_TARGET", absl::nullopt);
-  testing_util::ScopedEnvironment e3("K_CONFIGURATION", absl::nullopt);
-  testing_util::ScopedEnvironment e4("GAE_SERVICE", absl::nullopt);
+  testing_util::ScopedEnvironment e1("KUBERNETES_SERVICE_HOST", std::nullopt);
+  testing_util::ScopedEnvironment e2("FUNCTION_TARGET", std::nullopt);
+  testing_util::ScopedEnvironment e3("K_CONFIGURATION", std::nullopt);
+  testing_util::ScopedEnvironment e4("GAE_SERVICE", std::nullopt);
   auto constexpr kPayload = R"json({
   "instance": {
     "id": 1020304050607080900,

--- a/google/cloud/opentelemetry/internal/time_series.cc
+++ b/google/cloud/opentelemetry/internal/time_series.cc
@@ -70,7 +70,7 @@ double AsDouble(opentelemetry::sdk::metrics::ValueType const& v) {
 
 std::vector<google::monitoring::v3::CreateTimeSeriesRequest> ToRequestsHelper(
     std::string const& project,
-    absl::optional<google::api::MonitoredResource> const& mr_proto,
+    std::optional<google::api::MonitoredResource> const& mr_proto,
     std::vector<google::monitoring::v3::TimeSeries> tss) {
   std::vector<google::monitoring::v3::CreateTimeSeriesRequest> requests;
   for (auto& ts : tss) {
@@ -101,30 +101,30 @@ void ToTimeSeriesHelper(
         struct Visitor {
           opentelemetry::sdk::metrics::MetricData const& metric_data;
 
-          absl::optional<google::monitoring::v3::TimeSeries> operator()(
+          std::optional<google::monitoring::v3::TimeSeries> operator()(
               opentelemetry::sdk::metrics::SumPointData const& point) {
             return ToTimeSeries(metric_data, point);
           }
-          absl::optional<google::monitoring::v3::TimeSeries> operator()(
+          std::optional<google::monitoring::v3::TimeSeries> operator()(
               opentelemetry::sdk::metrics::LastValuePointData const& point) {
             return ToTimeSeries(metric_data, point);
           }
-          absl::optional<google::monitoring::v3::TimeSeries> operator()(
+          std::optional<google::monitoring::v3::TimeSeries> operator()(
               opentelemetry::sdk::metrics::HistogramPointData const& point) {
             return ToTimeSeries(metric_data, point);
           }
 #if OPENTELEMETRY_VERSION_MAJOR > 1 || \
     (OPENTELEMETRY_VERSION_MAJOR == 1 && OPENTELEMETRY_VERSION_MINOR >= 21)
-          absl::optional<google::monitoring::v3::TimeSeries> operator()(
+          std::optional<google::monitoring::v3::TimeSeries> operator()(
               opentelemetry::sdk::metrics::
                   Base2ExponentialHistogramPointData const&) {
             // TODO(#xxxxx): Add support for exponential histograms.
-            return absl::nullopt;
+            return std::nullopt;
           }
 #endif
-          absl::optional<google::monitoring::v3::TimeSeries> operator()(
+          std::optional<google::monitoring::v3::TimeSeries> operator()(
               opentelemetry::sdk::metrics::DropPointData const&) {
-            return absl::nullopt;
+            return std::nullopt;
           }
         };
         auto ts = std::visit(Visitor{metric_data}, pda.point_data);
@@ -269,7 +269,7 @@ google::monitoring::v3::TimeSeries ToTimeSeries(
 
 google::api::MonitoredResource ToMonitoredResource(
     opentelemetry::sdk::metrics::ResourceMetrics const& data,
-    absl::optional<google::api::MonitoredResource> const& mr_proto) {
+    std::optional<google::api::MonitoredResource> const& mr_proto) {
   if (mr_proto) return *mr_proto;
   google::api::MonitoredResource resource;
   if (data.resource_) {
@@ -343,7 +343,7 @@ std::vector<google::monitoring::v3::CreateTimeSeriesRequest> ToRequests(
 std::vector<google::monitoring::v3::CreateTimeSeriesRequest> ToRequests(
     std::string const& project,
     std::vector<google::monitoring::v3::TimeSeries> tss) {
-  return ToRequestsHelper(project, absl::nullopt, std::move(tss));
+  return ToRequestsHelper(project, std::nullopt, std::move(tss));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/opentelemetry/internal/time_series.h
+++ b/google/cloud/opentelemetry/internal/time_series.h
@@ -17,13 +17,13 @@
 
 #include "google/cloud/opentelemetry/internal/monitoring_exporter.h"
 #include "google/cloud/version.h"
-#include "absl/types/optional.h"
 #include "google/api/metric.pb.h"
 #include "google/api/monitored_resource.pb.h"
 #include "google/monitoring/v3/metric_service.pb.h"
 #include <opentelemetry/sdk/metrics/metric_reader.h>
 #include <opentelemetry/sdk/resource/resource.h>
 #include <functional>
+#include <optional>
 #include <string>
 
 namespace google {
@@ -63,7 +63,7 @@ google::monitoring::v3::TimeSeries ToTimeSeries(
 
 google::api::MonitoredResource ToMonitoredResource(
     opentelemetry::sdk::metrics::ResourceMetrics const& data,
-    absl::optional<google::api::MonitoredResource> const& mr_proto);
+    std::optional<google::api::MonitoredResource> const& mr_proto);
 
 /**
  * We need to convert from the C++ OpenTelemetry metrics implementation to

--- a/google/cloud/opentelemetry/internal/time_series_test.cc
+++ b/google/cloud/opentelemetry/internal/time_series_test.cc
@@ -583,7 +583,7 @@ TEST(ToMonitoredResource, FromMetricData) {
   auto const resource = TestResource();
   rm.resource_ = &resource;
 
-  auto mr = ToMonitoredResource(rm, absl::nullopt);
+  auto mr = ToMonitoredResource(rm, std::nullopt);
   EXPECT_THAT(mr, IsTestResource());
 }
 

--- a/google/cloud/opentelemetry/trace_exporter_test.cc
+++ b/google/cloud/opentelemetry/trace_exporter_test.cc
@@ -93,7 +93,7 @@ TEST(TraceExporter, Failure) {
 
 TEST(TraceExporter, LogsOnError) {
   // Disable library logging for a more conclusive test.
-  ScopedEnvironment env{"GOOGLE_CLOUD_CPP_ENABLE_TRACING", absl::nullopt};
+  ScopedEnvironment env{"GOOGLE_CLOUD_CPP_ENABLE_TRACING", std::nullopt};
 
   ScopedLog log;
 

--- a/google/cloud/osconfig/agentendpoint/v1/agent_endpoint_connection.cc
+++ b/google/cloud/osconfig/agentendpoint/v1/agent_endpoint_connection.cc
@@ -45,8 +45,8 @@ AgentEndpointServiceConnection::ReceiveTaskNotification(
   return google::cloud::internal::MakeStreamRange<
       google::cloud::osconfig::agentendpoint::v1::
           ReceiveTaskNotificationResponse>(
-      []() -> absl::variant<Status, google::cloud::osconfig::agentendpoint::v1::
-                                        ReceiveTaskNotificationResponse> {
+      []() -> std::variant<Status, google::cloud::osconfig::agentendpoint::v1::
+                                       ReceiveTaskNotificationResponse> {
         return Status(StatusCode::kUnimplemented, "not implemented");
       });
 }

--- a/google/cloud/osconfig/agentendpoint/v1/internal/agent_endpoint_connection_impl.cc
+++ b/google/cloud/osconfig/agentendpoint/v1/internal/agent_endpoint_connection_impl.cc
@@ -96,8 +96,8 @@ AgentEndpointServiceConnectionImpl::ReceiveTaskNotification(
   return internal::MakeStreamRange<google::cloud::osconfig::agentendpoint::v1::
                                        ReceiveTaskNotificationResponse>(
       [resumable = std::move(resumable)]()
-          -> absl::variant<Status, google::cloud::osconfig::agentendpoint::v1::
-                                       ReceiveTaskNotificationResponse> {
+          -> std::variant<Status, google::cloud::osconfig::agentendpoint::v1::
+                                      ReceiveTaskNotificationResponse> {
         google::cloud::osconfig::agentendpoint::v1::
             ReceiveTaskNotificationResponse response;
         auto status = resumable->Read(&response);

--- a/google/cloud/rest_options.h
+++ b/google/cloud/rest_options.h
@@ -20,6 +20,7 @@
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
 #include <chrono>
+#include <functional>
 #include <string>
 
 namespace google {

--- a/google/cloud/spanner/encryption_config.h
+++ b/google/cloud/spanner/encryption_config.h
@@ -17,7 +17,7 @@
 
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/kms_key_name.h"
-#include "absl/types/variant.h"
+#include <variant>
 
 namespace google {
 namespace cloud {
@@ -57,8 +57,8 @@ class CustomerManagedEncryption {
  *  - `DatabaseAdminClient::CreateBackup()`
  *  - `DatabaseAdminClient::RestoreDatabase()`
  */
-using EncryptionConfig = absl::variant<DefaultEncryption, GoogleEncryption,
-                                       CustomerManagedEncryption>;
+using EncryptionConfig = std::variant<DefaultEncryption, GoogleEncryption,
+                                      CustomerManagedEncryption>;
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace spanner

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -35,6 +35,7 @@
 #include <grpcpp/grpcpp.h>
 #include <algorithm>
 #include <functional>
+#include <variant>
 
 namespace google {
 namespace cloud {
@@ -51,7 +52,7 @@ class DirectedReadVisitor {
       std::function<google::spanner::v1::DirectedReadOptions*()> factory)
       : factory_(std::move(factory)) {}
 
-  void operator()(absl::monostate) const {
+  void operator()(std::monostate) const {
     // No inclusions/exclusions.
   }
 
@@ -638,10 +639,10 @@ spanner::RowStream ConnectionImpl::ReadImpl(
         *std::move(params.read_options.request_tag));
   }
   request->mutable_request_options()->set_transaction_tag(ctx.tag);
-  absl::visit(DirectedReadVisitor([&request] {
-                return request->mutable_directed_read_options();
-              }),
-              params.directed_read_option);
+  std::visit(DirectedReadVisitor([&request] {
+               return request->mutable_directed_read_options();
+             }),
+             params.directed_read_option);
 
   // Capture a copy of `stub` to ensure the `shared_ptr<>` remains valid through
   // the lifetime of the lambda.
@@ -825,10 +826,10 @@ StatusOr<ResultType> ConnectionImpl::ExecuteSqlImpl(
         *params.query_options.request_tag());
   }
   request.mutable_request_options()->set_transaction_tag(ctx.tag);
-  absl::visit(DirectedReadVisitor([&request] {
-                return request.mutable_directed_read_options();
-              }),
-              params.directed_read_option);
+  std::visit(DirectedReadVisitor([&request] {
+               return request.mutable_directed_read_options();
+             }),
+             params.directed_read_option);
 
   for (;;) {
     auto reader = retry_resume_fn(request);
@@ -1426,7 +1427,7 @@ spanner::BatchedCommitResultStream ConnectionImpl::BatchWriteImpl(
   // until the stream is exhausted.
   return internal::MakeStreamRange<spanner::BatchedCommitResult>(
       [reader = std::move(reader), session = std::move(session)]()
-          -> absl::variant<Status, spanner::BatchedCommitResult> {
+          -> std::variant<Status, spanner::BatchedCommitResult> {
         google::spanner::v1::BatchWriteResponse response;
         auto result = reader->Read(&response);
         if (result.has_value()) {

--- a/google/cloud/spanner/options.h
+++ b/google/cloud/spanner/options.h
@@ -49,12 +49,12 @@
 #include "google/cloud/spanner/transaction.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/options.h"
-#include "absl/types/variant.h"
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <variant>
 
 namespace google {
 namespace cloud {
@@ -79,7 +79,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  */
 struct GOOGLE_CLOUD_CPP_DEPRECATED("Multiplex Sessions are always enabled")
     EnableMultiplexedSessionOption {
-  using Type = absl::monostate;
+  using Type = std::monostate;
 };
 
 /**
@@ -392,7 +392,7 @@ struct PartitionDataBoostOption {
  * be excluded from serving the request.
  */
 struct DirectedReadOption {
-  using Type = absl::variant<absl::monostate, IncludeReplicas, ExcludeReplicas>;
+  using Type = std::variant<std::monostate, IncludeReplicas, ExcludeReplicas>;
 };
 
 /**

--- a/google/cloud/storage/BUILD.bazel
+++ b/google/cloud/storage/BUILD.bazel
@@ -145,7 +145,6 @@ cc_library(
         "@abseil-cpp//absl/strings:str_format",
         "@abseil-cpp//absl/time",
         "@abseil-cpp//absl/types:span",
-        "@abseil-cpp//absl/types:variant",
         "@curl",
         "@nlohmann_json//:json",
     ] + select({

--- a/google/cloud/storage/async/client.cc
+++ b/google/cloud/storage/async/client.cc
@@ -22,6 +22,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace google {
@@ -222,7 +223,7 @@ AsyncClient::StartBufferedUpload(
       .then([](auto f) -> StatusOr<std::pair<AsyncWriter, AsyncToken>> {
         auto w = f.get();
         if (!w) return std::move(w).status();
-        auto t = absl::holds_alternative<google::storage::v2::Object>(
+        auto t = std::holds_alternative<google::storage::v2::Object>(
                      (*w)->PersistedState())
                      ? AsyncToken()
                      : storage_internal::MakeAsyncToken(w->get());
@@ -247,7 +248,7 @@ AsyncClient::ResumeBufferedUpload(
       .then([](auto f) -> StatusOr<std::pair<AsyncWriter, AsyncToken>> {
         auto w = f.get();
         if (!w) return std::move(w).status();
-        auto t = absl::holds_alternative<google::storage::v2::Object>(
+        auto t = std::holds_alternative<google::storage::v2::Object>(
                      (*w)->PersistedState())
                      ? AsyncToken()
                      : storage_internal::MakeAsyncToken(w->get());
@@ -275,7 +276,7 @@ AsyncClient::StartUnbufferedUpload(
       .then([](auto f) -> StatusOr<std::pair<AsyncWriter, AsyncToken>> {
         auto w = f.get();
         if (!w) return std::move(w).status();
-        auto t = absl::holds_alternative<google::storage::v2::Object>(
+        auto t = std::holds_alternative<google::storage::v2::Object>(
                      (*w)->PersistedState())
                      ? AsyncToken()
                      : storage_internal::MakeAsyncToken(w->get());
@@ -300,7 +301,7 @@ AsyncClient::ResumeUnbufferedUpload(
       .then([](auto f) -> StatusOr<std::pair<AsyncWriter, AsyncToken>> {
         auto w = f.get();
         if (!w) return std::move(w).status();
-        auto t = absl::holds_alternative<google::storage::v2::Object>(
+        auto t = std::holds_alternative<google::storage::v2::Object>(
                      (*w)->PersistedState())
                      ? AsyncToken()
                      : storage_internal::MakeAsyncToken(w->get());

--- a/google/cloud/storage/async/reader.cc
+++ b/google/cloud/storage/async/reader.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/internal/make_status.h"
 #include <memory>
 #include <utility>
+#include <variant>
 
 namespace google {
 namespace cloud {
@@ -46,7 +47,7 @@ class Discard : public std::enable_shared_from_this<Discard> {
     self->impl_->Read().then([self](auto f) mutable {
       auto s = std::move(self);
       auto response = f.get();
-      if (absl::holds_alternative<Status>(response)) return;
+      if (std::holds_alternative<Status>(response)) return;
       s->Loop();
     });
   }
@@ -84,8 +85,8 @@ future<StatusOr<std::pair<ReadPayload, AsyncToken>>> AsyncReader::Read(
   };
   return impl_->Read().then([this, v = Visitor{std::move(t)}](auto f) mutable {
     auto response = f.get();
-    if (absl::holds_alternative<Status>(response)) finished_ = true;
-    return absl::visit(std::move(v), std::move(response));
+    if (std::holds_alternative<Status>(response)) finished_ = true;
+    return std::visit(std::move(v), std::move(response));
   });
 }
 

--- a/google/cloud/storage/async/reader_connection.h
+++ b/google/cloud/storage/async/reader_connection.h
@@ -20,7 +20,7 @@
 #include "google/cloud/rpc_metadata.h"
 #include "google/cloud/status.h"
 #include "google/cloud/version.h"
-#include "absl/types/variant.h"
+#include <variant>
 
 namespace google {
 namespace cloud {
@@ -38,7 +38,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AsyncReaderConnection {
  public:
   /// The value returned by `Read()`. See the function for more details.
-  using ReadResponse = absl::variant<ReadPayload, Status>;
+  using ReadResponse = std::variant<ReadPayload, Status>;
 
   virtual ~AsyncReaderConnection() = default;
 
@@ -73,7 +73,7 @@ class AsyncReaderConnection {
    *   satisfied with a `ReadResponse` containing an OK `Status`.
    *
    * A `StatusOr<>` cannot represent the last bullet point, so we need an
-   * `absl::variant<>` in this case.  We could have used
+   * `std::variant<>` in this case.  We could have used
    * `StatusOr<std::optional<ReadPayload>>` but that sounds unnecessarily
    * complicated.
    */

--- a/google/cloud/storage/async/writer.cc
+++ b/google/cloud/storage/async/writer.cc
@@ -49,7 +49,7 @@ std::string AsyncWriter::UploadId() const {
   return {};
 }
 
-absl::variant<std::int64_t, google::storage::v2::Object>
+std::variant<std::int64_t, google::storage::v2::Object>
 AsyncWriter::PersistedState() const {
   if (impl_) return impl_->PersistedState();
   return -1;

--- a/google/cloud/storage/async/writer.h
+++ b/google/cloud/storage/async/writer.h
@@ -21,11 +21,11 @@
 #include "google/cloud/future.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include "absl/types/variant.h"
 #include "google/storage/v2/storage.pb.h"
 #include <memory>
 #include <string>
 #include <utility>
+#include <variant>
 
 namespace google {
 namespace cloud {
@@ -108,7 +108,7 @@ class AsyncWriter {
    * Calling this function on a default-constructed or moved-from `AsyncWriter`
    * results in undefined behavior.
    */
-  absl::variant<std::int64_t, google::storage::v2::Object> PersistedState()
+  std::variant<std::int64_t, google::storage::v2::Object> PersistedState()
       const;
 
   /// Upload @p payload returning a new token to continue the upload.

--- a/google/cloud/storage/async/writer_connection.h
+++ b/google/cloud/storage/async/writer_connection.h
@@ -22,10 +22,10 @@
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include "absl/types/variant.h"
 #include "google/storage/v2/storage.pb.h"
 #include <cstdint>
 #include <string>
+#include <variant>
 
 namespace google {
 namespace cloud {
@@ -103,7 +103,7 @@ class AsyncWriterConnection {
 
   /// Returns the last known state of the upload. Updated during initialization
   /// and by successful `Query()` or `Finalize()` requests.
-  virtual absl::variant<std::int64_t, google::storage::v2::Object>
+  virtual std::variant<std::int64_t, google::storage::v2::Object>
   PersistedState() const = 0;
 
   /// Uploads some data to the service.

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -39,7 +39,6 @@
 #include "google/cloud/options.h"
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
-#include "absl/meta/type_traits.h"
 #include "absl/strings/string_view.h"
 #include <memory>
 #include <string>
@@ -1321,7 +1320,7 @@ class Client {
     // does not support (nor should it support) the UseResumableUploadSession
     // option.
     using HasUseResumableUpload =
-        absl::disjunction<std::is_same<UseResumableUploadSession, Options>...>;
+        std::disjunction<std::is_same<UseResumableUploadSession, Options>...>;
     return UploadFileImpl(file_name, bucket_name, object_name,
                           HasUseResumableUpload{},
                           std::forward<Options>(options)...);

--- a/google/cloud/storage/client_object_test.cc
+++ b/google/cloud/storage/client_object_test.cc
@@ -26,6 +26,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace google {
@@ -204,7 +205,7 @@ TEST_F(ObjectTest, ListObjectsAndPrefixes) {
       "test-bucket-name", Options{}.set<UserProjectOption>("u-p-test"));
   for (auto&& o : list) {
     EXPECT_STATUS_OK(o);
-    names.push_back(absl::get<ObjectMetadata>(*o).name());
+    names.push_back(std::get<ObjectMetadata>(*o).name());
   }
   EXPECT_THAT(names, ElementsAre("object-1", "object-2", "object-3"));
 }

--- a/google/cloud/storage/examples/storage_async_samples.cc
+++ b/google/cloud/storage/examples/storage_async_samples.cc
@@ -34,6 +34,7 @@
 #include <stdexcept>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace {
@@ -759,7 +760,7 @@ void CreateAndWriteAppendableObject(google::cloud::storage::AsyncClient& client,
     if (!flush_status.ok()) throw std::runtime_error(flush_status.message());
 
     std::cout << "Flush completed. Persisted size is now "
-              << absl::get<std::int64_t>(writer.PersistedState()) << "\n";
+              << std::get<std::int64_t>(writer.PersistedState()) << "\n";
 
     // The writer is still open. We can write more data.
     token = (co_await writer.Write(std::move(token),
@@ -850,7 +851,7 @@ void PauseAndResumeAppendableUpload(google::cloud::storage::AsyncClient& client,
              gcs::BucketName(bucket_name), object_name, metadata.generation()))
             .value();
     std::cout << "Upload resumed from offset "
-              << absl::get<std::int64_t>(writer.PersistedState()) << "\n";
+              << std::get<std::int64_t>(writer.PersistedState()) << "\n";
 
     // Append the rest of the data.
     token = (co_await writer.Write(std::move(token),

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -26,6 +26,7 @@
 #include <string>
 #include <thread>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace {
@@ -92,11 +93,11 @@ void ListObjectsAndPrefixes(google::cloud::storage::Client client,
              bucket_name, gcs::Prefix(bucket_prefix), gcs::Delimiter("/"))) {
       if (!item) throw std::move(item).status();
       auto result = *std::move(item);
-      if (absl::holds_alternative<gcs::ObjectMetadata>(result)) {
+      if (std::holds_alternative<gcs::ObjectMetadata>(result)) {
         std::cout << "object_name="
-                  << absl::get<gcs::ObjectMetadata>(result).name() << "\n";
-      } else if (absl::holds_alternative<std::string>(result)) {
-        std::cout << "prefix     =" << absl::get<std::string>(result) << "\n";
+                  << std::get<gcs::ObjectMetadata>(result).name() << "\n";
+      } else if (std::holds_alternative<std::string>(result)) {
+        std::cout << "prefix     =" << std::get<std::string>(result) << "\n";
       }
     }
   }
@@ -115,11 +116,11 @@ void ListObjectsAndFolders(google::cloud::storage::Client client,
              gcs::IncludeFoldersAsPrefixes(true))) {
       if (!item) throw std::move(item).status();
       auto result = *std::move(item);
-      if (absl::holds_alternative<gcs::ObjectMetadata>(result)) {
+      if (std::holds_alternative<gcs::ObjectMetadata>(result)) {
         std::cout << "object_name="
-                  << absl::get<gcs::ObjectMetadata>(result).name() << "\n";
-      } else if (absl::holds_alternative<std::string>(result)) {
-        std::cout << "prefix     =" << absl::get<std::string>(result) << "\n";
+                  << std::get<gcs::ObjectMetadata>(result).name() << "\n";
+      } else if (std::holds_alternative<std::string>(result)) {
+        std::cout << "prefix     =" << std::get<std::string>(result) << "\n";
       }
     }
   }

--- a/google/cloud/storage/google_cloud_cpp_storage.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage.cmake
@@ -246,7 +246,6 @@ target_link_libraries(
            absl::memory
            absl::strings
            absl::time
-           absl::variant
            google-cloud-cpp::common
            google-cloud-cpp::rest_internal
            nlohmann_json::nlohmann_json
@@ -320,7 +319,6 @@ google_cloud_cpp_add_pkgconfig(
     "absl_strings"
     "absl_str_format"
     "absl_time"
-    "absl_variant"
     NON_WIN32_REQUIRES
     openssl
     WIN32_LIBS

--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
@@ -282,7 +282,6 @@ google_cloud_cpp_add_pkgconfig(
     "google_cloud_cpp_grpc_utils"
     "google_cloud_cpp_common"
     "grpc++"
-    "absl_optional"
     "absl_strings"
     "absl_time"
     ${EXTRA_MODULES})

--- a/google/cloud/storage/internal/async/connection_impl_appendable_upload_test.cc
+++ b/google/cloud/storage/internal/async/connection_impl_appendable_upload_test.cc
@@ -29,6 +29,7 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
+#include <variant>
 
 namespace google {
 namespace cloud {
@@ -290,7 +291,7 @@ TEST_F(AsyncConnectionImplAppendableTest, StartAppendableObjectUploadSuccess) {
   auto r = pending.get();
   ASSERT_STATUS_OK(r);
   auto writer = *std::move(r);
-  EXPECT_EQ(absl::get<std::int64_t>(writer->PersistedState()), 0);
+  EXPECT_EQ(std::get<std::int64_t>(writer->PersistedState()), 0);
 
   // Write some data.
   // An empty payload might be a no-op in the implementation, which would
@@ -363,7 +364,7 @@ TEST_F(AsyncConnectionImplAppendableTest, ResumeAppendableObjectUploadSuccess) {
   ASSERT_STATUS_OK(r);
   auto writer = *std::move(r);
   // Verify the persisted state is correctly reported.
-  EXPECT_EQ(absl::get<std::int64_t>(writer->PersistedState()), kPersistedSize);
+  EXPECT_EQ(std::get<std::int64_t>(writer->PersistedState()), kPersistedSize);
 
   auto w1 = writer->Write(storage::WritePayload("some more data"));
   next = sequencer.PopFrontWithName();
@@ -512,7 +513,7 @@ TEST_F(AsyncConnectionImplAppendableTest, AppendableUploadRedirect) {
   auto r = pending.get();
   ASSERT_STATUS_OK(r);
   auto writer = *std::move(r);
-  EXPECT_EQ(absl::get<std::int64_t>(writer->PersistedState()), 1024);
+  EXPECT_EQ(std::get<std::int64_t>(writer->PersistedState()), 1024);
 
   // Write some data.
   auto w1 = writer->Write(storage::WritePayload("some data"));
@@ -612,7 +613,7 @@ TEST_F(AsyncConnectionImplAppendableTest, AppendableUploadRedirectNoHandle) {
   auto r = pending.get();
   ASSERT_STATUS_OK(r);
   auto writer = *std::move(r);
-  EXPECT_EQ(absl::get<std::int64_t>(writer->PersistedState()), 1024);
+  EXPECT_EQ(std::get<std::int64_t>(writer->PersistedState()), 1024);
 
   // Write some data.
   auto w1 = writer->Write(storage::WritePayload("some data"));

--- a/google/cloud/storage/internal/async/connection_impl_open_test.cc
+++ b/google/cloud/storage/internal/async/connection_impl_open_test.cc
@@ -457,9 +457,9 @@ TEST(AsyncConnectionImplTest, OpenWithReadRanges) {
         EXPECT_CALL(*stream, Read)
             .WillOnce([&]() {
               return sequencer.PushBack("Read").then(
-                  [=](auto f) -> absl::optional<
+                  [=](auto f) -> std::optional<
                                   google::storage::v2::BidiReadObjectResponse> {
-                    if (!f.get()) return absl::nullopt;
+                    if (!f.get()) return std::nullopt;
                     auto constexpr kHandleText = R"pb(
                       handle: "handle-12345"
                     )pb";
@@ -474,9 +474,9 @@ TEST(AsyncConnectionImplTest, OpenWithReadRanges) {
             })
             .WillOnce([&sequencer]() {
               return sequencer.PushBack("Read[N]").then(
-                  [](auto f) -> absl::optional<
+                  [](auto f) -> std::optional<
                                  google::storage::v2::BidiReadObjectResponse> {
-                    if (!f.get()) return absl::nullopt;
+                    if (!f.get()) return std::nullopt;
                     return google::storage::v2::BidiReadObjectResponse{};
                   });
             });

--- a/google/cloud/storage/internal/async/connection_impl_read_test.cc
+++ b/google/cloud/storage/internal/async/connection_impl_read_test.cc
@@ -31,6 +31,7 @@
 #include "google/cloud/testing_util/validate_metadata.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
+#include <variant>
 
 namespace google {
 namespace cloud {
@@ -211,7 +212,7 @@ TEST_F(AsyncConnectionImplTest, ReadObject) {
   EXPECT_EQ(next.second, "Read");
   next.first.set_value(true);
   auto response = data.get();
-  ASSERT_TRUE(absl::holds_alternative<storage::ReadPayload>(response));
+  ASSERT_TRUE(std::holds_alternative<storage::ReadPayload>(response));
 
   // The `Read()` and `Finish()` calls must happen before the second `Read()` is
   // satisfied.
@@ -311,7 +312,7 @@ TEST_F(AsyncConnectionImplTest, ReadObjectWithTimeout) {
   next.first.set_value(true);
 
   auto response = data.get();
-  ASSERT_TRUE(absl::holds_alternative<storage::ReadPayload>(response));
+  ASSERT_TRUE(std::holds_alternative<storage::ReadPayload>(response));
 
   // Trigger another read. Since this closes the stream, the `Read()` and
   // `Finish()` calls must happen before the second `Read()` is satisfied.

--- a/google/cloud/storage/internal/async/connection_impl_upload_hash_test.cc
+++ b/google/cloud/storage/internal/async/connection_impl_upload_hash_test.cc
@@ -32,6 +32,7 @@
 #include <gmock/gmock.h>
 #include <iomanip>
 #include <iostream>
+#include <variant>
 
 namespace google {
 namespace cloud {
@@ -267,7 +268,7 @@ TEST_P(AsyncConnectionImplUploadHashTest, StartUnbuffered) {
   ASSERT_STATUS_OK(r);
   auto writer = *std::move(r);
   EXPECT_EQ(writer->UploadId(), "test-upload-id");
-  EXPECT_EQ(absl::get<std::int64_t>(writer->PersistedState()), 0);
+  EXPECT_EQ(std::get<std::int64_t>(writer->PersistedState()), 0);
 
   auto w2 = writer->Finalize(storage::WritePayload(kQuickFox));
   next = sequencer.PopFrontWithName();
@@ -377,7 +378,7 @@ TEST_P(AsyncConnectionImplUploadHashTest,
   ASSERT_STATUS_OK(r);
   auto writer = *std::move(r);
   EXPECT_EQ(writer->UploadId(), "resume-upload-id");
-  EXPECT_EQ(absl::get<std::int64_t>(writer->PersistedState()), 0);
+  EXPECT_EQ(std::get<std::int64_t>(writer->PersistedState()), 0);
 
   auto w2 = writer->Finalize(storage::WritePayload(kQuickFox));
   next = sequencer.PopFrontWithName();
@@ -485,7 +486,7 @@ TEST_P(AsyncConnectionImplUploadHashTest, ResumeUnbufferedWithPersistedData) {
   ASSERT_STATUS_OK(r);
   auto writer = *std::move(r);
   EXPECT_EQ(writer->UploadId(), "resume-upload-id");
-  EXPECT_EQ(absl::get<std::int64_t>(writer->PersistedState()), 256 * 1024);
+  EXPECT_EQ(std::get<std::int64_t>(writer->PersistedState()), 256 * 1024);
 
   auto w2 = writer->Finalize(storage::WritePayload(kQuickFox));
   next = sequencer.PopFrontWithName();
@@ -609,7 +610,7 @@ TEST_P(AsyncConnectionImplUploadHashTest, StartBuffered) {
   ASSERT_STATUS_OK(r);
   auto writer = *std::move(r);
   EXPECT_EQ(writer->UploadId(), "test-upload-id");
-  EXPECT_EQ(absl::get<std::int64_t>(writer->PersistedState()), 0);
+  EXPECT_EQ(std::get<std::int64_t>(writer->PersistedState()), 0);
 
   auto w2 = writer->Finalize(storage::WritePayload(kQuickFox));
   // The `Finalize()` call triggers a `Flush()` first.
@@ -726,7 +727,7 @@ TEST_P(AsyncConnectionImplUploadHashTest, ResumeBufferedWithoutPersistedData) {
   ASSERT_STATUS_OK(r);
   auto writer = *std::move(r);
   EXPECT_EQ(writer->UploadId(), "resume-upload-id");
-  EXPECT_EQ(absl::get<std::int64_t>(writer->PersistedState()), 0);
+  EXPECT_EQ(std::get<std::int64_t>(writer->PersistedState()), 0);
 
   auto w2 = writer->Finalize(storage::WritePayload(kQuickFox));
   next = sequencer.PopFrontWithName();
@@ -834,7 +835,7 @@ TEST_P(AsyncConnectionImplUploadHashTest, ResumeBufferedWithPersistedData) {
   ASSERT_STATUS_OK(r);
   auto writer = *std::move(r);
   EXPECT_EQ(writer->UploadId(), "resume-upload-id");
-  EXPECT_EQ(absl::get<std::int64_t>(writer->PersistedState()), 256 * 1024);
+  EXPECT_EQ(std::get<std::int64_t>(writer->PersistedState()), 256 * 1024);
 
   auto w2 = writer->Finalize(storage::WritePayload(kQuickFox));
   next = sequencer.PopFrontWithName();

--- a/google/cloud/storage/internal/async/connection_impl_upload_test.cc
+++ b/google/cloud/storage/internal/async/connection_impl_upload_test.cc
@@ -30,6 +30,7 @@
 #include "google/cloud/testing_util/validate_metadata.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
+#include <variant>
 
 namespace google {
 namespace cloud {
@@ -249,7 +250,7 @@ TEST_F(AsyncConnectionImplTest, StartUnbufferedUpload) {
   ASSERT_STATUS_OK(r);
   auto writer = *std::move(r);
   EXPECT_EQ(writer->UploadId(), "test-upload-id");
-  EXPECT_EQ(absl::get<std::int64_t>(writer->PersistedState()), 0);
+  EXPECT_EQ(std::get<std::int64_t>(writer->PersistedState()), 0);
 
   auto w1 = writer->Write({});
   next = sequencer.PopFrontWithName();
@@ -361,7 +362,7 @@ TEST_F(AsyncConnectionImplTest, UnbufferedUploadNewUploadWithTimeout) {
   ASSERT_STATUS_OK(r);
   auto writer = *std::move(r);
   EXPECT_EQ(writer->UploadId(), "test-upload-id");
-  EXPECT_EQ(absl::get<std::int64_t>(writer->PersistedState()), 0);
+  EXPECT_EQ(std::get<std::int64_t>(writer->PersistedState()), 0);
 
   auto w2 = writer->Finalize({});
   timer = sequencer.PopFrontWithName();
@@ -591,7 +592,7 @@ TEST_F(AsyncConnectionImplTest, ResumeUnbufferedUpload) {
   ASSERT_STATUS_OK(r);
   auto writer = *std::move(r);
   EXPECT_EQ(writer->UploadId(), "test-upload-id");
-  EXPECT_EQ(absl::get<std::int64_t>(writer->PersistedState()), 16384);
+  EXPECT_EQ(std::get<std::int64_t>(writer->PersistedState()), 16384);
 
   auto w1 = writer->Write({});
   next = sequencer.PopFrontWithName();
@@ -957,7 +958,7 @@ TEST_F(AsyncConnectionImplTest, BufferedUploadNewUpload) {
   ASSERT_STATUS_OK(r);
   auto writer = *std::move(r);
   EXPECT_EQ(writer->UploadId(), "test-upload-id");
-  EXPECT_EQ(absl::get<std::int64_t>(writer->PersistedState()), 0);
+  EXPECT_EQ(std::get<std::int64_t>(writer->PersistedState()), 0);
 
   auto w1 = writer->Finalize({});
   next = sequencer.PopFrontWithName();
@@ -1210,7 +1211,7 @@ TEST_F(AsyncConnectionImplTest, ResumeBufferedUpload) {
   ASSERT_STATUS_OK(r);
   auto writer = *std::move(r);
   EXPECT_EQ(writer->UploadId(), "test-upload-id");
-  EXPECT_EQ(absl::get<std::int64_t>(writer->PersistedState()), 16384);
+  EXPECT_EQ(std::get<std::int64_t>(writer->PersistedState()), 16384);
 
   auto w1 = writer->Write({});
   next = sequencer.PopFrontWithName();

--- a/google/cloud/storage/internal/async/object_descriptor_reader_tracing.cc
+++ b/google/cloud/storage/internal/async/object_descriptor_reader_tracing.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/version.h"
 #include <opentelemetry/semconv/incubating/thread_attributes.h>
 #include <memory>
+#include <variant>
 
 namespace google {
 namespace cloud {
@@ -59,8 +60,8 @@ class ObjectDescriptorReaderTracing : public ObjectDescriptorReader {
             auto f) -> ReadResponse {
           auto result = f.get();
           internal::DetachOTelContext(oc);
-          if (!absl::holds_alternative<Status>(result)) {
-            auto const& payload = absl::get<storage::ReadPayload>(result);
+          if (!std::holds_alternative<Status>(result)) {
+            auto const& payload = std::get<storage::ReadPayload>(result);
 
             span->AddEvent(
                 "gl-cpp.read-range",
@@ -73,7 +74,7 @@ class ObjectDescriptorReaderTracing : public ObjectDescriptorReader {
                 {{/*sc::kRpcMessageType=*/"rpc.message.type", "RECEIVED"},
                  {sc::thread::kThreadId, internal::CurrentThreadId()}});
             return internal::EndSpan(*span,
-                                     absl::get<Status>(std::move(result)));
+                                     std::get<Status>(std::move(result)));
           }
           return result;
         });

--- a/google/cloud/storage/internal/async/reader_connection_resume.cc
+++ b/google/cloud/storage/internal/async/reader_connection_resume.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/internal/make_status.h"
 #include "google/cloud/log.h"
 #include "absl/strings/str_cat.h"
+#include <variant>
 
 namespace google {
 namespace cloud {
@@ -55,9 +56,9 @@ future<ReadResponse> AsyncReaderConnectionResume::Read(
 }
 
 future<ReadResponse> AsyncReaderConnectionResume::OnRead(ReadResponse r) {
-  if (absl::holds_alternative<storage::ReadPayload>(r)) {
+  if (std::holds_alternative<storage::ReadPayload>(r)) {
     resume_policy_->OnStartSuccess();
-    auto response = absl::get<storage::ReadPayload>(std::move(r));
+    auto response = std::get<storage::ReadPayload>(std::move(r));
     hash_validator_->ProcessHashValues(
         ReadPayloadImpl::GetObjectHashes(response).value_or(
             storage::internal::HashValues{}));
@@ -74,7 +75,7 @@ future<ReadResponse> AsyncReaderConnectionResume::OnRead(ReadResponse r) {
     }
     return make_ready_future(ReadResponse(std::move(response)));
   }
-  auto const& status = absl::get<Status>(r);
+  auto const& status = std::get<Status>(r);
   if (status.ok()) {
     CheckOverrun();
     // The download finished. Validate the hash results, if any.

--- a/google/cloud/storage/internal/async/reader_connection_tracing.cc
+++ b/google/cloud/storage/internal/async/reader_connection_tracing.cc
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <string>
 #include <utility>
+#include <variant>
 
 namespace google {
 namespace cloud {
@@ -48,7 +49,7 @@ class AsyncReaderConnectionTracing : public storage::AsyncReaderConnection {
     return impl_->Read()
         .then([count = ++count_, span = span_](auto f) -> ReadResponse {
           auto r = f.get();
-          if (absl::holds_alternative<Status>(r)) {
+          if (std::holds_alternative<Status>(r)) {
             span->AddEvent(
                 "gl-cpp.read",
                 {
@@ -56,9 +57,9 @@ class AsyncReaderConnectionTracing : public storage::AsyncReaderConnection {
                     {/*sc::kRpcMessageId=*/"rpc.message.id", count},
                     {sc::thread::kThreadId, internal::CurrentThreadId()},
                 });
-            return internal::EndSpan(*span, absl::get<Status>(std::move(r)));
+            return internal::EndSpan(*span, std::get<Status>(std::move(r)));
           }
-          auto const& payload = absl::get<storage::ReadPayload>(r);
+          auto const& payload = std::get<storage::ReadPayload>(r);
           span->AddEvent(
               "gl-cpp.read",
               {

--- a/google/cloud/storage/internal/async/writer_connection_buffered.cc
+++ b/google/cloud/storage/internal/async/writer_connection_buffered.cc
@@ -24,6 +24,7 @@
 #include <deque>
 #include <memory>
 #include <mutex>
+#include <variant>
 #include <vector>
 
 namespace google {
@@ -86,15 +87,15 @@ class AsyncWriterConnectionBufferedState
     finalized_future_ = finalized_.get_future();
     closed_future_ = closed_.get_future();
     auto state = impl_->PersistedState();
-    if (absl::holds_alternative<google::storage::v2::Object>(state)) {
+    if (std::holds_alternative<google::storage::v2::Object>(state)) {
       SetFinalized(std::unique_lock<std::mutex>(mu_),
-                   absl::get<google::storage::v2::Object>(std::move(state)));
+                   std::get<google::storage::v2::Object>(std::move(state)));
       cancelled_ = true;
       resume_status_ = internal::CancelledError("upload already finalized",
                                                 GCP_ERROR_INFO());
       return;
     }
-    buffer_offset_ = absl::get<std::int64_t>(state);
+    buffer_offset_ = std::get<std::int64_t>(state);
   }
 
   void Cancel() {
@@ -113,7 +114,7 @@ class AsyncWriterConnectionBufferedState
     return Impl(std::unique_lock<std::mutex>(mu_))->WriteHandle();
   }
 
-  absl::variant<std::int64_t, google::storage::v2::Object> PersistedState()
+  std::variant<std::int64_t, google::storage::v2::Object> PersistedState()
       const {
     return Impl(std::unique_lock<std::mutex>(mu_))->PersistedState();
   }
@@ -319,10 +320,10 @@ class AsyncWriterConnectionBufferedState
     auto impl = Impl(lk);
     auto const& state = impl->PersistedState();
     std::int64_t persisted_size = 0;
-    if (absl::holds_alternative<google::storage::v2::Object>(state)) {
-      persisted_size = absl::get<google::storage::v2::Object>(state).size();
+    if (std::holds_alternative<google::storage::v2::Object>(state)) {
+      persisted_size = std::get<google::storage::v2::Object>(state).size();
     } else {
-      persisted_size = absl::get<std::int64_t>(state);
+      persisted_size = std::get<std::int64_t>(state);
     }
     lk.unlock();
     OnQuery(persisted_size);
@@ -462,11 +463,11 @@ class AsyncWriterConnectionBufferedState
     if (was_finalizing) {
       // If resuming due to a finalization error, we *must* complete the
       // finalized_ promise now, based on the resume attempt's outcome.
-      if (absl::holds_alternative<google::storage::v2::Object>(state)) {
+      if (std::holds_alternative<google::storage::v2::Object>(state)) {
         // Resume found the object is finalized. Success.
         return SetFinalized(
             std::move(lk),
-            absl::get<google::storage::v2::Object>(std::move(state)));
+            std::get<google::storage::v2::Object>(std::move(state)));
       }
       // Resume succeeded, but the object is still not finalized.
       // This means the original finalization attempt failed permanently.
@@ -479,7 +480,7 @@ class AsyncWriterConnectionBufferedState
     if (was_closing) {
       // If resuming due to a close error, we must complete the
       // closed_ promise now, based on the resume attempt's outcome.
-      if (absl::holds_alternative<google::storage::v2::Object>(state)) {
+      if (std::holds_alternative<google::storage::v2::Object>(state)) {
         // Resume found the object is finalized (which implies closed). Success.
         return SetClosed(std::move(lk), Status{});
       }
@@ -491,13 +492,13 @@ class AsyncWriterConnectionBufferedState
       return SetError(std::move(lk), std::move(original_status));
     }
 
-    if (absl::holds_alternative<google::storage::v2::Object>(state)) {
+    if (std::holds_alternative<google::storage::v2::Object>(state)) {
       // Found finalized object (maybe finalized concurrently or resumed).
-      return SetFinalized(std::move(lk), absl::get<google::storage::v2::Object>(
+      return SetFinalized(std::move(lk), std::get<google::storage::v2::Object>(
                                              std::move(state)));
     }
     // Regular resume succeeded, object not finalized. Continue writing.
-    OnQuery(std::move(lk), absl::get<std::int64_t>(state), /*is_resume=*/true);
+    OnQuery(std::move(lk), std::get<std::int64_t>(state), /*is_resume=*/true);
   }
 
   void SetFinalized(std::unique_lock<std::mutex> lk,
@@ -810,7 +811,7 @@ class AsyncWriterConnectionBuffered : public storage::AsyncWriterConnection {
     return state_->WriteHandle();
   }
 
-  absl::variant<std::int64_t, google::storage::v2::Object> PersistedState()
+  std::variant<std::int64_t, google::storage::v2::Object> PersistedState()
       const override {
     return state_->PersistedState();
   }
@@ -848,7 +849,7 @@ std::unique_ptr<storage::AsyncWriterConnection> MakeWriterConnectionBuffered(
     WriterConnectionFactory factory,
     std::unique_ptr<storage::AsyncWriterConnection> impl,
     Options const& options) {
-  return absl::make_unique<AsyncWriterConnectionBuffered>(
+  return std::make_unique<AsyncWriterConnectionBuffered>(
       std::move(factory), std::move(impl), options,
       options.get<storage::BufferedUploadLwmOption>(),
       options.get<storage::BufferedUploadHwmOption>());

--- a/google/cloud/storage/internal/async/writer_connection_buffered_test.cc
+++ b/google/cloud/storage/internal/async/writer_connection_buffered_test.cc
@@ -54,7 +54,7 @@ Options TestOptions() {
       .set<storage::BufferedUploadHwmOption>(32 * 1024);
 }
 
-absl::variant<std::int64_t, google::storage::v2::Object> MakePersistedState(
+std::variant<std::int64_t, google::storage::v2::Object> MakePersistedState(
     std::int64_t persisted_size) {
   return persisted_size;
 }

--- a/google/cloud/storage/internal/async/writer_connection_finalized.cc
+++ b/google/cloud/storage/internal/async/writer_connection_finalized.cc
@@ -45,7 +45,7 @@ AsyncWriterConnectionFinalized::WriteHandle() const {
   return std::nullopt;
 }
 
-absl::variant<std::int64_t, google::storage::v2::Object>
+std::variant<std::int64_t, google::storage::v2::Object>
 AsyncWriterConnectionFinalized::PersistedState() const {
   return object_;
 }

--- a/google/cloud/storage/internal/async/writer_connection_finalized.h
+++ b/google/cloud/storage/internal/async/writer_connection_finalized.h
@@ -53,7 +53,7 @@ class AsyncWriterConnectionFinalized : public storage::AsyncWriterConnection {
   std::string UploadId() const override;
   std::optional<google::storage::v2::BidiWriteHandle> WriteHandle()
       const override;
-  absl::variant<std::int64_t, google::storage::v2::Object> PersistedState()
+  std::variant<std::int64_t, google::storage::v2::Object> PersistedState()
       const override;
 
   future<Status> Write(storage::WritePayload payload) override;

--- a/google/cloud/storage/internal/async/writer_connection_impl.cc
+++ b/google/cloud/storage/internal/async/writer_connection_impl.cc
@@ -22,6 +22,7 @@
 #include "google/cloud/storage/internal/grpc/object_metadata_parser.h"
 #include "google/cloud/storage/internal/grpc/object_request_parser.h"
 #include "google/cloud/internal/make_status.h"
+#include <variant>
 
 namespace google {
 namespace cloud {
@@ -116,7 +117,7 @@ std::string AsyncWriterConnectionImpl::UploadId() const {
   return request_.upload_id();
 }
 
-absl::variant<std::int64_t, google::storage::v2::Object>
+std::variant<std::int64_t, google::storage::v2::Object>
 AsyncWriterConnectionImpl::PersistedState() const {
   std::unique_lock<std::mutex> lk(mu_);
   return persisted_state_;
@@ -215,11 +216,11 @@ future<Status> AsyncWriterConnectionImpl::Close(storage::WritePayload payload) {
 
 future<StatusOr<std::int64_t>> AsyncWriterConnectionImpl::Query() {
   std::unique_lock<std::mutex> lk(mu_);
-  if (auto* size = absl::get_if<std::int64_t>(&persisted_state_)) {
+  if (auto* size = std::get_if<std::int64_t>(&persisted_state_)) {
     return make_ready_future(make_status_or(*size));
   }
   if (auto* meta =
-          absl::get_if<google::storage::v2::Object>(&persisted_state_)) {
+          std::get_if<google::storage::v2::Object>(&persisted_state_)) {
     return make_ready_future(
         make_status_or(static_cast<std::int64_t>(meta->size())));
   }
@@ -284,8 +285,7 @@ future<Status> AsyncWriterConnectionImpl::OnFlush(std::size_t upload_size,
     std::int64_t expected_offset;
 
     future<Status> operator()(
-        future<absl::optional<google::storage::v2::BidiWriteObjectResponse>>
-            f) {
+        future<std::optional<google::storage::v2::BidiWriteObjectResponse>> f) {
       auto response = std::move(f).get();
       if (!response.has_value()) {
         return self->Finish().then(HandleFinishAfterError(
@@ -371,8 +371,7 @@ AsyncWriterConnectionImpl::OnFinalUpload(std::size_t upload_size,
     std::shared_ptr<StreamingRpc> impl;
 
     future<void> operator()(
-        future<absl::optional<google::storage::v2::BidiWriteObjectResponse>>
-            f) {
+        future<std::optional<google::storage::v2::BidiWriteObjectResponse>> f) {
       auto response = std::move(f).get();
       if (!response.has_value()) return make_ready_future();
       {
@@ -397,13 +396,13 @@ AsyncWriterConnectionImpl::OnFinalUpload(std::size_t upload_size,
         [this](auto f2) -> StatusOr<google::storage::v2::Object> {
           auto status = f2.get();
           if (!status.ok()) return status;
-          if (!absl::holds_alternative<google::storage::v2::Object>(
+          if (!std::holds_alternative<google::storage::v2::Object>(
                   persisted_state_)) {
             return internal::InternalError(
                 "no object metadata returned after finalizing upload",
                 GCP_ERROR_INFO());
           }
-          return absl::get<google::storage::v2::Object>(persisted_state_);
+          return std::get<google::storage::v2::Object>(persisted_state_);
         });
   });
 }

--- a/google/cloud/storage/internal/async/writer_connection_impl.h
+++ b/google/cloud/storage/internal/async/writer_connection_impl.h
@@ -59,7 +59,7 @@ class AsyncWriterConnectionImpl : public storage::AsyncWriterConnection {
     std::unique_lock<std::mutex> lk(mu_);
     return latest_write_handle_;
   }
-  absl::variant<std::int64_t, google::storage::v2::Object> PersistedState()
+  std::variant<std::int64_t, google::storage::v2::Object> PersistedState()
       const override;
 
   future<Status> Write(storage::WritePayload payload) override;
@@ -72,7 +72,7 @@ class AsyncWriterConnectionImpl : public storage::AsyncWriterConnection {
 
  private:
   using PersistedStateType =
-      absl::variant<std::int64_t, google::storage::v2::Object>;
+      std::variant<std::int64_t, google::storage::v2::Object>;
   AsyncWriterConnectionImpl(
       google::cloud::internal::ImmutableOptions options,
       google::storage::v2::BidiWriteObjectRequest request,

--- a/google/cloud/storage/internal/async/writer_connection_resumed.cc
+++ b/google/cloud/storage/internal/async/writer_connection_resumed.cc
@@ -25,6 +25,7 @@
 #include <deque>
 #include <memory>
 #include <mutex>
+#include <variant>
 #include <vector>
 
 namespace google {
@@ -89,10 +90,10 @@ class AsyncWriterConnectionResumedState
     finalized_future_ = finalized_.get_future();
     closed_future_ = closed_.get_future();
     auto state = impl_->PersistedState();
-    if (absl::holds_alternative<google::storage::v2::Object>(state)) {
-      buffer_offset_ = absl::get<google::storage::v2::Object>(state).size();
+    if (std::holds_alternative<google::storage::v2::Object>(state)) {
+      buffer_offset_ = std::get<google::storage::v2::Object>(state).size();
     } else {
-      buffer_offset_ = absl::get<std::int64_t>(state);
+      buffer_offset_ = std::get<std::int64_t>(state);
     }
     if (first_response_.has_write_handle()) {
       latest_write_handle_ = first_response_.write_handle();
@@ -120,7 +121,7 @@ class AsyncWriterConnectionResumedState
     return latest_write_handle_;
   }
 
-  absl::variant<std::int64_t, google::storage::v2::Object> PersistedState()
+  std::variant<std::int64_t, google::storage::v2::Object> PersistedState()
       const {
     return Impl(std::unique_lock<std::mutex>(mu_))->PersistedState();
   }
@@ -336,10 +337,10 @@ class AsyncWriterConnectionResumedState
     auto impl = Impl(lk);
     auto const& state = impl->PersistedState();
     std::int64_t persisted_size = 0;
-    if (absl::holds_alternative<google::storage::v2::Object>(state)) {
-      persisted_size = absl::get<google::storage::v2::Object>(state).size();
+    if (std::holds_alternative<google::storage::v2::Object>(state)) {
+      persisted_size = std::get<google::storage::v2::Object>(state).size();
     } else {
-      persisted_size = absl::get<std::int64_t>(state);
+      persisted_size = std::get<std::int64_t>(state);
     }
     lk.unlock();
     OnQuery(persisted_size);
@@ -504,12 +505,12 @@ class AsyncWriterConnectionResumedState
       persisted_offset = first_res.persisted_size();
     } else {
       auto state = impl_->PersistedState();
-      if (absl::holds_alternative<google::storage::v2::Object>(state)) {
+      if (std::holds_alternative<google::storage::v2::Object>(state)) {
         finalized = true;
         finalized_object =
-            absl::get<google::storage::v2::Object>(std::move(state));
+            std::get<google::storage::v2::Object>(std::move(state));
       } else {
-        persisted_offset = absl::get<std::int64_t>(state);
+        persisted_offset = std::get<std::int64_t>(state);
       }
     }
 
@@ -861,7 +862,7 @@ class AsyncWriterConnectionResumed : public storage::AsyncWriterConnection {
     return state_->WriteHandle();
   }
 
-  absl::variant<std::int64_t, google::storage::v2::Object> PersistedState()
+  std::variant<std::int64_t, google::storage::v2::Object> PersistedState()
       const override {
     return state_->PersistedState();
   }
@@ -902,7 +903,7 @@ std::unique_ptr<storage::AsyncWriterConnection> MakeWriterConnectionResumed(
     std::shared_ptr<storage::internal::HashFunction> hash_function,
     google::storage::v2::BidiWriteObjectResponse const& first_response,
     Options const& options) {
-  return absl::make_unique<AsyncWriterConnectionResumed>(
+  return std::make_unique<AsyncWriterConnectionResumed>(
       std::move(factory), std::move(impl), std::move(initial_request),
       std::move(hash_function), std::move(first_response), std::move(options));
 }

--- a/google/cloud/storage/internal/async/writer_connection_resumed_test.cc
+++ b/google/cloud/storage/internal/async/writer_connection_resumed_test.cc
@@ -53,7 +53,7 @@ using MockFactory =
 using MockStreamingRpc =
     ::testing::MockFunction<std::unique_ptr<WriteObject::StreamingRpc>()>;
 
-absl::variant<std::int64_t, google::storage::v2::Object> MakePersistedState(
+std::variant<std::int64_t, google::storage::v2::Object> MakePersistedState(
     std::int64_t persisted_size) {
   return persisted_size;
 }

--- a/google/cloud/storage/internal/async/writer_connection_tracing.cc
+++ b/google/cloud/storage/internal/async/writer_connection_tracing.cc
@@ -54,7 +54,7 @@ class AsyncWriterConnectionTracing : public storage::AsyncWriterConnection {
     return impl_->WriteHandle();
   }
 
-  absl::variant<std::int64_t, google::storage::v2::Object> PersistedState()
+  std::variant<std::int64_t, google::storage::v2::Object> PersistedState()
       const override {
     // No tracing, this is a local call without any significant work.
     return impl_->PersistedState();

--- a/google/cloud/storage/internal/bucket_metadata_cache.cc
+++ b/google/cloud/storage/internal/bucket_metadata_cache.cc
@@ -56,11 +56,11 @@ void BucketMetadataCache::MoveToFront(std::list<std::string>::iterator it) {
   list_.splice(list_.begin(), list_, it);
 }
 
-absl::optional<BucketCacheEntry> BucketMetadataCache::Get(
+std::optional<BucketCacheEntry> BucketMetadataCache::Get(
     std::string const& bucket_name) {
   std::unique_lock<std::mutex> lk(mu_);
   auto it = map_.find(bucket_name);
-  if (it == map_.end()) return absl::nullopt;
+  if (it == map_.end()) return std::nullopt;
 
   MoveToFront(it->second.second);
   return it->second.first;

--- a/google/cloud/storage/internal/bucket_metadata_cache.h
+++ b/google/cloud/storage/internal/bucket_metadata_cache.h
@@ -18,11 +18,11 @@
 #include "google/cloud/storage/version.h"
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
-#include "absl/types/optional.h"
 #include <cstddef>
 #include <list>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -54,7 +54,7 @@ class BucketMetadataCache {
 
   static std::string NormalizeBucketName(std::string const& bucket);
 
-  absl::optional<BucketCacheEntry> Get(std::string const& bucket_name);
+  std::optional<BucketCacheEntry> Get(std::string const& bucket_name);
   void Put(std::string const& bucket_name, BucketCacheEntry entry);
   void Invalidate(std::string const& bucket_name);
   void Clear();

--- a/google/cloud/storage/internal/grpc/make_cord.h
+++ b/google/cloud/storage/internal/grpc/make_cord.h
@@ -17,7 +17,6 @@
 
 #include "google/cloud/internal/invoke_result.h"
 #include "google/cloud/version.h"
-#include "absl/meta/type_traits.h"
 #include "absl/strings/cord.h"
 #include "absl/strings/string_view.h"
 #include <cstddef>
@@ -35,7 +34,7 @@ namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 template <typename T>
-using IsPayloadType = absl::disjunction<
+using IsPayloadType = std::disjunction<
 #if GOOGLE_CLOUD_CPP_CPP_VERSION >= 201703L
     std::is_same<T, std::byte>,
 #endif

--- a/google/cloud/storage/internal/grpc/metrics_exporter_options.cc
+++ b/google/cloud/storage/internal/grpc/metrics_exporter_options.cc
@@ -19,12 +19,12 @@
 #include "google/cloud/common_options.h"
 #include "google/cloud/internal/invocation_id_generator.h"
 #include "google/cloud/universe_domain_options.h"
-#include "absl/types/variant.h"
 #include "google/api/monitored_resource.pb.h"
 #include <opentelemetry/semconv/incubating/cloud_attributes.h>
 #include <opentelemetry/semconv/incubating/host_attributes.h>
 #include <algorithm>
 #include <type_traits>
+#include <variant>
 
 namespace google {
 namespace cloud {
@@ -36,7 +36,7 @@ auto ByName(opentelemetry::sdk::resource::ResourceAttributes const& attributes,
             std::string const& name, std::string default_value) {
   auto const l = attributes.find(name);
   if (l == attributes.end()) return default_value;
-  return absl::get<std::string>(l->second);
+  return std::get<std::string>(l->second);
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/storage_metadata_decorator.cc
+++ b/google/cloud/storage/internal/storage_metadata_decorator.cc
@@ -165,7 +165,7 @@ StatusOr<google::iam::v1::Policy> StorageMetadata::GetIamPolicy(
                         std::regex::optimize}},
             {[](google::iam::v1::GetIamPolicyRequest const& request)
                  -> std::string const& { return request.resource(); },
-             absl::nullopt},
+             std::nullopt},
         }};
   }();
   bucket_matcher->AppendParam(request, params);
@@ -195,7 +195,7 @@ StatusOr<google::iam::v1::Policy> StorageMetadata::SetIamPolicy(
                         std::regex::optimize}},
             {[](google::iam::v1::SetIamPolicyRequest const& request)
                  -> std::string const& { return request.resource(); },
-             absl::nullopt},
+             std::nullopt},
         }};
   }();
   bucket_matcher->AppendParam(request, params);
@@ -230,7 +230,7 @@ StorageMetadata::TestIamPermissions(
                         std::regex::optimize}},
             {[](google::iam::v1::TestIamPermissionsRequest const& request)
                  -> std::string const& { return request.resource(); },
-             absl::nullopt},
+             std::nullopt},
         }};
   }();
   bucket_matcher->AppendParam(request, params);

--- a/google/cloud/storage/internal/tuple_filter.h
+++ b/google/cloud/storage/internal/tuple_filter.h
@@ -19,7 +19,6 @@
 #include "google/cloud/internal/invoke_result.h"
 #include "google/cloud/internal/tuple.h"
 #include "google/cloud/internal/utility.h"
-#include "absl/meta/type_traits.h"
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -148,7 +147,7 @@ StaticTupleFilter(Tuple&& t) {
 template <typename... Types>
 struct Among {
   template <typename T>
-  using TPred = absl::disjunction<std::is_same<std::decay_t<T>, Types>...>;
+  using TPred = std::disjunction<std::is_same<std::decay_t<T>, Types>...>;
 };
 
 /**
@@ -160,7 +159,7 @@ template <typename... Types>
 struct NotAmong {
   template <typename T>
   using TPred = std::integral_constant<
-      bool, !absl::disjunction<std::is_same<std::decay_t<T>, Types>...>::value>;
+      bool, !std::disjunction<std::is_same<std::decay_t<T>, Types>...>::value>;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/list_objects_and_prefixes_reader.h
+++ b/google/cloud/storage/list_objects_and_prefixes_reader.h
@@ -17,16 +17,16 @@
 
 #include "google/cloud/storage/internal/object_requests.h"
 #include "google/cloud/internal/pagination_range.h"
-#include "absl/types/variant.h"
 #include <iterator>
 #include <string>
+#include <variant>
 #include <vector>
 
 namespace google {
 namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-using ObjectOrPrefix = absl::variant<ObjectMetadata, std::string>;
+using ObjectOrPrefix = std::variant<ObjectMetadata, std::string>;
 
 using ListObjectsAndPrefixesReader =
     google::cloud::internal::PaginationRange<ObjectOrPrefix>;
@@ -41,8 +41,8 @@ inline void SortObjectsAndPrefixes(std::vector<ObjectOrPrefix>& in) {
   };
   std::sort(in.begin(), in.end(),
             [](ObjectOrPrefix const& a, ObjectOrPrefix const& b) {
-              return (absl::visit(GetNameOrPrefix{}, a) <
-                      absl::visit(GetNameOrPrefix{}, b));
+              return (std::visit(GetNameOrPrefix{}, a) <
+                      std::visit(GetNameOrPrefix{}, b));
             });
 }
 }  // namespace internal

--- a/google/cloud/storage/mocks/mock_async_writer_connection.h
+++ b/google/cloud/storage/mocks/mock_async_writer_connection.h
@@ -31,7 +31,7 @@ class MockAsyncWriterConnection : public storage::AsyncWriterConnection {
   MOCK_METHOD(std::string, UploadId, (), (const, override));
   MOCK_METHOD(std::optional<google::storage::v2::BidiWriteHandle>, WriteHandle,
               (), (const, override));
-  MOCK_METHOD((absl::variant<std::int64_t, google::storage::v2::Object>),
+  MOCK_METHOD((std::variant<std::int64_t, google::storage::v2::Object>),
               PersistedState, (), (const, override));
   MOCK_METHOD(future<Status>, Write, (storage::WritePayload), (override));
   MOCK_METHOD(future<StatusOr<google::storage::v2::Object>>, Finalize,

--- a/google/cloud/storage/tests/async_client_integration_test.cc
+++ b/google/cloud/storage/tests/async_client_integration_test.cc
@@ -32,6 +32,7 @@
 #include <string>
 #include <tuple>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace google {
@@ -378,7 +379,7 @@ TEST_F(AsyncClientIntegrationTest, StartUnbufferedUploadResume) {
   // Incidentally, this shows the value fits into an `int`.
   ASSERT_THAT(persisted, VariantWith<std::int64_t>(Le(kDesiredSize)));
   // Cast to `int` because otherwise we need to write multiple casts below.
-  auto offset = static_cast<int>(absl::get<std::int64_t>(persisted));
+  auto offset = static_cast<int>(std::get<std::int64_t>(persisted));
   if (offset % kBlockSize != 0) {
     auto s = block.substr(offset % kBlockSize);
     auto const size = s.size();
@@ -844,7 +845,7 @@ TEST_F(AsyncClientIntegrationTest, ResumeAppendableObjectUpload) {
   auto const persisted = writer.PersistedState();
   ASSERT_THAT(persisted, VariantWith<std::int64_t>(Le(kDesiredSize)));
   // Cast to `int` because otherwise we need to write multiple casts below.
-  auto offset = static_cast<int>(absl::get<std::int64_t>(persisted));
+  auto offset = static_cast<int>(std::get<std::int64_t>(persisted));
   if (offset % kBlockSize != 0) {
     auto s = block.substr(offset % kBlockSize);
     auto const size = s.size();

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -29,6 +29,7 @@
 #include <sstream>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace google {
@@ -162,10 +163,10 @@ TEST_F(ObjectIntegrationTest, ListObjectsAndPrefixes) {
   std::vector<std::string> objects;
   for (auto& it : reader) {
     auto const& result = it.value();
-    if (absl::holds_alternative<std::string>(result)) {
-      prefixes.push_back(absl::get<std::string>(result));
+    if (std::holds_alternative<std::string>(result)) {
+      prefixes.push_back(std::get<std::string>(result));
     } else {
-      auto const& meta = absl::get<ObjectMetadata>(result);
+      auto const& meta = std::get<ObjectMetadata>(result);
       EXPECT_EQ(bucket_name_, meta.bucket());
       objects.push_back(meta.name());
     }
@@ -196,10 +197,10 @@ TEST_F(ObjectIntegrationTest, ListObjectsAndPrefixesWithFolders) {
   std::vector<std::string> objects;
   for (auto& it : reader) {
     auto const& result = it.value();
-    if (absl::holds_alternative<std::string>(result)) {
-      prefixes.push_back(absl::get<std::string>(result));
+    if (std::holds_alternative<std::string>(result)) {
+      prefixes.push_back(std::get<std::string>(result));
     } else {
-      auto const& meta = absl::get<ObjectMetadata>(result);
+      auto const& meta = std::get<ObjectMetadata>(result);
       EXPECT_EQ(bucket_name_, meta.bucket());
       objects.push_back(meta.name());
     }
@@ -230,10 +231,10 @@ TEST_F(ObjectIntegrationTest, ListObjectsStartEndOffset) {
   std::vector<std::string> objects;
   for (auto& it : reader) {
     auto const& result = it.value();
-    if (absl::holds_alternative<std::string>(result)) {
-      prefixes.push_back(absl::get<std::string>(result));
+    if (std::holds_alternative<std::string>(result)) {
+      prefixes.push_back(std::get<std::string>(result));
     } else {
-      auto const& meta = absl::get<ObjectMetadata>(result);
+      auto const& meta = std::get<ObjectMetadata>(result);
       EXPECT_EQ(bucket_name_, meta.bucket());
       objects.push_back(meta.name());
     }
@@ -286,10 +287,10 @@ TEST_F(ObjectIntegrationTest, ListObjectsIncludeTrailingDelimiter) {
   std::vector<std::string> objects;
   for (auto& it : reader) {
     auto const& result = it.value();
-    if (absl::holds_alternative<std::string>(result)) {
-      prefixes.push_back(absl::get<std::string>(result));
+    if (std::holds_alternative<std::string>(result)) {
+      prefixes.push_back(std::get<std::string>(result));
     } else {
-      auto const& meta = absl::get<ObjectMetadata>(result);
+      auto const& meta = std::get<ObjectMetadata>(result);
       EXPECT_EQ(bucket_name_, meta.bucket());
       objects.push_back(meta.name());
     }

--- a/google/cloud/storagecontrol/v2/internal/storage_control_metadata_decorator.cc
+++ b/google/cloud/storagecontrol/v2/internal/storage_control_metadata_decorator.cc
@@ -951,7 +951,7 @@ StatusOr<google::iam::v1::Policy> StorageControlMetadata::GetIamPolicy(
                         std::regex::optimize}},
             {[](google::iam::v1::GetIamPolicyRequest const& request)
                  -> std::string const& { return request.resource(); },
-             absl::nullopt},
+             std::nullopt},
         }};
   }();
   bucket_matcher->AppendParam(request, params);
@@ -981,7 +981,7 @@ StatusOr<google::iam::v1::Policy> StorageControlMetadata::SetIamPolicy(
                         std::regex::optimize}},
             {[](google::iam::v1::SetIamPolicyRequest const& request)
                  -> std::string const& { return request.resource(); },
-             absl::nullopt},
+             std::nullopt},
         }};
   }();
   bucket_matcher->AppendParam(request, params);
@@ -1016,7 +1016,7 @@ StorageControlMetadata::TestIamPermissions(
                         std::regex::optimize}},
             {[](google::iam::v1::TestIamPermissionsRequest const& request)
                  -> std::string const& { return request.resource(); },
-             absl::nullopt},
+             std::nullopt},
         }};
   }();
   bucket_matcher->AppendParam(request, params);

--- a/google/cloud/stream_range.h
+++ b/google/cloud/stream_range.h
@@ -20,10 +20,10 @@
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include "absl/types/variant.h"
 #include <functional>
 #include <iterator>
 #include <utility>
+#include <variant>
 
 namespace google {
 namespace cloud {
@@ -54,11 +54,11 @@ namespace internal {
  * @endcode
  */
 template <typename T>
-using StreamReader = std::function<absl::variant<Status, T>()>;
+using StreamReader = std::function<std::variant<Status, T>()>;
 
 template <typename T>
 using StreamReaderExplicit =
-    std::function<absl::variant<Status, T>(Options const&)>;
+    std::function<std::variant<Status, T>(Options const&)>;
 
 // Defined below.
 template <typename T>
@@ -205,7 +205,7 @@ class StreamRange {
     };
     internal::ScopedCallContext scope(call_context_);
     auto v = reader_(*call_context_.options);
-    absl::visit(UnpackVariant{*this}, std::move(v));
+    std::visit(UnpackVariant{*this}, std::move(v));
   }
 
   template <typename U>

--- a/google/cloud/stream_range_test.cc
+++ b/google/cloud/stream_range_test.cc
@@ -286,7 +286,7 @@ class FakeReader {
 
   ~FakeReader() { EXPECT_THAT(span_, IsActive()); }
 
-  absl::variant<Status, int> operator()(Options const&) {
+  std::variant<Status, int> operator()(Options const&) {
     EXPECT_THAT(span_, IsActive());
     return 1;
   }

--- a/google/cloud/testing_util/command_line_parsing.cc
+++ b/google/cloud/testing_util/command_line_parsing.cc
@@ -60,7 +60,7 @@ std::chrono::seconds ParseDuration(std::string const& val) {
   return absl::ToChronoSeconds(d);
 }
 
-absl::optional<bool> ParseBoolean(std::string const& val) {
+std::optional<bool> ParseBoolean(std::string const& val) {
   auto lower = val;
   std::transform(
       lower.begin(), lower.end(), lower.begin(),

--- a/google/cloud/testing_util/command_line_parsing.h
+++ b/google/cloud/testing_util/command_line_parsing.h
@@ -16,9 +16,10 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_COMMAND_LINE_PARSING_H
 
 #include "google/cloud/version.h"
-#include "absl/types/optional.h"
 #include <chrono>
 #include <cinttypes>
+#include <functional>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -53,7 +54,7 @@ std::chrono::seconds ParseDuration(std::string const& val);
 
 /// Parse a string as a boolean, returning a not-present value if the string is
 /// empty.
-absl::optional<bool> ParseBoolean(std::string const& val);
+std::optional<bool> ParseBoolean(std::string const& val);
 
 /// Defines a command-line option.
 struct OptionDescriptor {

--- a/google/cloud/testing_util/is_proto_equal.cc
+++ b/google/cloud/testing_util/is_proto_equal.cc
@@ -20,18 +20,18 @@ namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace testing_util {
 
-absl::optional<std::string> CompareProtos(
+std::optional<std::string> CompareProtos(
     google::protobuf::Message const& arg,
     google::protobuf::Message const& value) {
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
   auto const result = differencer.Compare(arg, value);
-  if (result) return absl::nullopt;
+  if (result) return std::nullopt;
   return delta;
 }
 
-absl::optional<std::string> CompareProtosApproximately(
+std::optional<std::string> CompareProtosApproximately(
     google::protobuf::Message const& arg,
     google::protobuf::Message const& value) {
   std::string delta;
@@ -43,11 +43,11 @@ absl::optional<std::string> CompareProtosApproximately(
   differencer.set_field_comparator(&comparator);
   differencer.ReportDifferencesToString(&delta);
   auto const result = differencer.Compare(arg, value);
-  if (result) return absl::nullopt;
+  if (result) return std::nullopt;
   return delta;
 }
 
-absl::optional<std::string> CompareProtosApproximately(
+std::optional<std::string> CompareProtosApproximately(
     google::protobuf::Message const& arg,
     google::protobuf::Message const& value, double fraction, double margin) {
   std::string delta;
@@ -59,7 +59,7 @@ absl::optional<std::string> CompareProtosApproximately(
   differencer.set_field_comparator(&comparator);
   differencer.ReportDifferencesToString(&delta);
   auto const result = differencer.Compare(arg, value);
-  if (result) return absl::nullopt;
+  if (result) return std::nullopt;
   return delta;
 }
 

--- a/google/cloud/testing_util/is_proto_equal.h
+++ b/google/cloud/testing_util/is_proto_equal.h
@@ -16,9 +16,9 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_IS_PROTO_EQUAL_H
 
 #include "google/cloud/version.h"
-#include "absl/types/optional.h"
 #include <google/protobuf/message.h>
 #include <gmock/gmock.h>
+#include <optional>
 #include <string>
 
 namespace google {
@@ -26,12 +26,12 @@ namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace testing_util {
 
-absl::optional<std::string> CompareProtos(
+std::optional<std::string> CompareProtos(
     google::protobuf::Message const& arg,
     google::protobuf::Message const& value);
 
 MATCHER_P(IsProtoEqual, value, "Checks whether protos are equal") {
-  absl::optional<std::string> delta = CompareProtos(arg, value);
+  std::optional<std::string> delta = CompareProtos(arg, value);
   if (delta.has_value()) {
     *result_listener << "\n" << *delta;
   }
@@ -40,13 +40,13 @@ MATCHER_P(IsProtoEqual, value, "Checks whether protos are equal") {
 
 // Compares float and double fields approximately, using the default
 // google::protobuf::MessageDifferencer tolerances.
-absl::optional<std::string> CompareProtosApproximately(
+std::optional<std::string> CompareProtosApproximately(
     google::protobuf::Message const& arg,
     google::protobuf::Message const& value);
 
 MATCHER_P(IsProtoApproximatelyEqual, value,
           "Checks whether protos are approximately equal") {
-  absl::optional<std::string> delta = CompareProtosApproximately(arg, value);
+  std::optional<std::string> delta = CompareProtosApproximately(arg, value);
   if (delta.has_value()) {
     *result_listener << "\n" << *delta;
   }
@@ -55,13 +55,13 @@ MATCHER_P(IsProtoApproximatelyEqual, value,
 
 // Compares float and double fields approximately, using the given
 // @p fraction and @p margin.
-absl::optional<std::string> CompareProtosApproximately(
+std::optional<std::string> CompareProtosApproximately(
     google::protobuf::Message const& arg,
     google::protobuf::Message const& value, double fraction, double margin);
 
 MATCHER_P3(IsProtoApproximatelyEqual, value, fraction, margin,
            "Checks whether protos are approximately equal") {
-  absl::optional<std::string> delta =
+  std::optional<std::string> delta =
       CompareProtosApproximately(arg, value, fraction, margin);
   if (delta.has_value()) {
     *result_listener << "\n" << *delta;

--- a/google/cloud/testing_util/scoped_environment.cc
+++ b/google/cloud/testing_util/scoped_environment.cc
@@ -22,7 +22,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace testing_util {
 
 ScopedEnvironment::ScopedEnvironment(std::string variable,
-                                     absl::optional<std::string> const& value)
+                                     std::optional<std::string> const& value)
     : variable_(std::move(variable)),
       prev_value_(internal::GetEnv(variable_.c_str())) {
   SetEnv(variable_.c_str(), value);

--- a/google/cloud/testing_util/scoped_environment.h
+++ b/google/cloud/testing_util/scoped_environment.h
@@ -16,7 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_SCOPED_ENVIRONMENT_H
 
 #include "google/cloud/version.h"
-#include "absl/types/optional.h"
+#include <optional>
 #include <string>
 
 namespace google {
@@ -39,7 +39,7 @@ class ScopedEnvironment {
    * of the variable will be restored upon destruction.
    */
   ScopedEnvironment(std::string variable,
-                    absl::optional<std::string> const& value);
+                    std::optional<std::string> const& value);
 
   ~ScopedEnvironment();
 
@@ -51,7 +51,7 @@ class ScopedEnvironment {
 
  private:
   std::string variable_;
-  absl::optional<std::string> prev_value_;
+  std::optional<std::string> prev_value_;
 };
 
 }  // namespace testing_util

--- a/google/cloud/testing_util/scoped_environment.h
+++ b/google/cloud/testing_util/scoped_environment.h
@@ -35,7 +35,7 @@ class ScopedEnvironment {
  public:
   /**
    * Set the @p variable environment variable to @p value. If @value is
-   * an unset `absl::optional` then the variable is unset. The previous value
+   * an unset `std::optional` then the variable is unset. The previous value
    * of the variable will be restored upon destruction.
    */
   ScopedEnvironment(std::string variable,

--- a/google/cloud/testing_util/setenv.cc
+++ b/google/cloud/testing_util/setenv.cc
@@ -35,7 +35,7 @@ void SetEnv(char const* variable, char const* value) {
 #endif  // _WIN32
 }
 
-void SetEnv(char const* variable, absl::optional<std::string> value) {
+void SetEnv(char const* variable, std::optional<std::string> value) {
   if (!value.has_value()) {
     UnsetEnv(variable);
     return;

--- a/google/cloud/testing_util/setenv.h
+++ b/google/cloud/testing_util/setenv.h
@@ -44,7 +44,7 @@ void SetEnv(char const* variable, char const* value);
 /**
  * Set the @p variable environment variable to @p value.
  *
- * If @value is an unset `absl::optional` then the variable is unset.
+ * If @value is an unset `std::optional` then the variable is unset.
  *
  * @warning A modification to the environment must be serialized with all
  *   other environment reads and writes, so this should only be used when

--- a/google/cloud/testing_util/setenv.h
+++ b/google/cloud/testing_util/setenv.h
@@ -16,7 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_SETENV_H
 
 #include "google/cloud/version.h"
-#include "absl/types/optional.h"
+#include <optional>
 #include <string>
 
 namespace google {
@@ -50,7 +50,7 @@ void SetEnv(char const* variable, char const* value);
  *   other environment reads and writes, so this should only be used when
  *   we are single-threaded.
  */
-void SetEnv(char const* variable, absl::optional<std::string> value);
+void SetEnv(char const* variable, std::optional<std::string> value);
 
 /**
  * Unset (remove) an environment variable.

--- a/google/cloud/testing_util/validate_metadata.cc
+++ b/google/cloud/testing_util/validate_metadata.cc
@@ -16,7 +16,6 @@
 #include "google/cloud/internal/url_encode.h"
 #include "google/cloud/log.h"
 #include "google/cloud/status_or.h"
-#include "absl/meta/type_traits.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_replace.h"
 #include "absl/strings/str_split.h"
@@ -188,7 +187,7 @@ RoutingHeaders FromRoutingRule(google::api::RoutingRule const& routing,
  * containing `"foo"->"bar", "baz"->"rab"` is returned.
  */
 RoutingHeaders FromHttpRule(google::api::HttpRule const& http,
-                            absl::optional<std::string> const& resource_name) {
+                            std::optional<std::string> const& resource_name) {
   RoutingHeaders headers;
   std::string pattern;
   if (!http.get().empty()) {
@@ -226,7 +225,7 @@ RoutingHeaders FromHttpRule(google::api::HttpRule const& http,
 RoutingHeaders ExtractRoutingHeaders(
     google::protobuf::MethodDescriptor const* method,
     google::protobuf::Message const& request,
-    absl::optional<std::string> const& resource_name) {
+    std::optional<std::string> const& resource_name) {
   auto options = method->options();
   if (options.HasExtension(google::api::routing)) {
     auto const& routing = options.GetExtension(google::api::routing);
@@ -301,22 +300,22 @@ std::multimap<std::string, std::string> ValidateMetadataFixture::GetMetadata(
 }
 
 // Older versions of gRPC do not provide `ExperimentalGetAuthority()`. In that
-// case just return `absl::nullopt`, to indicate that the test cannot run.
+// case just return `std::nullopt`, to indicate that the test cannot run.
 template <typename T, typename AlwaysVoid = void>
 struct GetAuthorityImpl {
-  absl::optional<std::string> Get(T& /*sc*/) { return absl::nullopt; }
+  std::optional<std::string> Get(T& /*sc*/) { return std::nullopt; }
 };
 
 template <typename T>
 struct GetAuthorityImpl<
-    T, absl::void_t<decltype(std::declval<T>().ExperimentalGetAuthority())>> {
-  absl::optional<std::string> Get(T& sc) {
+    T, std::void_t<decltype(std::declval<T>().ExperimentalGetAuthority())>> {
+  std::optional<std::string> Get(T& sc) {
     auto result = sc.ExperimentalGetAuthority();
     return std::string(result.data(), result.size());
   }
 };
 
-absl::optional<std::string> ValidateMetadataFixture::GetAuthority(
+std::optional<std::string> ValidateMetadataFixture::GetAuthority(
     grpc::ClientContext& client_context) {
   // Set the deadline to far in the future. If the deadline is in the past,
   // gRPC doesn't send the initial metadata at all (which makes sense, given
@@ -356,8 +355,8 @@ void ValidateMetadataFixture::IsContextMDValid(
     grpc::ClientContext& context, std::string const& method_name,
     google::protobuf::Message const& request,
     std::string const& api_client_header,
-    absl::optional<std::string> const& resource_name,
-    absl::optional<std::string> const& resource_prefix_header) {
+    std::optional<std::string> const& resource_name,
+    std::optional<std::string> const& resource_prefix_header) {
   auto headers = GetMetadata(context);
 
   // Check x-goog-api-client first, because it should always be present.

--- a/google/cloud/testing_util/validate_metadata.h
+++ b/google/cloud/testing_util/validate_metadata.h
@@ -73,7 +73,7 @@ class ValidateMetadataFixture {
   /**
    * Get the `authority` field from `ClientContext`.
    *
-   * With older versions of gRPC this returns `absl::nullopt`, the caller may
+   * With older versions of gRPC this returns `std::nullopt`, the caller may
    * want to skip the rest of the test.
    *
    * @note A `grpc::ClientContext` can be used in only one gRPC. The caller

--- a/google/cloud/testing_util/validate_metadata.h
+++ b/google/cloud/testing_util/validate_metadata.h
@@ -18,11 +18,11 @@
 #include "google/cloud/rpc_metadata.h"
 #include "google/cloud/status.h"
 #include "google/cloud/version.h"
-#include "absl/types/optional.h"
 #include <google/protobuf/message.h>
 #include <grpcpp/generic/async_generic_service.h>
 #include <grpcpp/grpcpp.h>
 #include <map>
+#include <optional>
 #include <string>
 
 namespace google {
@@ -79,7 +79,7 @@ class ValidateMetadataFixture {
    * @note A `grpc::ClientContext` can be used in only one gRPC. The caller
    *   cannot reuse @p context for other RPCs or other calls to this function.
    */
-  absl::optional<std::string> GetAuthority(grpc::ClientContext& client_context);
+  std::optional<std::string> GetAuthority(grpc::ClientContext& client_context);
 
   /**
    * Set server metadata on a `ClientContext`.
@@ -112,8 +112,8 @@ class ValidateMetadataFixture {
       grpc::ClientContext& context, std::string const& method_name,
       google::protobuf::Message const& request,
       std::string const& api_client_header,
-      absl::optional<std::string> const& resource_name = {},
-      absl::optional<std::string> const& resource_prefix_header = {});
+      std::optional<std::string> const& resource_name = {},
+      std::optional<std::string> const& resource_prefix_header = {});
 
  private:
   /**


### PR DESCRIPTION
There are no logic changes in this PR, simply updating to C++17 std types that used to use absl types. Changes in the use of `auto` will be made in a separate PR.

fixes #16354 