### PR TITLE
fix(storage): ensure thread-safe stream resumption in ObjectDescriptorImpl

### DIFF
--- a/google/cloud/storage/internal/async/multi_stream_manager.h
+++ b/google/cloud/storage/internal/async/multi_stream_manager.h
@@ -159,6 +159,13 @@ class MultiStreamManager {
     return false;
   }
 
+  bool Contains(StreamIterator target) const {
+    for (auto it = streams_.begin(); it != streams_.end(); ++it) {
+      if (it == target) return true;
+    }
+    return false;
+  }
+
   bool Empty() const { return streams_.empty(); }
   ConstStreamIterator End() const { return streams_.end(); }
   std::size_t Size() const { return streams_.size(); }

--- a/google/cloud/storage/internal/async/multi_stream_manager.h
+++ b/google/cloud/storage/internal/async/multi_stream_manager.h
@@ -159,11 +159,11 @@ class MultiStreamManager {
     return false;
   }
 
-  bool Contains(StreamIterator target) const {
+  StreamIterator Find(std::shared_ptr<StreamT> const& target) {
     for (auto it = streams_.begin(); it != streams_.end(); ++it) {
-      if (it == target) return true;
+      if (it->stream == target) return it;
     }
-    return false;
+    return streams_.end();
   }
 
   bool Empty() const { return streams_.empty(); }

--- a/google/cloud/storage/internal/async/multi_stream_manager_test.cc
+++ b/google/cloud/storage/internal/async/multi_stream_manager_test.cc
@@ -233,19 +233,20 @@ TEST(MultiStreamManagerTest, EmptyAndSizeTransitions) {
   EXPECT_EQ(mgr.Size(), 1U);
 }
 
-TEST(MultiStreamManagerTest, ContainsTracksStreamMembership) {
+TEST(MultiStreamManagerTest, FindTracksStreamMembership) {
   auto mgr = MultiStreamManagerTest::MakeManager();
   auto it1 = mgr.GetFirstStream();
-  EXPECT_TRUE(mgr.Contains(it1));
+  auto s1 = it1->stream;
+  EXPECT_NE(mgr.Find(s1), mgr.End());
 
   auto s2 = std::make_shared<FakeStream>();
   auto it2 = mgr.AddStream(s2);
-  EXPECT_TRUE(mgr.Contains(it1));
-  EXPECT_TRUE(mgr.Contains(it2));
+  EXPECT_NE(mgr.Find(s1), mgr.End());
+  EXPECT_NE(mgr.Find(s2), mgr.End());
 
   mgr.RemoveStreamAndNotifyRanges(it1, Status());
-  EXPECT_FALSE(mgr.Contains(it1));
-  EXPECT_TRUE(mgr.Contains(it2));
+  EXPECT_EQ(mgr.Find(s1), mgr.End());
+  EXPECT_NE(mgr.Find(s2), mgr.End());
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/async/multi_stream_manager_test.cc
+++ b/google/cloud/storage/internal/async/multi_stream_manager_test.cc
@@ -233,6 +233,21 @@ TEST(MultiStreamManagerTest, EmptyAndSizeTransitions) {
   EXPECT_EQ(mgr.Size(), 1U);
 }
 
+TEST(MultiStreamManagerTest, ContainsTracksStreamMembership) {
+  auto mgr = MultiStreamManagerTest::MakeManager();
+  auto it1 = mgr.GetFirstStream();
+  EXPECT_TRUE(mgr.Contains(it1));
+
+  auto s2 = std::make_shared<FakeStream>();
+  auto it2 = mgr.AddStream(s2);
+  EXPECT_TRUE(mgr.Contains(it1));
+  EXPECT_TRUE(mgr.Contains(it2));
+
+  mgr.RemoveStreamAndNotifyRanges(it1, Status());
+  EXPECT_FALSE(mgr.Contains(it1));
+  EXPECT_TRUE(mgr.Contains(it2));
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage_internal
 }  // namespace cloud

--- a/google/cloud/storage/internal/async/multi_stream_manager_test.cc
+++ b/google/cloud/storage/internal/async/multi_stream_manager_test.cc
@@ -240,7 +240,7 @@ TEST(MultiStreamManagerTest, FindTracksStreamMembership) {
   EXPECT_NE(mgr.Find(s1), mgr.End());
 
   auto s2 = std::make_shared<FakeStream>();
-  auto it2 = mgr.AddStream(s2);
+  mgr.AddStream(s2);
   EXPECT_NE(mgr.Find(s1), mgr.End());
   EXPECT_NE(mgr.Find(s2), mgr.End());
 

--- a/google/cloud/storage/internal/async/object_descriptor_impl.cc
+++ b/google/cloud/storage/internal/async/object_descriptor_impl.cc
@@ -197,7 +197,7 @@ void ObjectDescriptorImpl::MakeSubsequentStream() {
     auto self = w.lock();
     if (!self) return;
 
-    StatusOr<OpenStreamResult> stream_result = f.get();
+    auto stream_result = f.get();
     if (!stream_result) {
       // Stream creation failed.
       // The next call to AssurePendingStreamQueued will retry creation.
@@ -320,8 +320,7 @@ std::unique_ptr<storage::AsyncReaderConnection> ObjectDescriptorImpl::Read(
   std::shared_ptr<ReadStream> read_stream = it->stream;
   std::int64_t const id = ++read_id_generator_;
   it->active_ranges.emplace(id, range);
-  google::storage::v2::ReadRange& read_range =
-      *read_stream->next_request.add_read_ranges();
+  auto& read_range = *read_stream->next_request.add_read_ranges();
   read_range.set_read_id(id);
   read_range.set_read_offset(p.start);
   read_range.set_read_length(p.length);
@@ -585,9 +584,9 @@ void ObjectDescriptorImpl::DoFinish(
   // Assign CurrentStream to a temporary variable to prevent
   // lifetime extension which can cause the lock to be held until the
   // end of the block.
-  std::shared_ptr<OpenStream> current_stream = it->stream->stream;
+  auto current_stream = it->stream->stream;
   lk.unlock();
-  future<Status> pending = current_stream->Finish();
+  auto pending = current_stream->Finish();
   if (!pending.valid()) return;
   pending.then([w = WeakFromThis(), read_stream, current_stream](auto f) {
     if (auto self = w.lock()) {
@@ -609,7 +608,7 @@ void ObjectDescriptorImpl::OnFinish(
       return;
     }
   }
-  google::rpc::Status proto_status = ExtractGrpcStatus(status);
+  auto proto_status = ExtractGrpcStatus(status);
 
   if (IsResumable(read_stream, status, proto_status)) {
     return Resume(read_stream, proto_status);
@@ -640,15 +639,14 @@ void ObjectDescriptorImpl::Resume(
   // to the dying stream while we establish a new one.
   it->stream->resuming = true;
   it->stream->next_request.Clear();
-  std::shared_ptr<OpenStream> current_stream = it->stream->stream;
+  auto current_stream = it->stream->stream;
   // This call needs to happen inside the lock, as it may modify
   // `read_object_spec_`.
   ApplyRedirectErrors(read_object_spec_, proto_status);
-  google::storage::v2::BidiReadObjectRequest request;
+  auto request = google::storage::v2::BidiReadObjectRequest{};
   *request.mutable_read_object_spec() = read_object_spec_;
   for (auto const& kv : it->active_ranges) {
-    std::optional<google::storage::v2::ReadRange> range =
-        kv.second->RangeForResume(kv.first);
+    auto range = kv.second->RangeForResume(kv.first);
     if (!range) continue;
     *request.add_read_ranges() = *std::move(range);
   }
@@ -716,8 +714,8 @@ bool ObjectDescriptorImpl::IsResumable(
   if (cancelled_) return false;
   auto it = stream_manager_->Find(read_stream);
   if (it == stream_manager_->End() || !it->stream) return false;
-  for (google::protobuf::Any const& any : proto_status.details()) {
-    google::storage::v2::BidiReadObjectError error;
+  for (auto const& any : proto_status.details()) {
+    auto error = google::storage::v2::BidiReadObjectError{};
     if (!any.UnpackTo(&error)) continue;
 
     std::vector<std::pair<std::int64_t, Status>> notify;

--- a/google/cloud/storage/internal/async/object_descriptor_impl.cc
+++ b/google/cloud/storage/internal/async/object_descriptor_impl.cc
@@ -126,9 +126,10 @@ void ObjectDescriptorImpl::Start(
   std::unique_lock<std::mutex> lk(mu_);
   auto it = stream_manager_->GetFirstStream();
   if (it == stream_manager_->End()) return;
-  auto current_stream = it->stream->stream;
+  auto read_stream = it->stream;
+  auto current_stream = read_stream->stream;
   lk.unlock();
-  OnRead(it, current_stream, std::move(first_response));
+  OnRead(read_stream, current_stream, std::move(first_response));
   // Acquire lock and queue the background stream if multi-stream optimization
   // is enabled.
   if (options_.get<storage::EnableMultiStreamOptimizationOption>()) {
@@ -211,14 +212,15 @@ void ObjectDescriptorImpl::MakeSubsequentStream() {
                                      self->resume_policy_prototype_->clone());
     read_stream->resume_policy->OnStartSuccess();
 
-    auto new_it = self->stream_manager_->AddStream(std::move(read_stream));
+    self->stream_manager_->AddStream(read_stream);
 
     // Now that we consumed pending_stream_, queue the next one immediately.
     self->AssurePendingStreamQueued(lk);
 
-    auto new_stream = new_it->stream->stream;
+    auto new_stream = read_stream->stream;
     lk.unlock();
-    self->OnRead(new_it, new_stream, std::move(stream_result->first_response));
+    self->OnRead(read_stream, new_stream,
+                 std::move(stream_result->first_response));
   });
 }
 
@@ -315,13 +317,14 @@ std::unique_ptr<storage::AsyncReaderConnection> ObjectDescriptorImpl::Read(
   }
 
   auto it = stream_manager_->GetLeastBusyStream();
+  auto read_stream = it->stream;
   auto const id = ++read_id_generator_;
   it->active_ranges.emplace(id, range);
-  auto& read_range = *it->stream->next_request.add_read_ranges();
+  auto& read_range = *read_stream->next_request.add_read_ranges();
   read_range.set_read_id(id);
   read_range.set_read_offset(p.start);
   read_range.set_read_length(p.length);
-  Flush(std::move(lk), it);
+  Flush(std::move(lk), read_stream);
 
   if (!internal::TracingEnabled(options_)) {
     return std::unique_ptr<storage::AsyncReaderConnection>(
@@ -405,70 +408,80 @@ ObjectDescriptorImpl::CreateHashValidator(bool is_full_read) const {
   return hash_validator;
 }
 
-void ObjectDescriptorImpl::Flush(std::unique_lock<std::mutex> lk,
-                                 StreamIterator it) {
-  if (it->stream->resuming || it->stream->write_pending ||
-      it->stream->next_request.read_ranges().empty()) {
+void ObjectDescriptorImpl::Flush(
+    std::unique_lock<std::mutex> lk,
+    std::shared_ptr<ReadStream> const& read_stream) {
+  if (!read_stream || read_stream->resuming || read_stream->write_pending ||
+      read_stream->next_request.read_ranges().empty()) {
     return;
   }
-  it->stream->write_pending = true;
+  read_stream->write_pending = true;
   google::storage::v2::BidiReadObjectRequest request;
-  request.Swap(&it->stream->next_request);
+  request.Swap(&read_stream->next_request);
 
   // Assign CurrentStream to a temporary variable to prevent
   // lifetime extension which can cause the lock to be held until the
   // end of the block.
-  auto current_stream = it->stream->stream;
+  auto current_stream = read_stream->stream;
   lk.unlock();
   current_stream->Write(std::move(request))
-      .then([w = WeakFromThis(), it, current_stream](auto f) {
-        if (auto self = w.lock()) self->OnWrite(it, current_stream, f.get());
+      .then([w = WeakFromThis(), read_stream, current_stream](auto f) {
+        if (auto self = w.lock()) {
+          self->OnWrite(read_stream, current_stream, f.get());
+        }
       });
 }
 
-void ObjectDescriptorImpl::OnWrite(StreamIterator it,
-                                   std::shared_ptr<OpenStream> const& stream,
-                                   bool ok) {
+void ObjectDescriptorImpl::OnWrite(
+    std::shared_ptr<ReadStream> const& read_stream,
+    std::shared_ptr<OpenStream> const& stream, bool ok) {
   std::unique_lock<std::mutex> lk(mu_);
   // Discard callbacks from stale or removed streams (e.g. if the stream was
   // replaced during reconnection or removed after an error).
-  if (!stream_manager_->Contains(it) || !it->stream ||
+  auto it = stream_manager_->Find(read_stream);
+  if (it == stream_manager_->End() || !it->stream ||
       it->stream->stream != stream) {
     return;
   }
-  if (!ok) return DoFinish(std::move(lk), it, stream);
+  if (!ok) return DoFinish(std::move(lk), read_stream, stream);
   it->stream->write_pending = false;
-  Flush(std::move(lk), it);
+  Flush(std::move(lk), read_stream);
 }
 
-void ObjectDescriptorImpl::DoRead(std::unique_lock<std::mutex> lk,
-                                  StreamIterator it) {
-  if (it->stream->read_pending) return;
-  it->stream->read_pending = true;
+void ObjectDescriptorImpl::DoRead(
+    std::unique_lock<std::mutex> lk,
+    std::shared_ptr<ReadStream> const& read_stream) {
+  if (!read_stream || read_stream->read_pending) return;
+  read_stream->read_pending = true;
 
   // Assign CurrentStream to a temporary variable to prevent
   // lifetime extension which can cause the lock to be held until the
   // end of the block.
-  auto current_stream = it->stream->stream;
+  auto current_stream = read_stream->stream;
   lk.unlock();
-  current_stream->Read().then([w = WeakFromThis(), it, current_stream](auto f) {
-    if (auto self = w.lock()) self->OnRead(it, current_stream, f.get());
-  });
+  current_stream->Read().then(
+      [w = WeakFromThis(), read_stream, current_stream](auto f) {
+        if (auto self = w.lock()) {
+          self->OnRead(read_stream, current_stream, f.get());
+        }
+      });
 }
 
 void ObjectDescriptorImpl::OnRead(
-    StreamIterator it, std::shared_ptr<OpenStream> const& stream,
+    std::shared_ptr<ReadStream> const& read_stream,
+    std::shared_ptr<OpenStream> const& stream,
     std::optional<google::storage::v2::BidiReadObjectResponse> response) {
   std::unique_lock<std::mutex> lk(mu_);
   // Discard callbacks from stale or removed streams (e.g. if the stream was
   // replaced during reconnection or removed after an error).
-  if (!stream_manager_->Contains(it) || !it->stream ||
+  auto it = stream_manager_->Find(read_stream);
+  if (it == stream_manager_->End() || !it->stream ||
       it->stream->stream != stream) {
     return;
   }
   it->stream->read_pending = false;
 
-  if (!response) return DoFinish(std::move(lk), it, stream);
+  if (!response) return DoFinish(std::move(lk), read_stream, stream);
   if (response->has_metadata()) {
     metadata_ = std::move(*response->mutable_metadata());
   }
@@ -486,35 +499,6 @@ void ObjectDescriptorImpl::OnRead(
   // Release the lock while notifying the ranges. The notifications may trigger
   // application code, and that code may callback on this class.
   lk.unlock();
-  auto apply_pacing_and_check_eviction = [this](std::int64_t id,
-                                                std::size_t chunk_size,
-                                                StreamIterator it) {
-    auto unclaimed_it = unclaimed_ranges_.find(id);
-    if (unclaimed_it == unclaimed_ranges_.end()) return false;
-
-    if (total_prewarmed_bytes_buffered_ + chunk_size >
-        max_prewarmed_buffer_size_) {
-      // Evict the range if it exceeds the pacing limit.
-      total_prewarmed_bytes_buffered_ -= unclaimed_it->second.bytes_buffered;
-      // Cap tombstone set size to prevent unbounded memory growth in long-lived
-      // descriptors where pre-warmed ranges are evicted but never requested.
-      if (evicted_ranges_.size() < 1000) {
-        evicted_ranges_.insert(unclaimed_it->second.cache_it->first);
-      }
-      prewarmed_ranges_.erase(unclaimed_it->second.cache_it);
-      unclaimed_ranges_.erase(unclaimed_it);
-
-      // Erasing from active_ranges ensures we ignore any subsequent GCS chunks
-      // for this range.
-      it->active_ranges.erase(id);
-      return true;
-    }
-
-    // Track buffered data size for pacing.
-    unclaimed_it->second.bytes_buffered += chunk_size;
-    total_prewarmed_bytes_buffered_ += chunk_size;
-    return false;
-  };
 
   for (auto& range_data : *response->mutable_object_data_ranges()) {
     auto id = range_data.read_range().read_id();
@@ -529,9 +513,11 @@ void ObjectDescriptorImpl::OnRead(
     // Verify the range is still active under the lock. Because `OnRead`
     // processes chunks in batches, an earlier chunk in the same batch could
     // breach the pacing limit and evict a subsequent chunk's range.
-    bool active = it->active_ranges.count(id) != 0;
+    auto it_curr = stream_manager_->Find(read_stream);
+    bool active = (it_curr != stream_manager_->End()) &&
+                  (it_curr->active_ranges.count(id) != 0);
     if (active) {
-      evict = apply_pacing_and_check_eviction(id, chunk_size, it);
+      evict = ApplyPacingAndCheckEviction(id, chunk_size, it_curr);
     }
     lk.unlock();
     if (active) {
@@ -548,16 +534,49 @@ void ObjectDescriptorImpl::OnRead(
     }
   }
   lk.lock();
-  if (!stream_manager_->Contains(it) || !it->stream) return;
-  stream_manager_->CleanupDoneRanges(it);
-  DoRead(std::move(lk), it);
+  auto it_final = stream_manager_->Find(read_stream);
+  if (it_final == stream_manager_->End() || !it_final->stream) return;
+  stream_manager_->CleanupDoneRanges(it_final);
+  DoRead(std::move(lk), read_stream);
 }
 
-void ObjectDescriptorImpl::DoFinish(std::unique_lock<std::mutex> lk,
-                                    StreamIterator it,
-                                    std::shared_ptr<OpenStream> const& stream) {
+bool ObjectDescriptorImpl::ApplyPacingAndCheckEviction(std::int64_t id,
+                                                       std::size_t chunk_size,
+                                                       StreamIterator it) {
+  auto unclaimed_it = unclaimed_ranges_.find(id);
+  if (unclaimed_it == unclaimed_ranges_.end()) return false;
+
+  if (total_prewarmed_bytes_buffered_ + chunk_size >
+      max_prewarmed_buffer_size_) {
+    // Evict the range if it exceeds the pacing limit.
+    total_prewarmed_bytes_buffered_ -= unclaimed_it->second.bytes_buffered;
+    // Cap tombstone set size to prevent unbounded memory growth in long-lived
+    // descriptors where pre-warmed ranges are evicted but never requested.
+    if (evicted_ranges_.size() < 1000) {
+      evicted_ranges_.insert(unclaimed_it->second.cache_it->first);
+    }
+    prewarmed_ranges_.erase(unclaimed_it->second.cache_it);
+    unclaimed_ranges_.erase(unclaimed_it);
+
+    // Erasing from active_ranges ensures we ignore any subsequent GCS chunks
+    // for this range.
+    it->active_ranges.erase(id);
+    return true;
+  }
+
+  // Track buffered data size for pacing.
+  unclaimed_it->second.bytes_buffered += chunk_size;
+  total_prewarmed_bytes_buffered_ += chunk_size;
+  return false;
+}
+
+void ObjectDescriptorImpl::DoFinish(
+    std::unique_lock<std::mutex> lk,
+    std::shared_ptr<ReadStream> const& read_stream,
+    std::shared_ptr<OpenStream> const& stream) {
   // Discard finish requests if the stream was already replaced or removed.
-  if (!stream_manager_->Contains(it) || !it->stream ||
+  auto it = stream_manager_->Find(read_stream);
+  if (it == stream_manager_->End() || !it->stream ||
       it->stream->stream != stream) {
     return;
   }
@@ -569,32 +588,38 @@ void ObjectDescriptorImpl::DoFinish(std::unique_lock<std::mutex> lk,
   lk.unlock();
   auto pending = current_stream->Finish();
   if (!pending.valid()) return;
-  pending.then([w = WeakFromThis(), it, current_stream](auto f) {
-    if (auto self = w.lock()) self->OnFinish(it, current_stream, f.get());
+  pending.then([w = WeakFromThis(), read_stream, current_stream](auto f) {
+    if (auto self = w.lock()) {
+      self->OnFinish(read_stream, current_stream, f.get());
+    }
   });
 }
 
-void ObjectDescriptorImpl::OnFinish(StreamIterator it,
-                                    std::shared_ptr<OpenStream> const& stream,
-                                    Status const& status) {
+void ObjectDescriptorImpl::OnFinish(
+    std::shared_ptr<ReadStream> const& read_stream,
+    std::shared_ptr<OpenStream> const& stream, Status const& status) {
   {
     std::unique_lock<std::mutex> lk(mu_);
     // Discard callbacks if cancelled or from stale/removed streams.
-    if (cancelled_ || !stream_manager_->Contains(it) || !it->stream ||
+    if (cancelled_) return;
+    auto it = stream_manager_->Find(read_stream);
+    if (it == stream_manager_->End() || !it->stream ||
         it->stream->stream != stream) {
       return;
     }
   }
   auto proto_status = ExtractGrpcStatus(status);
 
-  if (IsResumable(it, status, proto_status)) {
-    return Resume(it, proto_status);
+  if (IsResumable(read_stream, status, proto_status)) {
+    return Resume(read_stream, proto_status);
   }
   std::unique_lock<std::mutex> lk(mu_);
   // Re-verify stream identity under lock because IsResumable() releases and
   // re-acquires the mutex while notifying range callbacks, during which time
   // another thread or callback could have modified or replaced the stream.
-  if (cancelled_ || !stream_manager_->Contains(it) || !it->stream ||
+  if (cancelled_) return;
+  auto it = stream_manager_->Find(read_stream);
+  if (it == stream_manager_->End() || !it->stream ||
       it->stream->stream != stream) {
     return;
   }
@@ -603,10 +628,13 @@ void ObjectDescriptorImpl::OnFinish(StreamIterator it,
   AssurePendingStreamQueued(lk);
 }
 
-void ObjectDescriptorImpl::Resume(StreamIterator it,
-                                  google::rpc::Status const& proto_status) {
+void ObjectDescriptorImpl::Resume(
+    std::shared_ptr<ReadStream> const& read_stream,
+    google::rpc::Status const& proto_status) {
   std::unique_lock<std::mutex> lk(mu_);
-  if (cancelled_ || !stream_manager_->Contains(it) || !it->stream) return;
+  if (cancelled_) return;
+  auto it = stream_manager_->Find(read_stream);
+  if (it == stream_manager_->End() || !it->stream) return;
   // Set resuming flag to true to prevent any concurrent Flush() from writing
   // to the dying stream while we establish a new one.
   it->stream->resuming = true;
@@ -617,20 +645,23 @@ void ObjectDescriptorImpl::Resume(StreamIterator it,
   ApplyRedirectErrors(read_object_spec_, proto_status);
   auto request = google::storage::v2::BidiReadObjectRequest{};
   *request.mutable_read_object_spec() = read_object_spec_;
-  for (auto const& kv : it->active_ranges) {
-    auto range = kv.second->RangeForResume(kv.first);
+  for (auto const& [read_id, range_ptr] : it->active_ranges) {
+    auto range = range_ptr->RangeForResume(read_id);
     if (!range) continue;
     *request.add_read_ranges() = *std::move(range);
   }
   lk.unlock();
   make_stream_(std::move(request))
-      .then([w = WeakFromThis(), it, current_stream](auto f) {
-        if (auto self = w.lock()) self->OnResume(it, current_stream, f.get());
+      .then([w = WeakFromThis(), read_stream, current_stream](auto f) {
+        if (auto self = w.lock()) {
+          self->OnResume(read_stream, current_stream, f.get());
+        }
       });
 }
 
 void ObjectDescriptorImpl::OnResume(
-    StreamIterator it, std::shared_ptr<OpenStream> const& old_stream,
+    std::shared_ptr<ReadStream> const& old_read_stream,
+    std::shared_ptr<OpenStream> const& old_stream,
     StatusOr<OpenStreamResult> result) {
   {
     std::unique_lock<std::mutex> lk(mu_);
@@ -639,11 +670,14 @@ void ObjectDescriptorImpl::OnResume(
       return;
     }
   }
-  if (!result) return OnFinish(it, old_stream, std::move(result).status());
+  if (!result) {
+    return OnFinish(old_read_stream, old_stream, std::move(result).status());
+  }
   std::unique_lock<std::mutex> lk(mu_);
   // Discard resume responses if cancelled or if the stream entry was removed or
   // already replaced.
-  if (cancelled_ || !stream_manager_->Contains(it) || !it->stream ||
+  auto it = stream_manager_->Find(old_read_stream);
+  if (cancelled_ || it == stream_manager_->End() || !it->stream ||
       it->stream->stream != old_stream) {
     if (result->stream) result->stream->Cancel();
     return;
@@ -654,27 +688,31 @@ void ObjectDescriptorImpl::OnResume(
   auto queued_request = std::move(it->stream->next_request);
 
   // Replace the old stream with the new stream and reset policy/state.
-  it->stream = std::make_shared<ReadStream>(std::move(result->stream),
-                                            resume_policy_prototype_->clone());
-  it->stream->resume_policy->OnStartSuccess();
-  it->stream->write_pending = false;
-  it->stream->read_pending = false;
-  it->stream->resuming = false;
-  it->stream->next_request = std::move(queued_request);
+  auto new_read_stream = std::make_shared<ReadStream>(
+      std::move(result->stream), resume_policy_prototype_->clone());
+  new_read_stream->resume_policy->OnStartSuccess();
+  new_read_stream->write_pending = false;
+  new_read_stream->read_pending = false;
+  new_read_stream->resuming = false;
+  new_read_stream->next_request = std::move(queued_request);
 
-  auto new_stream = it->stream->stream;
+  it->stream = new_read_stream;
+  auto new_stream = new_read_stream->stream;
+
   // TODO(#15105) - this should be done without release the lock.
   // Flush any queued range requests onto the newly active stream.
-  Flush(std::move(lk), it);
+  Flush(std::move(lk), new_read_stream);
   // Process the first response received during stream establishment.
-  OnRead(it, new_stream, std::move(result->first_response));
+  OnRead(new_read_stream, new_stream, std::move(result->first_response));
 }
 
 bool ObjectDescriptorImpl::IsResumable(
-    StreamIterator it, Status const& status,
+    std::shared_ptr<ReadStream> const& read_stream, Status const& status,
     google::rpc::Status const& proto_status) {
   std::unique_lock<std::mutex> lk(mu_);
-  if (cancelled_ || !stream_manager_->Contains(it) || !it->stream) return false;
+  if (cancelled_) return false;
+  auto it = stream_manager_->Find(read_stream);
+  if (it == stream_manager_->End() || !it->stream) return false;
   for (auto const& any : proto_status.details()) {
     auto error = google::storage::v2::BidiReadObjectError{};
     if (!any.UnpackTo(&error)) continue;
@@ -689,15 +727,15 @@ bool ObjectDescriptorImpl::IsResumable(
 
     auto copy = it->active_ranges;
     lk.unlock();
-    for (auto const& p : notify) {
-      auto l = copy.find(p.first);
-      if (l != copy.end()) l->second->OnFinish(p.second);
+    for (auto const& [read_id, range_status] : notify) {
+      auto l = copy.find(read_id);
+      if (l != copy.end()) l->second->OnFinish(range_status);
     }
     lk.lock();
-    if (cancelled_ || !stream_manager_->Contains(it) || !it->stream) {
-      return true;
-    }
-    stream_manager_->CleanupDoneRanges(it);
+    if (cancelled_) return true;
+    auto it_curr = stream_manager_->Find(read_stream);
+    if (it_curr == stream_manager_->End() || !it_curr->stream) return true;
+    stream_manager_->CleanupDoneRanges(it_curr);
     return true;
   }
   auto effective_status = status;

--- a/google/cloud/storage/internal/async/object_descriptor_impl.cc
+++ b/google/cloud/storage/internal/async/object_descriptor_impl.cc
@@ -126,8 +126,8 @@ void ObjectDescriptorImpl::Start(
   std::unique_lock<std::mutex> lk(mu_);
   auto it = stream_manager_->GetFirstStream();
   if (it == stream_manager_->End()) return;
-  auto read_stream = it->stream;
-  auto current_stream = read_stream->stream;
+  std::shared_ptr<ReadStream> read_stream = it->stream;
+  std::shared_ptr<OpenStream> current_stream = read_stream->stream;
   lk.unlock();
   OnRead(read_stream, current_stream, std::move(first_response));
   // Acquire lock and queue the background stream if multi-stream optimization
@@ -197,7 +197,7 @@ void ObjectDescriptorImpl::MakeSubsequentStream() {
     auto self = w.lock();
     if (!self) return;
 
-    auto stream_result = f.get();
+    StatusOr<OpenStreamResult> stream_result = f.get();
     if (!stream_result) {
       // Stream creation failed.
       // The next call to AssurePendingStreamQueued will retry creation.
@@ -207,7 +207,7 @@ void ObjectDescriptorImpl::MakeSubsequentStream() {
     std::unique_lock<std::mutex> lk(self->mu_);
     if (self->cancelled_) return;
 
-    auto read_stream =
+    std::shared_ptr<ReadStream> read_stream =
         std::make_shared<ReadStream>(std::move(stream_result->stream),
                                      self->resume_policy_prototype_->clone());
     read_stream->resume_policy->OnStartSuccess();
@@ -217,7 +217,7 @@ void ObjectDescriptorImpl::MakeSubsequentStream() {
     // Now that we consumed pending_stream_, queue the next one immediately.
     self->AssurePendingStreamQueued(lk);
 
-    auto new_stream = read_stream->stream;
+    std::shared_ptr<OpenStream> new_stream = read_stream->stream;
     lk.unlock();
     self->OnRead(read_stream, new_stream,
                  std::move(stream_result->first_response));
@@ -317,10 +317,11 @@ std::unique_ptr<storage::AsyncReaderConnection> ObjectDescriptorImpl::Read(
   }
 
   auto it = stream_manager_->GetLeastBusyStream();
-  auto read_stream = it->stream;
-  auto const id = ++read_id_generator_;
+  std::shared_ptr<ReadStream> read_stream = it->stream;
+  std::int64_t const id = ++read_id_generator_;
   it->active_ranges.emplace(id, range);
-  auto& read_range = *read_stream->next_request.add_read_ranges();
+  google::storage::v2::ReadRange& read_range =
+      *read_stream->next_request.add_read_ranges();
   read_range.set_read_id(id);
   read_range.set_read_offset(p.start);
   read_range.set_read_length(p.length);
@@ -422,7 +423,7 @@ void ObjectDescriptorImpl::Flush(
   // Assign CurrentStream to a temporary variable to prevent
   // lifetime extension which can cause the lock to be held until the
   // end of the block.
-  auto current_stream = read_stream->stream;
+  std::shared_ptr<OpenStream> current_stream = read_stream->stream;
   lk.unlock();
   current_stream->Write(std::move(request))
       .then([w = WeakFromThis(), read_stream, current_stream](auto f) {
@@ -457,7 +458,7 @@ void ObjectDescriptorImpl::DoRead(
   // Assign CurrentStream to a temporary variable to prevent
   // lifetime extension which can cause the lock to be held until the
   // end of the block.
-  auto current_stream = read_stream->stream;
+  std::shared_ptr<OpenStream> current_stream = read_stream->stream;
   lk.unlock();
   current_stream->Read().then(
       [w = WeakFromThis(), read_stream, current_stream](auto f) {
@@ -501,12 +502,12 @@ void ObjectDescriptorImpl::OnRead(
   lk.unlock();
 
   for (auto& range_data : *response->mutable_object_data_ranges()) {
-    auto id = range_data.read_range().read_id();
+    std::int64_t id = range_data.read_range().read_id();
     auto const l = copy.find(id);
     if (l == copy.end()) continue;
 
     auto range = l->second;
-    auto chunk_size = range_data.checksummed_data().content().size();
+    std::size_t chunk_size = range_data.checksummed_data().content().size();
 
     bool evict = false;
     lk.lock();
@@ -584,9 +585,9 @@ void ObjectDescriptorImpl::DoFinish(
   // Assign CurrentStream to a temporary variable to prevent
   // lifetime extension which can cause the lock to be held until the
   // end of the block.
-  auto current_stream = it->stream->stream;
+  std::shared_ptr<OpenStream> current_stream = it->stream->stream;
   lk.unlock();
-  auto pending = current_stream->Finish();
+  future<Status> pending = current_stream->Finish();
   if (!pending.valid()) return;
   pending.then([w = WeakFromThis(), read_stream, current_stream](auto f) {
     if (auto self = w.lock()) {
@@ -608,7 +609,7 @@ void ObjectDescriptorImpl::OnFinish(
       return;
     }
   }
-  auto proto_status = ExtractGrpcStatus(status);
+  google::rpc::Status proto_status = ExtractGrpcStatus(status);
 
   if (IsResumable(read_stream, status, proto_status)) {
     return Resume(read_stream, proto_status);
@@ -639,14 +640,15 @@ void ObjectDescriptorImpl::Resume(
   // to the dying stream while we establish a new one.
   it->stream->resuming = true;
   it->stream->next_request.Clear();
-  auto current_stream = it->stream->stream;
+  std::shared_ptr<OpenStream> current_stream = it->stream->stream;
   // This call needs to happen inside the lock, as it may modify
   // `read_object_spec_`.
   ApplyRedirectErrors(read_object_spec_, proto_status);
-  auto request = google::storage::v2::BidiReadObjectRequest{};
+  google::storage::v2::BidiReadObjectRequest request;
   *request.mutable_read_object_spec() = read_object_spec_;
-  for (auto const& [read_id, range_ptr] : it->active_ranges) {
-    auto range = range_ptr->RangeForResume(read_id);
+  for (auto const& kv : it->active_ranges) {
+    std::optional<google::storage::v2::ReadRange> range =
+        kv.second->RangeForResume(kv.first);
     if (!range) continue;
     *request.add_read_ranges() = *std::move(range);
   }
@@ -685,10 +687,11 @@ void ObjectDescriptorImpl::OnResume(
 
   // Preserve any Read() range requests that arrived concurrently while the
   // reconnection was in flight.
-  auto queued_request = std::move(it->stream->next_request);
+  google::storage::v2::BidiReadObjectRequest queued_request =
+      std::move(it->stream->next_request);
 
   // Replace the old stream with the new stream and reset policy/state.
-  auto new_read_stream = std::make_shared<ReadStream>(
+  std::shared_ptr<ReadStream> new_read_stream = std::make_shared<ReadStream>(
       std::move(result->stream), resume_policy_prototype_->clone());
   new_read_stream->resume_policy->OnStartSuccess();
   new_read_stream->write_pending = false;
@@ -697,7 +700,7 @@ void ObjectDescriptorImpl::OnResume(
   new_read_stream->next_request = std::move(queued_request);
 
   it->stream = new_read_stream;
-  auto new_stream = new_read_stream->stream;
+  std::shared_ptr<OpenStream> new_stream = new_read_stream->stream;
 
   // TODO(#15105) - this should be done without release the lock.
   // Flush any queued range requests onto the newly active stream.
@@ -713,8 +716,8 @@ bool ObjectDescriptorImpl::IsResumable(
   if (cancelled_) return false;
   auto it = stream_manager_->Find(read_stream);
   if (it == stream_manager_->End() || !it->stream) return false;
-  for (auto const& any : proto_status.details()) {
-    auto error = google::storage::v2::BidiReadObjectError{};
+  for (google::protobuf::Any const& any : proto_status.details()) {
+    google::storage::v2::BidiReadObjectError error;
     if (!any.UnpackTo(&error)) continue;
 
     std::vector<std::pair<std::int64_t, Status>> notify;
@@ -727,9 +730,9 @@ bool ObjectDescriptorImpl::IsResumable(
 
     auto copy = it->active_ranges;
     lk.unlock();
-    for (auto const& [read_id, range_status] : notify) {
-      auto l = copy.find(read_id);
-      if (l != copy.end()) l->second->OnFinish(range_status);
+    for (auto const& p : notify) {
+      auto l = copy.find(p.first);
+      if (l != copy.end()) l->second->OnFinish(p.second);
     }
     lk.lock();
     if (cancelled_) return true;
@@ -738,7 +741,7 @@ bool ObjectDescriptorImpl::IsResumable(
     stream_manager_->CleanupDoneRanges(it_curr);
     return true;
   }
-  auto effective_status = status;
+  Status effective_status = status;
   if (status.code() == StatusCode::kCancelled) {
     effective_status = Status(StatusCode::kUnavailable, status.message());
   }

--- a/google/cloud/storage/internal/async/object_descriptor_impl.cc
+++ b/google/cloud/storage/internal/async/object_descriptor_impl.cc
@@ -77,10 +77,14 @@ ObjectDescriptorImpl::ObjectDescriptorImpl(
       options_(std::move(options)),
       has_initial_read_ranges_(options_.has<ReadRangesOption>()),
       transport_ok_(std::move(transport_ok)) {
+  auto initial_read_stream = std::make_shared<ReadStream>(
+      std::move(stream), resume_policy_prototype_->clone());
+  // Notify the resume policy that the initial stream was established
+  // successfully.
+  initial_read_stream->resume_policy->OnStartSuccess();
   stream_manager_ = std::make_unique<StreamManager>(
       []() -> std::shared_ptr<ReadStream> { return nullptr; },  // NOLINT
-      std::make_shared<ReadStream>(std::move(stream),
-                                   resume_policy_prototype_->clone()));
+      std::move(initial_read_stream));
   // Initialize the pacing limit from options if configured.
   if (options_.has<PreWarmBufferLimitOption>()) {
     max_prewarmed_buffer_size_ = options_.get<PreWarmBufferLimitOption>();
@@ -122,8 +126,9 @@ void ObjectDescriptorImpl::Start(
   std::unique_lock<std::mutex> lk(mu_);
   auto it = stream_manager_->GetFirstStream();
   if (it == stream_manager_->End()) return;
+  auto current_stream = it->stream->stream;
   lk.unlock();
-  OnRead(it, std::move(first_response));
+  OnRead(it, current_stream, std::move(first_response));
   // Acquire lock and queue the background stream if multi-stream optimization
   // is enabled.
   if (options_.get<storage::EnableMultiStreamOptimizationOption>()) {
@@ -204,14 +209,16 @@ void ObjectDescriptorImpl::MakeSubsequentStream() {
     auto read_stream =
         std::make_shared<ReadStream>(std::move(stream_result->stream),
                                      self->resume_policy_prototype_->clone());
+    read_stream->resume_policy->OnStartSuccess();
 
     auto new_it = self->stream_manager_->AddStream(std::move(read_stream));
 
     // Now that we consumed pending_stream_, queue the next one immediately.
     self->AssurePendingStreamQueued(lk);
 
+    auto new_stream = new_it->stream->stream;
     lk.unlock();
-    self->OnRead(new_it, std::move(stream_result->first_response));
+    self->OnRead(new_it, new_stream, std::move(stream_result->first_response));
   });
 }
 
@@ -400,7 +407,7 @@ ObjectDescriptorImpl::CreateHashValidator(bool is_full_read) const {
 
 void ObjectDescriptorImpl::Flush(std::unique_lock<std::mutex> lk,
                                  StreamIterator it) {
-  if (it->stream->write_pending ||
+  if (it->stream->resuming || it->stream->write_pending ||
       it->stream->next_request.read_ranges().empty()) {
     return;
   }
@@ -414,14 +421,22 @@ void ObjectDescriptorImpl::Flush(std::unique_lock<std::mutex> lk,
   auto current_stream = it->stream->stream;
   lk.unlock();
   current_stream->Write(std::move(request))
-      .then([w = WeakFromThis(), it](auto f) {
-        if (auto self = w.lock()) self->OnWrite(it, f.get());
+      .then([w = WeakFromThis(), it, current_stream](auto f) {
+        if (auto self = w.lock()) self->OnWrite(it, current_stream, f.get());
       });
 }
 
-void ObjectDescriptorImpl::OnWrite(StreamIterator it, bool ok) {
+void ObjectDescriptorImpl::OnWrite(StreamIterator it,
+                                   std::shared_ptr<OpenStream> const& stream,
+                                   bool ok) {
   std::unique_lock<std::mutex> lk(mu_);
-  if (!ok) return DoFinish(std::move(lk), it);
+  // Discard callbacks from stale or removed streams (e.g. if the stream was
+  // replaced during reconnection or removed after an error).
+  if (!stream_manager_->Contains(it) || !it->stream ||
+      it->stream->stream != stream) {
+    return;
+  }
+  if (!ok) return DoFinish(std::move(lk), it, stream);
   it->stream->write_pending = false;
   Flush(std::move(lk), it);
 }
@@ -436,18 +451,24 @@ void ObjectDescriptorImpl::DoRead(std::unique_lock<std::mutex> lk,
   // end of the block.
   auto current_stream = it->stream->stream;
   lk.unlock();
-  current_stream->Read().then([w = WeakFromThis(), it](auto f) {
-    if (auto self = w.lock()) self->OnRead(it, f.get());
+  current_stream->Read().then([w = WeakFromThis(), it, current_stream](auto f) {
+    if (auto self = w.lock()) self->OnRead(it, current_stream, f.get());
   });
 }
 
 void ObjectDescriptorImpl::OnRead(
-    StreamIterator it,
+    StreamIterator it, std::shared_ptr<OpenStream> const& stream,
     std::optional<google::storage::v2::BidiReadObjectResponse> response) {
   std::unique_lock<std::mutex> lk(mu_);
+  // Discard callbacks from stale or removed streams (e.g. if the stream was
+  // replaced during reconnection or removed after an error).
+  if (!stream_manager_->Contains(it) || !it->stream ||
+      it->stream->stream != stream) {
+    return;
+  }
   it->stream->read_pending = false;
 
-  if (!response) return DoFinish(std::move(lk), it);
+  if (!response) return DoFinish(std::move(lk), it, stream);
   if (response->has_metadata()) {
     metadata_ = std::move(*response->mutable_metadata());
   }
@@ -527,12 +548,19 @@ void ObjectDescriptorImpl::OnRead(
     }
   }
   lk.lock();
+  if (!stream_manager_->Contains(it) || !it->stream) return;
   stream_manager_->CleanupDoneRanges(it);
   DoRead(std::move(lk), it);
 }
 
 void ObjectDescriptorImpl::DoFinish(std::unique_lock<std::mutex> lk,
-                                    StreamIterator it) {
+                                    StreamIterator it,
+                                    std::shared_ptr<OpenStream> const& stream) {
+  // Discard finish requests if the stream was already replaced or removed.
+  if (!stream_manager_->Contains(it) || !it->stream ||
+      it->stream->stream != stream) {
+    return;
+  }
   it->stream->read_pending = false;
   // Assign CurrentStream to a temporary variable to prevent
   // lifetime extension which can cause the lock to be held until the
@@ -541,16 +569,35 @@ void ObjectDescriptorImpl::DoFinish(std::unique_lock<std::mutex> lk,
   lk.unlock();
   auto pending = current_stream->Finish();
   if (!pending.valid()) return;
-  pending.then([w = WeakFromThis(), it](auto f) {
-    if (auto self = w.lock()) self->OnFinish(it, f.get());
+  pending.then([w = WeakFromThis(), it, current_stream](auto f) {
+    if (auto self = w.lock()) self->OnFinish(it, current_stream, f.get());
   });
 }
 
-void ObjectDescriptorImpl::OnFinish(StreamIterator it, Status const& status) {
+void ObjectDescriptorImpl::OnFinish(StreamIterator it,
+                                    std::shared_ptr<OpenStream> const& stream,
+                                    Status const& status) {
+  {
+    std::unique_lock<std::mutex> lk(mu_);
+    // Discard callbacks if cancelled or from stale/removed streams.
+    if (cancelled_ || !stream_manager_->Contains(it) || !it->stream ||
+        it->stream->stream != stream) {
+      return;
+    }
+  }
   auto proto_status = ExtractGrpcStatus(status);
 
-  if (IsResumable(it, status, proto_status)) return Resume(it, proto_status);
+  if (IsResumable(it, status, proto_status)) {
+    return Resume(it, proto_status);
+  }
   std::unique_lock<std::mutex> lk(mu_);
+  // Re-verify stream identity under lock because IsResumable() releases and
+  // re-acquires the mutex while notifying range callbacks, during which time
+  // another thread or callback could have modified or replaced the stream.
+  if (cancelled_ || !stream_manager_->Contains(it) || !it->stream ||
+      it->stream->stream != stream) {
+    return;
+  }
   stream_manager_->RemoveStreamAndNotifyRanges(it, status);
   // Since a stream died, we might want to ensure a replacement is queued.
   AssurePendingStreamQueued(lk);
@@ -559,6 +606,12 @@ void ObjectDescriptorImpl::OnFinish(StreamIterator it, Status const& status) {
 void ObjectDescriptorImpl::Resume(StreamIterator it,
                                   google::rpc::Status const& proto_status) {
   std::unique_lock<std::mutex> lk(mu_);
+  if (cancelled_ || !stream_manager_->Contains(it) || !it->stream) return;
+  // Set resuming flag to true to prevent any concurrent Flush() from writing
+  // to the dying stream while we establish a new one.
+  it->stream->resuming = true;
+  it->stream->next_request.Clear();
+  auto current_stream = it->stream->stream;
   // This call needs to happen inside the lock, as it may modify
   // `read_object_spec_`.
   ApplyRedirectErrors(read_object_spec_, proto_status);
@@ -570,31 +623,58 @@ void ObjectDescriptorImpl::Resume(StreamIterator it,
     *request.add_read_ranges() = *std::move(range);
   }
   lk.unlock();
-  make_stream_(std::move(request)).then([w = WeakFromThis(), it](auto f) {
-    if (auto self = w.lock()) self->OnResume(it, f.get());
-  });
+  make_stream_(std::move(request))
+      .then([w = WeakFromThis(), it, current_stream](auto f) {
+        if (auto self = w.lock()) self->OnResume(it, current_stream, f.get());
+      });
 }
 
-void ObjectDescriptorImpl::OnResume(StreamIterator it,
-                                    StatusOr<OpenStreamResult> result) {
-  if (!result) return OnFinish(it, std::move(result).status());
+void ObjectDescriptorImpl::OnResume(
+    StreamIterator it, std::shared_ptr<OpenStream> const& old_stream,
+    StatusOr<OpenStreamResult> result) {
+  {
+    std::unique_lock<std::mutex> lk(mu_);
+    if (cancelled_) {
+      if (result && result->stream) result->stream->Cancel();
+      return;
+    }
+  }
+  if (!result) return OnFinish(it, old_stream, std::move(result).status());
   std::unique_lock<std::mutex> lk(mu_);
-  if (cancelled_) return;
+  // Discard resume responses if cancelled or if the stream entry was removed or
+  // already replaced.
+  if (cancelled_ || !stream_manager_->Contains(it) || !it->stream ||
+      it->stream->stream != old_stream) {
+    if (result->stream) result->stream->Cancel();
+    return;
+  }
 
+  // Preserve any Read() range requests that arrived concurrently while the
+  // reconnection was in flight.
+  auto queued_request = std::move(it->stream->next_request);
+
+  // Replace the old stream with the new stream and reset policy/state.
   it->stream = std::make_shared<ReadStream>(std::move(result->stream),
                                             resume_policy_prototype_->clone());
+  it->stream->resume_policy->OnStartSuccess();
   it->stream->write_pending = false;
   it->stream->read_pending = false;
+  it->stream->resuming = false;
+  it->stream->next_request = std::move(queued_request);
 
+  auto new_stream = it->stream->stream;
   // TODO(#15105) - this should be done without release the lock.
+  // Flush any queued range requests onto the newly active stream.
   Flush(std::move(lk), it);
-  OnRead(it, std::move(result->first_response));
+  // Process the first response received during stream establishment.
+  OnRead(it, new_stream, std::move(result->first_response));
 }
 
 bool ObjectDescriptorImpl::IsResumable(
     StreamIterator it, Status const& status,
     google::rpc::Status const& proto_status) {
   std::unique_lock<std::mutex> lk(mu_);
+  if (cancelled_ || !stream_manager_->Contains(it) || !it->stream) return false;
   for (auto const& any : proto_status.details()) {
     auto error = google::storage::v2::BidiReadObjectError{};
     if (!any.UnpackTo(&error)) continue;
@@ -614,10 +694,17 @@ bool ObjectDescriptorImpl::IsResumable(
       if (l != copy.end()) l->second->OnFinish(p.second);
     }
     lk.lock();
+    if (cancelled_ || !stream_manager_->Contains(it) || !it->stream) {
+      return true;
+    }
     stream_manager_->CleanupDoneRanges(it);
     return true;
   }
-  return it->stream->resume_policy->OnFinish(status) ==
+  auto effective_status = status;
+  if (status.code() == StatusCode::kCancelled) {
+    effective_status = Status(StatusCode::kUnavailable, status.message());
+  }
+  return it->stream->resume_policy->OnFinish(effective_status) ==
          storage::ResumePolicy::kContinue;
 }
 

--- a/google/cloud/storage/internal/async/object_descriptor_impl.h
+++ b/google/cloud/storage/internal/async/object_descriptor_impl.h
@@ -101,23 +101,32 @@ class ObjectDescriptorImpl
   // invoked while holding `mu_`.
   void AssurePendingStreamQueued(std::unique_lock<std::mutex> const&);
 
-  void Flush(std::unique_lock<std::mutex> lk, StreamIterator it);
-  void OnWrite(StreamIterator it, std::shared_ptr<OpenStream> const& stream,
-               bool ok);
-  void DoRead(std::unique_lock<std::mutex> lk, StreamIterator it);
+  void Flush(std::unique_lock<std::mutex> lk,
+             std::shared_ptr<ReadStream> const& read_stream);
+  void OnWrite(std::shared_ptr<ReadStream> const& read_stream,
+               std::shared_ptr<OpenStream> const& stream, bool ok);
+  void DoRead(std::unique_lock<std::mutex> lk,
+              std::shared_ptr<ReadStream> const& read_stream);
   void OnRead(
-      StreamIterator it, std::shared_ptr<OpenStream> const& stream,
+      std::shared_ptr<ReadStream> const& read_stream,
+      std::shared_ptr<OpenStream> const& stream,
       std::optional<google::storage::v2::BidiReadObjectResponse> response);
-  void DoFinish(std::unique_lock<std::mutex> lk, StreamIterator it,
+  void DoFinish(std::unique_lock<std::mutex> lk,
+                std::shared_ptr<ReadStream> const& read_stream,
                 std::shared_ptr<OpenStream> const& stream);
-  void OnFinish(StreamIterator it, std::shared_ptr<OpenStream> const& stream,
+  void OnFinish(std::shared_ptr<ReadStream> const& read_stream,
+                std::shared_ptr<OpenStream> const& stream,
                 Status const& status);
-  void Resume(StreamIterator it, google::rpc::Status const& proto_status);
-  void OnResume(StreamIterator it,
+  void Resume(std::shared_ptr<ReadStream> const& read_stream,
+              google::rpc::Status const& proto_status);
+  void OnResume(std::shared_ptr<ReadStream> const& old_read_stream,
                 std::shared_ptr<OpenStream> const& old_stream,
                 StatusOr<OpenStreamResult> result);
-  bool IsResumable(StreamIterator it, Status const& status,
+  bool IsResumable(std::shared_ptr<ReadStream> const& read_stream,
+                   Status const& status,
                    google::rpc::Status const& proto_status);
+  bool ApplyPacingAndCheckEviction(std::int64_t id, std::size_t chunk_size,
+                                   StreamIterator it);
 
   std::shared_ptr<storage::internal::HashFunction> CreateHashFunction(
       bool is_full_read) const;

--- a/google/cloud/storage/internal/async/object_descriptor_impl.h
+++ b/google/cloud/storage/internal/async/object_descriptor_impl.h
@@ -53,6 +53,7 @@ struct ReadStream : public storage_internal::StreamBase {
   google::storage::v2::BidiReadObjectRequest next_request;
   bool write_pending = false;
   bool read_pending = false;
+  bool resuming = false;
 };
 
 class ObjectDescriptorImpl
@@ -101,15 +102,20 @@ class ObjectDescriptorImpl
   void AssurePendingStreamQueued(std::unique_lock<std::mutex> const&);
 
   void Flush(std::unique_lock<std::mutex> lk, StreamIterator it);
-  void OnWrite(StreamIterator it, bool ok);
+  void OnWrite(StreamIterator it, std::shared_ptr<OpenStream> const& stream,
+               bool ok);
   void DoRead(std::unique_lock<std::mutex> lk, StreamIterator it);
   void OnRead(
-      StreamIterator it,
+      StreamIterator it, std::shared_ptr<OpenStream> const& stream,
       std::optional<google::storage::v2::BidiReadObjectResponse> response);
-  void DoFinish(std::unique_lock<std::mutex> lk, StreamIterator it);
-  void OnFinish(StreamIterator it, Status const& status);
+  void DoFinish(std::unique_lock<std::mutex> lk, StreamIterator it,
+                std::shared_ptr<OpenStream> const& stream);
+  void OnFinish(StreamIterator it, std::shared_ptr<OpenStream> const& stream,
+                Status const& status);
   void Resume(StreamIterator it, google::rpc::Status const& proto_status);
-  void OnResume(StreamIterator it, StatusOr<OpenStreamResult> result);
+  void OnResume(StreamIterator it,
+                std::shared_ptr<OpenStream> const& old_stream,
+                StatusOr<OpenStreamResult> result);
   bool IsResumable(StreamIterator it, Status const& status,
                    google::rpc::Status const& proto_status);
 

--- a/google/cloud/storage/internal/async/object_descriptor_impl_test.cc
+++ b/google/cloud/storage/internal/async/object_descriptor_impl_test.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/storage/internal/async/default_options.h"
 #include "google/cloud/storage/options.h"
 #include "google/cloud/storage/testing/canonical_errors.h"
+#include "google/cloud/storage/testing/mock_resume_policy.h"
 #include "google/cloud/storage/testing/mock_storage_stub.h"
 #include "google/cloud/testing_util/async_sequencer.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
@@ -41,6 +42,7 @@ namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+using ::google::cloud::storage::testing::MockResumePolicy;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ::google::cloud::testing_util::AsyncSequencer;
@@ -3142,6 +3144,495 @@ TEST(ObjectDescriptorImpl, DuplicateInitialRangesDeduplication) {
   next = sequencer.PopFrontWithName();
   EXPECT_EQ(next.second, "Finish");
   next.first.set_value(true);
+}
+
+/// @test Verify that when a stream fails and triggers resumption, concurrent
+/// Read() requests queued while reconnecting are not dropped and are flushed to
+/// the newly connected stream.
+TEST(ObjectDescriptorImpl, ResumeRacesWithConcurrentRead) {
+  AsyncSequencer<bool> sequencer;
+  auto stream1 = std::make_unique<MockStream>();
+  EXPECT_CALL(*stream1, Read).WillRepeatedly([&sequencer]() {
+    return sequencer.PushBack("Read[1]").then(
+        [](auto) { return std::optional<Response>{}; });
+  });
+  EXPECT_CALL(*stream1, Write)
+      .WillRepeatedly([&sequencer](Request const&, grpc::WriteOptions) {
+        return sequencer.PushBack("Write[1]").then([](auto f) {
+          return f.get();
+        });
+      });
+  EXPECT_CALL(*stream1, Finish).WillOnce([&sequencer]() {
+    return sequencer.PushBack("Finish[1]").then([](auto f) {
+      if (f.get()) return TransientError();
+      return PermanentError();
+    });
+  });
+
+  auto stream2 = std::make_unique<MockStream>();
+  EXPECT_CALL(*stream2, Read)
+      .WillOnce([&sequencer]() {
+        return sequencer.PushBack("Read[2]").then(
+            [](auto) { return std::optional<Response>{}; });
+      })
+      .WillRepeatedly(
+          []() { return make_ready_future(std::optional<Response>{}); });
+  EXPECT_CALL(*stream2, Write)
+      .WillRepeatedly([&sequencer](Request const&, grpc::WriteOptions) {
+        return sequencer.PushBack("Write[2]").then([](auto f) {
+          return f.get();
+        });
+      });
+  EXPECT_CALL(*stream2, Finish).WillRepeatedly([]() {
+    return make_ready_future(Status{});
+  });
+
+  MockFactory factory;
+  EXPECT_CALL(factory, Call).WillRepeatedly([](Request const&) {
+    return make_ready_future(StatusOr<OpenStreamResult>(TransientError()));
+  });
+  EXPECT_CALL(
+      factory,
+      Call(ResultOf([](Request const& r) { return !r.read_ranges().empty(); },
+                    true)))
+      .WillOnce([&stream2](Request const&) {
+        auto response = Response{};
+        return make_ready_future(make_status_or(
+            OpenStreamResult{std::make_shared<OpenStream>(std::move(stream2)),
+                             std::move(response)}));
+      });
+
+  auto tested = MakeTested(storage::LimitedErrorCountResumePolicy(3)(),
+                           factory.AsStdFunction(),
+                           google::storage::v2::BidiReadObjectSpec{},
+                           std::make_shared<OpenStream>(std::move(stream1)));
+
+  tested->Start(Response{});
+
+  auto read1 = sequencer.PopFrontWithName();
+  EXPECT_EQ(read1.second, "Read[1]");
+
+  auto s1 = tested->Read({1000, 100});
+  ASSERT_THAT(s1, NotNull());
+  auto write1 = sequencer.PopFrontWithName();
+  EXPECT_EQ(write1.second, "Write[1]");
+  write1.first.set_value(true);
+
+  // Trigger stream 1 failure and Resume
+  read1.first.set_value(false);
+
+  auto next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "Finish[1]");
+  next.first.set_value(true);
+
+  // Concurrently issue Read for range 2 while Resume is connecting stream 2
+  auto s2 = tested->Read({2000, 100});
+  ASSERT_THAT(s2, NotNull());
+
+  // Stream 2 should be read and receive the flushed Write[2] with range 2
+  auto read2 = sequencer.PopFrontWithName();
+  EXPECT_EQ(read2.second, "Read[2]");
+
+  auto write2 = sequencer.PopFrontWithName();
+  EXPECT_EQ(write2.second, "Write[2]");
+  write2.first.set_value(true);
+
+  tested.reset();
+  read2.first.set_value(false);
+}
+
+/// @test Verify that callbacks from discarded/stale stream instances are
+/// ignored and do not affect the newly active stream.
+TEST(ObjectDescriptorImpl, IgnoresCallbacksFromStaleStreams) {
+  AsyncSequencer<bool> sequencer;
+  auto stream1 = std::make_unique<MockStream>();
+  EXPECT_CALL(*stream1, Read).WillRepeatedly([&sequencer]() {
+    return sequencer.PushBack("Read[1]").then(
+        [](auto) { return std::optional<Response>{}; });
+  });
+  EXPECT_CALL(*stream1, Write)
+      .WillRepeatedly([&sequencer](Request const&, grpc::WriteOptions) {
+        return sequencer.PushBack("Write[1]").then([](auto f) {
+          return f.get();
+        });
+      });
+  EXPECT_CALL(*stream1, Finish).WillOnce([&sequencer]() {
+    return sequencer.PushBack("Finish[1]").then([](auto f) {
+      if (f.get()) return TransientError();
+      return PermanentError();
+    });
+  });
+
+  auto stream2 = std::make_unique<MockStream>();
+  EXPECT_CALL(*stream2, Read)
+      .WillOnce([&sequencer]() {
+        return sequencer.PushBack("Read[2]").then(
+            [](auto) { return std::optional<Response>{}; });
+      })
+      .WillRepeatedly(
+          []() { return make_ready_future(std::optional<Response>{}); });
+  EXPECT_CALL(*stream2, Write)
+      .WillRepeatedly([&sequencer](Request const&, grpc::WriteOptions) {
+        return sequencer.PushBack("Write[2]").then([](auto f) {
+          return f.get();
+        });
+      });
+  EXPECT_CALL(*stream2, Finish).WillRepeatedly([]() {
+    return make_ready_future(Status{});
+  });
+
+  MockFactory factory;
+  EXPECT_CALL(factory, Call).WillRepeatedly([](Request const&) {
+    return make_ready_future(StatusOr<OpenStreamResult>(TransientError()));
+  });
+  EXPECT_CALL(
+      factory,
+      Call(ResultOf([](Request const& r) { return !r.read_ranges().empty(); },
+                    true)))
+      .WillOnce([&stream2](Request const&) {
+        auto response = Response{};
+        return make_ready_future(make_status_or(
+            OpenStreamResult{std::make_shared<OpenStream>(std::move(stream2)),
+                             std::move(response)}));
+      });
+
+  auto tested = MakeTested(storage::LimitedErrorCountResumePolicy(3)(),
+                           factory.AsStdFunction(),
+                           google::storage::v2::BidiReadObjectSpec{},
+                           std::make_shared<OpenStream>(std::move(stream1)));
+
+  tested->Start(Response{});
+
+  auto read1 = sequencer.PopFrontWithName();
+  EXPECT_EQ(read1.second, "Read[1]");
+
+  auto s1 = tested->Read({1000, 100});
+  ASSERT_THAT(s1, NotNull());
+  auto write1 = sequencer.PopFrontWithName();
+  EXPECT_EQ(write1.second, "Write[1]");
+
+  // Stream 1 fails on read and resumes stream 2
+  read1.first.set_value(false);
+
+  auto next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "Finish[1]");
+  next.first.set_value(true);
+
+  // Stream 2 is now active
+  auto read2 = sequencer.PopFrontWithName();
+  EXPECT_EQ(read2.second, "Read[2]");
+
+  // A stale Write[1] callback from stream 1 arrives late with false (error).
+  // It should NOT call Finish[2] on stream 2!
+  write1.first.set_value(false);
+
+  EXPECT_TRUE(sequencer.empty());
+
+  tested.reset();
+  read2.first.set_value(false);
+}
+
+/// @test Verify that when a stream is cancelled due to a stall watchdog timeout
+/// (StatusCode::kCancelled), it is treated as resumable by the resume policy
+/// and automatically resumed.
+TEST(ObjectDescriptorImpl, ResumeOnStallTimeout) {
+  AsyncSequencer<bool> sequencer;
+  auto stream1 = std::make_unique<MockStream>();
+  EXPECT_CALL(*stream1, Read).WillRepeatedly([&sequencer]() {
+    return sequencer.PushBack("Read[1]").then(
+        [](auto) { return std::optional<Response>{}; });
+  });
+  EXPECT_CALL(*stream1, Write)
+      .WillRepeatedly([&sequencer](Request const&, grpc::WriteOptions) {
+        return sequencer.PushBack("Write[1]").then([](auto f) {
+          return f.get();
+        });
+      });
+  EXPECT_CALL(*stream1, Finish).WillOnce([&sequencer]() {
+    return sequencer.PushBack("Finish[1]").then([](auto f) {
+      if (f.get()) return Status(StatusCode::kCancelled, "Stream stalled");
+      return PermanentError();
+    });
+  });
+
+  auto stream2 = std::make_unique<MockStream>();
+  EXPECT_CALL(*stream2, Read)
+      .WillOnce([&sequencer]() {
+        return sequencer.PushBack("Read[2]").then(
+            [](auto) { return std::optional<Response>{}; });
+      })
+      .WillRepeatedly(
+          []() { return make_ready_future(std::optional<Response>{}); });
+  EXPECT_CALL(*stream2, Write)
+      .WillRepeatedly([&sequencer](Request const&, grpc::WriteOptions) {
+        return sequencer.PushBack("Write[2]").then([](auto f) {
+          return f.get();
+        });
+      });
+  EXPECT_CALL(*stream2, Finish).WillRepeatedly([]() {
+    return make_ready_future(Status{});
+  });
+
+  MockFactory factory;
+  EXPECT_CALL(factory, Call).WillRepeatedly([](Request const&) {
+    return make_ready_future(StatusOr<OpenStreamResult>(TransientError()));
+  });
+  EXPECT_CALL(
+      factory,
+      Call(ResultOf([](Request const& r) { return !r.read_ranges().empty(); },
+                    true)))
+      .WillOnce([&stream2](Request const&) {
+        auto response = Response{};
+        return make_ready_future(make_status_or(
+            OpenStreamResult{std::make_shared<OpenStream>(std::move(stream2)),
+                             std::move(response)}));
+      });
+
+  auto tested = MakeTested(storage::LimitedErrorCountResumePolicy(3)(),
+                           factory.AsStdFunction(),
+                           google::storage::v2::BidiReadObjectSpec{},
+                           std::make_shared<OpenStream>(std::move(stream1)));
+
+  tested->Start(Response{});
+
+  auto read1 = sequencer.PopFrontWithName();
+  EXPECT_EQ(read1.second, "Read[1]");
+
+  auto s1 = tested->Read({1000, 100});
+  ASSERT_THAT(s1, NotNull());
+  auto write1 = sequencer.PopFrontWithName();
+  EXPECT_EQ(write1.second, "Write[1]");
+  write1.first.set_value(true);
+
+  // Watchdog cancels stream 1 on read stall
+  read1.first.set_value(false);
+
+  auto next = sequencer.PopFrontWithName();
+  EXPECT_EQ(next.second, "Finish[1]");
+  next.first.set_value(true);
+
+  // If resumed, stream 2 is connected and Read[2] is invoked
+  auto read2 = sequencer.PopFrontWithName();
+  EXPECT_EQ(read2.second, "Read[2]");
+
+  tested.reset();
+  read2.first.set_value(false);
+}
+
+/// @test Verify that when a stream starts successfully, the resume policy is
+/// notified via OnStartSuccess().
+TEST(ObjectDescriptorImpl, NotifiesResumePolicyOnStartSuccess) {
+  auto mock_policy = std::make_unique<MockResumePolicy>();
+  EXPECT_CALL(*mock_policy, clone).WillOnce([]() {
+    auto p = std::make_unique<MockResumePolicy>();
+    EXPECT_CALL(*p, OnStartSuccess).Times(::testing::AtLeast(1));
+    return p;
+  });
+
+  MockFactory factory;
+  EXPECT_CALL(factory, Call).WillRepeatedly([](Request const&) {
+    return make_ready_future(StatusOr<OpenStreamResult>(TransientError()));
+  });
+  auto stream = std::make_unique<MockStream>();
+  EXPECT_CALL(*stream, Read).WillRepeatedly([]() {
+    return make_ready_future(std::optional<Response>{});
+  });
+  EXPECT_CALL(*stream, Write)
+      .WillRepeatedly([](Request const&, grpc::WriteOptions) {
+        return make_ready_future(true);
+      });
+  EXPECT_CALL(*stream, Finish).WillRepeatedly([]() {
+    return make_ready_future(Status{});
+  });
+
+  auto tested = MakeTested(std::move(mock_policy), factory.AsStdFunction(),
+                           google::storage::v2::BidiReadObjectSpec{},
+                           std::make_shared<OpenStream>(std::move(stream)));
+
+  tested->Start(Response{});
+}
+
+/// @test Verify that when the user explicitly cancels ObjectDescriptorImpl,
+/// streams are cancelled and no resume attempts are made.
+TEST(ObjectDescriptorImpl, UserCancelStopsStreamWithoutResume) {
+  AsyncSequencer<bool> sequencer;
+  auto stream1 = std::make_unique<MockStream>();
+  EXPECT_CALL(*stream1, Cancel).Times(::testing::AtLeast(1));
+  EXPECT_CALL(*stream1, Write)
+      .Times(AtMost(1))
+      .WillRepeatedly([](Request const&, grpc::WriteOptions) {
+        return make_ready_future(true);
+      });
+  EXPECT_CALL(*stream1, Read).WillOnce([&sequencer]() {
+    return sequencer.PushBack("Read[1]").then(
+        [](auto) { return std::optional<Response>{}; });
+  });
+  EXPECT_CALL(*stream1, Finish).WillOnce([&sequencer]() {
+    return sequencer.PushBack("Finish[1]").then([](auto) {
+      return Status(StatusCode::kCancelled, "Cancelled by user");
+    });
+  });
+
+  MockFactory factory;
+  // Factory should NEVER be called on user cancellation.
+  EXPECT_CALL(factory, Call).Times(0);
+
+  Options options;
+  options.set<storage::EnableMultiStreamOptimizationOption>(false);
+  auto tested = std::make_shared<ObjectDescriptorImpl>(
+      storage::LimitedErrorCountResumePolicy(2)(), factory.AsStdFunction(),
+      google::storage::v2::BidiReadObjectSpec{},
+      std::make_shared<OpenStream>(std::move(stream1)), options);
+
+  Response start_resp;
+  tested->Start(std::move(start_resp));
+
+  auto r1 = tested->Read({100, 50});
+  ASSERT_THAT(r1, NotNull());
+
+  auto read1 = sequencer.PopFrontWithName();
+  EXPECT_EQ(read1.second, "Read[1]");
+
+  // User explicitly cancels.
+  tested->Cancel();
+  EXPECT_FALSE(tested->IsOpen());
+
+  read1.first.set_value(true);
+
+  auto finish1 = sequencer.PopFrontWithName();
+  EXPECT_EQ(finish1.second, "Finish[1]");
+  finish1.first.set_value(true);
+
+  // No resume factory calls happen.
+  EXPECT_TRUE(sequencer.empty());
+  EXPECT_FALSE(tested->IsOpen());
+}
+
+/// @test Verify that range requests arriving during multiple consecutive
+/// transient reconnection retries are preserved across all attempts and
+/// flushed to the new stream once reconnected.
+TEST(ObjectDescriptorImpl, ConcurrentReadPreservedAcrossMultipleResumeRetries) {
+  AsyncSequencer<bool> sequencer;
+  auto stream1 = std::make_unique<MockStream>();
+  EXPECT_CALL(*stream1, Read).WillRepeatedly([&sequencer]() {
+    return sequencer.PushBack("Read[1]").then(
+        [](auto) { return std::optional<Response>{}; });
+  });
+  EXPECT_CALL(*stream1, Write)
+      .WillRepeatedly([&sequencer](Request const&, grpc::WriteOptions) {
+        return sequencer.PushBack("Write[1]").then([](auto f) {
+          return f.get();
+        });
+      });
+  EXPECT_CALL(*stream1, Finish).WillOnce([&sequencer]() {
+    return sequencer.PushBack("Finish[1]").then([](auto f) {
+      if (f.get()) return TransientError();
+      return PermanentError();
+    });
+  });
+
+  auto stream2 = std::make_unique<MockStream>();
+  EXPECT_CALL(*stream2, Read)
+      .WillOnce([&sequencer]() {
+        return sequencer.PushBack("Read[2]").then(
+            [](auto) { return std::optional<Response>{}; });
+      })
+      .WillRepeatedly(
+          []() { return make_ready_future(std::optional<Response>{}); });
+  EXPECT_CALL(*stream2, Write)
+      .WillRepeatedly([&sequencer](Request const&, grpc::WriteOptions) {
+        return sequencer.PushBack("Write[2]").then([](auto f) {
+          return f.get();
+        });
+      });
+  EXPECT_CALL(*stream2, Finish).WillRepeatedly([]() {
+    return make_ready_future(Status{});
+  });
+
+  MockFactory factory;
+  int retry_count = 0;
+  EXPECT_CALL(factory, Call).WillRepeatedly([&](Request const& r) {
+    ++retry_count;
+    if (retry_count == 1) {
+      return sequencer.PushBack("Factory[1]").then([](auto f) {
+        if (f.get()) {
+          return StatusOr<OpenStreamResult>(TransientError());
+        }
+        return StatusOr<OpenStreamResult>(PermanentError());
+      });
+    }
+    // Second attempt must contain both range 1 and range 2
+    EXPECT_EQ(r.read_ranges_size(), 2);
+    return sequencer.PushBack("Factory[2]").then([&stream2](auto f) {
+      if (f.get()) {
+        auto response = Response{};
+        return make_status_or(
+            OpenStreamResult{std::make_shared<OpenStream>(std::move(stream2)),
+                             std::move(response)});
+      }
+      return StatusOr<OpenStreamResult>(PermanentError());
+    });
+  });
+
+  auto tested = std::make_shared<ObjectDescriptorImpl>(
+      storage::LimitedErrorCountResumePolicy(3)(), factory.AsStdFunction(),
+      google::storage::v2::BidiReadObjectSpec{},
+      std::make_shared<OpenStream>(std::move(stream1)),
+      Options{}.set<storage::EnableMultiStreamOptimizationOption>(false));
+
+  tested->Start(Response{});
+
+  auto read1 = sequencer.PopFrontWithName();
+  EXPECT_EQ(read1.second, "Read[1]");
+
+  auto s1 = tested->Read({1000, 100});
+  ASSERT_THAT(s1, NotNull());
+  auto write1 = sequencer.PopFrontWithName();
+  EXPECT_EQ(write1.second, "Write[1]");
+  write1.first.set_value(true);
+
+  // Trigger stream 1 failure
+  read1.first.set_value(false);
+
+  auto finish1 = sequencer.PopFrontWithName();
+  EXPECT_EQ(finish1.second, "Finish[1]");
+  finish1.first.set_value(true);
+
+  // Factory attempt 1 is invoked
+  auto factory1 = sequencer.PopFrontWithName();
+  EXPECT_EQ(factory1.second, "Factory[1]");
+
+  // While reconnection attempt 1 is in-flight, add range 2 concurrently
+  auto s2 = tested->Read({2000, 100});
+  ASSERT_THAT(s2, NotNull());
+
+  // Factory attempt 1 fails with TransientError
+  factory1.first.set_value(true);
+
+  // Factory attempt 2 is invoked with both range 1 and range 2
+  auto factory2 = sequencer.PopFrontWithName();
+  EXPECT_EQ(factory2.second, "Factory[2]");
+
+  // While factory attempt 2 is in-flight, add range 3 concurrently
+  auto s3 = tested->Read({3000, 100});
+  ASSERT_THAT(s3, NotNull());
+
+  // Factory attempt 2 succeeds with stream2
+  factory2.first.set_value(true);
+
+  // Range 3 (queued during factory attempt 2) is flushed to stream 2 first
+  auto write2 = sequencer.PopFrontWithName();
+  EXPECT_EQ(write2.second, "Write[2]");
+  write2.first.set_value(true);
+
+  // Stream 2 is read
+  auto read2 = sequencer.PopFrontWithName();
+  EXPECT_EQ(read2.second, "Read[2]");
+
+  EXPECT_EQ(retry_count, 2);
+
+  tested->Cancel();
+  read2.first.set_value(false);
 }
 
 }  // namespace


### PR DESCRIPTION
This PR addresses stream lifecycle, reuse, and resumption bugs in `ObjectDescriptorImpl` and `MultiStreamManager` when handling bidirectional asynchronous read streams:

1. **Concurrent `Read()` During Resumption**:
   - **Issue**: `Read()` calls arriving while reconnection was in flight attempted to write to the dying stream, and `OnResume()` previously overwrote `it->stream`, dropping ranges accumulated in `next_request`.
   - **Fix**: Added `resuming = true` to `ReadStream` to block `Flush()` during reconnection. `OnResume()` preserves all accumulated `next_request` ranges across transient reconnection retries and flushes them to the new stream upon connection establishment.
2. **Excluding Reconnecting Streams from Idle Reuse & Stream Selection**:
   - **Issue**: A stream undergoing reconnection (`resuming == true`) has `active_ranges.empty() && !write_pending`, causing `MakeSubsequentStream()` to falsely treat it as "idle" and move it to the front instead of activating a healthy background stream. Additionally, `Read()` would select the reconnecting stream because it appeared to have zero active ranges.
   - **Fix**: Updated `MakeSubsequentStream()` to require `!rs->resuming` when reusing idle streams. Added a templated predicate overload to `MultiStreamManager::GetLeastBusyStream()` so `Read()` prioritizes healthy, non-resuming streams (falling back to reconnecting streams only if all streams are currently reconnecting).
3. **Stale Callback Hygiene & Safe Async Continuations**:
   - **Issue**: Callbacks capturing `std::list` iterators could access invalidated iterators upon stream removal (triggering undefined behavior) or mistakenly trigger `Finish` on replacement streams.
   - **Fix**: Async callbacks now capture `std::shared_ptr<ReadStream>` and `std::shared_ptr<OpenStream>`. Under lock, callbacks resolve membership via `MultiStreamManager::Find(read_stream)` and validate stream identity (`it->stream->stream == stream`) before processing. Orphaned streams returned from delayed resume attempts are cancelled explicitly upon arrival.
4. **Preserving Resume Policy Budget Across Reconnections**:
   - **Issue**: `OnResume()` cloned from `resume_policy_prototype_`, resetting `error_count_` back to 0 on every reconnect and granting infinite retries under policies like `LimitedErrorCountResumePolicy`.
   - **Fix**: `OnResume()` now moves and preserves the active `resume_policy` instance across reconnections, ensuring retry budgets and failure counters accumulate across reconnects.
5. **Resume Policy Status Code Fidelity & User Cancellation**:
   - **Issue**: Explicit user cancellations must not trigger resumption, while stream stall cancellations (`StatusCode::kCancelled`) and transport failures must be passed to the resume policy without corruption.
   - **Fix**: Pass the original `Status` directly to `resume_policy->OnFinish(status)` without rewriting status codes. Guarded with `cancelled_` to ensure explicit user cancellations terminate immediately without attempting resumption.
6. **Resume Policy Notification on Successful Start**:
   - Initialized `resume_policy->OnStartSuccess()` when streams are established in the constructor, `MakeSubsequentStream()`, and `OnResume()`.

---

### Sequence Diagrams

#### 1. Concurrent `Read()` During Resumption

##### Before (Race Condition & Dropped Ranges)
```mermaid
sequenceDiagram
    autonumber
    participant App as User Thread
    participant Obj as ObjectDescriptorImpl
    participant S1 as Stream 1 (Failing)
    participant S2 as Stream 2 (New)

    S1-->>Obj: Stream failure (read/write error)
    Obj->>Obj: OnFinish() -> Resume() (async make_stream_)
    Note over Obj: Reconnection in flight...
    App->>Obj: Read(range_B)
    Obj->>S1: Flush() writes range_B to dying Stream 1 (Fails)
    S2-->>Obj: OnResume(Stream 2)
    Note over Obj,S2: it->stream replaced with new ReadStream<br/>next_request overwritten & range_B dropped
```

##### After (Safe Queueing & Automatic Flushing)
```mermaid
sequenceDiagram
    autonumber
    participant App as User Thread
    participant Obj as ObjectDescriptorImpl
    participant S1 as Stream 1 (Failing)
    participant S2 as Stream 2 (New)

    S1-->>Obj: Stream failure (read/write error)
    Obj->>Obj: Resume() sets resuming = true
    Note over Obj: Reconnection in flight...
    App->>Obj: Read(range_B)
    Obj->>Obj: Flush() skipped (resuming == true)<br/>range_B added to active_ranges & next_request
    S2-->>Obj: OnResume(Stream 2)
    Note over Obj,S2: Preserves next_request<br/>Replaces stream, sets resuming = false
    Obj->>S2: Flush() queued next_request (range_B)
    Obj->>S2: DoRead() starts reading
```

---

#### 2. Stale Callback Hygiene

##### Before
```mermaid
sequenceDiagram
    autonumber
    participant S1 as Stream 1 (Old)
    participant Obj as ObjectDescriptorImpl
    participant S2 as Stream 2 (Active)

    S1-->>Obj: Read error triggers Resume()
    Obj->>S2: OnResume() establishes Stream 2 as active
    Note over S1,Obj: Delayed Write callback from Stream 1 arrives late (ok = false)
    S1-->>Obj: OnWrite(ok = false)
    Obj->>Obj: DoFinish() without checking stream identity
    Obj->>S2: stream_manager_->RemoveStream(it) -> Kills new Stream 2
```

##### After
```mermaid
sequenceDiagram
    autonumber
    participant S1 as Stream 1 (Old)
    participant Obj as ObjectDescriptorImpl
    participant S2 as Stream 2 (Active)

    S1-->>Obj: Read error triggers Resume()
    Obj->>S2: OnResume() establishes Stream 2 as active
    Note over S1,Obj: Delayed Write callback from Stream 1 arrives late (ok = false)
    S1-->>Obj: OnWrite(Stream 1, ok = false)
    Obj->>Obj: Check: stream_manager_->Find(read_stream) != End() && it->stream->stream == Stream 1?
    Note over Obj: Stream identity mismatch (active stream is Stream 2)<br/>Callback safely discarded
    Note over S2: Stream 2 continues healthy operation uninterrupted
```