### PR TITLE
impl: enable GDCH Service Account credentials for gRPC endpoints

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -43,6 +43,7 @@ extend-exclude = [
     "google/cloud/internal/oauth2_google_credentials_test.cc",
     "google/cloud/internal/oauth2_service_account_credentials_test.cc",
     "google/cloud/internal/rest_client_integration_test.cc",
+    "google/cloud/internal/unified_grpc_credentials_test.cc",
     "google/cloud/testing_util/credentials_constants.h",
     "google/cloud/storage/client_options_test.cc",
     "google/cloud/storage/client_sign_policy_document_test.cc",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -53,6 +53,14 @@ python.toolchain(
 )
 
 bazel_dep(name = "grpc", version = "1.83.0")
+
+# grpc v1.84.0-pre1
+git_override(
+    module_name = "grpc",
+    commit = "56e86cb3b88de5b01cc5112e9c3c33be24c47aa5",
+    remote = "https://github.com/grpc/grpc.git",
+)
+
 bazel_dep(name = "googleapis", version = "0.0.0-20260825-d10ac924")
 bazel_dep(name = "googleapis-cc", version = "1.1.5")
 bazel_dep(name = "googleapis-grpc-cc", version = "1.1.5")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -54,10 +54,10 @@ python.toolchain(
 
 bazel_dep(name = "grpc", version = "1.83.0")
 
-# grpc v1.84.0-pre1
+# grpc v1.84.0-pre2
 git_override(
     module_name = "grpc",
-    commit = "56e86cb3b88de5b01cc5112e9c3c33be24c47aa5",
+    commit = "c633e391bb20236fa7bd07b3fcce600d66a3ca69",
     remote = "https://github.com/grpc/grpc.git",
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -53,14 +53,6 @@ python.toolchain(
 )
 
 bazel_dep(name = "grpc", version = "1.83.0")
-
-# grpc v1.84.0-pre2
-git_override(
-    module_name = "grpc",
-    commit = "c633e391bb20236fa7bd07b3fcce600d66a3ca69",
-    remote = "https://github.com/grpc/grpc.git",
-)
-
 bazel_dep(name = "googleapis", version = "0.0.0-20260825-d10ac924")
 bazel_dep(name = "googleapis-cc", version = "1.1.5")
 bazel_dep(name = "googleapis-grpc-cc", version = "1.1.5")

--- a/google/cloud/BUILD.bazel
+++ b/google/cloud/BUILD.bazel
@@ -153,6 +153,7 @@ cc_library(
         "@googleapis//google/rpc:error_details_cc_proto",
         "@googleapis//google/rpc:status_cc_proto",
         "@grpc//:grpc++",
+        "@nlohmann_json//:json",
     ],
 )
 
@@ -178,6 +179,7 @@ cc_library(
         "@googleapis//google/bigtable/admin/v2:admin_cc_grpc",
         "@googleapis//google/bigtable/v2:bigtable_cc_grpc",
         "@googletest//:gtest_main",
+        "@nlohmann_json//:json",
     ],
 ) for test in google_cloud_cpp_grpc_utils_unit_tests]
 

--- a/google/cloud/config-grpc-utils.cmake.in
+++ b/google/cloud/config-grpc-utils.cmake.in
@@ -17,5 +17,6 @@ include(CMakeFindDependencyMacro)
 find_dependency(google_cloud_cpp_googleapis)
 find_dependency(google_cloud_cpp_common)
 find_dependency(absl)
+find_dependency(nlohmann_json)
 
 include("${CMAKE_CURRENT_LIST_DIR}/grpc_utils-targets.cmake")

--- a/google/cloud/google_cloud_cpp_grpc_utils.cmake
+++ b/google/cloud/google_cloud_cpp_grpc_utils.cmake
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ~~~
+find_package(nlohmann_json CONFIG REQUIRED)
 
 # the library
 add_library(
@@ -121,7 +122,8 @@ target_link_libraries(
            google-cloud-cpp::rpc_status_protos
            google-cloud-cpp::common
            gRPC::grpc++
-           gRPC::grpc)
+           gRPC::grpc
+           nlohmann_json::nlohmann_json)
 google_cloud_cpp_add_common_options(google_cloud_cpp_grpc_utils)
 target_include_directories(
     google_cloud_cpp_grpc_utils PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
@@ -276,6 +278,7 @@ if (BUILD_TESTING)
     # List the unit tests, then setup the targets and dependencies.
     set(google_cloud_cpp_grpc_utils_integration_tests
         # cmake-format: sort
+        internal/grpc_gdch_service_account_integration_test.cc
         internal/grpc_impersonate_service_account_integration_test.cc)
 
     # Export the list of unit and integration tests so the Bazel BUILD file can

--- a/google/cloud/google_cloud_cpp_grpc_utils_integration_tests.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils_integration_tests.bzl
@@ -17,5 +17,6 @@
 """Automatically generated unit tests list - DO NOT EDIT."""
 
 google_cloud_cpp_grpc_utils_integration_tests = [
+    "internal/grpc_gdch_service_account_integration_test.cc",
     "internal/grpc_impersonate_service_account_integration_test.cc",
 ]

--- a/google/cloud/internal/grpc_gdch_service_account_integration_test.cc
+++ b/google/cloud/internal/grpc_gdch_service_account_integration_test.cc
@@ -1,0 +1,112 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/completion_queue.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/internal/unified_grpc_credentials.h"
+#include "google/cloud/testing_util/scoped_environment.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include <gmock/gmock.h>
+#if __has_include(<grpcpp/version_info.h>)
+#include <grpcpp/version_info.h>
+#endif
+#include <fstream>
+
+namespace google {
+namespace cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+namespace {
+
+using ::google::cloud::testing_util::IsOk;
+using ::google::cloud::testing_util::ScopedEnvironment;
+using ::testing::IsEmpty;
+using ::testing::Not;
+using ::testing::NotNull;
+
+TEST(GrpcGdchServiceAccountIntegrationTest,
+     RetrievesBearerTokenFromMemoryInAdhocEnvironment) {
+#if !defined(GRPC_CPP_VERSION_MAJOR) || \
+    (GRPC_CPP_VERSION_MAJOR < 1 ||      \
+     (GRPC_CPP_VERSION_MAJOR == 1 && GRPC_CPP_VERSION_MINOR < 84))
+  GTEST_SKIP() << "GDCH credentials require gRPC >= 1.84.0";
+#endif
+  std::optional<std::string> key_file_env = GetEnv("GRPC_TEST_GDCH_KEY_FILE");
+  std::optional<std::string> audience_env = GetEnv("GRPC_TEST_GDCH_AUDIENCE");
+  if (!key_file_env.has_value() || !audience_env.has_value()) GTEST_SKIP();
+
+  std::ifstream is(*key_file_env);
+  std::string contents = std::string{std::istreambuf_iterator<char>{is}, {}};
+  ASSERT_THAT(contents, Not(IsEmpty()));
+
+  CompletionQueue cq;
+
+  std::shared_ptr<Credentials> creds =
+      MakeGDCHServiceAccountCredentials(contents, *audience_env);
+  ASSERT_THAT(creds, NotNull());
+
+  std::shared_ptr<GrpcAuthenticationStrategy> auth =
+      CreateAuthenticationStrategy(*creds, cq);
+  ASSERT_THAT(auth, NotNull());
+
+  grpc::ClientContext context;
+  Status status = auth->ConfigureContext(context);
+  EXPECT_THAT(status, IsOk());
+
+  std::shared_ptr<grpc::Channel> channel =
+      auth->CreateChannel("localhost:443", grpc::ChannelArguments{});
+  EXPECT_THAT(channel, NotNull());
+}
+
+TEST(GrpcGdchServiceAccountIntegrationTest,
+     RetrievesBearerTokenFromFileInAdhocEnvironment) {
+#if !defined(GRPC_CPP_VERSION_MAJOR) || \
+    (GRPC_CPP_VERSION_MAJOR < 1 ||      \
+     (GRPC_CPP_VERSION_MAJOR == 1 && GRPC_CPP_VERSION_MINOR < 84))
+  GTEST_SKIP() << "GDCH credentials require gRPC >= 1.84.0";
+#endif
+  std::optional<std::string> key_file_env = GetEnv("GRPC_TEST_GDCH_KEY_FILE");
+  std::optional<std::string> audience_env = GetEnv("GRPC_TEST_GDCH_AUDIENCE");
+  if (!key_file_env.has_value() || !audience_env.has_value()) GTEST_SKIP();
+
+  std::ifstream is(*key_file_env);
+  std::string contents = std::string{std::istreambuf_iterator<char>{is}, {}};
+  ASSERT_THAT(contents, Not(IsEmpty()));
+
+  CompletionQueue cq;
+
+  ScopedEnvironment env("GOOGLE_APPLICATION_CREDENTIALS", key_file_env);
+  std::shared_ptr<Credentials> creds =
+      MakeGDCHServiceAccountCredentials(*audience_env);
+  ASSERT_THAT(creds, NotNull());
+
+  std::shared_ptr<GrpcAuthenticationStrategy> auth =
+      CreateAuthenticationStrategy(*creds, cq);
+  ASSERT_THAT(auth, NotNull());
+
+  grpc::ClientContext context;
+  Status status = auth->ConfigureContext(context);
+  EXPECT_THAT(status, IsOk());
+
+  std::shared_ptr<grpc::Channel> channel =
+      auth->CreateChannel("localhost:443", grpc::ChannelArguments{});
+  EXPECT_THAT(channel, NotNull());
+}
+
+}  // namespace
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/internal/unified_grpc_credentials.cc
+++ b/google/cloud/internal/unified_grpc_credentials.cc
@@ -22,6 +22,10 @@
 #include "google/cloud/internal/grpc_impersonate_service_account.h"
 #include "google/cloud/internal/grpc_service_account_authentication.h"
 #include <grpcpp/security/credentials.h>
+#if __has_include(<grpcpp/version_info.h>)
+#include <grpcpp/version_info.h>
+#endif
+#include <nlohmann/json.hpp>
 #include <fstream>
 
 namespace {
@@ -161,12 +165,68 @@ std::shared_ptr<GrpcAuthenticationStrategy> CreateAuthenticationStrategy(
               "or Access Token Credentials instead.",
               GCP_ERROR_INFO())});
     }
-    void visit(GDCHServiceAccountConfig const&) override {
+    void visit(GDCHServiceAccountConfig const& cfg) override {
+#if defined(GRPC_CPP_VERSION_MAJOR) && \
+    (GRPC_CPP_VERSION_MAJOR > 1 ||     \
+     (GRPC_CPP_VERSION_MAJOR == 1 && GRPC_CPP_VERSION_MINOR >= 84))
+      std::string json_contents;
+      if (cfg.file_path().has_value()) {
+        std::ifstream is(*cfg.file_path());
+        if (!is.is_open()) {
+          result = std::make_unique<GrpcErrorCredentialsAuthentication>(
+              ErrorCredentialsConfig{UnknownError(
+                  "Cannot open credentials file " + *cfg.file_path(),
+                  GCP_ERROR_INFO())});
+          return;
+        }
+        json_contents = std::string{std::istreambuf_iterator<char>{is}, {}};
+      } else if (!cfg.json_object().empty()) {
+        json_contents = cfg.json_object();
+      } else {
+        result = std::make_unique<GrpcErrorCredentialsAuthentication>(
+            ErrorCredentialsConfig{
+                InternalError("GDCHServiceAccountConfig has neither "
+                              "json_object nor file_path",
+                              GCP_ERROR_INFO())});
+        return;
+      }
+
+      std::shared_ptr<grpc::CallCredentials> gdch_creds =
+          grpc::GDCHServiceAccountCredentials(json_contents, cfg.audience());
+      if (!gdch_creds) {
+        result = std::make_unique<GrpcErrorCredentialsAuthentication>(
+            ErrorCredentialsConfig{InternalError(
+                "Error creating grpc::GDCHServiceAccountCredentials",
+                GCP_ERROR_INFO())});
+        return;
+      }
+
+      std::string ca_cert_path;
+      nlohmann::json j = nlohmann::json::parse(json_contents, nullptr, false);
+      if (!j.is_discarded() && j.is_object()) {
+        ca_cert_path = j.value("ca_cert_path", "");
+      }
+      grpc::SslCredentialsOptions ssl_options;
+      if (!ca_cert_path.empty()) {
+        std::ifstream is(ca_cert_path);
+        if (is.is_open()) {
+          ssl_options.pem_root_certs =
+              std::string{std::istreambuf_iterator<char>{is.rdbuf()}, {}};
+        }
+      } else {
+        std::optional<std::string> cainfo = LoadCAInfo(options);
+        if (cainfo) ssl_options.pem_root_certs = std::move(*cainfo);
+      }
+      result = std::make_unique<GrpcChannelCredentialsAuthentication>(
+          grpc::CompositeChannelCredentials(grpc::SslCredentials(ssl_options),
+                                            gdch_creds));
+#else
+      (void)cfg;
       result = std::make_unique<GrpcErrorCredentialsAuthentication>(
-          ErrorCredentialsConfig{
-              UnimplementedError("GDCHServiceAccountCredentials are not yet "
-                                 "supported for gRPC endpoints",
-                                 GCP_ERROR_INFO())});
+          ErrorCredentialsConfig{UnimplementedError(
+              "GDCHServiceAccountCredentials require gRPC v1.84.0 or greater",
+              GCP_ERROR_INFO())});
+#endif
     }
 
   } visitor(std::move(cq), std::move(options));

--- a/google/cloud/internal/unified_grpc_credentials.cc
+++ b/google/cloud/internal/unified_grpc_credentials.cc
@@ -204,15 +204,23 @@ std::shared_ptr<GrpcAuthenticationStrategy> CreateAuthenticationStrategy(
       std::string ca_cert_path;
       nlohmann::json j = nlohmann::json::parse(json_contents, nullptr, false);
       if (!j.is_discarded() && j.is_object()) {
-        ca_cert_path = j.value("ca_cert_path", "");
+        auto it = j.find("ca_cert_path");
+        if (it != j.end() && it->is_string()) {
+          ca_cert_path = it->get<std::string>();
+        }
       }
       grpc::SslCredentialsOptions ssl_options;
       if (!ca_cert_path.empty()) {
         std::ifstream is(ca_cert_path);
-        if (is.is_open()) {
-          ssl_options.pem_root_certs =
-              std::string{std::istreambuf_iterator<char>{is.rdbuf()}, {}};
+        if (!is.is_open()) {
+          result = std::make_unique<GrpcErrorCredentialsAuthentication>(
+              ErrorCredentialsConfig{UnknownError(
+                  "Cannot open CA certificate file " + ca_cert_path,
+                  GCP_ERROR_INFO())});
+          return;
         }
+        ssl_options.pem_root_certs =
+            std::string{std::istreambuf_iterator<char>{is.rdbuf()}, {}};
       } else {
         std::optional<std::string> cainfo = LoadCAInfo(options);
         if (cainfo) ssl_options.pem_root_certs = std::move(*cainfo);

--- a/google/cloud/internal/unified_grpc_credentials_test.cc
+++ b/google/cloud/internal/unified_grpc_credentials_test.cc
@@ -42,6 +42,7 @@ using ::google::cloud::testing_util::ScopedEnvironment;
 using ::google::cloud::testing_util::StatusIs;
 using ::google::cloud::testing_util::ValidateMetadataFixture;
 using ::testing::Contains;
+using ::testing::HasSubstr;
 using ::testing::IsEmpty;
 using ::testing::IsNull;
 using ::testing::NotNull;
@@ -202,7 +203,7 @@ X3IM7YomoAWiNKWwBVskpXWj7L9dLkqhyQ==
 -----END EC PRIVATE KEY-----
 )""";
 
-std::string MakeGDCHServiceAccountContents(std::string_view ca_cert_path = "") {
+std::string MakeGDCHServiceAccountContents(std::string_view ca_cert_path) {
   nlohmann::json j{
       {"type", "gdch_service_account"},
       {"format_version", "1"},
@@ -216,6 +217,10 @@ std::string MakeGDCHServiceAccountContents(std::string_view ca_cert_path = "") {
     j["ca_cert_path"] = ca_cert_path;
   }
   return j.dump();
+}
+
+std::string MakeGDCHServiceAccountContents() {
+  return MakeGDCHServiceAccountContents("");
 }
 
 TEST(UnifiedGrpcCredentialsTest, WithGDCHServiceAccountCredentialsFromJson) {
@@ -352,6 +357,28 @@ TEST(UnifiedGrpcCredentialsTest,
   Status status = auth->ConfigureContext(context);
   EXPECT_THAT(status, IsOk());
   EXPECT_THAT(context.credentials(), IsNull());
+}
+
+TEST(UnifiedGrpcCredentialsTest,
+     WithGDCHServiceAccountCredentialsMissingCACertFile) {
+#if !defined(GRPC_CPP_VERSION_MAJOR) || \
+    (GRPC_CPP_VERSION_MAJOR < 1 ||      \
+     (GRPC_CPP_VERSION_MAJOR == 1 && GRPC_CPP_VERSION_MINOR < 84))
+  GTEST_SKIP() << "GDCH credentials require gRPC >= 1.84.0";
+#endif
+  std::string ca_filename = CreateRandomFileName();
+  std::string json_contents = MakeGDCHServiceAccountContents(ca_filename);
+  CompletionQueue cq;
+  std::shared_ptr<Credentials> creds = MakeGDCHServiceAccountCredentials(
+      json_contents, "https://my-audience.com");
+  std::shared_ptr<GrpcAuthenticationStrategy> auth =
+      CreateAuthenticationStrategy(*creds, cq);
+  ASSERT_THAT(auth, NotNull());
+
+  grpc::ClientContext context;
+  Status status = auth->ConfigureContext(context);
+  EXPECT_THAT(status, StatusIs(StatusCode::kUnknown,
+                               HasSubstr("Cannot open CA certificate file")));
 }
 
 }  // namespace

--- a/google/cloud/internal/unified_grpc_credentials_test.cc
+++ b/google/cloud/internal/unified_grpc_credentials_test.cc
@@ -24,7 +24,12 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include "google/cloud/testing_util/validate_metadata.h"
 #include <gmock/gmock.h>
+#if __has_include(<grpcpp/version_info.h>)
+#include <grpcpp/version_info.h>
+#endif
+#include <nlohmann/json.hpp>
 #include <fstream>
+#include <string_view>
 
 namespace google {
 namespace cloud {
@@ -188,6 +193,165 @@ TEST(UnifiedGrpcCredentialsTest, LoadCAInfoContents) {
   (void)std::remove(filename.c_str());  // remove the temporary file
   ASSERT_TRUE(contents.has_value());
   EXPECT_EQ(*contents, expected);
+}
+
+auto constexpr kWellFormattedECKey = R"""(-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIDGD4hNeIBG3lo4BKS1k4jpYhbnJSZwAuUwyK8wEiOP5oAoGCCqGSM49
+AwEHoUQDQgAEWK7gDAGAAzOfl6pHhpmvjbTeUPyclQk7+HgAWE6uGUtox/U8/sQQ
+X3IM7YomoAWiNKWwBVskpXWj7L9dLkqhyQ==
+-----END EC PRIVATE KEY-----
+)""";
+
+std::string MakeGDCHServiceAccountContents(std::string_view ca_cert_path = "") {
+  nlohmann::json j{
+      {"type", "gdch_service_account"},
+      {"format_version", "1"},
+      {"project", "test-project"},
+      {"private_key_id", "test-private-key-id"},
+      {"private_key", kWellFormattedECKey},
+      {"name", "test-name"},
+      {"token_uri", "https://test-token-uri.com/token"},
+  };
+  if (!ca_cert_path.empty()) {
+    j["ca_cert_path"] = ca_cert_path;
+  }
+  return j.dump();
+}
+
+TEST(UnifiedGrpcCredentialsTest, WithGDCHServiceAccountCredentialsFromJson) {
+#if !defined(GRPC_CPP_VERSION_MAJOR) || \
+    (GRPC_CPP_VERSION_MAJOR < 1 ||      \
+     (GRPC_CPP_VERSION_MAJOR == 1 && GRPC_CPP_VERSION_MINOR < 84))
+  GTEST_SKIP() << "GDCH credentials require gRPC >= 1.84.0";
+#endif
+  CompletionQueue cq;
+  std::string json_contents = MakeGDCHServiceAccountContents();
+  std::shared_ptr<Credentials> creds = MakeGDCHServiceAccountCredentials(
+      json_contents, "https://my-audience.com");
+  std::shared_ptr<GrpcAuthenticationStrategy> auth =
+      CreateAuthenticationStrategy(*creds, cq);
+  ASSERT_THAT(auth, NotNull());
+
+  grpc::ClientContext context;
+  Status status = auth->ConfigureContext(context);
+  EXPECT_THAT(status, IsOk());
+  EXPECT_THAT(context.credentials(), IsNull());
+}
+
+TEST(UnifiedGrpcCredentialsTest, WithGDCHServiceAccountCredentialsFromFile) {
+#if !defined(GRPC_CPP_VERSION_MAJOR) || \
+    (GRPC_CPP_VERSION_MAJOR < 1 ||      \
+     (GRPC_CPP_VERSION_MAJOR == 1 && GRPC_CPP_VERSION_MINOR < 84))
+  GTEST_SKIP() << "GDCH credentials require gRPC >= 1.84.0";
+#endif
+  std::string filename = CreateRandomFileName();
+  std::ofstream(filename) << MakeGDCHServiceAccountContents();
+  ScopedEnvironment env("GOOGLE_APPLICATION_CREDENTIALS", filename);
+
+  CompletionQueue cq;
+  std::shared_ptr<Credentials> creds =
+      MakeGDCHServiceAccountCredentials("https://my-audience.com");
+  std::shared_ptr<GrpcAuthenticationStrategy> auth =
+      CreateAuthenticationStrategy(*creds, cq);
+  (void)std::remove(filename.c_str());
+  ASSERT_THAT(auth, NotNull());
+
+  grpc::ClientContext context;
+  Status status = auth->ConfigureContext(context);
+  EXPECT_THAT(status, IsOk());
+  EXPECT_THAT(context.credentials(), IsNull());
+}
+
+TEST(UnifiedGrpcCredentialsTest, WithGDCHServiceAccountCredentialsMissingFile) {
+#if !defined(GRPC_CPP_VERSION_MAJOR) || \
+    (GRPC_CPP_VERSION_MAJOR < 1 ||      \
+     (GRPC_CPP_VERSION_MAJOR == 1 && GRPC_CPP_VERSION_MINOR < 84))
+  GTEST_SKIP() << "GDCH credentials require gRPC >= 1.84.0";
+#endif
+  std::string filename = CreateRandomFileName();
+  ScopedEnvironment env("GOOGLE_APPLICATION_CREDENTIALS", filename);
+
+  CompletionQueue cq;
+  std::shared_ptr<Credentials> creds =
+      MakeGDCHServiceAccountCredentials("https://my-audience.com");
+  std::shared_ptr<GrpcAuthenticationStrategy> auth =
+      CreateAuthenticationStrategy(*creds, cq);
+  ASSERT_THAT(auth, NotNull());
+
+  grpc::ClientContext context;
+  Status status = auth->ConfigureContext(context);
+  EXPECT_THAT(status, StatusIs(StatusCode::kUnknown));
+}
+
+TEST(UnifiedGrpcCredentialsTest, WithGDCHServiceAccountCredentialsInvalidJson) {
+#if !defined(GRPC_CPP_VERSION_MAJOR) || \
+    (GRPC_CPP_VERSION_MAJOR < 1 ||      \
+     (GRPC_CPP_VERSION_MAJOR == 1 && GRPC_CPP_VERSION_MINOR < 84))
+  GTEST_SKIP() << "GDCH credentials require gRPC >= 1.84.0";
+#endif
+  CompletionQueue cq;
+  std::shared_ptr<Credentials> creds = MakeGDCHServiceAccountCredentials(
+      "invalid json", "https://my-audience.com");
+  std::shared_ptr<GrpcAuthenticationStrategy> auth =
+      CreateAuthenticationStrategy(*creds, cq);
+  ASSERT_THAT(auth, NotNull());
+
+  grpc::ClientContext context;
+  Status status = auth->ConfigureContext(context);
+  EXPECT_THAT(status, StatusIs(StatusCode::kInternal));
+}
+
+auto constexpr kCACertificate = R"""(
+-----BEGIN CERTIFICATE-----
+MIIEPTCCAyWgAwIBAgIUXa/2HsbYrolo1Cox/1SOqLDnNYQwDQYJKoZIhvcNAQEL
+BQAwga0xCzAJBgNVBAYTAlVTMREwDwYDVQQIDAhOZXcgWW9yazERMA8GA1UEBwwI
+TmV3IFlvcmsxGjAYBgNVBAoMEVRlc3QtT25seSBJbnZhbGlkMRIwEAYDVQQLDAlU
+ZXN0LU9ubHkxGjAYBgNVBAMMEVRlc3QtT25seSBJbnZhbGlkMSwwKgYJKoZIhvcN
+AQkBFh10ZXN0LW9ubHlAaW52YWxpZC5leGFtcGxlLmNvbTAeFw0yMTA1MjUxOTQy
+MTdaFw0zMTA1MjMxOTQyMTdaMIGtMQswCQYDVQQGEwJVUzERMA8GA1UECAwITmV3
+IFlvcmsxETAPBgNVBAcMCE5ldyBZb3JrMRowGAYDVQQKDBFUZXN0LU9ubHkgSW52
+YWxpZDESMBAGA1UECwwJVGVzdC1Pbmx5MRowGAYDVQQDDBFUZXN0LU9ubHkgSW52
+YWxpZDEsMCoGCSqGSIb3DQEJARYddGVzdC1vbmx5QGludmFsaWQuZXhhbXBsZS5j
+b20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDL66K2V2OQHcb2Ab7o
+ucWqb3iOF1IGvc6lzC2XeqrqCvYF5HB9jK+cWHDmeGjJMoYI35S2fp+Wzh3Qek0Y
+ilQBylUq91y2ZnqAmFu7gc83wWgWPHCkKPKTS5tcK5sQTbhBuaQBQs5hWCeNfZOy
+AtAU2ysNde79DwSXfq/e8NLRvaKsS8etqiLyfIuDWfXHzIDgAgyyi49m67fYnLYx
+y2W555Zh0vAnd4MQYh0SYQ64BgaUg59WLRYhsHN5r9D06JEur9uxMLmtiQy7UyL2
+xuw6u2y/+vcdTb9L9zaNEnITPl+3N23TG5KgBxLfKkHzNE7gS/w7ljS0ljNExuUO
+UZutAgMBAAGjUzBRMB0GA1UdDgQWBBS7T7DuKDv1Hz1e693kY7gLXSu8PjAfBgNV
+HSMEGDAWgBS7T7DuKDv1Hz1e693kY7gLXSu8PjAPBgNVHRMBAf8EBTADAQH/MA0G
+CSqGSIb3DQEBCwUAA4IBAQC/4HmQwp7KjKF5FEnlHG5Chqob/yiPkwbMDV1yKA+i
+ZMknQFgm8h0X4kLAbOiao71MPI5Zi5OQge6GoSXJJQYkesgdakPw6xkFfz9MsfCp
+zMKm7sKIIGNaPMMqMJJ/cciCRIzXKl6gcOkZLlIFU1T2uE764Lc08yXIY7eXkVo1
+8w4Gv6nH7uaQiESa2wt3TWGISG9wdDkcVG01tTr4jzq77yWuC1Ela2UvQK7AIWbK
+OB6Sby1bvjYv0kqjinu9AcSCHUHJ1sJaPD5DvAyKP7W01YedP4iqLxkTlIRjaikD
+KlXA1yQW/ClmnHVg57SN1g1rvOJCcnHBnSbT7kGFqUol
+-----END CERTIFICATE-----
+)""";
+
+TEST(UnifiedGrpcCredentialsTest,
+     WithGDCHServiceAccountCredentialsCustomCACertPath) {
+#if !defined(GRPC_CPP_VERSION_MAJOR) || \
+    (GRPC_CPP_VERSION_MAJOR < 1 ||      \
+     (GRPC_CPP_VERSION_MAJOR == 1 && GRPC_CPP_VERSION_MINOR < 84))
+  GTEST_SKIP() << "GDCH credentials require gRPC >= 1.84.0";
+#endif
+  std::string ca_filename = CreateRandomFileName();
+  std::ofstream(ca_filename) << kCACertificate;
+
+  std::string json_contents = MakeGDCHServiceAccountContents(ca_filename);
+  CompletionQueue cq;
+  std::shared_ptr<Credentials> creds = MakeGDCHServiceAccountCredentials(
+      json_contents, "https://my-audience.com");
+  std::shared_ptr<GrpcAuthenticationStrategy> auth =
+      CreateAuthenticationStrategy(*creds, cq);
+  (void)std::remove(ca_filename.c_str());
+  ASSERT_THAT(auth, NotNull());
+
+  grpc::ClientContext context;
+  Status status = auth->ConfigureContext(context);
+  EXPECT_THAT(status, IsOk());
+  EXPECT_THAT(context.credentials(), IsNull());
 }
 
 }  // namespace


### PR DESCRIPTION
This PR adds support for creating GDCH Service Account Credentials if gRPC v1.84.0 or later is being used. Manual testing with v1.84.0 has been done.

As part of the v3 major version, nlohmann::json became a required dependency. Adding it to the grpc library is in line with that change.