### PR TITLE
fix(compute): ensure trailing newline in fetched discovery doc

### DIFF
--- a/generator/discovery/update_discovery_doc.sh
+++ b/generator/discovery/update_discovery_doc.sh
@@ -101,6 +101,11 @@ if ! curl -fsSL "${COMPUTE_DISCOVERY_DOCUMENT_URL}" >"${TEMP_JSON}"; then
   exit 1
 fi
 
+# Ensure the discovery document ends with a trailing newline.
+if [[ -s "${TEMP_JSON}" && -n "$(tail -c1 "${TEMP_JSON}")" ]]; then
+  echo "" >>"${TEMP_JSON}"
+fi
+
 REVISION=$(sed -En 's/  \"revision\": \"([[:digit:]]+)\",/\1/p' "${TEMP_JSON}")
 if [[ -z "${REVISION}" ]]; then
   io::log_red "Could not parse revision from fetched discovery document."

--- a/generator/discovery/update_discovery_doc.sh
+++ b/generator/discovery/update_discovery_doc.sh
@@ -102,8 +102,8 @@ if ! curl -fsSL "${COMPUTE_DISCOVERY_DOCUMENT_URL}" >"${TEMP_JSON}"; then
 fi
 
 # Ensure the discovery document ends with a trailing newline.
-if [[ -s "${TEMP_JSON}" && -n "$(tail -c1 "${TEMP_JSON}")" ]]; then
-  echo "" >>"${TEMP_JSON}"
+if [[ -s "${TEMP_JSON}" && -n "$(tail -c 1 "${TEMP_JSON}")" ]]; then
+  echo >>"${TEMP_JSON}"
 fi
 
 REVISION=$(sed -En 's/  \"revision\": \"([[:digit:]]+)\",/\1/p' "${TEMP_JSON}")


### PR DESCRIPTION
Fixes a failure encountered during the scheduled run of the `.github/workflows/update-compute-discovery.yml` automation workflow.