### PR TITLE
ci: adjust concurrency for gha trusted approval

### DIFF
--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -33,19 +33,8 @@ on: # zizmor: ignore[dangerous-triggers]
 
 # Cancel in-progress runs of the workflow if somebody adds a new commit to the
 # PR or branch, or if a maintainer posts a new `/gharun` command.
-# Non-`/gharun` comments get unique group IDs (run_id) so they don't cancel active runs.
-concurrency:
-  group: >-
-    ${{
-      github.workflow
-    }}-${{
-      (github.event_name == 'issue_comment' && !contains(github.event.comment.body, '/gharun') && github.run_id) ||
-      (github.event.pull_request.number && format('pr-{0}', github.event.pull_request.number)) ||
-      (github.event.issue.number && format('pr-{0}', github.event.issue.number)) ||
-      github.head_ref ||
-      github.ref
-    }}
-  cancel-in-progress: true
+# Concurrency is defined at the job level so that issue comments without `/gharun`
+# (which are skipped in pre-flight) do not cancel in-progress builds.
 
 jobs:
   pre-flight:
@@ -53,10 +42,12 @@ jobs:
     if: >-
       github.event_name != 'issue_comment' ||
       (github.event.issue.pull_request != null && contains(github.event.comment.body, '/gharun'))
+    concurrency:
+      group: ${{ github.workflow }}-pre-flight-${{ github.event.pull_request.number || github.event.issue.number || github.head_ref || github.ref }}
+      cancel-in-progress: true
     environment: >-
       ${{
-          (github.event_name == 'push' && 'internal') ||
-          (github.event_name == 'schedule' && 'internal') ||
+          (github.event_name != 'pull_request_target' && 'internal') ||
           (github.event.pull_request.head.repo.full_name == github.repository && 'internal')
       }}
     name: Save PR ref
@@ -121,6 +112,9 @@ jobs:
   macos-bazel:
     name: macOS-Bazel
     needs: [pre-flight]
+    concurrency:
+      group: ${{ github.workflow }}-macos-bazel-${{ github.event.pull_request.number || github.event.issue.number || github.head_ref || github.ref }}
+      cancel-in-progress: true
     uses: ./.github/workflows/macos-bazel.yml # zizmor: ignore[secrets-inherit]
     with:
       checkout-ref: ${{ needs.pre-flight.outputs.checkout-sha }}
@@ -132,6 +126,9 @@ jobs:
     if: false
     name: Windows-Bazel
     needs: [pre-flight]
+    concurrency:
+      group: ${{ github.workflow }}-windows-bazel-${{ github.event.pull_request.number || github.event.issue.number || github.head_ref || github.ref }}
+      cancel-in-progress: true
     uses: ./.github/workflows/windows-bazel.yml # zizmor: ignore[secrets-inherit]
     with:
       checkout-ref: ${{ needs.pre-flight.outputs.checkout-sha }}
@@ -143,6 +140,9 @@ jobs:
     if: false
     name: macOS-CMake
     needs: [pre-flight]
+    concurrency:
+      group: ${{ github.workflow }}-macos-cmake-${{ github.event.pull_request.number || github.event.issue.number || github.head_ref || github.ref }}
+      cancel-in-progress: true
     uses: ./.github/workflows/macos-cmake.yml # zizmor: ignore[secrets-inherit]
     with:
       checkout-ref: ${{ needs.pre-flight.outputs.checkout-sha }}
@@ -163,6 +163,9 @@ jobs:
   windows-cmake:
     name: Windows-CMake
     needs: [pre-flight]
+    concurrency:
+      group: ${{ github.workflow }}-windows-cmake-${{ github.event.pull_request.number || github.event.issue.number || github.head_ref || github.ref }}
+      cancel-in-progress: true
     uses: ./.github/workflows/windows-cmake.yml # zizmor: ignore[secrets-inherit]
     with:
       checkout-ref: ${{ needs.pre-flight.outputs.checkout-sha }}


### PR DESCRIPTION
- When non-/gharun comments (e.g. /gcbrun, bot notifications) arrive, pre-flight.if evaluates to false and skips immediately without ever acquiring the concurrency lock or cancelling any active build.
- When /gharun is commented, pre-flight.if is true, and it cancels any previous obsolete run for that PR and runs the build.
