### PR TITLE
impl(bigtable): only record client schema metric when instance is available

### DIFF
--- a/google/cloud/bigtable/data_connection.cc
+++ b/google/cloud/bigtable/data_connection.cc
@@ -157,14 +157,6 @@ DataConnectionComponents MakeDataConnectionComponents(
 
 std::shared_ptr<bigtable::DataConnection> MakeSingleStubDataConnection(
     DataConnectionComponents components) {
-#ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  if (components.direct_access_compatibility != nullptr) {
-    components.direct_access_compatibility->Record(
-        opentelemetry::context::RuntimeContext::GetCurrent(), 0,
-        bigtable_internal::DirectAccessCompatibilityLabels{
-            "", "manually_disabled"});
-  }
-#endif
   std::shared_ptr<bigtable_internal::BigtableStub> stub =
       bigtable_internal::CreateBigtableStub(std::move(components.auth),
                                             components.background->cq(),
@@ -194,7 +186,7 @@ std::shared_ptr<bigtable::DataConnection> MakeInstanceAffinityDataConnection(
       affinity_stubs = bigtable_internal::CreateBigtableAffinityStubs(
           instances, stub_creation_fn);
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_OTEL_METRICS
-  if (components.direct_access_compatibility != nullptr) {
+  if (!instances.empty() && components.direct_access_compatibility != nullptr) {
     components.direct_access_compatibility->Record(
         opentelemetry::context::RuntimeContext::GetCurrent(), 0,
         bigtable_internal::DirectAccessCompatibilityLabels{

--- a/google/cloud/ftp/CMakeLists.txt
+++ b/google/cloud/ftp/CMakeLists.txt
@@ -27,6 +27,7 @@ if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
         NAME ftp_quickstart
         COMMAND cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
                 $<TARGET_FILE:ftp_quickstart> GOOGLE_CLOUD_PROJECT)
-    set_tests_properties(ftp_quickstart
-                         PROPERTIES LABELS "integration-test;quickstart")
+    set_tests_properties(
+        ftp_quickstart PROPERTIES DISABLED "True" LABELS
+                                  "integration-test;quickstart")
 endif ()


### PR DESCRIPTION
The legacy static pool Connection does not require specifying an instance, which makes recording/exporting a client schema metric invalid.