### PR TITLE
ci(gha): add comment command for trusted users to run gha workflows on PRs

### DIFF
--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -1,5 +1,7 @@
 permissions:
   contents: read
+  pull-requests: read
+  issues: read
 
 name: "gha: macOS & Windows"
 
@@ -22,6 +24,10 @@ on: # zizmor: ignore[dangerous-triggers]
     - opened
     - synchronize
     - reopened
+  # Allow trusted maintainers to trigger this workflow on external PRs by
+  # commenting `/gharun`.
+  issue_comment:
+    types: [ created ]
   schedule:
     - cron: '0 5 * * 1,2,3,4,5'
 
@@ -29,15 +35,19 @@ on: # zizmor: ignore[dangerous-triggers]
 # PR or branch. That reduces billing, but it creates more noise about cancelled
 # jobs
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.head.label || github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.label || (github.event.issue.number && format('pr-{0}', github.event.issue.number)) || github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
   pre-flight:
     # Save the `ref` of the pull request, so downstream jobs know what to checkout.
+    if: >-
+      github.event_name != 'issue_comment' ||
+      (github.event.issue.pull_request != null && contains(github.event.comment.body, '/gharun'))
     environment: >-
       ${{
-          (github.event_name != 'pull_request_target' && 'internal') ||
+          (github.event_name == 'push' && 'internal') ||
+          (github.event_name == 'schedule' && 'internal') ||
           (github.event.pull_request.head.repo.full_name == github.repository && 'internal')
       }}
     name: Save PR ref
@@ -45,31 +55,54 @@ jobs:
     outputs:
       checkout-sha: ${{ steps.save-pull-request.outputs.sha }}
     steps:
-      - name: Verify author permissions
+      - name: Verify permissions
         if: >-
           github.event_name == 'pull_request_target' ||
+          github.event_name == 'issue_comment' ||
           (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/ci-gha'))
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          AUTHOR: ${{ github.event.pull_request.user.login || github.actor }}
+          EVENT_NAME: ${{ github.event_name }}
+          USER_TO_CHECK: >-
+            ${{
+              (github.event_name == 'pull_request_target' && github.event.pull_request.user.login) ||
+              (github.event_name == 'issue_comment' && (github.event.comment.user.login || github.actor)) ||
+              github.actor
+            }}
         run: |
-          permission=$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${AUTHOR}/permission" --jq '.permission')
-          echo "Author: ${AUTHOR}, permission: ${permission}"
+          permission=$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${USER_TO_CHECK}/permission" --jq '.permission')
+          echo "Event: ${EVENT_NAME}, User: ${USER_TO_CHECK}, permission: ${permission}"
           case "${permission}" in
             admin|write|maintain)
-              echo "Author is trusted."
+              echo "User '${USER_TO_CHECK}' is trusted."
               ;;
             *)
-              echo "::error::Author '${AUTHOR}' is not trusted (permission: '${permission}')."
+              if [[ "${EVENT_NAME}" == "pull_request_target" ]]; then
+                echo "::error::Author '${USER_TO_CHECK}' is not trusted (permission: '${permission}'). A maintainer can comment '/gharun' to trigger this workflow."
+              else
+                echo "::error::User '${USER_TO_CHECK}' is not trusted (permission: '${permission}')."
+              fi
               exit 1
               ;;
           esac
       - name: Save Pull Request
         id: save-pull-request
         env:
-          PR_SHA: ${{ github.event.pull_request.head.sha || github.ref }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          FALLBACK_SHA: ${{ github.ref }}
         run: |
-          echo "sha=${PR_SHA}" >> "${GITHUB_OUTPUT}"
+          if [[ "${EVENT_NAME}" == "issue_comment" ]]; then
+            sha=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')
+          elif [[ "${EVENT_NAME}" == "pull_request_target" ]]; then
+            sha="${PR_HEAD_SHA}"
+          else
+            sha="${FALLBACK_SHA}"
+          fi
+          echo "Resolved checkout SHA: ${sha}"
+          echo "sha=${sha}" >> "${GITHUB_OUTPUT}"
 
   # Run other jobs once the `pre-flight` job passes. When the `pre-flight`
   # job requires approval, these blocks all the other jobs. The jobs are defined
@@ -111,7 +144,8 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'push' ||
-          contains(github.event.pull_request.labels.*.name, 'gha:full-build')
+          contains(github.event.pull_request.labels.*.name, 'gha:full-build') ||
+          contains(github.event.issue.labels.*.name, 'gha:full-build')
         }}
       sccache-mode: 'READ_WRITE'
       vcpkg-cache-mode: 'readwrite'
@@ -130,7 +164,8 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'push' ||
-          contains(github.event.pull_request.labels.*.name, 'gha:full-build')
+          contains(github.event.pull_request.labels.*.name, 'gha:full-build') ||
+          contains(github.event.issue.labels.*.name, 'gha:full-build')
         }}
       sccache-mode: 'READ_WRITE'
       vcpkg-cache-mode: 'readwrite'


### PR DESCRIPTION
Enables trusted users to issue a `/gharun` comment on otherwise non-trusted PRs.