### PR TITLE
fix(rest): merge env vars when setting CURLOPT_NOPROXY

### DIFF
--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/internal/curl_options.h"
 #include "google/cloud/internal/curl_writev.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/make_status.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/internal/user_agent_prefix.h"
@@ -30,6 +31,7 @@
 #include <curl/easy.h>
 #include <algorithm>
 #include <sstream>
+#include <string_view>
 #include <thread>
 
 // Note that TRACE-level messages are disabled by default, even in
@@ -90,6 +92,20 @@ Status AsStatus(CURLMcode result, char const* where) {
 }
 
 }  // namespace
+
+std::string NoProxyValue() {
+  std::vector<std::string_view> parts = {"metadata.google.internal"};
+  std::optional<std::string> const no_proxy = internal::GetEnv("no_proxy");
+  if (no_proxy && !no_proxy->empty()) {
+    parts.push_back(*no_proxy);
+  }
+  std::optional<std::string> const no_proxy_upper =
+      internal::GetEnv("NO_PROXY");
+  if (no_proxy_upper && !no_proxy_upper->empty()) {
+    parts.push_back(*no_proxy_upper);
+  }
+  return absl::StrJoin(parts, ",");
+}
 
 extern "C" {  // libcurl callbacks
 
@@ -397,7 +413,8 @@ Status CurlImpl::MakeRequest(HttpMethod method, RestContext& context,
 
 #ifndef GOOGLE_CLOUD_CPP_WINDOWS_BAZEL_CI_WORKAROUND
 #if CURL_AT_LEAST_VERSION(7, 19, 4)
-  status = handle_.SetOption(CURLOPT_NOPROXY, "metadata.google.internal");
+  std::string const no_proxy = NoProxyValue();
+  status = handle_.SetOption(CURLOPT_NOPROXY, no_proxy.c_str());
   if (!status.ok()) return OnTransferError(context, std::move(status));
 #endif
 #endif

--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -93,18 +93,23 @@ Status AsStatus(CURLMcode result, char const* where) {
 
 }  // namespace
 
-std::string NoProxyValue() {
+std::string MakeNoProxyValue(std::optional<std::string> const& no_proxy,
+                             std::optional<std::string> const& no_proxy_upper) {
   std::vector<std::string_view> parts = {"metadata.google.internal"};
-  std::optional<std::string> const no_proxy = internal::GetEnv("no_proxy");
   if (no_proxy && !no_proxy->empty()) {
     parts.push_back(*no_proxy);
   }
-  std::optional<std::string> const no_proxy_upper =
-      internal::GetEnv("NO_PROXY");
   if (no_proxy_upper && !no_proxy_upper->empty()) {
     parts.push_back(*no_proxy_upper);
   }
   return absl::StrJoin(parts, ",");
+}
+
+std::string NoProxyValue() {
+  static std::string const* const kNoProxyValue =
+      new std::string(MakeNoProxyValue(internal::GetEnv("no_proxy"),
+                                       internal::GetEnv("NO_PROXY")));
+  return *kNoProxyValue;
 }
 
 extern "C" {  // libcurl callbacks

--- a/google/cloud/internal/curl_impl.h
+++ b/google/cloud/internal/curl_impl.h
@@ -43,7 +43,16 @@ namespace rest_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 // Returns a comma-delimited string containing the Google metadata server
+// and any values from the provided `no_proxy` and `NO_PROXY` strings.
+// NOTE: This function is only exposed for testing. Use NoProxyValue in
+//     non test code.
+std::string MakeNoProxyValue(std::optional<std::string> const& no_proxy,
+                             std::optional<std::string> const& no_proxy_upper);
+
+// Returns a comma-delimited string containing the Google metadata server
 // and any values from the `no_proxy` and `NO_PROXY` environment variables.
+// NOTE: This functions caches the result of MakeNoProxyValue to improve
+//     performance.
 std::string NoProxyValue();
 
 // libcurl will never pass a block larger than CURL_MAX_WRITE_SIZE to the

--- a/google/cloud/internal/curl_impl.h
+++ b/google/cloud/internal/curl_impl.h
@@ -42,6 +42,10 @@ namespace cloud {
 namespace rest_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+// Returns a comma-delimited string containing the Google metadata server
+// and any values from the `no_proxy` and `NO_PROXY` environment variables.
+std::string NoProxyValue();
+
 // libcurl will never pass a block larger than CURL_MAX_WRITE_SIZE to the
 // [write callback](https://curl.se/libcurl/c/CURLOPT_WRITEFUNCTION.html).
 // However, CurlImpl::Read() may not be given a buffer large enough to

--- a/google/cloud/internal/curl_impl_test.cc
+++ b/google/cloud/internal/curl_impl_test.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/internal/curl_impl.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/rest_options.h"
-#include "google/cloud/testing_util/scoped_environment.h"
 #include <gmock/gmock.h>
 #include <vector>
 
@@ -393,37 +392,33 @@ TEST_F(CurlImplTest, MergeAndWriteHeadersDoNotMergeContentLength) {
   EXPECT_THAT(headers_written, ElementsAre(std::string(expected)));
 }
 
-TEST(NoProxyValueTest, NoProxyValueDefault) {
-  testing_util::ScopedEnvironment env_lower("no_proxy", std::nullopt);
-  testing_util::ScopedEnvironment env_upper("NO_PROXY", std::nullopt);
-  EXPECT_THAT(NoProxyValue(), testing::Eq("metadata.google.internal"));
+TEST(NoProxyValueTest, MakeNoProxyValueDefault) {
+  EXPECT_THAT(MakeNoProxyValue(std::nullopt, std::nullopt),
+              testing::Eq("metadata.google.internal"));
 }
 
-TEST(NoProxyValueTest, NoProxyValueLowerOnly) {
-  testing_util::ScopedEnvironment env_lower("no_proxy", "localhost,127.0.0.1");
-  testing_util::ScopedEnvironment env_upper("NO_PROXY", std::nullopt);
-  EXPECT_THAT(NoProxyValue(),
+TEST(NoProxyValueTest, MakeNoProxyValueLowerOnly) {
+  EXPECT_THAT(MakeNoProxyValue("localhost,127.0.0.1", std::nullopt),
               testing::Eq("metadata.google.internal,localhost,127.0.0.1"));
 }
 
-TEST(NoProxyValueTest, NoProxyValueUpperOnly) {
-  testing_util::ScopedEnvironment env_lower("no_proxy", std::nullopt);
-  testing_util::ScopedEnvironment env_upper("NO_PROXY", "10.0.0.0/8");
-  EXPECT_THAT(NoProxyValue(),
+TEST(NoProxyValueTest, MakeNoProxyValueUpperOnly) {
+  EXPECT_THAT(MakeNoProxyValue(std::nullopt, "10.0.0.0/8"),
               testing::Eq("metadata.google.internal,10.0.0.0/8"));
 }
 
-TEST(NoProxyValueTest, NoProxyValueBothSet) {
-  testing_util::ScopedEnvironment env_lower("no_proxy", "localhost");
-  testing_util::ScopedEnvironment env_upper("NO_PROXY", "10.0.0.0/8");
-  EXPECT_THAT(NoProxyValue(),
+TEST(NoProxyValueTest, MakeNoProxyValueBothSet) {
+  EXPECT_THAT(MakeNoProxyValue("localhost", "10.0.0.0/8"),
               testing::Eq("metadata.google.internal,localhost,10.0.0.0/8"));
 }
 
-TEST(NoProxyValueTest, NoProxyValueEmpty) {
-  testing_util::ScopedEnvironment env_lower("no_proxy", "");
-  testing_util::ScopedEnvironment env_upper("NO_PROXY", "");
-  EXPECT_THAT(NoProxyValue(), testing::Eq("metadata.google.internal"));
+TEST(NoProxyValueTest, MakeNoProxyValueEmpty) {
+  EXPECT_THAT(MakeNoProxyValue("", ""),
+              testing::Eq("metadata.google.internal"));
+}
+
+TEST(NoProxyValueTest, NoProxyValue) {
+  EXPECT_THAT(NoProxyValue(), testing::HasSubstr("metadata.google.internal"));
 }
 
 }  // namespace

--- a/google/cloud/internal/curl_impl_test.cc
+++ b/google/cloud/internal/curl_impl_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/internal/curl_impl.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/rest_options.h"
+#include "google/cloud/testing_util/scoped_environment.h"
 #include <gmock/gmock.h>
 #include <vector>
 
@@ -390,6 +391,39 @@ TEST_F(CurlImplTest, MergeAndWriteHeadersDoNotMergeContentLength) {
   impl.MergeAndWriteHeaders(write_fn);
   HttpHeader expected("content-length", "42");
   EXPECT_THAT(headers_written, ElementsAre(std::string(expected)));
+}
+
+TEST(NoProxyValueTest, NoProxyValueDefault) {
+  testing_util::ScopedEnvironment env_lower("no_proxy", std::nullopt);
+  testing_util::ScopedEnvironment env_upper("NO_PROXY", std::nullopt);
+  EXPECT_THAT(NoProxyValue(), testing::Eq("metadata.google.internal"));
+}
+
+TEST(NoProxyValueTest, NoProxyValueLowerOnly) {
+  testing_util::ScopedEnvironment env_lower("no_proxy", "localhost,127.0.0.1");
+  testing_util::ScopedEnvironment env_upper("NO_PROXY", std::nullopt);
+  EXPECT_THAT(NoProxyValue(),
+              testing::Eq("metadata.google.internal,localhost,127.0.0.1"));
+}
+
+TEST(NoProxyValueTest, NoProxyValueUpperOnly) {
+  testing_util::ScopedEnvironment env_lower("no_proxy", std::nullopt);
+  testing_util::ScopedEnvironment env_upper("NO_PROXY", "10.0.0.0/8");
+  EXPECT_THAT(NoProxyValue(),
+              testing::Eq("metadata.google.internal,10.0.0.0/8"));
+}
+
+TEST(NoProxyValueTest, NoProxyValueBothSet) {
+  testing_util::ScopedEnvironment env_lower("no_proxy", "localhost");
+  testing_util::ScopedEnvironment env_upper("NO_PROXY", "10.0.0.0/8");
+  EXPECT_THAT(NoProxyValue(),
+              testing::Eq("metadata.google.internal,localhost,10.0.0.0/8"));
+}
+
+TEST(NoProxyValueTest, NoProxyValueEmpty) {
+  testing_util::ScopedEnvironment env_lower("no_proxy", "");
+  testing_util::ScopedEnvironment env_upper("NO_PROXY", "");
+  EXPECT_THAT(NoProxyValue(), testing::Eq("metadata.google.internal"));
 }
 
 }  // namespace


### PR DESCRIPTION
fixes #16416 