### PR TITLE
fix(storage): bypass full object checksum validation on unfinalized objects in ObjectDescriptorImpl

### DIFF
--- a/google/cloud/storage/internal/async/object_descriptor_impl.cc
+++ b/google/cloud/storage/internal/async/object_descriptor_impl.cc
@@ -218,13 +218,21 @@ void ObjectDescriptorImpl::MakeSubsequentStream() {
 std::unique_ptr<storage::AsyncReaderConnection> ObjectDescriptorImpl::Read(
     ReadParams p) {
   // Full-object checksum validation (both CRC32C and MD5) is only supported for
-  // full-object reads (starting at offset 0 and reading the entire object).
+  // full-object reads (starting at offset 0 and reading the entire object) of
+  // finalized objects.
+  //
+  // For unfinalized objects, full-object checksum validation is bypassed
+  // because the object size and checksums can dynamically change as data is
+  // appended, while chunk-level CRC32C validation continues to protect data on
+  // the wire.
   //
   // Note that MD5 validation is not supported for partial/ranged reads because
   // GCS does not compute or send chunk-level MD5 checksums (unlike CRC32C,
   // which is validated per-chunk on the gRPC layer).
-  bool is_full_read = (p.start == 0 && metadata_.has_value() &&
-                       (p.length == 0 || p.length >= metadata_->size()));
+  bool const is_finalized =
+      metadata_.has_value() && metadata_->has_finalize_time();
+  bool const is_full_read = is_finalized && (p.start == 0) &&
+                            (p.length == 0 || p.length >= metadata_->size());
 
   auto hash_function = CreateHashFunction(is_full_read);
   auto hash_validator = CreateHashValidator(is_full_read);

--- a/google/cloud/storage/internal/async/object_descriptor_impl_test.cc
+++ b/google/cloud/storage/internal/async/object_descriptor_impl_test.cc
@@ -2400,7 +2400,7 @@ TEST(ObjectDescriptorImpl,
               VariantWith<storage::ReadPayload>(ResultOf(
                   "contents are",
                   [](storage::ReadPayload const& p) { return p.contents(); },
-                  ElementsAre(absl::string_view{
+                  ElementsAre(std::string_view{
                       "The quick brown fox jumps over the lazy dog"}))));
 
   EXPECT_THAT(s1->Read().get(), VariantWith<Status>(IsOk()));
@@ -2511,7 +2511,7 @@ TEST(ObjectDescriptorImpl,
               VariantWith<storage::ReadPayload>(ResultOf(
                   "contents are",
                   [](storage::ReadPayload const& p) { return p.contents(); },
-                  ElementsAre(absl::string_view{
+                  ElementsAre(std::string_view{
                       "The quick brown fox jumps over the lazy dog"}))));
 
   EXPECT_THAT(s1->Read().get(),

--- a/google/cloud/storage/internal/async/object_descriptor_impl_test.cc
+++ b/google/cloud/storage/internal/async/object_descriptor_impl_test.cc
@@ -1876,6 +1876,7 @@ TEST(ObjectDescriptorImpl, FullReadChecksumValidationSuccess) {
       name: "test-object"
       generation: 42
       size: 43
+      finalize_time { seconds: 1234567890 }
       checksums {
         crc32c: 576848900
         md5_hash: "\236\020\175\235\067\053\266\202\153\330\035\065\102\244\031\326"
@@ -1983,6 +1984,7 @@ TEST(ObjectDescriptorImpl, FullReadChecksumValidationMismatchCrc32c) {
       name: "test-object"
       generation: 42
       size: 43
+      finalize_time { seconds: 1234567890 }
       checksums {
         crc32c: 12345
         md5_hash: "\236\020\175\235\067\053\266\202\153\330\035\065\102\244\031\326"
@@ -2091,6 +2093,7 @@ TEST(ObjectDescriptorImpl, FullReadChecksumValidationMismatchMd5) {
       name: "test-object"
       generation: 42
       size: 43
+      finalize_time { seconds: 1234567890 }
       checksums {
         crc32c: 576848900
         md5_hash: "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
@@ -2289,6 +2292,230 @@ TEST(ObjectDescriptorImpl, PartialReadChecksumValidationBypassed) {
                       "The quick brown fox jumps over the lazy dog"}))));
 
   EXPECT_THAT(s1->Read().get(), VariantWith<Status>(IsOk()));
+
+  next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "Read[2]");
+  next.first.set_value(true);
+
+  next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "Finish");
+  next.first.set_value(true);
+}
+
+/// @test Verify that reading an unfinalized object (e.g. appendable object
+/// without finalize_time) from offset 0 bypasses full-object checksum
+/// validation against open-time metadata checksums, while still validating
+/// chunk-level CRC32C.
+TEST(ObjectDescriptorImpl,
+     UnfinalizedObjectReadFromOffset0BypassesFullChecksumValidation) {
+  auto constexpr kResponseMetadata = R"pb(
+    metadata {
+      bucket: "projects/_/buckets/test-bucket"
+      name: "test-object"
+      generation: 42
+      size: 16
+      checksums {
+        crc32c: 12345
+        md5_hash: "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
+      }
+    }
+    read_handle { handle: "handle-12345" }
+  )pb";
+
+  auto constexpr kRequest1 = R"pb(
+    read_ranges { read_id: 1 read_offset: 0 read_length: 0 }
+  )pb";
+
+  auto constexpr kResponse1 = R"pb(
+    read_handle { handle: "handle-23456" }
+    object_data_ranges {
+      range_end: true
+      read_range { read_id: 1 read_offset: 0 }
+      checksummed_data {
+        content: "The quick brown fox jumps over the lazy dog"
+        crc32c: 576848900
+      }
+    }
+  )pb";
+
+  AsyncSequencer<bool> sequencer;
+  auto stream = std::make_unique<MockStream>();
+  EXPECT_CALL(*stream, Write)
+      .WillOnce([&](Request const& request, grpc::WriteOptions) {
+        auto expected = Request{};
+        EXPECT_TRUE(TextFormat::ParseFromString(kRequest1, &expected));
+        EXPECT_THAT(request, IsProtoEqual(expected));
+        return sequencer.PushBack("Write[1]").then([](auto f) {
+          return f.get();
+        });
+      });
+  EXPECT_CALL(*stream, Read)
+      .WillOnce([=, &sequencer]() {
+        return sequencer.PushBack("Read[1]").then([&](auto) {
+          auto response = Response{};
+          EXPECT_TRUE(TextFormat::ParseFromString(kResponse1, &response));
+          return std::make_optional(response);
+        });
+      })
+      .WillOnce([&sequencer]() {
+        return sequencer.PushBack("Read[2]").then(
+            [](auto) { return std::optional<Response>{}; });
+      });
+  EXPECT_CALL(*stream, Finish).WillOnce([&sequencer]() {
+    return sequencer.PushBack("Finish").then(
+        [](auto) { return PermanentError(); });
+  });
+  EXPECT_CALL(*stream, Cancel).Times(AtMost(1));
+
+  MockFactory factory;
+  EXPECT_CALL(factory, Call).WillOnce([](Request const&) {
+    return make_ready_future(StatusOr<OpenStreamResult>(PermanentError()));
+  });
+
+  Options options;
+  options.set<storage::EnableCrc32cValidationOption>(true);
+  options.set<storage::EnableMD5ValidationOption>(true);
+
+  auto tested = std::make_shared<ObjectDescriptorImpl>(
+      NoResume(), factory.AsStdFunction(),
+      google::storage::v2::BidiReadObjectSpec{},
+      std::make_shared<OpenStream>(std::move(stream)), options);
+
+  auto response = Response{};
+  EXPECT_TRUE(TextFormat::ParseFromString(kResponseMetadata, &response));
+  tested->Start(std::move(response));
+
+  auto read1 = sequencer.PopFrontWithName();
+  EXPECT_EQ(read1.second, "Read[1]");
+
+  auto s1 = tested->Read({0, 0});
+  auto s1r1 = s1->Read();
+
+  auto next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "Write[1]");
+  next.first.set_value(true);
+  read1.first.set_value(true);
+
+  EXPECT_THAT(s1r1.get(),
+              VariantWith<storage::ReadPayload>(ResultOf(
+                  "contents are",
+                  [](storage::ReadPayload const& p) { return p.contents(); },
+                  ElementsAre(absl::string_view{
+                      "The quick brown fox jumps over the lazy dog"}))));
+
+  EXPECT_THAT(s1->Read().get(), VariantWith<Status>(IsOk()));
+
+  next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "Read[2]");
+  next.first.set_value(true);
+
+  next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "Finish");
+  next.first.set_value(true);
+}
+
+/// @test Verify that reading an unfinalized object from offset 0 still
+/// validates chunk-level CRC32C and fails with DATA_LOSS if a chunk contains
+/// corrupted data.
+TEST(ObjectDescriptorImpl,
+     UnfinalizedObjectReadFromOffset0FailsOnCorruptChunkCrc32c) {
+  auto constexpr kResponseMetadata = R"pb(
+    metadata {
+      bucket: "projects/_/buckets/test-bucket"
+      name: "test-object"
+      generation: 42
+      size: 16
+      checksums {
+        crc32c: 12345
+        md5_hash: "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
+      }
+    }
+    read_handle { handle: "handle-12345" }
+  )pb";
+
+  auto constexpr kRequest1 = R"pb(
+    read_ranges { read_id: 1 read_offset: 0 read_length: 0 }
+  )pb";
+
+  auto constexpr kResponse1 = R"pb(
+    read_handle { handle: "handle-23456" }
+    object_data_ranges {
+      range_end: true
+      read_range { read_id: 1 read_offset: 0 }
+      checksummed_data {
+        content: "The quick brown fox jumps over the lazy dog"
+        crc32c: 999999
+      }
+    }
+  )pb";
+
+  AsyncSequencer<bool> sequencer;
+  auto stream = std::make_unique<MockStream>();
+  EXPECT_CALL(*stream, Write)
+      .WillOnce([&](Request const& request, grpc::WriteOptions) {
+        auto expected = Request{};
+        EXPECT_TRUE(TextFormat::ParseFromString(kRequest1, &expected));
+        EXPECT_THAT(request, IsProtoEqual(expected));
+        return sequencer.PushBack("Write[1]").then([](auto f) {
+          return f.get();
+        });
+      });
+  EXPECT_CALL(*stream, Read)
+      .WillOnce([=, &sequencer]() {
+        return sequencer.PushBack("Read[1]").then([&](auto) {
+          auto response = Response{};
+          EXPECT_TRUE(TextFormat::ParseFromString(kResponse1, &response));
+          return std::make_optional(response);
+        });
+      })
+      .WillOnce([&sequencer]() {
+        return sequencer.PushBack("Read[2]").then(
+            [](auto) { return std::optional<Response>{}; });
+      });
+  EXPECT_CALL(*stream, Finish).WillOnce([&sequencer]() {
+    return sequencer.PushBack("Finish").then(
+        [](auto) { return PermanentError(); });
+  });
+  EXPECT_CALL(*stream, Cancel).Times(AtMost(1));
+
+  MockFactory factory;
+  EXPECT_CALL(factory, Call).WillOnce([](Request const&) {
+    return make_ready_future(StatusOr<OpenStreamResult>(PermanentError()));
+  });
+
+  Options options;
+  options.set<storage::EnableCrc32cValidationOption>(true);
+  options.set<storage::EnableMD5ValidationOption>(true);
+
+  auto tested = std::make_shared<ObjectDescriptorImpl>(
+      NoResume(), factory.AsStdFunction(),
+      google::storage::v2::BidiReadObjectSpec{},
+      std::make_shared<OpenStream>(std::move(stream)), options);
+
+  auto response = Response{};
+  EXPECT_TRUE(TextFormat::ParseFromString(kResponseMetadata, &response));
+  tested->Start(std::move(response));
+
+  auto read1 = sequencer.PopFrontWithName();
+  EXPECT_EQ(read1.second, "Read[1]");
+
+  auto s1 = tested->Read({0, 0});
+  auto s1r1 = s1->Read();
+
+  auto next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "Write[1]");
+  next.first.set_value(true);
+  read1.first.set_value(true);
+
+  EXPECT_THAT(s1r1.get(),
+              VariantWith<storage::ReadPayload>(ResultOf(
+                  "contents are",
+                  [](storage::ReadPayload const& p) { return p.contents(); },
+                  ElementsAre(absl::string_view{
+                      "The quick brown fox jumps over the lazy dog"}))));
+
+  EXPECT_THAT(s1->Read().get(),
+              VariantWith<Status>(StatusIs(StatusCode::kInvalidArgument)));
 
   next = sequencer.PopFrontWithName();
   EXPECT_EQ(next.second, "Read[2]");


### PR DESCRIPTION
This PR updates the Storage library to bypass full-object CRC32C and MD5 checksum validation when reading unfinalized objects from offset 0 in ObjectDescriptorImpl.

For unfinalized objects, the size and checksums dynamically change on the server as data is appended. Validating total stream checksums in this case causes false DATA_LOSS errors. Chunk-level CRC32C validation on incoming gRPC messages remains active to guarantee wire integrity.

## Cross-SDK Parity
This change aligns C++ with the behavior implemented in other language SDKs:
1. Go SDK: [storage/grpc_client.go](https://github.com/googleapis/google-cloud-go/blob/main/storage/grpc_client.go#L1443-L1455)
Bypasses full-object checksum verification if the object is unfinalized (`!finalized`), and relies strictly on per-chunk wire CRC32C validation.

1. Python SDK: [storage/asyncio/async_read_object_stream.py](https://github.com/googleapis/google-cloud-python/blob/main/packages/google-cloud-storage/google/cloud/storage/asyncio/async_read_object_stream.py#L144-L154)
Checks finalize_time during stream open. If the object is not finalized (`is_finalized == False`), leaves `full_obj_server_crc32c = None` so full-object validation is skipped, while chunk-level CRC32C is verified on each frame.
