### PR TITLE
feat(bigquery): add statement_type to PostQueryResults

### DIFF
--- a/google/cloud/bigquery/v2/minimal/internal/job_response.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response.cc
@@ -198,6 +198,7 @@ std::string PostQueryResults::DebugString(absl::string_view name,
   return internal::DebugFormatter(name, options, indent)
       .StringField("kind", kind)
       .StringField("page_token", page_token)
+      .StringField("statement_type", statement_type)
       .Field("total_rows", total_rows)
       .Field("total_bytes_processed", total_bytes_processed)
       .Field("num_dml_affected_rows", num_dml_affected_rows)
@@ -229,6 +230,7 @@ StatusOr<QueryResponse> QueryResponse::BuildFromHttpResponse(
   PostQueryResults query_results;
   query_results.kind = json->value("kind", "");
   query_results.page_token = json->value("pageToken", "");
+  SafeGetTo(query_results.statement_type, *json, "statementType");
   // May not be present in certain query scenarios (e.g in dry-run mode).
   if (json->contains("totalRows")) {
     query_results.total_rows =
@@ -288,6 +290,7 @@ void from_json(nlohmann::json const& j, SessionInfo& s) {
 void to_json(nlohmann::json& j, PostQueryResults const& q) {
   j = nlohmann::json{{"kind", q.kind},
                      {"pageToken", q.page_token},
+                     {"statementType", q.statement_type},
                      {"totalRows", q.total_rows},
                      {"totalBytesProcessed", q.total_bytes_processed},
                      {"numDmlAffectedRows", q.num_dml_affected_rows},
@@ -304,6 +307,7 @@ void to_json(nlohmann::json& j, PostQueryResults const& q) {
 void from_json(nlohmann::json const& j, PostQueryResults& q) {
   SafeGetTo(q.kind, j, "kind");
   SafeGetTo(q.page_token, j, "pageToken");
+  SafeGetTo(q.statement_type, j, "statementType");
   SafeGetTo(q.total_rows, j, "totalRows");
   SafeGetTo(q.total_bytes_processed, j, "totalBytesProcessed");
   SafeGetTo(q.num_dml_affected_rows, j, "numDmlAffectedRows");

--- a/google/cloud/bigquery/v2/minimal/internal/job_response.h
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response.h
@@ -103,6 +103,7 @@ struct PostQueryResults {
 
   std::string kind;
   std::string page_token;
+  std::string statement_type;
 
   std::uint64_t total_rows = 0;
   std::int64_t total_bytes_processed = 0;

--- a/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
@@ -1998,6 +1998,7 @@ TEST(QueryResponseTest, DebugString) {
       R"( status_code: 200 payload: REDACTED })"
       R"( query_results {)"
       R"( kind: "query-kind" page_token: "np123")"
+      R"( statement_type: "statement_type")"
       R"( total_rows: 1000 total_bytes_processed: 1000 num_dml_affected_rows: 5)"
       R"( job_complete: true cache_hit: true)"
       R"( rows { columns { value: "col1" is_null: false } columns { value: "col2" is_null: false })"
@@ -2018,7 +2019,8 @@ TEST(QueryResponseTest, DebugString) {
       R"(QueryResponse { http_response {)"
       R"( status_code: 200 payload: REDACTED })"
       R"( query_results { kind: "query-k...<truncated>...")"
-      R"( page_token: "np123" total_rows: 1000 total_bytes_processed: 1000)"
+      R"( page_token: "np123" statement_type: "stateme...<truncated>...")"
+      R"( total_rows: 1000 total_bytes_processed: 1000)"
       R"( num_dml_affected_rows: 5 job_complete: true cache_hit: true)"
       R"( rows { columns { value: "col1" is_null: false } columns { value: "col2" is_null: false })"
       R"( columns { value: "col3" is_null: false } columns { value: "col4" is_null: false })"
@@ -2041,6 +2043,7 @@ TEST(QueryResponseTest, DebugString) {
   query_results {
     kind: "query-kind"
     page_token: "np123"
+    statement_type: "statement_type"
     total_rows: 1000
     total_bytes_processed: 1000
     num_dml_affected_rows: 5

--- a/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
+++ b/google/cloud/bigquery/v2/minimal/internal/job_response_test.cc
@@ -1955,6 +1955,17 @@ TEST(CancelJobResponseTest, DebugString) {
 })");
 }
 
+TEST(PostQueryResultsTest, FromJson) {
+  auto const expected = MakePostQueryResults();
+  nlohmann::json j;
+  to_json(j, expected);
+
+  PostQueryResults actual;
+  from_json(j, actual);
+
+  bigquery_v2_minimal_testing::AssertEquals(expected, actual);
+}
+
 TEST(QueryResponseTest, Success) {
   BigQueryHttpResponse http_response;
   http_response.payload = MakeQueryResponsePayload();

--- a/google/cloud/bigquery/v2/minimal/testing/job_query_test_utils.cc
+++ b/google/cloud/bigquery/v2/minimal/testing/job_query_test_utils.cc
@@ -160,6 +160,7 @@ PostQueryResults MakePostQueryResults() {
   expected.kind = "query-kind";
   expected.num_dml_affected_rows = 5;
   expected.page_token = "np123";
+  expected.statement_type = "statement_type";
   expected.rows.push_back(MakeRowData());
 
   expected.schema = MakeTable().schema;
@@ -217,6 +218,7 @@ void AssertEquals(bigquery_v2_minimal_internal::PostQueryResults const& lhs,
   EXPECT_EQ(lhs.kind, rhs.kind);
   EXPECT_EQ(lhs.num_dml_affected_rows, rhs.num_dml_affected_rows);
   EXPECT_EQ(lhs.page_token, rhs.page_token);
+  EXPECT_EQ(lhs.statement_type, rhs.statement_type);
 
   ASSERT_THAT(lhs.schema.fields, Not(IsEmpty()));
   ASSERT_THAT(rhs.schema.fields, Not(IsEmpty()));


### PR DESCRIPTION
Adds `statement_type` to `PostQueryResults` in `bigquery_v2_minimal_internal` to parse the `statementType` field returned by BigQuery's `jobs.query` API.